### PR TITLE
Issue #2842045 by jaapjan: fix search index of demo content during UI…

### DIFF
--- a/social.profile
+++ b/social.profile
@@ -310,6 +310,7 @@ function social_final_site_setup(&$install_state) {
   $final_batched = [
     'profile_weight' => t('Set weight of profile.'),
     'router_rebuild' => t('Rebuild router.'),
+    'trigger_sapi_index' => t('Index search'),
     'cron_run' => t('Run cron.'),
     'import_optional_config' => t('Import optional configuration'),
   ];
@@ -447,6 +448,14 @@ function _social_finalise_batch($process, $description, &$context) {
       // This would normally happen upon KernelEvents::TERMINATE, but since the
       // installer does not use an HttpKernel, that event is never triggered.
       \Drupal::service('router.builder')->rebuild();
+      break;
+
+    case 'trigger_sapi_index':
+      $indexes = \Drupal\search_api\Entity\Index::loadMultiple();
+      /** @var \Drupal\search_api\Entity\Index $index */
+      foreach ($indexes as $index) {
+        $index->reindex();
+      }
       break;
 
     case 'cron_run':


### PR DESCRIPTION
See: https://www.drupal.org/node/2842045

After a node_access_rebuild() the search index needs to be rebuild as well. I added an extra batch item in the UI installation.

Will commit a drush command in our developer install scripts as well in open_social_docker.

HTT:

- [x] Install with UI and select demo content
- [x] Login as a demo user and verify that all the content items are visible in the search results as expected
- [x] (just to be sure) create a new topic/event in a group and login as another user and verify the item is in the search results