### PR TITLE
DS-2157: patch address module - fix installation error due to access level

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,8 @@
                 "Fixes access control on entities": "https://www.drupal.org/files/issues/profile-accesscontrol-2703825-6.patch"
             },
             "drupal/address": {
-                "Fix form errorElement": "https://www.drupal.org/files/issues/address-2619878-29.patch"
+                "Fix form errorElement": "https://www.drupal.org/files/issues/address-2619878-29.patch",
+                "Access level of getDefaultLocale method": "https://www.drupal.org/files/issues/address-2822309.patch"
             },
             "drupal/core": {
                 "Fix region string issue": "https://www.drupal.org/files/issues/2724283-block-22.patch",


### PR DESCRIPTION
See: https://www.drupal.org/node/2822309

I'm not sure what would be the side effect of using this patch with library version 0.7.3. But I guess if you would run composer update on your project it should automatically update to the latest version of commerceguys/intl as well.