### PR TITLE
Improve screenshot naming for failed behat tests

### DIFF
--- a/tests/behat/features/bootstrap/SocialMinkContext.php
+++ b/tests/behat/features/bootstrap/SocialMinkContext.php
@@ -62,15 +62,25 @@ class SocialMinkContext extends MinkContext{
   /**
    * @AfterStep
    */
-  public function takeScreenShotAfterFailedStep(afterStepScope $scope)
+  public function takeScreenShotAfterFailedStep(AfterStepScope $scope)
   {
     if (99 === $scope->getTestResult()->getResultCode()) {
       $driver = $this->getSession()->getDriver();
       if (!($driver instanceof Selenium2Driver)) {
         return;
       }
-      $today = date("H_i_s");
-      $this->iMakeAScreenshotWithFileName($today . '-error');
+      $feature = $scope->getFeature();
+      $title = $feature->getTitle();
+
+      $filename = date("Ymd-H_i_s");
+
+      if (!empty($title)) {
+        $filename .= '-' . str_replace(' ', '-', strtolower($title));
+      }
+
+      $filename .= '-error';
+
+      $this->iMakeAScreenshotWithFileName($filename);
     }
   }
 


### PR DESCRIPTION
Currently tests are quite difficult to find if you aggregate all
the CI screenshots in a centralised storage. We can tweak the names
slightly by adding today's date and by adding the name of the
feature that the screenshot corresponds to.