### PR TITLE
DS-3034 by frankgraave: disable group hero block on create group content page

### DIFF
--- a/modules/social_features/social_core/src/Plugin/Block/SocialPageTitleBlock.php
+++ b/modules/social_features/social_core/src/Plugin/Block/SocialPageTitleBlock.php
@@ -49,20 +49,20 @@ class SocialPageTitleBlock extends PageTitleBlock {
     else {
       $request = \Drupal::request();
       $group = _social_group_get_current_group();
-      if ($group && $request->attributes->get('_route') == 'entity.group_content.create_form') {
-        return [
-          '#type' => 'page_title',
-          '#title' => 'Foo',
-        ];
-      } else {}
 
       if ($route = $request->attributes->get(RouteObjectInterface::ROUTE_OBJECT)) {
         $title = \Drupal::service('title_resolver')->getTitle($request, $route);
-
-        return [
-          '#type' => 'page_title',
-          '#title' => $title,
-        ];
+        if ($group && $request->attributes->get('_route') == 'entity.group_content.create_form') {
+          return [
+            '#type' => 'page_title',
+            '#title' => t($title . ' in ' . $group->label()),
+          ];
+        } else {
+          return [
+            '#type' => 'page_title',
+            '#title' => t($title),
+          ];
+        }
       }
       else {
         return [

--- a/modules/social_features/social_core/src/Plugin/Block/SocialPageTitleBlock.php
+++ b/modules/social_features/social_core/src/Plugin/Block/SocialPageTitleBlock.php
@@ -48,6 +48,13 @@ class SocialPageTitleBlock extends PageTitleBlock {
     }
     else {
       $request = \Drupal::request();
+      $group = _social_group_get_current_group();
+      if ($group && $request->attributes->get('_route') == 'entity.group_content.create_form') {
+        return [
+          '#type' => 'page_title',
+          '#title' => 'Foo',
+        ];
+      } else {}
 
       if ($route = $request->attributes->get(RouteObjectInterface::ROUTE_OBJECT)) {
         $title = \Drupal::service('title_resolver')->getTitle($request, $route);

--- a/modules/social_features/social_core/src/Plugin/Block/SocialPageTitleBlock.php
+++ b/modules/social_features/social_core/src/Plugin/Block/SocialPageTitleBlock.php
@@ -60,7 +60,7 @@ class SocialPageTitleBlock extends PageTitleBlock {
         } else {
           return [
             '#type' => 'page_title',
-            '#title' => t($title),
+            '#title' => $title,
           ];
         }
       }

--- a/modules/social_features/social_group/social_group.module
+++ b/modules/social_features/social_group/social_group.module
@@ -923,3 +923,14 @@ function social_group_get_all_group_members($uid) {
   $group_ids = $query->execute()->fetchAllAssoc('gid');
   return array_keys($group_ids);
 }
+
+/**
+ * Implements hook_block_view_BASE_BLOCK_ID_alter().
+ */
+function social_group_block_view_group_hero_block_alter(array &$build, \Drupal\Core\Block\BlockPluginInterface $block) {
+  $current_route = Drupal::routeMatch()->getRouteName();
+  // Hide the group_hero_block on the content creation page
+  if ($current_route == 'entity.group_content.create_form') {
+    $build['#pre_render'] = [];
+  }
+}


### PR DESCRIPTION
# Background
Currently, when creating content in a group, the group hero is shown together with the Joined button. This button is really prominent and it is not relevant to the function of content creation page.
It causes confusion to users, and it makes the intention of the page unclear.

# HTT
- [x] Check out the code
- [x] Check out this branch `git checkout feature/DS-3034-remove-joined-button`
- [x] Log in as any user
- [x] Go to a group you're member of
- [x] Create a topic or event
- [x] Notice the group hero block is gone along with the "joined" button
- [x] Notice the title now contains the title of the group as well