### PR TITLE
Add sticky, promoted and unpublished classes to node templates in socialbase theme

### DIFF
--- a/themes/socialbase/socialbase.theme
+++ b/themes/socialbase/socialbase.theme
@@ -839,12 +839,6 @@ function socialbase_preprocess_node(&$variables) {
     unset($variables['label']);
   }
 
-  // Try to add unpublished as a article class for now when nodes are published
-  // or unpublished.
-  if (!$variables['elements']['#node']->isPublished()) {
-    $variables['attributes']['class'][] = 'unpublished';
-  }
-
   // Date formats.
   $date = $variables['node']->getCreatedTime();
   if ($variables['view_mode'] === 'small_teaser') {

--- a/themes/socialbase/templates/node/node--default.html.twig
+++ b/themes/socialbase/templates/node/node--default.html.twig
@@ -65,12 +65,13 @@
 #}
 {%
   set classes = [
-    node.bundle|clean_class,
-    view_mode ? view_mode|clean_class,
-    'clearfix',
+    'card',
+    node.isPromoted() ? 'promoted',
+    node.isSticky() ? 'sticky',
+    not node.isPublished() ? 'unpublished',
   ]
 %}
-<article{{ attributes.addClass('card') }}>
+<article{{ attributes.addClass(classes) }}>
 
   <div{{ content_attributes.addClass('card-body extra-padding') }}>
     {{ content.body }}

--- a/themes/socialbase/templates/node/node--full.html.twig
+++ b/themes/socialbase/templates/node/node--full.html.twig
@@ -63,13 +63,23 @@
  *   in different view modes.
  */
 #}
+
+{%
+  set classes = [
+    'card',
+    node.isPromoted() ? 'promoted',
+    node.isSticky() ? 'sticky',
+    not node.isPublished() ? 'unpublished',
+  ]
+%}
+
 {% if details_label %}
   <h4 class="section-title section-title-node">
     {{ details_label }}
   </h4>
 {% endif %}
 
-<article{{ attributes.addClass('card') }}>
+<article{{ attributes.addClass(classes) }}>
 
   <div{{ content_attributes.addClass('card-body extra-padding body-text') }}>
     {{ content.body }}

--- a/themes/socialbase/templates/node/node--teaser.html.twig
+++ b/themes/socialbase/templates/node/node--teaser.html.twig
@@ -73,6 +73,9 @@
     'card-with-actionbar',
     view_mode == 'activity' ? 'card--teaser-stream',
     view_mode == 'activity_comment' ? 'card--teaser-stream',
+    node.isPromoted() ? 'promoted',
+    node.isSticky() ? 'sticky',
+    not node.isPublished() ? 'unpublished',
   ]
 %}
 


### PR DESCRIPTION
# HTT
- [ ] Checkout the branch, clear the cache
- [ ] Check that all node teasers and full views looks like before
- [ ] Edit some node, make it sticky, promoted and unpublished. Check that node teaser and full view now have new classes.