### PR TITLE
Issue #2889883: novalidate on all forms

### DIFF
--- a/themes/socialbase/includes/form.inc
+++ b/themes/socialbase/includes/form.inc
@@ -217,6 +217,12 @@ function socialbase_form_profile_profile_edit_form_alter(&$form, FormStateInterf
  * @param $form_id
  */
 function socialbase_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+
+  // Clientside validation is not consistent accross devices. Disable for now.
+  if (!isset($form['#attributes']['novalidate'])) {
+    $form['#attributes']['novalidate'] = 'novalidate';
+  }
+
   // These forms have a container with class form-action at the bottom and
   // we style it in a way that the primary/submit button is aligned right
   // Also we define the style of the buttons based on their function


### PR DESCRIPTION
**Description:**
When users try to save an event in some cases there is an error. Especially on mobile devices. This has to do with the validation of the date widget. Peter and I discussed and decided that the HTML5 validation is too device-specific for now and we determined to turn it off for all the forms. Our Drupal validation will catch any errors.

**How to test:**
Test in Xcode simulator and notice it works. Even though the widget says "12 July" it will still validate on save.
Notice that all the tests are green :-)

