### PR TITLE
Issue #2820234 : Check for access in create content/groups links in header

### DIFF
--- a/modules/social_features/social_user/src/Plugin/Block/AccountHeaderBlock.php
+++ b/modules/social_features/social_user/src/Plugin/Block/AccountHeaderBlock.php
@@ -34,41 +34,7 @@ class AccountHeaderBlock extends BlockBase {
           'label' => $this->t('New content'),
           'title_classes' => 'sr-only',
           'url' => '#',
-          'below' => array(
-            'add_event' => array(
-              'classes' => '',
-              'link_attributes' => '',
-              'link_classes' => '',
-              'icon_classes' => '',
-              'icon_label' => '',
-              'title' => $this->t('Create New Event'),
-              'label' => $this->t('New event'),
-              'title_classes' => '',
-              'url' => Url::fromUserInput('/node/add/event'),
-            ),
-            'add_topic' => array(
-              'classes' => '',
-              'link_attributes' => '',
-              'link_classes' => '',
-              'icon_classes' => '',
-              'icon_label' => '',
-              'title' => $this->t('Create New Topic'),
-              'label' => $this->t('New topic'),
-              'title_classes' => '',
-              'url' => Url::fromUserInput('/node/add/topic'),
-            ),
-            'add_group' => array(
-              'classes' => '',
-              'link_attributes' => '',
-              'link_classes' => '',
-              'icon_classes' => '',
-              'icon_label' => '',
-              'title' => $this->t('Create New Group'),
-              'label' => $this->t('New group'),
-              'title_classes' => '',
-              'url' => Url::fromUserInput('/group/add'),
-            ),
-          ),
+          'below' => array(),
         ),
         'groups' => array(
           'classes' => '',
@@ -80,6 +46,51 @@ class AccountHeaderBlock extends BlockBase {
           'url' => Url::fromUserInput('/user/' . $account_uid . '/groups'),
         ),
       ];
+
+      // Check if the current user is allowed to create Events.
+      if ($account->hasPermission('create event content')) {
+        $links['add']['below']['add_event'] = array(
+          'classes' => '',
+          'link_attributes' => '',
+          'link_classes' => '',
+          'icon_classes' => '',
+          'icon_label' => '',
+          'title' => $this->t('Create New Event'),
+          'label' => $this->t('New event'),
+          'title_classes' => '',
+          'url' => Url::fromUserInput('/node/add/event'),
+        );
+      }
+
+      // Check if the current user is allowed to create Topics.
+      if ($account->hasPermission('create topic content')) {
+        $links['add']['below']['add_topic'] = array(
+          'classes' => '',
+          'link_attributes' => '',
+          'link_classes' => '',
+          'icon_classes' => '',
+          'icon_label' => '',
+          'title' => $this->t('Create New Topic'),
+          'label' => $this->t('New topic'),
+          'title_classes' => '',
+          'url' => Url::fromUserInput('/node/add/topic'),
+        );
+      }
+
+      // Check if the current user is allowed to create new Groups.
+      if($account->hasPermission('create open_group group')){
+        $links['add']['below']['add_group'] = array(
+          'classes' => '',
+          'link_attributes' => '',
+          'link_classes' => '',
+          'icon_classes' => '',
+          'icon_label' => '',
+          'title' => $this->t('Create New Group'),
+          'label' => $this->t('New group'),
+          'title_classes' => '',
+          'url' => Url::fromUserInput('/group/add/open_group'),
+        );
+      }
 
       // Check if the current user is allowed to create new books.
       if (\Drupal::moduleHandler()->moduleExists('social_book') && $account->hasPermission('create new books')) {
@@ -110,7 +121,12 @@ class AccountHeaderBlock extends BlockBase {
           'url' => Url::fromUserInput('/node/add/page'),
         );
       }
-      
+
+      // Check if user can create anything of the above if not remove add link.
+      if(count($links['add']['below']) == 0) {
+        unset($links['add']);
+      }
+
       if (\Drupal::moduleHandler()->moduleExists('activity_creator')) {
         $notifications_view = views_embed_view('activity_stream_notifications', 'block_1');
         $notifications = \Drupal::service('renderer')->render($notifications_view);


### PR DESCRIPTION
https://www.drupal.org/node/2820234

it makes sense to check for access in these blocks. I've copied the code from this PR https://github.com/goalgorilla/open_social/pull/157 from @spuky and let's see what our test suite does.