### PR TITLE
DS-839 by ronaldtebrake: add group to events and topics teaser

### DIFF
--- a/modules/social_features/social_core/templates/page-hero-data.html.twig
+++ b/modules/social_features/social_core/templates/page-hero-data.html.twig
@@ -94,7 +94,7 @@
             {%- trans -%}By&nbsp;{%- endtrans -%}
               {{ author_name }}
             {% if group_link %}
-              <span>in group{{ group_link }} </span>
+              <span>in group {{ group_link }} </span>
             {% endif %}
           </div>
         {% endif %}

--- a/modules/social_features/social_topic/src/Controller/SocialTopicController.php
+++ b/modules/social_features/social_topic/src/Controller/SocialTopicController.php
@@ -21,11 +21,14 @@ class SocialTopicController extends ControllerBase {
     // TODO This might change depending on the view exposed filter settings.
     $topic_type_id = $attributes = \Drupal::request()->query->get('field_topic_type_target_id');
     if ($topic_type_id !== NULL) {
-      $term = \Drupal\taxonomy\Entity\Term::load($topic_type_id);
+      // Topic type can be "All" will crash overview on /newest-topics.
+      if (is_numeric(($topic_type_id))) {
+        $term = \Drupal\taxonomy\Entity\Term::load($topic_type_id);
 
-      if ($term->access('view') && $term->getVocabularyId() === 'topic_types') {
-        $term_title = $term->getName();
-        $title = $this->t('Topics of type @type', ['@type' => $term_title]);
+        if ($term->access('view') && $term->getVocabularyId() === 'topic_types') {
+          $term_title = $term->getName();
+          $title = $this->t('Topics of type @type', ['@type' => $term_title]);
+        }
       }
     }
 

--- a/modules/social_features/social_topic/src/Controller/SocialTopicController.php
+++ b/modules/social_features/social_topic/src/Controller/SocialTopicController.php
@@ -22,7 +22,7 @@ class SocialTopicController extends ControllerBase {
     $topic_type_id = $attributes = \Drupal::request()->query->get('field_topic_type_target_id');
     if ($topic_type_id !== NULL) {
       // Topic type can be "All" will crash overview on /newest-topics.
-      if (is_numeric(($topic_type_id))) {
+      if (is_numeric($topic_type_id)) {
         $term = \Drupal\taxonomy\Entity\Term::load($topic_type_id);
 
         if ($term->access('view') && $term->getVocabularyId() === 'topic_types') {

--- a/tests/behat/features/capabilities/group/group-create-open.feature
+++ b/tests/behat/features/capabilities/group/group-create-open.feature
@@ -97,6 +97,7 @@ Feature: Create Open Group
   # And I should see "1 Jan" in the "Sidebar second"
     And I click "Events"
     And I should see "Test group event" in the "Main content"
+    And I should see "Test open group" in the "Main content"
 
   # DS-644 As a LU I want to see the topics of a group
     When I click "Topics"
@@ -119,6 +120,7 @@ Feature: Create Open Group
   # And I should see "Test group topic" in the "Sidebar second"
     And I click "Topics"
     And I should see "Test group topic" in the "Main content"
+    And I should see "Test open group" in the "Main content"
 
   # DS-703 As a LU I want to leave a group
     And I click the xth "4" element with the css ".dropdown-toggle"

--- a/themes/socialbase/socialbase.theme
+++ b/themes/socialbase/socialbase.theme
@@ -818,6 +818,26 @@ function socialbase_preprocess_node(&$variables) {
 
   // Only add submitted data on teasers since we have the page hero block.
   if ($variables['view_mode'] === 'teaser') {
+
+    // Not for AN..
+    $is_anonymous = \Drupal::currentUser()->isAnonymous();
+    if (!$is_anonymous) {
+      // Only on Events & Topics.
+      if ($variables['node']->getType() == 'event' || $variables['node']->getType() == 'topic') {
+        // Add group name to the teaser (if it's part of a group).
+        $group_content = \Drupal\group\Entity\GroupContent::loadByEntity($variables['node']);
+        if (!empty($group_content)) {
+          // It can only exist in one group. So we get the first pointer out of
+          // the array that gets returned from loading GroupContent.
+          $group = reset($group_content)->getGroup();
+
+          if (!empty($group)) {
+            $variables['content']['group_name'] = $group->label();
+          }
+        }
+      }
+    }
+
     $variables['display_submitted'] = TRUE;
   }
   if ($variables['view_mode'] === 'hero') {

--- a/themes/socialbase/templates/node/event/node--event--teaser.html.twig
+++ b/themes/socialbase/templates/node/event/node--event--teaser.html.twig
@@ -23,4 +23,11 @@
     {%- block field_value -%} {{ content.field_event_location }} {%- endblock -%}
   {% endembed %}
 
+  {% if content.group_name %}
+    {% embed "node--teaser__field.html.twig" %}
+      {%- block field_icon -%} group {%- endblock -%}
+      {%- block field_value -%} {{ content.group_name }} {%- endblock -%}
+    {% endembed %}
+  {% endif %}
+
 {% endblock %}

--- a/themes/socialbase/templates/node/topic/node--topic--teaser.html.twig
+++ b/themes/socialbase/templates/node/topic/node--topic--teaser.html.twig
@@ -22,4 +22,12 @@
     {%- block field_value -%} {{ topic_type }} {%- endblock -%}
   {% endembed %}
 
+  {% if content.group_name %}
+    {{ kint(content.group_name) }}
+    {% embed "node--teaser__field.html.twig" %}
+      {%- block field_icon -%} group {%- endblock -%}
+      {%- block field_value -%} {{ content.group_name }} {%- endblock -%}
+    {% endembed %}
+  {% endif %}
+
 {% endblock %}

--- a/themes/socialbase/templates/node/topic/node--topic--teaser.html.twig
+++ b/themes/socialbase/templates/node/topic/node--topic--teaser.html.twig
@@ -23,7 +23,6 @@
   {% endembed %}
 
   {% if content.group_name %}
-    {{ kint(content.group_name) }}
     {% embed "node--teaser__field.html.twig" %}
       {%- block field_icon -%} group {%- endblock -%}
       {%- block field_value -%} {{ content.group_name }} {%- endblock -%}


### PR DESCRIPTION
# HTT

- [x] Check that Events / Topics placed in a Group now have a teaser reflecting which group they belong to
- [x] Check that it works on creating Events & Topics inside a group too 
- [x] Check that community topic overview now works if you go to page 1 / 2 (broken on nightly)
