### PR TITLE
Issue #2840421 - (event) Managers tab is also shown on other content types

### DIFF
--- a/modules/social_features/social_event/modules/social_event_managers/social_event_managers.module
+++ b/modules/social_features/social_event/modules/social_event_managers/social_event_managers.module
@@ -154,3 +154,29 @@ function social_event_managers_node_access(NodeInterface $node, $op, AccountInte
 
   return SocialEventManagersAccessHelper::getEntityAccessResult($node, $op, $account);
 }
+
+/**
+ * Implements hook_menu_local_tasks_alter().
+ */
+function social_event_managers_menu_local_tasks_alter(&$data, $route_name) {
+  $can_show_managers_link = FALSE;
+  $routes_to_check = [
+    'view.event_enrollments.view_enrollments',
+    'entity.node.canonical',
+    'view.managers.view_managers',
+  ];
+  if (in_array($route_name, $routes_to_check)) {
+    $node = \Drupal::service('current_route_match')->getParameter('node');
+    if (!is_null($node) && (!$node instanceof Node)) {
+      $node = Node::load($node);
+    }
+    if (($node instanceof Node) && $node->getType() === 'event') {
+      $can_show_managers_link = TRUE;
+    }
+
+  }
+  // PLace this here, since hiding it should happen always and not only on the mentioned routes.
+  if (!$can_show_managers_link) {
+    unset($data['tabs'][0]['views_view:view.managers.view_managers']);
+  }
+}

--- a/tests/behat/features/capabilities/event-management/event-management.feature
+++ b/tests/behat/features/capabilities/event-management/event-management.feature
@@ -78,3 +78,10 @@ Feature: Event Management
     And I click "Edit content"
     Then I should see "Save and keep published"
     And I should not see "Authoring information"
+
+    # Regression test for topic
+    Given "topic" content:
+      | title                   | body          |
+      | Topic regression test   | Description   |
+    And I open the "topic" node with title "Topic regression test"
+    Then I should not see the link "Managers"


### PR DESCRIPTION
See: https://www.drupal.org/node/2840421

Fixed it per your suggestion to implement the same hook as we do for the enrollments tab. Also added a regression test.

HTT:

- [x] Enable the social_event_managers feature.
- [x] Go to a topic node and make sure you do not see the Managers tab.
- [x] Verify the tab is still present on nodes of type event.