### PR TITLE
#2852602 by peterpolman: Added missing color configurations except ck…

### DIFF
--- a/modules/custom/improved_theme_settings/improved_theme_settings.module
+++ b/modules/custom/improved_theme_settings/improved_theme_settings.module
@@ -103,7 +103,9 @@ function _improved_theme_settings_update_palette($colors = '') {
       }
     }
 
-    #navbar-search.is-open .search-icon, .no-js #navbar-search .search-icon {
+    .hero-form[role='search'] .search-icon,
+    #navbar-search.is-open .search-icon,
+    .no-js #navbar-search .search-icon {
       fill: $primary !important;
     }
 
@@ -187,10 +189,6 @@ function _improved_theme_settings_update_palette($colors = '') {
     .navbar-default .dropdown-menu > .active > a,
     .navbar-default .dropdown-menu > .active > a:hover,
     .navbar-default .dropdown-menu > .active > a:focus {
-      background-color: $primary !important;
-    }
-
-    .cover.brand-bg-primary {
       background-color: $primary !important;
     }
 

--- a/themes/socialbase/templates/layout/page.html.twig
+++ b/themes/socialbase/templates/layout/page.html.twig
@@ -106,7 +106,7 @@
 </main>
 
 {% if page.footer %}
-  <footer class="site-footer" role="contentinfo">
+  <footer class="site-footer brand-bg-secondary" role="contentinfo">
     <div class="container clearfix">
       {{ page.footer }}
     </div>


### PR DESCRIPTION
# HTT

- Logo background color in hover state (https://www.screencast.com/t/asJlntrh)
- User profile hero area color (https://www.screencast.com/t/NAHa0A2LbzZk)
- Footer bar (https://www.screencast.com/t/kOnqwuJJMcDx)
- Search hero color (https://www.screencast.com/t/xcshnMVY8v)
- Bookmodule table of content

Should al follow the set color configuration.

# Note 

- WYSIWYG link text (https://www.screencast.com/t/67EXRv7j)
This is currently not possible because the iframe only holds 1 css file (ckeditor.css) and we do no change the color hexadecimals in this file.