### PR TITLE
SaaS bug - where SM does not get zeh library attached

### DIFF
--- a/themes/socialbase/includes/page.inc
+++ b/themes/socialbase/includes/page.inc
@@ -8,8 +8,11 @@ use Drupal\node\Entity\Node;
 function socialbase_preprocess_page(&$variables) {
   $variables['display_page_title'] = TRUE;
 
-  // If we have the admin toolbar on screen we need overrides for our styles.
-  if ($variables['is_admin']) {
+  // If we have the admin toolbar permission.
+  $user = \Drupal::currentUser();
+
+  // Check for permission
+  if ($user->hasPermission('access toolbar')) {
     $variables['#attached']['library'][] = 'socialbase/admin-toolbar';
   }
   // Add plain title for node preview page templates.


### PR DESCRIPTION
# HTT.
Make sure you have a sitemanager, check that with this new code and the permission "use the administration toolbar" enabled.. site managers actually get the correct library attached. This library makes sure the social menu plays nicely with the admin toolbar.