### PR TITLE
DS-3993 by maikelkoopman: include comment library in post template

### DIFF
--- a/themes/socialbase/templates/post/post--activity-comment.html.twig
+++ b/themes/socialbase/templates/post/post--activity-comment.html.twig
@@ -15,6 +15,7 @@
   * @ingroup themeable
   */
   #}
+{{ attach_library('socialbase/comment') }}
 
 {%
   set classes = [

--- a/themes/socialbase/templates/post/post--activity.html.twig
+++ b/themes/socialbase/templates/post/post--activity.html.twig
@@ -15,7 +15,7 @@
   * @ingroup themeable
   */
   #}
-
+{{ attach_library('socialbase/comment') }}
 {%
   set classes = [
     'margin-top-s',


### PR DESCRIPTION
How to test:
- This bug only occurs when there is no comment in the stream yet.
- Log in as normal user
- Create a new group
- Post something in the group
- The comment form with this new post (only item in the stream) show only the icon on mobile and only the text on desktop (aka it loads the library)