### PR TITLE
Issue 2903582 by tarasich, Kingdutch: Add dependency on profile modul…

### DIFF
--- a/modules/social_features/social_core/social_core.install
+++ b/modules/social_features/social_core/social_core.install
@@ -57,6 +57,18 @@ function social_core_install() {
 }
 
 /**
+ * Implements hook_update_dependencies().
+ */
+function social_core_update_dependencies() {
+  // Update field schema only after Profile module bug fixed.
+  $dependencies['social_core'][8020] = [
+    'profile' => 8001,
+  ];
+
+  return $dependencies;
+}
+
+/**
  * Re-set permissions.
  */
 function social_core_update_8001(&$sandbox) {


### PR DESCRIPTION
…e update

Open Social performs an update that requires the profile module to
be updated first. This change tells the Drupal update system about
this dependency.

## How to test
Update from RC5 or earlier to 1.3 or from beta11 to 1.2. The error is caused by update 8020 which seems to have been introduced in RC7. Upgrades between other versions that touch this update hook may also suffer the error without the patch applied but these have not (yet) been observed.

## Related drupal.org issue
https://www.drupal.org/node/2903582