### PR TITLE
Issue #2900559 by Kingdutch: clarify content reach of open groups

### DIFF
--- a/modules/social_features/social_group/config/install/group.type.open_group.yml
+++ b/modules/social_features/social_group/config/install/group.type.open_group.yml
@@ -3,7 +3,7 @@ status: true
 dependencies: {  }
 id: open_group
 label: 'Open group'
-description: 'This is an open group. Users may join without approval and all content added in this group will be visible for non members as well.'
+description: 'This is an open group. Users may join without approval and all content added in this group will be visible to all community members.'
 creator_membership: true
 creator_wizard: false
 creator_roles:

--- a/tests/behat/features/capabilities/activity-stream/create_topic_event.feature
+++ b/tests/behat/features/capabilities/activity-stream/create_topic_event.feature
@@ -124,7 +124,7 @@ Feature: See and get notified when content is created
     And I am on "user"
     And I click "Groups"
     And I click "Add a group"
-    And I click radio button "Open group This is an open group. Users may join without approval and all content added in this group will be visible for non members as well." with the id "edit-group-type-open-group"
+    And I click radio button "Open group This is an open group. Users may join without approval and all content added in this group will be visible to all community members." with the id "edit-group-type-open-group"
     And I press "Continue"
     When I fill in "Title" with "Test open group"
     And I fill in the "edit-field-group-description-0-value" WYSIWYG editor with "Description text"

--- a/tests/behat/features/capabilities/group/group-create-open.feature
+++ b/tests/behat/features/capabilities/group/group-create-open.feature
@@ -13,7 +13,7 @@ Feature: Create Open Group
     And I am on "user"
     And I click "Groups"
     And I click "Add a group"
-    Then I click radio button "Open group This is an open group. Users may join without approval and all content added in this group will be visible for non members as well." with the id "edit-group-type-open-group"
+    Then I click radio button "Open group This is an open group. Users may join without approval and all content added in this group will be visible to all community members." with the id "edit-group-type-open-group"
     And I press "Continue"
     When I fill in "Title" with "Test open group"
     And I fill in the "edit-field-group-description-0-value" WYSIWYG editor with "Description text"


### PR DESCRIPTION
https://www.drupal.org/node/2900559

When creating a group, the Open Group option says "This is a open group. Users may join without approval and all content added in this group will be visible for non members as well."

Only LUs can see the Topics and Events, so when you say "non members" you're referring to the Group rather than to the community, which isn't immediately obvious. Perhaps to "This is an open group. Users may join without approval and all content added in this group will be visible to all community members."

