### PR TITLE
DS-1734 by nielsvandermolen: Fixed redirect issue when deleting posts

### DIFF
--- a/modules/social_features/social_post/src/Form/PostDeleteForm.php
+++ b/modules/social_features/social_post/src/Form/PostDeleteForm.php
@@ -3,6 +3,7 @@
 namespace Drupal\social_post\Form;
 
 use Drupal\Core\Entity\ContentEntityDeleteForm;
+use Drupal\Core\Url;
 
 /**
  * Provides a form for deleting Post entities.
@@ -11,4 +12,14 @@ use Drupal\Core\Entity\ContentEntityDeleteForm;
  */
 class PostDeleteForm extends ContentEntityDeleteForm {
 
+  public function getRedirectUrl() {
+    // Set the redirect url to the destination in the url.
+    if (\Drupal::request()->query->has('destination')) {
+      $destination = \Drupal::destination();
+      $path = $destination->get();
+      return Url::fromUserInput($path);
+    }
+    // Default to the frontpage.
+    return  Url::fromRoute('<front>');
+  }
 }

--- a/modules/social_features/social_post/src/PostViewBuilder.php
+++ b/modules/social_features/social_post/src/PostViewBuilder.php
@@ -96,6 +96,7 @@ class PostViewBuilder extends EntityViewBuilder {
         'title' => t('Delete'),
         'weight' => 100,
         'url' => $entity->urlInfo('delete-form'),
+        'query' => array('destination' => \Drupal::destination()->get()),
       );
     }
 


### PR DESCRIPTION
HTT:

Check that you can delete posts in the home stream / group stream and profile stream and that you get redirected to the correct stream.

Check the destination in the url.

Check that you get redirected to the front page when you remove the destination from the url on a group stream and refresh the page.

Check code