### PR TITLE
Update Address

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,9 +22,6 @@
             "drupal/profile": {
                 "Fixes access control on entities": "https://www.drupal.org/files/issues/profile-accesscontrol-2703825-6.patch"
             },
-            "drupal/address": {
-                "Fix form errorElement": "https://www.drupal.org/files/issues/address-2619878-29.patch"
-            },
             "drupal/core": {
                 "Fix region string issue": "https://www.drupal.org/files/issues/2724283-block-22.patch",
                 "Make sure exposed filters work": "https://www.drupal.org/files/issues/2369119-120.patch",
@@ -50,7 +47,7 @@
         "drupal-composer/drupal-scaffold": "^2.0.0",
         "drupal/core": "8.2.6",
         "drupal/crop": "1.0.0",
-        "drupal/address": "1.0-rc3",
+        "drupal/address": "1.0-rc4",
         "drupal/addtoany": "1.7",
         "drupal/admin_toolbar": "1.18",
         "drupal/config_update": "1.3",


### PR DESCRIPTION
RC4 removes the need for a patch.

Note that if you had any alters targeting the address form element, you'll need to update them, since there's now an address form element used by the widget.