### PR TITLE
DS-3620 by jochemvn: Change 'edit account' into 'settings'

### DIFF
--- a/modules/custom/social_auth_extra/config/install/social_auth_extra.mail.yml
+++ b/modules/custom/social_auth_extra/config/install/social_auth_extra.mail.yml
@@ -1,3 +1,3 @@
 email_social_login:
   subject: 'Account details for [user:display-name] at [site:name]'
-  body: "[user:display-name],\r\n\r\nThank you for registering at [site:name]. You are now able to log in with social account at [site:login-url]\r\n\r\nIf you want to be able to log in with username or email address and password you need to set a password on the edit account page.\r\n\r\n-- [site:name]."
+  body: "[user:display-name],\r\n\r\nThank you for registering at [site:name]. You are now able to log in with social account at [site:login-url]\r\n\r\nIf you want to be able to log in with username or email address and password you need to set a password on the settings page.\r\n\r\n-- [site:name]."

--- a/modules/custom/social_auth_extra/social_auth_extra.install
+++ b/modules/custom/social_auth_extra/social_auth_extra.install
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * @file
+ * Contains social_auth_extra.instal.
+ */
+
+/**
+ *  Change'edit account' to 'settings' in registration mail.
+ */
+function social_auth_extra_update_8001(&$sandbox) {
+  // Get config.
+  $config = \Drupal::service('config.factory')->getEditable('social_auth_extra.mail');
+  // Fetch the body field.
+  $body = $config->get('email_social_login.body');
+  // Replace 'edit account' with 'settings'.
+  $new_body = str_replace('edit account', 'settings', $body);
+  // And save it.
+  $config->set('email_social_login.body', $new_body)->save();
+}

--- a/modules/social_features/social_user/src/Plugin/Block/AccountHeaderBlock.php
+++ b/modules/social_features/social_user/src/Plugin/Block/AccountHeaderBlock.php
@@ -240,8 +240,8 @@ class AccountHeaderBlock extends BlockBase {
             'link_classes' => '',
             'icon_classes' => '',
             'icon_label' => '',
-            'title' => $this->t('Edit account'),
-            'label' => $this->t('Edit account'),
+            'title' => $this->t('Settings'),
+            'label' => $this->t('Settings'),
             'title_classes' => '',
             'url' => Url::fromRoute('entity.user.edit_form', [
               'user' => $account->id(),

--- a/tests/behat/features/capabilities/profile/hide-profile-email.feature
+++ b/tests/behat/features/capabilities/profile/hide-profile-email.feature
@@ -27,7 +27,7 @@ Feature: I want to be able to hide my email address
     And I should not see "user_1@example.com"
 
     And I click the xth "0" element with the css ".navbar-nav .profile"
-    And I click "Edit account"
+    And I click "Settings"
     Then I should see "Show my email on my profile"
     And I show hidden checkboxes
     And I check the box "Show my email on my profile"


### PR DESCRIPTION
## Description
Edit account has been changed to Settings as per https://jira.goalgorilla.com/browse/DS-3620. This story can be reviewed after RC6.

## HTT

- [x] Check the code
- [x] Enable the social_auth_extra module
- [x] Revert your features
- [x] Log in on the site
- [x] Notice that in the menu 'edit account' is now 'settings'
- [x] run an `drush updb --yes`
- [x] Since I did not know where this email was being sent from I checked the config table for social_auth_extra
- [x] Notice that the text in that mail now refers to settings and not edit account
- [x] Notice the behats pass

- [x] From a fresh install everything should be good at once