### PR TITLE
ISSUE-2877309 by nielsvandermolen: CRON stuck because of infinite loo…

### DIFF
--- a/modules/custom/activity_logger/src/Plugin/QueueWorker/MessageQueueCreator.php
+++ b/modules/custom/activity_logger/src/Plugin/QueueWorker/MessageQueueCreator.php
@@ -34,10 +34,10 @@ class MessageQueueCreator extends MessageQueueBase {
       $timestamp = $entity->getCreatedTime();
       // Current time.
       $now = time();
-      $diff = $now - $timestamp;
+      $diff = abs($now - $timestamp);
 
       // Items must be at least 5 seconds old.
-      if ($diff <= 5) {
+      if ($diff <= 5 && $now > $timestamp) {
         // Wait for 100 milliseconds.
         // We don't want to flood the DB with unprocessable queue items.
         usleep(100000);


### PR DESCRIPTION
…p for nodes authored on a created date

HTT:
Found a way to reproduce it. As a CM it is possible to set an authored on date which is the created date.

When this date is set in the future the CRON task will be stuck (and the process will not abort).

There is a potential issue that an incorrect notification is being sent for nodes that are created in a group with a authored on date set in the future. But that issue is less critical than the CRON breaking.