### PR TITLE
DS-3742 by frankgraave: added visibility icon to content of closed gr…

### DIFF
--- a/themes/socialbase/includes/node.inc
+++ b/themes/socialbase/includes/node.inc
@@ -117,6 +117,11 @@ function socialbase_preprocess_node(&$variables) {
         $variables['visibility_icon'] = 'public';
         $variables['visibility_label'] = t('public');
         break;
+
+      case 'group':
+        $variables['visibility_icon'] = 'lock';
+        $variables['visibility_label'] = t('group');
+        break;
     }
   }
 


### PR DESCRIPTION
## HTT

- [x] Create a closed group
- [x] Create a topic and/or event inside the closed group
- [x] Notice the teasers of these topics/events in overviews have the visibility lock icon 
- [x] Notice the lock icon is also visible in the detail page