### PR TITLE
Issue #2880631 by peterpolman: Moved styles for comment form from com…

### DIFF
--- a/themes/socialbase/assets/css/stream.css
+++ b/themes/socialbase/assets/css/stream.css
@@ -75,6 +75,24 @@
 
 .card--stream .comment {
   font-size: 0.875rem;
+  position: relative;
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  width: 100%;
+}
+
+.card--stream .comment__avatar {
+  margin-right: 8px;
+  width: 44px;
+  -ms-flex-negative: 0;
+      flex-shrink: 0;
+}
+
+.card--stream .comment__content {
+  -webkit-box-flex: 1;
+      -ms-flex: 1;
+          flex: 1;
 }
 
 .teaser--stream {
@@ -119,6 +137,10 @@
   .card--stream:after {
     border-width: 8px;
     top: 36px;
+  }
+
+  .card--stream .comment__avatar {
+    margin-right: 12px;
   }
 
   .teaser--stream {

--- a/themes/socialbase/components/04-organisms/stream/stream.scss
+++ b/themes/socialbase/components/04-organisms/stream/stream.scss
@@ -109,6 +109,24 @@
 
   .comment {
     font-size: 0.875rem;
+    position: relative;
+    display: flex;
+    width: 100%;
+  }
+
+  .comment__avatar {
+    margin-right: 8px;
+    width: 44px;
+    flex-shrink: 0;
+
+    @include for-tablet-portrait-up {
+      margin-right: 12px;
+    }
+
+  }
+
+  .comment__content {
+    flex: 1;
   }
 
 }


### PR DESCRIPTION
# Summary

Moved styles for a comment form from comment component library to the stream component library since these assets are only loaded in the comment twig file. The form however will also get loaded when no comments are present and therefor miss it's assets:( Adding the styles to the stream component makes more sense, so that's where I moved them.

# HTT

To reproduce see https://www.drupal.org/node/2880631#comment-12144847 