### PR TITLE
DS-1946 by ribel: As admin I want the whole interface to be translatable 

### DIFF
--- a/modules/custom/activity_creator/src/ActivityFactory.php
+++ b/modules/custom/activity_creator/src/ActivityFactory.php
@@ -124,7 +124,7 @@ class ActivityFactory extends ControllerBase {
       $value = $message->getText(NULL);
       // Text for aggregated activities.
       if (!empty($value[1]) && !empty($arguments)) {
-        $text = t($value[1], $arguments);
+        $text = str_replace('@count', $arguments['@count'], $value[1]);
       }
       // Text for default activities.
       else {


### PR DESCRIPTION
# Changes:

This PR fix localization warning: https://localize.drupal.org/translate/projects/social/releases/468365#source-warnings
 
`The first parameter to t() should be a literal string. There should be no variables, concatenation, constants or other non-literal strings there. At t($value[1],$arguments) in social/modules/custom/activity_creator/src/ActivityFactory.php on line 127. Read more at http://drupal.org/node/322732`

# HTT:
- [x] Pull code
- [x] Create some aggregated activites
- [x] Check that counter replacing works good as before.