### PR TITLE
DS-2976 by maikelkoopman: put labels above date fields

### DIFF
--- a/modules/social_features/social_event/config/install/field.field.node.event.field_event_date.yml
+++ b/modules/social_features/social_event/config/install/field.field.node.event.field_event_date.yml
@@ -10,7 +10,7 @@ id: node.event.field_event_date
 field_name: field_event_date
 entity_type: node
 bundle: event
-label: 'Start date'
+label: 'Start'
 description: ''
 required: true
 translatable: false

--- a/modules/social_features/social_event/config/install/field.field.node.event.field_event_date_end.yml
+++ b/modules/social_features/social_event/config/install/field.field.node.event.field_event_date_end.yml
@@ -10,7 +10,7 @@ id: node.event.field_event_date_end
 field_name: field_event_date_end
 entity_type: node
 bundle: event
-label: 'End date'
+label: 'End'
 description: ''
 required: false
 translatable: false

--- a/themes/socialbase/assets/css/form-elements.css
+++ b/themes/socialbase/assets/css/form-elements.css
@@ -9,6 +9,11 @@ label {
   font-size: 0.875rem;
 }
 
+.control-label--above {
+  display: block;
+  margin-bottom: 3px;
+}
+
 .form-group {
   margin-bottom: 1rem;
   position: relative;

--- a/themes/socialbase/components/03-molecules/form-elements/form-elements.scss
+++ b/themes/socialbase/components/03-molecules/form-elements/form-elements.scss
@@ -47,6 +47,11 @@ label {
   font-size: 0.875rem;
 }
 
+.control-label--above {
+  display: block;
+  margin-bottom: 3px;
+}
+
 // Form groups
 //
 // Designed to help with the organization and spacing of vertical forms. For

--- a/themes/socialbase/src/Plugin/Preprocess/FormElementLabel.php
+++ b/themes/socialbase/src/Plugin/Preprocess/FormElementLabel.php
@@ -35,6 +35,26 @@ class FormElementLabel extends BaseFormElementLabel {
         $variables['title_display'] = 'invisible';
       }
 
+      // Date fields that need labels to distinguish date from time fields
+      // These include daterange fields already as well.
+      // @TODO update date fields of event to daterange fields and remove
+      // the last 4 variables of this array.
+      $date_fields = [
+        'edit-field-date-0-value-time',
+        'edit-field-date-0-value-date',
+        'edit-field-date-0-end-value-date',
+        'edit-field-date-0-end-value-time',
+        'edit-field-event-date-0-value-date',
+        'edit-field-event-date-0-value-time',
+        'edit-field-event-date-end-0-value-date',
+        'edit-field-event-date-end-0-value-time',
+
+      ];
+
+      if (in_array($element['#id'], $date_fields)) {
+        $variables['title_display'] = 'above';
+      }
+
     }
 
     parent::preprocessElement($element, $variables);

--- a/themes/socialbase/templates/form/form-element-label.html.twig
+++ b/themes/socialbase/templates/form/form-element-label.html.twig
@@ -22,6 +22,7 @@
     'control-label',
     title_display == 'after' ? 'option',
     title_display == 'invisible' ? 'sr-only',
+    title_display == 'above' ? 'control-label--above',
     required ? 'js-form-required',
     required ? 'form-required',
   ]


### PR DESCRIPTION
## Problem
- In user testing, it is shown that there is not indication at all on event start/end time.
- The label of the field should be changed to "End" and "Start" since the fieldset title already reflects that it's about the Event date AND time.

## Solution
- Force labels to be shown on these event date fields
- Change labels by removing "date"

## HTT
- [x] Revert social_event feature, rebuild cache
- [x] Login as LU
- [x] Go to /node/event/add
- [x] See that labels are changed on date fields
