### PR TITLE
DS-2866 by ronaldtebrake: Change placeholder text for posts based on context

### DIFF
--- a/modules/social_features/social_post/social_post.module
+++ b/modules/social_features/social_post/social_post.module
@@ -24,6 +24,22 @@ function social_post_form_post_form_alter(&$form, FormStateInterface $form_state
 
   // Set submit button caption to Post instead of Save.
   $form['actions']['submit']['#value'] = t('Post');
+
+  if (!empty($form['field_post']) && !empty($form['field_post']['widget'][0])) {
+    // For posting on the stream on the group stream.
+    if (!empty(_social_group_get_current_group())) {
+      $form['field_post']['widget'][0]['#placeholder'] = t('Say something to the group');
+    }
+    // For the post on a users profile.
+    elseif (!empty(\Drupal::routeMatch()->getParameter('user'))) {
+      $user_profile = \Drupal::routeMatch()->getParameter('user');
+      $name = $user_profile->getDisplayName();
+      $form['field_post']['widget'][0]['#placeholder'] = t('Leave a message to ') . $name;
+    }
+    else {
+      $form['field_post']['widget'][0]['#placeholder'] = t('Say something to the Community');
+    }
+  }
 }
 
 /**

--- a/tests/behat/features/capabilities/like/like-post-stream.feature
+++ b/tests/behat/features/capabilities/like/like-post-stream.feature
@@ -13,7 +13,7 @@ Feature: Like post stream
 
     Given I am logged in as "user_1"
     And I am on the profile of "user_2"
-    And I fill in "Leave a message to Albert Einstein" with "This is a post by Albert Einstein for Isaac Newton."
+    And I fill in "Leave a message to Isaac Newton" with "This is a post by Albert Einstein for Isaac Newton."
     And I press "Post"
     Then I should see the success message "Your post has been posted."
 
@@ -36,7 +36,7 @@ Feature: Like post stream
       | user_1   | mail_1@example.com | 1      | Albert                   | Einstein                |
     Given I am logged in as "user_1"
     And I am on the homepage
-    When I fill in "Say something to the community" with "This is a public post."
+    When I fill in "Say something to the Community" with "This is a public post."
     And I select post visibility "Public"
     And I press "Post"
     Then I should see the success message "Your post has been posted."

--- a/tests/behat/features/capabilities/like/like-post-stream.feature
+++ b/tests/behat/features/capabilities/like/like-post-stream.feature
@@ -13,7 +13,7 @@ Feature: Like post stream
 
     Given I am logged in as "user_1"
     And I am on the profile of "user_2"
-    And I fill in "What's on your mind?" with "This is a post by Albert Einstein for Isaac Newton."
+    And I fill in "Leave a message to Albert Einstein" with "This is a post by Albert Einstein for Isaac Newton."
     And I press "Post"
     Then I should see the success message "Your post has been posted."
 
@@ -36,7 +36,7 @@ Feature: Like post stream
       | user_1   | mail_1@example.com | 1      | Albert                   | Einstein                |
     Given I am logged in as "user_1"
     And I am on the homepage
-    When I fill in "What's on your mind?" with "This is a public post."
+    When I fill in "Say something to the community" with "This is a public post."
     And I select post visibility "Public"
     And I press "Post"
     Then I should see the success message "Your post has been posted."

--- a/tests/behat/features/capabilities/mention/mention-post.feature
+++ b/tests/behat/features/capabilities/mention/mention-post.feature
@@ -12,7 +12,7 @@ Feature: Create Mention in a Post
       | user_3   | mail_3@example.com | 1      | Stephen                  | Hawking                 |
     And I am logged in as "user_1"
     And I am on the homepage
-    And I fill in "What's on your mind?" with "Hello [~user_2], [~user_3]!"
+    And I fill in "Say something to the community" with "Hello [~user_2], [~user_3]!"
     And I press "Post"
     Then I should see "Albert Einstein posted"
     And I should see "Hello user_2, user_3!"

--- a/tests/behat/features/capabilities/mention/mention-post.feature
+++ b/tests/behat/features/capabilities/mention/mention-post.feature
@@ -12,7 +12,7 @@ Feature: Create Mention in a Post
       | user_3   | mail_3@example.com | 1      | Stephen                  | Hawking                 |
     And I am logged in as "user_1"
     And I am on the homepage
-    And I fill in "Say something to the community" with "Hello [~user_2], [~user_3]!"
+    And I fill in "Say something to the Community" with "Hello [~user_2], [~user_3]!"
     And I press "Post"
     Then I should see "Albert Einstein posted"
     And I should see "Hello user_2, user_3!"

--- a/tests/behat/features/capabilities/post/post-comments.feature
+++ b/tests/behat/features/capabilities/post/post-comments.feature
@@ -13,7 +13,7 @@ Feature: Comment on a Post
     And I am on the homepage
 
         # Scenario: Succesfully create a private post
-   When I fill in "Say something to the community" with "This is a community post."
+   When I fill in "Say something to the Community" with "This is a community post."
     And I select post visibility "Community"
     And I press "Post"
    Then I should see the success message "Your post has been posted."

--- a/tests/behat/features/capabilities/post/post-comments.feature
+++ b/tests/behat/features/capabilities/post/post-comments.feature
@@ -13,7 +13,7 @@ Feature: Comment on a Post
     And I am on the homepage
 
         # Scenario: Succesfully create a private post
-   When I fill in "What's on your mind?" with "This is a community post."
+   When I fill in "Say something to the community" with "This is a community post."
     And I select post visibility "Community"
     And I press "Post"
    Then I should see the success message "Your post has been posted."

--- a/tests/behat/features/capabilities/post/post-create.feature
+++ b/tests/behat/features/capabilities/post/post-create.feature
@@ -12,7 +12,7 @@ Feature: Create Post
     And I am logged in as "PostCreateUser1"
     And I am on the homepage
   And I should not see "PostCreateUser1" in the "Main content front"
-  When I fill in "What's on your mind?" with "This is a public post."
+  When I fill in "Say something to the community" with "This is a public post."
     And I select post visibility "Public"
     And I press "Post"
    Then I should see the success message "Your post has been posted."
@@ -21,7 +21,7 @@ Feature: Create Post
     And I should be on "/stream"
 
         # Scenario: Succesfully create a private post
-   When I fill in "What's on your mind?" with "This is a community post."
+   When I fill in "Say something to the community" with "This is a community post."
     And I select post visibility "Community"
     And I press "Post"
    Then I should see the success message "Your post has been posted."
@@ -32,7 +32,7 @@ Feature: Create Post
         # Scenario: edit the post
    When I click the xth "5" element with the css ".dropdown-toggle"
     And I click "Edit"
-    And I fill in "What's on your mind?" with "This is a community post edited."
+    And I fill in "Say something to the community" with "This is a community post edited."
     And I press "Post"
    Then I should see the success message "Your post has been saved."
 
@@ -43,7 +43,7 @@ Feature: Create Post
 
         # Scenario: Post on someones profile stream
   Given I am on the profile of "PostCreateUser2"
-   When I fill in "What's on your mind?" with "This is a post by PostCreateUser1 for PostCreateUser2."
+   When I fill in "Leave a message to PostCreateUser2" with "This is a post by PostCreateUser1 for PostCreateUser2."
     And I press "Post"
    Then I should see the success message "Your post has been posted."
     And I should see "This is a post by PostCreateUser1 for PostCreateUser2."

--- a/tests/behat/features/capabilities/post/post-create.feature
+++ b/tests/behat/features/capabilities/post/post-create.feature
@@ -12,7 +12,7 @@ Feature: Create Post
     And I am logged in as "PostCreateUser1"
     And I am on the homepage
   And I should not see "PostCreateUser1" in the "Main content front"
-  When I fill in "Say something to the community" with "This is a public post."
+  When I fill in "Say something to the Community" with "This is a public post."
     And I select post visibility "Public"
     And I press "Post"
    Then I should see the success message "Your post has been posted."
@@ -21,7 +21,7 @@ Feature: Create Post
     And I should be on "/stream"
 
         # Scenario: Succesfully create a private post
-   When I fill in "Say something to the community" with "This is a community post."
+   When I fill in "Say something to the Community" with "This is a community post."
     And I select post visibility "Community"
     And I press "Post"
    Then I should see the success message "Your post has been posted."
@@ -32,7 +32,7 @@ Feature: Create Post
         # Scenario: edit the post
    When I click the xth "5" element with the css ".dropdown-toggle"
     And I click "Edit"
-    And I fill in "Say something to the community" with "This is a community post edited."
+    And I fill in "Say something to the Community" with "This is a community post edited."
     And I press "Post"
    Then I should see the success message "Your post has been saved."
 

--- a/tests/behat/features/capabilities/post/post-group.feature
+++ b/tests/behat/features/capabilities/post/post-group.feature
@@ -13,7 +13,7 @@ Feature: Create Post on Group
       | Open group | open_group | PostUser1 | This is an open group | en       |
     Given I am logged in as "PostUser1"
       And I am on the stream of group "Open group"
-      And I fill in "What's on your mind?" with "This is a community post in a group."
+      And I fill in "Say something to the group" with "This is a community post in a group."
       And I press "Post"
      Then I should see the success message "Your post has been posted."
       And I should see "This is a community post in a group."


### PR DESCRIPTION
# HTT:

- [x] Check on the homepage stream to see the text matches AC
- [x] Check on any group page stream the text matches AC
- [x] Check on any user profile stream the text matches AC with correct username from the user you are looking at.

# AC
On home page and own profile: Say something to the community
On a group page: Say something to the group
On other profile: Leave a message to [name of the user]