### PR TITLE
#2842079 - Override disabled public visibility

### DIFF
--- a/modules/custom/entity_access_by_field/entity_access_by_field.install
+++ b/modules/custom/entity_access_by_field/entity_access_by_field.install
@@ -1,0 +1,72 @@
+<?php
+/**
+ * @file
+ * Entity Access By Field module install file.
+ */
+
+
+/**
+ * Implements hook_install().
+ *
+ * Perform actions related to the installation of entity_access_by_field.
+ */
+function entity_access_by_field_install() {
+
+  // Set some default permissions.
+  _entity_access_by_field_set_permissions();
+
+}
+
+/**
+ * Set permissions.
+ */
+function entity_access_by_field_update_8001(&$sandbox) {
+  // Set some default permissions.
+  _entity_access_by_field_set_permissions();
+}
+
+/**
+ * Function to set permissions.
+ */
+function _entity_access_by_field_set_permissions() {
+  $roles = \Drupal\user\Entity\Role::loadMultiple();
+
+  /** @var \Drupal\user\Entity\Role $role */
+  foreach ($roles as $role) {
+    if ($role->id() === 'administrator') {
+      continue;
+    }
+
+    $permissions = _entity_access_by_field_get_permissions($role->id());
+    user_role_grant_permissions($role->id(), $permissions);
+  }
+}
+
+/**
+ * @param $role
+ * @return array
+ */
+function _entity_access_by_field_get_permissions($role) {
+  // Anonymous.
+  $permissions['anonymous'] = array(
+
+  );
+
+  // Authenticated.
+  $permissions['authenticated'] = array_merge($permissions['anonymous'], array(
+
+  ));
+
+
+  // Content manager.
+  $permissions['contentmanager'] = array_merge($permissions['authenticated'], array(
+    'override disabled public visibility',
+  ));
+
+  // Site manager.
+  $permissions['sitemanager'] = array_merge($permissions['contentmanager'], array(
+
+  ));
+
+  return $permissions[$role];
+}

--- a/modules/custom/entity_access_by_field/entity_access_by_field.links.menu.yml
+++ b/modules/custom/entity_access_by_field/entity_access_by_field.links.menu.yml
@@ -1,6 +1,6 @@
 entity_access_by_field.settings:
   title: 'Visibility settings'
-  parent: system.admin_structure
+  parent: social_core.admin.config.social
   description: 'Set who can post public items on this platform.'
   route_name: entity_access_by_field.settings
   weight: 10

--- a/modules/custom/entity_access_by_field/entity_access_by_field.module
+++ b/modules/custom/entity_access_by_field/entity_access_by_field.module
@@ -160,54 +160,43 @@ function entity_access_by_field_form_alter(&$form, \Drupal\Core\Form\FormStateIn
 
   if (isset($form['field_content_visibility']) || isset($form['field_visibility'])) {
 
-    // Load the current user.
-    $account = \Drupal::currentUser();
-    $roles = $account->getRoles();
     // Fetch the data.
     $config = \Drupal::config('entity_access_by_field.settings');
     $data = $config->getRawData();
-    // Check if it's an existing node.
-    $nid = \Drupal::routeMatch()->getRawParameter('node');
+    // Load the current user.
+    $account = \Drupal::currentUser();
 
-    // Edit node, so look at the node owner.
-    /** @var \Drupal\node\Entity\Node $node */
-    if (!empty($nid) && $node = Node::load($nid)) {
-      // Overwrite user.
-      $account = $node->getOwner();
-      $roles = $account->getRoles();
-    }
+    // Check if the option is enabled and the current user has no permission
+    // to override disabled public visibility.
+    if (isset($data['disable_public_visibility']) && $data['disable_public_visibility'] === 1 && !$account->hasPermission('override disabled public visibility')) {
 
-    // Check if this user is auth user only.
-    if (count($roles) == 1 && $roles[0] === \Drupal\user\RoleInterface::AUTHENTICATED_ID) {
+      // This is for nodes.
+      if (isset($form['field_content_visibility'])) {
+        // Some vars for easier reading.
+        $field = &$form['field_content_visibility'];
+        $widget = &$form['field_content_visibility']['widget'];
+        $options = &$form['field_content_visibility']['widget']['#options'];
 
-      // Check if we need to do someting here.
-      if (isset($data['disable_public_visibility']) && $data['disable_public_visibility'] === 1) {
-        // This is for nodes.
-        if (isset($form['field_content_visibility'])) {
-          $widget = &$form['field_content_visibility']['widget'];
-          $options = &$form['field_content_visibility']['widget']['#options'];
-
-          // Remove the public option.
-          unset($options['public']);
-          // Check if the public options is currently selected.
-          if ($widget['#default_value'] === 'public') {
-            $widget['#default_value'] = 'community';
-          }
+        // Remove the public option.
+        unset($options['public']);
+        // Check if the public options is currently selected.
+        if ($widget['#default_value'] === 'public') {
+          // Set the default value to community.
+          $widget['#default_value'] = 'community';
         }
-        // This is for posts.
-        else {
-          $widget = &$form['field_visibility']['widget'][0];
-          $options = &$form['field_visibility']['widget'][0]['#options'];
+      }
+      // This is for posts.
+      else {
+        $widget = &$form['field_visibility']['widget'][0];
+        $options = &$form['field_visibility']['widget'][0]['#options'];
 
-          // Remove the public option.
-          unset($options[1]);
+        // Remove the public option.
+        unset($options[1]);
 
-          // Check if the public options is currently selected.
-          if ($widget['#default_value'] === '1') {
-            $widget['#default_value'] = '2';
-          }
+        // Check if the public options is currently selected.
+        if ($widget['#default_value'] === '1') {
+          $widget['#default_value'] = '2';
         }
-
       }
     }
   }

--- a/modules/custom/entity_access_by_field/entity_access_by_field.permissions.yml
+++ b/modules/custom/entity_access_by_field/entity_access_by_field.permissions.yml
@@ -2,3 +2,5 @@ permission_callbacks:
   - \Drupal\entity_access_by_field\EntityAccessByFieldPermissions::permissions
 administer visibility settings:
   title: 'Administer visiblility settings'
+override disabled public visibility:
+  title: 'Override disabled public visiblility settings'

--- a/modules/custom/entity_access_by_field/entity_access_by_field.routing.yml
+++ b/modules/custom/entity_access_by_field/entity_access_by_field.routing.yml
@@ -1,5 +1,5 @@
 entity_access_by_field.settings:
-  path: '/admin/structure/visibility'
+  path: '/admin/config/opensocial/visibility'
   defaults:
     _form: '\Drupal\entity_access_by_field\Form\EntityVisibilityForm'
     _title: 'Visibility settings'


### PR DESCRIPTION
### Description
When public visibility is disabled for LU, the CM and SM should be able to override this.

### HTT

- [x] Login as an admin
- [x] Disable public visibility: Configuration >> Opensocial Settings >> Visibility settings
- [x]  Go to a node that is placed outside a group (EG: node/8 by chrishall)
- [x] Edit as admin and see you can switch visibility settings between public and community
- [x] Edit as LU and see you cannot switch visibility and it's set to community now (even thought the original value is public)
- [x] Try to save it for both users and check the public topic overview if it shows up or not (depending on with what value you saved it)

- [x] Also notice as a LU you can no longer post public
- [x] For edit posts there's no change since it's not possible to edit visibility settings during edit posts.