### PR TITLE
Issue #2845363 by peterpolman: Screen squeezed in a profile or a group

### DIFF
--- a/themes/socialbase/assets/css/layout.css
+++ b/themes/socialbase/assets/css/layout.css
@@ -24,6 +24,7 @@
   padding-bottom: 100px;
   position: relative;
   z-index: 0;
+  width: 100%;
 }
 
 .region--title {

--- a/themes/socialbase/components/05-templates/layout/layout.scss
+++ b/themes/socialbase/components/05-templates/layout/layout.scss
@@ -79,6 +79,7 @@
   padding-bottom: 100px;
   position: relative;
   z-index: 0;
+  width: 100%;
 }
 
 .region--title {
@@ -231,4 +232,3 @@
   }
 
 }
-


### PR DESCRIPTION
# HTT

1. Log in as admin after fresh install (no admin content) 
2. Go to profile page
3. Click topic in the secondary menu and see that the width of the page is just as wide as the window (as big as the content in it, apart from the menu that is full width)