### PR TITLE
#2842068 by jochemvn: Alter signup message for existing name or mail

### DIFF
--- a/modules/social_features/social_user/social_user.module
+++ b/modules/social_features/social_user/social_user.module
@@ -20,6 +20,29 @@ function social_user_form_user_register_form_alter(&$form, FormStateInterface $f
   if (isset($form['account']['notify']) && $form['account']['notify']['#access'] === TRUE) {
     $form['account']['notify']['#default_value'] = 1;
   }
+
+  // Add an extra validation option, to check for existing data.
+  $form['#validate'][] = 'social_user_register_validate';
+}
+
+/**
+ * @param $form
+ * @param \Drupal\Core\Form\FormStateInterface $form_state
+ */
+function social_user_register_validate(&$form, FormStateInterface $form_state) {
+
+  // Fetch input.
+  $input = $form_state->getValues();
+
+  // Check if mail or username already exist.
+  if (user_load_by_mail($input['mail']) || user_load_by_name($input['name'])) {
+    // If either the username or mail already exists in the DB, we clear ALL
+    // existing messages, making sure nothing about this is being disclosed.
+    $form_state->clearErrors();
+    // Set a new more general error.
+    $form_state->setErrorByName('mail', t('Due to privacy concerns, the policy of this web site is not to disclose the existence of registered email addresses or usernames. However, if you entered an email address or username that already exists, you will not be able to continue.
+    Please try again, or request a new password. Contact the site administrator if there are any problems.'));
+  }
 }
 
 /**


### PR DESCRIPTION
### Description
When registering on OS with an existing e-mail or username. A message states that that username or e-mail is already in use. In order not to directly disclose such data, a more general message is being show.

### HTT

- [x] Checkout this branch
- [x] Check the code
- [x] Go to the registration page
- [x] Type an e-mail that already exists OR
- [x] Type a username that already exists, OR do both
- [x] Notice there's a message stating the following:
`Due to privacy concerns, the policy of this web site is not to disclose the existence of registered email addresses or usernames. However, if you entered an email address or username that already exists, you will not be able to continue. Please try again, or request a new password. Contact the site administrator if there are any problems.`
 - [x] Eat, sleep, merge, repeat