### PR TITLE
#2892737 by ronaldtebrake: Render token for message:gurl

### DIFF
--- a/modules/custom/activity_logger/activity_logger.tokens.inc
+++ b/modules/custom/activity_logger/activity_logger.tokens.inc
@@ -103,8 +103,7 @@ function activity_logger_tokens($type, $tokens, array $data, array $options, Bub
                 }
                 if ($name === 'gurl') {
                   $gurl = Url::fromRoute('entity.group.canonical', array(
-                    'group' => $group->id(),
-                    array()
+                    'group' => $group->id()
                   ));
                   $replacements[$original] = $gurl->toString();
                 }


### PR DESCRIPTION
Full description of the issue here: https://www.drupal.org/node/2892737#comment-12157370

You can test it by checking out the stream on the nightly or on your local:
1. Login as chrishall
2. Check the democontent and see that when you hover over groups in activities it has a query parameter (?) behind it. 

![](https://www.drupal.org/files/issues/Screen%20Shot%202017-07-06%20at%2014.45.39.png)

3.Checkout this branch - Rerun the demo content and see that it works now. Or make sure a new activity get's aggregated so the token is created again.