### PR TITLE
Issue 2884811 by kedramon: Demo Content for Topics needs topic type field selected

### DIFF
--- a/modules/custom/social_demo/content/entity/topic.yml
+++ b/modules/custom/social_demo/content/entity/topic.yml
@@ -22,7 +22,7 @@
     <p><strong>Contact Us</strong></p>
     
     <p>Find out contact information. You can reach us by phone, fax, email, and after-hours cell phone number for members of the media.</p>
-  field_topic_type: blog
+  field_topic_type: Blog
   field_topic_image: aa51f918-dee0-11e5-b86d-9a79f06e9478
   field_content_visibility: community
 92e8d86c-da14-11e5-b5d2-0a1d41d68578:
@@ -34,7 +34,7 @@
   group: 3bc51523-4f40-459c-887c-056432fe17cd
   body: >
     <p><span>Welcome to the community website of the Educational Assistance Association (EAA). We are very happy and proud to be able to launch this new tool to bring together people that care for education. Through the effort of all the involved People, our Sponsors and GoalGorilla it was made possible to create a new way of connecting professionals and help to spread knowledge over education. </span></p>
-  field_topic_type: news
+  field_topic_type: News
   field_topic_image: aa51fec2-dee0-11e5-b86d-9a79f06e9478
   field_content_visibility: community
 426a6ea6-decd-11e5-b86d-9a79f06e9478:
@@ -46,7 +46,7 @@
   group: d6e37a3c-32d8-11e6-ac61-9e71128cae77
   body: >
     <p>We need to decide what will be the next event what we want to organize. I would propose that everybody who has an idea will post those in the comments. then we can decide which one seems the most promising.</p>
-  field_topic_type: discussion
+  field_topic_type: Discussion
   field_topic_image: aa51f774-dee0-11e5-b86d-9a79f06e9478
   field_content_visibility: community
 7096dc28-ded3-11e5-b86d-9a79f06e9478:
@@ -60,7 +60,7 @@
     <p>Hi guys,</p>
 
     <p>I just started working in the board of schools in my town. So I saw this group here and I thought it would be a good idea to open a thread where we could exchange our most finest hours ;-). I am especially interested in successful fund raising campaigns you guys ran, but of course any input is appreciated</p>
-  field_topic_type: discussion
+  field_topic_type: Discussion
   field_topic_image: aa52008e-dee0-11e5-b86d-9a79f06e9478
   field_content_visibility: community
 7096de80-ded3-11e5-b86d-9a79f06e9478:
@@ -79,7 +79,7 @@
     <p>Neque enim civitas in seditione beata esse potest nec in discordia dominorum domus; Suo genere perveniant ad extremum; <i>Paria sunt igitur.</i> Quid censes in Latino fore? <a href='http://loripsum.net/' target='_blank'>Nunc vides, quid faciat.</a> </p>
 
     <p><a href='http://loripsum.net/' target='_blank'>Verum hoc idem saepe faciamus.</a> <a href='http://loripsum.net/' target='_blank'>Sed nimis multa.</a> Conferam avum tuum Drusum cum C. <b>Dat enim intervalla et relaxat.</b> Quod si ita sit, cur opera philosophiae sit danda nescio. </p>
-  field_topic_type: blog
+  field_topic_type: Blog
   field_topic_image: aa52023c-dee0-11e5-b86d-9a79f06e9478
   field_content_visibility: community
 7096df84-ded3-11e5-b86d-9a79f06e9478:
@@ -98,7 +98,7 @@
     <p>Illum mallem levares, quo optimum atque humanissimum virum, Cn. <i>Quid sequatur, quid repugnet, vident.</i> Invidiosum nomen est, infame, suspectum. <b>Sequitur disserendi ratio cognitioque naturae;</b> Si est nihil nisi corpus, summa erunt illa: valitudo, vacuitas doloris, pulchritudo, cetera. <mark>Quis negat?</mark> Expressa vero in iis aetatibus, quae iam confirmatae sunt. </p>
 
     <p>Praeclare hoc quidem. Quid censes in Latino fore? Cupiditates non Epicuri divisione finiebat, sed sua satietate. Nam ante Aristippus, et ille melius. <a href='http://loripsum.net/' target='_blank'>Egone quaeris, inquit, quid sentiam?</a> Nihil opus est exemplis hoc facere longius. Ita fit cum gravior, tum etiam splendidior oratio. Hoc loco tenere se Triarius non potuit. </p>
-  field_topic_type: discussion
+  field_topic_type: Discussion
   field_topic_image: 
   field_content_visibility: community
 7096e290-ded3-11e5-b86d-9a79f06e9478:
@@ -115,7 +115,7 @@
     <p dir="ltr">Best Wishes</p>
     
     <p>Robert Andrews</p>
-  field_topic_type: news
+  field_topic_type: News
   field_topic_image: aa51f918-dee0-11e5-b86d-9a79f06e9478
   group: d6e37be0-32d8-11e6-ac61-9e71128cae77
   field_content_visibility: community
@@ -146,7 +146,7 @@
     <p>Minime vero istorum quidem, inquit. Ut enim consuetudo loquitur, id solum dicitur honestum, quod est populari fama gloriosum. Negat esse eam, inquit, propter se expetendam. Vitae autem degendae ratio maxime quidem illis placuit quieta. Ratio quidem vestra sic cogit. Ergo id est convenienter naturae vivere, a natura discedere. Tuo vero id quidem, inquam, arbitratu. Illud quaero, quid ei, qui in voluptate summum bonum ponat, consentaneum sit dicere. </p>
 
     <p>Vitae autem degendae ratio maxime quidem illis placuit quieta. Quid nunc honeste dicit? Quod cum dixissent, ille contra. <b>Gerendus est mos, modo recte sentiat.</b> Huius, Lyco, oratione locuples, rebus ipsis ielunior. </p>
-  field_topic_type: blog
+  field_topic_type: Blog
   field_topic_image: aa51fec2-dee0-11e5-b86d-9a79f06e9478
   group: 3bc51523-4f40-459c-887c-056432fe17cd
   field_content_visibility: community
@@ -210,7 +210,7 @@
     	<li>Itaque nostrum est-quod nostrum dico, artis est-ad ea principia, quae accepimus.</li>
     	<li>Qui enim existimabit posse se miserum esse beatus non erit.</li>
     </ul>
-  field_topic_type: blog
+  field_topic_type: Blog
   field_topic_image: c08b9e6c-3adb-11e6-ac61-9e71128cae77
   langcode: en
   group: 3bc51523-4f40-459c-887c-056432fe17cd
@@ -238,7 +238,7 @@
     <blockquote cite='http://loripsum.net'>
         Illud enim rectum est quod katortwma dicebas contingitque sapienti soli, hoc autem inchoati cuiusdam officii est, non perfecti, quod cadere in non nullos insipientes potest.
     </blockquote>
-  field_topic_type: discussion
+  field_topic_type: Discussion
   field_topic_image: aa51f058-dee0-11e5-b86d-9a79f06e9478
   group: da06bdb9-7ffa-4aa7-a98b-76360d8c40fd
   field_content_visibility: group

--- a/modules/custom/social_demo/src/Plugin/DemoContent/Topic.php
+++ b/modules/custom/social_demo/src/Plugin/DemoContent/Topic.php
@@ -75,7 +75,7 @@ class Topic extends DemoNode {
     $entry = parent::getEntry($item);
     $entry['field_content_visibility'] = $item['field_content_visibility'];
 
-    // Load term by uuid and set to node.
+    // Load term by name and set to node.
     if (!empty($item['field_topic_type'])) {
       $entry['field_topic_type'] = $this->prepareTopicType($item['field_topic_type']);
     }
@@ -114,13 +114,16 @@ class Topic extends DemoNode {
   /**
    * Returns taxonomy term id.
    *
-   * @param $uuid
+   * @param string $name
+   *   Term name.
+   *
    * @return array|null
+   *   Array containing related terms.
    */
-  protected function prepareTopicType($uuid) {
+  protected function prepareTopicType($name) {
     $value = NULL;
     $terms = $this->termStorage->loadByProperties([
-      'uuid' => $uuid,
+      'name' => $name,
     ]);
 
     if ($terms) {


### PR DESCRIPTION
Original PR: #409 
Original issue: https://www.drupal.org/node/2884811

# Changes
Fixed topic.yml field_topic_type values to be same as term names.
Changed prepareTopicType() function to work with term names.

# How to test
- run demo content as usual.
- go to _admin/content_ and edit some Topic content.
- topic type should be selected.