### PR TITLE
DS-3906 - Themed mails when send mails from admin theme

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,9 +39,6 @@
             },
             "drupal/flag": {
                 "Add relationship to flagged entities when Flagging is base table": "https://www.drupal.org/files/issues/2723703_31.patch"
-            },
-            "drupal/mailsystem": {
-                "Reimplement mail theme functionality": "https://www.drupal.org/files/issues/mailsystem_theme_mail_test-2498265-33.patch"
             }
         }
     },

--- a/composer.json
+++ b/composer.json
@@ -39,6 +39,9 @@
             },
             "drupal/flag": {
                 "Add relationship to flagged entities when Flagging is base table": "https://www.drupal.org/files/issues/2723703_31.patch"
+            },
+            "drupal/mailsystem": {
+                "Reimplement mail theme functionality": "https://www.drupal.org/files/issues/mailsystem_theme_mail_test-2498265-33.patch"
             }
         }
     },

--- a/modules/social_features/social_swiftmail/social_swiftmail.install
+++ b/modules/social_features/social_swiftmail/social_swiftmail.install
@@ -18,9 +18,18 @@ function social_swiftmail_install() {
   $swift_settings->set('format', 'text/html')->save();
   $swift_settings->set('respect_format', FALSE)->save();
   // Alter mailsystem settings.
-  $mailsystem_settings->set('theme', 'current')->save();
+  $mailsystem_settings->set('theme', 'default')->save();
   $mailsystem_settings->set('defaults.sender', 'social_swiftmailer')->save();
   $mailsystem_settings->set('defaults.formatter', 'social_swiftmailer')->save();
   $mailsystem_settings->set('modules.swiftmailer.none.sender', 'social_swiftmailer')->save();
   $mailsystem_settings->set('modules.swiftmailer.none.formatter', 'social_swiftmailer')->save();
+}
+
+/**
+ * Set which theme to use when sending emails.
+ */
+function social_swiftmail_update_8002(&$sandbox) {
+  // Alter mailsystem settings.
+  $mailsystem_settings = \Drupal::configFactory()->getEditable('mailsystem.settings');
+  $mailsystem_settings->set('theme','default')->save();
 }

--- a/modules/social_features/social_swiftmail/social_swiftmail.install
+++ b/modules/social_features/social_swiftmail/social_swiftmail.install
@@ -28,7 +28,7 @@ function social_swiftmail_install() {
 /**
  * Set which theme to use when sending emails.
  */
-function social_swiftmail_update_8002(&$sandbox) {
+function social_swiftmail_update_8001(&$sandbox) {
   // Alter mailsystem settings.
   $mailsystem_settings = \Drupal::configFactory()->getEditable('mailsystem.settings');
   $mailsystem_settings->set('theme','default')->save();


### PR DESCRIPTION
## Description
When sending emails as an admin, the theme used for the emails would be the admin theme.. This is now changed to the default theme.

## HTT
- [x] Login as admin
- [x] Create a new user (and notify the new user)
- [x] See that the new mail is now well formatted
- [x] Also unblock a bunch of users in bulk
- [x] See that those mails are also well formatted
- [x] Should work from update or from fresh install