### PR TITLE
DS-2905 by frankgraave: Rename 'see all' buttons in side blocks

### DIFF
--- a/modules/social_features/social_core/social_core.install
+++ b/modules/social_features/social_core/social_core.install
@@ -511,3 +511,29 @@ function social_core_update_8013() {
   $config->set('button_iconize', 0);
   $config->save();
 }
+
+/**
+ * Update topics path.
+ */
+function social_core_update_8014(&$sandbox) {
+  $links = \Drupal::entityTypeManager()->getStorage('menu_link_content')
+    ->loadByProperties(['link__uri' => 'internal:/newest-topics']);
+
+  if ($link = reset($links)) {
+    $link->set('link', ['uri' => 'internal:/all-topics']);
+    $link->save();
+  }
+}
+
+/**
+ * Update members path.
+ */
+function social_core_update_8015(&$sandbox) {
+  $links = \Drupal::entityTypeManager()->getStorage('menu_link_content')
+    ->loadByProperties(['link__uri' => 'internal:/newest-members']);
+
+  if ($link = reset($links)) {
+    $link->set('link', ['uri' => 'internal:/all-members']);
+    $link->save();
+  }
+}

--- a/modules/social_features/social_core/social_core.module
+++ b/modules/social_features/social_core/social_core.module
@@ -159,50 +159,74 @@ function social_core_preprocess_block(&$variables) {
   /** @var \Drupal\group\Entity\Group $group */
   $group = \Drupal::routeMatch()->getParameter('group');
 
+  if(!empty($variables['elements']['content']['#view'])) {
+    $view = $variables['elements']['content']['#view'];
+    if(!empty($view->getDisplay())) {
+      $link = $view->getDisplay();
+      if(!empty($link->useMoreText())) {
+        $more_link = $link->useMoreText();
+      }
+    }
+  }
+
   // Add variables to sidebar blocks
   switch ($variables['elements']['#derivative_plugin_id']) {
     case 'upcoming_events-block_my_upcoming_events':
       $variables['view_all_path'] = 'my-events';
+      $variables['button_text'] = t('All ') . $variables['label']['#markup'];
       break;
     case 'upcoming_events-block_community_events':
       $variables['subtitle'] = t('in the community');
       $variables['view_all_path'] = 'community-events';
+      $variables['button_text'] = t('All ') . $variables['label']['#markup'];
       break;
     case 'latest_topics-block_latest_topics':
       $variables['subtitle'] = t('in the community');
-      $variables['view_all_path'] = 'newest-topics';
+      $variables['view_all_path'] = 'all-topics';
+      $variables['button_text'] = $more_link;
+      $link->setOption('use_more', FALSE);
       break;
     case 'newest_groups-block_newest_groups':
       $variables['subtitle'] = t('in the community');
       $variables['view_all_path'] = 'all-groups';
+      $variables['button_text'] = $more_link;
+      $link->setOption('use_more', FALSE);
       break;
     case 'newest_users-block_newest_users':
       $variables['subtitle'] = t('in the community');
-      $variables['view_all_path'] = 'newest-members';
+      $variables['view_all_path'] = 'all-members';
+      $variables['button_text'] = $more_link;
+      $link->setOption('use_more', FALSE);
       break;
     case 'events-block_events_on_profile':
       $variables['subtitle'] = t('for this user');
       $variables['view_all_path'] = Url::fromRoute('view.events.events_overview', array('user' => $account->id()));
+      $variables['button_text'] = t('All ') . $variables['label']['#markup'];
       break;
     case 'topics-block_user_topics':
       $variables['subtitle'] = t('for this user');
       $variables['view_all_path'] = Url::fromRoute('view.topics.page_profile', array('user' => $account->id()));
+      $variables['button_text'] = t('All ') . $variables['label']['#markup'];
       break;
     case 'groups-block_user_groups':
       $variables['subtitle'] = t('for this user');
       $variables['view_all_path'] = Url::fromRoute('view.groups.page_user_groups', array('user' => $account->id()));
+      $variables['button_text'] = t('All ') . $variables['label']['#markup'];
       break;
     case 'group_members-block_newest_members':
       $variables['subtitle'] = t('in the group');
       $variables['view_all_path'] = Url::fromUserInput('/group/' . $group->id() . '/members');
+      $variables['button_text'] = t('All ') . $variables['label']['#markup'];
       break;
     case 'upcoming_events-upcoming_events_group':
       $variables['subtitle'] = t('in the group');
       $variables['view_all_path'] = Url::fromUserInput('/group/' . $group->id() . '/events');
+      $variables['button_text'] = t('All ') . $variables['label']['#markup'];
       break;
     case 'latest_topics-group_topics_block':
       $variables['subtitle'] = t('in the group');
       $variables['view_all_path'] = Url::fromUserInput('/group/' . $group->id() . '/topics');
+      $variables['button_text'] = t('All ') . $variables['label']['#markup'];
       break;
   }
 }

--- a/modules/social_features/social_core/social_core.module
+++ b/modules/social_features/social_core/social_core.module
@@ -206,17 +206,20 @@ function social_core_preprocess_block(&$variables) {
     case 'topics-block_user_topics':
       $variables['subtitle'] = t('for this user');
       $variables['view_all_path'] = Url::fromRoute('view.topics.page_profile', array('user' => $account->id()));
-      $variables['button_text'] = t('All ') . $variables['label']['#markup'];
+      $variables['button_text'] = $more_link;
+      $link->setOption('use_more', FALSE);
       break;
     case 'groups-block_user_groups':
       $variables['subtitle'] = t('for this user');
       $variables['view_all_path'] = Url::fromRoute('view.groups.page_user_groups', array('user' => $account->id()));
-      $variables['button_text'] = t('All ') . $variables['label']['#markup'];
+      $variables['button_text'] = $more_link;
+      $link->setOption('use_more', FALSE);
       break;
     case 'group_members-block_newest_members':
       $variables['subtitle'] = t('in the group');
       $variables['view_all_path'] = Url::fromUserInput('/group/' . $group->id() . '/members');
-      $variables['button_text'] = t('All ') . $variables['label']['#markup'];
+      $variables['button_text'] = $more_link;
+      $link->setOption('use_more', FALSE);
       break;
     case 'upcoming_events-upcoming_events_group':
       $variables['subtitle'] = t('in the group');
@@ -226,7 +229,8 @@ function social_core_preprocess_block(&$variables) {
     case 'latest_topics-group_topics_block':
       $variables['subtitle'] = t('in the group');
       $variables['view_all_path'] = Url::fromUserInput('/group/' . $group->id() . '/topics');
-      $variables['button_text'] = t('All ') . $variables['label']['#markup'];
+      $variables['button_text'] = $more_link;
+      $link->setOption('use_more', FALSE);
       break;
   }
 }

--- a/modules/social_features/social_event/config/install/views.view.upcoming_events.yml
+++ b/modules/social_features/social_event/config/install/views.view.upcoming_events.yml
@@ -55,7 +55,7 @@ display:
       pager:
         type: full
         options:
-          items_per_page: 4
+          items_per_page: 10
           offset: 0
           id: 0
           total_pages: null
@@ -324,6 +324,9 @@ display:
         row: false
         empty: false
         title: false
+        use_more: false
+        use_more_always: false
+        use_more_text: false
       relationships:
         reverse__event_enrollment__field_event:
           id: reverse__event_enrollment__field_event
@@ -535,6 +538,9 @@ display:
           content: 'No upcoming events you have enrolled for'
           plugin_id: text_custom
       title: 'My upcoming events'
+      use_more: false
+      use_more_always: true
+      use_more_text: 'All my upcoming events'
     cache_metadata:
       max-age: -1
       contexts:

--- a/modules/social_features/social_group/config/install/views.view.group_members.yml
+++ b/modules/social_features/social_group/config/install/views.view.group_members.yml
@@ -5,7 +5,6 @@ dependencies:
     - group.content_type.open_group-group_membership
   module:
     - group
-    - user
 id: group_members
 label: 'Group Members'
 module: views
@@ -233,6 +232,9 @@ display:
         pager: false
         sorts: false
         empty: false
+        use_more: false
+        use_more_always: false
+        use_more_text: false
       pager:
         type: some
         options:
@@ -266,6 +268,9 @@ display:
           tokenize: false
           content: 'No memebers in this group'
           plugin_id: text_custom
+      use_more: true
+      use_more_always: true
+      use_more_text: 'All members'
     cache_metadata:
       max-age: -1
       contexts:

--- a/modules/social_features/social_group/config/install/views.view.groups.yml
+++ b/modules/social_features/social_group/config/install/views.view.groups.yml
@@ -235,6 +235,9 @@ display:
         style: false
         row: false
         title: false
+        use_more: false
+        use_more_always: false
+        use_more_text: false
       block_description: 'User Groups'
       style:
         type: default
@@ -245,6 +248,9 @@ display:
           relationship: none
           view_mode: small_teaser
       title: 'Recently joined groups'
+      use_more: true
+      use_more_always: true
+      use_more_text: 'All groups'
     cache_metadata:
       max-age: -1
       contexts:

--- a/modules/social_features/social_group/config/install/views.view.newest_groups.yml
+++ b/modules/social_features/social_group/config/install/views.view.newest_groups.yml
@@ -52,7 +52,7 @@ display:
       pager:
         type: full
         options:
-          items_per_page: 4
+          items_per_page: 10
           offset: 0
           id: 0
           total_pages: null
@@ -187,6 +187,9 @@ display:
         pager: false
         style: false
         row: false
+        use_more: false
+        use_more_always: false
+        use_more_text: false
       pager:
         type: some
         options:
@@ -202,6 +205,9 @@ display:
           view_mode: small_teaser
       block_description: 'Newest groups block'
       display_description: ''
+      use_more: true
+      use_more_always: true
+      use_more_text: 'All groups'
     cache_metadata:
       max-age: -1
       contexts:

--- a/modules/social_features/social_profile/config/install/views.view.newest_users.yml
+++ b/modules/social_features/social_profile/config/install/views.view.newest_users.yml
@@ -166,6 +166,7 @@ display:
         - url.query_args
         - user.permissions
       tags:
+        - 'config:core.entity_view_display.profile.profile.autocomplete_item'
         - 'config:core.entity_view_display.profile.profile.compact'
         - 'config:core.entity_view_display.profile.profile.default'
         - 'config:core.entity_view_display.profile.profile.hero'
@@ -187,6 +188,9 @@ display:
         pager: false
         style: false
         row: false
+        use_more: false
+        use_more_always: false
+        use_more_text: false
       pager:
         type: some
         options:
@@ -202,12 +206,16 @@ display:
           view_mode: small_teaser
       display_description: ''
       block_description: 'Newest users block'
+      use_more: true
+      use_more_always: true
+      use_more_text: 'All members'
     cache_metadata:
       max-age: -1
       contexts:
         - 'languages:language_interface'
         - user.permissions
       tags:
+        - 'config:core.entity_view_display.profile.profile.autocomplete_item'
         - 'config:core.entity_view_display.profile.profile.compact'
         - 'config:core.entity_view_display.profile.profile.default'
         - 'config:core.entity_view_display.profile.profile.hero'
@@ -223,11 +231,11 @@ display:
     position: 1
     display_options:
       display_extenders: {  }
-      path: newest-members
+      path: all-members
       pager:
         type: full
         options:
-          items_per_page: 4
+          items_per_page: 10
           offset: 0
           id: 0
           total_pages: null
@@ -247,7 +255,9 @@ display:
           quantity: 9
       defaults:
         pager: false
+        title: false
       display_description: ''
+      title: 'All members'
     cache_metadata:
       max-age: -1
       contexts:
@@ -255,6 +265,7 @@ display:
         - url.query_args
         - user.permissions
       tags:
+        - 'config:core.entity_view_display.profile.profile.autocomplete_item'
         - 'config:core.entity_view_display.profile.profile.compact'
         - 'config:core.entity_view_display.profile.profile.default'
         - 'config:core.entity_view_display.profile.profile.hero'

--- a/modules/social_features/social_profile/social_profile.install
+++ b/modules/social_features/social_profile/social_profile.install
@@ -125,7 +125,7 @@ function _social_profile_create_menu_links() {
   if (!is_null($parent)) {
     MenuLinkContent::create([
       'title' => 'All members',
-      'link' => ['uri' => 'internal:/newest-members'],
+      'link' => ['uri' => 'internal:/all-members'],
       'menu_name' => 'main',
       'expanded' => FALSE,
       'weight' => 50,

--- a/modules/social_features/social_topic/config/install/views.view.latest_topics.yml
+++ b/modules/social_features/social_topic/config/install/views.view.latest_topics.yml
@@ -184,7 +184,7 @@ display:
           expose:
             label: ''
           granularity: second
-      title: 'Newest topics'
+      title: 'All topics'
       header: {  }
       footer: {  }
       empty:
@@ -219,6 +219,15 @@ display:
       display_extenders: {  }
       display_description: ''
       block_description: 'Latest topic block'
+      title: 'Newest topics'
+      defaults:
+        title: false
+        use_more: false
+        use_more_always: false
+        use_more_text: false
+      use_more: true
+      use_more_always: true
+      use_more_text: 'All topics'
     cache_metadata:
       max-age: -1
       contexts:
@@ -253,6 +262,10 @@ display:
         relationships: false
         arguments: false
         access: false
+        title: false
+        use_more: false
+        use_more_always: false
+        use_more_text: false
       relationships:
         group_content:
           id: group_content
@@ -308,6 +321,10 @@ display:
         type: group_permission
         options:
           group_permission: 'view group_node:topic content'
+      title: 'Newest topics'
+      use_more: true
+      use_more_always: true
+      use_more_text: 'All topics'
     cache_metadata:
       max-age: -1
       contexts:
@@ -343,7 +360,7 @@ display:
       pager:
         type: full
         options:
-          items_per_page: 4
+          items_per_page: 10
           offset: 0
           id: 0
           total_pages: null
@@ -361,7 +378,7 @@ display:
             offset: false
             offset_label: Offset
           quantity: 9
-      path: newest-topics
+      path: all-topics
       filters:
         status:
           value: '1'

--- a/modules/social_features/social_topic/config/install/views.view.topics.yml
+++ b/modules/social_features/social_topic/config/install/views.view.topics.yml
@@ -367,6 +367,9 @@ display:
         filters: false
         filter_groups: false
         sorts: false
+        use_more: false
+        use_more_always: false
+        use_more_text: false
       row:
         type: 'entity:node'
         options:
@@ -522,6 +525,9 @@ display:
           entity_type: node
           entity_field: created
           plugin_id: date
+      use_more: true
+      use_more_always: true
+      use_more_text: 'All topics'
     cache_metadata:
       max-age: -1
       contexts:

--- a/modules/social_features/social_topic/config/optional/block.block.exposedformlatest_topicspage_latest_topics.yml
+++ b/modules/social_features/social_topic/config/optional/block.block.exposedformlatest_topicspage_latest_topics.yml
@@ -23,6 +23,6 @@ settings:
 visibility:
   request_path:
     id: request_path
-    pages: /newest-topics
+    pages: /all-topics
     negate: false
     context_mapping: {  }

--- a/modules/social_features/social_topic/config/optional/block.block.socialblue_exposedformlatest_topicspage_latest_topics.yml
+++ b/modules/social_features/social_topic/config/optional/block.block.socialblue_exposedformlatest_topicspage_latest_topics.yml
@@ -23,6 +23,6 @@ settings:
 visibility:
   request_path:
     id: request_path
-    pages: /newest-topics
+    pages: /all-topics
     negate: false
     context_mapping: {  }

--- a/modules/social_features/social_topic/social_topic.install
+++ b/modules/social_features/social_topic/social_topic.install
@@ -114,7 +114,7 @@ function _social_topic_create_menu_links() {
   if (!is_null($parent)) {
     MenuLinkContent::create([
       'title' => t('All topics'),
-      'link' => ['uri' => 'internal:/newest-topics'],
+      'link' => ['uri' => 'internal:/all-topics'],
       'menu_name' => 'main',
       'expanded' => FALSE,
       'weight' => 40,

--- a/modules/social_features/social_topic/src/Controller/SocialTopicController.php
+++ b/modules/social_features/social_topic/src/Controller/SocialTopicController.php
@@ -17,7 +17,7 @@ class SocialTopicController extends ControllerBase {
    *   The page title.
    */
   public function latestTopicsPageTitle() {
-    $title = $this->t('Newest topics');
+    $title = $this->t('All topics');
 
     // TODO This might change depending on the view exposed filter settings.
     $topic_type_id = $attributes = \Drupal::request()->query->get('field_topic_type_target_id');

--- a/tests/behat/features/capabilities/group/group-create-open.feature
+++ b/tests/behat/features/capabilities/group/group-create-open.feature
@@ -50,7 +50,7 @@ Feature: Create Open Group
   # DS-648 As a LU I want to see the members of a group
     And I logout
     And I am logged in as "Group User Two"
-    And I am on "newest-members"
+    And I am on "all-members"
     And I click "Group User One"
   # And I should see "Recently joined groups" in the "Sidebar second"
     And I should see "Test open group" in the "Sidebar second"

--- a/tests/behat/features/capabilities/like/like-create-topic.feature
+++ b/tests/behat/features/capabilities/like/like-create-topic.feature
@@ -22,7 +22,7 @@ Feature: Create topic like
     Then I should see "Topic for likes has been created."
 
    Given I am logged in as "user_2"
-     And I am at "newest-topics"
+     And I am at "all-topics"
     Then I should see "Topic for likes"
      And I should see "Marie Curie"
     When I click "Topic for likes"

--- a/tests/behat/features/capabilities/profile/hide-profile-email.feature
+++ b/tests/behat/features/capabilities/profile/hide-profile-email.feature
@@ -16,7 +16,7 @@ Feature: I want to be able to hide my email address
     And I press "Save configuration"
 
     Given I am logged in as "user_1"
-    And I am on "newest-members"
+    And I am on "all-members"
     Then I click "user_2"
     And I click "Information"
     And I should not see "user_2@example.com"
@@ -41,7 +41,7 @@ Feature: I want to be able to hide my email address
     And I press "Save configuration"
 
     Given I am logged in as "user_1"
-    And I am on "newest-members"
+    And I am on "all-members"
     Then I click "user_2"
     And I click "Information"
     And I should see "user_2@example.com"

--- a/tests/behat/features/capabilities/profile/newest-members.feature
+++ b/tests/behat/features/capabilities/profile/newest-members.feature
@@ -1,4 +1,4 @@
-@api @profile @user @members @stability @perfect @community @newest @overview @block @LU @critical @1337
+@api @profile @user @members @stability @perfect @community @newest @overview @block @LU @critical
 Feature: See newest users in the community
   Benefit: In order to discover new people
   Role: LU

--- a/tests/behat/features/capabilities/profile/newest-members.feature
+++ b/tests/behat/features/capabilities/profile/newest-members.feature
@@ -9,7 +9,7 @@ Feature: See newest users in the community
     Given I am logged in as an "authenticated user"
     Then I should not see "Behat User 1"
     And I should not see "Behat User 2"
-    When I click "All Newest members"
+    When I click "All members"
     Then I should not see "Behat User 1"
     And I should not see "Behat User 2"
 
@@ -21,11 +21,11 @@ Feature: See newest users in the community
 
     Given I am logged in as an "authenticated user"
 
-    Then I should see "Newest members"
+    Then I should see "All members"
     And I should see "Behat User 1"
     And I should see "Behat User 2"
 
-    When I click "All Newest members"
+    When I click "All members"
     Then I should see "Behat User 1"
     And I should see "Behat User 2"
     And I should see "Newest members"

--- a/tests/behat/features/capabilities/profile/newest-members.feature
+++ b/tests/behat/features/capabilities/profile/newest-members.feature
@@ -1,4 +1,4 @@
-@api @profile @user @members @stability @perfect @community @newest @overview @block @LU @critical
+@api @profile @user @members @stability @perfect @community @newest @overview @block @LU @critical @1337
 Feature: See newest users in the community
   Benefit: In order to discover new people
   Role: LU
@@ -9,7 +9,7 @@ Feature: See newest users in the community
     Given I am logged in as an "authenticated user"
     Then I should not see "Behat User 1"
     And I should not see "Behat User 2"
-    When I click "All members"
+    When I am on "all-members"
     Then I should not see "Behat User 1"
     And I should not see "Behat User 2"
 
@@ -25,7 +25,7 @@ Feature: See newest users in the community
     And I should see "Behat User 1"
     And I should see "Behat User 2"
 
-    When I click "All members"
+    When I am on "all-members"
     Then I should see "Behat User 1"
     And I should see "Behat User 2"
-    And I should see "Newest members"
+    And I should see "All members"

--- a/tests/behat/features/capabilities/topic/newest-topics.feature
+++ b/tests/behat/features/capabilities/topic/newest-topics.feature
@@ -22,17 +22,16 @@ Feature: See newest topics in the community
     And I should see "Behat Topic 1"
     And I should see "Behat Topic 2"
 
-    When I click "All topics"
+    When I am on "all-topics"
     Then I should see "Behat Topic 1"
     And I should see "Behat Topic 2"
-    And I should see "Newest topics"
-
+    And I should see "All topics"
 
     Given I am logged in as an "authenticated user"
     Then I should see "Behat Topic 1"
     And I should see "Behat Topic 2"
 
-    When I click "All topics"
+    When I am on "all-topics"
     Then I should see "All topics"
     And I should see "Behat Topic 1"
     And I should see "Behat Topic 2"

--- a/tests/behat/features/capabilities/topic/newest-topics.feature
+++ b/tests/behat/features/capabilities/topic/newest-topics.feature
@@ -18,11 +18,11 @@ Feature: See newest topics in the community
 
     Given I am on the homepage
 
-    Then I should see "Newest topics"
+    Then I should see "All topics"
     And I should see "Behat Topic 1"
     And I should see "Behat Topic 2"
 
-    When I click "All Newest topics"
+    When I click "All topics"
     Then I should see "Behat Topic 1"
     And I should see "Behat Topic 2"
     And I should see "Newest topics"
@@ -32,7 +32,7 @@ Feature: See newest topics in the community
     Then I should see "Behat Topic 1"
     And I should see "Behat Topic 2"
 
-    When I click "All Newest topics"
-    Then I should see "Newest topics"
+    When I click "All topics"
+    Then I should see "All topics"
     And I should see "Behat Topic 1"
     And I should see "Behat Topic 2"

--- a/themes/socialbase/templates/block/block--views-block--sidebar.html.twig
+++ b/themes/socialbase/templates/block/block--views-block--sidebar.html.twig
@@ -47,7 +47,7 @@
     <footer class="card__actionbar">
       {% if view_all_path %}
       <a href="{{ view_all_path }}" class="btn btn-flat brand-text-primary">
-        {% trans %} All {% endtrans %} {{ label }}
+        {{ button_text }}
       </a>
       {% endif %}
   </footer>


### PR DESCRIPTION
# Why this change:
_Because all these buttons will lead users to an overview where all the topics, groups and users will be shown. It is more logical to name the buttons also the page title in the way it is. So users don't have wrong expectations._

## HTT

- [ ] Checkout this branch
- [ ] Do a `drush fra -y --bundle=social; drush updb` and `drush cr`
- [ ] Go to the homepage and see that the buttons of the blocks have changed according the acceptance criteria. _**(It should now show "All topics / All groups / All members")**_
- [ ] Also check other blocks in the sidebar across the platform such as: _**profile stream** and **group stream**_