### PR TITLE
DS-3189 by frankgraave: more logical scentence for activity items

### DIFF
--- a/modules/social_features/social_mentions/config/install/message.template.create_mention_comment.yml
+++ b/modules/social_features/social_mentions/config/install/message.template.create_mention_comment.yml
@@ -11,7 +11,6 @@ third_party_settings:
     activity_context: mention_activity_context
     activity_destinations:
       notifications: notifications
-      stream_profile: stream_profile
       email: email
     activity_create_direct: 1
     activity_aggregate: 0

--- a/modules/social_features/social_mentions/config/install/message.template.create_mention_comment_stream.yml
+++ b/modules/social_features/social_mentions/config/install/message.template.create_mention_comment_stream.yml
@@ -1,0 +1,29 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - activity_logger
+third_party_settings:
+  activity_logger:
+    activity_bundle_entities:
+      mentions-mentions: mentions-mentions
+    activity_action: create_entitiy_action
+    activity_context: mention_activity_context
+    activity_destinations:
+      stream_profile: stream_profile
+    activity_create_direct: 1
+    activity_aggregate: 0
+    activity_entity_condition: mention_comment
+template: create_mention_comment_stream
+label: 'Create mention in a comment (stream: profile)'
+description: 'A person mentioned me in a comment (stream: profile)'
+text:
+  -
+    value: "<p><a href=\"relative]\">[message:author:display-name]</a> mentioned<a href=\"\"> [social_mentions:mentioned_user] </a>in a comment</p>\r\n"
+    format: basic_html
+settings:
+  'token options':
+    clear: false
+    'token replace': true
+  purge_override: false
+  purge_methods: {  }

--- a/modules/social_features/social_mentions/config/install/message.template.create_mention_comment_stream.yml
+++ b/modules/social_features/social_mentions/config/install/message.template.create_mention_comment_stream.yml
@@ -19,7 +19,7 @@ label: 'Create mention in a comment (stream: profile)'
 description: 'A person mentioned me in a comment (stream: profile)'
 text:
   -
-    value: "<p><a href=\"relative]\">[message:author:display-name]</a> mentioned<a href=\"\"> [social_mentions:mentioned_user] </a>in a comment</p>\r\n"
+    value: "<p><a href=\"\">[message:author:display-name]</a> mentioned<a href=\"\"> [social_mentions:mentioned_user] </a>in a comment</p>\r\n"
     format: basic_html
 settings:
   'token options':

--- a/modules/social_features/social_mentions/config/install/message.template.create_mention_post.yml
+++ b/modules/social_features/social_mentions/config/install/message.template.create_mention_post.yml
@@ -11,7 +11,6 @@ third_party_settings:
     activity_context: mention_activity_context
     activity_destinations:
       notifications: notifications
-      stream_profile: stream_profile
       email: email
     activity_create_direct: 1
     activity_aggregate: 0

--- a/modules/social_features/social_mentions/config/install/message.template.create_mention_post_stream.yml
+++ b/modules/social_features/social_mentions/config/install/message.template.create_mention_post_stream.yml
@@ -1,0 +1,29 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - activity_logger
+third_party_settings:
+  activity_logger:
+    activity_bundle_entities:
+      mentions-mentions: mentions-mentions
+    activity_action: create_entitiy_action
+    activity_context: mention_activity_context
+    activity_destinations:
+      stream_profile: stream_profile
+    activity_create_direct: 1
+    activity_aggregate: 0
+    activity_entity_condition: mention_post
+template: create_mention_post_stream
+label: 'Create mention in a post (stream: profile)'
+description: 'A person mentioned me in a post (stream: profile)'
+text:
+  -
+    value: "<p><a href=\"relative]\">[message:author:display-name]</a> mentioned <a href=\"\">[social_mentions:mentioned_user]</a> in a post</p>\r\n"
+    format: basic_html
+settings:
+  'token options':
+    clear: false
+    'token replace': true
+  purge_override: false
+  purge_methods: {  }

--- a/modules/social_features/social_mentions/config/install/message.template.create_mention_post_stream.yml
+++ b/modules/social_features/social_mentions/config/install/message.template.create_mention_post_stream.yml
@@ -19,7 +19,7 @@ label: 'Create mention in a post (stream: profile)'
 description: 'A person mentioned me in a post (stream: profile)'
 text:
   -
-    value: "<p><a href=\"relative]\">[message:author:display-name]</a> mentioned <a href=\"\">[social_mentions:mentioned_user]</a> in a post</p>\r\n"
+    value: "<p><a href=\"\">[message:author:display-name]</a> mentioned <a href=\"\">[social_mentions:mentioned_user]</a> in a post</p>\r\n"
     format: basic_html
 settings:
   'token options':

--- a/modules/social_features/social_mentions/social_mentions.module
+++ b/modules/social_features/social_mentions/social_mentions.module
@@ -194,16 +194,3 @@ function social_mentions_form_mentions_settings_form_submit($form, FormStateInte
   $config->set('suggestions_format', $form_state->getValue('suggestions_format'));
   $config->save();
 }
-
-/**
- * Implements hook_preprocess().
- */
-function social_mentions_preprocess_page(&$variables, $hook) {
-
-  $mention = \Drupal::entityTypeManager()
-    ->getStorage('mentions')
-    ->load('14');
-
-  dpm($mention);
-
-}

--- a/modules/social_features/social_mentions/social_mentions.module
+++ b/modules/social_features/social_mentions/social_mentions.module
@@ -194,3 +194,16 @@ function social_mentions_form_mentions_settings_form_submit($form, FormStateInte
   $config->set('suggestions_format', $form_state->getValue('suggestions_format'));
   $config->save();
 }
+
+/**
+ * Implements hook_preprocess().
+ */
+function social_mentions_preprocess_page(&$variables, $hook) {
+
+  $mention = \Drupal::entityTypeManager()
+    ->getStorage('mentions')
+    ->load('14');
+
+  dpm($mention);
+
+}

--- a/modules/social_features/social_mentions/social_mentions.tokens.inc
+++ b/modules/social_features/social_mentions/social_mentions.tokens.inc
@@ -17,6 +17,11 @@ function social_mentions_token_info() {
     'needs-data' => 'profile',
   ];
 
+  $social_mentions['mentioned_user'] = [
+    'name' => t('Get the mentioned user'),
+    'description' => t('Display the mentioned user in a post'),
+  ];
+
   $social_mentions['user_name'] = [
     'name' => t('User name'),
     'description' => t('First and last name or username, depends on settings.'),
@@ -60,6 +65,35 @@ function social_mentions_tokens($type, $tokens, array $data, array $options, Bub
           }
 
           $replacements[$original] = $user_name;
+          break;
+
+      }
+    }
+  }
+
+  if ($type == 'social_mentions' && !empty($data['message'])) {
+    /** @var \Drupal\message\Entity\Message $message */
+    $message = $data['message'];
+
+    foreach ($tokens as $name => $original) {
+      switch ($name) {
+
+        case 'mentioned_user':
+
+          if($name === 'mentioned_user') {
+            if (isset($message->field_message_related_object)) {
+              $target_type = $message->field_message_related_object->target_type;
+              $target_id = $message->field_message_related_object->target_id;
+              $mention = \Drupal::entityTypeManager()
+                ->getStorage($target_type)
+                ->load($target_id);
+
+              if ($mention->getEntityTypeId() == 'mentions') {
+//                $replacements[$original] = $mention;
+              }
+            }
+          }
+
           break;
       }
     }

--- a/modules/social_features/social_mentions/social_mentions.tokens.inc
+++ b/modules/social_features/social_mentions/social_mentions.tokens.inc
@@ -89,7 +89,10 @@ function social_mentions_tokens($type, $tokens, array $data, array $options, Bub
                 ->load($target_id);
 
               if ($mention->getEntityTypeId() == 'mentions') {
-//                $replacements[$original] = $mention;
+                $loadUserId = \Drupal\user\Entity\User::load($mention->get('uid')->target_id);
+                $user = $loadUserId->getDisplayName();
+
+                $replacements[$original] = $user;
               }
             }
           }

--- a/modules/social_features/social_mentions/social_mentions.tokens.inc
+++ b/modules/social_features/social_mentions/social_mentions.tokens.inc
@@ -89,7 +89,7 @@ function social_mentions_tokens($type, $tokens, array $data, array $options, Bub
                 ->load($target_id);
 
               if ($mention->getEntityTypeId() == 'mentions') {
-                $loadUserId = \Drupal\user\Entity\User::load($mention->get('uid')->target_id);
+                $loadUserId = \Drupal\user\Entity\User::load($mention->getMentionedUserID());
                 $user = $loadUserId->getDisplayName();
 
                 $replacements[$original] = $user;

--- a/tests/behat/features/capabilities/mention/mention-comment.feature
+++ b/tests/behat/features/capabilities/mention/mention-comment.feature
@@ -18,5 +18,5 @@ Feature: Create Mention in a Comment
     And I should see "user_2, user_3, see my comment." in the "Main content"
     And I should see the link "user_2"
     When I click "user_3"
-    Then I should see "Albert Einstein mentioned you in a comment"
+    Then I should see "Albert Einstein mentioned Stephen Hawking in a comment"
     And I should see "user_2, user_3, see my comment."

--- a/tests/behat/features/capabilities/mention/mention-post.feature
+++ b/tests/behat/features/capabilities/mention/mention-post.feature
@@ -18,5 +18,5 @@ Feature: Create Mention in a Post
     And I should see "Hello user_2, user_3!"
     And I should see the link "user_3"
     When I click "user_2"
-    Then I should see "Albert Einstein mentioned you in a post"
+    Then I should see "Albert Einstein mentioned Isaac Newton in a post"
     And I should see "Hello user_2, user_3!"


### PR DESCRIPTION
As a LU, I want to see a logical sentence for all activity items (no more pronouns "you", but only username)

## HTT

- [x] Checkout to this branch
- [x] drush fra -y --bundle=social
- [x] Log in as any demo user
- [x] Create a post and mention any other demo user in it
- [x] Also comment on the post with a mention
- [x] Log in as the mentioned user and go to your profile stream
- [x] See the more logical scentences (no more "you", but the actual username)