### PR TITLE
DS-2074 by ribel: Add Views sort plugin for passed and upcoming events

### DIFF
--- a/modules/social_features/social_event/config/install/views.view.events.yml
+++ b/modules/social_features/social_event/config/install/views.view.events.yml
@@ -769,10 +769,26 @@ display:
       defaults:
         filters: false
         filter_groups: false
+        sorts: false
       filter_groups:
         operator: AND
         groups:
           1: AND
+      sorts:
+        event_passed_upcoming_sort:
+          id: event_passed_upcoming_sort
+          table: node
+          field: event_passed_upcoming_sort
+          relationship: none
+          group_type: group
+          admin_label: ''
+          order: ASC
+          exposed: false
+          expose:
+            label: ''
+          granularity: minute
+          entity_type: node
+          plugin_id: event_passed_upcoming_sort
     cache_metadata:
       max-age: -1
       contexts:

--- a/modules/social_features/social_event/config/install/views.view.upcoming_events.yml
+++ b/modules/social_features/social_event/config/install/views.view.upcoming_events.yml
@@ -671,12 +671,28 @@ display:
         filters: false
         filter_groups: false
         title: false
+        sorts: false
       filter_groups:
         operator: AND
         groups:
           1: AND
       exposed_block: true
       title: 'Community events'
+      sorts:
+        event_passed_upcoming_sort:
+          id: event_passed_upcoming_sort
+          table: node
+          field: event_passed_upcoming_sort
+          relationship: none
+          group_type: group
+          admin_label: ''
+          order: ASC
+          exposed: false
+          expose:
+            label: ''
+          granularity: minute
+          entity_type: node
+          plugin_id: event_passed_upcoming_sort
     cache_metadata:
       max-age: -1
       contexts:

--- a/modules/social_features/social_event/social_event.module
+++ b/modules/social_features/social_event/social_event.module
@@ -168,9 +168,17 @@ function social_event_views_data_alter(array &$data) {
     'title' => t('Event enrolled or created'),
     'filter' => array(
       'title' => t('Event enrolled or created'),
-      'help' => t('Enable events for on the user profles.'),
+      'help' => t('Enable events for on the user profiles.'),
       'field' => 'field_event',
       'id' => 'event_enrolled_or_created',
+    ),
+  );
+  $data['node']['event_passed_upcoming_sort'] = array(
+    'title' => t('Event sorting (passed and upcoming)'),
+    'help' => t('For upcoming events sort ASC by start date and for passed events change order to DESC.'),
+    'sort' => array(
+      'field' => 'field_event_date_value',
+      'id' => 'event_passed_upcoming_sort',
     ),
   );
 }

--- a/modules/social_features/social_event/src/Plugin/views/sort/EventPassedDesc.php
+++ b/modules/social_features/social_event/src/Plugin/views/sort/EventPassedDesc.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Drupal\social_event\Plugin\views\sort;
+
+use Drupal\views\Plugin\views\sort\Date;
+
+/**
+ * Basic sort handler for passed events.
+ *
+ * @ViewsSort("event_passed_upcoming_sort")
+ */
+class EventPassedDesc extends Date {
+
+  /**
+   * Called to add the sort to a query.
+   */
+  public function query() {
+    $order = ($this->view->exposed_data["{$this->realField}_op"] == '>=') ? 'ASC' : 'DESC';
+    $this->query->addOrderBy($this->tableAlias, $this->realField, $order);
+  }
+}

--- a/modules/social_features/social_group/config/install/views.view.group_events.yml
+++ b/modules/social_features/social_group/config/install/views.view.group_events.yml
@@ -8,6 +8,7 @@ dependencies:
     - datetime
     - group
     - node
+    - social_event
     - user
 id: group_events
 label: 'Group Events'
@@ -241,7 +242,21 @@ display:
             default_group_multiple: {  }
             group_items: {  }
           plugin_id: node_access
-      sorts: {  }
+      sorts:
+        event_passed_upcoming_sort:
+          id: event_passed_upcoming_sort
+          table: node
+          field: event_passed_upcoming_sort
+          relationship: gc__node
+          group_type: group
+          admin_label: ''
+          order: ASC
+          exposed: false
+          expose:
+            label: ''
+          granularity: minute
+          entity_type: node
+          plugin_id: event_passed_upcoming_sort
       title: 'Group Events'
       header: {  }
       footer: {  }

--- a/tests/behat/features/capabilities/event/homepage-community-events.feature
+++ b/tests/behat/features/capabilities/event/homepage-community-events.feature
@@ -48,4 +48,3 @@ Feature: See upcoming events in the community
 
     When I click radio button "Events that have started or are finished"
     And "Behat Event 1" should precede "Behat Event 2" for the query ".card-title"
-    And i break

--- a/tests/behat/features/capabilities/event/homepage-community-events.feature
+++ b/tests/behat/features/capabilities/event/homepage-community-events.feature
@@ -14,7 +14,7 @@ Feature: See upcoming events in the community
     Given event content:
       | title         | field_event_date | status | field_content_visibility |
       | Behat Event 1 | +10 minutes      | 1      | public                   |
-      | Behat Event 2 | +10 minutes      | 1      | public                   |
+      | Behat Event 2 | +20 minutes      | 1      | public                   |
 
     Given I am on the homepage
 
@@ -36,3 +36,16 @@ Feature: See upcoming events in the community
     Then I should see "Community events"
     And I should see "Behat Event 1"
     And I should see "Behat Event 2"
+
+    When I click radio button "Upcoming events"
+    And I press "Filter"
+    And "Behat Event 1" should precede "Behat Event 2" for the query ".card-title"
+
+    Given event content:
+      | title         | field_event_date | status | field_content_visibility |
+      | Behat Event 1 | -10 minutes      | 1      | public                   |
+      | Behat Event 2 | -20 minutes      | 1      | public                   |
+
+    When I click radio button "Events that have started or are finished"
+    And "Behat Event 1" should precede "Behat Event 2" for the query ".card-title"
+    And i break


### PR DESCRIPTION
# HTT
- [x] Go to `/community-events`
- [x] When you see upcoming events you should see events ordered by ASC from current date
- [x] When you see passed events you should see events ordered by DESC from current date
- [x] Check the same for events in Group
- [x] Check the same for events on User Profile