### PR TITLE
Issue #2907049 - fix posting comments without attachment

### DIFF
--- a/modules/social_features/social_comment/social_comment.module
+++ b/modules/social_features/social_comment/social_comment.module
@@ -49,6 +49,14 @@ function social_comment_form_comment_form_alter(&$form, FormStateInterface $form
       $form['actions']['submit']['#attributes']['value'] = t('Submit');
       $form['actions']['submit']['#value'] = t('Submit');
       break;
+
+    default:
+      // Redirect to the current url. We should not use this change for posts.
+      // See social_post_form_comment_post_comment_form_alter for posts.
+      if ($form_id !== 'comment_post_comment_form') {
+        $form['#action'] = \Drupal::request()->getRequestUri();
+      }
+      break;
   }
 
   $form['#attached']['library'][] = 'social_post/keycode-submit';


### PR DESCRIPTION
Issue:
https://www.drupal.org/node/2907049

The bug is introduced in: https://github.com/goalgorilla/open_social/pull/448

HTT:

**Without social_comment_upload:**

- [x] Create a reply on a comment on a node and you should be redirected to the node page after filling in the reply on the reply page.
- [x] Create a comment on a node and you should be redirected to the node page instantly.
- [x] Create a comment on a post on the post page and you should be redirected to the post page instantly.
- [x] Create a comment on a post (not the top post!) on the homepage stream and you should be redirected to the stream page instantly.
- [x] Create a comment on a post (not the top post!) on the group page stream and you should be redirected to the stream page instantly.


**With social_comment_upload:**

- [x] Create a reply on a comment on a node and you should be redirected to the node page after filling in the reply on the reply page.
- [x] Create a comment on a node and you should be redirected to the node page instantly.
- [x] Create a comment on a post on the post page and you should be redirected to the post page instantly.
- [x] Create a comment on a post (not the top post!) on the homepage stream and you should be redirected to the stream page instantly.
- [x] Create a comment on a post (not the top post!) on the group page stream and you should be redirected to the stream page instantly.