### PR TITLE
Correct path for retina version of file icon

### DIFF
--- a/themes/socialbase/templates/file/file-link.html.twig
+++ b/themes/socialbase/templates/file/file-link.html.twig
@@ -18,14 +18,14 @@
   <span{{ attributes }}>
 
   {% if icon_only %}
-    <span class="file-icon"><img class="node-file__icon" src="/{{ path_to_socialbase }}/assets/images/mime-icons/icon_1_{{ node_icon }}_x16.png" srcset="icon_1_{{ node_icon }}_x32.png 2x" alt="{{ node_icon }}" /></span>
+    <span class="file-icon"><img class="node-file__icon" src="/{{ path_to_socialbase }}/assets/images/mime-icons/icon_1_{{ node_icon }}_x16.png" srcset="/{{ path_to_socialbase }}/assets/images/mime-icons/icon_1_{{ node_icon }}_x32.png 2x" alt="{{ node_icon }}" /></span>
     <span class="sr-only">
       <span class="file-link">{{ link }}</span>
       <span class="file-size">{{ file_size }}</span>
     </span>
   {% else %}
 
-      <span class="file-icon"><img class="node-file__icon" src="/{{ path_to_socialbase }}/assets/images/mime-icons/icon_1_{{ node_icon }}_x16.png" srcset="icon_1_{{ node_icon }}_x32.png 2x" alt="{{ node_icon }}" /></span><span class="file-link">{{ link }}</span><span class="file-size">{{ file_size }}</span>
+      <span class="file-icon"><img class="node-file__icon" src="/{{ path_to_socialbase }}/assets/images/mime-icons/icon_1_{{ node_icon }}_x16.png" srcset="/{{ path_to_socialbase }}/assets/images/mime-icons/icon_1_{{ node_icon }}_x32.png 2x" alt="{{ node_icon }}" /></span><span class="file-link">{{ link }}</span><span class="file-size">{{ file_size }}</span>
 
   {% endif %}
 


### PR DESCRIPTION
The file icon doesn't display on retina screen, because the src is missing the correct path.