### PR TITLE
Issue #2907955  rounded corners on post button should be respected

### DIFF
--- a/modules/custom/improved_theme_settings/improved_theme_settings.module
+++ b/modules/custom/improved_theme_settings/improved_theme_settings.module
@@ -256,7 +256,7 @@ function improved_theme_settings_page_attachments(array &$page) {
           border-radius: ' . $border_radius . 'px 0 0 ' . $border_radius . 'px !important;
         }
 
-        div:not(.btn-group) > .btn {
+        :not(.btn-group) > .btn {
           border-radius: ' . $border_radius . 'px !important;
         }
 


### PR DESCRIPTION
## How to test:
- enable improved_theme_settings module
- Change value of border radius in theme settings
- Post button above activity streams should get the border-radius that is set in the form