### PR TITLE
Issue #2880265 by peterpolman: Removed z-index on card__block since p…

### DIFF
--- a/themes/socialbase/assets/css/cards.css
+++ b/themes/socialbase/assets/css/cards.css
@@ -46,7 +46,6 @@
       -ms-flex: 1 1 auto;
           flex: 1 1 auto;
   padding: 1.25rem;
-  z-index: 1;
 }
 
 .card__block + .card__block {

--- a/themes/socialbase/components/02-atoms/cards/cards.scss
+++ b/themes/socialbase/components/02-atoms/cards/cards.scss
@@ -85,9 +85,8 @@
   // as much space as possible, ensuring footers are aligned to the bottom.
   flex: 1 1 auto;
   padding: $card-spacer-x;
-  z-index: 1; // make sure the card__actionbar is over the body padding-bottom.
 
-  + .card__block {
+  & + .card__block {
     padding-top: 0;
   }
 


### PR DESCRIPTION
# Issue
https://www.drupal.org/node/2880265

# Summary
Removed z-index on card__block since previous overlapping issue with the card__actionbar is solved with flexbox properties now.

# HTT
- [x] Login as LU and create a topic
- [x] Click on the link "Upload requirements" in the "attachments" card 
- [x] See that the popover hovers over the radio buttons and not the other way around.