### PR TITLE
Issue #2888455 by peterpolman: Fixed brand border radius for cards in…

### DIFF
--- a/themes/socialbase/templates/form/form.html.twig
+++ b/themes/socialbase/templates/form/form.html.twig
@@ -15,7 +15,7 @@
 
 {% if attributes.hasClass('card') %}
   <form{{ attributes.removeClass('card') }}>
-    <div class="card">
+    <div class="card brand-border-radius">
       <div class="card__block">
         {{ children }}
     </form>

--- a/themes/socialbase/templates/system/status-messages.html.twig
+++ b/themes/socialbase/templates/system/status-messages.html.twig
@@ -1,0 +1,68 @@
+{#
+/**
+ * @file
+ * Default theme implementation for status messages.
+ *
+ * Displays status, error, and warning messages, grouped by type.
+ *
+ * An invisible heading identifies the messages for assistive technology.
+ * Sighted users see a colored box. See http://www.w3.org/TR/WCAG-TECHS/H69.html
+ * for info.
+ *
+ * Add an ARIA label to the contentinfo area so that assistive technology
+ * user agents will better describe this landmark.
+ *
+ * Available variables:
+ * - message_list: List of messages to be displayed, grouped by type.
+ * - status_headings: List of all status types.
+ * - display: (optional) May have a value of 'status' or 'error' when only
+ *   displaying messages of that specific type.
+ * - attributes: HTML attributes for the element, including:
+ *   - class: HTML classes.
+ *
+ * @ingroup templates
+ *
+ * @see template_preprocess_status_messages()
+ */
+#}
+{%
+  set status_heading = {
+    'status': 'Status message'|t,
+    'error': 'Error message'|t,
+    'warning': 'Warning message'|t,
+    'info': 'Informative message'|t,
+  }
+%}
+{%
+  set status_classes = {
+    'status': 'success',
+    'error': 'danger',
+    'warning': 'warning',
+    'info': 'info',
+  }
+%}
+{% for type, messages in message_list %}
+{%
+  set classes = [
+    'alert',
+    'alert-' ~ status_classes[type],
+    'alert-dismissible',
+    'brand-border-radius',
+  ]
+%}
+<div{{ attributes.addClass(classes) }} role="alert">
+  <a href="#" role="button" class="close" data-dismiss="alert" aria-label="{{ 'Close'|t }}"><span aria-hidden="true">&times;</span></a>
+  {% if status_headings[type] %}
+    <h4 class="sr-only">{{ status_headings[type] }}</h4>
+  {% endif %}
+  {% if messages|length > 1 %}
+    <ul class="item-list item-list--messages">
+      {% for message in messages %}
+        <li class="item item--message">{{ message }}</li>
+      {% endfor %}
+    </ul>
+  {% else %}
+    {{ messages|first }}
+  {% endif %}
+</div>
+{% endfor %}


### PR DESCRIPTION
# Issue 
https://www.drupal.org/node/2888455

# Summary
Added the brand-border-radius class to the form template and added status-messages.html.twig to the theme and implemented the brand-border-radius class.

# HTT
- [x] Login as SM or admin and go to /admin/appearance/settings/socialblue
- [x] Set the border-radius value to 0
- [x] Go to /stream and create a post
- [x] See that the alert message has no rounded corners
- [x] Log out and see that /user/login and /user/password have no rounded corners
- [x] Apply for an account and login with the one-time-login link. See that this card in the form also has no rounded corners.
