### PR TITLE
Issue #2914304 by frankgraave: fixed the filter for the topic types

### DIFF
--- a/modules/social_features/social_topic/src/Controller/SocialTopicController.php
+++ b/modules/social_features/social_topic/src/Controller/SocialTopicController.php
@@ -76,7 +76,7 @@ class SocialTopicController extends ControllerBase {
     if ($topic_type_id !== NULL) {
       // Topic type can be "All" will crash overview on /newest-topics.
       if (is_numeric($topic_type_id)) {
-        $term = $this->entityTypeManager->getStorage('topic')->load($topic_type_id);
+        $term = $this->entityTypeManager->getStorage('taxonomy_term')->load($topic_type_id);
 
         if ($term->access('view') && $term->getVocabularyId() === 'topic_types') {
           $term_title = $term->getName();

--- a/tests/behat/features/capabilities/topic/topic-overview.feature
+++ b/tests/behat/features/capabilities/topic/topic-overview.feature
@@ -22,11 +22,10 @@ Feature: Topic Overview
     And I should not see text matching "has the publish status of"
 
 #  Scenario: Successfully filter the topic overview
-#    Given I am logged in as an "authenticated user"
-#    And I am on "user"
-#    When I click "Topics"
-#    Then I should see the heading "Topics"
-#    And I should see the heading "I want to see topics that" in the "Sidebar second"
-#    And I should see text matching "is the type of"
-#    And I should see text matching "Sorted by publish date"
-#    And I should see text matching "has the publish status of"
+    Given I am logged in as an "authenticated user"
+    And I am on "/all-topics"
+    Then I should see "All topics"
+    And I click the xth "0" element with the css ".form-select"
+    And I click "News"
+    Then I press the "Apply" button
+    And I should see "Topics of type News"


### PR DESCRIPTION
# Background
The /all-topics page has a filter for topic type in the right sidebar. Select any topic type and click apply. This resulted in an error. Related issue: https://www.drupal.org/node/2914304

# HTT
- [ ] Check the code changes.
- [ ] Checkout this branch.
- [ ] Go to /all-topics and select any filter, then apply.
- [ ] See there's no error any more.