### PR TITLE
Issue 2897738 by frankgraave: fixed correct declaration in parameter …

### DIFF
--- a/modules/custom/social_auth_extra/src/UserManager.php
+++ b/modules/custom/social_auth_extra/src/UserManager.php
@@ -72,7 +72,7 @@ abstract class UserManager implements UserManagerInterface {
   /**
    * {@inheritdoc}
    */
-  public function createAccount($values = []) {
+  public function createAccount(array $values = []) {
     $langcode = $this->languageManager->getCurrentLanguage()->getId();
     $values = array_merge([
       'name' => '',
@@ -94,7 +94,7 @@ abstract class UserManager implements UserManagerInterface {
   /**
    * {@inheritdoc}
    */
-  public function createProfile($values = []) {
+  public function createProfile(array $values = []) {
     $values = array_merge([
       'uid' => $this->account ? $this->account->id() : NULL,
       'type' => $this->profileType,


### PR DESCRIPTION
# Background
Upon account creation through social auth, there was a fatal error caused by a bad declaration in a parameter. Related issue: https://www.drupal.org/node/2897738

# HTT
- [x] Check the code
- [x] Enable social_auth_extra and social_auth_google (or any other)
- [x] Set up the login feature
- [x] Sign up using the social auth feature
- [x] See that you are redirected as expected and not see a fatal error anymore