### PR TITLE
#2884590 - No need to filter on groups in the stream when no groups exist in the platform (yet).

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,6 @@ before_install:
   - export BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_BRANCH; else echo `curl -s $PR | jq -r .head.ref`; fi)
   - export COMPOSER_EXIT_ON_PATCH_FAILURE=1
   - echo "TRAVIS_BRANCH=$TRAVIS_BRANCH, PR=$PR, BRANCH=$BRANCH"
-  - composer clearcache
   - composer require goalgorilla/open_social:dev-${BRANCH}#${TRAVIS_COMMIT}
   # Lets install via docker-compose.
   - sudo rm /usr/local/bin/docker-compose || true

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,7 @@ before_install:
   - export BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_BRANCH; else echo `curl -s $PR | jq -r .head.ref`; fi)
   - export COMPOSER_EXIT_ON_PATCH_FAILURE=1
   - echo "TRAVIS_BRANCH=$TRAVIS_BRANCH, PR=$PR, BRANCH=$BRANCH"
+  - composer clearcache
   - composer require goalgorilla/open_social:dev-${BRANCH}#${TRAVIS_COMMIT}
   # Lets install via docker-compose.
   - sudo rm /usr/local/bin/docker-compose || true

--- a/modules/custom/activity_viewer/src/Plugin/views/filter/ActivityPostVisibilityAccess.php
+++ b/modules/custom/activity_viewer/src/Plugin/views/filter/ActivityPostVisibilityAccess.php
@@ -120,7 +120,7 @@ class ActivityPostVisibilityAccess extends FilterPluginBase {
     $or->condition($node_access);
 
     // Posts: retrieve all the posts in groups the user is a member of.
-    if ($account->isAuthenticated()) {
+    if ($account->isAuthenticated() && count($groups_unique) > 0) {
       $posts_in_groups = db_and();
       $posts_in_groups->condition('activity__field_activity_entity.field_activity_entity_target_type', 'post', '=');
       $posts_in_groups->condition('activity__field_activity_recipient_group.field_activity_recipient_group_target_id', $groups_unique,'IN');
@@ -145,10 +145,13 @@ class ActivityPostVisibilityAccess extends FilterPluginBase {
 
     // Comments: retrieve comments the user has access to.
     if ($account->hasPermission('access comments')) {
-      $comments_on_content_in_groups = db_and();
-      $comments_on_content_in_groups->condition('activity__field_activity_entity.field_activity_entity_target_type', 'comment', '=');
-      $comments_on_content_in_groups->condition('activity__field_activity_recipient_group.field_activity_recipient_group_target_id', $groups_unique, 'IN');
-      $or->condition($comments_on_content_in_groups);
+      // For comments in groups, the user must be a member of at least 1 group.
+      if (count($groups_unique) > 0) {
+        $comments_on_content_in_groups = db_and();
+        $comments_on_content_in_groups->condition('activity__field_activity_entity.field_activity_entity_target_type', 'comment', '=');
+        $comments_on_content_in_groups->condition('activity__field_activity_recipient_group.field_activity_recipient_group_target_id', $groups_unique, 'IN');
+        $or->condition($comments_on_content_in_groups);
+      }
 
       $comments_on_content = db_and();
       $comments_on_content->condition('activity__field_activity_entity.field_activity_entity_target_type', 'comment', '=');


### PR DESCRIPTION
## INFO
The issue was that the ActivityPostVisibility always assumed that at least 1 group was available on the platform. This is not the case sometimes. The fixed conditions failed in those cases.

## HTT
- [x] Check the code

- [x] Do a reinstall without demo content (turn off in install_script.sh)
- [x] Log in as admin an go to the homepage stream
- [x] Should work normally and show an empty homepage stream

- [x] Do another install, but this time with demo content
- [x] Open OS twice:
- [x] Once as petershaw (who IS a member of the closed group)
- [x] Once as robertandrews (who IS NOT a member of the closed group)
- [x] Go to a random open group and place a post and a comment on that post in the group
- [x] Notice that both petershaw and robertandrews see the post AND the comment on the homepage stream
- [x] Go to the closed group and place a post and a comment on that post in the group (as petershaw)
- [x] Notice that petershaw DOES see both on his homepage stream, but robertandrews DOES NOT see it.

- [x] Mi ma merge!!!