### PR TITLE
2918046 Better description when user removed from group

### DIFF
--- a/modules/social_features/social_group/social_group.module
+++ b/modules/social_features/social_group/social_group.module
@@ -125,6 +125,45 @@ function _social_group_edit_submit_redirect(array $form, FormStateInterface $for
 }
 
 /**
+ * Prepares variables for page templates.
+ *
+ * Default template: page-title.html.twig.
+ *
+ * @param array $variables
+ *   An associative array containing:
+ *   - title: The page title.
+ */
+function social_group_preprocess_page_title(array &$variables) {
+
+  // Define URL parameters.
+  $parameters = explode('/', \Drupal::request()->getpathInfo());
+
+  // Better descriptive page title when removing something from a group.
+  if($parameters[1] == 'group' && $parameters[3] == 'content' && $parameters[5] == 'delete') {
+    list($group_content, $group) = _social_group_get_group_labels();
+
+    // Adjust title.
+    $variables['title'] = t('Remove "@group_content" from <em>@group</em>', array('@group_content' => $group_content, '@group' => $group));
+  }
+}
+
+/**
+ * Load group content label and group label.
+ *
+ * @return array of gropu labels.
+ */
+function _social_group_get_group_labels() {
+
+  // Load the entity label from the group content being handled.
+  $group_content = \Drupal::routeMatch()->getParameter('group_content')->label();
+
+  // Load group name.
+  $group = \Drupal::routeMatch()->getParameter('group')->label();
+
+  return array($group_content, $group);
+}
+
+/**
  * Prepares variables for profile templates.
  *
  * Default template: profile.html.twig.
@@ -292,14 +331,21 @@ function social_group_form_alter(&$form, FormStateInterface $form_state, $form_i
     'group_content_open_group-group_membership_group-join_form',
     'group_content_open_group-group_membership_group-leave_form',
     'group_content_open_group-group_membership_add_form',
+    'group_content_open_group-group_membership_delete_form',
     'group_content_closed_group-group_membership_group-join_form',
     'group_content_closed_group-group_membership_group-leave_form',
     'group_content_closed_group-group_membership_add_form',
+    'group_content_closed_group-group_membership_delete_form',
   ];
 
   // Perform alterations on joining / leaving groups.
-  if (in_array($form_id, ['group_content_-group_membership_delete_form', 'group_content_closed_group-group_membership_delete_form'])) {
+  if (in_array($form_id, ['group_content_open_group-group_membership_delete_form', 'group_content_closed_group-group_membership_delete_form'])) {
     $form['actions']['submit']['#submit'][] = '_social_membership_delete_form_submit';
+
+    list($name, $group) = _social_group_get_group_labels();
+
+    // Give a better description.
+    $form['description']['#markup'] = t('Are you sure you want to remove %name from %group?', array('%name' => $name, '%group' => $group));
   }
 
   // Set some helpful text on the group join form now it's there.

--- a/modules/social_features/social_group/src/Controller/SocialGroupContentListBuilder.php
+++ b/modules/social_features/social_group/src/Controller/SocialGroupContentListBuilder.php
@@ -161,7 +161,7 @@ class SocialGroupContentListBuilder extends EntityListBuilder {
       $operations['edit']['title'] = $this->t('Edit');
     }
     if (isset($operations['delete'])) {
-      $operations['delete']['title'] = $this->t('Delete');
+      $operations['delete']['title'] = $this->t('Remove');
     }
 
     // Slap on redirect destinations for the administrative operations.


### PR DESCRIPTION
Try testing this solution:

- Make sure you have the right permission to remove a member from a group
- Go to a group membership overview page (e.g. group/4/membership)
- Verify that when the operations dropdown of a member was clicked, the word 'delete' has been replaced with 'remove'
- Click on 'remove' 
- In the following screen (e.g. group/4/content/20/delete): notice the clear page title, and the better handler description.