### PR TITLE
Maintenance - Bugfixes that were caused by coding standards

### DIFF
--- a/modules/social_features/social_mentions/src/Controller/AutocompleteController.php
+++ b/modules/social_features/social_mentions/src/Controller/AutocompleteController.php
@@ -12,10 +12,6 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Drupal\user\Entity\User;
 use Symfony\Component\HttpFoundation\Request;
 
-define('SOCIAL_MENTIONS_SUGGESTIONS_USERNAME', 'username');
-define('SOCIAL_MENTIONS_SUGGESTIONS_FULL_NAME', 'full_name');
-define('SOCIAL_MENTIONS_SUGGESTIONS_ALL', 'all');
-
 /**
  * Class AutocompleteController.
  *

--- a/modules/social_features/social_mentions/src/SocialMentionsConfigOverride.php
+++ b/modules/social_features/social_mentions/src/SocialMentionsConfigOverride.php
@@ -5,6 +5,10 @@ namespace Drupal\social_mentions;
 use Drupal\Core\Cache\CacheableMetadata;
 use Drupal\Core\Config\ConfigFactoryOverrideInterface;
 
+define('SOCIAL_MENTIONS_SUGGESTIONS_USERNAME', 'username');
+define('SOCIAL_MENTIONS_SUGGESTIONS_FULL_NAME', 'full_name');
+define('SOCIAL_MENTIONS_SUGGESTIONS_ALL', 'all');
+
 /**
  * Class SocialMentionsConfigOverride.
  *

--- a/modules/social_features/social_search/src/Form/SearchContentForm.php
+++ b/modules/social_features/social_search/src/Form/SearchContentForm.php
@@ -18,9 +18,9 @@ use Symfony\Component\HttpFoundation\RequestStack;
 class SearchContentForm extends FormBase implements ContainerInjectionInterface {
 
   /**
-   * The route match.
+   * The request stack.
    *
-   * @var \Drupal\Core\Routing\RouteMatchInterface
+   * @var \Symfony\Component\HttpFoundation\RequestStack
    */
   protected $requestStack;
 

--- a/modules/social_features/social_search/src/Form/SearchContentForm.php
+++ b/modules/social_features/social_search/src/Form/SearchContentForm.php
@@ -5,10 +5,10 @@ namespace Drupal\social_search\Form;
 use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
 use Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
-use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\Url;
 use Drupal\Component\Utility\UrlHelper;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
  * Class SearchContentForm.
@@ -22,16 +22,15 @@ class SearchContentForm extends FormBase implements ContainerInjectionInterface 
    *
    * @var \Drupal\Core\Routing\RouteMatchInterface
    */
-  protected $routeMatch;
+  protected $requestStack;
 
   /**
    * SearchHeroForm constructor.
    *
-   * @param \Drupal\Core\Routing\RouteMatchInterface $routeMatch
-   *   The route match.
+   * @param \Symfony\Component\HttpFoundation\RequestStack $requestStack
    */
-  public function __construct(RouteMatchInterface $routeMatch) {
-    $this->routeMatch = $routeMatch;
+  public function __construct(RequestStack $requestStack) {
+    $this->requestStack = $requestStack;
   }
 
   /**
@@ -39,7 +38,7 @@ class SearchContentForm extends FormBase implements ContainerInjectionInterface 
    */
   public static function create(ContainerInterface $container) {
     return new static(
-      $container->get('current_route_match')
+      $container->get('request_stack')
     );
   }
 


### PR DESCRIPTION
# Background
The constants that were moved during previous coding standards fixes, were moved to the wrong class. This is now fixed. Besides that the search was not working since it had the wrong dependeny, also fixed.

# HTT
- [ ] Check that the search is working (confirm the correct dependency is used)
- [ ] See you won't get a notice on your local environment about social mention constants any longer