### PR TITLE
DS-2175 by ribel: As a LU I can't select if Comments should be open or closed anymore 

### DIFF
--- a/modules/social_features/social_comment/social_comment.install
+++ b/modules/social_features/social_comment/social_comment.install
@@ -49,6 +49,7 @@ function _social_comment_get_permissions($role) {
     'skip comment approval',
     'edit own comments',
     'delete own comments',
+    'administer own comments',
   ));
 
 
@@ -63,4 +64,22 @@ function _social_comment_get_permissions($role) {
   ));
 
   return $permissions[$role];
+}
+
+/**
+ * Enable 'administer own comments' permission for authenticated users.
+ */
+function social_comment_update_8001(&$sandbox) {
+  $roles = \Drupal\user\Entity\Role::loadMultiple();
+
+  $permissions = array(
+    'administer own comments',
+  );
+
+  /** @var \Drupal\user\Entity\Role $role */
+  foreach ($roles as $role) {
+    if ($role->id() === 'authenticated') {
+      user_role_grant_permissions($role->id(), $permissions);
+    }
+  }
 }

--- a/modules/social_features/social_comment/social_comment.module
+++ b/modules/social_features/social_comment/social_comment.module
@@ -214,3 +214,14 @@ function social_comment_comment_view(array &$build, EntityInterface $entity, Ent
       ->view($entity, 'full');
   }
 }
+
+/**
+ * Implements hook_field_info_alter().
+ *
+ * Change the default list_class for fields of type 'comment'.
+ */
+function social_comment_field_info_alter(&$info) {
+  if (isset($info['comment'])) {
+    $info['comment']['list_class'] = '\Drupal\social_comment\SocialCommentFieldItemList';
+  }
+}

--- a/modules/social_features/social_comment/social_comment.permissions.yml
+++ b/modules/social_features/social_comment/social_comment.permissions.yml
@@ -1,2 +1,4 @@
 delete own comments:
   title: 'Delete own comments'
+administer own comments:
+  title: 'Administer own comment settings'

--- a/modules/social_features/social_comment/src/SocialCommentFieldItemList.php
+++ b/modules/social_features/social_comment/src/SocialCommentFieldItemList.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Drupal\social_comment;
+
+use Drupal\Core\Access\AccessResult;
+use Drupal\comment\CommentFieldItemList;
+use Drupal\Core\Session\AccountInterface;
+
+/**
+ * Override default item list class for comment fields.
+ */
+class SocialCommentFieldItemList extends CommentFieldItemList {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function access($operation = 'view', AccountInterface $account = NULL, $return_as_object = FALSE) {
+    if ($operation === 'edit') {
+      // Only users with administer own comment settings permission can edit
+      // the comment status field.
+      $result = AccessResult::allowedIfHasPermission($account ?: \Drupal::currentUser(), 'administer own comments');
+      return $return_as_object ? $result : $result->isAllowed();
+    }
+    return parent::access($operation, $account, $return_as_object);
+  }
+
+}


### PR DESCRIPTION
# Changes:
- Add new permission `administer own comments`
- Enable `administer own comments` permission for authenticated users.
- Alter the default `list_class` for fields of type `comment`

# HTT
- [x] Log in as normal user
- [x] Check that you can't set "Comment status" when you add or edit content
- [x] Checkout this branch and do a `drush updb -y; drush cr` (to make sure it works for update path)
- [x] Check that now you are able to set "Comment status" when you add or edit content
- [x] Reinstall site in this branch and check that nothing is broken.
- [x] Check the code