### PR TITLE
DS-2150 Notification centre improvements

### DIFF
--- a/modules/social_features/social_activity/config/install/message.template.create_comment_author_node_post.yml
+++ b/modules/social_features/social_activity/config/install/message.template.create_comment_author_node_post.yml
@@ -11,6 +11,7 @@ third_party_settings:
     activity_action: create_entitiy_action
     activity_context: owner_activity_context
     activity_destinations:
+      notifications: notifications
       email: email
     activity_create_direct: 1
     activity_aggregate: 0
@@ -21,13 +22,13 @@ description: 'A person commented on a post, topic or event created or organised 
 text:
   -
     format: full_html
-    value: '<p><a href="[message:author:url:absolute]">[message:author:display-name]</a> commented on your <a href="[message:field_message_related_object:entity:url:absolute]">content</a></p>'
+    value: '<p><a href=\"[message:author:url:absolute]\">[message:author:display-name]</a> commented on your <a href="[message:field_message_related_object:entity:url:absolute]">content</a></p>'
   -
     format: full_html
-    value: '<p><a href="[message:author:url:absolute]">[message:author:display-name]</a> commented on your <a href="[message:field_message_related_object:entity:url:absolute]">content</a></p>'
+    value: '<p><a href=\"[message:author:url:absolute]\">[message:author:display-name]</a> commented on your <a href="[message:field_message_related_object:entity:url:absolute]">content</a></p>'
   -
     format: full_html
-    value: '<p><a href="[message:author:url:absolute]">[message:author:display-name]</a> commented on your <a href="[message:field_message_related_object:entity:url:absolute]">content</a></p>'
+    value: '<p><a href=\"[message:author:url:absolute]\">[message:author:display-name]</a> commented on your <a href="[message:field_message_related_object:entity:url:absolute]">content</a></p>'
 settings:
   'token options':
     clear: false

--- a/modules/social_features/social_activity/config/install/message.template.create_comment_post_profile.yml
+++ b/modules/social_features/social_activity/config/install/message.template.create_comment_post_profile.yml
@@ -10,6 +10,7 @@ third_party_settings:
     activity_action: create_entitiy_action
     activity_context: profile_activity_context
     activity_destinations:
+      notifications: notifications
       email: email
     activity_create_direct: 1
     activity_aggregate: 0

--- a/modules/social_features/social_activity/config/install/message.template.create_comment_reply.yml
+++ b/modules/social_features/social_activity/config/install/message.template.create_comment_reply.yml
@@ -10,6 +10,7 @@ third_party_settings:
     activity_action: create_entitiy_action
     activity_context: owner_activity_context
     activity_destinations:
+      notifications: notifications
       email: email
     activity_create_direct: 1
     activity_aggregate: 0

--- a/themes/socialbase/templates/views/views-view-unformatted--activity-stream-notifications--block.html.twig
+++ b/themes/socialbase/templates/views/views-view-unformatted--activity-stream-notifications--block.html.twig
@@ -19,7 +19,7 @@
 #}
 <li>
   <div class="dropdown-header">
-    {% trans %}Notifications{% endtrans %}
+    {% trans %}Notification Centre{% endtrans %}
   </div>
 </li>
 <li class="divider"></li>


### PR DESCRIPTION
See DS-2150

# Acceptance criteria of DS-2150:
- 'Notification' should be renamed to 'Notification Centre' in navbar (dropdown)
- Email notifications that have been build so far, should also be in your Notification Centre
- If the person is currently active on the platform, he will only receive a notification in the Centre, and not via e-mail.

# HTT

- [x] Do an update of 8.x-1.x and a drush fra --bundle=social

- [x] Make sure you login with chrishall and petershaw

- [x] comment on each others profile stream

- [x] Comment with petershaw on http://social.dev/node/10

- [x] Reply with chrishall

- [x] Should give both of the users the correct notifications in the notification centre dropdown (see new title)

- [x] Change settings @ http://social.dev/admin/config/system/activity-send to 0.

- [x] Do it again, see that now you receive notification in the centre and one in your e-mail. Because thats where it checks the offline settings in order to make sure a users session has passed.

