### PR TITLE
#2924082 by maikelkoopman: update css for jquery UI close button

### DIFF
--- a/themes/socialbase/assets/css/modal.css
+++ b/themes/socialbase/assets/css/modal.css
@@ -131,26 +131,24 @@
   -webkit-appearance: none;
   -webkit-transition: 0.3s;
   transition: 0.3s;
+  position: relative;
 }
 
 .ui-dialog-titlebar-close:before {
   content: 'x';
+  position: absolute;
+  text-indent: 0;
+  top: 0;
+  right: 0;
 }
 
 .ui-dialog-titlebar-close:hover {
   opacity: .75;
 }
 
-.ui-dialog-titlebar-close .ui-button-text {
-  position: absolute;
-  height: 1px;
-  width: 1px;
-  overflow: hidden;
-  word-wrap: normal;
-  margin: -1px;
-  padding: 0;
-  clip: rect(0, 0, 0, 0);
-  border: 0;
+.ui-button-icon-only {
+  text-indent: -9999px;
+  white-space: nowrap;
 }
 
 .ui-dialog-content {

--- a/themes/socialbase/components/04-organisms/modal/modal.scss
+++ b/themes/socialbase/components/04-organisms/modal/modal.scss
@@ -108,19 +108,25 @@
   outline: 0;
   -webkit-appearance: none;
   transition: 0.3s;
+  position: relative;
 
   &:before {
     content: 'x';
+    position: absolute;
+    text-indent: 0;
+    top: 0;
+    right: 0;
   }
 
   &:hover {
     opacity: .75;
   }
 
-  .ui-button-text {
-    @include visually-hidden;
-  }
+}
 
+.ui-button-icon-only {
+  text-indent: -9999px;
+  white-space: nowrap;
 }
 
 .ui-dialog-content {


### PR DESCRIPTION
## Problem
jQuery dialog suddenly has a label next to the close button

## Solution
Update CSS selectors to match update in jQuery UI

## Issue tracker
https://www.drupal.org/project/social/issues/2924082

## HTT
- [x] Check out the code changes
- [x] Login as chrishall and click on a like (the word) below a post in the stream
- [x] The close label is gone and everything still works fine

