### PR TITLE
2901465 - Book table of contents should only show up for node type book

### DIFF
--- a/modules/social_features/social_book/config/optional/block.block.booknavigation.yml
+++ b/modules/social_features/social_book/config/optional/block.block.booknavigation.yml
@@ -3,6 +3,7 @@ status: true
 dependencies:
   module:
     - book
+    - node
   theme:
     - socialbase
 id: booknavigation
@@ -17,4 +18,11 @@ settings:
   provider: book
   label_display: visible
   block_mode: 'book pages'
-visibility: {  }
+visibility:
+  node_type:
+    id: node_type
+    bundles:
+      book: book
+    negate: false
+    context_mapping:
+      node: '@node.node_route_context:node'

--- a/modules/social_features/social_book/config/optional/block.block.booknavigation_2.yml
+++ b/modules/social_features/social_book/config/optional/block.block.booknavigation_2.yml
@@ -3,12 +3,13 @@ status: true
 dependencies:
   module:
     - book
+    - node
   theme:
     - socialblue
 id: booknavigation_2
 theme: socialblue
 region: complementary_top
-weight: null
+weight: 0
 provider: null
 plugin: book_navigation
 settings:
@@ -17,4 +18,11 @@ settings:
   provider: book
   label_display: visible
   block_mode: 'book pages'
-visibility: {  }
+visibility:
+  node_type:
+    id: node_type
+    bundles:
+      book: book
+    negate: false
+    context_mapping:
+      node: '@node.node_route_context:node'


### PR DESCRIPTION
## Description
The sidebar first region only shows up if the complementary area's are empty. The table of content block from the book module is setup to ALWAYS show up in the complementary top area. This is changed, so it only shows up for books.

## Drupal
https://www.drupal.org/node/2901465

## HTT

- [x] Create a fresh install from 8.x-1.x
- [x] Add some block to the sidebar_first region on the /search/* page
- [x] Go to the search and see it shows up there. Also notice there's a 50/50 layout
- [x] Enable the social_book module
- [x] Create 1 book and 1 book page in that book
- [x] See it works fine and on both pages there's a table of contents
- [x] Go to the search and notice your placed block is gone
- [x] Checkout this branch
- [x] run: `drush fr social_book --yes`
- [x] Notice the two book pages still work with the TOC
- [x] Notice the search also works well now
- [x] Merge