### PR TITLE
Fix the project usage stats and update status of Open Social

### DIFF
--- a/social.info.yml
+++ b/social.info.yml
@@ -3,6 +3,7 @@ type: profile
 description: 'Open Social install profile.'
 core: '8.x'
 version: '8.x-1.6'
+project: social
 
 dependencies:
   - config


### PR DESCRIPTION
Because we removed the project: social in social.info.yml the Composer-based Drupal installations never phoned home to drupal.org to do the update check. This has impact on the usage stats of d.o (which is why they are relatively low) and it has impact on the update status page because Open Social does not appear there even when you are running an older version.

Versions affected:
1.4 - 1.6

