### PR TITLE
Issue #2884358 by maikelkoopman: Set brand-primary class back on node save form

### DIFF
--- a/modules/custom/improved_theme_settings/improved_theme_settings.module
+++ b/modules/custom/improved_theme_settings/improved_theme_settings.module
@@ -247,7 +247,7 @@ function improved_theme_settings_page_attachments(array &$page) {
           border-radius: ' . $border_radius . 'px 0 0 ' . $border_radius . 'px !important;
         }
 
-        .btn {
+        div:not(.btn-group) > .btn {
           border-radius: ' . $border_radius . 'px !important;
         }
 

--- a/themes/socialbase/assets/css/button.css
+++ b/themes/socialbase/assets/css/button.css
@@ -378,6 +378,16 @@ input[type="button"].btn-block {
   margin-left: 0;
 }
 
+.btn-group--operations {
+  width: 100%;
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+      -ms-flex-pack: center;
+          justify-content: center;
+}
+
 .block-group-add-event-block,
 .block-group-add-topic-block,
 .block-event-add-block,

--- a/themes/socialbase/components/02-atoms/button/button.scss
+++ b/themes/socialbase/components/02-atoms/button/button.scss
@@ -532,6 +532,14 @@ input[type="button"] {
   }
 }
 
+// Operations dropdown buttons
+
+.btn-group--operations {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+}
+
 
 // on mobile we want to "add" and "filter" buttons to be on one row
 // We need to add these selectors here now, because they need to be loaded regardless of other libraries being loaded

--- a/themes/socialbase/includes/input.inc
+++ b/themes/socialbase/includes/input.inc
@@ -63,6 +63,12 @@ function socialbase_preprocess_input(&$variables) {
 
   }
 
+  if (isset($variables['element']['#button_size'])) {
+    if ($variables['element']['#button_size'] == 'small') {
+      $variables['button_size'] = 'small';
+    }
+  }
+
   // If a split button desn't have a button_type variable, set it to default (fallback)
   if (isset($variables['element']['#split']) && !isset($variables['element']['#button_type'])) {
     $variables['button_type'] = 'default';

--- a/themes/socialbase/src/Plugin/Preprocess/BootstrapDropdown.php
+++ b/themes/socialbase/src/Plugin/Preprocess/BootstrapDropdown.php
@@ -6,6 +6,9 @@
 
 namespace Drupal\socialbase\Plugin\Preprocess;
 
+use Drupal\bootstrap\Utility\Variables;
+use Drupal\bootstrap\Utility\Unicode;
+
 /**
  * Pre-processes variables for the "bootstrap_dropdown" theme hook.
  *
@@ -22,6 +25,31 @@ class BootstrapDropdown extends \Drupal\bootstrap\Plugin\Preprocess\BootstrapDro
     parent::preprocess($variables, $hook, $info);
     if (isset($variables['items']['#items']['publish']['element']['#button_type']) && $variables['items']['#items']['publish']['element']['#button_type'] == 'primary') {
       $variables['alignment'] = 'right';
+
+      if (isset($variables['toggle'])) {
+        $variables['toggle']['#button_type'] = 'primary';
+        $variables['toggle']['#button_level'] = 'raised';
+
+      }
+
     }
+
   }
+
+  protected function preprocessLinks(Variables $variables) {
+    parent::preprocessLinks($variables);
+
+    $operations = !!Unicode::strpos($variables->theme_hook_original, 'operations');
+
+    // Make operations button small, not smaller ;).
+    // Bootstrap basetheme override
+
+    if ($operations) {
+      $variables->toggle['#attributes']['class'] = ['btn-sm'];
+      $variables['btn_context'] = 'operations';
+      $variables['alignment'] = 'right';
+    }
+
+  }
+
 }

--- a/themes/socialbase/src/Plugin/Preprocess/InputButton.php
+++ b/themes/socialbase/src/Plugin/Preprocess/InputButton.php
@@ -7,6 +7,9 @@
 
 namespace Drupal\socialbase\Plugin\Preprocess;
 
+use Drupal\bootstrap\Utility\Element;
+use Drupal\bootstrap\Utility\Variables;
+
 /**
  * Pre-processes variables for the "input__button" theme hook.
  *
@@ -19,8 +22,16 @@ class InputButton extends \Drupal\bootstrap\Plugin\Preprocess\InputButton {
   /**
    * {@inheritdoc}
    */
-  public function preprocess(array &$variables, $hook, array $info) {
-    parent::preprocess($variables, $hook, $info);
+  public function preprocessElement(Element $element, Variables $variables) {
+    $element->setButtonSize();
+    $element->setIcon($element->getProperty('icon'));
+    $variables['icon_only'] = $element->getProperty('icon_only');
+    $variables['icon_position'] = $element->getProperty('icon_position');
+    $variables['label'] = $element->getProperty('value');
+    if ($element->getProperty('split')) {
+      $variables->map([$variables::SPLIT_BUTTON]);
+    }
+    parent::preprocessElement($element, $variables);
     $variables['attributes']->removeClass('btn-default');
   }
 

--- a/themes/socialbase/templates/form/bootstrap-dropdown.html.twig
+++ b/themes/socialbase/templates/form/bootstrap-dropdown.html.twig
@@ -20,6 +20,7 @@
     'dropdown',
     alignment == 'up' ? 'dropup',
     alignment == 'right' ? 'btn-group--primary',
+    btn_context == 'operations' ? 'btn-group--operations',
   ]
 %}
 <div{{ attributes.addClass(classes) }}>

--- a/themes/socialbase/templates/form/input.html.twig
+++ b/themes/socialbase/templates/form/input.html.twig
@@ -30,6 +30,7 @@
     button_type == 'flat' ? 'btn-flat brand-text-primary',
     button_type == 'primary' ? 'btn-primary brand-bg-primary  waves-effect',
     button_type == 'accent' ? 'btn-accent brand-bg-accent  waves-effect',
+    button_size == 'small' ? 'btn-sm',
     attributes.hasClass('crop-preview-wrapper__crop-reset') ? 'btn-flat',
     icon and icon_position and not icon_only ? 'icon-' ~ icon_position,
   ]

--- a/themes/socialbase/templates/system/table.html.twig
+++ b/themes/socialbase/templates/system/table.html.twig
@@ -50,10 +50,11 @@
   {% set classes = [
     'table',
     'tablesaw',
-    context.bordered is not empty or theme.settings.table_bordered ? 'table-bordered',
-    context.condensed is not empty or theme.settings.table_condensed ? 'table-condensed',
-    context.hover is not empty or theme.settings.table_hover ? 'table-hover',
-    context.striped is not empty or theme.settings.table_striped ? 'table-striped',
+    bordered ? 'table-bordered',
+    condensed ? 'table-condensed',
+    hover ? 'table-hover',
+    striped ? 'table-striped',
+    sticky ? 'sticky-enabled',
   ] %}
 
     <table{{ attributes.addClass(classes) }} data-tablesaw-mode="swipe" data-tablesaw-minimap>


### PR DESCRIPTION
- [x] set brand-primary class back on node save form. 
- [x] Restore classes on tables (condensed, bordered, hover -bootstrap update). 
- [x] Make operations button larger (group/*/membership).
- [x] Fix border-radius issue with buttons in dropdown -> improved_theme_settings module