### PR TITLE
DS-2134 by nielsvandermolen: Added core patch to fix unpublished book…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,8 @@
                 "Fix region string issue": "https://www.drupal.org/files/issues/2724283-block-22.patch",
                 "Make sure exposed filters work": "https://www.drupal.org/files/issues/grouped_filters-2369119-73.patch",
                 "Redirect to install.php on empty DB": "https://www.drupal.org/files/issues/drupal-redirect_to_install-728702-92.patch",
-                "Exposed filter checkbox not working": "https://www.drupal.org/files/issues/2651102-90-reroll-checkboxes-in-exposed-forms-for-8-1-issues-with-pagers.patch"
+                "Exposed filter checkbox not working": "https://www.drupal.org/files/issues/2651102-90-reroll-checkboxes-in-exposed-forms-for-8-1-issues-with-pagers.patch",
+                "Unpublished book fatal error fix": "https://www.drupal.org/files/issues/navigation_block_8.1.x-2743183-20.patch"
             },
             "drupal/devel": {
                 "Fix vars in function in entity manager wrapper": "https://www.drupal.org/files/issues/fix_entity_manager_wrapper_2749249_5.patch"


### PR DESCRIPTION
… issue in the book navigation block

HTT:

- [x] Checkout branch and do a composer update and check that the patch applies correctly

- [x] Check that you can create unpublished book with the "Create new book page" option.

- [x] Check that the book navigation block still shows up when adding other books to a page. 

- [x] Check patch and Drupal.org issue https://www.drupal.org/node/2743183