### PR TITLE
#2894160 by jochemvn, Kingdutch: Change 'comment on a photo' into 'comment on a post'

### DIFF
--- a/modules/social_features/social_comment/social_comment.tokens.inc
+++ b/modules/social_features/social_comment/social_comment.tokens.inc
@@ -90,18 +90,18 @@ function social_comment_tokens($type, $tokens, array $data, array $options, Bubb
 
               if (!empty($comment)) {
                 if ($comment->getEntityTypeId() == 'comment') {
-                  if (!empty($comment->getCommentedEntity())) {
-                    /** @var \Drupal\Core\Entity\Entity $node */
-                    $node = $comment->getCommentedEntity();
-                    $bundle = $node->bundle();
-                    $type = $node->getEntityTypeId();
+                  /** @var \Drupal\Core\Entity\Entity $entity */
+                  $entity = $comment->getCommentedEntity();
+                  if (!empty($entity)) {
+                    if (is_callable([$entity, 'getDisplayName'])) {
+                      $display_name = $entity->getDisplayName();
+                    }
+                    else {
+                      $display_name = $entity->bundle();
+                    }
 
-                    if (!empty($bundle)) {
-                      // For posts, we don't use the bundle name, but the entity type id.
-                      if (isset($type) && $type == 'post') {
-                        $bundle = $type;
-                      }
-                      $replacements[$original] = $bundle;
+                    if (!empty($display_name)) {
+                      $replacements[$original] = $display_name;
                     }
                   }
                 }

--- a/modules/social_features/social_comment/social_comment.tokens.inc
+++ b/modules/social_features/social_comment/social_comment.tokens.inc
@@ -83,6 +83,7 @@ function social_comment_tokens($type, $tokens, array $data, array $options, Bubb
             if (isset($message->field_message_related_object)) {
               $target_type = $message->field_message_related_object->target_type;
               $target_id = $message->field_message_related_object->target_id;
+              /** @var \Drupal\comment\Entity\Comment $comment */
               $comment = \Drupal::entityTypeManager()
                 ->getStorage($target_type)
                 ->load($target_id);
@@ -90,10 +91,16 @@ function social_comment_tokens($type, $tokens, array $data, array $options, Bubb
               if (!empty($comment)) {
                 if ($comment->getEntityTypeId() == 'comment') {
                   if (!empty($comment->getCommentedEntity())) {
+                    /** @var \Drupal\Core\Entity\Entity $node */
                     $node = $comment->getCommentedEntity();
                     $bundle = $node->bundle();
+                    $type = $node->getEntityTypeId();
 
                     if (!empty($bundle)) {
+                      // For posts, we don't use the bundle name, but the entity type id.
+                      if (isset($type) && $type == 'post') {
+                        $bundle = $type;
+                      }
                       $replacements[$original] = $bundle;
                     }
                   }

--- a/modules/social_features/social_post/src/Entity/Post.php
+++ b/modules/social_features/social_post/src/Entity/Post.php
@@ -146,6 +146,10 @@ class Post extends ContentEntityBase implements PostInterface {
     return $this;
   }
 
+  public function getDisplayName() {
+    return $this->label();
+  }
+
   /**
    * {@inheritdoc}
    */

--- a/modules/social_features/social_post/src/Entity/Post.php
+++ b/modules/social_features/social_post/src/Entity/Post.php
@@ -147,7 +147,7 @@ class Post extends ContentEntityBase implements PostInterface {
   }
 
   public function getDisplayName() {
-    if (!$this->get('field_post_image')->isEmpty()) {
+    if ($this->hasField('field_post_image') && !$this->get('field_post_image')->isEmpty()) {
       return t('photo');
     }
 

--- a/modules/social_features/social_post/src/Entity/Post.php
+++ b/modules/social_features/social_post/src/Entity/Post.php
@@ -147,7 +147,11 @@ class Post extends ContentEntityBase implements PostInterface {
   }
 
   public function getDisplayName() {
-    return $this->label();
+    if (!$this->get('field_post_image')->isEmpty()) {
+      return t('photo');
+    }
+
+    return t('post');
   }
 
   /**


### PR DESCRIPTION
This is a duplicate of #490 because it had issues with feature states even though this issue doesn't touch those features. This code has been reapplied to the tip of the 8.x-1.x branch (unfortunately, merging did not work correctly). Original issue follows.

## Description
When someone comments on a post that has no photo attached to it, the author gets a notification that someone commented on his/her photo. To make sure it fits both cases with and without photo, we've changed it back to 'post'

## Drupal 
https://www.drupal.org/node/2894160

## HTT
- [x] Check the code
- [x] Checkout this branch and clear caches
- [x] Login as user A and create two posts (on with and one without photo). Also create a topic and an event
- [x] Login as user B and place comments on all created content types
- [x] Login as user A again.
- [x] Notice that you have four notifications (and/or emails)
- [x] Two of those say "User B commented on your post"
- [x] One says "User B commented on your topic"
- [x] One says "User B commented on your event"
- [x] Check both notifications AND emails


