### PR TITLE
#2876613 - Make book node body field a non optional field 

### DIFF
--- a/modules/social_features/social_book/config/install/field.field.node.book.body.yml
+++ b/modules/social_features/social_book/config/install/field.field.node.book.body.yml
@@ -1,0 +1,21 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.body
+    - node.type.book
+  module:
+    - text
+id: node.book.body
+field_name: body
+entity_type: node
+bundle: book
+label: Body
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  display_summary: true
+field_type: text_with_summary


### PR DESCRIPTION
## HTT

- [x] Check the code
- [x] Install OS through the UI and enable the book module.
- [x] Make sure to also install demo content otherwise it will fail (https://www.drupal.org/node/2884590)
- [x] Notice that the social_book module is now enabled and you can add books
- [x] Merge