### PR TITLE
DS-2183 by jochemvn: Add the required asterisk for required radio button

### DIFF
--- a/themes/socialbase/templates/form/fieldset--radios.html.twig
+++ b/themes/socialbase/templates/form/fieldset--radios.html.twig
@@ -22,8 +22,21 @@
  * @ingroup themeable
  */
 #}
+
+{%-
+set classes = [
+'control-label',
+title_display == 'invisible' ? 'sr-only',
+required ? 'js-form-required',
+required ? 'form-required',
+]
+-%}
+
 <div class="form-group radios">
-  <label>{{ legend.title }}</label>
+  <label{{ attributes.addClass(classes) }}>{{ legend.title }}</label>
+  {%- if required -%}
+    <span class="form-required">*</span>
+  {%- endif -%}
 
   {% if errors %}
     <div>


### PR DESCRIPTION
### HTT

The story described the topic type field. Next to that one the visibility field had the same issue (although a value is preselected). 

- [x] Check topic add and noticed that topic_type and visibility have asterisks now.
- [x] Check create event and page for the asterisks on visibility
- [x] Merge it
