### PR TITLE
DS-2431 - Social Admin Menu alterations

### DIFF
--- a/modules/custom/social_admin_menu/social_admin_menu.info.yml
+++ b/modules/custom/social_admin_menu/social_admin_menu.info.yml
@@ -1,0 +1,9 @@
+name: Social Admin Menu
+type: module
+description: Social Admin Menu enhancements.
+core: 8.x
+package: Social
+dependencies:
+  - toolbar
+  - admin_toolbar
+  - admin_toolbar_tools

--- a/modules/custom/social_admin_menu/social_admin_menu.module
+++ b/modules/custom/social_admin_menu/social_admin_menu.module
@@ -1,0 +1,41 @@
+<?php
+/**
+ * @file
+ * The Social Admin Menu module.
+ */
+
+/**
+ * Implements hook_toolbar_alter().
+ */
+function social_admin_menu_toolbar_alter(&$items) {
+  $items['administration']['tray']['toolbar_administration']['#pre_render'] = array('social_admin_menu_prerender_toolbar_administration_tray');
+}
+
+/**
+ * Renders the toolbar's administration tray.
+ * This is a clone of core's toolbar_prerender_toolbar_administration_tray()
+ * function, which uses setMaxDepth(4) instead of setTopLevelOnly()
+ * @param array $element
+ *   A renderable array.
+ *
+ * @return array
+ *   The updated renderable array.
+ *
+ * @see admin_toolbar_prerender_toolbar_administration_tray()
+ */
+function social_admin_menu_prerender_toolbar_administration_tray(array $element) {
+  $menu_tree = \Drupal::service('toolbar.menu_tree');
+  $parameters = new \Drupal\Core\Menu\MenuTreeParameters();
+  $parameters->setRoot('system.admin')->excludeRoot()->setMaxDepth(4)->onlyEnabledLinks();
+  $tree = $menu_tree->load(NULL, $parameters);
+  $manipulators = array(
+    array('callable' => 'menu.default_tree_manipulators:checkAccess'),
+    array('callable' => 'menu.default_tree_manipulators:generateIndexAndSort'),
+    array('callable' => 'toolbar_tools_menu_navigation_links'),
+    array('callable' => 'social_admin_menu.administrator_menu_tree_manipulators:checkAccess')
+  );
+  $tree = $menu_tree->transform($tree, $manipulators);
+  $element['administration_menu'] = $menu_tree->build($tree);
+  $element['administration_menu']['#cache']['contexts'][] = 'user.roles';
+  return $element;
+}

--- a/modules/custom/social_admin_menu/social_admin_menu.services.yml
+++ b/modules/custom/social_admin_menu/social_admin_menu.services.yml
@@ -1,0 +1,4 @@
+services:
+  social_admin_menu.administrator_menu_tree_manipulators:
+    class: Drupal\social_admin_menu\Menu\SocialAdminMenuAdministratorMenuLinkTreeManipulators
+    arguments: ['@access_manager', '@current_user', '@entity.query']

--- a/modules/custom/social_admin_menu/src/Menu/SocialAdminMenuAdministratorMenuLinkTreeManipulators.php
+++ b/modules/custom/social_admin_menu/src/Menu/SocialAdminMenuAdministratorMenuLinkTreeManipulators.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Drupal\social_admin_menu\Menu;
+
+use Drupal\Core\Menu\DefaultMenuLinkTreeManipulators;
+
+/**
+ * Provides a couple of menu link tree manipulators.
+ *
+ * This class provides menu link tree manipulators to:
+ * - perform render cached menu-optimized access checking
+ * - optimized node access checking
+ * - generate a unique index for the elements in a tree and sorting by it
+ * - flatten a tree (i.e. a 1-dimensional tree)
+ */
+class SocialAdminMenuAdministratorMenuLinkTreeManipulators extends DefaultMenuLinkTreeManipulators {
+
+  /**
+   * Performs access checks of a menu tree.
+   *
+   * Sets the 'access' property to AccessResultInterface objects on menu link
+   * tree elements. Descends into subtrees if the root of the subtree is
+   * accessible. Inaccessible subtrees are deleted, except the top-level
+   * inaccessible link, to be compatible with render caching.
+   *
+   * (This means that top-level inaccessible links are *not* removed; it is up
+   * to the code doing something with the tree to exclude inaccessible links,
+   * just like MenuLinkTree::build() does. This allows those things to specify
+   * the necessary cacheability metadata.)
+   *
+   * This is compatible with render caching, because of cache context bubbling:
+   * conditionally defined cache contexts (i.e. subtrees that are only
+   * accessible to some users) will bubble just like they do for render arrays.
+   * This is why inaccessible subtrees are deleted, except at the top-level
+   * inaccessible link: if we didn't keep the first (depth-wise) inaccessible
+   * link, we wouldn't be able to know which cache contexts would cause those
+   * subtrees to become accessible again, thus forcing us to conclude that that
+   * subtree is unconditionally inaccessible.
+   *
+   * @param \Drupal\Core\Menu\MenuLinkTreeElement[] $tree
+   *   The menu link tree to manipulate.
+   *
+   * @return \Drupal\Core\Menu\MenuLinkTreeElement[]
+   *   The manipulated menu link tree.
+   */
+  public function checkAccess(array $tree) {
+
+    if ($this->account->id() !== 1) {
+      $account_roles = $this->account->getRoles();
+      // Define routes to hide for a role.
+      // 'content' => 'system.admin_content',
+      // 'structure' => 'system.admin_structure',
+      // 'config' => 'system.admin_config',
+      // 'reports' => 'system.admin_reports',
+      // 'themes' => 'system.themes_page',
+      // 'people' => 'entity.user.collection',
+      // 'help' => 'help.main',
+      $routes = [
+        'contentmanager' => [
+          'config' => 'system.admin_config',
+          'reports' => 'system.admin_reports',
+          'help' => 'help.main',
+        ],
+        'sitemanager' => [
+          'help' => 'help.main',
+        ],
+      ];
+
+      // Define which routes to hide based on hierarchy.
+      if (in_array('sitemanager', $account_roles)) {
+        $hide_routes = $routes['sitemanager'];
+      }
+      elseif (in_array('contentmanager', $account_roles)) {
+        $hide_routes = $routes['contentmanager'];
+      }
+      else {
+        $hide_routes = [];
+      }
+
+      foreach ($tree as $key => $element) {
+        // Always hide the admin_toolbar_tools.help.
+        $plugin_id = $tree[$key]->link->getPluginId();
+        if ($plugin_id === 'admin_toolbar_tools.help') {
+          unset($tree[$key]);
+          continue;
+        }
+
+        $route = $tree[$key]->link->getRouteName();
+        if (in_array($route, $hide_routes)) {
+          unset($tree[$key]);
+          continue;
+        }
+
+      }
+    }
+
+    return $tree;
+  }
+
+}


### PR DESCRIPTION
Currently the admin menu contains a lot of broken links. This is due to issues:
https://www.drupal.org/node/296693
https://www.drupal.org/node/2673914

I think the solution I'm proposing is not the best solution, but it's a good start. I'm hiding some level 0 items to make sure it only contains items a certain role needs. In the future we need to make it a bit smarter and turn the logic around by showing only allowed items.