### PR TITLE
Issue #2852308 by frankgraave: adjust "new group" when there is more than one group type

### DIFF
--- a/modules/social_features/social_group/src/Plugin/Block/GroupAddBlock.php
+++ b/modules/social_features/social_group/src/Plugin/Block/GroupAddBlock.php
@@ -43,7 +43,7 @@ class GroupAddBlock extends BlockBase {
     $build = [];
 
     //@TODO: Change url and add caching when closed groups will be added.
-    $url = Url::fromUserInput('/group/add/open_group');
+    $url = Url::fromUserInput('/group/add');
     $link_options = array(
       'attributes' => array(
         'class' => array(

--- a/modules/social_features/social_user/src/Plugin/Block/AccountHeaderBlock.php
+++ b/modules/social_features/social_user/src/Plugin/Block/AccountHeaderBlock.php
@@ -66,7 +66,7 @@ class AccountHeaderBlock extends BlockBase {
               'title' => $this->t('Create New Group'),
               'label' => $this->t('New group'),
               'title_classes' => '',
-              'url' => Url::fromUserInput('/group/add/open_group'),
+              'url' => Url::fromUserInput('/group/add'),
             ),
           ),
         ),
@@ -110,29 +110,7 @@ class AccountHeaderBlock extends BlockBase {
           'url' => Url::fromUserInput('/node/add/page'),
         );
       }
-
-      // Get all group types
-      $group_types = \Drupal::entityQuery('group_type')->execute();
-
-      // Check if there are more group_types and alter the url. Permission check is not needed since group module handles it for us!
-      if (count($group_types) >= 2) {
-        $url = Url::fromUserInput('/group/add/');
-      } else {
-        $url = Url::fromUserInput('/group/add/' . $group_types);
-      }
-
-      $links['add']['below']['add_group'] = array(
-        'classes' => '',
-        'link_attributes' => '',
-        'link_classes' => '',
-        'icon_classes' => '',
-        'icon_label' => '',
-        'title' => $this->t('Create New Group'),
-        'label' => $this->t('New group'),
-        'title_classes' => '',
-        'url' => $url,
-      );
-
+      
       if (\Drupal::moduleHandler()->moduleExists('activity_creator')) {
         $notifications_view = views_embed_view('activity_stream_notifications', 'block_1');
         $notifications = \Drupal::service('renderer')->render($notifications_view);

--- a/modules/social_features/social_user/src/Plugin/Block/AccountHeaderBlock.php
+++ b/modules/social_features/social_user/src/Plugin/Block/AccountHeaderBlock.php
@@ -113,32 +113,25 @@ class AccountHeaderBlock extends BlockBase {
 
       // Get all group types
       $group_types = \Drupal::entityQuery('group_type')->execute();
-      // Check if there are more group_types and alter the url.
+
+      // Check if there are more group_types and alter the url. Permission check is not needed since group module handles it for us!
       if (count($group_types) >= 2) {
-        $links['add']['below']['add_group'] = array(
-          'classes' => '',
-          'link_attributes' => '',
-          'link_classes' => '',
-          'icon_classes' => '',
-          'icon_label' => '',
-          'title' => $this->t('Create New Group'),
-          'label' => $this->t('New group'),
-          'title_classes' => '',
-          'url' => Url::fromUserInput('/group/add/'),
-        );
+        $url = Url::fromUserInput('/group/add/');
       } else {
-        $links['add']['below']['add_group'] = array(
-          'classes' => '',
-          'link_attributes' => '',
-          'link_classes' => '',
-          'icon_classes' => '',
-          'icon_label' => '',
-          'title' => $this->t('Create New Group'),
-          'label' => $this->t('New group'),
-          'title_classes' => '',
-          'url' => Url::fromUserInput('/group/add/open_group'),
-        );
+        $url = Url::fromUserInput('/group/add/' . $group_types);
       }
+
+      $links['add']['below']['add_group'] = array(
+        'classes' => '',
+        'link_attributes' => '',
+        'link_classes' => '',
+        'icon_classes' => '',
+        'icon_label' => '',
+        'title' => $this->t('Create New Group'),
+        'label' => $this->t('New group'),
+        'title_classes' => '',
+        'url' => $url,
+      );
 
       if (\Drupal::moduleHandler()->moduleExists('activity_creator')) {
         $notifications_view = views_embed_view('activity_stream_notifications', 'block_1');

--- a/modules/social_features/social_user/src/Plugin/Block/AccountHeaderBlock.php
+++ b/modules/social_features/social_user/src/Plugin/Block/AccountHeaderBlock.php
@@ -111,6 +111,35 @@ class AccountHeaderBlock extends BlockBase {
         );
       }
 
+      // Get all group types
+      $group_types = \Drupal::entityQuery('group_type')->execute();
+      // Check if there are more group_types and alter the url.
+      if (count($group_types) >= 2) {
+        $links['add']['below']['add_group'] = array(
+          'classes' => '',
+          'link_attributes' => '',
+          'link_classes' => '',
+          'icon_classes' => '',
+          'icon_label' => '',
+          'title' => $this->t('Create New Group'),
+          'label' => $this->t('New group'),
+          'title_classes' => '',
+          'url' => Url::fromUserInput('/group/add/'),
+        );
+      } else {
+        $links['add']['below']['add_group'] = array(
+          'classes' => '',
+          'link_attributes' => '',
+          'link_classes' => '',
+          'icon_classes' => '',
+          'icon_label' => '',
+          'title' => $this->t('Create New Group'),
+          'label' => $this->t('New group'),
+          'title_classes' => '',
+          'url' => Url::fromUserInput('/group/add/open_group'),
+        );
+      }
+
       if (\Drupal::moduleHandler()->moduleExists('activity_creator')) {
         $notifications_view = views_embed_view('activity_stream_notifications', 'block_1');
         $notifications = \Drupal::service('renderer')->render($notifications_view);


### PR DESCRIPTION
Related issue: [2852308](https://www.drupal.org/node/2852308)

When there is more than one group type available, the url to create a new group directs the user to an overview with group types. 

## HTT
- [x] 1. Log in as admin and create a new group type.
- [x] 2. Go incognito as any demo user, click the [+] icon in the nav to create a new group _(hovering "New Group" should say /group/add)_.
- [x] 3. Notice how you are being redirected to /group/add/open_group.
- [x] 4. As admin, give permissions for the new group type to LU
- [x] 5. Repeat step 2 and 3 and see the overview.