### PR TITLE
DS-4076: add timezone settings in user profile if enabled in settings

### DIFF
--- a/modules/social_features/social_user/config/install/core.entity_form_display.user.user.default.yml
+++ b/modules/social_features/social_user/config/install/core.entity_form_display.user.user.default.yml
@@ -18,6 +18,18 @@ third_party_settings:
         required_fields: true
         id: ''
         classes: ''
+    group_locale_settings:
+      children:
+        - timezone
+      parent_name: ''
+      weight: 1
+      format_type: fieldset
+      format_settings:
+        id: ''
+        classes: ''
+        description: ''
+        required_fields: true
+      label: 'Locale settings'
 id: user.user.default
 targetEntityType: user
 bundle: user
@@ -25,10 +37,14 @@ mode: default
 content:
   account:
     weight: 1
+    region: content
     settings: {  }
     third_party_settings: {  }
+  timezone:
+    weight: 0
     region: content
+    settings: {  }
+    third_party_settings: {  }
 hidden:
   contact: true
   language: true
-  timezone: true


### PR DESCRIPTION
When a user h as the permission to change his/her timezone it does not show up on the user edit form. Let's add this field to the form display of account settings.

HTT:

- [x] Login as LU
- [x] Go to your account settings and verify there is no timezone field.
- [x] Login as admin, enable timezone configuration for authenticated users on /admin/config/regional/settings
- [x] Login as LU and go to your account settings and change timezone.
- [x] Create some content and verify with another user that the displayed date is different depending on the timezone settings.