### PR TITLE
DS-4194 - fix dev warnings

### DIFF
--- a/modules/custom/dropdown/src/Plugin/Field/FieldType/Dropdown.php
+++ b/modules/custom/dropdown/src/Plugin/Field/FieldType/Dropdown.php
@@ -132,7 +132,7 @@ class Dropdown extends FieldItemBase {
    * {@inheritdoc}
    */
   public function isEmpty() {
-    return empty($this->values['value']) && (string) $this->values['value'] !== '0';
+    return (!isset($this->values['value'])) || (empty($this->values['value']) && (string) $this->values['value'] !== '0');
   }
 
   /**

--- a/modules/social_features/social_profile/social_profile.module
+++ b/modules/social_features/social_profile/social_profile.module
@@ -380,21 +380,27 @@ function social_profile_profile_view_alter(array &$build, EntityInterface $entit
   // have access to the users profile.
   if (!$current_user->hasPermission('view any profile profile') && ($display->getMode() === 'compact' || $display->getMode() === 'compact_notification')) {
     // Try to load the profile picture.
-    $file = File::load($entity->get('field_profile_image')->target_id);
-    if ($file instanceof File) {
-      // Potentially the file is in the private file system. In that case,
-      // anonymous user don't have access to it.
-      if (!$file->access('view', $current_user)) {
-        // Load default data.
-        $replacement_data = social_profile_get_default_image();
-        /** @var \Drupal\image\Plugin\Field\FieldType\ImageItem $imgitem */
-        $imgitem = $build['field_profile_image'][0]['#item'];
-        // Time to override the data that going to be rendered.
-        $imgitem->set('target_id', $replacement_data['id']);
-        $imgitem->set('width', $replacement_data['width']);
-        $imgitem->set('height', $replacement_data['height']);
-        // Put replacement data back in the object that's about to be built.
-        $build['field_profile_image'][0]['#item'] = $imgitem;
+    $fid = $entity->get('field_profile_image')->target_id;
+    // Must have a value and not be NULL.
+    if (!is_null($fid)) {
+      // Load the file.
+      $file = File::load($fid);
+      // Check if it's a real file.
+      if ($file instanceof File) {
+        // Potentially the file is in the private file system. In that case,
+        // anonymous user don't have access to it.
+        if (!$file->access('view', $current_user)) {
+          // Load default data.
+          $replacement_data = social_profile_get_default_image();
+          /** @var \Drupal\image\Plugin\Field\FieldType\ImageItem $imgitem */
+          $imgitem = $build['field_profile_image'][0]['#item'];
+          // Time to override the data that going to be rendered.
+          $imgitem->set('target_id', $replacement_data['id']);
+          $imgitem->set('width', $replacement_data['width']);
+          $imgitem->set('height', $replacement_data['height']);
+          // Put replacement data back in the object that's about to be built.
+          $build['field_profile_image'][0]['#item'] = $imgitem;
+        }
       }
     }
   }


### PR DESCRIPTION
# How to test

## Start on 8.x-1.x branch

Put the following line in your local settings:
`$config['system.logging']['error_level'] = 'verbose';`

Log in as admin

You should get warnings like:
`Warning: array_flip(): Can only flip STRING and INTEGER values! in Drupal\Core\Entity\EntityStorageBase->loadMultiple() (line 227 of core/lib/Drupal/Core/Entity/EntityStorageBase.php).`
and 
`Notice: Undefined index: value in Drupal\dropdown\Plugin\Field\FieldType\Dropdown->isEmpty() (line 135 of profiles/contrib/social/modules/custom/dropdown/src/Plugin/Field/FieldType/Dropdown.php).`
on the home page / stream pages
## checkout this branch
Warnings should be gone