### PR TITLE
Issue #2888110 by peterpolman: Added preprocess for field items in AN…

### DIFF
--- a/themes/socialbase/includes/field.inc
+++ b/themes/socialbase/includes/field.inc
@@ -61,6 +61,17 @@ function socialbase_preprocess_field(&$variables) {
     $variables['nodelink'] = Link::fromTextAndUrl(t('Comment'), $urlwithoptions);
   }
 
+  if ($variables['element']['#field_name'] == 'field_call_to_action_link') {
+    $url_options = array(
+      'attributes' => array('class' => array('btn btn-primary waves-effect')),
+    );
+    $variables['element'][0]['#url']->setOptions($url_options);
+    $url_options = array(
+      'attributes' => array('class' => array('btn btn-default waves-effect')),
+    );
+    $variables['element'][1]['#url']->setOptions($url_options);
+  }
+
 }
 
 /**

--- a/themes/socialbase/templates/field/field--block-content--field-call-to-action-link.html.twig
+++ b/themes/socialbase/templates/field/field--block-content--field-call-to-action-link.html.twig
@@ -37,27 +37,6 @@
  * @see template_preprocess_field()
  */
 #}
-
-{%
-set classes1 = [
-  'btn',
-  'btn-primary',
-  'waves-effect',
-  ]
-%}
-
-{%
-set classes2 = [
-  'btn',
-  'btn-default',
-  'waves-effect',
-  ]
-%}
-
 {% for item in items %}
-  {% if loop.first %}
-    <div{{ item.attributes.addClass(classes1) }}>{{ item.content }}</div>
-  {% else %}
-    <div{{ item.attributes.addClass(classes2) }}>{{ item.content }}</div>
-  {% endif %}
+  {{ item.content }}
 {% endfor %}


### PR DESCRIPTION
# Summary

Added preprocess for field items in AN intro block that sets the correct classes on the anchors instead of the wrapper. This way the links are fully clickable.

# HTT

- [x] Go to the AN homepage.
- [x] Hover with the mouse over the links.
- [x] Click on the bottom part of the button (outside of the text) and see that you get refered to a new page.