### PR TITLE
Issue #2907743 by slowflyer: Custom Font and border radius not working on subtheme

### DIFF
--- a/modules/custom/improved_theme_settings/improved_theme_settings.module
+++ b/modules/custom/improved_theme_settings/improved_theme_settings.module
@@ -246,7 +246,7 @@ function improved_theme_settings_page_attachments(array &$page) {
   // We render our color & font settings in the head. Only if socialblue is
   // the default theme. And only if the current active theme is socialblue.
   // Otherwise we also render it on all admin pages.
-  if ($system_theme_settings === 'socialblue' || $system_theme_settings === 'socialsaas') {
+  if (array_key_exists('socialbase', \Drupal::service('theme.manager')->getActiveTheme()->getBaseThemes())) {
     if ($active_theme == $system_theme_settings) {
       $style_to_add = '';
       if (\Drupal::moduleHandler()->moduleExists('social_font')) {

--- a/modules/custom/social_font/social_font.module
+++ b/modules/custom/social_font/social_font.module
@@ -39,7 +39,7 @@ function social_font_render($font_id = NULL) {
 
   if ($font_id == NULL) {
     $system_theme_settings = \Drupal::configFactory()->get('system.theme')->get('default');
-    if ($system_theme_settings == 'socialblue' || $system_theme_settings == 'socialsaas') {
+    if (array_key_exists('socialbase', \Drupal::service('theme.manager')->getActiveTheme()->getBaseThemes())) {
       $config = \Drupal::config($system_theme_settings . '.settings');
       $font_id = $config->get('font_primary');
     }


### PR DESCRIPTION
## Description
For new subthemes, after enabling it, colors can be changed, but the border-radius and font definitions cannot.

This is due to an explicit check in the `improved_theme_settings` and `social_font` modules.

Drupal issue: https://www.drupal.org/node/2907743.

## How to test
- [x] Create and enable a new subtheme, configure the border radius and font definitions
- [x] Notice the changes are reflected in the site