### PR TITLE
Issue #2874542 by peterpolman: Privacy Settings Label and Checkboxes …

### DIFF
--- a/modules/custom/activity_send/modules/activity_send_email/activity_send_email.module
+++ b/modules/custom/activity_send/modules/activity_send_email/activity_send_email.module
@@ -31,7 +31,6 @@ function activity_send_email_form_user_form_alter(&$form, FormStateInterface $fo
     foreach ($email_message_templates as $key => $title) {
       $form['email_notifications'][$key] = array(
         '#type' => 'checkbox',
-        '#title_display' => 'before',
         '#title' => $title,
         '#default_value' => isset($user_email_settings[$key]) ? $user_email_settings[$key] : TRUE,
       );

--- a/modules/social_features/social_profile/social_profile.module
+++ b/modules/social_features/social_profile/social_profile.module
@@ -238,7 +238,6 @@ function social_profile_form_user_form_alter(&$form, FormStateInterface $form_st
       );
       $form['profile_privacy']['social_profile_show_email'] = array(
         '#type' => 'checkbox',
-        '#title_display' => 'before',
         '#title' => t('Show my email on my profile'),
         '#default_value' => $show_email,
       );


### PR DESCRIPTION
Issue: https://www.drupal.org/node/2874542

For privacy settings the inline layout is fixed.

I can't figure out where the E-mail notifications fieldset on the user/*/edit page is configured. The <label> elements there need to class .option to be aligned correctly. 