### PR TITLE
2844611 - Modals dont work after update to beta 9

### DIFF
--- a/themes/socialbase/socialbase.info.yml
+++ b/themes/socialbase/socialbase.info.yml
@@ -51,6 +51,9 @@ libraries-extend:
   # attach the bootstrap library script and css component
   bootstrap/popover:
     - socialbase/popover
+  # Extend the bootstrap modal with our own implementation
+  bootstrap/modal:
+    - socialbase/modal
 
 
 


### PR DESCRIPTION
See: https://www.drupal.org/node/2844611

This will fix the CKEditor since modals doesnt work. 
Solution is to extend the bootstrap modal library with our own implementation.