### PR TITLE
DS-1710 unexpected error on group delete

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,6 +46,9 @@
             "drupal/address": {
                 "Fix form errorElement": "https://www.drupal.org/files/issues/address-2619878-29.patch"
             },
+            "drupal/group": {
+                "Fix group overview for administrator": "https://www.drupal.org/files/issues/group-2788213-2.patch"
+            },
             "drupal/core": {
                 "Fix region string issue": "https://www.drupal.org/files/issues/2724283-block-22.patch",
                 "Make sure exposed filters work": "https://www.drupal.org/files/issues/grouped_filters-2369119-73.patch",


### PR DESCRIPTION
[Story](https://goalgorilla.cloudshards.net/browse/DS-1856)

**Background info**
1. On the alpha (Groups version alpha 3) whenever we delete a group we get redirected to /admin/group with a group overview, this redirect is fixed in the Beta 1 release see [drupal.org](https://www.drupal.org/node/2731157), but that wasn't on the PSH environment at the time it was tested last sprint. It is in the distribution now, so we can't really reproduce this workflow. 
2.  So the admin/group is a list of all groups with Title / Author etc. But since there is no author for this user there is a error that they encounter because it tries to get the label from the user that created it. 
The only way to get this error is to login as a user who has the permission to view the admin/group list. 

group-edit-open.feature should check this in Behat already!


**HTT**

- [ ] Login as user 1.
- [ ] Remove user Onno and make sure all the content is assigned to Anonymous 
- [ ] Now go to /admin/group and see the epic fail
- [ ] Download and Apply the patch created and see this fixes the issue.
- [ ] Verify that as a normal LU you can still create / edit / delete a group and you can't see the admin overview
