### PR TITLE
Feature/ds 1809 page titles

### DIFF
--- a/modules/social_features/social_core/config/install/block.block.pagetitleblock_content.yml
+++ b/modules/social_features/social_core/config/install/block.block.pagetitleblock_content.yml
@@ -20,6 +20,6 @@ settings:
 visibility:
   request_path:
     id: request_path
-    pages: "/user\r\n/user/*\r\n/group/*\r\n/explore\r\n/community-events\r\n/newest-topics\r\n/newest-members\r\n/all-groups\r\n<front>"
-    negate: false
+    pages: '/search/*'
+    negate: true
     context_mapping: {  }

--- a/modules/social_features/social_core/config/install/block.block.socialbase_pagetitleblock.yml
+++ b/modules/social_features/social_core/config/install/block.block.socialbase_pagetitleblock.yml
@@ -18,8 +18,12 @@ settings:
   provider: social_core
   label_display: '0'
 visibility:
-  request_path:
-    id: request_path
-    pages: "/user\r\n/user/*\r\n/group/*\r\n/search/*\r\n/explore\r\n/community-events\r\n/newest-topics\r\n/newest-members\r\n/all-groups\r\n<front>"
-    negate: true
-    context_mapping: {  }
+  node_type:
+    id: node_type
+    bundles:
+      event: event
+      page: page
+      topic: topic
+    negate: false
+    context_mapping:
+      node: '@node.node_route_context:node'

--- a/modules/social_features/social_core/config/install/block.block.socialbase_pagetitleblock_2.yml
+++ b/modules/social_features/social_core/config/install/block.block.socialbase_pagetitleblock_2.yml
@@ -6,29 +6,20 @@ dependencies:
     - system
   theme:
     - socialbase
-id: socialbase_pagetitleblock
+id: socialbase_pagetitleblock_2
 theme: socialbase
 region: hero
-weight: -15
+weight: -20
 provider: null
 plugin: social_page_title_block
 settings:
   id: social_page_title_block
-  label: 'Page title for nodes'
+  label: 'Page title for enrollments'
   provider: social_core
   label_display: '0'
 visibility:
-  node_type:
-    id: node_type
-    bundles:
-      event: event
-      page: page
-      topic: topic
-    negate: false
-    context_mapping:
-      node: '@node.node_route_context:node'
   request_path:
     id: request_path
-    pages: '/node/add/*'
-    negate: true
+    pages: '*/enrollments'
+    negate: false
     context_mapping: {  }

--- a/themes/socialbase/components/asset-builds/css/cards.css
+++ b/themes/socialbase/components/asset-builds/css/cards.css
@@ -149,17 +149,17 @@ a.card:hover {
   pointer-events: none;
   width: 30px;
   height: 30px;
-  padding: 9px;
+  padding: 6px;
   background-color: #adadad;
-  border-radius: 0 0 10px -2 10px -2;
+  border-radius: 0 0 8px 8px;
   left: 20px;
   position: relative;
   margin-bottom: -10px;
 }
 
 .card--teaser .teaser-type .teaser-type-icon {
-  width: 12px;
-  height: 12px;
+  width: 18px;
+  height: 18px;
   display: table;
   fill: white;
 }
@@ -302,11 +302,6 @@ a.card:hover {
     height: 44px;
     padding: 12px;
     border-radius: 0 0 10px 0;
-  }
-
-  .card--teaser .teaser-type .teaser-type-icon {
-    width: 18px;
-    height: 18px;
   }
 
   .unpublished .card-image.blue-overlay:before {

--- a/themes/socialbase/components/asset-builds/css/materialize.css
+++ b/themes/socialbase/components/asset-builds/css/materialize.css
@@ -5573,7 +5573,7 @@ a.list-group-item {
 }
 
 .offcanvas-body {
-  padding: 10px 0;
+  margin-top: 30px;
 }
 
 /***************
@@ -6530,6 +6530,10 @@ input[type=range]:focus::-ms-fill-upper {
     top: 0;
     padding: 0;
     background: transparent;
+  }
+  .offcanvas-body{
+    margin-top: 0;
+    margin-bottom: 30px;
   }
 }
 

--- a/themes/socialbase/components/components/_off-canvas.scss
+++ b/themes/socialbase/components/components/_off-canvas.scss
@@ -55,5 +55,10 @@
 }
 
 .offcanvas-body {
-	padding: 10px 0;
+	margin-top: 30px;
+
+  @include MQ($small) {
+    margin-top: 0;
+    margin-bottom: 30px;
+  }
 }

--- a/themes/socialbase/components/components/cards/cards.scss
+++ b/themes/socialbase/components/components/cards/cards.scss
@@ -200,16 +200,16 @@ a.card:hover {
     pointer-events: none;
     width: 30px;
     height: 30px;
-    padding: 9px;
+    padding: 6px;
     background-color: $gray-light-1;
-    border-radius: 0 0 ($card-border-radius -2) ($card-border-radius -2);
+    border-radius: 0 0 ($card-border-radius - 2px) ($card-border-radius - 2px);
     left: 20px;
     position: relative;
     margin-bottom: -10px;
 
     .teaser-type-icon {
-      width: 12px;
-      height: 12px;
+      width: 18px;
+      height: 18px;
       display: table;
       fill: white;
     }
@@ -223,11 +223,6 @@ a.card:hover {
       height: 44px;
       padding: 12px;
       border-radius: 0 0 $card-border-radius 0;
-
-      .teaser-type-icon {
-        width: 18px;
-        height: 18px;
-      }
     }
   }
 

--- a/themes/socialbase/socialbase.theme
+++ b/themes/socialbase/socialbase.theme
@@ -721,6 +721,8 @@ function socialbase_preprocess_field(&$variables) {
  * Implements hook_preprocess_page().
  */
 function socialbase_preprocess_page(&$variables) {
+  $variables['display_page_title'] = TRUE;
+
   // If we have the admin toolbar on screen we need overrides for our styles.
   if ($variables['is_admin']) {
     $variables['#attached']['library'][] = 'socialbase/admin';
@@ -732,6 +734,27 @@ function socialbase_preprocess_page(&$variables) {
 
   $svg = file_get_contents(drupal_get_path('theme', 'socialbase') . '/images/icons.svg');
   $variables['svg_icons'] = t('svg', array('svg' => $svg));
+
+  // Hide page title for pages where we want to display it in the Hero instead, like event, topic, basic page.
+
+  // Determine if we are looking at a node
+  if ($node = \Drupal::routeMatch()->getParameter('node')) {
+
+    $content_type = $node->bundle();
+
+    // list pages where we want to hide the default page title
+    $page_to_exclude = array(
+      'event',
+      'topic',
+      'page',
+      'book',
+    );
+    if (in_array($content_type, $page_to_exclude)) {
+      $variables['display_page_title'] = FALSE;
+    }
+
+  }
+
 }
 
 

--- a/themes/socialbase/socialbase.theme
+++ b/themes/socialbase/socialbase.theme
@@ -457,7 +457,7 @@ function socialbase_preprocess_container(&$variables) {
 function socialbase_preprocess_page_title(&$variables) {
   // Get the current path and if is it stream return a variable.
   $current_path = \Drupal::service('path.current')->getPath();
-  if (strpos($current_path, 'stream') !== FALSE) {
+  if (strpos($current_path, 'stream') !== FALSE || strpos($current_path, 'explore') !== FALSE) {
     $variables['stream'] = TRUE;
   }
 

--- a/themes/socialbase/socialbase.theme
+++ b/themes/socialbase/socialbase.theme
@@ -13,6 +13,8 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\Component\Utility\Html as HtmlUtility;
 use \Drupal\Core\Link;
 use Drupal\Core\Url;
+use Drupal\node\Entity\Node;
+use Drupal\Core\Block\Plugin\Block\PageTitleBlock;
 
 /**
  * Implements hook_form_FORM_ID_alter().
@@ -738,21 +740,27 @@ function socialbase_preprocess_page(&$variables) {
   // Hide page title for pages where we want to display it in the Hero instead, like event, topic, basic page.
 
   // Determine if we are looking at a node
-  if ($node = \Drupal::routeMatch()->getParameter('node')) {
 
-    $content_type = $node->bundle();
+  $nid = \Drupal::routeMatch()->getRawParameter('node');
+  $node = FALSE;
 
-    // list pages where we want to hide the default page title
-    $page_to_exclude = array(
+  if (!is_null($nid) && !is_object($nid)) {
+    $node = Node::load($nid);
+  }
+
+  if ($node instanceof Node) {
+
+  // list pages where we want to hide the default page title
+    $page_to_exclude = [
       'event',
       'topic',
       'page',
       'book',
-    );
-    if (in_array($content_type, $page_to_exclude)) {
+    ];
+
+    if (in_array($node->bundle(), $page_to_exclude)) {
       $variables['display_page_title'] = FALSE;
     }
-
   }
 
 }

--- a/themes/socialbase/templates/block/block--views-exposed-filter-block.html.twig
+++ b/themes/socialbase/templates/block/block--views-exposed-filter-block.html.twig
@@ -45,7 +45,7 @@
  * @ingroup templates
  */
 #}
-<br><br>
+
 <button class="waves-effect waves-light btn btn-default btn-block btn-raised visible-xs-inline-block js-open-canvas">
   <svg class="pull-left btn-icon icon-black">
     <title> Filter list</title>

--- a/themes/socialbase/templates/layout/page.html.twig
+++ b/themes/socialbase/templates/layout/page.html.twig
@@ -92,7 +92,7 @@
       </div>
 
       <div class="col-xs-12 col-sm-8">
-        {% if page.title %}
+        {% if page.title and display_page_title %}
           {{ page.title }}
         {% endif %}
 

--- a/themes/socialbase/templates/profile/profile--profile--hero.html.twig
+++ b/themes/socialbase/templates/profile/profile--profile--hero.html.twig
@@ -30,7 +30,7 @@
 {% endif %}
 
 <div class="cover-wrap">
-  <h1 class="page-title h2">
+  <h1 class="page-title">
     {{ profile_name }}
   </h1>
   <br />


### PR DESCRIPTION
HTD
- do a reinstall, the logic for displaying page titles has changed.
- By default all page titles are rendered above the content
- Only event, page, book, topic nodes get the page title in the hero section
- Remove page title for search as it is rendered different.