### PR TITLE
DS-3739 - Improved placement of the tooltip arrow on deskopt, altered…

### DIFF
--- a/modules/custom/social_tour/config/install/tour.tour.social_event_overview.yml
+++ b/modules/custom/social_tour/config/install/tour.tour.social_event_overview.yml
@@ -15,6 +15,6 @@ tips:
     id: filter_tooltip
     plugin: text
     location: 'left'
-    body: 'Use this filter if you only want to see either upcoming or past events'
+    body: 'Use the event filter if you only want to see either upcoming or past events'
     attributes:
-     data-id: views-exposed-form-upcoming-events-page-community-events
+     data-id: block-socialblue-exposedformupcoming-eventspage-community-events

--- a/modules/custom/social_tour/config/install/tour.tour.social_explore.yml
+++ b/modules/custom/social_tour/config/install/tour.tour.social_explore.yml
@@ -15,7 +15,7 @@ tips:
     id: explore_tooltip
     plugin: text
     location: 'bottom'
-    body: 'Click here to explore all the content in the community'
+    body: 'Click on the explore button to browse to all content in the community'
     weight: 1
     attributes:
-      data-class: navbar-collapse .dropdown-toggle
+      data-id: main-navigation

--- a/modules/custom/social_tour/config/install/tour.tour.social_group_overview.yml
+++ b/modules/custom/social_tour/config/install/tour.tour.social_group_overview.yml
@@ -15,7 +15,7 @@ tips:
     id: content_tooltip
     plugin: text
     location: 'bottom'
-    body: 'Use this button to create a new topic, or to start a new event or group'
+    body: 'Use the plus button in the navigation bar to create a new topic, or to start a new event or group'
     weight: 2
     attributes:
-      data-class: navbar-right .icon-add_box
+      data-id: main-navigation

--- a/modules/custom/social_tour/config/install/tour.tour.social_topic_overview.yml
+++ b/modules/custom/social_tour/config/install/tour.tour.social_topic_overview.yml
@@ -15,6 +15,6 @@ tips:
     id: filter_tooltip_topic
     plugin: text
     location: 'left'
-    body: 'Here you can filter content for topic types'
+    body: 'Use the topic filter to filter on topic type.'
     attributes:
       data-id: block-socialblue-exposedformlatest-topicspage-latest-topics

--- a/modules/custom/social_tour/js/social_tour.js
+++ b/modules/custom/social_tour/js/social_tour.js
@@ -38,9 +38,8 @@
                     model.set('isActive', true);
 
                     // Alter the tour button templates.
-                    $('.button.button--primary', '.tip-module-social-tour').each(function(){
-                        $(this).removeClass('button').addClass('btn');
-                        $(this).removeClass('button--primary').addClass('btn-primary');
+                    $('.tip-module-social-tour').each(function(){
+                        $(this).find('.button.button--primary').removeClass('button').addClass('btn').removeClass('button--primary').addClass('btn-primary');;
                     })
 
                     // For our social tour, we only want to show the next button if there is more than 1 tool tip.
@@ -49,8 +48,9 @@
                     }
 
                     // Add another button
-                    var closetips = Drupal.t("Don't show tips like this anymore");
-                    $('.joyride-content-wrapper').append('<br/><a class="btn btn-link" href="/user/tour/disable">'+closetips+'</a>');
+                    var closetips = Drupal.t("Always hide tips like this");
+                    // $('.joyride-content-wrapper').append('<a class="btn btn-primary" href="/user/tour/disable">'+closetips+'</a>');
+                    $('.joyride-content-wrapper').append('<a class="joyride-tip-remove" href="/user/tour/disable">'+closetips+'</a>');
                 }
             });
 

--- a/modules/custom/social_tour/js/social_tour.js
+++ b/modules/custom/social_tour/js/social_tour.js
@@ -49,7 +49,6 @@
 
                     // Add another button
                     var closetips = Drupal.t("Always hide tips like this");
-                    // $('.joyride-content-wrapper').append('<a class="btn btn-primary" href="/user/tour/disable">'+closetips+'</a>');
                     $('.joyride-content-wrapper').append('<a class="joyride-tip-remove" href="/user/tour/disable">'+closetips+'</a>');
                 }
             });

--- a/modules/custom/social_tour/js/social_tour.js
+++ b/modules/custom/social_tour/js/social_tour.js
@@ -48,7 +48,7 @@
                     }
 
                     // Add another button
-                    var closetips = Drupal.t("Always hide tips like this");
+                    var closetips = Drupal.t("Don't show tips like this anymore");
                     $('.joyride-content-wrapper').append('<a class="joyride-tip-remove" href="/user/tour/disable">'+closetips+'</a>');
                 }
             });

--- a/tests/behat/features/capabilities/tour/tour.feature
+++ b/tests/behat/features/capabilities/tour/tour.feature
@@ -31,10 +31,10 @@ Scenario: Successfully take the tour and see all pop-ups
     And I should not see "Don't show tips like this anymore"
 
   Given I am on "all-groups"
-   Then I should see "Use this button to create a new topic, or to start a new event or group"
+   Then I should see "Use the plus button in the navigation bar to create a new topic, or to start a new event or group"
     And I should see "Don't show tips like this anymore"
    When I close the open tip
-   Then I should not see "Use this button to create a new topic, or to start a new event or group"
+   Then I should not see "Use the plus button in the navigation bar to create a new topic, or to start a new event or group"
     And I should not see "Don't show tips like this anymore"
 
   Given I am on "/user"
@@ -81,7 +81,7 @@ Scenario: Stop showing me tips
    When I am logged in as an "authenticated user"
     And I enable the tour setting
     And I am on "all-topics"
-   Then I should see "Here you can filter content for topic types"
+   Then I should see "Use the topic filter to filter on topic type."
     And I should see "Don't show tips like this anymore"
    When I click "Don't show tips like this anymore"
    Then I should see "You will not see tips like this anymore."

--- a/tests/behat/features/capabilities/tour/tour.feature
+++ b/tests/behat/features/capabilities/tour/tour.feature
@@ -17,17 +17,17 @@ Scenario: Successfully take the tour and see all pop-ups
     And I should not see "Don't show tips like this anymore"
 
   Given I am on "all-topics"
-   Then I should see "Here you can filter content for topic types"
+   Then I should see "Use the topic filter to filter on topic type."
     And I should see "Don't show tips like this anymore"
    When I close the open tip
-   Then I should not see "Here you can filter content for topic types"
+   Then I should not see "Use the topic filter to filter on topic type."
     And I should not see "Don't show tips like this anymore"
 
   Given I am on "community-events"
-   Then I should see "Use this filter if you only want to see either upcoming or past events"
+   Then I should see "Use the event filter if you only want to see either upcoming or past events"
     And I should see "Don't show tips like this anymore"
    When I close the open tip
-   Then I should not see "Use this filter if you only want to see either upcoming or past events"
+   Then I should not see "Use the event filter if you only want to see either upcoming or past events"
     And I should not see "Don't show tips like this anymore"
 
   Given I am on "all-groups"
@@ -45,10 +45,10 @@ Scenario: Successfully take the tour and see all pop-ups
     And I should not see "Don't show tips like this anymore"
 
    When I click "Information"
-   Then I should see "Click here to explore all the content in the community"
+   Then I should see "Click on the explore button to browse to all content in the community"
     And I should see "Don't show tips like this anymore"
    When I close the open tip
-   Then I should not see "Click here to explore all the content in the community"
+   Then I should not see "Click on the explore button to browse to all content in the community"
     And I should not see "Don't show tips like this anymore"
 
     Given topic content:
@@ -87,5 +87,5 @@ Scenario: Stop showing me tips
    Then I should see "You will not see tips like this anymore."
 
   Given I am on "community-events"
-   Then I should not see "Use this filter if you only want to see either upcoming or past events"
+   Then I should not see "Use the event filter if you only want to see either upcoming or past events"
     And I should not see "Don't show tips like this anymore"

--- a/themes/socialbase/assets/css/tour.css
+++ b/themes/socialbase/assets/css/tour.css
@@ -115,7 +115,7 @@
   }
 
   .joyride-tip-guide .joyride-nub.top {
-    left: -15px;
+    left: -25px;
   }
 
   .joyride-tip-guide .joyride-nub.top + .joyride-content-wrapper {
@@ -123,7 +123,7 @@
   }
 
   .joyride-tip-guide .joyride-nub.bottom {
-    left: -15px;
+    left: -25px;
   }
 
   .joyride-tip-guide .joyride-nub.bottom + .joyride-content-wrapper {

--- a/themes/socialbase/assets/css/tour.css
+++ b/themes/socialbase/assets/css/tour.css
@@ -68,14 +68,27 @@
   right: 28px;
 }
 
-.joyride-next-tip {
-  margin-left: 10px;
+.joyride-tip-guide .tour-progress {
+  position: absolute;
+  bottom: 25px;
+}
+
+.joyride-tip-guide .joyride-tip-remove {
+  position: absolute;
+  right: 10px;
+  bottom: 10px;
+  font-size: 12px;
+}
+
+.joyride-tip-guide .joyride-tip-remove:hover {
+  text-decoration: underline;
 }
 
 .joyride-content-wrapper {
   background: white;
   color: #4d4d4d;
   box-shadow: 0 0 15px rgba(0, 0, 0, 0.5);
+  padding: 20px 50px 35px 20px;
 }
 
 .tour-tip-body,
@@ -101,7 +114,46 @@
     width: 450px;
   }
 
+  .joyride-tip-guide .joyride-nub.top {
+    left: -15px;
+  }
+
+  .joyride-tip-guide .joyride-nub.top + .joyride-content-wrapper {
+    left: -40px;
+  }
+
+  .joyride-tip-guide .joyride-nub.bottom {
+    left: -15px;
+  }
+
+  .joyride-tip-guide .joyride-nub.bottom + .joyride-content-wrapper {
+    left: -40px;
+  }
+
+  .joyride-tip-guide .joyride-nub.left {
+    top: -25px;
+  }
+
+  .joyride-tip-guide .joyride-nub.left + .joyride-content-wrapper {
+    top: -45px;
+  }
+
+  .joyride-tip-guide .joyride-nub.right {
+    top: -25px;
+  }
+
+  .joyride-tip-guide .joyride-nub.right + .joyride-content-wrapper {
+    top: -45px;
+  }
+
   .joyride-content-wrapper {
     padding: 35px 65px 35px 35px;
+  }
+}
+
+@media (max-width: 599px) {
+
+  .joyride-tip-guide {
+    display: none !important;
   }
 }

--- a/themes/socialbase/components/03-molecules/tour/tour.scss
+++ b/themes/socialbase/components/03-molecules/tour/tour.scss
@@ -47,7 +47,7 @@
     }
 
     @include for-tablet-portrait-up {
-      left: -15px;
+      left: -25px;
 
       & + .joyride-content-wrapper {
         left: -40px;
@@ -65,7 +65,7 @@
     }
 
     @include for-tablet-portrait-up {
-      left: -15px;
+      left: -25px;
 
       & + .joyride-content-wrapper {
         left: -40px;

--- a/themes/socialbase/components/03-molecules/tour/tour.scss
+++ b/themes/socialbase/components/03-molecules/tour/tour.scss
@@ -29,6 +29,10 @@
   background: transparent;
   z-index: $zindex-tour;
 
+  @include for-phone-only {
+    display: none !important; // We hide tooltips on mobile since edge detectiond and arrow placement is not working propertly.
+  }
+
   @include for-tablet-portrait-up {
     width: 450px;
   }
@@ -41,6 +45,14 @@
     & + .joyride-content-wrapper {
       top: 28px;
     }
+
+    @include for-tablet-portrait-up {
+      left: -15px;
+
+      & + .joyride-content-wrapper {
+        left: -40px;
+      }
+    }
   }
 
   .joyride-nub.bottom {
@@ -50,6 +62,14 @@
 
     & + .joyride-content-wrapper {
       bottom: 28px;
+    }
+
+    @include for-tablet-portrait-up {
+      left: -15px;
+
+      & + .joyride-content-wrapper {
+        left: -40px;
+      }
     }
   }
 
@@ -61,6 +81,14 @@
     & + .joyride-content-wrapper {
       left: 28px;
     }
+
+    @include for-tablet-portrait-up {
+      top: -25px;
+
+      & + .joyride-content-wrapper {
+        top: -45px;
+      }
+    }
   }
 
   .joyride-nub.right {
@@ -71,18 +99,40 @@
     & + .joyride-content-wrapper {
       right: 28px;
     }
+
+    @include for-tablet-portrait-up {
+      top: -25px;
+
+      & + .joyride-content-wrapper {
+        top: -45px;
+      }
+    }
   }
 
-}
+  .tour-progress {
+    position: absolute;
+    bottom: 25px;
+  }
 
-.joyride-next-tip {
-  margin-left: 10px;
+  .joyride-tip-remove {
+    position: absolute;
+    right: 10px;
+    bottom: 10px;
+    font-size: 12px;
+
+    &:hover {
+      text-decoration: underline;
+    }
+
+  }
+
 }
 
 .joyride-content-wrapper {
   background: $tour-background-color;
   color: $tour-text-color;
   box-shadow: 0 0 15px rgba(0, 0, 0, 0.5);
+  padding: 20px 50px 35px 20px;
 
   @include for-tablet-portrait-up {
     padding: 35px 65px 35px 35px;


### PR DESCRIPTION
# HTT
- [x] User should be able to close one modal window with the X and the "Hide tooltips forever" link should be less prominent.
- [x] Test on desktop and see that the tooltips don't show up on mobile.
- [x] Go to groups overview  and see that the tooltip points to the navbar and that the text is descriptive enough for a user to be able to click on right button (the plus button:P)
- [x] Go to the events overview and see that the tooltips points to the upper left corner of the widget containing the filter
- [x] Go to the topic overview and see that the tooltips points to the upper left corner of the widget containing the filter 
- [x] Go to a node detail page and see that the tooltip is pointing to the follow button
- [ ] Go to the profile page (information) and see that the tooltip points to the main navigation and that the text is descriptive enough to let the user click on the explore button. 