### PR TITLE
DS-2157: add local tasks for anonymous user

### DIFF
--- a/modules/social_features/social_core/config/install/block.block.socialbase_local_tasks.yml
+++ b/modules/social_features/social_core/config/install/block.block.socialbase_local_tasks.yml
@@ -23,8 +23,8 @@ visibility:
   user_role:
     id: user_role
     roles:
+      anonymous: anonymous
       authenticated: authenticated
-      administrator: administrator
     negate: false
     context_mapping:
       user: '@user.current_user_context:current_user'


### PR DESCRIPTION
Right now the local tasks are not shown to the Anonymous user. Developers should just be able to change permissions and tabs should be shown accordingly.