### PR TITLE
#2872565 by jochemvn: Make email privacy settings a bit more understandable

### DIFF
--- a/modules/social_features/social_profile/social_profile.module
+++ b/modules/social_features/social_profile/social_profile.module
@@ -227,6 +227,9 @@ function social_profile_form_user_form_alter(&$form, FormStateInterface $form_st
 
   if ($profile instanceof Profile) {
     if (isset($profile->field_profile_show_email)) {
+      // Check what the global value is.
+      $global_show_email = \Drupal::config('social_profile.settings')->get('social_profile_show_email');
+      // Account value.
       $show_email = $profile->field_profile_show_email->value;
       $form['profile_privacy'] = array(
         '#type' => 'fieldset',
@@ -239,7 +242,17 @@ function social_profile_form_user_form_alter(&$form, FormStateInterface $form_st
         '#title' => t('Show my email on my profile'),
         '#default_value' => $show_email,
       );
-      $form['actions']['submit']['#submit'][] = '_social_profile_form_user_form_submit';
+
+      // If global setting is set, disable the setting and give a reason why.
+      if ($global_show_email == TRUE) {
+        $form['profile_privacy']['social_profile_show_email']['#disabled'] = TRUE;
+        $form['profile_privacy']['social_profile_show_email']['#value'] = TRUE;
+        $form['profile_privacy']['social_profile_show_email']['#description'] = t('This setting is currently being controlled by a platform wide setting and cannot be changed. Please contact a sitemanager if you have questions.');
+      }
+      else {
+        // Submit function only when the data is actualy editable.
+        $form['actions']['submit']['#submit'][] = '_social_profile_form_user_form_submit';
+      }
     }
   }
 }

--- a/modules/social_features/social_profile/src/Form/SocialProfileSettingsForm.php
+++ b/modules/social_features/social_profile/src/Form/SocialProfileSettingsForm.php
@@ -39,7 +39,7 @@ class SocialProfileSettingsForm extends ConfigFormBase {
       '#type' => 'checkbox',
       '#title' => $this->t('Show email on all user profiles'),
       '#default_value' => $config->get('social_profile_show_email'),
-      '#description' => $this->t('If this setting is turned off, users will be able override it for their profiles. Also users with permission "view profile email" will be able to see email in any case.'),
+      '#description' => $this->t('When enabled, users are not able to hide their email address on their profile. When disabled, users will be able to control the visibility of their emailaddress.'),
     );
 
     return parent::buildForm($form, $form_state);


### PR DESCRIPTION
## HTT

- [x] Check the code
- [x] Checkout this branch and do a reinstall
- [x] Login as LU and as a SM
- [x] As SM go to "/admin/config/people/social-profile" and notice the setting is ON
- [x] As a LU go to edit your account and notice the 'Hide my email' setting is not ON and there's an explanation that this setting is controlled centrally.
- [x] As the SM turn the feauture off and relaod the LU page
- [x] Notice as the LU that you can now change the setting and that the original value (OFF) is restored

- [x] Not affected, but check on view profile as another LU that you can see or not see the adres according to the settings.