### PR TITLE
Feature/2748391 - Disable Enroll option for past events

### DIFF
--- a/modules/social_features/social_event/src/Form/EnrollActionForm.php
+++ b/modules/social_features/social_event/src/Form/EnrollActionForm.php
@@ -103,7 +103,17 @@ class EnrollActionForm extends FormBase implements ContainerInjectionInterface {
       '#value' => $nid,
     );
 
-    $submit_text = $this->t('Enroll');
+    // Get Event end date to compare w/ current timestamp.
+    $event_end_timestamp = strtotime($node->field_event_date_end->value);
+
+    // Check to see if Event end date is in the future, hence we can still "Enroll".
+    $enrollment_closed = TRUE;
+    if ($event_end_timestamp > time()) {
+      $submit_text = $this->t('Enroll');
+      $enrollment_closed = FALSE;
+    } else {
+      $submit_text = $this->t('Enrollment Closed');
+    }
 
     $conditions = array(
       'field_account' => $uid,
@@ -118,7 +128,7 @@ class EnrollActionForm extends FormBase implements ContainerInjectionInterface {
       $current_enrollment_status = $enrollment->field_enrollment_status->value;
       if ($current_enrollment_status === '1') {
         $submit_text = $this->t('Enrolled');
-
+        $enrollment_closed = FALSE;
         $to_enroll_status = '0';
       }
     }
@@ -131,6 +141,7 @@ class EnrollActionForm extends FormBase implements ContainerInjectionInterface {
     $form['enroll_for_this_event'] = array(
       '#type' => 'submit',
       '#value' => $submit_text,
+      '#disabled' => $enrollment_closed,
     );
 
     $form['#attributes']['name'] = 'enroll_action_form';

--- a/modules/social_features/social_event/src/Form/EnrollActionForm.php
+++ b/modules/social_features/social_event/src/Form/EnrollActionForm.php
@@ -107,12 +107,12 @@ class EnrollActionForm extends FormBase implements ContainerInjectionInterface {
     $event_end_timestamp = strtotime($node->field_event_date_end->value);
 
     // Check to see if Event end date is in the future, hence we can still "Enroll".
-    $enrollment_closed = TRUE;
+    $enrollment_open = TRUE;
     if ($event_end_timestamp > time()) {
       $submit_text = $this->t('Enroll');
-      $enrollment_closed = FALSE;
     } else {
       $submit_text = $this->t('Enrollment Closed');
+      $enrollment_open = FALSE;
     }
 
     $conditions = array(
@@ -128,7 +128,6 @@ class EnrollActionForm extends FormBase implements ContainerInjectionInterface {
       $current_enrollment_status = $enrollment->field_enrollment_status->value;
       if ($current_enrollment_status === '1') {
         $submit_text = $this->t('Enrolled');
-        $enrollment_closed = FALSE;
         $to_enroll_status = '0';
       }
     }
@@ -141,7 +140,7 @@ class EnrollActionForm extends FormBase implements ContainerInjectionInterface {
     $form['enroll_for_this_event'] = array(
       '#type' => 'submit',
       '#value' => $submit_text,
-      '#disabled' => $enrollment_closed,
+      '#disabled' => !$enrollment_open,
     );
 
     $form['#attributes']['name'] = 'enroll_action_form';


### PR DESCRIPTION
Hi, first PR for this project, so let me know if i missed something.

This fix meets the AC here: https://www.drupal.org/node/2748391/revisions/9775721/view

1) if the end time of the Event is before Now, meaning the event is in the past, the button changes from "Enroll" to "Enrollment Closed" and the button is disabled.

We might want to decide if we prefer the cutoff to be the begin time of the Event, b/c that's a valid option, and a minor adjustment to the code.

Thx,
m