### PR TITLE
2900630 - Prevent a user form having two profiles, if profile fields are already asked during registration

### DIFF
--- a/modules/social_features/social_profile/social_profile.module
+++ b/modules/social_features/social_profile/social_profile.module
@@ -233,11 +233,18 @@ function social_profile_user_insert(UserInterface $account) {
   // If the new account has a UID, we can create a default profile.
   // Default image is added through the field settings.
   if (!empty($account->id())) {
-    $profile = Profile::create($expected = [
-      'type' => ProfileType::load('profile')->id(),
-      'uid' => $account->id(),
-    ]);
-    $profile->save();
+    /** @var ProfileType $profile_type */
+    $profile_type = ProfileType::load('profile');
+    // Sometimes profile fields are already requested during registrataion.
+    // In those cases, the profile will already be created from that.
+    if ($profile_type->getRegistration() === FALSE) {
+      // Create a profile.
+      $profile = Profile::create($expected = [
+        'type' => $profile_type->id(),
+        'uid' => $account->id(),
+      ]);
+      $profile->save();
+    }
   }
 }
 


### PR DESCRIPTION
## Description
Sometimes people choose to enable profile fields during registration. This leads to a user having 2 pofile after registration

## Drupal
https://www.drupal.org/node/2900630

## HTT
- [x] Check the code
- [x] Go to /admin/config/people/profiles/types/manage/profile
- [x] Select the checkbox: " Include in user registration form"
- [x] Register as a new user
- [x] Check in the profile table that there are now 2 profiles
- [x] Notice that during login, the fields for the profile you filled out during registration are gone
- [x] Checkout this branch
- [x] Test again and notice you now have only 1 profile
