### PR TITLE
Issue 2884351 by ozin: Fixed redirect after tour disable.

### DIFF
--- a/modules/custom/social_tour/js/social_tour.js
+++ b/modules/custom/social_tour/js/social_tour.js
@@ -49,7 +49,8 @@
 
                     // Add another button
                     var closetips = Drupal.t("Don't show tips like this anymore");
-                    $('.joyride-content-wrapper').append('<a class="joyride-tip-remove" href="/user/tour/disable">'+closetips+'</a>');
+                    var destination = $(location).attr('pathname');
+                    $('.joyride-content-wrapper').append('<a class="joyride-tip-remove" href="/user/tour/disable?destination=' + destination + '">'+closetips+'</a>');
                 }
             });
 

--- a/modules/custom/social_tour/src/SocialTourController.php
+++ b/modules/custom/social_tour/src/SocialTourController.php
@@ -106,10 +106,11 @@ class SocialTourController extends ControllerBase {
   public function disableOnboarding() {
     // Save the value in the user_data.
     $this->setData(TRUE);
+    $redirect = \Drupal::request()->get('destination') ?: '/stream';
     // Set a message that they can be turned on again.
     drupal_set_message($this->t('You will not see tips like this anymore.'));
     // Return to Profile.
-    return new RedirectResponse('/user');
+    return new RedirectResponse($redirect);
   }
 
   /**


### PR DESCRIPTION
**Original issue:** https://www.drupal.org/node/2884351
**Solution**:
Fixed redirect after tour has been disabled, removed hardcoded URL '/user' & added destination parameter for the '/user/tour/disable' URL.
**HTT**:
- [ ] Login to the site;
- [ ] Go to some page with the Tour message;
- [ ] Click the "Don't show tips like this anymore" link;
- [ ] You should stay on the same page. 