### PR TITLE
#2856934 - wrong notification text for comments on posts

### DIFF
--- a/modules/social_features/social_like/social_like.tokens.inc
+++ b/modules/social_features/social_like/social_like.tokens.inc
@@ -63,7 +63,8 @@ function social_like_tokens($type, $tokens, array $data, array $options, Bubblea
               // Then get the bundle name
               $content_type = $entity->bundle();
             }
-            $replacements[$original] = $entity->bundle();
+
+            $replacements[$original] = $content_type;
             break;
 
         }


### PR DESCRIPTION
# HTT
1. Create a post as Chrishall
2. Comment on this post as chrishall
3. Login as admin and like both the post_comment and the post
4. See that as chrishall you get a notification admin likes your comment and admin likes your post
5. Also check that for nodes you still see event/topic