### PR TITLE
Core update 8.2.7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
         "cweagans/composer-patches": "^1.5.0",
         "composer/installers": "^1.0",
         "drupal-composer/drupal-scaffold": "^2.0.0",
-        "drupal/core": "8.2.6",
+        "drupal/core": "8.2.7",
         "drupal/crop": "1.0.0",
         "drupal/address": "1.0-rc4",
         "drupal/addtoany": "1.7",

--- a/drupal-org-core.make
+++ b/drupal-org-core.make
@@ -1,7 +1,7 @@
 api = 2
 core = 8.x
 projects[drupal][type] = core
-projects[drupal][version] = 8.2.6
+projects[drupal][version] = 8.2.7
 projects[drupal][patch][] = "https://www.drupal.org/files/issues/2724283-block-22.patch"
 projects[drupal][patch][] = "https://www.drupal.org/files/issues/2369119-120.patch"
 projects[drupal][patch][] = "https://www.drupal.org/files/issues/728702-163.patch"


### PR DESCRIPTION
https://www.drupal.org/SA-2017-001

We could also consider merging to a separate branch, but considering the sprint is just started 8.x-1.x is still identical to 1.0.0-beta13