### PR TITLE
DS-2070 by jaapjan: add any profile permission for sm, cm

### DIFF
--- a/modules/social_features/social_profile/social_profile.install
+++ b/modules/social_features/social_profile/social_profile.install
@@ -80,6 +80,7 @@ function _social_profile_get_permissions($role) {
 
   // Content manager.
   $permissions['contentmanager'] = array_merge($permissions['authenticated'], array(
+    'add any profile profile',
     'edit any profile profile',
     'edit profile tags',
   ));


### PR DESCRIPTION
The permission is necessary to prevent wsod when creating a users profile as sm, cm.