### PR TITLE
DS-2866 by frankgraave: Change placeholder text for posts based on context

### DIFF
--- a/modules/social_features/social_post/social_post.module
+++ b/modules/social_features/social_post/social_post.module
@@ -31,7 +31,7 @@ function social_post_form_post_form_alter(&$form, FormStateInterface $form_state
       $form['field_post']['widget'][0]['#placeholder'] = t('Say something to the group');
     }
     // For the post on a users profile.
-    elseif (!empty(\Drupal::routeMatch()->getParameter('user'))) {
+    elseif (!empty(\Drupal::routeMatch()->getParameter('user')) && \Drupal::routeMatch()->getParameter('user')->id() != \Drupal::currentUser()->id()) {
       $user_profile = \Drupal::routeMatch()->getParameter('user');
       $name = $user_profile->getDisplayName();
       $form['field_post']['widget'][0]['#placeholder'] = t('Leave a message to ') . $name;


### PR DESCRIPTION
# HTT:

- [x] Check on the homepage stream to see the text matches AC
- [x] Check on any group page stream the text matches AC
- [x] Check on any user profile stream the text matches AC with correct username from the user you are looking at.

- [ ] Log in as any demo user and check their own profile. The placeholder text should not contain their username anymore.

# AC
On home page and own profile: Say something to the community
On a group page: Say something to the group
On other profile: Leave a message to [name of the user]
On own profile: Say something to the community