### PR TITLE
SSGT-254 by maikelkoopman: truncate long names in user dropdown

### DIFF
--- a/themes/socialbase/components/asset-builds/css/dropdowns.css
+++ b/themes/socialbase/components/asset-builds/css/dropdowns.css
@@ -157,6 +157,8 @@
   clear: both;
   line-height: 1.5;
   color: #4d4d4d;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .dropdown-menu .divider {

--- a/themes/socialbase/components/components/dropdowns/dropdowns.scss
+++ b/themes/socialbase/components/components/dropdowns/dropdowns.scss
@@ -15,6 +15,8 @@
     clear: both;
     line-height: $line-height-base;
     color: $dropdown-link-color;
+    overflow: hidden;
+    text-overflow: ellipsis;
 
     @include MQ($small) {
       padding: 4px 10px 4px 15px;


### PR DESCRIPTION
How to test: Replace any string in a dropdown with a very long string such as "Global Research Consortium on Economic Structural Transformation (GReCEST)" for the user dropdown in the navbar.