### PR TITLE
Issue #2862779 by frankgraave: changed argument according to core upd…

### DIFF
--- a/modules/custom/social_admin_menu/social_admin_menu.services.yml
+++ b/modules/custom/social_admin_menu/social_admin_menu.services.yml
@@ -1,4 +1,4 @@
 services:
   social_admin_menu.administrator_menu_tree_manipulators:
     class: Drupal\social_admin_menu\Menu\SocialAdminMenuAdministratorMenuLinkTreeManipulators
-    arguments: ['@access_manager', '@current_user', '@entity.query']
+    arguments: ['@access_manager', '@current_user', '@entity_type.manager']

--- a/modules/custom/social_admin_menu/src/Menu/SocialAdminMenuAdministratorMenuLinkTreeManipulators.php
+++ b/modules/custom/social_admin_menu/src/Menu/SocialAdminMenuAdministratorMenuLinkTreeManipulators.php
@@ -45,7 +45,7 @@ class SocialAdminMenuAdministratorMenuLinkTreeManipulators extends DefaultMenuLi
    */
   public function checkAccess(array $tree) {
 
-    if ($this->account->id() !== 1) {
+    if ($this->account->id() != 1) {
       $account_roles = $this->account->getRoles();
       // Define routes to hide for a role.
       // 'content' => 'system.admin_content',


### PR DESCRIPTION
**Side note:** As this issue ([#2862779](https://www.drupal.org/node/2862779)) stated the social_admin_menu was broken. Also found out that with the new core update (8.3.1) the 3rd argument of DefaultMenuLinkTreeManipulators::__construct() was changed from '@query.factory' to '@entity_type.manager'. This change has also been done.

## HTT

- [x] Checkout this branch (feature/2862779)
- [ ] Enable the social_admin_menu
- [ ] Log in as CM and/or SM
- [ ] See the module works and behaves normal.

Logged in as CM, in the toolbar you should see 2 links: Content and Structure
Logged in as SM, in the toolbar you should see 6 tabs: Content, Structure, Appearance, Configuration, People and Reports
