### PR TITLE
DS-1724 by nielsvandermolen: Added distinct option to view, probably …

### DIFF
--- a/modules/social_features/social_activity/config/install/views.view.activity_stream.yml
+++ b/modules/social_features/social_activity/config/install/views.view.activity_stream.yml
@@ -32,7 +32,7 @@ display:
         type: views_query
         options:
           disable_sql_rewrite: false
-          distinct: false
+          distinct: true
           replica: false
           query_comment: ''
           query_tags: {  }
@@ -247,9 +247,9 @@ display:
         - 'languages:language_interface'
         - url.query_args
       tags:
-        - 'config:core.entity_view_display.activity.activity.default'
         - 'config:core.entity_view_display.activity.activity.notification'
         - 'config:core.entity_view_display.activity.activity.notification_archive'
+        - 'config:core.entity_view_display.activity.activity.default'
   page_activity_stream:
     display_plugin: page
     id: page_activity_stream


### PR DESCRIPTION
…could improve this by adding group by's by the joins in the visibility access filter

There was still an issue with multiple results in the activity stream. This is due the join on the node_access table that will return duplicate results when there are multiple matches in the join. There are ways to create a subquery in all the joins that groups them by id but I have chosen to go for a simpler solution for now and enable the distinct in the view. This could potentially lead to performance degradation which we should monitor when we have more data.

htt: Check that there are no double items in the activity stream

