### PR TITLE
2866028 by ronaldtebrake: Add post form returns InvalidArgumentException

### DIFF
--- a/modules/social_features/social_post/src/PostHtmlRouteProvider.php
+++ b/modules/social_features/social_post/src/PostHtmlRouteProvider.php
@@ -62,7 +62,7 @@ class PostHtmlRouteProvider extends AdminHtmlRouteProvider {
       $route
         ->setDefaults([
           '_entity_form' => "{$entity_type_id}.{$operation}",
-          '_title' => $title,
+          '_title' => $title->render(),
         ])
         ->setRequirement('_entity_create_access', $entity_type_id);
 


### PR DESCRIPTION
Since we use a string in the t() function, it needs to be rendered as a string. 
The t() will return an SafeMarkup array, after we render it it will return a rendered string.

This makes sure we will fix: https://www.drupal.org/node/2866028

