### PR TITLE
DS-1945: Make download_count module optional, override file fields config in social_download_count module

### DIFF
--- a/modules/custom/download_count/download_count.install
+++ b/modules/custom/download_count/download_count.install
@@ -86,3 +86,46 @@ function download_count_uninstall() {
     ->delete();
   drupal_set_message(t('The download count module has been uninstalled.'));
 }
+
+/**
+ * Implements hook_install().
+ *
+ * Perform actions related to the installation of download_count.
+ */
+function download_count_install() {
+  // Set some default permissions.
+  _download_count_set_permissions();
+}
+
+/**
+ * Function to set permissions.
+ */
+function _download_count_set_permissions() {
+  $roles = \Drupal\user\Entity\Role::loadMultiple();
+
+  /** @var \Drupal\user\Entity\Role $role */
+  foreach ($roles as $role) {
+    if ($role->id() === 'administrator') {
+      continue;
+    }
+
+    $permissions = _download_count_get_permissions($role->id());
+    user_role_grant_permissions($role->id(), $permissions);
+  }
+}
+
+/**
+ * @param $role
+ * @return array
+ */
+function _download_count_get_permissions($role) {
+  // Anonymous.
+  $permissions['anonymous'] = array(
+    'view download counts',
+  );
+
+  // Authenticated.
+  $permissions['authenticated'] = $permissions['anonymous'];
+
+  return $permissions[$role];
+}

--- a/modules/custom/download_count/download_count.install
+++ b/modules/custom/download_count/download_count.install
@@ -109,23 +109,10 @@ function _download_count_set_permissions() {
       continue;
     }
 
-    $permissions = _download_count_get_permissions($role->id());
+    $permissions = array(
+      'view download counts',
+    );
+
     user_role_grant_permissions($role->id(), $permissions);
   }
-}
-
-/**
- * @param $role
- * @return array
- */
-function _download_count_get_permissions($role) {
-  // Anonymous.
-  $permissions['anonymous'] = array(
-    'view download counts',
-  );
-
-  // Authenticated.
-  $permissions['authenticated'] = $permissions['anonymous'];
-
-  return $permissions[$role];
 }

--- a/modules/social_features/social_book/config/install/core.entity_view_display.node.book.default.yml
+++ b/modules/social_features/social_book/config/install/core.entity_view_display.node.book.default.yml
@@ -9,7 +9,6 @@ dependencies:
     - field.field.node.book.field_files
     - node.type.book
   module:
-    - download_count
     - file
     - group_core_comments
     - text
@@ -33,7 +32,7 @@ content:
       pager_id: 0
     third_party_settings: {  }
   field_files:
-    type: FieldDownloadCount
+    type: file_default
     weight: 3
     label: above
     settings: {  }

--- a/modules/social_features/social_core/social_core.info.yml
+++ b/modules/social_features/social_core/social_core.info.yml
@@ -20,5 +20,4 @@ dependencies:
   - override_node_options
   - template_suggestions_extra
   - admin_toolbar_tools
-  - download_count
 package: Social

--- a/modules/social_features/social_download_count/social_download_count.info.yml
+++ b/modules/social_features/social_download_count/social_download_count.info.yml
@@ -1,0 +1,7 @@
+name: 'Social Download Count'
+description: 'Tracks file downloads for Drupal private core file fields for Open Social'
+type: module
+core: 8.x
+dependencies:
+  - download_count
+package: Social

--- a/modules/social_features/social_download_count/social_download_count.services.yml
+++ b/modules/social_features/social_download_count/social_download_count.services.yml
@@ -1,0 +1,5 @@
+services:
+  social_download_count.overrider:
+    class: \Drupal\social_download_count\SocialDownloadCountConfigOverride
+    tags:
+      - {name: config.factory.override, priority: 5}

--- a/modules/social_features/social_download_count/src/SocialDownloadCountConfigOverride.php
+++ b/modules/social_features/social_download_count/src/SocialDownloadCountConfigOverride.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * @file
+ * Contains \Drupal\social_download_count\SocialDownloadCountConfigOverride.
+ */
+namespace Drupal\social_download_count;
+
+use Drupal\Core\Cache\CacheableMetadata;
+use Drupal\Core\Config\ConfigFactoryOverrideInterface;
+
+/**
+ * Example configuration override.
+ */
+class SocialDownloadCountConfigOverride implements ConfigFactoryOverrideInterface {
+  public function loadOverrides($names) {
+    $overrides = array();
+
+    // Set private file system to files field.
+    $config_name =  'field.storage.node.field_files';
+    if (in_array($config_name, $names)) {
+      $overrides[$config_name] = ['settings' => ['uri_scheme' => 'private']];
+    }
+
+    // Set download count widget to files fields.
+    $content_types = ['book', 'event', 'page', 'topic'];
+    foreach ($content_types as $content_type) {
+      $config_name = "core.entity_view_display.node.{$content_type}.default";
+      $overrides[$config_name] = ['content' => ['field_files' => ['type' => 'FieldDownloadCount']]];
+    }
+
+    return $overrides;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCacheSuffix() {
+    return 'SocialDownloadCountConfigOverride';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCacheableMetadata($name) {
+    return new CacheableMetadata();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function createConfigObject($name, $collection = StorageInterface::DEFAULT_COLLECTION) {
+    return NULL;
+  }
+}

--- a/modules/social_features/social_event/config/install/core.entity_view_display.node.event.default.yml
+++ b/modules/social_features/social_event/config/install/core.entity_view_display.node.event.default.yml
@@ -13,7 +13,6 @@ dependencies:
     - field.field.node.event.field_files
     - node.type.event
   module:
-    - download_count
     - group_core_comments
     - text
     - user
@@ -40,7 +39,7 @@ content:
     label: above
     settings: {  }
     third_party_settings: {  }
-    type: FieldDownloadCount
+    type: file_default
 hidden:
   field_content_visibility: true
   field_event_address: true

--- a/modules/social_features/social_event/config/install/core.entity_view_display.node.event.default.yml
+++ b/modules/social_features/social_event/config/install/core.entity_view_display.node.event.default.yml
@@ -13,6 +13,7 @@ dependencies:
     - field.field.node.event.field_files
     - node.type.event
   module:
+    - file
     - group_core_comments
     - text
     - user

--- a/modules/social_features/social_event/config/install/field.storage.node.field_files.yml
+++ b/modules/social_features/social_event/config/install/field.storage.node.field_files.yml
@@ -11,7 +11,7 @@ type: file
 settings:
   display_field: false
   display_default: false
-  uri_scheme: private
+  uri_scheme: public
   target_type: file
 module: file
 locked: false

--- a/modules/social_features/social_event/social_event.info.yml
+++ b/modules/social_features/social_event/social_event.info.yml
@@ -7,7 +7,6 @@ dependencies:
   - block
   - comment
   - datetime
-  - download_count
   - entity_access_by_field
   - field
   - field_group

--- a/modules/social_features/social_page/config/install/core.entity_view_display.node.page.default.yml
+++ b/modules/social_features/social_page/config/install/core.entity_view_display.node.page.default.yml
@@ -10,7 +10,6 @@ dependencies:
     - node.type.page
   module:
     - comment
-    - download_count
     - text
     - user
 id: node.page.default
@@ -29,7 +28,7 @@ content:
     label: above
     settings: {  }
     third_party_settings: {  }
-    type: FieldDownloadCount
+    type: file_default
   field_page_comments:
     weight: 2
     label: above

--- a/modules/social_features/social_page/config/install/core.entity_view_display.node.page.default.yml
+++ b/modules/social_features/social_page/config/install/core.entity_view_display.node.page.default.yml
@@ -10,6 +10,7 @@ dependencies:
     - node.type.page
   module:
     - comment
+    - file
     - text
     - user
 id: node.page.default

--- a/modules/social_features/social_page/social_page.info.yml
+++ b/modules/social_features/social_page/social_page.info.yml
@@ -4,7 +4,6 @@ type: module
 core: 8.x
 dependencies:
   - comment
-  - download_count
   - entity_access_by_field
   - field
   - field_group

--- a/modules/social_features/social_topic/config/install/core.entity_view_display.node.topic.default.yml
+++ b/modules/social_features/social_topic/config/install/core.entity_view_display.node.topic.default.yml
@@ -10,7 +10,6 @@ dependencies:
     - field.field.node.topic.field_topic_type
     - node.type.topic
   module:
-    - download_count
     - group_core_comments
     - text
     - user
@@ -30,7 +29,7 @@ content:
     label: above
     settings: {  }
     third_party_settings: {  }
-    type: FieldDownloadCount
+    type: file_default
   field_topic_comments:
     weight: 1
     label: above

--- a/modules/social_features/social_topic/config/install/core.entity_view_display.node.topic.default.yml
+++ b/modules/social_features/social_topic/config/install/core.entity_view_display.node.topic.default.yml
@@ -10,6 +10,7 @@ dependencies:
     - field.field.node.topic.field_topic_type
     - node.type.topic
   module:
+    - file
     - group_core_comments
     - text
     - user

--- a/modules/social_features/social_topic/social_topic.info.yml
+++ b/modules/social_features/social_topic/social_topic.info.yml
@@ -5,7 +5,6 @@ core: 8.x
 dependencies:
   - block
   - comment
-  - download_count
   - entity_access_by_field
   - field
   - field_group

--- a/modules/social_features/social_topic/social_topic.install
+++ b/modules/social_features/social_topic/social_topic.install
@@ -125,9 +125,4 @@ function _social_topic_create_menu_links() {
  */
 function social_topic_update_8001() {
 
-  $modules = array(
-    'download_count',
-  );
-  \Drupal::service('module_installer')->install($modules);
-
 }

--- a/tests/behat/features/bootstrap/SocialDrupalContext.php
+++ b/tests/behat/features/bootstrap/SocialDrupalContext.php
@@ -127,4 +127,14 @@ class SocialDrupalContext extends DrupalContext {
     $milliseconds = (int) ($seconds * 1000);
     $this->getSession()->wait($milliseconds, $condition);
   }
+
+  /**
+   * I enable the module :module_name.
+   *
+   * @When /^(?:|I )enable the module "([^"]*)"/
+   */
+  public function iEnableTheModule($module_name) {
+    $modules = [$module_name];
+    \Drupal::service('module_installer')->install($modules);
+  }
 }

--- a/tests/behat/features/capabilities/topic/topic-create.feature
+++ b/tests/behat/features/capabilities/topic/topic-create.feature
@@ -20,11 +20,5 @@ Feature: Create Topic
     And I should see "This is a test topic" in the "Hero block"
     And I should see "Discussion" in the "Hero block"
     And I should see "Body description text" in the "Main content"
-    And I should not see "Enrollments"
-    And I click "humans.txt"
-    Given I am logged in as an "administrator"
-    And I am on the homepage
-    And I click "This is a test topic"
     And I should see "humans.txt"
-    And I should see "1 download"
-
+    And I should not see "Enrollments"

--- a/tests/behat/features/capabilities/topic/topic-download-count.feature
+++ b/tests/behat/features/capabilities/topic/topic-download-count.feature
@@ -5,12 +5,7 @@ Feature: Download Topic
   Goal/desire: I want to see number of downloads for files attached to nodes
 
   Scenario: Track downloads of files attached to nodes
-    Given I am logged in as an "administrator"
-    And I am on "admin/modules"
-    And I check the box "Social Download Count"
-    And I press "Install"
-    # Modules "Social Download Count" and "Download Count" should be disabled by default
-    And I press "Continue"
+    Given I enable the module "social_download_count"
     And I am logged in as an "authenticated user"
     And I am on "user"
     And I click "Topics"

--- a/tests/behat/features/capabilities/topic/topic-download-count.feature
+++ b/tests/behat/features/capabilities/topic/topic-download-count.feature
@@ -1,0 +1,36 @@
+@api @topic @stability @perfect @critical @DS-1933
+Feature: Download Topic
+  Benefit: In order to see which files are popular
+  Role: As a LU
+  Goal/desire: I want to see number of downloads for files attached to nodes
+
+  Scenario: Track downloads of files attached to nodes
+    Given I am logged in as an "administrator"
+    And I am on "admin/modules"
+    And I check the box "Social Download Count"
+    And I press "Install"
+    # Modules "Social Download Count" and "Download Count" should be disabled by default
+    And I press "Continue"
+    And I am logged in as an "authenticated user"
+    And I am on "user"
+    And I click "Topics"
+    And I click "Create Topic"
+    When I fill in "Title" with "This is a test topic"
+    When I fill in the following:
+      | Title | This is a test topic |
+     And I fill in the "edit-body-0-value" WYSIWYG editor with "Body description text"
+    And I click radio button "Discussion"
+    And I attach the file "/files/humans.txt" to "Add a new file"
+    And I press "Save"
+    And I should see "Topic This is a test topic has been created."
+    And I should see "This is a test topic" in the "Hero block"
+    And I should see "Discussion" in the "Hero block"
+    And I should see "Body description text" in the "Main content"
+    And I should not see "Enrollments"
+    And I click "humans.txt"
+    Given I am logged in as an "authenticated user"
+    And I am on the homepage
+    And I click "This is a test topic"
+    And I should see "humans.txt"
+    And I should see "1 download"
+


### PR DESCRIPTION
# Changes
- Removed dependencies from topic, event, book, page features, set default file widget and public FS by default.
- Created new module `social_download_count` with just config overrides.

# HTT
- [x] Reinstall the site 
- [x] Log in as admin and enable `social_download_count` module
- [x] Log in as normal user
- [x] Create node with files
- [x] Download files and see that counter works