### PR TITLE
DS-2691 by jochemvn: Remove body from book teaser

### DIFF
--- a/modules/social_features/social_book/config/install/core.entity_view_display.node.book.teaser.yml
+++ b/modules/social_features/social_book/config/install/core.entity_view_display.node.book.teaser.yml
@@ -13,20 +13,12 @@ dependencies:
   module:
     - image
     - options
-    - text
     - user
 id: node.book.teaser
 targetEntityType: node
 bundle: book
 mode: teaser
 content:
-  body:
-    label: hidden
-    type: text_summary_or_trimmed
-    weight: 1
-    settings:
-      trim_length: 200
-    third_party_settings: {  }
   field_book_image:
     type: image
     weight: 0
@@ -46,5 +38,6 @@ content:
     settings: {  }
     third_party_settings: {  }
 hidden:
+  body: true
   field_book_comments: true
   field_files: true


### PR DESCRIPTION
## HTT

A bit difficult to test, since in the theme it's already fixed in beta 7 and already the body text is no longer displayed. This story is basically a clean up, since we also don't want to send the body to the teaser if we're not going to display it.

- [x] Start from 8.x-1.x branch

- [x] Install social_book module

- [x] Create a book page and look for it in the search

- [x] Notice that the body text is already NOT showing up there anymore

- [x] Go to manage display >> teaser from the book content type

- [x] Notice that the body is in the teaser

- [x] Switch to this branch

- [x] revert social_book: "drush fr social_book --yes"

- [x] Go to manage display >> teaser from the book content type

- [x] Notice that the body is NO LONGER in the teaser

- [x] merge & drink beer!