### PR TITLE
Issue #2909681 by Kingdutch: Call parent::preprocess for socialbase a…

### DIFF
--- a/themes/socialbase/src/Plugin/Preprocess/SocialBaseActivity.php
+++ b/themes/socialbase/src/Plugin/Preprocess/SocialBaseActivity.php
@@ -17,6 +17,7 @@ class SocialBaseActivity extends PreprocessBase {
    * {@inheritdoc}
    */
   public function preprocess(array &$variables, $hook, array $info) {
+    parent::preprocess($variables, $hook, $info);
 
     // Check if the view mode is one of the notification view modes.
     if (in_array($variables['content']['field_activity_output_text']['#view_mode'], array(

--- a/themes/socialbase/src/Plugin/Preprocess/SocialBaseBlock.php
+++ b/themes/socialbase/src/Plugin/Preprocess/SocialBaseBlock.php
@@ -21,6 +21,7 @@ class SocialBaseBlock extends PreprocessBase {
    * {@inheritdoc}
    */
   public function preprocess(array &$variables, $hook, array $info) {
+    parent::preprocess($variables, $hook, $info);
 
     // Early return because block missing ID, for example because
     // Rendered in panels display

--- a/themes/socialbase/src/Plugin/Preprocess/SocialBaseBookNavigation.php
+++ b/themes/socialbase/src/Plugin/Preprocess/SocialBaseBookNavigation.php
@@ -17,6 +17,8 @@ class SocialBaseBookNavigation extends PreprocessBase {
    * {@inheritdoc}
    */
   public function preprocess(array &$variables, $hook, array $info) {
+    parent::preprocess($variables, $hook, $info);
+
     // Disables the menu tree below the content on a
     // book node in full display mode.
     $variables['tree'] = '';

--- a/themes/socialbase/src/Plugin/Preprocess/SocialBaseDetails.php
+++ b/themes/socialbase/src/Plugin/Preprocess/SocialBaseDetails.php
@@ -17,6 +17,7 @@ class SocialBaseDetails extends PreprocessBase {
    * {@inheritdoc}
    */
   public function preprocess(array &$variables, $hook, array $info) {
+    parent::preprocess($variables, $hook, $info);
 
     // Do not display the details title in file upload widget.
     if (isset($variables['element']['#theme']) && $variables['element']['#theme'] == 'file_widget_multiple') {

--- a/themes/socialbase/src/Plugin/Preprocess/SocialBaseDropdown.php
+++ b/themes/socialbase/src/Plugin/Preprocess/SocialBaseDropdown.php
@@ -20,6 +20,7 @@ class SocialBaseDropdown extends BootstrapDropdown {
    */
   public function preprocess(array &$variables, $hook, array $info) {
     parent::preprocess($variables, $hook, $info);
+
     if (isset($variables['items']['#items']['publish']['element']['#button_type']) && $variables['items']['#items']['publish']['element']['#button_type'] == 'primary') {
       $variables['alignment'] = 'right';
 

--- a/themes/socialbase/src/Plugin/Preprocess/SocialBaseField.php
+++ b/themes/socialbase/src/Plugin/Preprocess/SocialBaseField.php
@@ -21,7 +21,6 @@ class SocialBaseField extends PreprocessBase {
    * {@inheritdoc}
    */
   protected function preprocessElement(Element $element, Variables $variables) {
-
     // For each field that doesn't need a div to wrap the content in.
     switch ($element['#field_name']) {
       case 'field_profile_image':

--- a/themes/socialbase/src/Plugin/Preprocess/SocialBaseFieldDropdown.php
+++ b/themes/socialbase/src/Plugin/Preprocess/SocialBaseFieldDropdown.php
@@ -17,6 +17,7 @@ class SocialBaseFieldDropdown extends PreprocessBase {
    * {@inheritdoc}
    */
   public function preprocess(array &$variables, $hook, array $info) {
+    parent::preprocess($variables, $hook, $info);
 
     if (isset($variables['active']) && is_numeric($variables['active'])) {
       $title = $variables['element'][$variables['active']]['#title'];

--- a/themes/socialbase/src/Plugin/Preprocess/SocialBaseFileWidgetMultiple.php
+++ b/themes/socialbase/src/Plugin/Preprocess/SocialBaseFileWidgetMultiple.php
@@ -17,6 +17,7 @@ class SocialBaseFileWidgetMultiple extends PreprocessBase {
    * {@inheritdoc}
    */
   public function preprocess(array &$variables, $hook, array $info) {
+    parent::preprocess($variables, $hook, $info);
 
     // Remove duplicated ajax wrapper for topic/events files field,
     // because one is already rendered in container.html.twig.

--- a/themes/socialbase/src/Plugin/Preprocess/SocialBaseHtml.php
+++ b/themes/socialbase/src/Plugin/Preprocess/SocialBaseHtml.php
@@ -18,6 +18,7 @@ class SocialBaseHtml extends PreprocessBase {
    * {@inheritdoc}
    */
   public function preprocess(array &$variables, $hook, array $info) {
+    parent::preprocess($variables, $hook, $info);
 
     // Identify the difference between nodes and node/add & node/edit.
     if ($variables['root_path'] == 'node') {

--- a/themes/socialbase/src/Plugin/Preprocess/SocialBaseNode.php
+++ b/themes/socialbase/src/Plugin/Preprocess/SocialBaseNode.php
@@ -21,7 +21,6 @@ class SocialBaseNode extends PreprocessBase {
    * {@inheritdoc}
    */
   protected function preprocessElement(Element $element, Variables $variables) {
-
     $node = $variables['node'];
     $account = $node->getOwner();
     $variables['content_type'] = $node->bundle();

--- a/themes/socialbase/src/Plugin/Preprocess/SocialBasePage.php
+++ b/themes/socialbase/src/Plugin/Preprocess/SocialBasePage.php
@@ -18,6 +18,7 @@ class SocialBasePage extends PreprocessBase {
    * {@inheritdoc}
    */
   public function preprocess(array &$variables, $hook, array $info) {
+    parent::preprocess($variables, $hook, $info);
 
     $variables['display_page_title'] = TRUE;
 

--- a/themes/socialbase/src/Plugin/Preprocess/SocialBasePageTitle.php
+++ b/themes/socialbase/src/Plugin/Preprocess/SocialBasePageTitle.php
@@ -17,6 +17,7 @@ class SocialBasePageTitle extends PreprocessBase {
    * {@inheritdoc}
    */
   public function preprocess(array &$variables, $hook, array $info) {
+    parent::preprocess($variables, $hook, $info);
 
     // Get the current path and if is it stream return a variable.
     $current_path = \Drupal::service('path.current')->getPath();

--- a/themes/socialbase/src/Plugin/Preprocess/SocialBaseViewsExposedForm.php
+++ b/themes/socialbase/src/Plugin/Preprocess/SocialBaseViewsExposedForm.php
@@ -17,6 +17,7 @@ class SocialBaseViewsExposedForm extends PreprocessBase {
    * {@inheritdoc}
    */
   public function preprocess(array &$variables, $hook, array $info) {
+    parent::preprocess($variables, $hook, $info);
 
     if (isset($variables['theme_hook_original']) && $variables['theme_hook_original'] === 'views_exposed_form') {
 

--- a/themes/socialbase/src/Plugin/Preprocess/SocialbaseContainer.php
+++ b/themes/socialbase/src/Plugin/Preprocess/SocialbaseContainer.php
@@ -18,6 +18,7 @@ class SocialbaseContainer extends PreprocessBase {
    * {@inheritdoc}
    */
   public function preprocess(array &$variables, $hook, array $info) {
+    parent::preprocess($variables, $hook, $info);
 
     // For pages in search we would like to render containers without divs.
     $routename = \Drupal::request()

--- a/themes/socialbase/src/Plugin/Preprocess/SocialbaseFieldset.php
+++ b/themes/socialbase/src/Plugin/Preprocess/SocialbaseFieldset.php
@@ -21,7 +21,6 @@ class SocialbaseFieldset extends PreprocessBase {
    * {@inheritdoc}
    */
   protected function preprocessElement(Element $element, Variables $variables) {
-
     if (isset($element['#type']) && $element['#type'] == ('radios' || 'checkboxes')) {
       $variables['form_group'] = TRUE;
     }


### PR DESCRIPTION
…lter plugins

We dictate that subthemes extend the SocialBase plugins so that
our functionality at least gets all the required theming variables
it requires. The function `PreprocessBase::process` in the
Bootstrap theme does quite some heavylifting for us that a
subtheme plugin might depend on. We should therefor ensure that
this function is always called whenever we overwrite the function
in our socialbase theme.