### PR TITLE
Speed up Travis a little bit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,9 +60,9 @@ install:
 
 script:
   - set -e
-  - docker exec -i social_ci_web bash /var/www/scripts/social/check-coding-standards.sh
-  - docker exec -i social_ci_web_scripts sh /var/www/scripts/social/unit-tests.sh
-  - docker exec -i social_ci_web bash /var/www/scripts/social/check-feature-state.sh social
+  - if [ "$TEST_SUITE" = "install_stability_1" ]; then docker exec -i social_ci_web bash /var/www/scripts/social/check-coding-standards.sh; fi
+  - if [ "$TEST_SUITE" = "install_stability_1" ]; then docker exec -i social_ci_web_scripts sh /var/www/scripts/social/unit-tests.sh; fi
+  - if [ "$TEST_SUITE" = "install_stability_1" ] || [ "$TEST_SUITE" = "install_update" ] ; then docker exec -i social_ci_web bash /var/www/scripts/social/check-feature-state.sh social; fi
   - if [ "$TEST_SUITE" = "install_stability_1" ]; then docker exec -it social_ci_behat sh /var/www/scripts/social/behatstability.sh stability-1; fi
   - if [ "$TEST_SUITE" = "install_stability_2" ]; then docker exec -it social_ci_behat sh /var/www/scripts/social/behatstability.sh notifications; fi
   - if [ "$TEST_SUITE" = "install_stability_2" ]; then docker exec -it social_ci_behat sh /var/www/scripts/social/behatstability.sh stability-2; fi


### PR DESCRIPTION
by only running coding standards, unit tests and feature-state test when needed.

## Problem
There is no reason to run the same coding standards, unit tests and feature-state test multiple times. This makes it harder to understand why certain jobs are failing in a specific build.

## Solution
I suggest to only run:
- Coding standards 1 time in install_stability_1
- Unit tests 1 time in install_stability_1
- Feature state test in install_stability_1 and install_update.

## HTT
- [ ] Check out the code changes and above proposal
- [ ] Check out the Travis build

## Follow-up:
- I checked quickly if there is a way to cancel jobs within a build if a job fails (e.g. if install_stability_1 fails lets just cancel all other jobs within that build). Does not seem possible.
- I think we should consider moving to a structure like this: https://docs.travis-ci.com/user/build-stages/ This would allow fast feedback for coding standards, unit tests and feature test and it would allow caching Docker containers so they can be re-used in the jobs within the build. Also it means that a lot less jobs will be run!