### PR TITLE
Increase specificity for selectors in LU homepage my events test

### DIFF
--- a/tests/behat/config/behat.yml
+++ b/tests/behat/config/behat.yml
@@ -48,3 +48,5 @@ default:
           'Sidebar second': 'aside[role=complementary]'
           'Modal footer': '.modal-footer'
           'WYSIWYG dialog': '.editor-image-dialog .form-actions'
+          'My Upcoming Events Block': '.view-display-id-block_my_upcoming_events'
+

--- a/tests/behat/features/capabilities/event/lu-homepage-my-events.feature
+++ b/tests/behat/features/capabilities/event/lu-homepage-my-events.feature
@@ -10,7 +10,7 @@ Feature: See my upcoming events
 
     Given I am logged in as an "authenticated user"
     Then I should see "My upcoming events"
-    And I should see "No upcoming events"
+    And I should see "No upcoming events" in the 'My Upcoming Events Block'
 
     Given I am viewing my event:
       | title            | My Behat Event created |
@@ -26,9 +26,9 @@ Feature: See my upcoming events
     Then I should see "Enrolled"
 
     When I go to the homepage
-    Then I should not see "My Behat Event created" in the "Sidebar second"
-    And I should see "My Behat Event enrolled" in the "Sidebar second"
-    And I should see "Enrolled" in the "Sidebar second"
+    Then I should not see "My Behat Event created" in the 'My Upcoming Events Block'
+    And I should see "My Behat Event enrolled" in the 'My Upcoming Events Block'
+    And I should see "Enrolled" in the 'My Upcoming Events Block'
 
     When I am at "my-events"
     Then I should see "Events for this user"


### PR DESCRIPTION
The LU homepage my events test tests for the existance of some
events but is not specific enough to target only the "My Events"
block. This causes the test to fail when the overview block of
"all community events" is also in the sidebar.

This commit adds a region map for the my events block to test the
existance of the enrolled and non-enrolled event there causing the
test to function correctly.