### PR TITLE
DS-2331 Remove user local tasks for AN on user register/login/pass reset

### DIFF
--- a/modules/social_features/social_core/social_core.module
+++ b/modules/social_features/social_core/social_core.module
@@ -255,6 +255,20 @@ function social_core_preprocess_block(&$variables) {
  * Implements hook_menu_local_tasks_alter().
  */
 function social_core_menu_local_tasks_alter(&$data, $route_name) {
+  
+  if (\Drupal::currentUser()->isAnonymous()) {
+    // Anonymous user so we unset the user tabs on login register etc.
+    if (isset($data['tabs'][0]['user.register'])) {
+      unset($data['tabs'][0]['user.register']);
+    }
+    if (isset($data['tabs'][0]['user.pass'])) {
+      unset($data['tabs'][0]['user.pass']);
+    }
+    if (isset($data['tabs'][0]['user.login'])) {
+      unset($data['tabs'][0]['user.login']);
+    }
+  }
+
   $node = \Drupal::service('current_route_match')->getParameter('node');
 
   if (!is_null($node) && !is_object($node)) {


### PR DESCRIPTION
# HTT

1. Go to register / login / passreset and see that the secondary navbar is gone as on nightly_build.socialci.goalgorilla.com/user/login

2. See that when logging in everything is fine

3. See that when users for the Distro still want to add custom links to the menu, they will be rendered. 
