### PR TITLE
DS-2157 by alex.ksis: Add batch script for cropping images for nodes …

### DIFF
--- a/modules/social_features/social_core/social_core.install
+++ b/modules/social_features/social_core/social_core.install
@@ -9,6 +9,8 @@ use Drupal\file\Entity\File;
 use \Drupal\menu_link_content\Entity\MenuLinkContent;
 use Drupal\crop\Entity\CropType;
 use Drupal\node\Entity\Node;
+use Drupal\profile\Entity\Profile;
+use Drupal\group\Entity\Group;
 
 /**
  * Implements hook_install().
@@ -262,7 +264,9 @@ function social_core_update_8005(&$sandbox) {
 
     $query = \Drupal::entityQuery('node', 'OR')
       ->condition('type', 'event')
-      ->condition('type', 'topic');
+      ->condition('type', 'topic')
+      ->condition('type', 'page')
+      ->condition('type', 'book');
 
     $sandbox['items']['node_ids'] = $query->execute();
     $sandbox['max'] = count($sandbox['items']['node_ids']);
@@ -271,9 +275,9 @@ function social_core_update_8005(&$sandbox) {
     $sandbox['items']['group_ids'] = $query->execute();
     $sandbox['max'] += count($sandbox['items']['group_ids']);
 
-    $query = \Drupal::entityQuery('user');
-    $sandbox['items']['user_ids'] = $query->execute();
-    $sandbox['max'] += count($sandbox['items']['user_ids']);
+    $query = \Drupal::entityQuery('profile');
+    $sandbox['items']['profile_ids'] = $query->execute();
+    $sandbox['max'] += count($sandbox['items']['profile_ids']);
   }
 
   $value = NULL;
@@ -282,25 +286,54 @@ function social_core_update_8005(&$sandbox) {
     $nid = array_shift($sandbox['items']['node_ids']);
     $node = Node::load($nid);
 
-    if ($node->getType() == 'topic') {
-      $value = $node->field_topic_image->first() ? $node->field_topic_image->first()->getValue() : NULL;
-    } elseif ($node->getType() == 'event') {
-      $value = $node->field_event_image->first() ? $node->field_event_image->first()->getValue() : NULL;
+    switch ($node->getType()) {
+      case 'topic':
+        $value = $node->field_topic_image->first() ? $node->field_topic_image->first()->getValue() : NULL;
+        break;
+
+      case 'event':
+        $value = $node->field_event_image->first() ? $node->field_event_image->first()->getValue() : NULL;
+        break;
+
+      case 'page':
+        $value = $node->field_page_image->first() ? $node->field_page_image->first()->getValue() : NULL;
+        break;
+
+      case 'book':
+        $value = $node->field_book_image->first() ? $node->field_book_image->first()->getValue() : NULL;
+        break;
     }
 
-    $crop_names = [
+    $crop_type_names = [
       'hero',
       'teaser',
+    ];
+  } elseif ($sandbox['items']['group_ids']) {
+    $gid = array_shift($sandbox['items']['group_ids']);
+    $group = Group::load($gid);
+    $value = $group->field_group_image->first() ? $group->field_group_image->first()->getValue() : NULL;
+    $crop_type_names = [
+      'hero',
+      'teaser',
+    ];
+  } elseif ($sandbox['items']['profile_ids']) {
+    $pid = array_shift($sandbox['items']['profile_ids']);
+    $profile = Profile::load($pid);
+    $value = $profile->field_profile_image->first() ? $profile->field_profile_image->first()->getValue() : NULL;
+    $crop_type_names = [
+      'teaser',
+      'profile_medium',
+      'profile_small',
     ];
   }
 
   if ($value) {
     $image_widget_crop_manager = \Drupal::service('image_widget_crop.manager');
 
-    foreach ($crop_names as $crop_name) {
+    foreach ($crop_type_names as $crop_type_name) {
       $crop_type = \Drupal::entityTypeManager()
         ->getStorage('crop_type')
-        ->load($crop_name);
+        ->load($crop_type_name);
 
       if (!empty($crop_type) && $crop_type instanceof CropType) {
         list($ratio_width, $ratio_height) = explode(':', $crop_type->aspect_ratio);
@@ -316,24 +349,34 @@ function social_core_update_8005(&$sandbox) {
           $height = $value['height'];
         }
 
+        $file = File::load($value['target_id']);
+        $crop_element = [
+          'file-uri' => $file->getFileUri(),
+          'file-id' => $file->id(),
+        ];
+
         $center_x = round($value['width'] / 2);
         $center_y = round($value['height'] / 2);
-
-        $file = File::load($value['target_id']);
         $crop_width_half  = round($width / 2);
         $crop_height_half = round($height / 2);
         $x = max(0, $center_x - $crop_width_half);
         $y = max(0, $center_y - $crop_height_half);
+        $image_styles = $image_widget_crop_manager->getImageStylesByCrop($crop_type_name);
+        $crops = $image_widget_crop_manager->loadImageStyleByCrop($image_styles, $crop_type, $crop_element['file-uri']);
 
-        $image_widget_crop_manager->applyCrop([
-          'x' => $x,
-          'y' => $y,
-          'width' => $width,
-          'height' => $height,
-        ], [
-          'file-uri' => $file->getFileUri(),
-          'file-id' => $value['target_id'],
-        ], $crop_type);
+        if (!$crops) {
+          $image_widget_crop_manager->applyCrop([
+            'x' => $x,
+            'y' => $y,
+            'width' => $width,
+            'height' => $height,
+          ], [
+            'file-uri' => $file->getFileUri(),
+            'file-id' => $value['target_id'],
+          ], $crop_type);
+
+          image_path_flush($file->getFileUri());
+        }
       }
     }
   }

--- a/modules/social_features/social_core/social_core.install
+++ b/modules/social_features/social_core/social_core.install
@@ -8,6 +8,7 @@ use Drupal\Core\Field\FieldItemList;
 use Drupal\file\Entity\File;
 use \Drupal\menu_link_content\Entity\MenuLinkContent;
 use Drupal\crop\Entity\CropType;
+use Drupal\node\Entity\Node;
 
 /**
  * Implements hook_install().
@@ -248,4 +249,95 @@ function social_core_update_8004() {
       user_role_grant_permissions($role->id(), $permissions);
     }
   }
+}
+
+/**
+ * Crop images for groups, profiles and nodes.
+ */
+function social_core_update_8005(&$sandbox) {
+  if (!isset($sandbox['progress'])) {
+    $sandbox['progress'] = 0;
+    $sandbox['items'] = [];
+    $sandbox['max'] = 0;
+
+    $query = \Drupal::entityQuery('node', 'OR')
+      ->condition('type', 'event')
+      ->condition('type', 'topic');
+
+    $sandbox['items']['node_ids'] = $query->execute();
+    $sandbox['max'] = count($sandbox['items']['node_ids']);
+
+    $query = \Drupal::entityQuery('group');
+    $sandbox['items']['group_ids'] = $query->execute();
+    $sandbox['max'] += count($sandbox['items']['group_ids']);
+
+    $query = \Drupal::entityQuery('user');
+    $sandbox['items']['user_ids'] = $query->execute();
+    $sandbox['max'] += count($sandbox['items']['user_ids']);
+  }
+
+  $value = NULL;
+
+  if ($sandbox['items']['node_ids']) {
+    $nid = array_shift($sandbox['items']['node_ids']);
+    $node = Node::load($nid);
+
+    if ($node->getType() == 'topic') {
+      $value = $node->field_topic_image->first() ? $node->field_topic_image->first()->getValue() : NULL;
+    } elseif ($node->getType() == 'event') {
+      $value = $node->field_event_image->first() ? $node->field_event_image->first()->getValue() : NULL;
+    }
+
+    $crop_names = [
+      'hero',
+      'teaser',
+    ];
+  }
+
+  if ($value) {
+    $image_widget_crop_manager = \Drupal::service('image_widget_crop.manager');
+
+    foreach ($crop_names as $crop_name) {
+      $crop_type = \Drupal::entityTypeManager()
+        ->getStorage('crop_type')
+        ->load($crop_name);
+
+      if (!empty($crop_type) && $crop_type instanceof CropType) {
+        list($ratio_width, $ratio_height) = explode(':', $crop_type->aspect_ratio);
+        $ratio = $ratio_width / $ratio_height;
+
+        if ($ratio > 1) {
+          $width = $value['width'];
+          $height = $value['height'] * (($value['width'] / $value['height']) / $ratio);
+        } elseif ($ratio === 1) {
+          $width = $height = min([$value['width'], $value['height']]);
+        } else {
+          $width = $value['width'] * (($value['width'] / $value['height']) / $ratio);
+          $height = $value['height'];
+        }
+
+        $center_x = round($value['width'] / 2);
+        $center_y = round($value['height'] / 2);
+
+        $file = File::load($value['target_id']);
+        $crop_width_half  = round($width / 2);
+        $crop_height_half = round($height / 2);
+        $x = max(0, $center_x - $crop_width_half);
+        $y = max(0, $center_y - $crop_height_half);
+
+        $image_widget_crop_manager->applyCrop([
+          'x' => $x,
+          'y' => $y,
+          'width' => $width,
+          'height' => $height,
+        ], [
+          'file-uri' => $file->getFileUri(),
+          'file-id' => $value['target_id'],
+        ], $crop_type);
+      }
+    }
+  }
+
+  $sandbox['progress']++;
+  $sandbox['#finished'] = empty($sandbox['max']) ? 1 : ($sandbox['progress'] / $sandbox['max']);
 }

--- a/modules/social_features/social_core/social_core.install
+++ b/modules/social_features/social_core/social_core.install
@@ -262,6 +262,7 @@ function social_core_update_8005(&$sandbox) {
     $sandbox['items'] = [];
     $sandbox['max'] = 0;
 
+    // First retrieve all the nodes, groups and profiles.
     $query = \Drupal::entityQuery('node', 'OR')
       ->condition('type', 'event')
       ->condition('type', 'topic')
@@ -282,6 +283,9 @@ function social_core_update_8005(&$sandbox) {
 
   $value = NULL;
 
+  // Check if this is a node, group or profile and continue by retrieving the:
+  // - Image uri value.
+  // - Crop style names we need to crop for.
   if ($sandbox['items']['node_ids']) {
     $nid = array_shift($sandbox['items']['node_ids']);
     $node = Node::load($nid);
@@ -308,7 +312,8 @@ function social_core_update_8005(&$sandbox) {
       'hero',
       'teaser',
     ];
-  } elseif ($sandbox['items']['group_ids']) {
+  }
+  elseif ($sandbox['items']['group_ids']) {
     $gid = array_shift($sandbox['items']['group_ids']);
     $group = Group::load($gid);
     $value = $group->field_group_image->first() ? $group->field_group_image->first()->getValue() : NULL;
@@ -316,7 +321,8 @@ function social_core_update_8005(&$sandbox) {
       'hero',
       'teaser',
     ];
-  } elseif ($sandbox['items']['profile_ids']) {
+  }
+  elseif ($sandbox['items']['profile_ids']) {
     $pid = array_shift($sandbox['items']['profile_ids']);
     $profile = Profile::load($pid);
     $value = $profile->field_profile_image->first() ? $profile->field_profile_image->first()->getValue() : NULL;
@@ -327,7 +333,7 @@ function social_core_update_8005(&$sandbox) {
     ];
   }
 
-  if ($value) {
+  if ($value && isset($crop_type_names)) {
     $image_widget_crop_manager = \Drupal::service('image_widget_crop.manager');
 
     foreach ($crop_type_names as $crop_type_name) {
@@ -336,18 +342,6 @@ function social_core_update_8005(&$sandbox) {
         ->load($crop_type_name);
 
       if (!empty($crop_type) && $crop_type instanceof CropType) {
-        list($ratio_width, $ratio_height) = explode(':', $crop_type->aspect_ratio);
-        $ratio = $ratio_width / $ratio_height;
-
-        if ($ratio > 1) {
-          $width = $value['width'];
-          $height = $value['height'] * (($value['width'] / $value['height']) / $ratio);
-        } elseif ($ratio === 1) {
-          $width = $height = min([$value['width'], $value['height']]);
-        } else {
-          $width = $value['width'] * (($value['width'] / $value['height']) / $ratio);
-          $height = $value['height'];
-        }
 
         $file = File::load($value['target_id']);
         $crop_element = [
@@ -355,26 +349,43 @@ function social_core_update_8005(&$sandbox) {
           'file-id' => $file->id(),
         ];
 
-        $center_x = round($value['width'] / 2);
-        $center_y = round($value['height'] / 2);
-        $crop_width_half  = round($width / 2);
-        $crop_height_half = round($height / 2);
-        $x = max(0, $center_x - $crop_width_half);
-        $y = max(0, $center_y - $crop_height_half);
         $image_styles = $image_widget_crop_manager->getImageStylesByCrop($crop_type_name);
         $crops = $image_widget_crop_manager->loadImageStyleByCrop($image_styles, $crop_type, $crop_element['file-uri']);
 
+        // Only crop if this uri is not yet cropped for this crop style already.
         if (!$crops) {
-          $image_widget_crop_manager->applyCrop([
+
+          list($ratio_width, $ratio_height) = explode(':', $crop_type->aspect_ratio);
+          $ratio = $ratio_width / $ratio_height;
+
+          if ($ratio > 1) {
+            $width = $value['width'];
+            $height = $value['height'] * (($value['width'] / $value['height']) / $ratio);
+          } elseif ($ratio === 1) {
+            $width = $height = min([$value['width'], $value['height']]);
+          } else {
+            $width = $value['width'] * (($value['width'] / $value['height']) / $ratio);
+            $height = $value['height'];
+          }
+
+          $center_x = round($value['width'] / 2);
+          $center_y = round($value['height'] / 2);
+          $crop_width_half  = round($width / 2);
+          $crop_height_half = round($height / 2);
+          $x = max(0, $center_x - $crop_width_half);
+          $y = max(0, $center_y - $crop_height_half);
+
+          $properties = [
             'x' => $x,
             'y' => $y,
             'width' => $width,
             'height' => $height,
-          ], [
-            'file-uri' => $file->getFileUri(),
+          ];
+          $field_value = [
+            'file-uri' => $crop_element['file-uri'],
             'file-id' => $value['target_id'],
-          ], $crop_type);
-
+          ];
+          $image_widget_crop_manager->applyCrop($properties, $field_value, $crop_type);
           image_path_flush($file->getFileUri());
         }
       }


### PR DESCRIPTION
The crop library and widget was added during release of beta4. This has the side-effect that existing images will not look good (squashed). This update hook should solve this problem by generating a 'default' image crop for these images.

HTT:

- Test the teaser and hero header image of event, topic, book and page.
- Test the group teaser image and hero header image
- Test the teaser images and full display of the profile image
