### PR TITLE
DS-3623 - Redirect LU Registering with Social Login To Edit Profile

### DIFF
--- a/modules/custom/social_auth_extra/social_auth_extra.module
+++ b/modules/custom/social_auth_extra/social_auth_extra.module
@@ -57,6 +57,11 @@ function social_auth_extra_form_user_register_form_alter(&$form, FormStateInterf
           $name = preg_replace('/[^0-9a-z]/si', '_', $name);
         }
 
+        // The user already selected an authentication method and there
+        // will be a drupal_set_message informing the user.
+        unset($form['social_auth_extra']);
+        unset($form['account']['title']);
+
         $form['account']['mail']['#default_value'] = $data_handler->get('mail');
         $form['account']['name']['#default_value'] = $name;
         $form['actions']['submit']['#submit'] = ['social_auth_extra_form_user_register_form_submit'];
@@ -197,9 +202,11 @@ function social_auth_extra_form_user_register_form_submit($form, FormStateInterf
         '@community_name' => \Drupal::config('system.site')->get('name'),
       ]));
 
-      $form_state->setRedirect('entity.user.edit_form', [
-        'user' => $account->id(),
-      ]);
+      // Redirect to profile.
+      $form_state->setRedirect(
+        'entity.profile.type.profile.user_profile_form',
+        array('user' => $account->id(), 'profile_type' => 'profile', array())
+      );
 
       // Send email notification.
       $params['account'] = $account;

--- a/modules/custom/social_auth_extra/social_auth_extra.module
+++ b/modules/custom/social_auth_extra/social_auth_extra.module
@@ -187,6 +187,19 @@ function social_auth_extra_form_user_register_form_submit($form, FormStateInterf
 
             $module_handler->invokeAll('social_auth_extra_profile_presave', [$account, $profile, $auth_manager, $user_manager]);
             $profile->save();
+
+            // Redirect to profile.
+            $form_state->setRedirect(
+              'entity.profile.type.profile.user_profile_form',
+                ['user' => $account->id(),
+                  'profile_type' => 'profile', []]
+            );
+          }
+          else {
+            // If the profile module does not exist redirect to account form.
+            $form_state->setRedirect('entity.user.edit_form', [
+              'user' => $account->id(),
+            ]);
           }
         }
       }
@@ -201,12 +214,6 @@ function social_auth_extra_form_user_register_form_submit($form, FormStateInterf
       drupal_set_message(t('Your account is created. We have sent an email with your account details. You can now start exploring @community_name.', [
         '@community_name' => \Drupal::config('system.site')->get('name'),
       ]));
-
-      // Redirect to profile.
-      $form_state->setRedirect(
-        'entity.profile.type.profile.user_profile_form',
-        array('user' => $account->id(), 'profile_type' => 'profile', array())
-      );
 
       // Send email notification.
       $params['account'] = $account;

--- a/modules/social_features/social_user/social_user.module
+++ b/modules/social_features/social_user/social_user.module
@@ -90,6 +90,12 @@ function social_user_form_user_form_alter(&$form, FormStateInterface $form_state
   }
 }
 
+/**
+ * Submit function for resetting password form.
+ *
+ * @param $form
+ * @param \Drupal\Core\Form\FormStateInterface $form_state
+ */
 function _social_user_pass_reset_submit($form, FormStateInterface $form_state) {
   $storage = $form_state->getValues();
   $submitted_user_id = isset($storage['uid']) ? $storage['uid'] : '';
@@ -114,7 +120,6 @@ function _social_user_pass_reset_submit($form, FormStateInterface $form_state) {
     }
   }
 }
-
 
 /**
  * Check if an users with the input field for name or mail field is blocked.


### PR DESCRIPTION
**Description:**
Users signing up to the platform with one of the social authentication methods don't need to set their password after registering. Instead we will redirect these users to the edit profile page. In addition to this the social login buttons on the top of the register page were still shown after selecting one of the social authentication methods. This could be confusing to the user.

**Solution:**
Redirect users registering with social authentication to the user edit profile form. Hide the icons after the user is redirected from the selected authenticated method. The behaviour did not change for normal registrations.

I've used an unset in the form_alter. I think this is save since most of the logic is in separate Services anyways.

**How to test:**

- [x] Setup social authentication of your choice: https://github.com/goalgorilla/drupal_social/wiki/Social-Login
- [x] Register and verify that after selecting the authentication method your e-mail and username are filled in and the header with the icons is not shown. 
- [x] Click on continue and notice you are redirected to "Edit Profile".
- [x] Verify the normal registration flow
- [x] Check the code


