### PR TITLE
Issue #2840680 by frankgraave: fix the behat for profile privacy setting

### DIFF
--- a/tests/behat/features/capabilities/profile/hide-profile-email.feature
+++ b/tests/behat/features/capabilities/profile/hide-profile-email.feature
@@ -2,7 +2,7 @@
 Feature: I want to be able to hide my email address
   Benefit: In order to have better privacy
   Role: LU
-  Goal/desire: So i can determine if I want to show my email address to everyone
+  Goal/desire: So I can determine if I want to show my email address to everyone
 
   Scenario: Successfully hide my email address
     Given users:
@@ -10,22 +10,25 @@ Feature: I want to be able to hide my email address
       | user_1        | user_1@example.com    | 1      |
       | user_2        | user_2@example.com    | 1      |
 
+    # Disable the privacy setting.
     Given I am logged in as an "administrator"
     And I am on "admin/config/people/social-profile"
     And I uncheck the box "social_profile_show_email"
     And I press "Save configuration"
 
+    # Check the profile of someone else, and now I should NOT see the email address.
     Given I am logged in as "user_1"
-    And I am on "all-members"
-    Then I click "user_2"
+    And I am on the profile of "user_2"
     And I click "Information"
     And I should not see "user_2@example.com"
 
+    # Check the profile of myself.
     And I click the xth "0" element with the css ".navbar-nav .profile"
     And I click "My profile"
     And I click "Information"
     And I should not see "user_1@example.com"
 
+    # Enable the setting on my profile.
     And I click the xth "0" element with the css ".navbar-nav .profile"
     And I click "Settings"
     Then I should see "Show my email on my profile"
@@ -35,13 +38,14 @@ Feature: I want to be able to hide my email address
     And I click "Information"
     And I should see "user_1@example.com"
 
+    # Enable the privacy setting.
     Given I am logged in as an "administrator"
     And I am on "admin/config/people/social-profile"
     And I check the box "social_profile_show_email"
     And I press "Save configuration"
 
+    # Check the profile of someone else, and now I should see the email address.
     Given I am logged in as "user_1"
-    And I am on "all-members"
-    Then I click "user_2"
+    And I am on the profile of "user_2"
     And I click "Information"
     And I should see "user_2@example.com"

--- a/tests/behat/features/capabilities/profile/hide-profile-email.feature
+++ b/tests/behat/features/capabilities/profile/hide-profile-email.feature
@@ -1,4 +1,4 @@
-@account @profile @AN @perfect @api @stability @stability-2
+@account @profile @AN @perfect @api @DS-2082 @stability @stability-2
 Feature: I want to be able to hide my email address
   Benefit: In order to have better privacy
   Role: LU

--- a/tests/behat/features/capabilities/profile/hide-profile-email.feature
+++ b/tests/behat/features/capabilities/profile/hide-profile-email.feature
@@ -1,4 +1,4 @@
-@account @profile @AN @perfect @api @DS-2082 @stability @stability-2
+@account @profile @AN @perfect @api @stability @stability-2
 Feature: I want to be able to hide my email address
   Benefit: In order to have better privacy
   Role: LU


### PR DESCRIPTION
# Background
There were two behats excluded since January 2017. One (`DS-811`) was already fixed, but now only the `DS-2082` remains. I ran the test locally and it seems to be running just fine. However it seems to fail on Travis, I looked at the behat and rewrote a small part since we don't need to go to the user information by using `"/all-members"` and clicking an username in there (where the test seemed to fail on Travis). Instead we now use `"I am on the profile of "user"`, this should now not only work locally, but also on Travis of course. Related issue: https://www.drupal.org/node/2840680

# HTT
- [x] Checkout this branch `git checkout feature/2840680-fix-behat`
- [x] Run the test on your machine and see it pass
- [ ] Update the d.o issue once it's merged

## To test this on Travis I think there's 2 ways to do so
1. Create a branch on the https://github.com/goalgorilla/open_social_scripts repo where the `DS-2082` test is no longer excluded from the `behatstability.sh` file. Checkout to this branch in the open_social repo and change your composer.json by replacing `"goalgorilla/open_social_scripts": "dev-master"` with `"goalgorilla/open_social_scripts": "dev-<your feature branch>"` from the PR you made on that repo. Then push the changes to this branch and the test should be running in this branch. 

2. Create a PR on the https://github.com/goalgorilla/open_social_scripts repo where the DS-2082 test is no longer excluded and merge it. Then restart the Travis build from this PR.
