### PR TITLE
DS-3731 - add support for private file uploads in WYSIWYG

### DIFF
--- a/modules/custom/social_file_private/social_file_private.services.yml
+++ b/modules/custom/social_file_private/social_file_private.services.yml
@@ -3,3 +3,7 @@ services:
     class: \Drupal\social_file_private\SocialFilePrivateFieldsConfigOverride
     tags:
       - {name: config.factory.override, priority: 5}
+  social_file_private_text_editor.overrider:
+    class: \Drupal\social_file_private\SocialFilePrivateTextEditorConfigOverride
+    tags:
+      - {name: config.factory.override, priority: 5}

--- a/modules/custom/social_file_private/src/SocialFilePrivateTextEditorConfigOverride.php
+++ b/modules/custom/social_file_private/src/SocialFilePrivateTextEditorConfigOverride.php
@@ -1,0 +1,78 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\social_file_private\SocialFilePrivateTextEditorConfigOverride.
+ */
+
+namespace Drupal\social_file_private;
+
+use Drupal\Core\Cache\CacheableMetadata;
+use Drupal\Core\Config\ConfigFactoryOverrideInterface;
+use Drupal\Core\Config\StorageInterface;
+
+/**
+ * Override the text editor configuration and set private scheme for files.
+ */
+class SocialFilePrivateTextEditorConfigOverride implements ConfigFactoryOverrideInterface {
+
+  /**
+   * Get all the editors/input formats we need to protect.
+   *
+   * @TODO Retrieve the input formats programmatically.
+   *
+   * Note: this list is now fixed, but an error will be shown in the status
+   * report when there are text editors using public scheme.
+   *
+   * @return array
+   */
+  public function getTextEditorsToProtect() {
+    $config_names = [
+      'editor.editor.basic_html',
+      'editor.editor.full_html',
+    ];
+    return $config_names;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function loadOverrides($names) {
+    $overrides = array();
+    if (\Drupal\Core\StreamWrapper\PrivateStream::basePath()) {
+      $config_names = $this->getTextEditorsToProtect();
+      foreach ($config_names as $config_name) {
+        if (in_array($config_name, $names)) {
+          $config = \Drupal::service('config.factory')->getEditable($config_name);
+          $scheme = $config->get('image_upload.scheme');
+          if ($scheme == 'public') {
+            $overrides[$config_name]['image_upload']['scheme'] = 'private';
+          }
+        }
+      }
+    }
+    return $overrides;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCacheSuffix() {
+    return 'SocialFilePrivateTextEditorConfigOverride';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCacheableMetadata($name) {
+    return new CacheableMetadata();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function createConfigObject($name, $collection = StorageInterface::DEFAULT_COLLECTION) {
+    return NULL;
+  }
+
+}

--- a/tests/behat/config/behat.yml
+++ b/tests/behat/config/behat.yml
@@ -46,3 +46,4 @@ default:
           'Main content': '.region--content'
           'Main content front': '.region--content'
           'Sidebar second': 'aside[role=complementary]'
+          'Modal footer': '.modal-footer'

--- a/tests/behat/features/bootstrap/FeatureContext.php
+++ b/tests/behat/features/bootstrap/FeatureContext.php
@@ -76,6 +76,49 @@ class FeatureContext extends RawMinkContext implements Context, SnippetAccepting
     }
 
     /**
+     * @When /^I click on the image icon in the WYSIWYG editor$/
+     */
+    public function clickImageIconInWysiwygEditor() {
+
+      $cssSelector = 'a.cke_button__drupalimage';
+
+      $session = $this->getSession();
+      $element = $session->getPage()->find(
+        'xpath',
+        $session->getSelectorsHandler()->selectorToXpath('css', $cssSelector)
+      );
+      if (null === $element) {
+        throw new \InvalidArgumentException(sprintf('Could not evaluate CSS Selector: "%s"', $cssSelector));
+      }
+
+      $element->click();
+
+    }
+
+    /**
+     * @Then /^The image path in the body description should be private$/
+     */
+    public function imagePathInBodyDescriptionShouldBePrivate() {
+
+      $cssSelector = 'article .card__body .body-text img';
+
+      $session = $this->getSession();
+      $element = $session->getPage()->find(
+        'xpath',
+        $session->getSelectorsHandler()->selectorToXpath('css', $cssSelector)
+      );
+      if (null === $element) {
+        throw new \InvalidArgumentException(sprintf('Could not evaluate CSS Selector: "%s"', $cssSelector));
+      }
+
+      $src = $element->getAttribute('src');
+
+      if (strpos($src, '/system/files/inline-images') === FALSE) {
+        throw new \InvalidArgumentException(sprintf('The image does not seem to be uploaded in the private file system: "%s"', $src));
+      }
+    }
+
+    /**
      * @When I click admin link :text
      */
     public function clickAdminLink($text) {

--- a/tests/behat/features/capabilities/security/private-file-uploads.feature
+++ b/tests/behat/features/capabilities/security/private-file-uploads.feature
@@ -58,3 +58,32 @@ Feature: Private files
     And I open the "topic" node with title "Private: topic"
     Then I should see "Access denied. You must log in to view this page."
     Then I open and check the access of the files uploaded by "private_file_user_1" and I expect access "denied"
+
+  Scenario: Upload files in the WYSIWYG
+    Given I enable the module "social_file_private"
+    And users:
+      | name                     | mail                               | status | field_profile_first_name  | field_profile_last_name | field_profile_organization | field_profile_function |
+      | wysiwyg_private_user_1   | wysiwyg_private_user_1@example.com | 1      | Real Slim                 | Shady                    | Privateering               | Private              |
+    And I am logged in as "wysiwyg_private_user_1"
+
+    Given I am on "node/add/topic"
+    And I click radio button "Discussion"
+    When I fill in the following:
+      | Title | Private WYSIWYG: topic |
+    And I click on the image icon in the WYSIWYG editor
+    And I wait for AJAX to finish
+    And I attach the file "/files/opensocial.jpg" to "files[fid]"
+    And I wait for AJAX to finish
+    And I fill in "Alternative text" with "Just a private image test"
+    And I press "Save" in the "Modal footer"
+    And I wait for AJAX to finish
+    And I wait for "3" seconds
+    And I press "Save"
+    Then I should see "Topic Private WYSIWYG: topic has been created."
+    And I should see "Private WYSIWYG: topic" in the "Hero block"
+    And The image path in the body description should be private
+    Then I open and check the access of the files uploaded by "wysiwyg_private_user_1" and I expect access "allowed"
+    When I logout
+    And I open the "topic" node with title "Private WYSIWYG: topic"
+    Then I should see "Access denied. You must log in to view this page."
+    Then I open and check the access of the files uploaded by "wysiwyg_private_user_1" and I expect access "denied"


### PR DESCRIPTION
HTT:

- [x] Check code
- [x] Upload files with WYSIWYG and make sure the files are uploaded in a private file directory
- [x] Verify with two accounts CM+ and LU.
- [x] Check the Behat test