### PR TITLE
DS-1358 by ronaldtebrake: removed entity list overview for our custom entities

### DIFF
--- a/modules/custom/activity_creator/activity_creator.links.menu.yml
+++ b/modules/custom/activity_creator/activity_creator.links.menu.yml
@@ -1,11 +1,3 @@
-# Activity menu items definition
-entity.activity.collection:
-  title: 'Activity list'
-  route_name: entity.activity.collection
-  description: 'List Activity entities'
-  parent: system.admin_structure
-  weight: 100
-
 activity.admin.structure.settings:
   title: Activity settings
   description: 'Configure Activity entities'

--- a/modules/custom/activity_creator/src/ActivityHtmlRouteProvider.php
+++ b/modules/custom/activity_creator/src/ActivityHtmlRouteProvider.php
@@ -26,10 +26,6 @@ class ActivityHtmlRouteProvider extends AdminHtmlRouteProvider {
 
     $entity_type_id = $entity_type->id();
 
-    if ($collection_route = $this->getCollectionRoute($entity_type)) {
-      $collection->add("entity.{$entity_type_id}.collection", $collection_route);
-    }
-
     if ($add_form_route = $this->getAddFormRoute($entity_type)) {
       $collection->add("entity.{$entity_type_id}.add_form", $add_form_route);
     }
@@ -39,31 +35,6 @@ class ActivityHtmlRouteProvider extends AdminHtmlRouteProvider {
     }
 
     return $collection;
-  }
-
-  /**
-   * Gets the collection route.
-   *
-   * @param \Drupal\Core\Entity\EntityTypeInterface $entity_type
-   *   The entity type.
-   *
-   * @return \Symfony\Component\Routing\Route|null
-   *   The generated route, if available.
-   */
-  protected function getCollectionRoute(EntityTypeInterface $entity_type) {
-    if ($entity_type->hasLinkTemplate('collection') && $entity_type->hasListBuilderClass()) {
-      $entity_type_id = $entity_type->id();
-      $route = new Route($entity_type->getLinkTemplate('collection'));
-      $route
-        ->setDefaults([
-          '_entity_list' => $entity_type_id,
-          '_title' => "{$entity_type->getLabel()} list",
-        ])
-        ->setRequirement('_permission', 'view activity entities')
-        ->setOption('_admin_route', TRUE);
-
-      return $route;
-    }
   }
 
   /**

--- a/modules/social_features/social_event/social_event.links.menu.yml
+++ b/modules/social_features/social_event/social_event.links.menu.yml
@@ -1,11 +1,3 @@
-# Event enrollment menu items definition
-entity.event_enrollment.collection:
-  title: 'Event enrollment list'
-  route_name: entity.event_enrollment.collection
-  description: 'List Event enrollment entities'
-  parent: system.admin_structure
-  weight: 100
-
 event_enrollment.admin.structure.settings:
   title: Event enrollment settings
   description: 'Configure Event enrollment entities'

--- a/modules/social_features/social_event/src/EventEnrollmentHtmlRouteProvider.php
+++ b/modules/social_features/social_event/src/EventEnrollmentHtmlRouteProvider.php
@@ -22,10 +22,6 @@ class EventEnrollmentHtmlRouteProvider extends AdminHtmlRouteProvider {
 
     $entity_type_id = $entity_type->id();
 
-    if ($collection_route = $this->getCollectionRoute($entity_type)) {
-      $collection->add("entity.{$entity_type_id}.collection", $collection_route);
-    }
-
     if ($add_form_route = $this->getAddFormRoute($entity_type)) {
       $collection->add("entity.{$entity_type_id}.add_form", $add_form_route);
     }
@@ -35,31 +31,6 @@ class EventEnrollmentHtmlRouteProvider extends AdminHtmlRouteProvider {
     }
 
     return $collection;
-  }
-
-  /**
-   * Gets the collection route.
-   *
-   * @param \Drupal\Core\Entity\EntityTypeInterface $entity_type
-   *   The entity type.
-   *
-   * @return \Symfony\Component\Routing\Route|null
-   *   The generated route, if available.
-   */
-  protected function getCollectionRoute(EntityTypeInterface $entity_type) {
-    if ($entity_type->hasLinkTemplate('collection') && $entity_type->hasListBuilderClass()) {
-      $entity_type_id = $entity_type->id();
-      $route = new Route($entity_type->getLinkTemplate('collection'));
-      $route
-        ->setDefaults([
-          '_entity_list' => $entity_type_id,
-          '_title' => "{$entity_type->getLabel()} list",
-        ])
-        ->setRequirement('_permission', 'view event enrollment entities')
-        ->setOption('_admin_route', TRUE);
-
-      return $route;
-    }
   }
 
   /**

--- a/modules/social_features/social_post/social_post.links.task.yml
+++ b/modules/social_features/social_post/social_post.links.task.yml
@@ -18,9 +18,3 @@ entity.post.delete_form:
   base_route:  entity.post.canonical
   title: Delete
   weight: 10
-
-
-entity.post.collection:
-  title: Posts
-  route_name: entity.post.collection
-  base_route: system.admin_content

--- a/modules/social_features/social_post/src/PostHtmlRouteProvider.php
+++ b/modules/social_features/social_post/src/PostHtmlRouteProvider.php
@@ -22,10 +22,6 @@ class PostHtmlRouteProvider extends AdminHtmlRouteProvider {
 
     $entity_type_id = $entity_type->id();
 
-    if ($collection_route = $this->getCollectionRoute($entity_type)) {
-      $collection->add("entity.{$entity_type_id}.collection", $collection_route);
-    }
-
     if ($add_form_route = $this->getAddFormRoute($entity_type)) {
       $collection->add("entity.{$entity_type_id}.add_form", $add_form_route);
     }
@@ -35,31 +31,6 @@ class PostHtmlRouteProvider extends AdminHtmlRouteProvider {
     }
 
     return $collection;
-  }
-
-  /**
-   * Gets the collection route.
-   *
-   * @param \Drupal\Core\Entity\EntityTypeInterface $entity_type
-   *   The entity type.
-   *
-   * @return \Symfony\Component\Routing\Route|null
-   *   The generated route, if available.
-   */
-  protected function getCollectionRoute(EntityTypeInterface $entity_type) {
-    if ($entity_type->hasLinkTemplate('collection') && $entity_type->hasListBuilderClass()) {
-      $entity_type_id = $entity_type->id();
-      $route = new Route($entity_type->getLinkTemplate('collection'));
-      $route
-        ->setDefaults([
-          '_entity_list' => $entity_type_id,
-          '_title' => "{$entity_type->getLabel()} list",
-        ])
-        ->setRequirement('_permission', 'view post entities')
-        ->setOption('_admin_route', TRUE);
-
-      return $route;
-    }
   }
 
   /**


### PR DESCRIPTION
# HTT

- [x] Reinstall your site first on 8.x-1.x branch, then checkout feature/DS-1358 and do a drush updb -y; drush fra -y; drush cr (to make sure it works for update path :) )

`git checkout 8.x-1.x;`
 `sreset;`
 `git checkout feature/DS-1358;`
 `drush updb -y;`
 `drush fra -y;`
 `drush cr`

- [x] Login as administrator (and CM and SM)

- [x] See that in the overview there is no longer a link to the list of Posts / Event Enrollments / Activities

- Posts are available at http://nightly_build.socialci.goalgorilla.com/admin/content
- Activities are available at http://nightly_build.socialci.goalgorilla.com/admin/structure
- Event enrollments are available at http://nightly_build.socialci.goalgorilla.com/admin/structure

- [x] Make sure the overviews are not available anymore:
- Posts is available at http://social.dev/admin/content/post
- Activities at: http://social.dev/admin/structure/activity
- Event enrollments at: http://social.dev/admin/structure/event_enrollment