### PR TITLE
DS-4471 by maikelkoopman: set socialblue as theme for SM+ user edit page

### DIFF
--- a/modules/social_features/social_user/src/Routing/RouteSubscriber.php
+++ b/modules/social_features/social_user/src/Routing/RouteSubscriber.php
@@ -40,6 +40,11 @@ class RouteSubscriber extends RouteSubscriberBase {
       $defaults['_title_callback'] = '\Drupal\social_user\Controller\SocialUserController::setUserStreamTitle';
       $route->setDefaults($defaults);
     }
+
+    if ($route = $collection->get('entity.user.edit_form')) {
+      $route->setOption('_admin_route', FALSE);
+    }
+
   }
 
 }


### PR DESCRIPTION
## Problem
As a SM I want to use the default SaaS theme when I edit my profile

## Solution
Set admin theme to false when editing your account (for all roles)

## HTT
- [x] Check out the code changes
- [x] Login as a Site manager and go to 'settings' in the user menu
- [x] The edit account page / form is shown in the social blue theme
- [x] Also test this for user1, should also work

