### PR TITLE
Issue #2839327 - personalised homepage

### DIFF
--- a/modules/custom/activity_viewer/activity_viewer.module
+++ b/modules/custom/activity_viewer/activity_viewer.module
@@ -1,0 +1,21 @@
+<?php
+/**
+ * ${NAME}
+ */
+
+
+/**
+ * Implements hook_views_data().
+ */
+function activity_viewer_views_data() {
+  $data['activity']['activity_filter_personalised_homepage_filter'] = array(
+    'title' => t('Filter on activities for the personalised homepage.'),
+    'filter' => array(
+      'title' => t('Filter activities for personalised homepage'),
+      'help' => t('Filter on activities for personalised homepage.'),
+      'field' => 'field_visibility',
+      'id' => 'activity_filter_personalised_homepage',
+    ),
+  );
+  return $data;
+}

--- a/modules/custom/activity_viewer/activity_viewer.module
+++ b/modules/custom/activity_viewer/activity_viewer.module
@@ -1,8 +1,7 @@
 <?php
 /**
- * ${NAME}
+ * Module file for activity_viewer.
  */
-
 
 /**
  * Implements hook_views_data().

--- a/modules/custom/activity_viewer/src/Plugin/views/filter/ActivityFilterPersonalisedHomepage.php
+++ b/modules/custom/activity_viewer/src/Plugin/views/filter/ActivityFilterPersonalisedHomepage.php
@@ -166,4 +166,15 @@ class ActivityFilterPersonalisedHomepage extends FilterPluginBase {
     $this->query->addWhere('visibility', $and_wrapper);
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  public function getCacheContexts() {
+    $contexts = parent::getCacheContexts();
+
+    $contexts[] = 'user';
+
+    return $contexts;
+  }
+
 }

--- a/modules/custom/activity_viewer/src/Plugin/views/filter/ActivityFilterPersonalisedHomepage.php
+++ b/modules/custom/activity_viewer/src/Plugin/views/filter/ActivityFilterPersonalisedHomepage.php
@@ -1,0 +1,169 @@
+<?php
+
+namespace Drupal\activity_viewer\Plugin\views\filter;
+
+use Drupal\views\Plugin\views\filter\FilterPluginBase;
+use Drupal\views\Views;
+
+/**
+ * Filters activity for a personalised homepage.
+ *
+ * @ingroup views_filter_handlers
+ *
+ * @ViewsFilter("activity_filter_personalised_homepage")
+ */
+class ActivityFilterPersonalisedHomepage extends FilterPluginBase {
+
+  /**
+   * Not exposable.
+   */
+  public function canExpose() {
+    return FALSE;
+  }
+
+  /**
+   * Filters out activity items the user is not allowed to see.
+   *
+   * The access to the activity items may be limited by the following:
+   *  1. Value in field_visibility_value on a Post entity.
+   *  2. Node access grants (this includes the field_node_visibility_value and
+   *     the nodes in a closed group)
+   *  3. The comment or post is posted in a (closed) group.
+   *
+   * In addition to the condition used in this filter there may be some other
+   * filters active in the given view (e.g. destination).
+   *
+   * Probably want to extend this to entity access based on the node grant
+   * system when this is implemented.
+   * See https://www.drupal.org/node/777578
+   */
+  public function query() {
+    $account = $this->view->getUser();
+    $group_memberships = social_group_get_all_group_members($account->id());
+
+    // Add tables and joins.
+    $this->query->addTable('activity__field_activity_recipient_group');
+    $this->query->addTable('activity__field_activity_entity');
+
+    $configuration = array(
+      'left_table' => 'activity__field_activity_entity',
+      'left_field' => 'field_activity_entity_target_id',
+      'table' => 'post_field_data',
+      'field' => 'id',
+      'operator' => '=',
+      'extra' => array(
+        0 => array(
+          'left_field' => 'field_activity_entity_target_type',
+          'value' => 'post',
+        ),
+      ),
+    );
+    $join = Views::pluginManager('join')->createInstance('standard', $configuration);
+    $this->query->addRelationship('post', $join, 'activity__field_activity_entity');
+
+    $configuration = array(
+      'left_table' => 'post',
+      'left_field' => 'id',
+      'table' => 'post__field_visibility',
+      'field' => 'entity_id',
+      'operator' => '=',
+    );
+    $join = Views::pluginManager('join')->createInstance('standard', $configuration);
+    $this->query->addRelationship('post__field_visibility', $join, 'post__field_visibility');
+
+    // Join node table.
+    $configuration = array(
+      'left_table' => 'activity__field_activity_entity',
+      'left_field' => 'field_activity_entity_target_id',
+      'table' => 'node_access',
+      'field' => 'nid',
+      'operator' => '=',
+      'extra' => array(
+        0 => array(
+          'left_field' => 'field_activity_entity_target_type',
+          'value' => 'node',
+        ),
+      ),
+    );
+    $join = Views::pluginManager('join')->createInstance('standard', $configuration);
+    $this->query->addRelationship('node_access', $join, 'node_access_relationship');
+
+    // Add queries.
+    $and_wrapper = db_and();
+    $or = db_or();
+
+    // Nodes: retrieve all the nodes 'created' activity by node access grants.
+    $node_access = db_and();
+    $node_access->condition('activity__field_activity_entity.field_activity_entity_target_type', 'node', '=');
+    $node_access_grants = node_access_grants('view', $account);
+    $grants = db_or();
+    foreach ($node_access_grants as $realm => $gids) {
+      if (!empty($gids)) {
+        $and = db_and();
+        $grants->condition($and
+          ->condition('node_access.gid', $gids, 'IN')
+          ->condition('node_access.realm', $realm)
+        );
+      }
+    }
+    $node_access->condition($grants);
+    // Get all nodes not posted in groups and in groups of user only.
+    if ($account->isAuthenticated() && count($group_memberships) > 0) {
+      $na_or = db_or();
+      $node_access->condition($na_or
+        ->isNull('activity__field_activity_recipient_group.field_activity_recipient_group_target_id')
+        ->condition('activity__field_activity_recipient_group.field_activity_recipient_group_target_id', $group_memberships, 'IN')
+      );
+    }
+    else {
+      $node_access->isNull('activity__field_activity_recipient_group.field_activity_recipient_group_target_id');
+    }
+    $or->condition($node_access);
+
+    // Posts: retrieve all the posts in groups the user is a member of.
+    if ($account->isAuthenticated() && count($group_memberships) > 0) {
+      $posts_in_groups = db_and();
+      $posts_in_groups->condition('activity__field_activity_entity.field_activity_entity_target_type', 'post', '=');
+      $posts_in_groups->condition('activity__field_activity_recipient_group.field_activity_recipient_group_target_id', $group_memberships, 'IN');
+
+      $or->condition($posts_in_groups);
+    }
+
+    // Posts: all the posts the user has access to and posted to community.
+    $post_access = db_and();
+    $post_access->condition('activity__field_activity_entity.field_activity_entity_target_type', 'post', '=');
+    $post_access->condition('post__field_visibility.field_visibility_value', '3', '!=');
+    if (!$account->hasPermission('view public posts')) {
+      $post_access->condition('post__field_visibility.field_visibility_value', '1', '!=');
+    }
+    if (!$account->hasPermission('view community posts')) {
+      $post_access->condition('post__field_visibility.field_visibility_value', '2', '!=');
+      // Also do not show recipient posts (e.g. on open groups).
+      $post_access->condition('post__field_visibility.field_visibility_value', '0', '!=');
+    }
+    $post_access->isNull('activity__field_activity_recipient_group.field_activity_recipient_group_target_id');
+
+    $or->condition($post_access);
+
+    // Comments: retrieve comments the user has access to.
+    if ($account->hasPermission('access comments')) {
+      // For comments in groups, the user must be a member of at least 1 group.
+      if (count($group_memberships) > 0) {
+        $comments_on_content_in_groups = db_and();
+        $comments_on_content_in_groups->condition('activity__field_activity_entity.field_activity_entity_target_type', 'comment', '=');
+        $comments_on_content_in_groups->condition('activity__field_activity_recipient_group.field_activity_recipient_group_target_id', $group_memberships, 'IN');
+        $or->condition($comments_on_content_in_groups);
+      }
+
+      $comments_on_content = db_and();
+      $comments_on_content->condition('activity__field_activity_entity.field_activity_entity_target_type', 'comment', '=');
+      $comments_on_content->isNull('activity__field_activity_recipient_group.field_activity_recipient_group_target_id');
+      $or->condition($comments_on_content);
+    }
+
+    // Lets add all the or conditions to the Views query.
+    $and_wrapper->condition($or);
+    $this->query->addWhere('visibility', $and_wrapper);
+  }
+
+}

--- a/modules/social_features/social_activity/config/install/message.template.create_comment_group_post.yml
+++ b/modules/social_features/social_activity/config/install/message.template.create_comment_group_post.yml
@@ -12,7 +12,6 @@ third_party_settings:
     activity_destinations:
       stream_explore: stream_explore
       stream_group: stream_group
-      stream_home: stream_home
       stream_profile: stream_profile
     activity_create_direct: 1
     activity_aggregate: 1

--- a/modules/social_features/social_activity/config/install/views.view.activity_stream.yml
+++ b/modules/social_features/social_activity/config/install/views.view.activity_stream.yml
@@ -347,6 +347,7 @@ display:
       contexts:
         - 'languages:language_interface'
         - url.query_args
+        - user
       tags:
         - 'config:core.entity_view_display.activity.activity.default'
         - 'config:core.entity_view_display.activity.activity.notification'

--- a/modules/social_features/social_activity/config/install/views.view.activity_stream.yml
+++ b/modules/social_features/social_activity/config/install/views.view.activity_stream.yml
@@ -246,7 +246,6 @@ display:
       contexts:
         - 'languages:language_interface'
         - url.query_args
-        - user
       tags:
         - 'config:core.entity_view_display.activity.activity.default'
         - 'config:core.entity_view_display.activity.activity.notification'
@@ -371,7 +370,6 @@ display:
       contexts:
         - 'languages:language_interface'
         - url.query_args
-        - user
       tags:
         - 'config:core.entity_view_display.activity.activity.default'
         - 'config:core.entity_view_display.activity.activity.notification'

--- a/modules/social_features/social_activity/config/install/views.view.activity_stream.yml
+++ b/modules/social_features/social_activity/config/install/views.view.activity_stream.yml
@@ -161,10 +161,10 @@ display:
             group_items: {  }
           reduce_duplicates: false
           plugin_id: list_field
-        activity_post_visibility_access_filter:
-          id: activity_post_visibility_access_filter
+        activity_filter_nodes_from_my_groups_filter:
+          id: activity_filter_nodes_from_my_groups_filter
           table: activity
-          field: activity_post_visibility_access_filter
+          field: activity_filter_nodes_from_my_groups_filter
           relationship: none
           group_type: group
           admin_label: ''
@@ -197,7 +197,7 @@ display:
             default_group_multiple: {  }
             group_items: {  }
           entity_type: activity
-          plugin_id: activity_post_visibility_access
+          plugin_id: activity_filter_nodes_from_my_groups
       sorts:
         created:
           id: created
@@ -246,6 +246,7 @@ display:
       contexts:
         - 'languages:language_interface'
         - url.query_args
+        - user
       tags:
         - 'config:core.entity_view_display.activity.activity.default'
         - 'config:core.entity_view_display.activity.activity.notification'
@@ -258,6 +259,90 @@ display:
     display_options:
       display_extenders: {  }
       display_description: ''
+      filters:
+        field_activity_destinations_value:
+          id: field_activity_destinations_value
+          table: activity__field_activity_destinations
+          field: field_activity_destinations_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: or
+          value:
+            stream_home: stream_home
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          plugin_id: list_field
+        activity_filter_personalised_homepage_filter:
+          id: activity_filter_personalised_homepage_filter
+          table: activity
+          field: activity_filter_personalised_homepage_filter
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: '='
+          value: ''
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: activity
+          plugin_id: activity_filter_personalised_homepage
+      defaults:
+        filters: false
+        filter_groups: false
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
     cache_metadata:
       max-age: -1
       contexts:
@@ -286,6 +371,7 @@ display:
       contexts:
         - 'languages:language_interface'
         - url.query_args
+        - user
       tags:
         - 'config:core.entity_view_display.activity.activity.default'
         - 'config:core.entity_view_display.activity.activity.notification'

--- a/tests/behat/features/capabilities/activity-stream/activity-stream-comments.feature
+++ b/tests/behat/features/capabilities/activity-stream/activity-stream-comments.feature
@@ -106,14 +106,14 @@ Feature: See comments in activity stream
     And I press "Comment"
 
     Given I am logged in as "SeeUser"
-    And I click "CreateUser"
+    And I am on the profile of "CreateUser"
     Then I should see "CreateUser created an event in Test open group"
     And I should see "Test group event"
     And I should see "This is a third event comment"
     And I should not see "This is a first event comment"
     And I should not see "This is a reply event comment"
 
-    And I click "Test open group"
+    And I am on the stream of group "Test open group"
     Then I should see "CreateUser created an event in Test open group"
     And I should see "Test group event"
     And I should see "This is a third event comment"
@@ -121,9 +121,8 @@ Feature: See comments in activity stream
     And I should not see "This is a reply event comment"
 
     When I am on the homepage
-    Then I should see "CreateUser created an event in Test open group"
-    And I should see "Test group event"
-    And I should see "This is a third event comment"
+    Then I should not see "CreateUser created an event in Test open group"
+    And I should not see "This is a third event comment"
     And I should not see "This is a first event comment"
     And I should not see "This is a reply event comment"
 

--- a/tests/behat/features/capabilities/activity-stream/create_topic_event.feature
+++ b/tests/behat/features/capabilities/activity-stream/create_topic_event.feature
@@ -1,4 +1,4 @@
-@wip @api @DS-1255 @activity_stream @topic @create
+@api @DS-1255 @activity_stream @topic @create @stability @stability-3
 Feature: See and get notified when content is created
   Benefit: So I can discover new content on the platform
   Role: As a LU
@@ -124,6 +124,8 @@ Feature: See and get notified when content is created
     And I am on "user"
     And I click "Groups"
     And I click "Add a group"
+    And I click radio button "Open group This is an open group. Users may join without approval and all content added in this group will be visible for non members as well." with the id "edit-group-type-open-group"
+    And I press "Continue"
     When I fill in "Title" with "Test open group"
     And I fill in the "edit-field-group-description-0-value" WYSIWYG editor with "Description text"
     And I press "Save"
@@ -152,18 +154,13 @@ Feature: See and get notified when content is created
     Given I am logged in as "SeeUser"
     And I click "CreateUser"
     Then I should see "CreateUser created an event in Test open group"
-    And I should see "Test group event"
-    When I am on the homepage
-    Then I should see "CreateUser created an event in Test open group"
-    And I should see "Test group event"
-    When I go to "explore"
-    Then I should not see "CreateUser created an event"
-    And I should not see "Test group event"
-
-    Given I am an anonymous user
     When I am on the homepage
     Then I should not see "CreateUser created an event in Test open group"
-    And I should not see "Test group event"
+    When I go to "explore"
+    Then I should see "CreateUser created an event"
+    And I should see "Test group event"
+
+    Given I am an anonymous user
     When I go to "explore"
     Then I should not see "CreateUser created an event in Test open group"
     And I should not see "Test group event"


### PR DESCRIPTION
Changes I've made:
- Created a custom filter which is designed especially for the homepage stream:
-- Shows nodes outside groups user has access to
-- Shows nodes inside groups user is a member of and has access to
-- Shows posts inside groups user is a member of
-- Shows posts outside groups and user has access to
-- Shows comments on nodes inside groups user is a member of
- Disabled comment on posts in group in the homepage stream since this clutters the homepage too much imho.
- Behat tests.

HTT:

- [x] Re-install without demo content
- [x] Create two user accounts: user x, user y
- [x] Login as User X and create a group, one topic inside that group, one post inside that group and comment on both the post and the node.
- [x] Login as User Y and create a new group, one topic inside that group, one post inside that group and comment on both the post and the node.
- [x] Create some content outside of groups: one node, one comment on that node, one post and a comment on that post.
- [x] Now check the homepage stream as both these users and make sure the result is as expected.
- [x] Logout and check the AN homepage stream.
- [x] Create a Third user account and login as that user. Check the homepage stream and note that you only see items which is not posted in any group.