### PR TITLE
#2842079 visibility regression

### DIFF
--- a/modules/custom/entity_access_by_field/entity_access_by_field.module
+++ b/modules/custom/entity_access_by_field/entity_access_by_field.module
@@ -182,7 +182,7 @@ function entity_access_by_field_form_alter(&$form, \Drupal\Core\Form\FormStateIn
         // change it to community. Just to make sure LU will always have
         // community selected on creating new nodes. On node edit we don't
         // want this behavior because SM can change the visibility.
-        $widget['#title'] = t('The visibility settings have been disabled. In order to change the visibility, please contact a site manager.')->render();
+        $widget['#title'] = t('The visibility setting has been disabled. In order to change the visibility, please contact a site manager.')->render();
         if ($route_name == 'node.add' && $widget['#default_value'] === 'public') {
           // Set the default value to community.
           $widget['#default_value'] = 'community';

--- a/modules/custom/entity_access_by_field/entity_access_by_field.module
+++ b/modules/custom/entity_access_by_field/entity_access_by_field.module
@@ -173,14 +173,17 @@ function entity_access_by_field_form_alter(&$form, \Drupal\Core\Form\FormStateIn
       // This is for nodes.
       if (isset($form['field_content_visibility'])) {
         // Some vars for easier reading.
-        $field = &$form['field_content_visibility'];
         $widget = &$form['field_content_visibility']['widget'];
-        $options = &$form['field_content_visibility']['widget']['#options'];
+        $route_name = \Drupal::routeMatch()->getRouteName();
 
         // Remove the public option.
-        unset($options['public']);
-        // Check if the public options is currently selected.
-        if ($widget['#default_value'] === 'public') {
+        $widget['#disabled'] = TRUE;
+        // Check if the public options is selected on node add. Than we
+        // change it to community. Just to make sure LU will always have
+        // community selected on creating new nodes. On node edit we don't
+        // want this behavior because SM can change the visibility.
+        $widget['#title'] = t('The visibility settings have been disabled. In order to change the visibility, please contact a site manager.')->render();
+        if ($route_name == 'node.add' && $widget['#default_value'] === 'public') {
           // Set the default value to community.
           $widget['#default_value'] = 'community';
         }


### PR DESCRIPTION
Problem: If the author edits his content (which was made public by a CM) the content is set to 'community' upon save.

Solution: Instead of hiding the public option, we disable it and we make sure we don't set the default_value on node edit anymore just on node add. This will ensure that a user knows what happens to their content, he can't change it back from public to community (he can still delete the content though) and the users with the correct permissions can actually do change it. 

# HTT.
1. Login as SM and set the visibility setting correctly at social.dev/admin/config/opensocial/visibility
2. Login as LU, create a new topic and see that you can't select the public visibility and community is enabled by default.
3. Login as SM and edit the node you just created, make sure you set it to public
4. Login as LU again and edit the node, see you still can't change it to public. 