### PR TITLE
#2858502 - Don't send notifications of replies on mentions to the acting user himself

### DIFF
--- a/modules/social_features/social_mentions/src/Plugin/ActivityContext/MentionActivityContext.php
+++ b/modules/social_features/social_mentions/src/Plugin/ActivityContext/MentionActivityContext.php
@@ -49,6 +49,11 @@ class MentionActivityContext extends ActivityContextBase {
           if (isset($mention->uid)) {
             $uid = $mention->getMentionedUserId();
 
+            // Don't send notifications to myself.
+            if ($uid === $data['actor']) {
+              continue;
+            }
+
             $entity_storage = \Drupal::entityTypeManager()
               ->getStorage($mention->getMentionedEntityTypeId());
             $mentioned_entity = $entity_storage->load($mention->getMentionedEntityId());


### PR DESCRIPTION
## Description
When replying on a comment you were mentioned in, you'd get a notification that someone (you yourself in this case) replied on a comment you were mentioned in. This is not really necessary to notify about, since you are probably aware of that fact that you (just) did this

## HTT
- [x] Check the code
- [x] Login in three different sessions (chrishall, robertandrews, alisonhendrix)
- [x] Post a comment as alisonhendrix and mention chrishall and robertandrews
- [x] Notice that C and R receive a notification
- [x] As C reply to the comment
- [x] Notice that A, C and R receive a notification
- [x] Checkout this branch
- [x] Do the same and notice that C no longer receives a notification
- [x] Also reply to the comment as R and notice that C and A receive the notifcation
