### PR TITLE
2894160 by jochemvn, Kingdutch: Change 'comment on a photo' into 'comment on a post'

### DIFF
--- a/modules/social_features/social_comment/social_comment.tokens.inc
+++ b/modules/social_features/social_comment/social_comment.tokens.inc
@@ -89,12 +89,18 @@ function social_comment_tokens($type, $tokens, array $data, array $options, Bubb
 
               if (!empty($comment)) {
                 if ($comment->getEntityTypeId() == 'comment') {
-                  if (!empty($comment->getCommentedEntity())) {
-                    $node = $comment->getCommentedEntity();
-                    $bundle = $node->bundle();
+                  /** @var \Drupal\Core\Entity\Entity $entity */
+                  $entity = $comment->getCommentedEntity();
+                  if (!empty($entity)) {
+                    if (is_callable([$entity, 'getDisplayName'])) {
+                      $display_name = $entity->getDisplayName();
+                    }
+                    else {
+                      $display_name = $entity->bundle();
+                    }
 
-                    if (!empty($bundle)) {
-                      $replacements[$original] = $bundle;
+                    if (!empty($display_name)) {
+                      $replacements[$original] = $display_name;
                     }
                   }
                 }

--- a/modules/social_features/social_post/src/Entity/Post.php
+++ b/modules/social_features/social_post/src/Entity/Post.php
@@ -146,6 +146,10 @@ class Post extends ContentEntityBase implements PostInterface {
     return $this;
   }
 
+  public function getDisplayName() {
+    return $this->label();
+  }
+
   /**
    * {@inheritdoc}
    */


### PR DESCRIPTION
## Description
This is an alternative for PR #490. The result of the changes is the same so the HTT is the same as well.

This pushes the logic of how to display something into the Entity itself and falls back to the current behaviour of the bundle. This improves extensibility and avoids the necessity for more special cases when bundle names of new entity types are not suitable for display to the user.

For now the implementation on the Post entity type will use the label of the Entity (which is Post) but we could implement some logic there to use "Photo" if the foto field is filled and "Post" otherwise.

When someone comments on a post that has no photo attached to it, the author gets a notification that someone commented on his/her photo. To make sure it fits both cases with and without photo, we've changed it back to 'post'

## Drupal 
https://www.drupal.org/node/2894160

## HTT
- [] Check the code
- [] Checkout this branch and clear caches
- [] Login as user A and create two posts (on with and one without photo). Also create a topic and an event
- [] Login as user B and place comments on all created content types
- [] Login as user A again.
- [] Notice that you have four notifications (and/or emails)
- [] Two of those say "User B commented on your post"
- [] One says "User B commented on your topic"
- [] One says "User B commented on your event"
- [] Check both notifications AND emails


