### PR TITLE
DS-2292 by alex.ksis: Add patch to fix fatal error when uploading files

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,6 +37,9 @@
             },
             "drupal/devel": {
                 "Fix vars in function in entity manager wrapper": "https://www.drupal.org/files/issues/fix_entity_manager_wrapper_2749249_5.patch"
+            },
+            "drupal/group": {
+                "Fix fatal error when uploading files for group": "https://www.drupal.org/files/issues/error-when-uploading-files-2793621-5.patch"
             }
         }
     },

--- a/drupal-org.make
+++ b/drupal-org.make
@@ -30,6 +30,7 @@ projects[flag][download][revision] = 6e93e43e1fd220bb5d4fd0153ffb8ba7780013a2
 projects[flag][download][branch] = 8.x-4.x
 projects[group][type] = module
 projects[group][version] = 1.0-beta4
+projects[group][patch][] = "https://www.drupal.org/files/issues/error-when-uploading-files-2793621-5.patch"
 projects[image_widget_crop][type] = module
 projects[image_widget_crop][version] = 1.3
 projects[libraries][type] = module


### PR DESCRIPTION
# HTT
- [x] Reinstall site on this branch.
- [x] Upload image for new group content.
- [x] Save new group content. 
- [x] Check the code.
# Changes
- Fixed calling the cache in Group module.

Here the patch: https://www.drupal.org/node/2793621#comment-11753511
