### PR TITLE
Issue #2865031 - update member teaser

### DIFF
--- a/tests/behat/features/capabilities/event/eventenrollment.feature
+++ b/tests/behat/features/capabilities/event/eventenrollment.feature
@@ -27,7 +27,7 @@ Feature: Enroll for an event
     Then I should see the button "Enrolled"
     And I should see the link "Enrollments"
     And I should see "View profile"
-    And I should see "Contact me"
+    And I should see "View activities"
 
   @AN
   Scenario: Successfully redirect an AN from an event enrollment action

--- a/themes/socialbase/templates/profile/profile--profile--teaser.html.twig
+++ b/themes/socialbase/templates/profile/profile--profile--teaser.html.twig
@@ -56,12 +56,11 @@
     </div>
 
     <div class="card__actionbar">
-      {#@todo: replace contact url#}
-      <a href="{{ profile_stream_url }}" class="card__link">
-        {% trans %}View profile {% endtrans %}
+      <a href="{{ profile_contact_url }}" class="card__link">
+        {% trans %}View profile{% endtrans %}
       </a>
-      <a href="{{ profile_contact_url }}" class="card__link hidden-for-phone-only">
-        {% trans %}Contact me {% endtrans %}
+      <a href="{{ profile_stream_url }}" class="card__link hidden-for-phone-only">
+        {% trans %}View activities{% endtrans %}
       </a>
     </div>
   </div>


### PR DESCRIPTION
For the member teaser the links "contact me" and "view profile" should be changed to "view activities" (link to profile steam) and "view profile (link to profile information page). This issue has been reported by multiple clients.