### PR TITLE
2896187 by valgibson: Reverted the sort order on my groups page

### DIFF
--- a/modules/social_features/social_group/config/install/views.view.groups.yml
+++ b/modules/social_features/social_group/config/install/views.view.groups.yml
@@ -147,7 +147,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
-          order: ASC
+          order: DESC
           exposed: false
           expose:
             label: ''


### PR DESCRIPTION
## Duplicate
https://github.com/goalgorilla/open_social/pull/596

## Drupal
https://www.drupal.org/node/2896185

## Description
When you visit 'my groups' on from your profile, the sorting order for the groups is ascending, where descending makes more sense

## HTT
- [ ] Check out code
- [ ] Stay on 8.x-1.x branch and login
- [ ] Go to your groups
- [ ] Notice the sorting order is asc (group create date)
- [ ] Switch to this branch
- [ ] Revert the social_group feature
- [ ] Reload the page
- [ ] Notice the sorting order is now descending
- [ ] Merge!
