### PR TITLE
DS-1937 / #2792543 - do not set any directory settings in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,26 +18,6 @@
         "drupal-scaffold": "DrupalComposer\\DrupalScaffold\\Plugin::scaffold"
     },
     "extra": {
-        "installer-paths": {
-            "html/core": [
-                "drupal/core"
-            ],
-            "html/modules/contrib/{$name}": [
-                "type:drupal-module"
-            ],
-            "html/profiles/contrib/social": [
-                "goalgorilla/open_social"
-            ],
-            "html/profiles/contrib/{$name}": [
-                "type:drupal-profile"
-            ],
-            "html/themes/contrib/{$name}": [
-                "type:drupal-theme"
-            ],
-            "drush/contrib/{$name}": [
-                "type:drupal-drush"
-            ]
-        },
         "patches": {
             "drupal/profile": {
                 "Fixes access control on entities": "https://www.drupal.org/files/issues/profile-accesscontrol-2703825-6.patch"


### PR DESCRIPTION
Issue:
- Installation is done in the /html directory, this is actually OK if you need to use the https://github.com/goalgorilla/drupal_social developer workflow or if you want to use the composer template on https://github.com/goalgorilla/social_template. But we should not enforce this in the composer.json in the distribution.

Solution:
- Remove the directory settings in composer.json in open_social repo.
- If developers use composer template to install the platform at least it can be set according to your specific needs (e.g. public_html or docroot instead of html)