### PR TITLE
#2893858 - Profile picture access

### DIFF
--- a/modules/social_features/social_profile/social_profile.module
+++ b/modules/social_features/social_profile/social_profile.module
@@ -339,7 +339,16 @@ function social_profile_profile_view_alter(array &$build, Drupal\Core\Entity\Ent
   $current_user = \Drupal::currentUser();
   // If the current user has no access to viewing user profiles, he might not have access to
   // the users profile.
-  if (!$current_user->hasPermission('view any profile profile')) {
+  if (!$current_user->hasPermission('view any profile profile') && $display->getMode() === 'compact') {
+    // Try to load the profile picture.
     $file = \Drupal\file\Entity\File::load($entity->get('field_profile_image')->target_id);
+    if ($file instanceof \Drupal\file\Entity\File) {
+      // Potentially the file is in the private file system. In that case,
+      // anonymous user don't have access to it.
+      if (!$file->access('view', $current_user)) {
+        // Remove the image.
+        unset($build['field_profile_image']);
+      }
+    }
   }
 }

--- a/modules/social_features/social_profile/social_profile.module
+++ b/modules/social_features/social_profile/social_profile.module
@@ -5,6 +5,7 @@
  * The Social profile module.
  */
 
+use Drupal\Core\Entity\EntityInterface;
 use Drupal\user\Entity\User;
 use Drupal\Core\Url;
 use Drupal\Core\Link;
@@ -328,27 +329,53 @@ function social_profile_profile_view(array &$build, \Drupal\Core\Entity\EntityIn
 
 /**
  * Implements hook_ENTITY_TYPE_view_alter().
- *
- * @param array $build
- * @param \Drupal\Core\Entity\EntityInterface $entity
- * @param \Drupal\Core\Entity\Display\EntityViewDisplayInterface $display
  */
-function social_profile_profile_view_alter(array &$build, Drupal\Core\Entity\EntityInterface $entity, \Drupal\Core\Entity\Display\EntityViewDisplayInterface $display) {
+function social_profile_profile_view_alter(array &$build, EntityInterface $entity, \Drupal\Core\Entity\Display\EntityViewDisplayInterface $display) {
 
   /** @var \Drupal\Core\Session\AccountProxy $current_user */
   $current_user = \Drupal::currentUser();
   // If the current user has no access to viewing user profiles, he might not have access to
   // the users profile.
-  if (!$current_user->hasPermission('view any profile profile') && $display->getMode() === 'compact') {
+  if (!$current_user->hasPermission('view any profile profile') && ($display->getMode() === 'compact' || $display->getMode() === 'compact_notification')) {
     // Try to load the profile picture.
     $file = \Drupal\file\Entity\File::load($entity->get('field_profile_image')->target_id);
     if ($file instanceof \Drupal\file\Entity\File) {
       // Potentially the file is in the private file system. In that case,
       // anonymous user don't have access to it.
       if (!$file->access('view', $current_user)) {
-        // Remove the image.
-        unset($build['field_profile_image']);
+        // Load default data.
+        $replacement_data = social_profile_get_default_image();
+        /** @var \Drupal\image\Plugin\Field\FieldType\ImageItem $imgitem */
+        $imgitem = $build['field_profile_image'][0]['#item'];
+        // Time to override the data that going to be rendered.
+        $imgitem->set('target_id', $replacement_data['id']);
+        $imgitem->set('width', $replacement_data['width']);
+        $imgitem->set('height', $replacement_data['height']);
+        // Put replacement data back in the object that's about to be built.
+        $build['field_profile_image'][0]['#item'] = $imgitem;
       }
     }
   }
+}
+
+/**
+ * Function to fetch the default profile image.
+ */
+function social_profile_get_default_image() {
+  // Load default image.
+  $config_factory = \Drupal::configFactory();
+  $field_image_config = $config_factory->getEditable('field.field.profile.profile.field_profile_image');
+  $default_image = $field_image_config->get('settings.default_image');
+  // Load by uuid.
+  $files = \Drupal::entityTypeManager()->getStorage('file')->loadByProperties(array('uuid' => $default_image['uuid']));
+  // Pop it
+  $file = array_pop($files);
+  // Set in an array.
+  $data = [
+    "id" => $file->id(),
+    "width" => $default_image['width'],
+    "height" => $default_image['height'],
+  ];
+  // Retun the array.
+  return $data;
 }

--- a/modules/social_features/social_profile/social_profile.module
+++ b/modules/social_features/social_profile/social_profile.module
@@ -324,3 +324,22 @@ function social_profile_profile_view(array &$build, \Drupal\Core\Entity\EntityIn
     $build['field_profile_image'][0]['#url'] = $url;
   }
 }
+
+
+/**
+ * Implements hook_ENTITY_TYPE_view_alter().
+ *
+ * @param array $build
+ * @param \Drupal\Core\Entity\EntityInterface $entity
+ * @param \Drupal\Core\Entity\Display\EntityViewDisplayInterface $display
+ */
+function social_profile_profile_view_alter(array &$build, Drupal\Core\Entity\EntityInterface $entity, \Drupal\Core\Entity\Display\EntityViewDisplayInterface $display) {
+
+  /** @var \Drupal\Core\Session\AccountProxy $current_user */
+  $current_user = \Drupal::currentUser();
+  // If the current user has no access to viewing user profiles, he might not have access to
+  // the users profile.
+  if (!$current_user->hasPermission('view any profile profile')) {
+    $file = \Drupal\file\Entity\File::load($entity->get('field_profile_image')->target_id);
+  }
+}


### PR DESCRIPTION
## Description
Since we implemented the private file system, anonymous users no longer have access to view profile pictures. So on pages where we show profile pictures, such as the stream. We need to check if the current user has access to the related file and if not, replace it with the default image, or hide the image entirely.

## HTT
- [x] Make sure the private file system module is enabled
- [x] Create a new account and a profile WITH an image.
- [x] Post something PUBLIC in the stream
- [x] Logout
- [x] Notice you get a broken link to an image in the stream
- [x] Checkout this branch
- [x] Check the code
- [x] Rebuild caches and refresh the page
- [x] Notice you see the default image
- [x] Login as a normal LU
- [x] See that you see normal profile images