### PR TITLE
DS-3164 Improved theme settings also for socialsaas

### DIFF
--- a/modules/custom/improved_theme_settings/improved_theme_settings.module
+++ b/modules/custom/improved_theme_settings/improved_theme_settings.module
@@ -37,13 +37,14 @@ function improved_theme_settings_form_system_theme_settings_alter(&$form, \Drupa
 /**
  * Function that returns the updated color pallete colors with the generated
  * CSS for in the head.
- * @param string $colors
+ * @param string $colors colors from the active theme
+ * @param string $system_theme_settings active theme
  * @return string
  */
-function _improved_theme_settings_update_palette($colors = '') {
+function _improved_theme_settings_update_palette($colors = '', $system_theme_settings = 'socialblue') {
 
   if (empty($colors)) {
-    $colors = color_get_palette('socialblue');
+    $colors = color_get_palette($system_theme_settings);
   }
 
   $primary = $colors['brand-bg-primary'];
@@ -229,76 +230,78 @@ function improved_theme_settings_page_attachments(array &$page) {
   // We render our color & font settings in the head. Only if socialblue is
   // the default theme. And only if the current active theme is socialblue.
   // Otherwise we also render it on all admin pages.
-  if ($system_theme_settings === 'socialblue' && $active_theme == $system_theme_settings) {
-    $style_to_add = '';
-    if (\Drupal::moduleHandler()->moduleExists('social_font')) {
-      // Render font value here.
-      $style_to_add .= social_font_render();
-    }
-
-    $border_radius = Drupal\Component\Utility\Xss::filter(theme_get_setting('border_radius', $system_theme_settings));
-    if (!empty($border_radius) || $border_radius == 0) {
-      $style_to_add .= '
-      .brand-border-radius {
-        border-radius: ' . $border_radius . 'px !important;
+  if ($system_theme_settings === 'socialblue' || $system_theme_settings === 'socialsaas') {
+    if ($active_theme == $system_theme_settings) {
+      $style_to_add = '';
+      if (\Drupal::moduleHandler()->moduleExists('social_font')) {
+        // Render font value here.
+        $style_to_add .= social_font_render();
       }
 
-      .tabs-left .vertical-tabs-list {
-        border-radius: ' . $border_radius . 'px 0 0 ' . $border_radius . 'px !important;
-      }
-
-      .btn {
-        border-radius: ' . $border_radius . 'px !important;
-      }
-
-      .teaser--stream:last-child {
-        border-bottom-left-radius: ' . $border_radius . 'px !important;
-        border-bottom-right-radius: ' . $border_radius . 'px !important;
-      }
-
-      .teaser--stream:last-child .teaser__image {
-        border-bottom-left-radius: ' . $border_radius . 'px !important;
-      }
-
-      .card__nested-section:last-child {
-        border-bottom-left-radius: ' . $border_radius . 'px !important;
-        border-bottom-right-radius: ' . $border_radius . 'px !important;
-      }
-
-      .off-canvas-xs-only {
-        border-radius: ' . $border_radius . 'px !important;
-      }
-
-      @media (min-width: 600px) {
-        .teaser__teaser-type {
-          border-radius: 0 0 ' . $border_radius . 'px 0 !important;
+      $border_radius = Drupal\Component\Utility\Xss::filter(theme_get_setting('border_radius', $system_theme_settings));
+      if (!empty($border_radius) || $border_radius == 0) {
+        $style_to_add .= '
+        .brand-border-radius {
+          border-radius: ' . $border_radius . 'px !important;
         }
+
+        .tabs-left .vertical-tabs-list {
+          border-radius: ' . $border_radius . 'px 0 0 ' . $border_radius . 'px !important;
+        }
+
+        .btn {
+          border-radius: ' . $border_radius . 'px !important;
+        }
+
+        .teaser--stream:last-child {
+          border-bottom-left-radius: ' . $border_radius . 'px !important;
+          border-bottom-right-radius: ' . $border_radius . 'px !important;
+        }
+
+        .teaser--stream:last-child .teaser__image {
+          border-bottom-left-radius: ' . $border_radius . 'px !important;
+        }
+
+        .card__nested-section:last-child {
+          border-bottom-left-radius: ' . $border_radius . 'px !important;
+          border-bottom-right-radius: ' . $border_radius . 'px !important;
+        }
+
+        .off-canvas-xs-only {
+          border-radius: ' . $border_radius . 'px !important;
+        }
+
+        @media (min-width: 600px) {
+          .teaser__teaser-type {
+            border-radius: 0 0 ' . $border_radius . 'px 0 !important;
+          }
+        }
+
+        ';
       }
 
-      ';
-    }
+      // Get the color palette saved for custom social blue
+      $colors = color_get_palette($system_theme_settings);
+      $default = color_get_palette($system_theme_settings, TRUE);
 
-    // Get the color palette saved for custom social blue
-    $colors = color_get_palette('socialblue');
-    $default = color_get_palette('socialblue', TRUE);
+      // Check if there are differences between socialblue default scheme and the
+      // saved palette. If yes we render our extra's in the head too.
+      if (count(array_diff($colors, $default)) > 0) {
+        $style_to_add .= _improved_theme_settings_update_palette($colors, $system_theme_settings);
+      }
 
-    // Check if there are differences between socialblue default scheme and the
-    // saved palette. If yes we render our extra's in the head too.
-    if (count(array_diff($colors, $default)) > 0) {
-      $style_to_add .= _improved_theme_settings_update_palette($colors);
-    }
+      if (!empty($style_to_add)) {
+        $page['#attached']['html_head'][] = [
+          [
+            '#type' => 'html_tag',
+            '#tag' => 'style',
+            '#value' => Drupal\Core\Render\Markup::create($style_to_add),
+          ],
 
-    if (!empty($style_to_add)) {
-      $page['#attached']['html_head'][] = [
-        [
-          '#type' => 'html_tag',
-          '#tag' => 'style',
-          '#value' => Drupal\Core\Render\Markup::create($style_to_add),
-        ],
-
-        // A key, to make it possible to recognize this HTML element when altering.
-        'social_theme_preprocess'
-      ];
+          // A key, to make it possible to recognize this HTML element when altering.
+          'social_theme_preprocess'
+        ];
+      }
     }
   }
 }

--- a/modules/custom/social_font/social_font.module
+++ b/modules/custom/social_font/social_font.module
@@ -34,8 +34,11 @@ function social_font_help($route_name, RouteMatchInterface $route_match) {
 function social_font_render($font_id = NULL) {
 
   if ($font_id == NULL) {
-    $config = \Drupal::config('socialblue.settings');
-    $font_id  = $config->get('font_primary');
+    $system_theme_settings = \Drupal::configFactory()->get('system.theme')->get('default');
+    if ($system_theme_settings == 'socialblue' || $system_theme_settings == 'socialsaas') {
+      $config = \Drupal::config($system_theme_settings . '.settings');
+      $font_id = $config->get('font_primary');
+    }
   }
 
   $font = \Drupal\social_font\Entity\Font::load($font_id);

--- a/themes/socialblue/assets/css/brand.css
+++ b/themes/socialblue/assets/css/brand.css
@@ -1,19 +1,19 @@
 .brand-bg-primary {
-  background-color: #29abe2;
-  border-color: #29abe2;
+  background-color: #29abe2 !important;
+  border-color: #29abe2 !important;
 }
 
 .brand-bg-secondary {
-  background-color: #1f80aa;
-  border-color: #1f80aa;
+  background-color: #1f80aa !important;
+  border-color: #1f80aa !important;
 }
 
 .brand-bg-accent {
-  background-color: #ffc142;
-  border-color: #ffc142;
+  background-color: #ffc142 !important;
+  border-color: #ffc142 !important;
 }
 
 .brand-text-primary {
-  color: #33b5e5;
-  fill: #33b5e5;
+  color: #33b5e5 !important;
+  fill: #33b5e5 !important;
 }

--- a/themes/socialblue/components/02-atoms/brand/brand.scss
+++ b/themes/socialblue/components/02-atoms/brand/brand.scss
@@ -1,21 +1,21 @@
 @import 'settings';
 
 .brand-bg-primary {
-  background-color: $brand-primary;
-  border-color: $brand-primary;
+  background-color: $brand-primary !important;
+  border-color: $brand-primary !important;
 }
 
 .brand-bg-secondary {
-  background-color: $brand-secondary;
-  border-color: $brand-secondary;
+  background-color: $brand-secondary !important;
+  border-color: $brand-secondary !important;
 }
 
 .brand-bg-accent {
-  background-color: $brand-accent;
-  border-color: $brand-accent;
+  background-color: $brand-accent !important;
+  border-color: $brand-accent !important;
 }
 
 .brand-text-primary {
-  color: $brand-info;
-  fill: $brand-info;
+  color: $brand-info !important;
+  fill: $brand-info !important;
 }

--- a/themes/socialblue/theme-settings.php
+++ b/themes/socialblue/theme-settings.php
@@ -6,7 +6,11 @@ function socialblue_form_system_theme_settings_alter(&$form, \Drupal\Core\Form\F
     return;
   }
 
-  $config = \Drupal::config('socialblue.settings');
+  $system_theme_settings = \Drupal::configFactory()->get('system.theme')->get('default');
+
+  if($system_theme_settings == 'socialblue' || $system_theme_settings == 'socialsaas') {
+    $config = \Drupal::config($system_theme_settings . '.settings');
+  }
 
   $form['open_social_settings'] = array(
     '#type' => 'vertical_tabs',


### PR DESCRIPTION
Made sure all the modules now also accept socialsaas as option for the color palette and font / borderradius settings.

# HTT
- [x] install https://bitbucket.org/goalgorilla/socialsaas by git cloning, checkout the branch feature/DS-3164 there so you can also test the changes in the theme. 

- [x] Enable socialsaas as default

- [x] Set default settings, add a font, add color settings see that it works (cache clear though ;) )

- [x] Change the color settings in socialblue, see that still socialsaas works because thats the active theme

- [x] Change the active theme back to socialblue, see that now we use the color settings from socialblue (cache clear though ;) )