### PR TITLE
DS-1841

### DIFF
--- a/modules/social_features/social_group/social_group.module
+++ b/modules/social_features/social_group/social_group.module
@@ -444,23 +444,9 @@ function social_group_menu_local_tasks_alter(&$data, $route_name) {
   // Get current Group.
   $group = _social_group_get_current_group();
 
-  if (is_object($group)) {
-    // Check for the Group permission.
-    $permission = 'administer members';
-    if ($group_membership = $group->getMember($account)) {
-      if ($group_membership->hasPermission($permission)) {
-        // For group managers we will show membership management interface.
-        unset($data['tabs'][0]['social_group.members']);
-      }
-    }
-    // For User 1 we will show membership management interface.
-    if ($account->id() == 1) {
-      unset($data['tabs'][0]['social_group.members']);
-    }
-  }
   // Rename Group "Related Entities" tab.
   if (isset($data['tabs'][0]['group.content']['#link'])) {
-    $data['tabs'][0]['group.content']['#link']['title'] = t('Members');
+    $data['tabs'][0]['group.content']['#link']['title'] = t('Manage members');
   }
 
   // Change the default 'View' tab title.

--- a/modules/social_features/social_group/social_group.routing.yml
+++ b/modules/social_features/social_group/social_group.routing.yml
@@ -1,0 +1,7 @@
+social_group.social_group_controller_redirectGroupMemberships:
+  path: '/group/{group}/membership'
+  defaults:
+    _content: '\Drupal\social_group\Controller\SocialGroupContentListBuilder::render'
+    _title_callback: '\Drupal\social_group\Controller\SocialGroupController::groupMembersTitle'
+  requirements:
+    _user_is_logged_in: 'TRUE'

--- a/modules/social_features/social_group/social_group.routing.yml
+++ b/modules/social_features/social_group/social_group.routing.yml
@@ -4,4 +4,4 @@ social_group.social_group_controller_redirectGroupMemberships:
     _content: '\Drupal\social_group\Controller\SocialGroupContentListBuilder::render'
     _title_callback: '\Drupal\social_group\Controller\SocialGroupController::groupMembersTitle'
   requirements:
-    _user_is_logged_in: 'TRUE'
+    _permission: 'administer members'

--- a/tests/behat/features/capabilities/group/group-edit-open.feature
+++ b/tests/behat/features/capabilities/group/group-edit-open.feature
@@ -34,7 +34,7 @@ Feature: Edit my group as a group manager
     And I should see "1 member"
 
   # DS-706 As a Group Manager I want to manage group memberships
-    And I click "Members"
+    And I click "Manage members"
     Then I should see "Members of Test open group"
     And I should see the link "Add member"
     And I should see "Member"


### PR DESCRIPTION
# Info
Changed the routing for Manage Members, it now is an extra tab next to the members view with teasers we already have. 

# HTT
- [x] Login as SM and CM - See that you can manage members in a group you are not a member off and also see the members tab with user teasers of all the members of a group.

- [x] Login as LU - Create a Group - See that you can manage members and see all the members in a group on a separate tab only for the group you created.

- [x] As the same LU, manage members and give some other LU a group manager status. Now login as that user and see you also have the Manage members & Members tab.

- [x] Login as a normal LU, see that you can only see the members tab.