### PR TITLE
DS-2259 by ribel: Enable all email notifications by default

### DIFF
--- a/modules/custom/activity_send/modules/activity_send_email/activity_send_email.module
+++ b/modules/custom/activity_send/modules/activity_send_email/activity_send_email.module
@@ -33,7 +33,7 @@ function activity_send_email_form_user_form_alter(&$form, FormStateInterface $fo
         '#type' => 'checkbox',
         '#title_display' => 'before',
         '#title' => $title,
-        '#default_value' => isset($user_email_settings[$key]) ? $user_email_settings[$key] : FALSE,
+        '#default_value' => isset($user_email_settings[$key]) ? $user_email_settings[$key] : TRUE,
       );
     }
 

--- a/modules/custom/activity_send/modules/activity_send_email/src/Plugin/QueueWorker/ActivitySendEmailWorker.php
+++ b/modules/custom/activity_send/modules/activity_send_email/src/Plugin/QueueWorker/ActivitySendEmailWorker.php
@@ -45,7 +45,11 @@ class ActivitySendEmailWorker extends ActivitySendWorkerBase {
         $user_email_settings = EmailActivityDestination::getSendEmailUserSettings($target_account);
 
         // Check if email notifications is enabled for this kind of activity.
-        if (!empty($user_email_settings[$message_template_id]) && isset($activity->field_activity_output_text)) {
+        // If user don't change it's enabled by default.
+        if ((!isset($user_email_settings[$message_template_id])
+            || (isset($user_email_settings[$message_template_id]) && $user_email_settings[$message_template_id] == 1))
+          && isset($activity->field_activity_output_text)
+        ) {
           // Send Email
           $langcode = \Drupal::currentUser()->getPreferredLangcode();
           $params['body'] = EmailActivityDestination::getSendEmailOutputText($message);


### PR DESCRIPTION
# Changes
- Enabled email notification by default on Edit account form (http://www.screencast.com/t/p9N7vz8kK)
- Enabled email notifications by default in ActivitySendEmailWorker.php

# HTT
- [x] Checkout to the branch from 8.x branch
- [x] Check table `user_activity_send` (it shows active configs, should be empty after fresh install)
- [x] Login as admin
- [x] Go to some user edit profile
- [x] Check that all email notifications are enabled by default
- [x] Write some post on users stream
- [x] Run cron
- [x] User should receive email
- [x] Go to some user edit profile
- [x] Disable "A person created a post on my profile"
- [x] Write some post on users stream
- [x] Run cron
- [x] User should NOT receive email
- [ ] Check the code