### PR TITLE
Patches in composer.json for Geolocation grouped filters and Drupal core Grouped filters

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -60,7 +60,7 @@
                 "Fix vars in function in entity manager wrapper": "https://www.drupal.org/files/issues/fix_entity_manager_wrapper_2749249_5.patch"
             },
             "drupal/geolocation": {
-                "Geolocation Views Grouped Filters": "https://www.drupal.org/files/issues/geolocation-grouped-views-filters-2778227-4.patch"
+                "Geolocation Views Grouped Filters": "https://www.drupal.org/files/issues/geolocation-8.x-1.7-grouped-views-filters-2778227-5_0.patch"
             }
         }
     },

--- a/composer.json
+++ b/composer.json
@@ -58,6 +58,9 @@
             },
             "drupal/devel": {
                 "Fix vars in function in entity manager wrapper": "https://www.drupal.org/files/issues/fix_entity_manager_wrapper_2749249_5.patch"
+            },
+            "drupal/geolocation": {
+                "Geolocation Views Grouped Filters": "https://www.drupal.org/files/issues/geolocation-grouped-views-filters-2778227-4.patch"
             }
         }
     },

--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,6 @@
                 "Fix region string issue": "https://www.drupal.org/files/issues/2724283-block-22.patch",
                 "Make sure exposed filters work": "https://www.drupal.org/files/issues/grouped_filters-2369119-73.patch",
                 "Redirect to install.php on empty DB": "https://www.drupal.org/files/issues/drupal-redirect_to_install-728702-92.patch",
-                "Problems with a number of views grouped filters": "https://www.drupal.org/files/issues/grouped_filters-2369119-73.patch",
                 "Exposed filter checkbox not working": "https://www.drupal.org/files/issues/2651102-90-reroll-checkboxes-in-exposed-forms-for-8-1-issues-with-pagers.patch"
             },
             "drupal/devel": {


### PR DESCRIPTION
The view 'search_groups' could not be imported due to the missing patch, see also: https://www.drupal.org/node/2778227

In addition to this I removed the double patch for Drupal Core.