### PR TITLE
Move content attribute classes to preprocess function.

### DIFF
--- a/themes/socialbase/src/Plugin/Preprocess/Page.php
+++ b/themes/socialbase/src/Plugin/Preprocess/Page.php
@@ -3,6 +3,7 @@
 namespace Drupal\socialbase\Plugin\Preprocess;
 
 use Drupal\bootstrap\Plugin\Preprocess\PreprocessBase;
+use Drupal\Core\Template\Attribute;
 use Drupal\node\Entity\Node;
 
 /**
@@ -18,9 +19,15 @@ class Page extends PreprocessBase {
    * {@inheritdoc}
    */
   public function preprocess(array &$variables, $hook, array $info) {
-    parent::preprocess($variables, $hook, $info);
 
-    $variables['display_page_title'] = TRUE;
+    // Add needed attributes so later in template we can manipulate with them.
+    $attributes = new Attribute();
+    // Default classes.
+    $attributes->addClass('row', 'container');
+    // If page has title.
+    if ($variables['page']['title']) {
+      $attributes->addClass('with-title-region');
+    }
 
     // If we have the admin toolbar permission.
     $user = \Drupal::currentUser();
@@ -55,11 +62,32 @@ class Page extends PreprocessBase {
         'book',
       ];
 
-      if (in_array($node->bundle(), $page_to_exclude)) {
-        $variables['display_page_title'] = FALSE;
+      // If there is a title and node type is excluded remove class.
+      if (in_array($node->bundle(), $page_to_exclude, TRUE)) {
+        $attributes->removeClass('with-title-region');
       }
 
     }
+
+    // Check complementary_top and complementary_bottom variables.
+    if ($variables['page']['complementary_top'] && $variables['page']['complementary_bottom']) {
+      $attributes->addClass('layout--with-complementary');
+    }
+    // Check if sidebars are empty.
+    if (empty($variables['page']['sidebar_first']) && empty($variables['page']['sidebar_second'])) {
+      $attributes->addClass('layout--with-complementary');
+    }
+    // Sidebars logic.
+    if (empty($variables['page']['complementary_top']) && empty($variables['page']['complementary_bottom'])) {
+      if ($variables['page']['sidebar_first'] && $variables['page']['sidebar_second']) {
+        $attributes->addClass('layout--with-three-columns');
+      }
+      if (!empty($variables['page']['sidebar_second']) || !empty($variables['page']['sidebar_first'])) {
+        $attributes->addClass('layout--with-two-columns');
+      }
+    }
+
+    $variables['content_attributes'] = $attributes;
 
   }
 

--- a/themes/socialbase/src/Plugin/Preprocess/SocialBasePage.php
+++ b/themes/socialbase/src/Plugin/Preprocess/SocialBasePage.php
@@ -2,11 +2,94 @@
 
 namespace Drupal\socialbase\Plugin\Preprocess;
 
+use Drupal\bootstrap\Plugin\Preprocess\PreprocessBase;
+use Drupal\Core\Template\Attribute;
+use Drupal\node\Entity\Node;
+
 /**
  * Pre-processes variables for the "page" theme hook.
  *
  * @ingroup plugins_preprocess
- * @deprecated
- * @see \Drupal\socialbase\Plugin\Preprocess\Page
+ *
+ * @BootstrapPreprocess("page")
  */
-class SocialBasePage extends Page {}
+class SocialBasePage extends PreprocessBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function preprocess(array &$variables, $hook, array $info) {
+
+    $display_page_title = TRUE;
+    // Add needed attributes so later in template we can manipulate with them.
+    $attributes = new Attribute();
+    // Default classes.
+    $attributes->addClass('row', 'container');
+    // If page has title.
+    if ($variables['page']['title']) {
+      $attributes->addClass('with-title-region');
+    }
+
+    // If we have the admin toolbar permission.
+    $user = \Drupal::currentUser();
+
+    // Check for permission.
+    if ($user->hasPermission('access toolbar')) {
+      $variables['#attached']['library'][] = 'socialbase/admin-toolbar';
+    }
+
+    // Add plain title for node preview page templates.
+    if (!empty($variables['page']['#title'])) {
+      $variables['plain_title'] = strip_tags($variables['page']['#title']);
+    }
+
+    // Hide page title for pages where we want to
+    // display it in the Hero instead, like event, topic, basic page.
+    // First determine if we are looking at a node.
+    $nid = \Drupal::routeMatch()->getRawParameter('node');
+    $node = FALSE;
+
+    if (!is_null($nid) && !is_object($nid)) {
+      $node = Node::load($nid);
+    }
+
+    if ($node instanceof Node) {
+
+      // List pages where we want to hide the default page title.
+      $page_to_exclude = [
+        'event',
+        'topic',
+        'page',
+        'book',
+      ];
+
+      // If there is a title and node type is excluded remove class.
+      if (in_array($node->bundle(), $page_to_exclude, TRUE)) {
+        $attributes->removeClass('with-title-region');
+      }
+
+    }
+
+    // Check complementary_top and complementary_bottom variables.
+    if ($variables['page']['complementary_top'] && $variables['page']['complementary_bottom']) {
+      $attributes->addClass('layout--with-complementary');
+    }
+    // Check if sidebars are empty.
+    if (empty($variables['page']['sidebar_first']) && empty($variables['page']['sidebar_second'])) {
+      $attributes->addClass('layout--with-complementary');
+    }
+    // Sidebars logic.
+    if (empty($variables['page']['complementary_top']) && empty($variables['page']['complementary_bottom'])) {
+      if ($variables['page']['sidebar_first'] && $variables['page']['sidebar_second']) {
+        $attributes->addClass('layout--with-three-columns');
+      }
+      if (!empty($variables['page']['sidebar_second']) || !empty($variables['page']['sidebar_first'])) {
+        $attributes->addClass('layout--with-two-columns');
+      }
+    }
+
+    $variables['content_attributes'] = $attributes;
+
+  }
+
+}

--- a/themes/socialbase/src/Plugin/Preprocess/SocialBasePage.php
+++ b/themes/socialbase/src/Plugin/Preprocess/SocialBasePage.php
@@ -2,94 +2,11 @@
 
 namespace Drupal\socialbase\Plugin\Preprocess;
 
-use Drupal\bootstrap\Plugin\Preprocess\PreprocessBase;
-use Drupal\Core\Template\Attribute;
-use Drupal\node\Entity\Node;
-
 /**
  * Pre-processes variables for the "page" theme hook.
  *
  * @ingroup plugins_preprocess
- *
- * @BootstrapPreprocess("page")
+ * @deprecated
+ * @see \Drupal\socialbase\Plugin\Preprocess\Page
  */
-class SocialBasePage extends PreprocessBase {
-
-  /**
-   * {@inheritdoc}
-   */
-  public function preprocess(array &$variables, $hook, array $info) {
-
-    $display_page_title = TRUE;
-    // Add needed attributes so later in template we can manipulate with them.
-    $attributes = new Attribute();
-    // Default classes.
-    $attributes->addClass('row', 'container');
-    // If page has title.
-    if ($variables['page']['title']) {
-      $attributes->addClass('with-title-region');
-    }
-
-    // If we have the admin toolbar permission.
-    $user = \Drupal::currentUser();
-
-    // Check for permission.
-    if ($user->hasPermission('access toolbar')) {
-      $variables['#attached']['library'][] = 'socialbase/admin-toolbar';
-    }
-
-    // Add plain title for node preview page templates.
-    if (!empty($variables['page']['#title'])) {
-      $variables['plain_title'] = strip_tags($variables['page']['#title']);
-    }
-
-    // Hide page title for pages where we want to
-    // display it in the Hero instead, like event, topic, basic page.
-    // First determine if we are looking at a node.
-    $nid = \Drupal::routeMatch()->getRawParameter('node');
-    $node = FALSE;
-
-    if (!is_null($nid) && !is_object($nid)) {
-      $node = Node::load($nid);
-    }
-
-    if ($node instanceof Node) {
-
-      // List pages where we want to hide the default page title.
-      $page_to_exclude = [
-        'event',
-        'topic',
-        'page',
-        'book',
-      ];
-
-      // If there is a title and node type is excluded remove class.
-      if (in_array($node->bundle(), $page_to_exclude, TRUE)) {
-        $attributes->removeClass('with-title-region');
-      }
-
-    }
-
-    // Check complementary_top and complementary_bottom variables.
-    if ($variables['page']['complementary_top'] && $variables['page']['complementary_bottom']) {
-      $attributes->addClass('layout--with-complementary');
-    }
-    // Check if sidebars are empty.
-    if (empty($variables['page']['sidebar_first']) && empty($variables['page']['sidebar_second'])) {
-      $attributes->addClass('layout--with-complementary');
-    }
-    // Sidebars logic.
-    if (empty($variables['page']['complementary_top']) && empty($variables['page']['complementary_bottom'])) {
-      if ($variables['page']['sidebar_first'] && $variables['page']['sidebar_second']) {
-        $attributes->addClass('layout--with-three-columns');
-      }
-      if (!empty($variables['page']['sidebar_second']) || !empty($variables['page']['sidebar_first'])) {
-        $attributes->addClass('layout--with-two-columns');
-      }
-    }
-
-    $variables['content_attributes'] = $attributes;
-
-  }
-
-}
+class SocialBasePage extends Page {}

--- a/themes/socialbase/templates/layout/page.html.twig
+++ b/themes/socialbase/templates/layout/page.html.twig
@@ -56,7 +56,7 @@
   {% endif %}
 
   {# Content attributes, see Style guide Templates for documentation #}
-  {% block content %}
+  {% block section %}
     <section{{ content_attributes }}>
 
       {% if page.title and display_page_title %}

--- a/themes/socialbase/templates/layout/page.html.twig
+++ b/themes/socialbase/templates/layout/page.html.twig
@@ -56,43 +56,45 @@
   {% endif %}
 
   {# Content attributes, see Style guide Templates for documentation #}
-  <section{{ content_attributes }}>
+  {% block content %}
+    <section{{ content_attributes }}>
 
-    {% if page.title and display_page_title %}
-      {{ page.title }}
-    {% endif %}
+      {% if page.title and display_page_title %}
+        {{ page.title }}
+      {% endif %}
 
-    {% if page.complementary_top or page.complementary_bottom %}
-      <aside class="region--complementary" role="complementary">
-        {% if page.complementary_top %}
-          {{ page.complementary_top }}
-        {% endif %}
-        {% if page.complementary_bottom %}
-          {{ page.complementary_bottom }}
-        {% endif %}
-      </aside>
-    {% endif %}
+      {% if page.complementary_top or page.complementary_bottom %}
+        <aside class="region--complementary" role="complementary">
+          {% if page.complementary_top %}
+            {{ page.complementary_top }}
+          {% endif %}
+          {% if page.complementary_bottom %}
+            {{ page.complementary_bottom }}
+          {% endif %}
+        </aside>
+      {% endif %}
 
-    {% block content %}
-      <a id="main-content" tabindex="-1"></a>
-      {{ page.content }}
-    {% endblock %}
-
-    {# an extra check for complementary regions to be empty #}
-    {% if page.sidebar_first and not page.complementary_top and not page.complementary_bottom %}
-      {% block sidebar_first %}
-        {{ page.sidebar_first }}
+      {% block content %}
+        <a id="main-content" tabindex="-1"></a>
+        {{ page.content }}
       {% endblock %}
-    {% endif %}
 
-    {# an extra check for complementary regions to be empty #}
-    {% if page.sidebar_second and not page.complementary_top and not page.complementary_bottom %}
-      {% block sidebar_second %}
-        {{ page.sidebar_second }}
-      {% endblock %}
-    {% endif %}
+      {# an extra check for complementary regions to be empty #}
+      {% if page.sidebar_first and not page.complementary_top and not page.complementary_bottom %}
+        {% block sidebar_first %}
+          {{ page.sidebar_first }}
+        {% endblock %}
+      {% endif %}
 
-  </section>
+      {# an extra check for complementary regions to be empty #}
+      {% if page.sidebar_second and not page.complementary_top and not page.complementary_bottom %}
+        {% block sidebar_second %}
+          {{ page.sidebar_second }}
+        {% endblock %}
+      {% endif %}
+
+    </section>
+  {% endblock %}
 
   {% if page.content_bottom %}
     {{ page.content_bottom }}

--- a/themes/socialbase/templates/layout/page.html.twig
+++ b/themes/socialbase/templates/layout/page.html.twig
@@ -55,21 +55,8 @@
     {{ page.content_top }}
   {% endif %}
 
-  {# Content, see Style guide Templates for documentation #}
-  {%
-    set content_classes = [
-      'row',
-      'container',
-      page.title and display_page_title ? 'with-title-region',
-      page.complementary_top or page.complementary_bottom ? 'layout--with-complementary',
-      page.sidebar_first is empty and page.sidebar_second is empty ? 'layout--with-complementary',
-      page.complementary_top is empty and page.complementary_bottom is empty and page.sidebar_first and page.sidebar_second ? 'layout--with-three-columns',
-      page.complementary_top is empty and page.complementary_bottom is empty and page.sidebar_second is empty and page.sidebar_first ? 'layout--with-two-columns',
-      page.complementary_top is empty and page.complementary_bottom is empty and page.sidebar_first is empty and page.sidebar_second ? 'layout--with-two-columns',
-    ]
-  %}
-
-  <section{{ content_attributes.addClass(content_classes) }}>
+  {# Content attributes, see Style guide Templates for documentation #}
+  <section{{ content_attributes }}>
 
     {% if page.title and display_page_title %}
       {{ page.title }}


### PR DESCRIPTION
As was described in https://www.drupal.org/node/2907221 there is no way to change content_attributes classes array as they are pre-populated in template.

All logic was moved to preprocess, so now user can alter in own theme this classes like this:
```
use Drupal\Core\Template\Attribute;

function THEME_preprocess_page(&$variables){

  if ($variables['content_attributes'] instanceof Attribute) {
    if (SOME_CONDITION) {
      $variables['content_attributes']->removeClass('layout--with-complementary')
    }
  }
}
```
Also `<section>` is now in a twig block.