### PR TITLE
DS-1735 by nielsvandermolen: Make sure the render arrays are build wi…

### DIFF
--- a/modules/social_features/social_event/social_event.module
+++ b/modules/social_features/social_event/social_event.module
@@ -102,6 +102,7 @@ function social_event_node_view_alter(array &$build, EntityInterface $entity, En
     // cache when people enrol. See EnrollActionForm->submitForm().
     $enrollmenttag = 'enrollment:' . $nid . '-' . $uid;
     $build['#cache']['tags'][] = $enrollmenttag;
+    $build['#cache']['contexts'][] = 'user';
 
     $conditions = array(
       'field_account' => $uid,


### PR DESCRIPTION
…th a user cache tag so the enrolled label can differ for each user

HTT:

Login as willemwilmink and go to /community-events. Note that 2 events are displayed as enrolled. Now login as bobhunter and to the same page and note that just one event has the enrolled status.