### PR TITLE
#2914807 Fix profile image issue next to post box in twig. Not in code

### DIFF
--- a/modules/social_features/social_post/social_post.module
+++ b/modules/social_features/social_post/social_post.module
@@ -30,9 +30,8 @@ function social_post_form_post_form_alter(&$form, FormStateInterface $form_state
           $content = \Drupal::entityTypeManager()
             ->getViewBuilder('profile')
             ->view($user_profile, 'compact_notification');
-          $content['#attributes']['class'][] = 'media-left avatar hidden-for-phone-only';
-          // Add the avatar class and show it!
-          $form['#prefix'] = render($content);
+          // Add to a new field, so twig can render it.
+          $form['current_user_image'] = $content;
         }
       }
     }

--- a/themes/socialbase/templates/block/block--social-post.html.twig
+++ b/themes/socialbase/templates/block/block--social-post.html.twig
@@ -48,7 +48,12 @@
 <div class="card card--stream brand-border-radius">
   <div class="card__block">
     <div class="media">
-      {{ content }}
+      <div class="media-left avatar hidden-for-phone-only">
+        {{ content.current_user_image }}
+      </div>
+      <div class="media-body">
+        {{ content|without('current_user_image') }}
+      </div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Description
The profile image next to the post box was sometimes malformed. We've solved this by moving the layout of this item into twig and out of the back-end code. This way the layout is fixed and not dependant on code execution!

## Drupal
https://www.drupal.org/node/2914807

# HTT

- [x] Try this with a couple of different users
- [x] Login and notice your profile image next to the post box is not a square, but round and nicely positioned (in the stream
- [x] Test this also on: your profile, someone else's profile. A group you are a member of.
- [x] On all 4 places, also resize you screen to a mobile size and notice the profile picture disappears