### PR TITLE
DS-3763 - Make sure content is visible for group members in closed group

### DIFF
--- a/modules/social_features/social_post/src/PostAccessControlHandler.php
+++ b/modules/social_features/social_post/src/PostAccessControlHandler.php
@@ -6,6 +6,7 @@ use Drupal\Core\Entity\EntityAccessControlHandler;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\Access\AccessResult;
+use Drupal\group\Entity\Group;
 
 /**
  * Access controller for the Post entity.
@@ -59,6 +60,23 @@ class PostAccessControlHandler extends EntityAccessControlHandler {
               return $this->checkDefaultAccess($entity, $operation, $account);
             }
             return AccessResult::forbidden();
+
+          // Group.
+          case "3":
+            // Check if the post has been posted in a group.
+            $group_id = $entity->field_recipient_group->target_id;
+            if ($group_id) {
+              /** @var Group $group */
+              $group = entity_load('group', $group_id);
+              if ($group->hasPermission('access posts in group', $account) && $this->checkDefaultAccess($entity, $operation, $account)) {
+                return AccessResult::allowed();
+              }
+              else {
+                return AccessResult::forbidden();
+              }
+            }
+            return AccessResult::forbidden();
+
         }
 
       case 'update':

--- a/tests/behat/features/bootstrap/FeatureContext.php
+++ b/tests/behat/features/bootstrap/FeatureContext.php
@@ -477,6 +477,92 @@ class FeatureContext extends RawMinkContext implements Context, SnippetAccepting
     }
 
     /**
+     * Opens the content from a group and check for access.
+     *
+     * @Then /I open and check the access of content in group "(?P<groupname>[^"]+)" and I expect access "(?P<access>[^"]+)"$/
+     */
+    public function openAndCheckGroupContentAccess($groupname, $access)
+    {
+      $allowed_access = array(
+        '0' => 'denied',
+        '1' => 'allowed',
+      );
+      if (!in_array($access, $allowed_access)) {
+        throw new \InvalidArgumentException(sprintf('This access option is not allowed: "%s"', $access));
+      }
+      $expected_access = 0;
+      if ($access == 'allowed') {
+        $expected_access = 1;
+      }
+
+      $query = \Drupal::entityQuery('group')
+        ->condition('label', $groupname);
+      $gid = $query->execute();
+
+      if (!empty($gid) && count($gid) === 1) {
+        $gid = reset($gid);
+
+        if ($gid) {
+          $group = Group::load($gid);
+          $group_content_types = \Drupal\group\Entity\GroupContentType::loadByEntityTypeId('node');
+          $group_content_types = array_keys($group_content_types);
+
+          // Get all the node's related to the current group
+          $query = \Drupal::database()->select('group_content_field_data', 'gcfd');
+          $query->addField('gcfd', 'entity_id');
+          $query->condition('gcfd.gid', $group->id());
+          $query->condition('gcfd.type', $group_content_types, 'IN');
+          $query->execute()->fetchAll();
+
+          $nodes = $query->execute()->fetchAllAssoc('entity_id');
+          foreach (array_keys($nodes) as $key => $entity_id) {
+            $this->openEntityAndExpectAccess('node', $entity_id, $expected_access);
+          }
+
+          // Get all the posts from this group
+          $query = \Drupal::database()->select('post__field_recipient_group', 'pfrg');
+          $query->addField('pfrg', 'entity_id');
+          $query->condition('pfrg.field_recipient_group_target_id', $group->id());
+          $query->execute()->fetchAll();
+
+          $post_ids = $query->execute()->fetchAllAssoc('entity_id');
+
+          foreach (array_keys($post_ids) as $key => $entity_id) {
+            $this->openEntityAndExpectAccess('post', $entity_id, $expected_access);
+          }
+        }
+      }
+      else {
+        throw new \Exception(sprintf("User '%s' does not exist.", $username));
+      }
+    }
+
+    /**
+     * This opens the entity and check for the expected access.
+     *
+     * @param $entity_type
+     * @param $entity_id
+     * @param $expected_access
+     *  0 = NO access
+     *  1 = YES access
+     */
+    public function openEntityAndExpectAccess($entity_type, $entity_id, $expected_access) {
+      $entity = entity_load($entity_type, $entity_id);
+      /** @var \Drupal\Core\Url $url */
+      $url = $entity->toUrl();
+      $page = $url->toString();
+
+      $this->visitPath($page);
+
+      if ($expected_access == 0) {
+        $this->assertSession()->pageTextContains('Access denied');
+      }
+      else {
+        $this->assertSession()->pageTextNotContains('Access denied');
+      }
+    }
+
+    /**
      * @When I close the open tip
      */
     public function iCloseTheOpenTip()

--- a/tests/behat/features/capabilities/group/group-create-closed.feature
+++ b/tests/behat/features/capabilities/group/group-create-closed.feature
@@ -71,7 +71,29 @@ Feature: Create Closed Group
     And I fill in the "edit-body-0-value" WYSIWYG editor with "Body description text."
     And I press "Save and publish"
     And I should see "Test closed group event"
+
+  # Lets add another user on the Manage members tab.
+    When I click "Test closed group"
+    And I click "Manage members"
+    And I click "Add member"
+    And I fill in "Group User Two" for "Select a member"
+    And I press "Save"
+    Then I click "Members"
+    And I should see "Group User Two"
     And I logout
+
+  # Now login as user two.
+    Given I am logged in as "Group User Two"
+    And I am on "/all-groups"
+    Then I should see "Test closed group"
+    When I click "Test closed group"
+    And I should see the button "Joined"
+    And I should see "Test closed group topic"
+    And I should see "Test closed group event"
+    And I should see "This is a closed group post."
+    And I open and check the access of content in group "Test closed group" and I expect access "allowed"
+    And I logout
+    And I open and check the access of content in group "Test closed group" and I expect access "denied"
 
   # As a non-member of the closed group, when I click on the closed group
   # I should be redirected to /group/x/about. I should not see the stream, events or topics page.
@@ -79,6 +101,7 @@ Feature: Create Closed Group
       | name           | mail                      | status |
       | Platform User  | platform_user@example.com | 1      |
     And I am logged in as "Platform User"
+    And I open and check the access of content in group "Test closed group" and I expect access "denied"
     And I am on "/all-groups"
     Then I should see "Test closed group"
     When I click "Test closed group"


### PR DESCRIPTION
Problem report:

Posts in a closed group where not accessible for other group members (other than the author) because there was no support for Visibility type "3". I've added support for this and added a lot of test steps to the Behat test including a custom one in FeatureContext.php which loops through all the group content and make sure the access is as expected. You can run the test and check with VNC viewer to make sure the output is expected.

HTT:

- [x] Check behat test and Run it
- [x] Create a post in a closed group
- [x] Make someone else member of this closed group
- [x] Login as this user and make sure he has access to the post