### PR TITLE
DS-3949 by bramtenhove: Improve cropping and imagestyle for AN Homepage Hero block

### DIFF
--- a/modules/social_features/social_core/config/install/core.entity_form_display.block_content.hero_call_to_action_block.default.yml
+++ b/modules/social_features/social_core/config/install/core.entity_form_display.block_content.hero_call_to_action_block.default.yml
@@ -6,7 +6,7 @@ dependencies:
     - field.field.block_content.hero_call_to_action_block.field_call_to_action_link
     - field.field.block_content.hero_call_to_action_block.field_hero_image
     - field.field.block_content.hero_call_to_action_block.field_text_block
-    - image.style.social_xx_large
+    - image.style.social_an_hero
   module:
     - image_widget_crop
     - link
@@ -30,10 +30,10 @@ content:
     settings:
       show_crop_area: true
       show_default_crop: true
-      preview_image_style: social_xx_large
+      preview_image_style: social_an_hero
       crop_preview_image_style: crop_thumbnail
       crop_list:
-        - hero
+        - hero_an
       progress_indicator: throbber
     third_party_settings: {  }
     region: content

--- a/modules/social_features/social_core/config/install/core.entity_view_display.block_content.hero_call_to_action_block.default.yml
+++ b/modules/social_features/social_core/config/install/core.entity_view_display.block_content.hero_call_to_action_block.default.yml
@@ -6,7 +6,7 @@ dependencies:
     - field.field.block_content.hero_call_to_action_block.field_call_to_action_link
     - field.field.block_content.hero_call_to_action_block.field_hero_image
     - field.field.block_content.hero_call_to_action_block.field_text_block
-    - image.style.social_xx_large
+    - image.style.social_an_hero
   module:
     - image
     - link
@@ -33,7 +33,7 @@ content:
     weight: 0
     label: hidden
     settings:
-      image_style: social_xx_large
+      image_style: social_an_hero
       image_link: ''
     third_party_settings: {  }
     region: content

--- a/modules/social_features/social_core/config/install/crop.type.hero_an.yml
+++ b/modules/social_features/social_core/config/install/crop.type.hero_an.yml
@@ -1,0 +1,11 @@
+langcode: en
+status: true
+dependencies: {  }
+label: 'Hero AN'
+id: hero_an
+description: 'Header image in the AN hero region'
+aspect_ratio: '1200:490'
+soft_limit_width: null
+soft_limit_height: null
+hard_limit_width: null
+hard_limit_height: null

--- a/modules/social_features/social_core/config/install/field.field.block_content.hero_call_to_action_block.field_hero_image.yml
+++ b/modules/social_features/social_core/config/install/field.field.block_content.hero_call_to_action_block.field_hero_image.yml
@@ -18,7 +18,7 @@ default_value: {  }
 default_value_callback: ''
 settings:
   file_directory: '[date:custom:Y]-[date:custom:m]'
-  file_extensions: 'gif jpg jpeg'
+  file_extensions: 'gif jpg jpeg png'
   max_filesize: '50 MB'
   max_resolution: 2048x1080
   min_resolution: 200x200

--- a/modules/social_features/social_core/config/install/field.field.block_content.hero_call_to_action_block.field_hero_image.yml
+++ b/modules/social_features/social_core/config/install/field.field.block_content.hero_call_to_action_block.field_hero_image.yml
@@ -22,8 +22,8 @@ settings:
   max_filesize: '50 MB'
   max_resolution: 2048x1080
   min_resolution: 200x200
-  alt_field: true
-  alt_field_required: true
+  alt_field: false
+  alt_field_required: false
   title_field: false
   title_field_required: false
   default_image:

--- a/modules/social_features/social_core/config/install/image.style.social_an_hero.yml
+++ b/modules/social_features/social_core/config/install/image.style.social_an_hero.yml
@@ -1,0 +1,28 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - crop
+    - image_effects
+name: social_an_hero
+label: 'social an hero image (1200 x 490)'
+effects:
+  4adec298-c9b1-4fa5-bb98-7ab5f49a00f9:
+    uuid: 4adec298-c9b1-4fa5-bb98-7ab5f49a00f9
+    id: crop_crop
+    weight: 1
+    data:
+      crop_type: hero_an
+  c4885faf-b34c-446f-b95b-e0a43dd71080:
+    uuid: c4885faf-b34c-446f-b95b-e0a43dd71080
+    id: image_resize
+    weight: 2
+    data:
+      width: 1200
+      height: 490
+  fa621cfb-8201-4ac7-8dd1-a9a1f6031115:
+    uuid: fa621cfb-8201-4ac7-8dd1-a9a1f6031115
+    id: image_effects_auto_orient
+    weight: 3
+    data:
+      scan_exif: true

--- a/modules/social_features/social_core/social_core.install
+++ b/modules/social_features/social_core/social_core.install
@@ -168,7 +168,7 @@ function _social_core_create_an_homepage_block() {
   ];
   $crop_type = \Drupal::entityTypeManager()
     ->getStorage('crop_type')
-    ->load('hero');
+    ->load('hero_an');
   if (!empty($crop_type) && $crop_type instanceof CropType) {
     $image_widget_crop_manager = \Drupal::service('image_widget_crop.manager');
     $image_widget_crop_manager->applyCrop($data, [


### PR DESCRIPTION
## Description
The image style used for the AN Homepage Hero block was the same as for hero images on for example event pages. This is incorrect as the image on the AN homepage is wider than on event pages.

In order to fix this new a new image style and cropping configuration was made.

- [x] As a SM+ edit the homepage block and start cropping the current image
- [x] After cropping and saving the block notice that the AN homepage image is exactly as you cropped
- [x] Now upload a new image, note that you can also upload *png* files now and you do not have the ALT text field required or even showing up
- [x] Crop the image and save it, notice that it ends up exactly as you cropped
- [x] Reinstall the site and notice the AN Hero image is shown correctly using the new imagestyle