### PR TITLE
DS-2168 by ribel: Maintenance fixes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,9 +35,6 @@
             },
             "drupal/devel": {
                 "Fix vars in function in entity manager wrapper": "https://www.drupal.org/files/issues/fix_entity_manager_wrapper_2749249_5.patch"
-            },
-            "drupal/addtoany": {
-                "Error 500 on install when a default content type has been deleted": "https://www.drupal.org/files/issues/addtoany-fix-install-content-types-2816369-4.patch"
             }
         }
     },
@@ -62,7 +59,7 @@
         "drupal/search_api": "1.0-beta2",
         "drupal/token": "1.0-beta2",
         "drupal/bootstrap": "3.0-rc2",
-        "drupal/addtoany": "1.5",
+        "drupal/addtoany": "1.6",
         "drupal/image_widget_crop": "1.3.0",
         "drupal/libraries": "3.x-dev#90a1937"
     }

--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,9 @@
             },
             "drupal/devel": {
                 "Fix vars in function in entity manager wrapper": "https://www.drupal.org/files/issues/fix_entity_manager_wrapper_2749249_5.patch"
+            },
+            "drupal/addtoany": {
+                "Error 500 on install when a default content type has been deleted": "https://www.drupal.org/files/issues/addtoany-fix-install-content-types-2816369-4.patch"
             }
         }
     },

--- a/modules/custom/social_demo/social_demo.info.yml
+++ b/modules/custom/social_demo/social_demo.info.yml
@@ -1,5 +1,5 @@
-name: Social Demo
+name: 'Social Demo'
 type: module
-description: Social demo content module.
+description: 'Provides demo content.'
 core: 8.x
 package: Social

--- a/modules/social_features/social_activity/config/install/field.field.activity.activity.field_activity_entity.yml
+++ b/modules/social_features/social_activity/config/install/field.field.activity.activity.field_activity_entity.yml
@@ -97,4 +97,7 @@ settings:
   search_api_task:
     handler: 'default:search_api_task'
     handler_settings: {  }
+  crop:
+    handler: 'default:crop'
+    handler_settings: {  }
 field_type: dynamic_entity_reference

--- a/modules/social_features/social_activity/config/install/field.field.message.create_comment_author_node_post.field_message_related_object.yml
+++ b/modules/social_features/social_activity/config/install/field.field.message.create_comment_author_node_post.field_message_related_object.yml
@@ -69,4 +69,7 @@ settings:
   search_api_task:
     handler: 'default:search_api_task'
     handler_settings: {  }
+  crop:
+    handler: 'default:crop'
+    handler_settings: {  }
 field_type: dynamic_entity_reference

--- a/modules/social_features/social_activity/config/install/field.field.message.create_comment_community_node.field_message_related_object.yml
+++ b/modules/social_features/social_activity/config/install/field.field.message.create_comment_community_node.field_message_related_object.yml
@@ -69,4 +69,7 @@ settings:
   search_api_task:
     handler: 'default:search_api_task'
     handler_settings: {  }
+  crop:
+    handler: 'default:crop'
+    handler_settings: {  }
 field_type: dynamic_entity_reference

--- a/modules/social_features/social_activity/config/install/field.field.message.create_comment_community_post.field_message_related_object.yml
+++ b/modules/social_features/social_activity/config/install/field.field.message.create_comment_community_post.field_message_related_object.yml
@@ -73,4 +73,7 @@ settings:
   search_api_task:
     handler: 'default:search_api_task'
     handler_settings: {  }
+  crop:
+    handler: 'default:crop'
+    handler_settings: {  }
 field_type: dynamic_entity_reference

--- a/modules/social_features/social_activity/config/install/field.field.message.create_comment_group_node.field_message_related_object.yml
+++ b/modules/social_features/social_activity/config/install/field.field.message.create_comment_group_node.field_message_related_object.yml
@@ -69,4 +69,7 @@ settings:
   search_api_task:
     handler: 'default:search_api_task'
     handler_settings: {  }
+  crop:
+    handler: 'default:crop'
+    handler_settings: {  }
 field_type: dynamic_entity_reference

--- a/modules/social_features/social_activity/config/install/field.field.message.create_comment_group_post.field_message_related_object.yml
+++ b/modules/social_features/social_activity/config/install/field.field.message.create_comment_group_post.field_message_related_object.yml
@@ -73,4 +73,7 @@ settings:
   search_api_task:
     handler: 'default:search_api_task'
     handler_settings: {  }
+  crop:
+    handler: 'default:crop'
+    handler_settings: {  }
 field_type: dynamic_entity_reference

--- a/modules/social_features/social_activity/config/install/field.field.message.create_comment_post_profile.field_message_related_object.yml
+++ b/modules/social_features/social_activity/config/install/field.field.message.create_comment_post_profile.field_message_related_object.yml
@@ -73,4 +73,7 @@ settings:
   search_api_task:
     handler: 'default:search_api_task'
     handler_settings: {  }
+  crop:
+    handler: 'default:crop'
+    handler_settings: {  }
 field_type: dynamic_entity_reference

--- a/modules/social_features/social_activity/config/install/field.field.message.create_comment_reply.field_message_related_object.yml
+++ b/modules/social_features/social_activity/config/install/field.field.message.create_comment_reply.field_message_related_object.yml
@@ -69,4 +69,7 @@ settings:
   search_api_task:
     handler: 'default:search_api_task'
     handler_settings: {  }
+  crop:
+    handler: 'default:crop'
+    handler_settings: {  }
 field_type: dynamic_entity_reference

--- a/modules/social_features/social_activity/config/install/field.field.message.create_event_community.field_message_related_object.yml
+++ b/modules/social_features/social_activity/config/install/field.field.message.create_event_community.field_message_related_object.yml
@@ -73,4 +73,7 @@ settings:
   search_api_task:
     handler: 'default:search_api_task'
     handler_settings: {  }
+  crop:
+    handler: 'default:crop'
+    handler_settings: {  }
 field_type: dynamic_entity_reference

--- a/modules/social_features/social_activity/config/install/field.field.message.create_event_group.field_message_related_object.yml
+++ b/modules/social_features/social_activity/config/install/field.field.message.create_event_group.field_message_related_object.yml
@@ -73,4 +73,7 @@ settings:
   search_api_task:
     handler: 'default:search_api_task'
     handler_settings: {  }
+  crop:
+    handler: 'default:crop'
+    handler_settings: {  }
 field_type: dynamic_entity_reference

--- a/modules/social_features/social_activity/config/install/field.field.message.create_post_community.field_message_related_object.yml
+++ b/modules/social_features/social_activity/config/install/field.field.message.create_post_community.field_message_related_object.yml
@@ -73,4 +73,7 @@ settings:
   search_api_task:
     handler: 'default:search_api_task'
     handler_settings: {  }
+  crop:
+    handler: 'default:crop'
+    handler_settings: {  }
 field_type: dynamic_entity_reference

--- a/modules/social_features/social_activity/config/install/field.field.message.create_post_group.field_message_related_object.yml
+++ b/modules/social_features/social_activity/config/install/field.field.message.create_post_group.field_message_related_object.yml
@@ -73,4 +73,7 @@ settings:
   search_api_task:
     handler: 'default:search_api_task'
     handler_settings: {  }
+  crop:
+    handler: 'default:crop'
+    handler_settings: {  }
 field_type: dynamic_entity_reference

--- a/modules/social_features/social_activity/config/install/field.field.message.create_post_profile.field_message_related_object.yml
+++ b/modules/social_features/social_activity/config/install/field.field.message.create_post_profile.field_message_related_object.yml
@@ -73,4 +73,7 @@ settings:
   search_api_task:
     handler: 'default:search_api_task'
     handler_settings: {  }
+  crop:
+    handler: 'default:crop'
+    handler_settings: {  }
 field_type: dynamic_entity_reference

--- a/modules/social_features/social_activity/config/install/field.field.message.create_topic_community.field_message_related_object.yml
+++ b/modules/social_features/social_activity/config/install/field.field.message.create_topic_community.field_message_related_object.yml
@@ -73,4 +73,7 @@ settings:
   search_api_task:
     handler: 'default:search_api_task'
     handler_settings: {  }
+  crop:
+    handler: 'default:crop'
+    handler_settings: {  }
 field_type: dynamic_entity_reference

--- a/modules/social_features/social_activity/config/install/field.field.message.create_topic_group.field_message_related_object.yml
+++ b/modules/social_features/social_activity/config/install/field.field.message.create_topic_group.field_message_related_object.yml
@@ -73,4 +73,7 @@ settings:
   search_api_task:
     handler: 'default:search_api_task'
     handler_settings: {  }
+  crop:
+    handler: 'default:crop'
+    handler_settings: {  }
 field_type: dynamic_entity_reference

--- a/modules/social_features/social_activity/config/install/field.storage.activity.field_activity_entity.yml
+++ b/modules/social_features/social_activity/config/install/field.storage.activity.field_activity_entity.yml
@@ -5,6 +5,7 @@ dependencies:
     - activity_creator
     - block_content
     - comment
+    - crop
     - dynamic_entity_reference
     - file
     - group

--- a/modules/social_features/social_activity/config/install/views.view.activity_stream_group.yml
+++ b/modules/social_features/social_activity/config/install/views.view.activity_stream_group.yml
@@ -213,7 +213,7 @@ display:
           group_type: group
           admin_label: ''
           operator: '='
-          value: true
+          value: '1'
           group: 1
           exposed: false
           expose:

--- a/modules/social_features/social_activity/config/install/views.view.activity_stream_notifications.yml
+++ b/modules/social_features/social_activity/config/install/views.view.activity_stream_notifications.yml
@@ -205,7 +205,7 @@ display:
           group_type: group
           admin_label: ''
           operator: '='
-          value: true
+          value: '1'
           group: 1
           exposed: false
           expose:

--- a/modules/social_features/social_activity/config/install/views.view.activity_stream_profile.yml
+++ b/modules/social_features/social_activity/config/install/views.view.activity_stream_profile.yml
@@ -213,7 +213,7 @@ display:
           group_type: group
           admin_label: ''
           operator: '='
-          value: true
+          value: '1'
           group: 1
           exposed: false
           expose:

--- a/modules/social_features/social_activity/social_activity.info.yml
+++ b/modules/social_features/social_activity/social_activity.info.yml
@@ -9,6 +9,7 @@ dependencies:
   - block
   - block_content
   - comment
+  - crop
   - dynamic_entity_reference
   - field
   - file

--- a/modules/social_features/social_book/social_book.info.yml
+++ b/modules/social_features/social_book/social_book.info.yml
@@ -1,5 +1,5 @@
 name: 'Social Book'
-description: 'Book feature'
+description: 'Provides book feature.'
 type: module
 core: 8.x
 dependencies:

--- a/modules/social_features/social_comment/social_comment.features.yml
+++ b/modules/social_features/social_comment/social_comment.features.yml
@@ -1,1 +1,2 @@
 bundle: social
+required: true

--- a/modules/social_features/social_comment/social_comment.info.yml
+++ b/modules/social_features/social_comment/social_comment.info.yml
@@ -1,5 +1,5 @@
-name: Comment
-description: 'Provides Comment comment type and related configuration. Default comment type.'
+name: 'Social Comment'
+description: 'Provides deafult comment type and related configuration'
 type: module
 core: 8.x
 dependencies:

--- a/modules/social_features/social_core/config/install/crop.type.profile_medium.yml
+++ b/modules/social_features/social_core/config/install/crop.type.profile_medium.yml
@@ -1,7 +1,7 @@
 langcode: en
 status: true
 dependencies: {  }
-label: Profile medium
+label: 'Profile medium'
 id: profile_medium
 description: 'Medium sized profile image'
 aspect_ratio: '44:44'

--- a/modules/social_features/social_core/config/install/crop.type.profile_small.yml
+++ b/modules/social_features/social_core/config/install/crop.type.profile_small.yml
@@ -1,7 +1,7 @@
 langcode: en
 status: true
 dependencies: {  }
-label: Profile small
+label: 'Profile small'
 id: profile_small
 description: 'Small sized profile image'
 aspect_ratio: '24:24'

--- a/modules/social_features/social_core/config/install/views.view.content.yml
+++ b/modules/social_features/social_core/config/install/views.view.content.yml
@@ -370,7 +370,7 @@ display:
           group_type: group
           admin_label: ''
           operator: '='
-          value: true
+          value: '1'
           group: 1
           exposed: true
           expose:

--- a/modules/social_features/social_core/social_core.features.yml
+++ b/modules/social_features/social_core/social_core.features.yml
@@ -1,1 +1,2 @@
 bundle: social
+required: true

--- a/modules/social_features/social_core/social_core.info.yml
+++ b/modules/social_features/social_core/social_core.info.yml
@@ -1,24 +1,25 @@
-name: Core
+name: 'Social Core'
 description: 'Provides core components required by other features.'
 type: module
 core: 8.x
 dependencies:
+  - admin_toolbar_tools
   - block
   - block_content
+  - crop
   - field
   - file
   - help
   - image
+  - image_widget_crop
   - link
   - node
+  - override_node_options
+  - r4032login
   - social_core
   - system
+  - template_suggestions_extra
   - text
   - user
   - views
-  - r4032login
-  - override_node_options
-  - template_suggestions_extra
-  - admin_toolbar_tools
-  - image_widget_crop
 package: Social

--- a/modules/social_features/social_download_count/social_download_count.info.yml
+++ b/modules/social_features/social_download_count/social_download_count.info.yml
@@ -1,5 +1,5 @@
 name: 'Social Download Count'
-description: 'Tracks file downloads for Drupal private core file fields for Open Social'
+description: 'Tracks file downloads for Drupal private core file fields for Open Social.'
 type: module
 core: 8.x
 dependencies:

--- a/modules/social_features/social_editor/social_editor.info.yml
+++ b/modules/social_features/social_editor/social_editor.info.yml
@@ -1,5 +1,5 @@
-name: Editor
-description: 'Provide site components.'
+name: 'Social Editor'
+description: 'Provides site editor components.'
 type: module
 core: 8.x
 dependencies:

--- a/modules/social_features/social_event/config/install/core.entity_view_display.node.event.default.yml
+++ b/modules/social_features/social_event/config/install/core.entity_view_display.node.event.default.yml
@@ -2,6 +2,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - core.entity_view_display.comment.comment.default
     - field.field.node.event.body
     - field.field.node.event.field_content_visibility
     - field.field.node.event.field_event_address

--- a/modules/social_features/social_event/config/install/core.entity_view_display.node.event.search_index.yml
+++ b/modules/social_features/social_event/config/install/core.entity_view_display.node.event.search_index.yml
@@ -2,6 +2,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - core.entity_view_display.comment.comment.default
     - core.entity_view_mode.node.search_index
     - field.field.node.event.body
     - field.field.node.event.field_content_visibility

--- a/modules/social_features/social_event/config/install/views.view.events.yml
+++ b/modules/social_features/social_event/config/install/views.view.events.yml
@@ -174,7 +174,7 @@ display:
           group_type: group
           admin_label: ''
           operator: '='
-          value: true
+          value: '1'
           group: 1
           exposed: true
           expose:
@@ -369,7 +369,7 @@ display:
           group_type: group
           admin_label: ''
           operator: '='
-          value: true
+          value: '1'
           group: 1
           exposed: false
           expose:
@@ -569,7 +569,7 @@ display:
           group_type: group
           admin_label: ''
           operator: '='
-          value: true
+          value: '1'
           group: 1
           exposed: true
           expose:

--- a/modules/social_features/social_event/config/install/views.view.upcoming_events.yml
+++ b/modules/social_features/social_event/config/install/views.view.upcoming_events.yml
@@ -130,7 +130,7 @@ display:
           field_api_classes: false
       filters:
         status:
-          value: true
+          value: '1'
           table: node_field_data
           field: status
           plugin_id: boolean
@@ -336,7 +336,7 @@ display:
           plugin_id: numeric
       filters:
         status:
-          value: true
+          value: '1'
           table: node_field_data
           field: status
           plugin_id: boolean
@@ -484,7 +484,7 @@ display:
       path: community-events
       filters:
         status:
-          value: true
+          value: '1'
           table: node_field_data
           field: status
           plugin_id: boolean
@@ -614,7 +614,7 @@ display:
           required: true
           group_content_plugins:
             'group_node:event': 'group_node:event'
-            'group_node:topic': 0
+            'group_node:topic': '0'
           entity_type: node
           plugin_id: group_content_to_entity_reverse
       arguments:
@@ -656,7 +656,7 @@ display:
           plugin_id: numeric
       filters:
         status:
-          value: true
+          value: '1'
           table: node_field_data
           field: status
           plugin_id: boolean

--- a/modules/social_features/social_event/social_event.info.yml
+++ b/modules/social_features/social_event/social_event.info.yml
@@ -1,4 +1,4 @@
-name: Event
+name: 'Social Event'
 description: 'Provides Event content type and related configuration. '
 type: module
 core: 8.x
@@ -14,11 +14,13 @@ dependencies:
   - group
   - group_core_comments
   - image
+  - image_widget_crop
   - menu_ui
   - node
   - options
   - path
   - profile
+  - social_comment
   - social_core
   - social_event
   - social_profile

--- a/modules/social_features/social_group/config/install/views.view.group_topics.yml
+++ b/modules/social_features/social_group/config/install/views.view.group_topics.yml
@@ -236,7 +236,7 @@ display:
           group_type: group
           admin_label: ''
           operator: '='
-          value: true
+          value: '1'
           group: 1
           exposed: true
           expose:

--- a/modules/social_features/social_group/social_group.info.yml
+++ b/modules/social_features/social_group/social_group.info.yml
@@ -25,5 +25,4 @@ dependencies:
   - text
   - user
   - views
-version: 8.x
 package: Social

--- a/modules/social_features/social_group/social_group.info.yml
+++ b/modules/social_features/social_group/social_group.info.yml
@@ -1,5 +1,5 @@
 name: 'Social Group'
-description: 'Group feature'
+description: 'Provides Group feature.'
 type: module
 core: 8.x
 dependencies:

--- a/modules/social_features/social_page/config/install/core.entity_view_display.node.page.default.yml
+++ b/modules/social_features/social_page/config/install/core.entity_view_display.node.page.default.yml
@@ -2,6 +2,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - core.entity_view_display.comment.comment.default
     - field.field.node.page.body
     - field.field.node.page.field_content_visibility
     - field.field.node.page.field_files

--- a/modules/social_features/social_page/social_page.info.yml
+++ b/modules/social_features/social_page/social_page.info.yml
@@ -1,5 +1,5 @@
 name: 'Social Basic Page'
-description: 'Use basic pages for your static content, such as an About us page.'
+description: 'Provide basic pages content type for your static content, such as an About us page.'
 type: module
 core: 8.x
 dependencies:
@@ -9,10 +9,12 @@ dependencies:
   - field_group
   - file
   - image
+  - image_widget_crop
   - menu_ui
   - node
   - options
   - path
+  - social_comment
   - social_core
   - social_event
   - text

--- a/modules/social_features/social_page/social_page.info.yml
+++ b/modules/social_features/social_page/social_page.info.yml
@@ -1,4 +1,4 @@
-name: 'Social Basic Page'
+name: 'Social Page'
 description: 'Provide basic pages content type for your static content, such as an About us page.'
 type: module
 core: 8.x

--- a/modules/social_features/social_post/social_post.features.yml
+++ b/modules/social_features/social_post/social_post.features.yml
@@ -1,1 +1,2 @@
 bundle: social
+required: true

--- a/modules/social_features/social_post/social_post.info.yml
+++ b/modules/social_features/social_post/social_post.info.yml
@@ -1,5 +1,5 @@
-name: Post
-description: 'Add Post functionality to Social.'
+name: 'Social Post'
+description: 'Provides Post functionality for Open Social.'
 type: module
 core: 8.x
 dependencies:

--- a/modules/social_features/social_profile/social_profile.info.yml
+++ b/modules/social_features/social_profile/social_profile.info.yml
@@ -1,5 +1,5 @@
 name: 'Social Profile'
-description: 'Social profile config'
+description: 'Provides user profiles.'
 type: module
 core: 8.x
 dependencies:

--- a/modules/social_features/social_sharing/social_sharing.features.yml
+++ b/modules/social_features/social_sharing/social_sharing.features.yml
@@ -2,5 +2,4 @@ bundle: social
 excluded:
   - block.block.views_block__activity_stream_group_block_stream_group
   - block.block.views_block__activity_stream_profile_block_1
-required:
-  - block.block.addtoanybuttons
+required: true

--- a/modules/social_features/social_sharing/social_sharing.info.yml
+++ b/modules/social_features/social_sharing/social_sharing.info.yml
@@ -1,5 +1,5 @@
-name: social_sharing
-description: 'Feature that bundles all the share functionality together. Regarding sharing of content to social media.'
+name: 'Social Sharing'
+description: 'Provides sharing of content to social media.'
 type: module
 core: 8.x
 dependencies:

--- a/modules/social_features/social_topic/config/install/core.entity_view_display.node.topic.default.yml
+++ b/modules/social_features/social_topic/config/install/core.entity_view_display.node.topic.default.yml
@@ -2,6 +2,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - core.entity_view_display.comment.comment.default
     - field.field.node.topic.body
     - field.field.node.topic.field_content_visibility
     - field.field.node.topic.field_files

--- a/modules/social_features/social_topic/config/install/core.entity_view_display.node.topic.search_index.yml
+++ b/modules/social_features/social_topic/config/install/core.entity_view_display.node.topic.search_index.yml
@@ -2,6 +2,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - core.entity_view_display.comment.comment.default
     - core.entity_view_mode.node.search_index
     - field.field.node.topic.body
     - field.field.node.topic.field_content_visibility

--- a/modules/social_features/social_topic/config/install/views.view.latest_topics.yml
+++ b/modules/social_features/social_topic/config/install/views.view.latest_topics.yml
@@ -113,7 +113,7 @@ display:
           field_api_classes: false
       filters:
         status:
-          value: true
+          value: '1'
           table: node_field_data
           field: status
           plugin_id: boolean
@@ -227,7 +227,7 @@ display:
           required: true
           group_content_plugins:
             'group_node:topic': 'group_node:topic'
-            'group_node:event': 0
+            'group_node:event': '0'
           entity_type: node
           plugin_id: group_content_to_entity_reverse
       arguments:
@@ -323,7 +323,7 @@ display:
       path: newest-topics
       filters:
         status:
-          value: true
+          value: '1'
           table: node_field_data
           field: status
           plugin_id: boolean

--- a/modules/social_features/social_topic/config/install/views.view.topics.yml
+++ b/modules/social_features/social_topic/config/install/views.view.topics.yml
@@ -189,7 +189,7 @@ display:
           group_type: group
           admin_label: ''
           operator: '='
-          value: true
+          value: '1'
           group: 1
           exposed: true
           expose:
@@ -400,7 +400,7 @@ display:
           group_type: group
           admin_label: ''
           operator: '='
-          value: true
+          value: '1'
           group: 1
           exposed: false
           expose:

--- a/modules/social_features/social_topic/social_topic.info.yml
+++ b/modules/social_features/social_topic/social_topic.info.yml
@@ -1,4 +1,4 @@
-name: Topic
+name: 'Social Topic'
 description: 'Provides Topic content type and related configuration. '
 type: module
 core: 8.x
@@ -12,10 +12,12 @@ dependencies:
   - group
   - group_core_comments
   - image
+  - image_widget_crop
   - menu_ui
   - node
   - options
   - path
+  - social_comment
   - social_core
   - social_event
   - social_topic

--- a/modules/social_features/social_user/config/install/core.entity_form_display.user.user.default.yml
+++ b/modules/social_features/social_user/config/install/core.entity_form_display.user.user.default.yml
@@ -28,6 +28,6 @@ content:
     settings: {  }
     third_party_settings: {  }
 hidden:
+  contact: true
   language: true
   timezone: true
-  contact: true

--- a/modules/social_features/social_user/config/install/core.entity_form_display.user.user.register.yml
+++ b/modules/social_features/social_user/config/install/core.entity_form_display.user.user.register.yml
@@ -15,6 +15,6 @@ content:
     settings: {  }
     third_party_settings: {  }
 hidden:
+  contact: true
   language: true
   timezone: true
-  contact: true

--- a/modules/social_features/social_user/config/install/views.view.user_admin_people.yml
+++ b/modules/social_features/social_user/config/install/views.view.user_admin_people.yml
@@ -705,7 +705,7 @@ display:
           group_type: group
           admin_label: ''
           operator: '='
-          value: true
+          value: '1'
           group: 1
           exposed: true
           expose:
@@ -753,7 +753,7 @@ display:
           group_type: group
           admin_label: ''
           operator: '='
-          value: true
+          value: '1'
           group: 1
           exposed: false
           expose:

--- a/modules/social_features/social_user/social_user.features.yml
+++ b/modules/social_features/social_user/social_user.features.yml
@@ -1,1 +1,2 @@
 bundle: social
+required: true

--- a/modules/social_features/social_user/social_user.info.yml
+++ b/modules/social_features/social_user/social_user.info.yml
@@ -1,5 +1,5 @@
-name: User
-description: 'Provide User related configuration.'
+name: 'Social User'
+description: 'Provides User related configuration.'
 type: module
 core: 8.x
 dependencies:


### PR DESCRIPTION
# Changes
- Updated all Social features to active state
- Clean up features names and descriptions
- Add own patch for addtoany module, which fix module installation when default content types has been deleted

# HTT
- [x] Reinstall your site first on 8.x-1.x branch, then checkout this branch and do a `drush updb -y; drush fra -y; drush cr` (to make sure it works for update path)
- [x] Log in as admin
- [x] Go to features and see that all features in Social bundle are reverted
- [x] Intall Addtoany module and see that it installs correctly
- [x] Reinstall site from scracth
- [x] Check the code