### PR TITLE
DS-4398 by bramtenhove: Fail Travis job immediately if task fails

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,7 @@ script:
   - docker exec -i social_ci_web bash /var/www/scripts/social/check-coding-standards.sh
   - docker exec -i social_ci_web_scripts sh /var/www/scripts/social/unit-tests.sh
   - docker exec -i social_ci_web bash /var/www/scripts/social/check-feature-state.sh social
-  - docker exec -i social_ci_web bash /var/www/html/profiles/contrib/social/travis-fail.sh
+  - if [ "$TEST_SUITE" = "install_stability_1" ]; then docker exec -i social_ci_web bash /var/www/html/profiles/contrib/social/travis-fail.sh; fi
   - if [ "$TEST_SUITE" = "install_stability_1" ]; then docker exec -it social_ci_behat sh /var/www/scripts/social/behatstability.sh stability-1; fi
   - if [ "$TEST_SUITE" = "install_stability_2" ]; then docker exec -it social_ci_behat sh /var/www/scripts/social/behatstability.sh notifications; fi
   - if [ "$TEST_SUITE" = "install_stability_2" ]; then docker exec -it social_ci_behat sh /var/www/scripts/social/behatstability.sh stability-2; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,7 @@ script:
   - docker exec -i social_ci_web bash /var/www/scripts/social/check-coding-standards.sh
   - docker exec -i social_ci_web_scripts sh /var/www/scripts/social/unit-tests.sh
   - docker exec -i social_ci_web bash /var/www/scripts/social/check-feature-state.sh social
-  - docker exec -i social_ci_web bash /var/www/html/travis-fail.sh
+  - docker exec -i social_ci_web bash /var/www/html/profiles/contrib/social/travis-fail.sh
   - if [ "$TEST_SUITE" = "install_stability_1" ]; then docker exec -it social_ci_behat sh /var/www/scripts/social/behatstability.sh stability-1; fi
   - if [ "$TEST_SUITE" = "install_stability_2" ]; then docker exec -it social_ci_behat sh /var/www/scripts/social/behatstability.sh notifications; fi
   - if [ "$TEST_SUITE" = "install_stability_2" ]; then docker exec -it social_ci_behat sh /var/www/scripts/social/behatstability.sh stability-2; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,6 @@ script:
   - docker exec -i social_ci_web bash /var/www/scripts/social/check-coding-standards.sh
   - docker exec -i social_ci_web_scripts sh /var/www/scripts/social/unit-tests.sh
   - docker exec -i social_ci_web bash /var/www/scripts/social/check-feature-state.sh social
-  - if [ "$TEST_SUITE" = "install_stability_1" ]; then docker exec -i social_ci_web bash /var/www/html/profiles/contrib/social/travis-fail.sh; fi
   - if [ "$TEST_SUITE" = "install_stability_1" ]; then docker exec -it social_ci_behat sh /var/www/scripts/social/behatstability.sh stability-1; fi
   - if [ "$TEST_SUITE" = "install_stability_2" ]; then docker exec -it social_ci_behat sh /var/www/scripts/social/behatstability.sh notifications; fi
   - if [ "$TEST_SUITE" = "install_stability_2" ]; then docker exec -it social_ci_behat sh /var/www/scripts/social/behatstability.sh stability-2; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ env:
     secure: "YUkomj6ieyi6AqrMnFyhPTORMvBhvMtZolvMZmckiAUaEV+Kiwb6TU6BsxARU1LeAfeSDuu5Ay69yib20AHe/OI8m7DmzZhhmnfRcV5aE09/xIdS7DN55g0a+9rWMHuYreeX7Xc8KX6DAEEcmW7EotyCO1pf8ljMD7wHuO+HpeydCLEGM200r1pSLCZpPCCTnHQXJBQ8MwSZu6tcPiVNnrmYs/fbbWOxB8QIv330SaF/i8trFDGJBUFLRw/7cIStA5Ye9EJp7AS7e+nR+kuCs/GPsRxSNH8BNtbk78iPwFILCH+xPhjRQ/hVL4St7DeN/F0PXn13GPAXkfrUXqrOgpDcpqPgtucEJekyDW9+YBuz2AJDynaIuWqjIWW1gheCVPSrsF7a9l7u/RVoQbeuSmGkbQXWzQuUaOkhVM6bq28qzRraeq/gNidV1ZikwoV7oi57HBxBQPZpVlKrLmNJ4Tsa9FkFwzjt55NV8VtxV8rav3r4zeQ3C/6yLAXr0Z3hX8bJdPCTgE4k+4dbA9nLjgZh6YV5yXwoIXNq8tF/A/rctpAA491AOk57qfLOH8Xi+y9kOPjshG5dNSprfIL/yZxz5CgED5OPNhh2veH9GrXlUcNzyO2+BI7kMQ8ipc+wy39Hw0xOu2JF40x4TVQuphc9flh/OQLDRludDY3aJd4="
 
 matrix:
+  fast_finish: true
   include:
   - env: TEST_SUITE=install_stability_1
   - env: TEST_SUITE=install_stability_2
@@ -58,9 +59,11 @@ install:
   - if [ "$TEST_SUITE" = "drush_make" ]; then bash scripts/social/ci/build-social-make.sh; fi
 
 script:
+  - set -e
   - docker exec -i social_ci_web bash /var/www/scripts/social/check-coding-standards.sh
   - docker exec -i social_ci_web_scripts sh /var/www/scripts/social/unit-tests.sh
   - docker exec -i social_ci_web bash /var/www/scripts/social/check-feature-state.sh social
+  - docker exec -i social_ci_web bash /var/www/html/travis-fail.sh
   - if [ "$TEST_SUITE" = "install_stability_1" ]; then docker exec -it social_ci_behat sh /var/www/scripts/social/behatstability.sh stability-1; fi
   - if [ "$TEST_SUITE" = "install_stability_2" ]; then docker exec -it social_ci_behat sh /var/www/scripts/social/behatstability.sh notifications; fi
   - if [ "$TEST_SUITE" = "install_stability_2" ]; then docker exec -it social_ci_behat sh /var/www/scripts/social/behatstability.sh stability-2; fi

--- a/travis-fail.sh
+++ b/travis-fail.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+exit 1

--- a/travis-fail.sh
+++ b/travis-fail.sh
@@ -1,2 +1,3 @@
 #!/bin/sh
+sleep 60
 exit 1

--- a/travis-fail.sh
+++ b/travis-fail.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-sleep 60
-exit 1


### PR DESCRIPTION
## Description

Currently, if the feature state is incorrect or the unit tests fail, the Behat tests will still run. This has a big impact on build time, in the end the job fails anyway.

Basically by adding `set -e` if one task exits with something other than `0` the rest of them are not run and the job fails. I also added `fast-finish`, although that won't do much at the moment.

In the future we will probably want https://github.com/travis-ci/travis-ci/issues/2062 as this allows us to cancel all the jobs if one fails. This comes with pros and cons, but in our case I think the pros outweigh the cons.

## How to test

- [ ] See that https://travis-ci.org/goalgorilla/open_social/jobs/297148903 did not execute Behat tests because of https://github.com/goalgorilla/open_social/commit/44f755adad97144f3b06e77eddc38abf9ef4d534#diff-0cd8e17f3121ddf05ed1cff8f54e32c1