### PR TITLE
DS-4076 by bramtenhove: For address fields set the site default country as default value

### DIFF
--- a/modules/social_features/social_event/config/install/core.entity_form_display.node.event.default.yml
+++ b/modules/social_features/social_event/config/install/core.entity_form_display.node.event.default.yml
@@ -128,7 +128,7 @@ content:
   field_event_address:
     weight: 14
     settings:
-      default_country: ''
+      default_country: site_default
     third_party_settings: {  }
     type: address_default
     region: content

--- a/modules/social_features/social_group/config/install/core.entity_form_display.group.closed_group.default.yml
+++ b/modules/social_features/social_group/config/install/core.entity_form_display.group.closed_group.default.yml
@@ -51,7 +51,7 @@ content:
   field_group_address:
     weight: 33
     settings:
-      default_country: null
+      default_country: site_default
     third_party_settings: {  }
     type: address_default
     region: content

--- a/modules/social_features/social_group/config/install/core.entity_form_display.group.open_group.default.yml
+++ b/modules/social_features/social_group/config/install/core.entity_form_display.group.open_group.default.yml
@@ -51,7 +51,7 @@ content:
   field_group_address:
     weight: 33
     settings:
-      default_country: null
+      default_country: site_default
     third_party_settings: {  }
     type: address_default
     region: content

--- a/modules/social_features/social_profile/config/install/core.entity_form_display.profile.profile.default.yml
+++ b/modules/social_features/social_profile/config/install/core.entity_form_display.profile.profile.default.yml
@@ -87,7 +87,7 @@ content:
   field_profile_address:
     weight: 7
     settings:
-      default_country: null
+      default_country: site_default
     third_party_settings: {  }
     type: address_default
     region: content

--- a/modules/social_features/social_profile/social_profile.module
+++ b/modules/social_features/social_profile/social_profile.module
@@ -238,11 +238,21 @@ function social_profile_user_insert(UserInterface $account) {
     // Sometimes profile fields are already requested during registrataion.
     // In those cases, the profile will already be created from that.
     if ($profile_type->getRegistration() === FALSE) {
-      // Create a profile.
-      $profile = Profile::create($expected = [
+      $default_values = [
         'type' => $profile_type->id(),
         'uid' => $account->id(),
-      ]);
+      ];
+
+      // Get all field instances for the profile entity and check if the address
+      // field exists.
+      $instances = \Drupal::service('entity_field.manager')->getFieldDefinitions('profile', $profile_type->id());
+      if (array_key_exists('field_profile_address', $instances)) {
+        // Set the users default country to the site default country.
+        $default_values['field_profile_address'][0]['country_code'] = \Drupal::config('system.date')->get('country.default');
+      }
+
+      // Create a profile.
+      $profile = Profile::create($default_values);
       $profile->save();
     }
   }

--- a/themes/socialbase/templates/field/address-plain.html.twig
+++ b/themes/socialbase/templates/field/address-plain.html.twig
@@ -55,7 +55,7 @@
   {{- locality.name -}},
 {% elseif locality.code %}
   {{- locality.code -}},
-{% elseif locality %}
+{% elseif locality|render is not empty %}
   {{- locality -}},
 {% endif %}
 


### PR DESCRIPTION
## How to test

- [x] Set a default country at /admin/config/regional/settings.
- [x] Go to /node/add/event, the site default country should already be selected.
- [x] Go to /group/add/open_group, the site default country should already be selected.
- [x] Go to /group/add/closed_group, the site default country should already be selected.
- [x] Add a new user and visit his profile. The site default country should already be selected.
- [x] Remove the address field from [the profile](http://social.dev/admin/config/people/profiles/types/manage/profile/fields). Add a new user, it should work without errors.