### PR TITLE
SSGT-107 by ribel: Fix setting permissions to follow content when there are some additional roles

### DIFF
--- a/modules/social_features/social_follow_content/social_follow_content.install
+++ b/modules/social_features/social_follow_content/social_follow_content.install
@@ -28,7 +28,9 @@ function _social_follow_content_set_permissions() {
     }
 
     $permissions = _social_follow_content_get_permissions($role->id());
-    user_role_grant_permissions($role->id(), $permissions);
+    if(!empty($permissions)){
+      user_role_grant_permissions($role->id(), $permissions);
+    }
   }
 }
 
@@ -46,7 +48,6 @@ function _social_follow_content_get_permissions($role) {
     'flag follow_content',
     'unflag follow_content',
   ));
-
 
   // Content manager.
   $permissions['contentmanager'] = array_merge($permissions['authenticated'], array(


### PR DESCRIPTION
Fix issue when there are some additional roles on the site:
`TypeError: Argument 2 passed to user_role_grant_permissions() must be of the type array, null given, called in /app/html/profiles/contrib/social/modules/social_features/social_follow_content/social_follow_content.install on line 31`