### PR TITLE
Issue #2875633 by alex.ksis: Add a new cache context for group teasers

### DIFF
--- a/modules/social_features/social_group/social_group.module
+++ b/modules/social_features/social_group/social_group.module
@@ -260,14 +260,20 @@ function social_group_group_insert(GroupInterface $group) {
 function social_group_entity_view_alter(array &$build, Drupal\Core\Entity\EntityInterface $entity, \Drupal\Core\Entity\Display\EntityViewDisplayInterface $display) {
   // For group entities.
   if ($entity instanceof Group) {
-    // Add cache contexts for the hero view mode.
-    if ($build['#view_mode'] == 'hero') {
-      // Add cache contexts for group type & permissions. We need join / leave for
-      // the CTA and also update permissions for the button to edit a group.
-      $build['#cache']['contexts'][] = 'group.type';
-      $build['#cache']['contexts'][] = 'group_membership.roles.permissions';
-      $build['#cache']['contexts'][] = 'group_membership.audience';
-      $build['#cache']['tags'][] = 'group_block:' . $entity->id();
+    // Add cache contexts for some view modes.
+    switch ($build['#view_mode']) {
+      case 'hero':
+        // Add cache contexts for group type & permissions. We need join / leave for
+        // the CTA and also update permissions for the button to edit a group.
+        $build['#cache']['contexts'][] = 'group.type';
+        $build['#cache']['contexts'][] = 'group_membership.roles.permissions';
+        $build['#cache']['contexts'][] = 'group_membership.audience';
+        $build['#cache']['tags'][] = 'group_block:' . $entity->id();
+        break;
+
+      case 'teaser':
+        $build['#cache']['contexts'][] = 'user';
+        break;
     }
   }
 }


### PR DESCRIPTION
Related issue: https://www.drupal.org/node/2875633

## HTT

- [x] Login as susanwilliams
- [x] Go to Explore > All groups
- [x] Notice that in the teasers it shows you are a member of all groups
- [x] Logout
- [x] Login as chrishall
- [x] Go to Explore > All groups
- [x] Notice that in the teasers it shows you are a member of only one group