### PR TITLE
DS-2035 by ribel: Fix status of default profile image file

### DIFF
--- a/modules/social_features/social_profile/social_profile.install
+++ b/modules/social_features/social_profile/social_profile.install
@@ -37,6 +37,7 @@ function _social_profile_add_default_profile_image() {
     'uri' => $uri,
   ]);
   $media->uuid = '4eb1d927-28f4-402a-8c87-017e637f434a';
+  $media->status = 1;
   $media->save();
 
   $default_image['uuid'] = $media->uuid();
@@ -129,7 +130,7 @@ function _social_profile_create_menu_links() {
 /**
  * Set default profile image.
  */
-function social_profile_update_8001(&$sandbox) {
+function social_profile_update_8002(&$sandbox) {
   // Only run when there is not a file added to the file managed table.
   // Confirmed that it's not there on our current platforms. (But is locally).
   $query = \Drupal::database()->select('file_managed', 'fm');


### PR DESCRIPTION
# Changes
This PR fix and replace `social_profile_update_8001` with `social_profile_update_8002`.

The issue with removing default image was caused because status of file was set to 0, and image was removed after 6 hours by cron.

File status was set to `1` in `_social_profile_add_default_profile_image()`

# HTT

- [x] Do a reinstall in the beta release, see that it still works

- [x] Remove the default profile image from the field at:

`/admin/config/people/profiles/types/manage/profile/fields/profile.profile.field_profile_image`

- [x] Add a new user, see that they don't have a default image anymore

- [x] Checkout this branch, do a updb 

- [x] Add a new user see that it does work
