### PR TITLE
DS-2298 by jaapjan: change order of update hooks 

### DIFF
--- a/modules/social_features/social_group/social_group.install
+++ b/modules/social_features/social_group/social_group.install
@@ -10,6 +10,25 @@ use Drupal\field\Entity\FieldStorageConfig;
 use Drupal\Core\Database\Database;
 
 /**
+ * Implements hook_update_dependencies().
+ *
+ * @return mixed
+ */
+function social_group_update_dependencies() {
+  // Indicate that the mymodule_update_8002() function provided by this module
+  // must run before the yet_another_module_update_8005() function provided by
+  // the 'yet_another_module' module. (Note that declaring dependencies in this
+  // direction should be done only in rare situations, since it can lead to the
+  // following problem: If a site has already run the yet_another_module
+  // module's database updates before it updates its codebase to pick up the
+  // newest mymodule code, then the dependency declared here will be ignored.)
+  $dependencies['system'][8200] = array(
+    'social_group' => 8005,
+  );
+  return $dependencies;
+}
+
+/**
  * Implements hook_install().
  *
  * Perform actions related to the installation of social_group.

--- a/modules/social_features/social_group/social_group.install
+++ b/modules/social_features/social_group/social_group.install
@@ -12,16 +12,11 @@ use Drupal\Core\Database\Database;
 /**
  * Implements hook_update_dependencies().
  *
- * @return mixed
+ * @return array
  */
 function social_group_update_dependencies() {
-  // Indicate that the mymodule_update_8002() function provided by this module
-  // must run before the yet_another_module_update_8005() function provided by
-  // the 'yet_another_module' module. (Note that declaring dependencies in this
-  // direction should be done only in rare situations, since it can lead to the
-  // following problem: If a site has already run the yet_another_module
-  // module's database updates before it updates its codebase to pick up the
-  // newest mymodule code, then the dependency declared here will be ignored.)
+  // Necessary because in system_update_8200 all the configuration files are
+  // updated and we delete some modules.
   $dependencies['system'][8200] = array(
     'social_group' => 8005,
   );

--- a/modules/social_features/social_search/social_search.install
+++ b/modules/social_features/social_search/social_search.install
@@ -13,18 +13,14 @@ use Drupal\views\Entity\View;
  * @return array
  */
 function social_search_update_dependencies() {
-  // Indicate that the mymodule_update_8002() function provided by this module
-  // must run before the yet_another_module_update_8005() function provided by
-  // the 'yet_another_module' module. (Note that declaring dependencies in this
-  // direction should be done only in rare situations, since it can lead to the
-  // following problem: If a site has already run the yet_another_module
-  // module's database updates before it updates its codebase to pick up the
-  // newest mymodule code, then the dependency declared here will be ignored.)
+  // Necessary because we delete a view with geolocation filter.
+  // Needs to be done before system_update_8200 and social_group_update_8005.
   $dependencies['social_group'][8005] = array(
     'social_search' => 8102,
   );
   return $dependencies;
 }
+
 /**
  * Implements hook_install().
  *

--- a/modules/social_features/social_search/social_search.install
+++ b/modules/social_features/social_search/social_search.install
@@ -8,6 +8,24 @@ use Drupal\block\Entity\Block;
 use Drupal\views\Entity\View;
 
 /**
+ * Implements hook_update_dependencies().
+ *
+ * @return array
+ */
+function social_search_update_dependencies() {
+  // Indicate that the mymodule_update_8002() function provided by this module
+  // must run before the yet_another_module_update_8005() function provided by
+  // the 'yet_another_module' module. (Note that declaring dependencies in this
+  // direction should be done only in rare situations, since it can lead to the
+  // following problem: If a site has already run the yet_another_module
+  // module's database updates before it updates its codebase to pick up the
+  // newest mymodule code, then the dependency declared here will be ignored.)
+  $dependencies['social_group'][8005] = array(
+    'social_search' => 8102,
+  );
+  return $dependencies;
+}
+/**
  * Implements hook_install().
  *
  * Perform actions related to the installation of social_search.


### PR DESCRIPTION
Necessary to prevent system_update_8200 errors because of deleted modules. As you can see in release notes in beta4 https://www.drupal.org/project/social/releases/8.x-1.0-beta4 we ask to run updatedb twice. Lets try and prevent that for everyone updating from beta2 => beta5.

HTT:

- [ ] Install first in beta2 - make sure you require "commerceguys/intl": "0.7.2", in your require section of your project composer.json and ofcourse the hardcoded 1.0-beta2 version of open_social.
- [ ] Now make a database backup (could be handy)
- [ ] Now update to the latest 8.x-1.x branch and remove the library version of commerceguys/intl from your require section.
- [ ] Run the updated update.sh script, see: https://github.com/goalgorilla/drupal_social/commit/db3d5308b526d1d837f4955e13e495e7b9d6622c
- [ ] You should see errors during the update, also not all update hooks are processed. You can fix it by running the script twice but we dont want that for our users.

Now try again with this branch by:
- [ ] drush sql-drop -y
- [ ] Now update to this branch in your project composer.json.
- [ ] Run the updated update.sh script, see: https://github.com/goalgorilla/drupal_social/commit/db3d5308b526d1d837f4955e13e495e7b9d6622c You should not see any errors and drush fl --bundle=social should be somewhat clean.