### PR TITLE
DS-2304 - Remove 'in the group' from activity stream items

### DIFF
--- a/modules/social_features/social_activity/config/install/message.template.create_comment_community_post.yml
+++ b/modules/social_features/social_activity/config/install/message.template.create_comment_community_post.yml
@@ -18,8 +18,8 @@ template: create_comment_community_post
 label: 'Create comment on post in the community'
 description: 'A user add a comment to post in the community'
 text:
-  - '<p><a href="[message:author:url:relative]">[message:author:display-name]</a> commented on post</p>'
-  - '<p><a href="[message:author:url:relative]">[message:author:display-name]</a> and @count others commented on post</p>'
+  - '<p><a href="[message:author:url:relative]">[message:author:display-name]</a> commented on a post</p>'
+  - '<p><a href="[message:author:url:relative]">[message:author:display-name]</a> and @count others commented on a post</p>'
 settings:
   'token options':
     clear: false

--- a/modules/social_features/social_activity/config/install/message.template.create_comment_group_node.yml
+++ b/modules/social_features/social_activity/config/install/message.template.create_comment_group_node.yml
@@ -20,8 +20,8 @@ template: create_comment_group_node
 label: 'Create comment on node in the group'
 description: 'A user add a comment to content in the group'
 text:
-  - '<p><a href="[message:author:url:relative]">[message:author:display-name]</a> commented on content in the group <a href="[message:gurl]">[message:gtitle]</a></p>'
-  - '<p><a href="[message:author:url:relative]">[message:author:display-name]</a> and @count others commented on content in the group <a href="[message:gurl]">[message:gtitle]</a></p>'
+  - '<p><a href="[message:author:url:relative]">[message:author:display-name]</a> commented on content in <a href="[message:gurl]">[message:gtitle]</a></p>'
+  - '<p><a href="[message:author:url:relative]">[message:author:display-name]</a> and @count others commented on content in <a href="[message:gurl]">[message:gtitle]</a></p>'
 settings:
   'token options':
     clear: false

--- a/modules/social_features/social_activity/config/install/message.template.create_comment_group_post.yml
+++ b/modules/social_features/social_activity/config/install/message.template.create_comment_group_post.yml
@@ -20,8 +20,8 @@ template: create_comment_group_post
 label: 'Create comment on post in the group'
 description: 'A user add a comment to post in the group'
 text:
-  - '<p><a href="[message:author:url:relative]">[message:author:display-name]</a> commented on post in the group <a href="[message:gurl]">[message:gtitle]</a></p>'
-  - '<p><a href="[message:author:url:relative]">[message:author:display-name]</a> and @count others commented on post in the group <a href="[message:gurl]">[message:gtitle]</a></p>'
+  - '<p><a href="[message:author:url:relative]">[message:author:display-name]</a> commented on a post in <a href="[message:gurl]">[message:gtitle]</a></p>'
+  - '<p><a href="[message:author:url:relative]">[message:author:display-name]</a> and @count others commented on a post in <a href="[message:gurl]">[message:gtitle]</a></p>'
 settings:
   'token options':
     clear: false

--- a/modules/social_features/social_activity/config/install/message.template.create_comment_post_profile.yml
+++ b/modules/social_features/social_activity/config/install/message.template.create_comment_post_profile.yml
@@ -18,9 +18,9 @@ template: create_comment_post_profile
 label: 'Create comment on post on my profile'
 description: 'A person commented on the post posted on my profile'
 text:
-  - "<p><a href=\"[message:author:url:absolute]\">[message:author:display-name]</a> commented on post&nbsp;on your <a href=\"[message:recipient-user-url]\">profile</a></p>\r\n"
-  - "<p><a href=\"[message:author:url:absolute]\">[message:author:display-name]</a> commented on post&nbsp;on your <a href=\"[message:recipient-user-url]\">profile</a></p>\r\n"
-  - "<p><a href=\"[message:author:url:absolute]\">[message:author:display-name]</a> commented on post&nbsp;on your <a href=\"[message:recipient-user-url]\">profile</a></p>\r\n"
+  - "<p><a href=\"[message:author:url:absolute]\">[message:author:display-name]</a> commented on a post on your <a href=\"[message:recipient-user-url]\">profile</a></p>\r\n"
+  - "<p><a href=\"[message:author:url:absolute]\">[message:author:display-name]</a> commented on a post on your <a href=\"[message:recipient-user-url]\">profile</a></p>\r\n"
+  - "<p><a href=\"[message:author:url:absolute]\">[message:author:display-name]</a> commented on a post on your <a href=\"[message:recipient-user-url]\">profile</a></p>\r\n"
 settings:
   'token options':
     clear: false

--- a/modules/social_features/social_activity/config/install/message.template.create_event_group.yml
+++ b/modules/social_features/social_activity/config/install/message.template.create_event_group.yml
@@ -19,7 +19,7 @@ template: create_event_group
 label: 'Create event in group'
 description: 'A user created an event in a group'
 text:
-  - '<p><a href="[message:author:url:relative]">[message:author:display-name]</a> created an event in group <a href="[message:gurl]">[message:gtitle]</a></p>'
+  - '<p><a href="[message:author:url:relative]">[message:author:display-name]</a> created an event in <a href="[message:gurl]">[message:gtitle]</a></p>'
 settings:
   'token options':
     clear: false

--- a/modules/social_features/social_activity/config/install/message.template.create_post_group.yml
+++ b/modules/social_features/social_activity/config/install/message.template.create_post_group.yml
@@ -18,7 +18,7 @@ template: create_post_group
 label: 'Create post in a group'
 description: 'A user created a post in a group'
 text:
-  - '<p><a href="[message:author:url:relative]">[message:author:display-name]</a> posted in the group <a href="[message:gurl]">[message:gtitle]</a></p>'
+  - '<p><a href="[message:author:url:relative]">[message:author:display-name]</a> posted in <a href="[message:gurl]">[message:gtitle]</a></p>'
 settings:
   'token options':
     clear: false

--- a/modules/social_features/social_activity/config/install/message.template.create_topic_group.yml
+++ b/modules/social_features/social_activity/config/install/message.template.create_topic_group.yml
@@ -19,7 +19,7 @@ template: create_topic_group
 label: 'Create topic in group'
 description: 'A user created a topic in a group'
 text:
-  - '<p><a href="[message:author:url:relative]">[message:author:display-name]</a> created a topic in group <a href="[message:gurl]">[message:gtitle]</a></p>'
+  - '<p><a href="[message:author:url:relative]">[message:author:display-name]</a> created a topic in <a href="[message:gurl]">[message:gtitle]</a></p>'
 settings:
   'token options':
     clear: false

--- a/modules/social_features/social_core/social_core.module
+++ b/modules/social_features/social_core/social_core.module
@@ -198,7 +198,9 @@ function social_core_preprocess_field(&$variables) {
  * Implements hook_preprocess_block().
  */
 function social_core_preprocess_block(&$variables) {
-  $profile_user_id = \Drupal::routeMatch()->getParameter('user');
+  /** @var \Drupal\user\Entity\User $account */
+  $account = \Drupal::routeMatch()->getParameter('user');
+  /** @var \Drupal\group\Entity\Group $group */
   $group = \Drupal::routeMatch()->getParameter('group');
 
   // Add variables to sidebar blocks
@@ -224,15 +226,15 @@ function social_core_preprocess_block(&$variables) {
       break;
     case 'events-block_events_on_profile':
       $variables['subtitle'] = t('for this user');
-      $variables['view_all_path'] = Url::fromRoute('view.events.events_overview', array('user' => $profile_user_id));
+      $variables['view_all_path'] = Url::fromRoute('view.events.events_overview', array('user' => $account->id()));
       break;
     case 'topics-block_user_topics':
       $variables['subtitle'] = t('for this user');
-      $variables['view_all_path'] = Url::fromRoute('view.topics.page_profile', array('user' => $profile_user_id));
+      $variables['view_all_path'] = Url::fromRoute('view.topics.page_profile', array('user' => $account->id()));
       break;
     case 'groups-block_user_groups':
       $variables['subtitle'] = t('for this user');
-      $variables['view_all_path'] = Url::fromRoute('view.groups.page_user_groups', array('user' => $profile_user_id));
+      $variables['view_all_path'] = Url::fromRoute('view.groups.page_user_groups', array('user' => $account->id()));
       break;
     case 'group_members-block_newest_members':
       $variables['subtitle'] = t('in the group');

--- a/modules/social_features/social_core/social_core.module
+++ b/modules/social_features/social_core/social_core.module
@@ -195,6 +195,61 @@ function social_core_preprocess_field(&$variables) {
 }
 
 /**
+ * Implements hook_preprocess_block().
+ */
+function social_core_preprocess_block(&$variables) {
+  $profile_user_id = \Drupal::routeMatch()->getParameter('user');
+  $group = \Drupal::routeMatch()->getParameter('group');
+
+  // Add variables to sidebar blocks
+  switch ($variables['elements']['#derivative_plugin_id']) {
+    case 'upcoming_events-block_my_upcoming_events':
+      $variables['view_all_path'] = 'my-events';
+      break;
+    case 'upcoming_events-block_community_events':
+      $variables['subtitle'] = t('in the community');
+      $variables['view_all_path'] = 'community-events';
+      break;
+    case 'latest_topics-block_latest_topics':
+      $variables['subtitle'] = t('in the community');
+      $variables['view_all_path'] = 'newest-topics';
+      break;
+    case 'newest_groups-block_newest_groups':
+      $variables['subtitle'] = t('in the community');
+      $variables['view_all_path'] = 'all-groups';
+      break;
+    case 'newest_users-block_newest_users':
+      $variables['subtitle'] = t('in the community');
+      $variables['view_all_path'] = 'newest-members';
+      break;
+    case 'events-block_events_on_profile':
+      $variables['subtitle'] = t('for this user');
+      $variables['view_all_path'] = Url::fromRoute('view.events.events_overview', array('user' => $profile_user_id));
+      break;
+    case 'topics-block_user_topics':
+      $variables['subtitle'] = t('for this user');
+      $variables['view_all_path'] = Url::fromRoute('view.topics.page_profile', array('user' => $profile_user_id));
+      break;
+    case 'groups-block_user_groups':
+      $variables['subtitle'] = t('for this user');
+      $variables['view_all_path'] = Url::fromRoute('view.groups.page_user_groups', array('user' => $profile_user_id));
+      break;
+    case 'group_members-block_newest_members':
+      $variables['subtitle'] = t('in the group');
+      $variables['view_all_path'] = Url::fromUserInput('/group/' . $group->id() . '/members');
+      break;
+    case 'upcoming_events-upcoming_events_group':
+      $variables['subtitle'] = t('in the group');
+      $variables['view_all_path'] = Url::fromUserInput('/group/' . $group->id() . '/events');
+      break;
+    case 'latest_topics-group_topics_block':
+      $variables['subtitle'] = t('in the group');
+      $variables['view_all_path'] = Url::fromUserInput('/group/' . $group->id() . '/topics');
+      break;
+  }
+}
+
+/**
  * Implements hook_menu_local_tasks_alter().
  */
 function social_core_menu_local_tasks_alter(&$data, $route_name) {

--- a/tests/behat/features/capabilities/activity-stream/activity-stream-comments.feature
+++ b/tests/behat/features/capabilities/activity-stream/activity-stream-comments.feature
@@ -80,7 +80,7 @@ Feature: See comments in activity stream
 
     When I wait for the queue to be empty
     When I am on "/user"
-    Then I should see "CreateUser created an event in group Test open group"
+    Then I should see "CreateUser created an event in Test open group"
     And I should see "Test group event"
 
     And I click "Test group event"
@@ -107,21 +107,21 @@ Feature: See comments in activity stream
 
     Given I am logged in as "SeeUser"
     And I click "CreateUser"
-    Then I should see "CreateUser created an event in group Test open group"
+    Then I should see "CreateUser created an event in Test open group"
     And I should see "Test group event"
     And I should see "This is a third event comment"
     And I should not see "This is a first event comment"
     And I should not see "This is a reply event comment"
 
     And I click "Test open group"
-    Then I should see "CreateUser created an event in group Test open group"
+    Then I should see "CreateUser created an event in Test open group"
     And I should see "Test group event"
     And I should see "This is a third event comment"
     And I should not see "This is a first event comment"
     And I should not see "This is a reply event comment"
 
     When I am on the homepage
-    Then I should see "CreateUser created an event in group Test open group"
+    Then I should see "CreateUser created an event in Test open group"
     And I should see "Test group event"
     And I should see "This is a third event comment"
     And I should not see "This is a first event comment"
@@ -134,11 +134,11 @@ Feature: See comments in activity stream
 
     Given I am an anonymous user
     When I am on the homepage
-    Then I should not see "CreateUser created an event in group Test open group"
+    Then I should not see "CreateUser created an event in Test open group"
     And I should not see "Test group event"
     And I should not see "This is a third event comment"
 
     When I go to "explore"
-    Then I should not see "CreateUser created an event in group Test open group"
+    Then I should not see "CreateUser created an event in Test open group"
     And I should not see "Test group event"
     And I should not see "This is a third event comment"

--- a/tests/behat/features/capabilities/activity-stream/create_topic_event.feature
+++ b/tests/behat/features/capabilities/activity-stream/create_topic_event.feature
@@ -147,15 +147,15 @@ Feature: See and get notified when content is created
     When I click "Test open group"
       When I wait for the queue to be empty
       When I am on "user"
-    Then I should see "CreateUser created an event in group Test open group"
+    Then I should see "CreateUser created an event in Test open group"
     And I should see "Test group event"
 
     Given I am logged in as "SeeUser"
     And I click "CreateUser"
-    Then I should see "CreateUser created an event in group Test open group"
+    Then I should see "CreateUser created an event in Test open group"
     And I should see "Test group event"
     When I am on the homepage
-    Then I should see "CreateUser created an event in group Test open group"
+    Then I should see "CreateUser created an event in Test open group"
     And I should see "Test group event"
     When I go to "explore"
     Then I should not see "CreateUser created an event"
@@ -163,8 +163,8 @@ Feature: See and get notified when content is created
 
     Given I am an anonymous user
     When I am on the homepage
-    Then I should not see "CreateUser created an event in group Test open group"
+    Then I should not see "CreateUser created an event in Test open group"
     And I should not see "Test group event"
     When I go to "explore"
-    Then I should not see "CreateUser created an event in group Test open group"
+    Then I should not see "CreateUser created an event in Test open group"
     And I should not see "Test group event"

--- a/themes/socialbase/socialbase.theme
+++ b/themes/socialbase/socialbase.theme
@@ -240,7 +240,6 @@ function socialbase_theme_suggestions_block_alter(array &$suggestions, array $va
  */
 function socialbase_preprocess_block(&$variables) {
   $profile_user_id = \Drupal::routeMatch()->getParameter('user');
-  $group = \Drupal::routeMatch()->getParameter('group');
   $block = \Drupal\block\Entity\Block::load($variables['elements']['#id']);
 
   // Fetch the current active (sub)theme.
@@ -357,55 +356,6 @@ function socialbase_preprocess_block(&$variables) {
 
       }
     }
-  }
-
-
-
-  // Add variables to sidebar blocks
-  switch ($variables['elements']['#derivative_plugin_id']) {
-    case 'upcoming_events-block_my_upcoming_events':
-      $variables['view_all_path'] = 'my-events';
-      break;
-    case 'upcoming_events-block_community_events':
-      $variables['subtitle'] = t('in the community');
-      $variables['view_all_path'] = 'community-events';
-      break;
-    case 'latest_topics-block_latest_topics':
-      $variables['subtitle'] = t('in the community');
-      $variables['view_all_path'] = 'newest-topics';
-      break;
-    case 'newest_groups-block_newest_groups':
-      $variables['subtitle'] = t('in the community');
-      $variables['view_all_path'] = 'all-groups';
-      break;
-    case 'newest_users-block_newest_users':
-      $variables['subtitle'] = t('in the community');
-      $variables['view_all_path'] = 'newest-members';
-      break;
-    case 'events-block_events_on_profile':
-      $variables['subtitle'] = t('for this user');
-      $variables['view_all_path'] = Url::fromRoute('view.events.events_overview', array('user' => $profile_user_id));
-      break;
-    case 'topics-block_user_topics':
-      $variables['subtitle'] = t('for this user');
-      $variables['view_all_path'] = Url::fromRoute('view.topics.page_profile', array('user' => $profile_user_id));
-      break;
-    case 'groups-block_user_groups':
-      $variables['subtitle'] = t('for this user');
-      $variables['view_all_path'] = Url::fromRoute('view.groups.page_user_groups', array('user' => $profile_user_id));
-      break;
-    case 'group_members-block_newest_members':
-      $variables['subtitle'] = t('in the group');
-      $variables['view_all_path'] = Url::fromUserInput('/group/' . $group->id() . '/members');
-      break;
-    case 'upcoming_events-upcoming_events_group':
-      $variables['subtitle'] = t('in the group');
-      $variables['view_all_path'] = Url::fromUserInput('/group/' . $group->id() . '/events');
-      break;
-    case 'latest_topics-group_topics_block':
-      $variables['subtitle'] = t('in the group');
-      $variables['view_all_path'] = Url::fromUserInput('/group/' . $group->id() . '/topics');
-      break;
   }
 }
 


### PR DESCRIPTION
# HTT

## Part 1:
- [x] revert the social_activity feature

- [x] create a topic/event/post in a group and empty the queue's

- [x] see that on the activity stream there's no longer the string 'created in the group ', but only 'in '

- [x] Do a re-install and notice the same for the demo content

## Part 2:

Check that on the pages below, the mentioned blocks in the complementary area have the correct subtitle and the links are also correct

### Subtitles should be:
Home stream >> 'in the community'
Group stream >> 'in the group'
Profile stream >> 'for this user'

- [x] Home stream
- Upcoming events
- Newest topics
- Newest groups
- Newest members

- [x] Group stream
- Upcoming events
- Newest topics
- Newest members

- [x] Profile stream
- Upcoming events
- Recently created topic
- Recently joined groups