### PR TITLE
Issue #2889920 by robertragas: Set events enrollments block pager to 12

### DIFF
--- a/modules/social_features/social_event/config/install/views.view.event_enrollments.yml
+++ b/modules/social_features/social_event/config/install/views.view.event_enrollments.yml
@@ -343,7 +343,7 @@ display:
       pager:
         type: some
         options:
-          items_per_page: 10
+          items_per_page: 12
           offset: 0
       arguments:
         nid:


### PR DESCRIPTION
Related issue: https://www.drupal.org/node/2889920

# HTT

- [x] Revert feature social_event
- [x] Enroll to an event with 13 users
- [x] See a maximum of 12 users being displayed