### PR TITLE
DS-2956 - Implemented design for top of content detail pages.

### DIFF
--- a/modules/social_features/social_follow_content/config/install/flag.flag.follow_content.yml
+++ b/modules/social_features/social_follow_content/config/install/flag.flag.follow_content.yml
@@ -9,10 +9,10 @@ bundles: {  }
 entity_type: node
 global: false
 weight: 0
-flag_short: Follow
+flag_short: Follow content
 flag_long: ''
 flag_message: ''
-unflag_short: Unfollow
+unflag_short: Unfollow content
 unflag_long: ''
 unflag_message: ''
 unflag_denied_text: ''

--- a/themes/socialbase/assets/css/badges.css
+++ b/themes/socialbase/assets/css/badges.css
@@ -43,7 +43,6 @@
 
 .badge label {
   margin-bottom: 0;
-  cursor: pointer;
   display: -webkit-box;
   display: -ms-flexbox;
   display: flex;
@@ -54,55 +53,53 @@
   overflow: hidden;
 }
 
-.badge--toggle {
-  padding: 0;
-  background-color: transparent;
-  -webkit-transition: width 0.3s ease;
-  transition: width 0.3s ease;
-}
-
-.badge--toggle,
-.badge--toggle * {
-  -webkit-user-select: none;
-     -moz-user-select: none;
-      -ms-user-select: none;
-          user-select: none;
-}
-
-.js .badge--toggle .badge--toggle__label {
-  width: 0;
-  opacity: 0;
-  display: inline-block;
-  -webkit-transition: opacity 0.3s ease;
-  transition: opacity 0.3s ease;
-}
-
-.js .badge--toggle input[type=checkbox]:checked ~ .icon-badge-toggle,
-.js .badge--toggle input[type=checkbox]:checked ~ .badge--toggle__label {
-  background-color: rgba(0, 0, 0, 0.1);
-  color: #4d4d4d;
-}
-
-.js .badge--toggle .badge--toggle__label {
-  border-radius: 0 8px 8px 0;
-}
-
-.js .badge--toggle input[type=checkbox]:checked ~ .badge--toggle__label {
-  width: auto;
-  padding: 4px 12px 4px 6px;
-  opacity: 1;
-}
-
+.badge--likes-count,
+.badge--visibility,
 a.badge--comment-count {
   padding: 0;
 }
 
+.badge--likes-count .icon-badge,
+.badge--visibility .icon-badge,
 a.badge--comment-count .icon-badge {
-  width: 22px;
+  width: 23px;
   height: 18px;
   padding-left: 8px;
 }
 
+.badge--likes-count .icon-badge {
+  margin-top: 2px;
+  fill: transparent !important;
+  stroke: #4d4d4d;
+  stroke-width: 15px;
+}
+
+a.badge--comment-count label:hover {
+  cursor: pointer;
+}
+
+.badge--likes-count__number,
+.badge--visibility__label,
 .badge--comment-count__number {
-  padding: 4px 8px 4px 4px;
+  padding: 5px 10px;
+  font-size: 0.75rem;
+  line-height: 1.5;
+}
+
+.badge--likes-count__text,
+.badge--comment-count__text {
+  padding-right: 10px;
+}
+
+.badge--likes-count__text,
+.badge--comment-count__text {
+  display: none;
+}
+
+@media (min-width: 600px) {
+
+  .badge--likes-count__text,
+  .badge--comment-count__text {
+    display: block;
+  }
 }

--- a/themes/socialbase/assets/css/badges.css
+++ b/themes/socialbase/assets/css/badges.css
@@ -69,9 +69,6 @@ a.badge--comment-count .icon-badge {
 
 .badge--likes-count .icon-badge {
   margin-top: 2px;
-  fill: transparent !important;
-  stroke: #4d4d4d;
-  stroke-width: 15px;
 }
 
 a.badge--comment-count label:hover {

--- a/themes/socialbase/assets/css/badges.css
+++ b/themes/socialbase/assets/css/badges.css
@@ -96,6 +96,49 @@ a.badge--comment-count label:hover {
   display: none;
 }
 
+.badge--toggle {
+  padding: 0;
+  background-color: transparent;
+  -webkit-transition: width 0.3s ease;
+  transition: width 0.3s ease;
+}
+
+.badge--toggle,
+.badge--toggle * {
+  -webkit-user-select: none;
+     -moz-user-select: none;
+      -ms-user-select: none;
+          user-select: none;
+}
+
+.js .badge--toggle .badge--toggle__label {
+  width: 0;
+  opacity: 0;
+  display: inline-block;
+  -webkit-transition: opacity 0.3s ease;
+  transition: opacity 0.3s ease;
+}
+
+.js .badge--toggle input[type=checkbox]:checked ~ .icon-badge-toggle,
+.js .badge--toggle input[type=checkbox]:checked ~ .badge--toggle__label {
+  background-color: rgba(0, 0, 0, 0.1);
+  color: #4d4d4d;
+}
+
+.js .badge--toggle .badge--toggle__label {
+  border-radius: 0 8px 8px 0;
+}
+
+.js .badge--toggle input[type=checkbox]:checked ~ .badge--toggle__label {
+  width: auto;
+  padding: 4px 12px 4px 6px;
+  opacity: 1;
+}
+
+.js .badge--toggle label {
+  cursor: pointer;
+}
+
 @media (min-width: 600px) {
 
   .badge--likes-count__text,

--- a/themes/socialbase/assets/css/meta.css
+++ b/themes/socialbase/assets/css/meta.css
@@ -70,6 +70,7 @@
       flex-basis: 100%;
 }
 
+.metainfo__brief .badge--likes-count,
 .metainfo__brief .badge--visibility,
 .metainfo__brief .badge--comment-count {
   margin-right: 3px;

--- a/themes/socialbase/assets/css/meta.css
+++ b/themes/socialbase/assets/css/meta.css
@@ -5,16 +5,20 @@
   -ms-flex-wrap: wrap;
       flex-wrap: wrap;
   position: relative;
-  margin-bottom: 20px;
+  margin-bottom: 30px;
   line-height: 1.4;
 }
 
 .metainfo__follow {
-  margin-top: 0.5em;
   -ms-flex-preferred-size: 100%;
       flex-basis: 100%;
   -ms-flex-item-align: start;
       align-self: flex-start;
+  padding-bottom: 30px;
+}
+
+.metainfo__follow .flag {
+  display: block;
 }
 
 .metainfo__avatar {
@@ -61,28 +65,36 @@
 }
 
 .metainfo__brief {
-  margin-top: 10px;
+  padding-bottom: 30px;
   -ms-flex-preferred-size: 100%;
       flex-basis: 100%;
 }
 
+.metainfo__brief .badge--visibility,
 .metainfo__brief .badge--comment-count {
   margin-right: 3px;
 }
 
 .article__special-fields {
-  padding: 20px 0;
-  margin-bottom: 20px;
-  border-bottom: 1px solid #e6e6e6;
+  padding: 30px 0;
+  border-top: 1px solid #e6e6e6;
+}
+
+.article__special-fields .article__special-field {
+  margin-bottom: 15px;
+}
+
+.article__special-fields .article__special-field:last-child {
+  margin-bottom: 0;
 }
 
 .article__special-fields .article__special-fields-icon {
-  width: 14px;
-  height: 14px;
-  line-height: 16px;
+  width: 18px;
+  height: 18px;
+  line-height: 20px;
   display: inline-block;
   vertical-align: middle;
-  fill: #555555;
+  fill: #222222;
   margin-right: 12px;
 }
 
@@ -99,8 +111,7 @@
 @media (min-width: 600px) {
 
   .metainfo__follow {
-    -ms-flex-preferred-size: auto;
-    flex-basis: auto;
-    margin-top: 0;
+    float: right;
+    padding-bottom: 0;
   }
 }

--- a/themes/socialbase/assets/css/teaser.css
+++ b/themes/socialbase/assets/css/teaser.css
@@ -110,6 +110,12 @@
   vertical-align: text-bottom;
 }
 
+.teaser__badge .badge--comment-count__number {
+  padding: 4px 8px 4px 4px;
+  font-size: 12px;
+  line-height: 1;
+}
+
 @media (min-width: 600px) {
 
   .teaser {

--- a/themes/socialbase/components/02-atoms/badges/badges.scss
+++ b/themes/socialbase/components/02-atoms/badges/badges.scss
@@ -100,3 +100,46 @@ a.badge--comment-count label:hover {
     display: block;
   }
 }
+
+.badge--toggle {
+  padding: 0;
+  background-color: transparent;
+  transition: width 0.3s ease;
+}
+
+.badge--toggle,
+.badge--toggle * {
+  user-select: none;
+}
+
+// custom badge modifier
+.js .badge--toggle {
+
+  .badge--toggle__label {
+    width: 0;
+    opacity: 0;
+    display: inline-block;
+    transition: opacity 0.3s ease;
+  }
+
+  input[type=checkbox]:checked ~ .icon-badge-toggle,
+  input[type=checkbox]:checked ~ .badge--toggle__label {
+    background-color: rgba(black,0.1); // by using transparency it will also work on gray backgrounds
+    color: $default-color;
+  }
+
+  .badge--toggle__label {
+    border-radius: 0 8px 8px 0;
+  }
+
+  input[type=checkbox]:checked ~ .badge--toggle__label {
+    width: auto;
+    padding: 4px $badge-font-size 4px ($badge-font-size/2);
+    opacity: 1;
+  }
+
+  label {
+    cursor: pointer;
+  }
+
+}

--- a/themes/socialbase/components/02-atoms/badges/badges.scss
+++ b/themes/socialbase/components/02-atoms/badges/badges.scss
@@ -49,63 +49,54 @@
 
 .badge label {
   margin-bottom: 0;
-  cursor: pointer;
   display: flex;
   align-items: center;
   border-radius: 8px;
   overflow: hidden;
 }
 
-.badge--toggle {
-  padding: 0;
-  background-color: transparent;
-  transition: width 0.3s ease;
-}
-
-.badge--toggle,
-.badge--toggle * {
-  user-select: none;
-}
-
-// custom badge modifier
-.js .badge--toggle {
-
-  .badge--toggle__label {
-    width: 0;
-    opacity: 0;
-    display: inline-block;
-    transition: opacity 0.3s ease;
-  }
-
-  input[type=checkbox]:checked ~ .icon-badge-toggle,
-  input[type=checkbox]:checked ~ .badge--toggle__label {
-    background-color: rgba(black,0.1); // by using transparency it will also work on gray backgrounds
-    color: $default-color;
-  }
-
-  .badge--toggle__label {
-    border-radius: 0 8px 8px 0;
-  }
-
-  input[type=checkbox]:checked ~ .badge--toggle__label {
-    width: auto;
-    padding: 4px $badge-font-size 4px ($badge-font-size/2);
-    opacity: 1;
-  }
-
-}
-
+.badge--likes-count,
+.badge--visibility,
 a.badge--comment-count {
   padding: 0;
 
   .icon-badge {
-    width: 22px;
+    width: 23px;
     height: 18px;
     padding-left: 8px;
   }
 
 }
 
+.badge--likes-count .icon-badge {
+  margin-top: 2px;
+  fill: transparent !important;
+  stroke: #4d4d4d;
+  stroke-width: 15px;
+}
+
+a.badge--comment-count label:hover {
+  cursor: pointer;
+}
+
+.badge--likes-count__number,
+.badge--visibility__label,
 .badge--comment-count__number {
-  padding: 4px 8px 4px 4px;
+  padding: 5px 10px;
+  font-size: 0.75rem;
+  line-height: 1.5;
+}
+
+.badge--likes-count__text,
+.badge--comment-count__text {
+  padding-right: 10px;
+}
+
+.badge--likes-count__text,
+.badge--comment-count__text {
+  display: none;
+
+  @include for-tablet-portrait-up {
+    display: block;
+  }
 }

--- a/themes/socialbase/components/02-atoms/badges/badges.scss
+++ b/themes/socialbase/components/02-atoms/badges/badges.scss
@@ -70,9 +70,6 @@ a.badge--comment-count {
 
 .badge--likes-count .icon-badge {
   margin-top: 2px;
-  fill: transparent !important;
-  stroke: #4d4d4d;
-  stroke-width: 15px;
 }
 
 a.badge--comment-count label:hover {

--- a/themes/socialbase/components/03-molecules/teaser/teaser.scss
+++ b/themes/socialbase/components/03-molecules/teaser/teaser.scss
@@ -166,8 +166,15 @@
 .teaser__badge {
   margin-bottom: 0;
   vertical-align: text-bottom;
-}
 
+  // Badges in teasers are reset to a smaller size to align with the styling of the visibility toggle badge.
+  .badge--comment-count__number {
+    padding: 4px 8px 4px 4px;
+    font-size: 12px;
+    line-height: 1;
+  }
+
+}
 
 // Unpublished teaser states
 @include for-tablet-portrait-up {
@@ -202,5 +209,3 @@
   }
 
 }
-
-

--- a/themes/socialbase/components/04-organisms/meta/meta.scss
+++ b/themes/socialbase/components/04-organisms/meta/meta.scss
@@ -68,6 +68,7 @@
   padding-bottom: 30px;
   flex-basis: 100%;
 
+  .badge--likes-count,
   .badge--visibility,
   .badge--comment-count {
     margin-right: 3px;

--- a/themes/socialbase/components/04-organisms/meta/meta.scss
+++ b/themes/socialbase/components/04-organisms/meta/meta.scss
@@ -4,18 +4,22 @@
   display: flex;
   flex-wrap: wrap;
   position: relative;
-  margin-bottom: 20px;
+  margin-bottom: 30px;
   line-height: 1.4;
 }
 
 .metainfo__follow {
-  margin-top: 0.5em;
   flex-basis: 100%;
   align-self: flex-start;
+  padding-bottom: 30px;
+
+  .flag {
+    display: block;
+  }
 
   @include for-tablet-portrait-up {
-    flex-basis: auto;
-    margin-top: 0;
+    float: right;
+    padding-bottom: 0;
   }
 }
 
@@ -61,9 +65,10 @@
 }
 
 .metainfo__brief {
-  margin-top: 10px;
+  padding-bottom: 30px;
   flex-basis: 100%;
 
+  .badge--visibility,
   .badge--comment-count {
     margin-right: 3px;
   }
@@ -71,17 +76,24 @@
 }
 
 .article__special-fields {
-  padding: 20px 0;
-  margin-bottom: 20px;
-  border-bottom: 1px solid $gray-lighter;
+  padding: 30px 0;
+  border-top: 1px solid $gray-lighter;
+
+  .article__special-field {
+    margin-bottom: 15px;
+
+    &:last-child {
+      margin-bottom: 0;
+    }
+  }
 
   .article__special-fields-icon {
-    width: 14px;
-    height: 14px;
-    line-height: 16px;
+    width: 18px;
+    height: 18px;
+    line-height: 20px;
     display: inline-block;
     vertical-align: middle;
-    fill: $gray;
+    fill: $gray-darker;
     margin-right: 12px;
   }
 }

--- a/themes/socialbase/includes/node.inc
+++ b/themes/socialbase/includes/node.inc
@@ -207,10 +207,13 @@ function _socialbase_node_get_comment_count(Node $node, $comment_field_name) {
 function _socialbase_node_get_like_count($type, $id) {
   $count = 0;
 
+  // The result function service needs entity type and entity id in order
+  // to get proper results.
   if (!empty($type) && !empty($id)) {
     $manager = Drupal::service('plugin.manager.votingapi.resultfunction');
     $results = $manager->getResults($type, $id);
 
+    // Lets see if our results carry the sum of all votes.
     if (!empty($results['like']['vote_sum'])) {
       $count = $results['like']['vote_sum'];
     }

--- a/themes/socialbase/includes/node.inc
+++ b/themes/socialbase/includes/node.inc
@@ -1,6 +1,7 @@
 <?php
 
 use Drupal\node\Entity\Node;
+use Drupal\Core\Entity\Entity;
 
 /**
  * Prepares variables for node templates.
@@ -163,6 +164,12 @@ function socialbase_preprocess_node(&$variables) {
     }
   }
 
+  // If we have the like and dislike widget, lets try and get the count in our
+  // node.
+  if (!empty($variables['content']['like_and_dislike'])) {
+    $variables['likes_count'] = _socialbase_node_get_like_count($variables['node']->getEntityTypeId(), $variables['node']->id());
+  }
+
   //Add styles for nodes in preview
   if ($node->in_preview) {
     $variables['#attached']['library'][] = 'socialbase/preview';
@@ -184,6 +191,29 @@ function _socialbase_node_get_comment_count(Node $node, $comment_field_name) {
 
   if ($comment_count) {
     $count = $comment_count;
+  }
+
+  return $count;
+}
+
+/**
+ * Get like count for a node.
+ *
+ * @param $type entity type
+ * @param $id entity id
+ * @return int
+ * @internal param $entity
+ */
+function _socialbase_node_get_like_count($type, $id) {
+  $count = 0;
+
+  if (!empty($type) && !empty($id)) {
+    $manager = Drupal::service('plugin.manager.votingapi.resultfunction');
+    $results = $manager->getResults($type, $id);
+
+    if (!empty($results['like']['vote_sum'])) {
+      $count = $results['like']['vote_sum'];
+    }
   }
 
   return $count;

--- a/themes/socialbase/templates/node/event/node--event--full.html.twig
+++ b/themes/socialbase/templates/node/event/node--event--full.html.twig
@@ -1,26 +1,32 @@
 {% extends "node--full.html.twig" %}
 
 {# add specific fields to body for events only #}
-{% block nodefull_body %}
+{% block nodefull_specialfields %}
 
   <div class="article__special-fields">
-    <div>
+    <div class="article__special-field">
       <svg class="article__special-fields-icon"><use xlink:href="#icon-event"></use></svg>
       <span class="sr-only">{% trans %}Event date {% endtrans %}</span>
-      <span class="inline-center">{{event_date}}</span>
+      <span class="inline-center">
+        <strong>{{event_date}}</strong>
+      </span>
     </div>
     {% if content.field_event_address|render is not empty and content.field_event_location|render is not empty %}
-      <div>
+      <div class="article__special-field">
         <svg class="article__special-fields-icon"><use xlink:href="#icon-location"></use></svg>
         <span class="sr-only">{% trans %}Event location {% endtrans %}</span>
         <span class="inline-center">
-          {{content.field_event_location}}
+          <strong>{{content.field_event_location}}</strong>
           {% if content.field_event_address|render is not empty and content.field_event_location|render is not empty %} &bullet; {% endif %}
           {{content.field_event_address}}
         </span>
       </div>
     {% endif %}
   </div>
+
+{% endblock %}
+
+{% block nodefull_body %}
 
   {{ content|without('field_event_address','field_event_location', 'field_event_type', 'book_navigation', 'flag_follow_content') }}
 

--- a/themes/socialbase/templates/node/node--full.html.twig
+++ b/themes/socialbase/templates/node/node--full.html.twig
@@ -116,48 +116,77 @@
 
         </div>
 
-
-        {% if content.flag_follow_content|render is not empty and logged_in %}
-          <div class="metainfo__follow">
-            {{ content.flag_follow_content }}
-          </div>
-        {% endif %}
-
-        {% if node.isSticky() or comment_field_status is not empty or logged_in %}
-          <div class="metainfo__brief">
-
-            {% if node.isSticky() %}
-              <span class="label label-featured brand-bg-accent">{% trans %}Featured{% endtrans %}</span>
-            {% endif %}
-
-            {% if comment_field_status is not empty %}
-              <a href="#section-comments" class="badge badge--comment-count" title="{% trans %}Total amount of comments{% endtrans %}">
-                <label>
-                  <svg class="icon-small icon-badge">
-                    <use xlink:href="#icon-comment"></use>
-                  </svg>
-                  <span class="badge--comment-count__number">{{ comment_count }}</span>
-                </label>
-              </a>
-            {% endif %}
-
-            {% if visibility_icon and visibility_label %}
-              <div class="badge badge--toggle">
-                <label title="{% trans %}The visibility of this content is set to {% endtrans %} {{ visibility_label }}">
-                  <input type="checkbox">
-                  <svg class="icon-gray icon-badge-toggle">
-                    <use xlink:href="#icon-{{ visibility_icon }}"></use>
-                  </svg>
-                  <span class="badge--toggle__label">{{ visibility_label }}</span>
-                </label>
-              </div>
-            {% endif %}
-
-          </div>
-        {% endif %}
-
       </header>
     {% endblock %}
+
+    {% if event_date %}
+      {% block nodefull_specialfields %}
+        {{ content }}
+      {% endblock %}
+    {% endif %}
+
+    {% if content.flag_follow_content|render is not empty and logged_in %}
+      <div class="metainfo__follow">
+        {{ content.flag_follow_content }}
+      </div>
+    {% endif %}
+
+    {% if node.isSticky() or comment_field_status is not empty or logged_in %}
+      <div class="metainfo__brief">
+
+        {% if node.isSticky() %}
+          <span class="label label-featured brand-bg-accent">{% trans %}Featured{% endtrans %}</span>
+        {% endif %}
+
+        {% if comment_field_status is not empty %}
+          <a href="#section-comments" class="badge badge--comment-count" title="{% trans %}Total amount of comments{% endtrans %}">
+            <label>
+              <svg class="icon-small icon-badge">
+                <use xlink:href="#icon-comment"></use>
+              </svg>
+              <span class="badge--comment-count__number">
+                {{ comment_count }}
+              </span>
+              <span class="badge--comment-count__text">
+                {% if comment_count == 1 %}
+                  {% trans %}comment{% endtrans %}
+                {% else %}
+                  {% trans %}comments{% endtrans %}
+                {% endif %}
+              </span>
+            </label>
+          </a>
+        {% endif %}
+
+        {% if visibility_icon and visibility_label %}
+          <div class="badge badge--visibility">
+            <label title="{% trans %}The visibility of this content is set to {% endtrans %} {{ visibility_label }}">
+              <svg class="icon-small icon-badge">
+                <use xlink:href="#icon-{{ visibility_icon }}"></use>
+              </svg>
+              <span class="badge--visibility__label">{{ visibility_label }}</span>
+            </label>
+          </div>
+        {% endif %}
+
+        {% if content.like_and_dislike %}
+          <div class="badge badge--likes-count">
+            <label>
+              <svg class="icon-small icon-badge">
+                <use xlink:href="#icon-like"></use>
+              </svg>
+              <span class="badge--likes-count__number">
+                33
+              </span>
+              <span class="badge--likes-count__text">
+                likes
+              </span>
+            </label>
+          </div>
+        {% endif %}
+
+      </div>
+    {% endif %}
 
     <div class="body-text">
       {% block nodefull_body %}

--- a/themes/socialbase/templates/node/node--full.html.twig
+++ b/themes/socialbase/templates/node/node--full.html.twig
@@ -165,7 +165,6 @@
                 <use xlink:href="#icon-like"></use>
               </svg>
               <span class="badge--likes-count__number">
-                {% set likes_count = 666 %}
                 {{ likes_count }}
               </span>
               <span class="badge--likes-count__text">

--- a/themes/socialbase/templates/node/node--full.html.twig
+++ b/themes/socialbase/templates/node/node--full.html.twig
@@ -158,17 +158,6 @@
           </a>
         {% endif %}
 
-        {% if visibility_icon and visibility_label %}
-          <div class="badge badge--visibility">
-            <label title="{% trans %}The visibility of this content is set to {% endtrans %} {{ visibility_label }}">
-              <svg class="icon-small icon-badge">
-                <use xlink:href="#icon-{{ visibility_icon }}"></use>
-              </svg>
-              <span class="badge--visibility__label">{{ visibility_label }}</span>
-            </label>
-          </div>
-        {% endif %}
-
         {% if content.like_and_dislike %}
           <div class="badge badge--likes-count">
             <label>
@@ -176,11 +165,23 @@
                 <use xlink:href="#icon-like"></use>
               </svg>
               <span class="badge--likes-count__number">
-                33
+                {% set likes_count = 666 %}
+                {{ likes_count }}
               </span>
               <span class="badge--likes-count__text">
                 likes
               </span>
+            </label>
+          </div>
+        {% endif %}
+
+        {% if visibility_icon and visibility_label %}
+          <div class="badge badge--visibility">
+            <label title="{% trans %}The visibility of this content is set to {% endtrans %} {{ visibility_label }}">
+              <svg class="icon-small icon-badge">
+                <use xlink:href="#icon-{{ visibility_icon }}"></use>
+              </svg>
+              <span class="badge--visibility__label">{{ visibility_label }}</span>
             </label>
           </div>
         {% endif %}

--- a/themes/socialbase/templates/node/node--teaser.html.twig
+++ b/themes/socialbase/templates/node/node--teaser.html.twig
@@ -128,13 +128,12 @@
         {% endif %}
 
         {% if visibility_icon and visibility_label %}
-          <div class="badge badge--toggle teaser__badge">
+          <div class="badge badge--visibility">
             <label title="{% trans %}The visibility of this content is set to {% endtrans %} {{ visibility_label }}">
-              <input type="checkbox">
               <svg class="icon-gray icon-badge-toggle">
                 <use xlink:href="#icon-{{ visibility_icon }}"></use>
               </svg>
-              <span class="badge--toggle__label">{{ visibility_label }}</span>
+              <span class="badge--visibility__label">{{ visibility_label }}</span>
             </label>
           </div>
         {% endif %}

--- a/themes/socialbase/templates/node/node--teaser.html.twig
+++ b/themes/socialbase/templates/node/node--teaser.html.twig
@@ -128,12 +128,13 @@
         {% endif %}
 
         {% if visibility_icon and visibility_label %}
-          <div class="badge badge--visibility">
+          <div class="badge badge--toggle teaser__badge">
             <label title="{% trans %}The visibility of this content is set to {% endtrans %} {{ visibility_label }}">
+              <input type="checkbox">
               <svg class="icon-gray icon-badge-toggle">
                 <use xlink:href="#icon-{{ visibility_icon }}"></use>
               </svg>
-              <span class="badge--visibility__label">{{ visibility_label }}</span>
+              <span class="badge--toggle__label">{{ visibility_label }}</span>
             </label>
           </div>
         {% endif %}

--- a/themes/socialblue/assets/css/badges.css
+++ b/themes/socialblue/assets/css/badges.css
@@ -6,11 +6,15 @@
   font-weight: 300;
 }
 
+.badge--likes-count,
+.badge--visibility,
 a.badge--comment-count {
   background-color: #e6e6e6;
   color: #4d4d4d;
 }
 
+.badge--likes-count .icon-badge,
+.badge--visibility .icon-badge,
 a.badge--comment-count .icon-badge {
   fill: #4d4d4d;
 }

--- a/themes/socialblue/assets/css/badges.css
+++ b/themes/socialblue/assets/css/badges.css
@@ -19,6 +19,12 @@ a.badge--comment-count .icon-badge {
   fill: #4d4d4d;
 }
 
+.badge--likes-count .icon-badge {
+  fill: transparent !important;
+  stroke: #4d4d4d;
+  stroke-width: 15px;
+}
+
 .list-group-item.active > .badge {
   color: #29abe2;
   background-color: #fff;

--- a/themes/socialblue/components/02-atoms/badges/badges.scss
+++ b/themes/socialblue/components/02-atoms/badges/badges.scss
@@ -20,6 +20,12 @@ a.badge--comment-count {
 
 }
 
+.badge--likes-count .icon-badge {
+  fill: transparent !important;
+  stroke: $default-color;
+  stroke-width: 15px;
+}
+
 // Account for badges in navs
 .list-group-item.active > .badge {
   color: $badge-active-color;

--- a/themes/socialblue/components/02-atoms/badges/badges.scss
+++ b/themes/socialblue/components/02-atoms/badges/badges.scss
@@ -8,6 +8,8 @@
   }
 }
 
+.badge--likes-count,
+.badge--visibility,
 a.badge--comment-count {
   background-color: $gray-lighter;
   color: $default-color;


### PR DESCRIPTION
@MaikelGG Communication as per DS-2957: 
Please see if these changes have big impact on the enterprise themes. 

@ronaldtebrake Development as per DS-2955: 
**Likes count badge:** Can you guys see if we can extract the count of the like on that level? I can only manage to print the count inside the like_and_dislike template itself, not in the parent node--full template. I can only print the full widget there.

**Follow button:** Also the button should contain the text "follow content" instead of "follow".

**Date and location formatting:** Frank will let us know tomorrow if the current implementation of the design is feasible. If not (when looking at event_date and event_location strings) then we need a custom formatting function for both event_location and event_date to place the values in the correct markup. 

I'll be on Slack for support. 