### PR TITLE
Issue #2884265 by maikelkoopman: restore classes on form-element temp…

### DIFF
--- a/themes/socialbase/templates/form/form-element.html.twig
+++ b/themes/socialbase/templates/form/form-element.html.twig
@@ -47,6 +47,12 @@
 #}
 {%
   set classes = [
+    'form-item',
+    'js-form-item',
+    'form-type-' ~ type|clean_class,
+    'js-form-type-' ~ type|clean_class,
+    'form-item-' ~ name|clean_class,
+    'js-form-item-' ~ name|clean_class,
     'brand-border-radius',
     title_display not in ['after', 'before'] ? 'form-no-label',
     disabled == 'disabled' ? 'form-disabled',


### PR DESCRIPTION
Issue #2884265 Restore classes on form-element template

How to test:

- [x] Enable a "summary input" on a content type. For example here: /admin/structure/types/manage/page/fields/node.page.body
- Check that the summary field is displayed

Original story:
https://www.drupal.org/node/2884265