### PR TITLE
#2900982 - Search 'all' tab won't show pages and books

### DIFF
--- a/modules/social_features/social_page/config/install/core.entity_view_display.node.page.search_index.yml
+++ b/modules/social_features/social_page/config/install/core.entity_view_display.node.page.search_index.yml
@@ -1,0 +1,47 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_display.comment.comment.default
+    - core.entity_view_mode.node.search_index
+    - field.field.node.page.body
+    - field.field.node.page.field_content_visibility
+    - field.field.node.page.field_files
+    - field.field.node.page.field_page_comments
+    - field.field.node.page.field_page_image
+    - node.type.page
+  module:
+    - comment
+    - text
+    - user
+id: node.page.search_index
+targetEntityType: node
+bundle: page
+mode: search_index
+content:
+  body:
+    label: hidden
+    type: text_default
+    weight: 0
+    settings: {  }
+    third_party_settings: {  }
+    region: content
+  field_page_comments:
+    weight: 1
+    label: above
+    settings:
+      pager_id: 0
+      view_mode: default
+    third_party_settings: {  }
+    type: comment_default
+    region: content
+  flag_follow_content:
+    weight: 2
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+hidden:
+  field_content_visibility: true
+  field_files: true
+  field_page_image: true
+  links: true

--- a/modules/social_features/social_search/config/install/search_api.index.social_all.yml
+++ b/modules/social_features/social_search/config/install/search_api.index.social_all.yml
@@ -32,7 +32,7 @@ field_settings:
       view_mode:
         'entity:node':
           event: search_index
-          page: default
+          page: search_index
           topic: search_index
         'entity:group':
           closed_group: teaser

--- a/modules/social_features/social_search/config/install/search_api.index.social_all.yml
+++ b/modules/social_features/social_search/config/install/search_api.index.social_all.yml
@@ -31,6 +31,7 @@ field_settings:
         anonymous: anonymous
       view_mode:
         'entity:node':
+          book: search_index
           event: search_index
           page: search_index
           topic: search_index

--- a/modules/social_features/social_search/config/install/search_api.index.social_content.yml
+++ b/modules/social_features/social_search/config/install/search_api.index.social_content.yml
@@ -29,7 +29,7 @@ field_settings:
         'entity:node':
           book: search_index
           event: search_index
-          page: default
+          page: search_index
           topic: search_index
   type:
     label: Type

--- a/modules/social_features/social_search/config/install/views.view.search_all.yml
+++ b/modules/social_features/social_search/config/install/views.view.search_all.yml
@@ -69,6 +69,7 @@ display:
               event: teaser
               page: teaser
               topic: teaser
+              book: teaser
             'entity:group':
               closed_group: teaser
               open_group: teaser

--- a/modules/social_features/social_search/social_search.install
+++ b/modules/social_features/social_search/social_search.install
@@ -140,3 +140,14 @@ function social_search_update_8103() {
     }
   }
 }
+
+/**
+ * Trigger a search_api re-index for social_all.
+ */
+function social_search_update_8104() {
+  $index = Index::load('social_all');
+  if ($index->status()) {
+    $index->clear();
+    $index->reindex();
+  }
+}


### PR DESCRIPTION
## Description
When searching for content on the 'all' tab in OS, book pages and basic pages don't show up. This is now fixed.

## Drupal
https://www.drupal.org/node/2900982

## HTT
- [x] Do a re-install from 8.x-1.x
- [x] Enable the book module
- [x] Create some book pages
- [x] Create some basic pages
- [x] Search for them and notice they don't show up on the 'all' tab
- [x] Notice that they DO show up on the content tab
- [x] Switch to this branch
- [x] do an updatedb (either interface or drush)
- [ ] Notice they now DO show up in the 'all' tab
