### PR TITLE
Issue #2875275: redirect destination cancel button post form

### DIFF
--- a/modules/social_features/social_post/src/Form/PostDeleteForm.php
+++ b/modules/social_features/social_post/src/Form/PostDeleteForm.php
@@ -3,6 +3,7 @@
 namespace Drupal\social_post\Form;
 
 use Drupal\Core\Entity\ContentEntityDeleteForm;
+use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Url;
 
 /**
@@ -12,6 +13,29 @@ use Drupal\Core\Url;
  */
 class PostDeleteForm extends ContentEntityDeleteForm {
 
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    $form = parent::buildForm($form, $form_state);
+
+    // Set the redirect url of the cancel button.
+    if (\Drupal::request()->query->has('destination')) {
+      $destination = \Drupal::destination();
+      $path = $destination->get();
+      $form['actions']['cancel']['#url'] = Url::fromUserInput($path);
+    }
+    else {
+      $curr_route_parr = \Drupal::routeMatch()->getRawParameters()->getDigits('post');
+      $redirect_url = Url::fromRoute('entity.post.edit_form', ['post' => $curr_route_parr]);
+      $form['actions']['cancel']['#url'] = $redirect_url;
+    }
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function getRedirectUrl() {
     // Set the redirect url to the destination in the url.
     if (\Drupal::request()->query->has('destination')) {
@@ -20,6 +44,7 @@ class PostDeleteForm extends ContentEntityDeleteForm {
       return Url::fromUserInput($path);
     }
     // Default to the stream page.
-    return  Url::fromRoute('social_core.homepage');
+    return Url::fromRoute('social_core.homepage');
   }
+
 }


### PR DESCRIPTION
This was added by @AntonMartyniuk in PR 
https://github.com/goalgorilla/open_social/pull/354

See Drupal issue for more context: https://www.drupal.org/node/2875275

The cancel button needs to redirect to a page the LU has access to. We should use the post/x/edit page or if the destination is already set we can use the destination provided in the url.