### PR TITLE
DS-4253 by frankgraave: make this behat more consistent

### DIFF
--- a/tests/behat/features/capabilities/activity-stream/create_topic_event.feature
+++ b/tests/behat/features/capabilities/activity-stream/create_topic_event.feature
@@ -152,7 +152,7 @@ Feature: See and get notified when content is created
     And I should see "Test group event"
 
     Given I am logged in as "SeeUser"
-    And I click "CreateUser"
+    And I am on the profile of "CreateUser"
     Then I should see "CreateUser created an event in Test open group"
     When I am on the homepage
     Then I should not see "CreateUser created an event in Test open group"


### PR DESCRIPTION
# Background
This behat had a weird step at the last section where CreateUser is creating an event inside an new open group, then SeeUser logs in and wants to click CreateUser. Instead I chose to make it:
And I am on the profile of "CreateUser" so that SeeUser doesn't have to click CreateUser (when it sometimes can't click for some reason).

# HTT
- [x] Check the change
- [x] Behats should be green