### PR TITLE
Issue #2906090 by bramtenhove: Remove drush dependency when updating to 1.4

### DIFF
--- a/modules/social_features/social_search/social_search.install
+++ b/modules/social_features/social_search/social_search.install
@@ -7,6 +7,7 @@
 
 use Drupal\block\Entity\Block;
 use Drupal\views\Entity\View;
+use Drupal\search_api\Entity\Index;
 use \Drupal\user\Entity\Role;
 
 /**
@@ -126,11 +127,16 @@ function social_search_update_8102(array &$sandbox) {
  * Trigger a search_api re-index.
  */
 function social_search_update_8103() {
-  // Clear the index.
-  drush_search_api_clear('social_all');
-  drush_search_api_clear('social_groups');
+  $indexes = [
+    'social_all',
+    'social_groups',
+  ];
 
-  // Schedule the indexes for a search re-index.
-  drush_search_api_reset_tracker('social_all');
-  drush_search_api_reset_tracker('social_groups');
+  foreach ($indexes as $index_id) {
+    $index = Index::load($index_id);
+    if ($index->status()) {
+      $index->clear();
+      $index->reindex();
+    }
+  }
 }


### PR DESCRIPTION
## Description
Issue https://www.drupal.org/node/2906090 was created after the 1.4 release. Apparently the social_search feature had an update hook containing drush commands. These work fine when updating via drush, but not if you use the interface.

See https://github.com/goalgorilla/open_social/pull/494 for the original pull request.

## How to test
Easiest way is to fake the update system that there is a new update hook. For this change the number of `social_search_update_8103()` to `social_search_update_8104()`, etc.

- [ ] Clear the index of /admin/config/search/search-api/index/social_all
- [ ] Run the update.php script via the interface, notice that there are no issues or fatal errors
- [ ] Check that /admin/config/search/search-api/index/social_all and /admin/config/search/search-api/index/social_groups are both re-indexed
- [ ] Repeat above using `drush updb`