### PR TITLE
by nielsvandermolen: Fix issue with the create open group Behat test

### DIFF
--- a/tests/behat/features/capabilities/group/group-create-open.feature
+++ b/tests/behat/features/capabilities/group/group-create-open.feature
@@ -86,8 +86,7 @@ Feature: Create Open Group
       | Location name       | Technopark |
     And I fill in the "edit-body-0-value" WYSIWYG editor with "Body description text."
   # TODO: Change title of this button when we will have one step
-    And I press "Continue to final step"
-    And I press "Create node in group"
+    And I press "Save and publish"
     And I should see "Test group event"
     And I should see "Body description text" in the "Main content"
     And I should see the button "Enroll"


### PR DESCRIPTION
HTT:

This test was disabled because of issues in Travis. We forgot to remove the double step for when creating events in an Open Group