### PR TITLE
#2888140 - Comments shows up in a wrong post in activity stream

### DIFF
--- a/modules/social_features/social_comment/social_comment.module
+++ b/modules/social_features/social_comment/social_comment.module
@@ -49,13 +49,6 @@ function social_comment_form_comment_form_alter(&$form, FormStateInterface $form
       $form['actions']['submit']['#attributes']['value'] = t('Submit');
       $form['actions']['submit']['#value'] = t('Submit');
       break;
-
-    default:
-      // By default the comment form has the "Reply comment" page URL in the "action" attribute.
-      // So we should set the current URL to exclude changing the route name.
-      // Otherwise this "switch" won't work.
-      $form['#action'] = \Drupal::request()->getRequestUri();
-      break;
   }
 
   $form['#attached']['library'][] = 'social_post/keycode-submit';


### PR DESCRIPTION
## Background 
This code was rewritten a while back (an if then else to a switch). A default action was added to the switch statement to handle cases that were not handled in the previous if .. else situation. Another issue as tried to fix with redirecting after posting. The goto URL of the comment form in the stream would be: 'post/12/comment'. This was changed to the url of the stream '/'. This is an issue, because the 12 is needed to attach the comment to the correct post.

## HTT
- [x] Check the code
- [x] Login as a regular LU
- [x] Comment on a post in the stream, but not on the first one
- [x] See that the comment is placed on the correct post
- [x] Try in group stream as well
- [x] Try on profile stream as well

- [x] Merge 