### PR TITLE
Issue #2761799 by bramtenhove: Social Search and other features are dependent on self

### DIFF
--- a/modules/social_features/social_core/social_core.info.yml
+++ b/modules/social_features/social_core/social_core.info.yml
@@ -18,7 +18,6 @@ dependencies:
   - node
   - override_node_options
   - r4032login
-  - social_core
   - system
   - template_suggestions_extra
   - text

--- a/modules/social_features/social_event/social_event.info.yml
+++ b/modules/social_features/social_event/social_event.info.yml
@@ -22,7 +22,6 @@ dependencies:
   - profile
   - social_comment
   - social_core
-  - social_event
   - social_profile
   - system
   - text

--- a/modules/social_features/social_group/social_group.info.yml
+++ b/modules/social_features/social_group/social_group.info.yml
@@ -18,7 +18,6 @@ dependencies:
   - profile
   - social_core
   - social_event
-  - social_group
   - social_profile
   - social_topic
   - system

--- a/modules/social_features/social_post/social_post.info.yml
+++ b/modules/social_features/social_post/social_post.info.yml
@@ -10,7 +10,6 @@ dependencies:
   - group
   - options
   - social_comment
-  - social_post
   - system
   - text
   - user

--- a/modules/social_features/social_profile/social_profile.info.yml
+++ b/modules/social_features/social_profile/social_profile.info.yml
@@ -12,7 +12,6 @@ dependencies:
   - image_widget_crop
   - profile
   - social_core
-  - social_profile
   - system
   - taxonomy
   - telephone

--- a/modules/social_features/social_search/social_search.info.yml
+++ b/modules/social_features/social_search/social_search.info.yml
@@ -12,7 +12,6 @@ dependencies:
   - search_api_views_taxonomy
   - social_group
   - social_profile
-  - social_search
   - system
   - user
   - views

--- a/modules/social_features/social_topic/social_topic.info.yml
+++ b/modules/social_features/social_topic/social_topic.info.yml
@@ -20,7 +20,6 @@ dependencies:
   - social_comment
   - social_core
   - social_event
-  - social_topic
   - system
   - taxonomy
   - text

--- a/modules/social_features/social_user/social_user.info.yml
+++ b/modules/social_features/social_user/social_user.info.yml
@@ -5,7 +5,6 @@ core: 8.x
 dependencies:
   - block
   - field_group
-  - social_user
   - user
   - views
 package: Social


### PR DESCRIPTION
## Description
Using Drush to update features probably made it so that some features are now dependent on self. This is an issue as there is no way modules or features can ever be disabled.

It was fixed before, but reintroduced, see https://www.drupal.org/node/2761799.

## How to test

- [x] Use main branch, notice you can disable for example social_search as it is dependent on self
- [x] Switch to this branch, notice you can now disable the feature(s)