### PR TITLE
DS-2035 add default profile image.

### DIFF
--- a/modules/social_features/social_profile/social_profile.install
+++ b/modules/social_features/social_profile/social_profile.install
@@ -32,7 +32,7 @@ function _social_profile_add_default_profile_image() {
   $default_image = $field_image_config->get('settings.default_image');
 
   $uri = file_unmanaged_copy(drupal_get_path('module', 'social_profile') . DIRECTORY_SEPARATOR . 'images' . DIRECTORY_SEPARATOR . 'default-profile-picture.png', 'public://default-profile-picture.png', FILE_EXISTS_REPLACE);
-  
+
   $media = File::create([
     'uri' => $uri,
   ]);
@@ -130,5 +130,17 @@ function _social_profile_create_menu_links() {
  * Set default profile image.
  */
 function social_profile_update_8001(&$sandbox) {
-  _social_profile_add_default_profile_image();
+  // Only run when there is not a file added to the file managed table.
+  // Confirmed that it's not there on our current platforms. (But is locally).
+  $query = \Drupal::database()->select('file_managed', 'fm');
+  $query->addField('fm', 'uuid');
+  $query->condition('fm.filename', 'default-profile-picture.png');
+  $query->range(0, 1);
+  $result = $query->execute()->fetchField();
+
+  // $result will be FALSE if there is no UUID available.
+  if (!$result) {
+    _social_profile_add_default_profile_image();
+  }
+
 }

--- a/modules/social_features/social_profile/social_profile.install
+++ b/modules/social_features/social_profile/social_profile.install
@@ -18,14 +18,21 @@ function social_profile_install() {
   _social_profile_set_permissions();
   // Add some links.
   _social_profile_create_menu_links();
+  // Add default profile image
+  _social_profile_add_default_profile_image();
+}
 
+/**
+ * Function to set default profile image if not set already.
+ */
+function _social_profile_add_default_profile_image() {
   // Add default image.
   $config_factory = \Drupal::configFactory();
   $field_image_config = $config_factory->getEditable('field.field.profile.profile.field_profile_image');
   $default_image = $field_image_config->get('settings.default_image');
 
-  $uri  = file_unmanaged_copy(drupal_get_path('module', 'social_profile') . DIRECTORY_SEPARATOR . 'images' . DIRECTORY_SEPARATOR . 'default-profile-picture.png', 'public://default-profile-picture.png', FILE_EXISTS_REPLACE);
-
+  $uri = file_unmanaged_copy(drupal_get_path('module', 'social_profile') . DIRECTORY_SEPARATOR . 'images' . DIRECTORY_SEPARATOR . 'default-profile-picture.png', 'public://default-profile-picture.png', FILE_EXISTS_REPLACE);
+  
   $media = File::create([
     'uri' => $uri,
   ]);
@@ -117,4 +124,11 @@ function _social_profile_create_menu_links() {
       'parent' => $parent,
     ])->save();
   }
+}
+
+/**
+ * Set default profile image.
+ */
+function social_profile_update_8001(&$sandbox) {
+  _social_profile_add_default_profile_image();
 }


### PR DESCRIPTION
# Process

Made sure we have the image profile only when it's not available in the database. 
When checking opensocial @ gg / and y4p we noticed there wasn't an entry for the default profile picture in the database.. But it is there in the config.

`SELECT * FROM file_managed WHERE filename = 'default-profile-picture.png';` Gave a 0.

That's why we will update the config / database (by doing the file save) only when needed in the update hook. Since probably several installs already have it correctly.

# HTT

- [x] Do a reinstall in the beta release, see that it still works

- [x] Remove the default profile image from the field at:

`/admin/config/people/profiles/types/manage/profile/fields/profile.profile.field_profile_image`

- [x] Add a new user, see that they don't have a default image anymore

- [x] Checkout this branch, do a updb 

- [x] Add a new user see that it does work
