### PR TITLE
DS-4036 Distro maintenance

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,7 @@
         "drupal/link_css": "1.x-dev",
         "drupal/mailsystem" : "4.1",
         "drupal/message": "1.0-beta1",
-        "drupal/override_node_options": "2.0",
+        "drupal/override_node_options": "2.1",
         "drupal/profile": "1.0-beta1",
         "drupal/r4032login": "1.x-dev#4b2077aa70e3f7b00b8a9cba25af5b948ba2e3b9",
         "drupal/search_api": "1.2",

--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,7 @@
         "drupal/override_node_options": "2.1",
         "drupal/profile": "1.0-beta1",
         "drupal/r4032login": "1.x-dev#4b2077aa70e3f7b00b8a9cba25af5b948ba2e3b9",
-        "drupal/search_api": "1.2",
+        "drupal/search_api": "1.3",
         "drupal/swiftmailer" : "1.0-beta1",
         "drupal/token": "1.0",
         "drupal/votingapi": "3.0-alpha2",

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "drupal/admin_toolbar": "1.19",
         "drupal/config_update": "1.3",
         "drupal/devel": "1.0-rc2",
-        "drupal/dynamic_entity_reference": "1.3",
+        "drupal/dynamic_entity_reference": "1.4",
         "drupal/entity": "1.0-alpha4",
         "drupal/features": "3.5",
         "drupal/field_group": "1.0-rc6",

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "cweagans/composer-patches": "^1.5.0",
         "composer/installers": "^1.0",
         "drupal-composer/drupal-scaffold": "^2.0.0",
-        "drupal/core": "8.3.5",
+        "drupal/core": "8.3.6",
         "drupal/crop": "1.2",
         "drupal/address": "1.0",
         "drupal/addtoany": "1.8",

--- a/modules/custom/group_core_comments/group_core_comments.info.yml
+++ b/modules/custom/group_core_comments/group_core_comments.info.yml
@@ -1,12 +1,11 @@
-name: 'Group Core Comments support'
-description: 'Enables Group functionality for the Comment module'
-package: 'Group'
-type: 'module'
+name: Group Core Comments support
+type: module
+description: Enables Group functionality for the Comment module
+core: 8.x
+package: Group
 dependencies:
-  - 'comment'
-  - 'node'
-  - 'group'
+  - comment
+  - node
+  - group
+version: 8.x-1.0-dev
 
-version: '8.x-1.0-dev'
-core: '8.x'
-project: 'group_core_comments'


### PR DESCRIPTION
## Information
Updated the following things: 

-  Drupal core to 8.3.6
- Dynamic entity reference to 1.4
- Override node options to 2.1
- Search API to 1.3
- Update manager no longer checks updates for group_core_comments. This is a contrib module so no need to check

## HTT

- [x] Check the release notes of the updated modules
- [x] Check if the site and especially the parts related to the updates still work
