### PR TITLE
#2882738: Remove grolesync as dependency and uninstall

### DIFF
--- a/modules/social_features/social_group/social_group.info.yml
+++ b/modules/social_features/social_group/social_group.info.yml
@@ -10,7 +10,6 @@ dependencies:
   - field_group
   - file
   - gnode
-  - grolesync
   - group
   - image
   - image_widget_crop

--- a/modules/social_features/social_group/social_group.install
+++ b/modules/social_features/social_group/social_group.install
@@ -264,3 +264,13 @@ function social_group_update_8006() {
   $permissions = _social_group_get_permissions('authenticated');
   user_role_grant_permissions('authenticated', $permissions);
 }
+
+/**
+ * Uninstall grolesync module (for now, more info: drupal.org/node/2850417).
+ */
+function social_group_update_8007() {
+  $modules = array(
+    'grolesync',
+  );
+  \Drupal::service('module_installer')->uninstall($modules);
+}


### PR DESCRIPTION
See:
https://www.drupal.org/node/2882738

I think it is safe to remove the dependency since the module should not be used anymore since the latest update anyway. I was not able to reproduce the issue reported though. I think it has to do with YAMLParser used and the commented lines in the .yml files in the grolesync module.

HTT:

- [x] Update from rc3 to this branch
- [x] Note that grolesync is not enabled anymore
- [x] Reinstall in this branch
- [x] Note that grolesync is not enabled anymore
