### PR TITLE
#2835114 Group overviews & Blocks have duplicates

### DIFF
--- a/modules/social_features/social_event/config/install/views.view.upcoming_events.yml
+++ b/modules/social_features/social_event/config/install/views.view.upcoming_events.yml
@@ -38,7 +38,7 @@ display:
         type: views_query
         options:
           disable_sql_rewrite: false
-          distinct: false
+          distinct: true
           replica: false
           query_comment: ''
           query_tags: {  }

--- a/modules/social_features/social_event/modules/social_event_type/config/install/views.view.group_events.yml
+++ b/modules/social_features/social_event/modules/social_event_type/config/install/views.view.group_events.yml
@@ -38,7 +38,7 @@ display:
         type: views_query
         options:
           disable_sql_rewrite: false
-          distinct: false
+          distinct: true
           replica: false
           query_comment: ''
           query_tags: {  }

--- a/modules/social_features/social_event/modules/social_event_type/config/install/views.view.upcoming_events.yml
+++ b/modules/social_features/social_event/modules/social_event_type/config/install/views.view.upcoming_events.yml
@@ -40,7 +40,7 @@ display:
         type: views_query
         options:
           disable_sql_rewrite: false
-          distinct: false
+          distinct: true
           replica: false
           query_comment: ''
           query_tags: {  }

--- a/modules/social_features/social_group/config/install/views.view.group_events.yml
+++ b/modules/social_features/social_group/config/install/views.view.group_events.yml
@@ -36,7 +36,7 @@ display:
         type: views_query
         options:
           disable_sql_rewrite: false
-          distinct: false
+          distinct: true
           replica: false
           query_comment: ''
           query_tags: {  }

--- a/modules/social_features/social_group/config/install/views.view.group_topics.yml
+++ b/modules/social_features/social_group/config/install/views.view.group_topics.yml
@@ -36,7 +36,7 @@ display:
         type: views_query
         options:
           disable_sql_rewrite: false
-          distinct: false
+          distinct: true
           replica: false
           query_comment: ''
           query_tags: {  }

--- a/modules/social_features/social_profile/config/install/views.view.newest_users.yml
+++ b/modules/social_features/social_profile/config/install/views.view.newest_users.yml
@@ -34,7 +34,7 @@ display:
         type: views_query
         options:
           disable_sql_rewrite: false
-          distinct: false
+          distinct: true
           replica: false
           query_comment: ''
           query_tags: {  }

--- a/modules/social_features/social_topic/config/install/views.view.latest_topics.yml
+++ b/modules/social_features/social_topic/config/install/views.view.latest_topics.yml
@@ -37,7 +37,7 @@ display:
         type: views_query
         options:
           disable_sql_rewrite: false
-          distinct: false
+          distinct: true
           replica: false
           query_comment: ''
           query_tags: {  }


### PR DESCRIPTION
See https://www.drupal.org/node/2835114#comment-11858863

# HTT

Topics that are posted in a group are presented twice in the group.
Login in as user1 I do not see the duplicated topics, but login in as a normal user (wether I am a member of the group or not) I do see them duplicated. Same goes for SM.
And one last thing, I also see duplicated events in the group. So not just topics.

Make sure there are no duplicates in the group overviews or in any of the streams (LU / Profile / Group stream), also check explore.