### PR TITLE
DS-2285 by ribel: Disallow <a> tags from body fields in teasers

### DIFF
--- a/themes/socialbase/templates/field/field.html.twig
+++ b/themes/socialbase/templates/field/field.html.twig
@@ -42,7 +42,7 @@
   {% for item in items %}
     {% if entity_type == "node" %}
       {% if field_name == "body" and part_of_teaser %}
-        {{ item.content|render|striptags('<a>')|raw }}
+        {{ item.content|render|striptags }}
       {% else %}
         {{ item.content }}
       {% endif %}


### PR DESCRIPTION
When adding a link as header in the descriptive text of a book page: it is reflecting in the teaser.