### PR TITLE
DS-1724 fixed multiple activities shown in the stream and submit form js

### DIFF
--- a/modules/custom/activity_viewer/src/Plugin/views/filter/ActivityPostVisibilityAccess.php
+++ b/modules/custom/activity_viewer/src/Plugin/views/filter/ActivityPostVisibilityAccess.php
@@ -45,6 +45,12 @@ class ActivityPostVisibilityAccess extends FilterPluginBase {
       'table' => 'post_field_data',
       'field' => 'id',
       'operator' => '=',
+      'extra' => array(
+        0 => array(
+          'left_field' => 'field_activity_entity_target_type',
+          'value' => 'post',
+        ),
+      ),
     );
     $join = Views::pluginManager('join')->createInstance('standard', $configuration);
     $this->query->addRelationship('post', $join, 'activity__field_activity_entity');
@@ -66,9 +72,15 @@ class ActivityPostVisibilityAccess extends FilterPluginBase {
       'table' => 'node_access',
       'field' => 'nid',
       'operator' => '=',
+      'extra' => array(
+        0 => array(
+          'left_field' => 'field_activity_entity_target_type',
+          'value' => 'node',
+        ),
+      ),
     );
     $join = Views::pluginManager('join')->createInstance('standard', $configuration);
-    $this->query->addRelationship('node_access', $join, 'asdfasfd');
+    $this->query->addRelationship('node_access', $join, 'node_access_relationship');
 
     // Add queries.
     $and_wrapper = db_and();
@@ -112,6 +124,12 @@ class ActivityPostVisibilityAccess extends FilterPluginBase {
         'table' => 'comment_field_data',
         'field' => 'cid',
         'operator' => '=',
+        'extra' => array(
+          0 => array(
+            'left_field' => 'field_activity_entity_target_type',
+            'value' => 'comment',
+          ),
+        ),
       );
       $join = Views::pluginManager('join')->createInstance('standard', $configuration);
       $this->query->addRelationship('comment_field_data', $join, 'comments');

--- a/themes/socialbase/socialbase.libraries.yml
+++ b/themes/socialbase/socialbase.libraries.yml
@@ -13,6 +13,8 @@ global-styling:
   js:
     js/custom/offcanvas.js: {}
     js/contrib/bootstrap.min.js: {}
+  dependencies:
+    - core/drupal.form
 
 layout:
   css:


### PR DESCRIPTION
Two fixes.
One was that for posts and comments the submit button could create multiple entities if pressed multiple times. This was fixed by loading the form.js of drupal core on every page (see core/misc/form.js formSingleSubmit).

Second fix was in the joins in the query. What happened was that activities were joined with node, comment and post specific tables which resulted in sometimes that the ID of a post was returned by matching it to a nid in the node access table. This was fixed by adding extra fields to the join queries.