### PR TITLE
#2890000 - When deleting a comment, also remove any attached files

### DIFF
--- a/modules/social_features/social_comment_upload/social_comment_upload.module
+++ b/modules/social_features/social_comment_upload/social_comment_upload.module
@@ -52,3 +52,20 @@ function social_comment_upload_preprocess_file_widget_multiple(&$variables) {
     $variables['table']['#tabledrag'] = [];
   }
 }
+
+/**
+ * Implements hook_comment_delete().
+ */
+function social_comment_upload_comment_delete(Drupal\Core\Entity\EntityInterface $entity) {
+  // Loop through the files in the comment.
+  foreach ($entity->field_comment_files as $filefield) {
+    // Try to load the actual file object.
+    $file = \Drupal\file\Entity\File::load($filefield->target_id);
+    // Check if it's an actual file object.
+    if ($file instanceof \Drupal\file\Entity\File) {
+      // Delete the file object.
+      $file->delete();
+    }
+  }
+
+}


### PR DESCRIPTION
## Description
For description see: https://www.drupal.org/node/2890000

## HTT
- [x] Enable the social_comment_upload module
- [x] Notice that on topics/events you can now add attachments to comments
- [x] Add one or more attachments to a comment and save it
- [x] See them in the `file_managed` table
- [x] See that you can access the file from the URL (copy it from source)
- [x] See that when you log out you can no longer access the file through the URL (private file system)
- [x] Now delete the comment
- [x] Notice that the entry in the `file_managed` table is gone and you can no longer access the file from the URL anymore (as the comment creator)