### PR TITLE
DS-1722 - Remove enrollment tab form edit pages

### DIFF
--- a/modules/social_features/social_book/social_book.module
+++ b/modules/social_features/social_book/social_book.module
@@ -6,6 +6,7 @@
  */
 
 use \Drupal\node\NodeInterface;
+use Drupal\node\Entity\Node;
 
 /**
  * Implements hook_node_links_alter().
@@ -16,3 +17,12 @@ function social_book_node_links_alter(array &$links, NodeInterface $entity, arra
   unset($links['book']['#links']['book_add_child']);
 }
 
+/**
+ * Implements hook_menu_local_tasks_alter().
+ */
+function social_book_menu_local_tasks_alter(&$data, $route_name) {
+  // Remove the outline from edit pages.
+  if ($route_name === 'entity.node.edit_form') {
+      unset($data['tabs'][0]['entity.node.book_outline_form']);
+  }
+}

--- a/modules/social_features/social_book/social_book.module
+++ b/modules/social_features/social_book/social_book.module
@@ -6,7 +6,6 @@
  */
 
 use \Drupal\node\NodeInterface;
-use Drupal\node\Entity\Node;
 
 /**
  * Implements hook_node_links_alter().

--- a/modules/social_features/social_book/social_book.module
+++ b/modules/social_features/social_book/social_book.module
@@ -20,8 +20,8 @@ function social_book_node_links_alter(array &$links, NodeInterface $entity, arra
  * Implements hook_menu_local_tasks_alter().
  */
 function social_book_menu_local_tasks_alter(&$data, $route_name) {
-  // Remove the outline from edit pages.
-  if ($route_name === 'entity.node.edit_form') {
+  // Remove the outline from ALL pages.
+  if (isset($data['tabs'][0]['entity.node.book_outline_form'])) {
       unset($data['tabs'][0]['entity.node.book_outline_form']);
   }
 }

--- a/modules/social_features/social_event/social_event.module
+++ b/modules/social_features/social_event/social_event.module
@@ -76,16 +76,17 @@ function social_event_menu_local_tasks_alter(&$data, $route_name) {
   $can_show_enrollments_link = FALSE;
   if ($route_name === "view.event_enrollments.view_enrollments" || $route_name === 'entity.node.canonical') {
     $node = \Drupal::service('current_route_match')->getParameter('node');
-    if (!is_null($node) && !is_object($node)) {
+    if (!is_null($node) && (!$node instanceof Node)) {
       $node = Node::load($node);
     }
-    if (is_object($node) && $node->getType() === 'event') {
+    if (($node instanceof Node) && $node->getType() === 'event') {
       $can_show_enrollments_link = TRUE;
     }
 
-    if (!$can_show_enrollments_link) {
-      unset($data['tabs'][0]['views_view:view.event_enrollments.view_enrollments']);
-    }
+  }
+  // PLace this here, since hiding it should happen always and not only on the mentioned routes.
+  if (!$can_show_enrollments_link) {
+    unset($data['tabs'][0]['views_view:view.event_enrollments.view_enrollments']);
   }
 }
 

--- a/tests/behat/features/capabilities/event/event-create.feature
+++ b/tests/behat/features/capabilities/event/event-create.feature
@@ -31,3 +31,12 @@ Feature: Create Event
     And I should see "Oldenzaalsestraat" in the "Hero block"
     And I should see "7514DR" in the "Hero block"
     And I should see "Enschede" in the "Hero block"
+
+    # Quick edit
+    Given I click "Edit content"
+    Then I should not see "Enrollments" in the "Hero block"
+    When I fill in the following:
+      | Title | This is a test event - edit |
+    And I press "Save and keep published"
+    Then I should see "Event This is a test event - edit has been updated"
+    And I should see "THIS IS A TEST EVENT - EDIT"

--- a/tests/behat/features/capabilities/topic/topic-create.feature
+++ b/tests/behat/features/capabilities/topic/topic-create.feature
@@ -22,3 +22,12 @@ Feature: Create Topic
     And I should see "Body description text" in the "Main content"
     And I should see "humans.txt"
     And I should not see "Enrollments"
+
+    # Quick edit
+    Given I click "Edit content"
+    Then I should not see "Enrollments"
+    When I fill in the following:
+      | Title | This is a test topic - edit |
+    And I press "Save and keep published"
+    Then I should see "Topic This is a test topic - edit has been updated"
+    And I should see "This is a test topic - edit" in the "Hero block"


### PR DESCRIPTION
## HTT

- [x] Check the code
- [x] Checkout this branch and rebuild caches
- [x] Edit an event, a topic and a page
- [x] Notice that on all three EDIT pages there's NO enrollment tab
- [x] Enable the social_book module
- [x] Notice there are also no 'outline' on any tabs anymore (can be edited on the book edit page itself anyway)