### PR TITLE
DS-4194 by frankgraave, bramtenhove: check if view exists before assu…

### DIFF
--- a/modules/social_features/social_activity/social_activity.install
+++ b/modules/social_features/social_activity/social_activity.install
@@ -8,6 +8,7 @@
 use \Drupal\menu_link_content\Entity\MenuLinkContent;
 use Drupal\message\Entity\MessageTemplate;
 use \Drupal\block\Entity\Block;
+use Drupal\views\Views;
 
 /**
  * Social activity install function.
@@ -64,8 +65,18 @@ function social_activity_update_8001() {
  */
 function _social_activity_create_activity_homepage_block() {
   // Revert view so it has the block display.
-  $config_revert = \Drupal::service('features.config_update');
-  $config_revert->revert('view', 'activity_stream');
+  $config_update_service = \Drupal::service('features.config_update');
+
+  // Check if view exists.
+  $view = Views::getView('activity_stream');
+  if (is_object($view)) {
+    // If exists, we revert.
+    $config_update_service->revert('view', 'activity_stream');
+  }
+  else {
+    // Otherwise we import.
+    $config_update_service->import('view', 'activity_stream');
+  }
 
   $config = \Drupal::configFactory();
 


### PR DESCRIPTION
# Background
Since our nightly build has turned into a nightmare build which continuously builds a WSOD I've investigated why this happens. After looking into the logs of the nightly build I see a returning issue on many failed builds regarding social_activity.install. We assume there is a view called activity_stream that should be reverted. But we should first check if it's there in the first place before performing a feature revert since it throws an exception when there's no view at all. So if the view does not exist, then we should do a feature import.