### PR TITLE
DS-2234 by alex.ksis: Fix the missing button "read more"

### DIFF
--- a/modules/social_features/social_core/social_core.module
+++ b/modules/social_features/social_core/social_core.module
@@ -159,7 +159,7 @@ function social_core_node_links_alter(array &$links, NodeInterface $entity, arra
   unset($links['comment__field_topic_comments']);
   unset($links['comment__field_event_comments']);
 
-  if (isset($context['view_mode']) && $context['view_mode'] === 'activity') {
+  if (isset($context['view_mode']) && in_array($context['view_mode'], ['activity', 'activity_comment'])) {
     // Add a readmore link.
     $node_title_stripped = strip_tags($entity->label());
     $links['node']['#links']['node-readmore'] = array(


### PR DESCRIPTION
# HTT

- [x] Add comment to event or topic.
- [x] Go to homepage.
- [x] Check that the button "Read More" is present in teaser.
- [x] Check the code.

# Changes

- Added button "Read More" to the "activity_comment" view mode.