### PR TITLE
DS-1717 - Wrong date in event

### DIFF
--- a/themes/socialbase/templates/event/node--event--small-teaser.html.twig
+++ b/themes/socialbase/templates/event/node--event--small-teaser.html.twig
@@ -77,7 +77,7 @@
 
   {{ title_suffix }}
 
-  <small class="text-gray-lighter list-group-item-text">{{ content.field_event_date }}
+  <small class="text-gray-lighter list-group-item-text">{{ event_date }}
     {% if content.enrolled %}
       <span class="label label-primary">
         {{  content.enrolled }}


### PR DESCRIPTION
## HTT

**Try the following as onnevanveldhuizen and jorikscholten**

- [x] Login
- [x] See the Utopical event on the homepage (small_teaser) and check the date/time in the small teaser
- [x] Click on it
- [x] See the same date/tim (other format) in the hero area
- [x] Search for Utopical
- [x] See the same date/time in the normal teaser