### PR TITLE
DS-2206 by nielsvandermolen: Disable views caching for search views

### DIFF
--- a/modules/social_features/social_search/config/install/search_api.index.social_content.yml
+++ b/modules/social_features/social_search/config/install/search_api.index.social_content.yml
@@ -20,7 +20,6 @@ field_settings:
     boost: !!float 8
   rendered_item:
     label: 'Rendered HTML output'
-    datasource_id: null
     property_path: rendered_item
     type: text
     configuration:
@@ -53,7 +52,6 @@ field_settings:
     type_locked: true
   search_api_node_grants:
     label: 'Node access information'
-    datasource_id: null
     property_path: search_api_node_grants
     type: string
     indexed_locked: true

--- a/modules/social_features/social_search/config/install/search_api.index.social_groups.yml
+++ b/modules/social_features/social_search/config/install/search_api.index.social_groups.yml
@@ -41,7 +41,6 @@ field_settings:
         - field.storage.group.field_group_description
   rendered_item:
     label: 'Rendered HTML output'
-    datasource_id: null
     property_path: rendered_item
     type: text
     configuration:

--- a/modules/social_features/social_search/config/install/search_api.index.social_users.yml
+++ b/modules/social_features/social_search/config/install/search_api.index.social_users.yml
@@ -17,7 +17,6 @@ read_only: false
 field_settings:
   rendered_item:
     label: 'Rendered HTML output'
-    datasource_id: null
     property_path: rendered_item
     type: text
     configuration:

--- a/modules/social_features/social_search/config/install/views.view.search_content.yml
+++ b/modules/social_features/social_search/config/install/views.view.search_content.yml
@@ -26,12 +26,8 @@ display:
         options:
           perm: 'access content search'
       cache:
-        type: search_api
-        options:
-          results_lifespan: '3600'
-          results_lifespan_custom: '0'
-          output_lifespan: '3600'
-          output_lifespan_custom: '0'
+        type: none
+        options: {  }
       query:
         type: views_query
         options:

--- a/modules/social_features/social_search/config/install/views.view.search_groups.yml
+++ b/modules/social_features/social_search/config/install/views.view.search_groups.yml
@@ -26,12 +26,8 @@ display:
         options:
           perm: 'access group search'
       cache:
-        type: search_api
-        options:
-          results_lifespan: '3600'
-          results_lifespan_custom: '0'
-          output_lifespan: '3600'
-          output_lifespan_custom: '0'
+        type: none
+        options: {  }
       query:
         type: views_query
         options:

--- a/modules/social_features/social_search/config/install/views.view.search_users.yml
+++ b/modules/social_features/social_search/config/install/views.view.search_users.yml
@@ -30,12 +30,8 @@ display:
         options:
           perm: 'access users search'
       cache:
-        type: search_api
-        options:
-          results_lifespan: '3600'
-          results_lifespan_custom: '0'
-          output_lifespan: '3600'
-          output_lifespan_custom: '0'
+        type: none
+        options: {  }
       query:
         type: views_query
         options:


### PR DESCRIPTION
There was an issue with changes not being displayed correctly in the teaser. The only place I could reproduce it was in the search pages.

The fix was to disable caching for the views page. the render cache for the individual teasers should still apply. Changing the views caching to tag based also did not solve the issue. 

HTT:

- [x] Enable caching if it is disabled
- [x] Checkout 8.1.x
- [x] Create an topic / event / book page.
- [x] Go to the search page
- [x] Change some fields
- [x] Changes should not be reflected in the teaser.
- [x] Checkout this branch and feature revert and cache clear
- [x] Go to the search page
- [x] Change some fields
- [x] Changes should now be reflected 
- [x] Check teasers on other places as well