### PR TITLE
DS-1974 - sidebar blocks order

### DIFF
--- a/modules/social_features/social_core/config/install/block.block.mainnavigation.yml
+++ b/modules/social_features/social_core/config/install/block.block.mainnavigation.yml
@@ -10,7 +10,7 @@ dependencies:
 id: mainnavigation
 theme: socialbase
 region: header
-weight: -19
+weight: 4
 provider: null
 plugin: 'system_menu_block:main'
 settings:

--- a/modules/social_features/social_core/config/install/block.block.sitebranding.yml
+++ b/modules/social_features/social_core/config/install/block.block.sitebranding.yml
@@ -8,7 +8,7 @@ dependencies:
 id: sitebranding
 theme: socialbase
 region: header
-weight: -20
+weight: 3
 provider: null
 plugin: system_branding_block
 settings:

--- a/modules/social_features/social_core/config/install/block.block.socialbase_account_menu.yml
+++ b/modules/social_features/social_core/config/install/block.block.socialbase_account_menu.yml
@@ -11,7 +11,7 @@ dependencies:
 id: socialbase_account_menu
 theme: socialbase
 region: header
-weight: -5
+weight: 1
 provider: null
 plugin: 'system_menu_block:account'
 settings:

--- a/modules/social_features/social_event/config/install/block.block.event_add_block.yml
+++ b/modules/social_features/social_event/config/install/block.block.event_add_block.yml
@@ -9,7 +9,7 @@ dependencies:
 id: event_add_block
 theme: socialbase
 region: complementary_top
-weight: -1
+weight: -99
 provider: null
 plugin: event_add_block
 settings:

--- a/modules/social_features/social_event/config/install/block.block.exposedformeventsevents_overview.yml
+++ b/modules/social_features/social_event/config/install/block.block.exposedformeventsevents_overview.yml
@@ -12,7 +12,7 @@ dependencies:
 id: exposedformeventsevents_overview
 theme: socialbase
 region: complementary_top
-weight: -17
+weight: 1
 provider: null
 plugin: 'views_exposed_filter_block:events-events_overview'
 settings:

--- a/modules/social_features/social_event/config/install/block.block.exposedformupcoming_eventspage_community_events.yml
+++ b/modules/social_features/social_event/config/install/block.block.exposedformupcoming_eventspage_community_events.yml
@@ -11,15 +11,15 @@ dependencies:
 id: exposedformupcoming_eventspage_community_events
 theme: socialbase
 region: complementary_top
-weight: -12
+weight: 3
 provider: null
 plugin: 'views_exposed_filter_block:upcoming_events-page_community_events'
 settings:
   id: 'views_exposed_filter_block:upcoming_events-page_community_events'
   label: ''
   provider: views
-  label_display: '0'
-  views_label: ''
+  label_display: visible
+  views_label: Filter
 visibility:
   request_path:
     id: request_path

--- a/modules/social_features/social_event/config/install/block.block.views_block__events_block_events_on_profile.yml
+++ b/modules/social_features/social_event/config/install/block.block.views_block__events_block_events_on_profile.yml
@@ -10,8 +10,8 @@ dependencies:
     - socialbase
 id: views_block__events_block_events_on_profile
 theme: socialbase
-region: complementary_top
-weight: -18
+region: complementary_bottom
+weight: 1
 provider: null
 plugin: 'views_block:events-block_events_on_profile'
 settings:

--- a/modules/social_features/social_event/config/install/block.block.views_block__upcoming_events_block_community_events.yml
+++ b/modules/social_features/social_event/config/install/block.block.views_block__upcoming_events_block_community_events.yml
@@ -11,7 +11,7 @@ dependencies:
 id: views_block__upcoming_events_block_community_events
 theme: socialbase
 region: complementary_bottom
-weight: -21
+weight: 2
 provider: null
 plugin: 'views_block:upcoming_events-block_community_events'
 settings:

--- a/modules/social_features/social_event/config/install/block.block.views_block__upcoming_events_block_my_upcoming_events.yml
+++ b/modules/social_features/social_event/config/install/block.block.views_block__upcoming_events_block_my_upcoming_events.yml
@@ -12,7 +12,7 @@ dependencies:
 id: views_block__upcoming_events_block_my_upcoming_events
 theme: socialbase
 region: complementary_bottom
-weight: -22
+weight: 1
 provider: null
 plugin: 'views_block:upcoming_events-block_my_upcoming_events'
 settings:

--- a/modules/social_features/social_event/config/install/block.block.views_block__upcoming_events_upcoming_events_group.yml
+++ b/modules/social_features/social_event/config/install/block.block.views_block__upcoming_events_upcoming_events_group.yml
@@ -11,7 +11,7 @@ dependencies:
 id: views_block__upcoming_events_upcoming_events_group
 theme: socialbase
 region: complementary_bottom
-weight: -20
+weight: 2
 provider: null
 plugin: 'views_block:upcoming_events-upcoming_events_group'
 settings:

--- a/modules/social_features/social_group/config/install/block.block.group_add_block.yml
+++ b/modules/social_features/social_group/config/install/block.block.group_add_block.yml
@@ -9,7 +9,7 @@ dependencies:
 id: group_add_block
 theme: socialbase
 region: complementary_top
-weight: -4
+weight: -97
 provider: null
 plugin: group_add_block
 settings:

--- a/modules/social_features/social_group/config/install/block.block.group_add_event_block.yml
+++ b/modules/social_features/social_group/config/install/block.block.group_add_event_block.yml
@@ -9,7 +9,7 @@ dependencies:
 id: group_add_event_block
 theme: socialbase
 region: complementary_top
-weight: -24
+weight: -96
 provider: null
 plugin: group_add_event_block
 settings:

--- a/modules/social_features/social_group/config/install/block.block.group_add_topic_block.yml
+++ b/modules/social_features/social_group/config/install/block.block.group_add_topic_block.yml
@@ -9,7 +9,7 @@ dependencies:
 id: group_add_topic_block
 theme: socialbase
 region: complementary_top
-weight: -23
+weight: -95
 provider: null
 plugin: group_add_topic_block
 settings:

--- a/modules/social_features/social_group/config/install/block.block.views_block__group_members_block_newest_members.yml
+++ b/modules/social_features/social_group/config/install/block.block.views_block__group_members_block_newest_members.yml
@@ -11,7 +11,7 @@ dependencies:
 id: views_block__group_members_block_newest_members
 theme: socialbase
 region: complementary_bottom
-weight: -19
+weight: 5
 provider: null
 plugin: 'views_block:group_members-block_newest_members'
 settings:

--- a/modules/social_features/social_group/config/install/block.block.views_block__groups_block_user_groups.yml
+++ b/modules/social_features/social_group/config/install/block.block.views_block__groups_block_user_groups.yml
@@ -11,7 +11,7 @@ dependencies:
 id: views_block__groups_block_user_groups
 theme: socialbase
 region: complementary_bottom
-weight: -15
+weight: 4
 provider: null
 plugin: 'views_block:groups-block_user_groups'
 settings:

--- a/modules/social_features/social_group/config/install/block.block.views_block__newest_groups_block_newest_groups.yml
+++ b/modules/social_features/social_group/config/install/block.block.views_block__newest_groups_block_newest_groups.yml
@@ -11,7 +11,7 @@ dependencies:
 id: views_block__newest_groups_block_newest_groups
 theme: socialbase
 region: complementary_bottom
-weight: -16
+weight: 4
 provider: null
 plugin: 'views_block:newest_groups-block_newest_groups'
 settings:

--- a/modules/social_features/social_profile/config/install/block.block.views_block__newest_users_block_newest_users.yml
+++ b/modules/social_features/social_profile/config/install/block.block.views_block__newest_users_block_newest_users.yml
@@ -11,7 +11,7 @@ dependencies:
 id: views_block__newest_users_block_newest_users
 theme: socialbase
 region: complementary_bottom
-weight: -14
+weight: 5
 provider: null
 plugin: 'views_block:newest_users-block_newest_users'
 settings:

--- a/modules/social_features/social_search/config/install/block.block.exposed_form_search_content_page_sidebar.yml
+++ b/modules/social_features/social_search/config/install/block.block.exposed_form_search_content_page_sidebar.yml
@@ -11,7 +11,7 @@ dependencies:
 id: exposed_form_search_content_page_sidebar
 theme: socialbase
 region: complementary_top
-weight: -15
+weight: 3
 provider: null
 plugin: 'views_exposed_filter_block:search_content-page'
 settings:

--- a/modules/social_features/social_search/config/install/block.block.exposed_form_search_groups_proximity_page_sidebar.yml
+++ b/modules/social_features/social_search/config/install/block.block.exposed_form_search_groups_proximity_page_sidebar.yml
@@ -11,7 +11,7 @@ dependencies:
 id: exposed_form_search_groups_proximity_page_sidebar
 theme: socialbase
 region: complementary_top
-weight: -3
+weight: 5
 provider: null
 plugin: 'views_exposed_filter_block:search_groups_proximity-page'
 settings:

--- a/modules/social_features/social_search/config/install/block.block.exposed_form_search_users_page_sidebar.yml
+++ b/modules/social_features/social_search/config/install/block.block.exposed_form_search_users_page_sidebar.yml
@@ -11,7 +11,7 @@ dependencies:
 id: exposed_form_search_users_page_sidebar
 theme: socialbase
 region: complementary_top
-weight: -14
+weight: 4
 provider: null
 plugin: 'views_exposed_filter_block:search_users-page'
 settings:

--- a/modules/social_features/social_search/config/install/block.block.exposedformsearch_groups_proximitypage.yml
+++ b/modules/social_features/social_search/config/install/block.block.exposedformsearch_groups_proximitypage.yml
@@ -11,7 +11,7 @@ dependencies:
 id: exposedformsearch_groups_proximitypage
 theme: socialbase
 region: complementary_top
-weight: -3
+weight: 10
 provider: null
 plugin: 'views_exposed_filter_block:search_groups_proximity-page'
 settings:

--- a/modules/social_features/social_topic/config/install/block.block.exposedformlatest_topicspage_latest_topics.yml
+++ b/modules/social_features/social_topic/config/install/block.block.exposedformlatest_topicspage_latest_topics.yml
@@ -11,15 +11,15 @@ dependencies:
 id: exposedformlatest_topicspage_latest_topics
 theme: socialbase
 region: complementary_top
-weight: -16
+weight: 1
 provider: null
 plugin: 'views_exposed_filter_block:latest_topics-page_latest_topics'
 settings:
   id: 'views_exposed_filter_block:latest_topics-page_latest_topics'
   label: ''
   provider: views
-  label_display: '0'
-  views_label: ''
+  label_display: visible
+  views_label: Filter
 visibility:
   request_path:
     id: request_path

--- a/modules/social_features/social_topic/config/install/block.block.socialbase_exposedformtopicspage_profile.yml
+++ b/modules/social_features/social_topic/config/install/block.block.socialbase_exposedformtopicspage_profile.yml
@@ -12,7 +12,7 @@ dependencies:
 id: socialbase_exposedformtopicspage_profile
 theme: socialbase
 region: complementary_top
-weight: -13
+weight: 3
 provider: null
 plugin: 'views_exposed_filter_block:topics-page_profile'
 settings:

--- a/modules/social_features/social_topic/config/install/block.block.topic_add_block.yml
+++ b/modules/social_features/social_topic/config/install/block.block.topic_add_block.yml
@@ -9,7 +9,7 @@ dependencies:
 id: topic_add_block
 theme: socialbase
 region: complementary_top
-weight: -4
+weight: -98
 provider: null
 plugin: topic_add_block
 settings:

--- a/modules/social_features/social_topic/config/install/block.block.views_block__latest_topics_default.yml
+++ b/modules/social_features/social_topic/config/install/block.block.views_block__latest_topics_default.yml
@@ -11,7 +11,7 @@ dependencies:
 id: views_block__latest_topics_default
 theme: socialbase
 region: complementary_bottom
-weight: -19
+weight: 3
 provider: null
 plugin: 'views_block:latest_topics-block_latest_topics'
 settings:

--- a/modules/social_features/social_topic/config/install/block.block.views_block__latest_topics_group_topics_block.yml
+++ b/modules/social_features/social_topic/config/install/block.block.views_block__latest_topics_group_topics_block.yml
@@ -11,7 +11,7 @@ dependencies:
 id: views_block__latest_topics_group_topics_block
 theme: socialbase
 region: complementary_bottom
-weight: -18
+weight: 3
 provider: null
 plugin: 'views_block:latest_topics-group_topics_block'
 settings:

--- a/modules/social_features/social_topic/config/install/block.block.views_block__topics_block_user_topics.yml
+++ b/modules/social_features/social_topic/config/install/block.block.views_block__topics_block_user_topics.yml
@@ -11,7 +11,7 @@ dependencies:
 id: views_block__topics_block_user_topics
 theme: socialbase
 region: complementary_bottom
-weight: -17
+weight: 3
 provider: null
 plugin: 'views_block:topics-block_user_topics'
 settings:

--- a/modules/social_features/social_user/config/install/block.block.accountheaderblock.yml
+++ b/modules/social_features/social_user/config/install/block.block.accountheaderblock.yml
@@ -9,7 +9,7 @@ dependencies:
 id: accountheaderblock
 theme: socialbase
 region: header
-weight: -6
+weight: 2
 provider: null
 plugin: account_header_block
 settings:

--- a/tests/behat/features/capabilities/event/event-overview.feature
+++ b/tests/behat/features/capabilities/event/event-overview.feature
@@ -10,7 +10,7 @@ Feature: Overview
     And I am on "user"
     When I click "Events"
     Then I should see "Events" in the "Page title block"
-    And I should see "Filter" in the "Sidebar second"
+    And I should see "FILTER" in the "Sidebar second"
     And I should see "Upcoming events"
     And I should see "Events that have started or are finished"
     And I should see text matching "Publish status"
@@ -19,7 +19,7 @@ Feature: Overview
     Given I am on "user/1"
     When I click "Events"
     Then I should see "Events" in the "Page title block"
-    And I should see "Filter" in the "Sidebar second"
+    And I should see "FILTER" in the "Sidebar second"
     And I should not see text matching "Publish status"
 
     #@TODO make a scenario for filters to work.

--- a/tests/behat/features/capabilities/group/group-create-open.feature
+++ b/tests/behat/features/capabilities/group/group-create-open.feature
@@ -136,7 +136,7 @@ Feature: Create Open Group
   # DS-722 As an outsider I am not allowed to enrol to an event in group
     When I click "Events"
     And I click "Test group event"
-    And I should not see "Enroll" in the "Hero block"
+    And I should not see the button "Enroll"
 
   # Check for latest groups block on LU homepage
     When I am on "stream"

--- a/tests/behat/features/capabilities/topic/topic-overview.feature
+++ b/tests/behat/features/capabilities/topic/topic-overview.feature
@@ -10,7 +10,7 @@ Feature: Topic Overview
     And I am on "user"
     When I click "Topics"
      Then I should see "Topics" in the "Page title block"
-    And I should see "Filter" in the "Sidebar second"
+    And I should see "FILTER" in the "Sidebar second"
     And I should see text matching "is the type of"
     And I should see text matching "has the publish status of"
 
@@ -18,7 +18,7 @@ Feature: Topic Overview
     Given I am on "user/1"
     When I click "Topics"
     Then I should see "Topics" in the "Page title block"
-    And I should see "Filter" in the "Sidebar second"
+    And I should see "FILTER" in the "Sidebar second"
     And I should not see text matching "has the publish status of"
 
 #  Scenario: Successfully filter the topic overview

--- a/themes/socialbase/components/asset-builds/css/cards.css
+++ b/themes/socialbase/components/asset-builds/css/cards.css
@@ -63,6 +63,10 @@
   font-size: 0.875rem;
 }
 
+.teaser--small .card-head {
+  text-align: center;
+}
+
 a.card:hover {
   box-shadow: 0 10px 20px rgba(0, 0, 0, 0.19), 0 6px 6px rgba(0, 0, 0, 0.23);
 }

--- a/themes/socialbase/components/asset-builds/css/forms.css
+++ b/themes/socialbase/components/asset-builds/css/forms.css
@@ -632,6 +632,12 @@ span.form-required {
   color: #8a6d3b;
 }
 
+.radio,
+.checkbox {
+  margin-top: 0;
+  margin-bottom: 5px;
+}
+
 /* Remove default Radio Buttons */
 [type="radio"]:not(:checked),
 [type="radio"]:checked,

--- a/themes/socialbase/components/asset-builds/css/navbar.css
+++ b/themes/socialbase/components/asset-builds/css/navbar.css
@@ -1066,6 +1066,17 @@ fieldset[disabled] .navbar-inverse .btn-link:focus {
 
   .navbar-collapse .navbar-nav {
     margin: 6.5px -0.9375rem;
+    -webkit-box-ordinal-group: 2;
+    -ms-flex-order: 1;
+    order: 1;
+  }
+
+  .navbar-collapse .navbar-collapse-order {
+    display: -webkit-box;
+    display: -ms-flexbox;
+    display: flex;
+    -ms-flex-flow: column;
+    flex-flow: column;
   }
 
   .navbar-collapse .navbar-nav > li > a {

--- a/themes/socialbase/components/asset-builds/css/off-canvas.css
+++ b/themes/socialbase/components/asset-builds/css/off-canvas.css
@@ -7,7 +7,7 @@
   background-color: white;
   padding: 20px;
   box-shadow: 0 8px 17px 0 transparent, 0 6px 20px 0 transparent;
-  z-index: 2;
+  z-index: 4;
   -webkit-backface-visibility: hidden;
           backface-visibility: hidden;
   -webkit-transition: box-shadow 0.3s, -webkit-transform 0.5s;
@@ -52,6 +52,7 @@
 @media screen and (min-width: 768px) {
 
   .off-canvas-xs-only {
+    margin-bottom: 0.75rem;
     position: relative;
     width: 100%;
     height: auto;
@@ -61,12 +62,32 @@
     overflow: visible;
     top: 0;
     padding: 0;
-    background: transparent;
+    border-radius: 10px;
+    background-clip: padding-box;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.24);
+  }
+
+  .btn-primary ~ .off-canvas-xs-only {
+    margin-top: 0.75rem;
+  }
+
+  .offcanvas-head {
+    padding: 15px 20px 0;
+    color: #777777;
+    line-height: 1;
+  }
+
+  .offcanvas-head .complementary-title {
+    vertical-align: middle;
+    font-weight: 500;
+    text-transform: uppercase;
+    font-size: 0.875rem;
+    text-align: center;
   }
 
   .offcanvas-body {
     margin-top: 0;
-    margin-bottom: 30px;
+    padding: 20px;
   }
 }
 

--- a/themes/socialbase/components/asset-builds/css/tabs.css
+++ b/themes/socialbase/components/asset-builds/css/tabs.css
@@ -3,7 +3,6 @@
   border: 0;
   font-weight: 300;
   position: relative;
-  text-transform: uppercase;
   -webkit-user-select: none;
      -moz-user-select: none;
       -ms-user-select: none;
@@ -162,6 +161,7 @@
   float: left;
   border-right: 1px solid #e6e6e6;
   border-radius: 10px 0 0 10px;
+  overflow: hidden;
 }
 
 .tabs-left > .nav-tabs > li > a {

--- a/themes/socialbase/components/components/cards/cards.scss
+++ b/themes/socialbase/components/components/cards/cards.scss
@@ -66,6 +66,10 @@
   font-size: 0.875rem;
 }
 
+.teaser--small .card-head {
+  text-align: center;
+}
+
 a.card:hover {
   @include z-depth-3;
 }

--- a/themes/socialbase/components/components/forms/forms.scss
+++ b/themes/socialbase/components/components/forms/forms.scss
@@ -189,6 +189,12 @@ span.form-required {
 // Radio Buttons
 // ***************
 
+.radio,
+.checkbox {
+  margin-top: 0;
+  margin-bottom: 5px;
+}
+
 /* Remove default Radio Buttons */
 [type="radio"]:not(:checked),
 [type="radio"]:checked,

--- a/themes/socialbase/components/components/navbar/navbar.scss
+++ b/themes/socialbase/components/components/navbar/navbar.scss
@@ -136,9 +136,15 @@
 
   .navbar-collapse .navbar-nav {
     margin: ($navbar-padding-vertical / 2) (-$navbar-padding-horizontal);
+    order: 1;
   }
 
   .navbar-collapse {
+
+    .navbar-collapse-order {
+      display: flex;
+      flex-flow: column;
+    }
 
     .navbar-nav > li > a {
       padding: 5px 15px 5px 25px;

--- a/themes/socialbase/components/components/off-canvas/off-canvas.scss
+++ b/themes/socialbase/components/components/off-canvas/off-canvas.scss
@@ -9,7 +9,7 @@
   background-color: $card-bg-color;
   padding: $card-padding;
   box-shadow: 0 8px 17px 0 transparent, 0 6px 20px 0 transparent;
-  z-index: 2;
+  z-index: 4;
   backface-visibility: hidden;
   transition: transform 0.5s, box-shadow 0.3s;
 
@@ -32,6 +32,7 @@
 
 .off-canvas-xs-only {
   @include MQ($small) {
+    margin-bottom: 0.75rem;
     position: relative;
     width: 100%;
     height: auto;
@@ -40,13 +41,35 @@
     overflow: visible;
     top: 0;
     padding: 0;
-    background: transparent;
+    border-radius: 10px;
+    background-clip: padding-box;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.24);
   }
 
 }
 
+.btn-primary ~ .off-canvas-xs-only {
+  @include MQ($small) {
+    margin-top: 0.75rem;
+  }
+}
+
 .offcanvas-head {
   position: relative;
+
+  @include MQ($small) {
+    padding: 15px 20px 0;
+    color: $gray-light;
+    line-height: 1;
+
+    .complementary-title {
+      vertical-align: middle;
+      font-weight: 500;
+      text-transform: uppercase;
+      font-size: 0.875rem;
+      text-align: center;
+    }
+  }
 }
 
 .offcanvas-tools {
@@ -61,6 +84,6 @@
 
   @include MQ($small) {
     margin-top: 0;
-    margin-bottom: 30px;
+    padding: 20px;
   }
 }

--- a/themes/socialbase/components/components/tabs/tabs.scss
+++ b/themes/socialbase/components/components/tabs/tabs.scss
@@ -19,7 +19,6 @@
       border: 0;
       font-weight: 300;
       position: relative;
-      text-transform: uppercase;
       user-select: none;
       -webkit-touch-callout: none;
       -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
@@ -239,6 +238,7 @@
 	float: left;
   border-right: 1px solid $gray-lighter;
   border-radius: 10px 0 0 10px;
+  overflow: hidden;
 }
 
 .tabs-left > .nav-tabs > li > a {

--- a/themes/socialbase/socialbase.theme
+++ b/themes/socialbase/socialbase.theme
@@ -311,20 +311,20 @@ function socialbase_preprocess_block(&$variables) {
   }
   if (isset($variables['content']['search_users_form'])) {
     // Add class for the forms as well.
-    $variables['content']['search_users_form']['#attributes']['class'][] = 'hero-form';
     $variables['content']['search_users_form']['#attributes']['role'] = 'search';
     $variables['content']['search_users_form']['actions']['submit']['#is_button'] = FALSE;
     $variables['content']['search_users_form']['search_input_users']['#name'] = 'search_input_users';
-    // @TODO: Replace with SVG icon.
-    $variables['content']['search_users_form']['actions']['submit']['#suffix'] = '<span class="search-icon"><i class="material-icons">search</i></span>';
+    $variables['content']['search_users_form']['actions']['submit']['#addsearchicon'] = TRUE;
+    $variables['content']['search_users_form']['#attributes']['class'][] = 'hero-form';
+    $variables['content']['search_users_form']['#region'] = 'hero';
   }
   if (isset($variables['content']['search_groups_form'])) {
-    $variables['content']['search_groups_form']['#attributes']['class'][] = 'hero-form';
     $variables['content']['search_groups_form']['#attributes']['role'] = 'search';
     $variables['content']['search_groups_form']['actions']['submit']['#is_button'] = FALSE;
     $variables['content']['search_groups_form']['search_input_groups']['#name'] = 'search_input_groups';
-    // @TODO: Replace with SVG icon.
-    $variables['content']['search_groups_form']['actions']['submit']['#suffix'] = '<span class="search-icon"><i class="material-icons">search</i></span>';
+    $variables['content']['search_groups_form']['actions']['submit']['#addsearchicon'] = TRUE;
+    $variables['content']['search_groups_form']['#attributes']['class'][] = 'hero-form';
+    $variables['content']['search_groups_form']['#region'] = 'hero';
   }
 
   // Add Group ID for "See all groups link".
@@ -1093,7 +1093,7 @@ function socialbase_preprocess_form(&$variables) {
   $element = $variables['element'];
 
   // If this is a search content form set a variable for twig
-  if ($element['#form_id'] === 'search_content_form') {
+  if ($element['#form_id'] === 'search_content_form' || $element['#form_id'] === 'search_users_form' || $element['#form_id'] === 'search_groups_form') {
     $variables['is_search_form'] = TRUE;
   }
 

--- a/themes/socialbase/templates/block/block--system-menu-block--main.html.twig
+++ b/themes/socialbase/templates/block/block--system-menu-block--main.html.twig
@@ -34,10 +34,12 @@
  */
 #}
 <div id="main-navigation" class="collapse navbar-collapse">
-  {% block content %}
-    {{ content }}
-  {% endblock %}
-  <div class='navbar-search'>{{ content.links.search_block }}</div>
+  <div class="navbar-collapse-order">
+    {% block content %}
+      {{ content }}
+    {% endblock %}
+    <div class='navbar-search'>{{ content.links.search_block }}</div>
+  </div>
 </div>
 
 {# We attach a library for the search block. #}

--- a/themes/socialbase/templates/block/block--views-block--sidebar.html.twig
+++ b/themes/socialbase/templates/block/block--views-block--sidebar.html.twig
@@ -29,11 +29,11 @@
  * @ingroup themeable
  */
 #}
-<div class="card card-with-actionbar hidden-xs">
+<div class="card card-with-actionbar teaser--small">
     <div class="card-head">
-        <header class="text-center">{{ title_prefix }} {{ label }} {{ title_suffix }}</header>
+        <header>{{ title_prefix }} {{ label }} {{ title_suffix }}</header>
         {% if subtitle %}
-        <div class="subtitle text-center">
+        <div class="subtitle">
             {{ subtitle }}
         </div>
         {% endif %}


### PR DESCRIPTION
Do a reinstall first.

- [x] Order of blocks in header (mobile view bug)
- [x] Order of blocks in sidebar (make sure add buttons are always first)
- [x] Filters are now in cards and all have block titles
- [x] Fixed bug in search form of users and groups
@ronaldtebrake Maybe you can have a look if this theming function be be written more compact? 
- [x] Tabs are no longer uppercase, improve readability
