### PR TITLE
Follow up: improve see who liked content on mobile

### DIFF
--- a/themes/socialbase/assets/css/comment.css
+++ b/themes/socialbase/assets/css/comment.css
@@ -57,11 +57,6 @@
   padding: 2px 0.6em;
 }
 
-.comment__text .vote-widget {
-  margin-top: 0.25em;
-  margin-left: -0.25em;
-}
-
 .comments {
   margin-bottom: 0.5em;
   padding: 1em 0.5em 1em 1em;

--- a/themes/socialbase/assets/css/like.css
+++ b/themes/socialbase/assets/css/like.css
@@ -31,6 +31,11 @@
   stroke-width: 15px;
   -webkit-transition: 0.3s;
   transition: 0.3s;
+  vertical-align: text-top;
+}
+
+svg[class^="icon-vote"] {
+  vertical-align: text-bottom;
 }
 
 .vote__count {
@@ -66,9 +71,8 @@
 }
 
 .view--who-liked .row {
-  display: -webkit-box;
-  display: -ms-flexbox;
-  display: flex;
+  -ms-flex-wrap: nowrap;
+      flex-wrap: nowrap;
   -webkit-box-pack: start;
       -ms-flex-pack: start;
           justify-content: flex-start;
@@ -89,39 +93,26 @@
           flex: 0 0 54px;
 }
 
+.view--who-liked .views-field-rendered-entity-1 a:focus {
+  outline: 0;
+}
+
 .view--who-liked .views-field-name {
   -webkit-box-flex: 2;
-      -ms-flex: 2 0 auto;
-          flex: 2 0 auto;
+      -ms-flex: 2 1 auto;
+          flex: 2 1 auto;
+  min-width: 0;
+}
+
+.view--who-liked .views-field-name a {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .view--who-liked .views-field-view-user {
-  margin-right: 0;
-}
-
-.view--who-liked .views-field-view-user a {
-  display: inline-block;
-  margin-bottom: 0;
-  font-weight: normal;
-  text-align: center;
-  vertical-align: middle;
-  -ms-touch-action: manipulation;
-      touch-action: manipulation;
-  cursor: pointer;
-  background-image: none;
-  border: 1px solid transparent;
-  white-space: nowrap;
-  padding: 6px 12px;
-  font-size: 0.875rem;
-  line-height: 1.5;
-  -webkit-user-select: none;
-     -moz-user-select: none;
-      -ms-user-select: none;
-          user-select: none;
-  text-transform: uppercase;
-  -webkit-transition: .3s ease-out;
-  transition: .3s ease-out;
-  outline: 0;
+  display: none;
 }
 
 .view--who-liked .mini-pager {
@@ -152,5 +143,57 @@
 
   .view--who-liked {
     width: 500px;
+  }
+
+  .view--who-liked .views-field-view-user {
+    margin-right: 0;
+    display: block;
+  }
+
+  .view--who-liked .views-field-view-user a {
+    display: inline-block;
+    margin-bottom: 0;
+    font-weight: normal;
+    text-align: center;
+    vertical-align: middle;
+    -ms-touch-action: manipulation;
+    touch-action: manipulation;
+    cursor: pointer;
+    background-image: none;
+    border: 1px solid transparent;
+    white-space: nowrap;
+    padding: 6px 12px;
+    font-size: 0.875rem;
+    line-height: 1.5;
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+    text-transform: uppercase;
+    -webkit-transition: .3s ease-out;
+    transition: .3s ease-out;
+    outline: 0;
+  }
+}
+
+@media (max-width: 599px) {
+
+  .vote-widget {
+    width: 100%;
+  }
+
+  .vote__wrapper {
+    -webkit-box-pack: justify;
+    -ms-flex-pack: justify;
+    justify-content: space-between;
+  }
+
+  .vote-like {
+    margin-right: 10px;
+  }
+
+  .icon-vote {
+    width: 22px;
+    height: 22px;
   }
 }

--- a/themes/socialbase/assets/css/modal.css
+++ b/themes/socialbase/assets/css/modal.css
@@ -1,3 +1,47 @@
+@-webkit-keyframes fadein {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 0.5;
+  }
+}
+
+@keyframes fadein {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 0.5;
+  }
+}
+
+@-webkit-keyframes fadein_scale {
+  from {
+    opacity: 0;
+    -webkit-transform: translateY(-30px);
+            transform: translateY(-30px);
+  }
+  to {
+    opacity: 1;
+    -webkit-transform: translateY(0);
+            transform: translateY(0);
+  }
+}
+
+@keyframes fadein_scale {
+  from {
+    opacity: 0;
+    -webkit-transform: translateY(-30px);
+            transform: translateY(-30px);
+  }
+  to {
+    opacity: 1;
+    -webkit-transform: translateY(0);
+            transform: translateY(0);
+  }
+}
+
 .ui-front {
   z-index: 100;
 }
@@ -12,6 +56,8 @@
   z-index: 1040;
   background-color: #000;
   opacity: 0.5;
+  -webkit-animation: fadein 0.3s;
+          animation: fadein 0.3s;
 }
 
 .ui-helper-hidden-accessible {
@@ -29,8 +75,10 @@
   overflow-x: hidden;
   overflow-y: auto;
   position: absolute;
+  max-width: 100%;
   top: 0;
-  left: 0;
+  margin-left: 0.5rem;
+  margin-right: 0.5rem;
   padding: .2em;
   outline: 0;
   z-index: 1050;
@@ -38,6 +86,10 @@
   border: 1px solid rgba(0, 0, 0, 0.2);
   box-shadow: 0 3px 9px rgba(0, 0, 0, 0.5);
   background-clip: padding-box;
+  -webkit-backface-visibility: hidden;
+          backface-visibility: hidden;
+  -webkit-animation: fadein_scale 0.5s ease-out;
+          animation: fadein_scale 0.5s ease-out;
 }
 
 .ui-dialog-titlebar {
@@ -70,7 +122,7 @@
   color: #000;
   text-shadow: 0 1px 0 #fff;
   opacity: .5;
-  padding: 0;
+  padding: 0 0 0 1em;
   cursor: pointer;
   background: 0 0;
   border: 0;
@@ -166,5 +218,11 @@
 @media (min-width: 900px) {
   .ui-dialog-title {
     font-size: 1.25rem;
+  }
+}
+
+@media (max-width: 599px) {
+  .ui-dialog-content {
+    max-height: 60vh !important;
   }
 }

--- a/themes/socialbase/components/00-config/_mixins.scss
+++ b/themes/socialbase/components/00-config/_mixins.scss
@@ -4,7 +4,7 @@
 @import "mixins/elevation";
 @import "mixins/image";
 @import "mixins/list-unstyled";
-@import "mixins/multiline-ellipsis";
+@import "mixins/ellipsis";
 @import "mixins/nav-divider";
 @import "mixins/reset-text";
 @import "mixins/visually-hidden";

--- a/themes/socialbase/components/00-config/mixins/_ellipsis.scss
+++ b/themes/socialbase/components/00-config/mixins/_ellipsis.scss
@@ -1,10 +1,25 @@
-// Multiline ellipsis
+// Single line ellipsis
+//
+// Allows a text to be truncated and get '...' at the end.
+//
+// Weight: 6
+//
+// Style guide: sass.singleline-ellipsis
+
+@mixin singleLineEllipsis() {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+// Multi line ellipsis
 //
 // Allows an text to be truncated and get '...' at the end when it exceeds the
 // maximum amount of lines.
 // `@mixin multiLineEllipsis($lineHeight: 1.2em, $lineCount: 1, $bgColor: white)`
 //
-// Weight: 6
+// Weight: 7
 //
 // Style guide: sass.multiline-ellipsis
 

--- a/themes/socialbase/components/03-molecules/like/like.scss
+++ b/themes/socialbase/components/03-molecules/like/like.scss
@@ -5,6 +5,10 @@
   display: inline-block;
   vertical-align: middle;
 
+  @include for-phone-only {
+    width: 100%;
+  }
+
   .vote-dislike {
     display: none;
   }
@@ -14,11 +18,19 @@
 .vote__wrapper {
   display: flex;
   align-items: center;
+
+  @include for-phone-only {
+    justify-content: space-between;
+  }
 }
 
 .vote-like {
   margin-right: 3px;
   cursor: pointer;
+
+  @include for-phone-only {
+    margin-right: 10px;
+  }
 }
 
 .icon-vote {
@@ -30,6 +42,18 @@
   stroke: $default-color;
   stroke-width: 15px;
   transition: 0.3s;
+  vertical-align: text-top;
+
+  @include for-phone-only {
+    width: 22px;
+    height: 22px;
+  }
+
+}
+
+// specifity horror, override base component
+svg[class^="icon-vote"] {
+  vertical-align: text-bottom;
 }
 
 .vote__count {
@@ -104,7 +128,7 @@
   }
 
   .row {
-    display: flex;
+    flex-wrap: nowrap;
     justify-content: flex-start;
     align-items: center;
     border-bottom: 1px solid $gray-lighter;
@@ -119,34 +143,49 @@
 
   .views-field-rendered-entity-1 {
     flex: 0 0 54px;
+
+    a:focus {
+      outline: 0;
+    }
   }
 
   .views-field-name {
-    flex: 2 0 auto;
+    flex: 2 1 auto;
+    min-width: 0; // critical to prevent children from growing
+    a {
+      @include singleLineEllipsis;
+    }
   }
 
   .views-field-view-user {
-    margin-right: 0;
+    display: none;
 
-    a {
-      display: inline-block;
-      margin-bottom: 0; // For input.btn
-      font-weight: $btn-font-weight;
-      text-align: center;
-      vertical-align: middle;
-      touch-action: manipulation;
-      cursor: pointer;
-      background-image: none; // Reset unusual Firefox-on-Android default style;
-      border: 1px solid transparent;
-      white-space: nowrap;
-      padding: $padding-base-vertical $padding-base-horizontal;
-      font-size: $button-font-size;
-      line-height: $line-height-base;
-      user-select: none;
-      text-transform: uppercase;
-      transition: .3s ease-out;
-      outline: 0;
+    @include for-tablet-landscape-up {
+      margin-right: 0;
+      display: block;
+
+      a {
+        display: inline-block;
+        margin-bottom: 0; // For input.btn
+        font-weight: $btn-font-weight;
+        text-align: center;
+        vertical-align: middle;
+        touch-action: manipulation;
+        cursor: pointer;
+        background-image: none; // Reset unusual Firefox-on-Android default style;
+        border: 1px solid transparent;
+        white-space: nowrap;
+        padding: $padding-base-vertical $padding-base-horizontal;
+        font-size: $button-font-size;
+        line-height: $line-height-base;
+        user-select: none;
+        text-transform: uppercase;
+        transition: .3s ease-out;
+        outline: 0;
+      }
+
     }
+
   }
 
   .mini-pager {

--- a/themes/socialbase/components/04-organisms/comment/comment.scss
+++ b/themes/socialbase/components/04-organisms/comment/comment.scss
@@ -61,11 +61,6 @@
     padding: 2px 0.6em
   }
 
-  .vote-widget {
-    margin-top: 0.25em;
-    margin-left: -0.25em; // optical alignment
-  }
-
 }
 
 .comments {

--- a/themes/socialbase/components/04-organisms/modal/modal.scss
+++ b/themes/socialbase/components/04-organisms/modal/modal.scss
@@ -14,6 +14,17 @@
 // http://api.jqueryui.com/dialog/#theming
 //
 
+
+@keyframes fadein {
+  from { opacity: 0; }
+  to   { opacity: $modal-backdrop-opacity; }
+}
+
+@keyframes fadein_scale {
+  from { opacity: 0; transform: translateY(-30px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
 .ui-front {
   z-index: 100;
 }
@@ -28,6 +39,7 @@
   z-index: $zindex-modal-background;
   background-color: $modal-backdrop-bg;
   opacity: $modal-backdrop-opacity;
+  animation: fadein 0.3s;
 }
 
 .ui-helper-hidden-accessible {
@@ -46,8 +58,10 @@
   overflow-x: hidden;
   overflow-y: auto;
   position: absolute;
+  max-width: 100%;
   top: 0;
-  left: 0;
+  margin-left: 0.5rem;
+  margin-right: 0.5rem;
   padding: .2em;
   outline: 0;
   z-index: $zindex-modal;
@@ -55,6 +69,8 @@
   border: 1px solid $modal-content-border-color;
   box-shadow: 0 3px 9px rgba(0,0,0,.5);
   background-clip: padding-box;
+  backface-visibility: hidden;
+  animation: fadein_scale 0.5s ease-out;
 }
 
 .ui-dialog-titlebar {
@@ -85,7 +101,7 @@
   color: #000;
   text-shadow: 0 1px 0 #fff;
   opacity: .5;
-  padding: 0;
+  padding: 0 0 0 1em;
   cursor: pointer;
   background: 0 0;
   border: 0;
@@ -113,6 +129,10 @@
   box-shadow: none;
   flex: 1 1 auto;
   padding: 1rem;
+
+  @include for-phone-only {
+    max-height: 60vh !important; // make sure the height doesn't stretch beyond the height of th e screen including the browser toolbar
+  }
 }
 
 


### PR DESCRIPTION
Test on mobile:
Run yarn install from the socialbase theme folder.
- On your gulpfile set the correct value on line 42 (options.drupalURL). eg: options.drupalURL = 'http://social.dev:32787'

Run `gulp watch`

You should see an external URL, use this url on your mobile device. 

The following things have changed:

 Make sure icon to like and number of likes have enough space to tap on them:
- [x] On mobile the text is aligned right, so it is easy to distinguish 

- [x] Hide "see" profile" text on mobile

- [x] Test with long names: the name must stay on the line and not push the modal window outside the viewport
- [x] Added animation for modal dialogues, so it feels less "hard". 

- [x] when "who liked" modal opens, the focus on the first avatar is gone

- [x]  when viewing a long list of users in the modal, keep the height of the modal above the browser toolbar, so scrolling inside the viewport. The height of the modal doesn't exceed the viewport itself (height of 60vh = 60% of viewport height + title bar = safe)