### PR TITLE
DS-4408 - Add possibility to disable comments upload feature

### DIFF
--- a/modules/social_features/social_comment_upload/social_comment_upload.install
+++ b/modules/social_features/social_comment_upload/social_comment_upload.install
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * @file
+ * Installation file for Social Comment Upload.
+ */
+
+/**
+ * Install the module.
+ */
+function social_comment_upload_install() {
+  _social_comment_upload_set_defaults();
+}
+
+/**
+ * Set default values for social comment upload access.
+ */
+function social_comment_upload_update_8001() {
+  _social_comment_upload_set_defaults();
+}
+
+/**
+ * Function that sets the default configuration value(s) for this module.
+ */
+function _social_comment_upload_set_defaults() {
+  // Set allow to true, since that's the case by default.
+  \Drupal::getContainer()->get('config.factory')->getEditable('social_comment_upload.settings')->set('allow_upload_comments', 1)->save();
+  // SM should be able to change the permissions.
+  user_role_grant_permissions('sitemanager', ['administer social_comment_upload settings']);
+}

--- a/modules/social_features/social_comment_upload/social_comment_upload.links.menu.yml
+++ b/modules/social_features/social_comment_upload/social_comment_upload.links.menu.yml
@@ -1,0 +1,5 @@
+social_comment_upload.settings:
+  title: 'Comment upload settings'
+  description: 'Configure if people can attach files to comments.'
+  parent: social_core.admin.config.social
+  route_name: social_comment_upload.settings

--- a/modules/social_features/social_comment_upload/social_comment_upload.module
+++ b/modules/social_features/social_comment_upload/social_comment_upload.module
@@ -15,14 +15,23 @@ use Drupal\file\Entity\File;
  * Alter the weight of the actions, so the upload is last.
  */
 function social_comment_upload_form_comment_comment_form_alter(&$form, FormStateInterface $form_state, $form_id) {
-  if (isset($form['field_comment_files'])) {
-    $form['field_comment_files']['widget']['#file_upload_title'] = '';
-    $form['#attached']['library'][] = 'social_comment_upload/comment_upload';
-    $form['#after_build'][] = 'social_comment_upload_form_comment_comment_form_after_build';
-    // Workaround for fixing behat tests,
-    // which is caused by alter in social_comment module.
-    $form['field_comment_files']['#weight'] = 9;
-    $form['actions']['#weight'] = 8;
+
+  $settings = \Drupal::config('social_comment_upload.settings')->get('allow_upload_comments');
+
+  if (\Drupal::config('social_comment_upload.settings')->get('allow_upload_comments') == TRUE) {
+    if (isset($form['field_comment_files'])) {
+      $form['field_comment_files']['widget']['#file_upload_title'] = '';
+      $form['#attached']['library'][] = 'social_comment_upload/comment_upload';
+      $form['#after_build'][] = 'social_comment_upload_form_comment_comment_form_after_build';
+      // Workaround for fixing behat tests,
+      // which is caused by alter in social_comment module.
+      $form['field_comment_files']['#weight'] = 9;
+      $form['actions']['#weight'] = 8;
+    }
+  }
+  else {
+    // Turn it off.
+    $form['field_comment_files']['#access'] = FALSE;
   }
 }
 
@@ -42,22 +51,24 @@ function social_comment_upload_form_comment_comment_form_after_build($form, Form
  * Implements hook_preprocess_HOOK().
  */
 function social_comment_upload_preprocess_file_widget_multiple(&$variables) {
-  $element = $variables['element'];
+  if (\Drupal::config('social_comment_upload.settings')->get('allow_upload_comments') == TRUE) {
+    $element = $variables['element'];
 
-  if ($element['#field_name'] == 'field_comment_files') {
-    // Remove "weight" column.
-    foreach ($variables['table']['#rows'] as $key => $row) {
-      if (!empty($element['#display_field'])) {
-        unset($variables['table']['#rows'][$key]['data'][2]);
+    if ($element['#field_name'] == 'field_comment_files') {
+      // Remove "weight" column.
+      foreach ($variables['table']['#rows'] as $key => $row) {
+        if (!empty($element['#display_field'])) {
+          unset($variables['table']['#rows'][$key]['data'][2]);
+        }
+        else {
+          unset($variables['table']['#rows'][$key]['data'][1]);
+        }
       }
-      else {
-        unset($variables['table']['#rows'][$key]['data'][1]);
-      }
+
+      // Remove headers and disable sorting rows.
+      $variables['table']['#header'] = [];
+      $variables['table']['#tabledrag'] = [];
     }
-
-    // Remove headers and disable sorting rows.
-    $variables['table']['#header'] = [];
-    $variables['table']['#tabledrag'] = [];
   }
 }
 

--- a/modules/social_features/social_comment_upload/social_comment_upload.permissions.yml
+++ b/modules/social_features/social_comment_upload/social_comment_upload.permissions.yml
@@ -1,0 +1,4 @@
+administer social_comment_upload settings:
+  title: 'Administer Comment upload settings'
+  description: 'Allow to access the social_comment_upload settings form.'
+  restrict access: true

--- a/modules/social_features/social_comment_upload/social_comment_upload.routing.yml
+++ b/modules/social_features/social_comment_upload/social_comment_upload.routing.yml
@@ -1,0 +1,7 @@
+social_comment_upload.settings:
+  path: '/admin/config/opensocial/comment-upload-settings'
+  defaults:
+    _form: '\Drupal\social_comment_upload\Form\SocialCommentUploadSettingsForm'
+    _title: 'Comment upload settings'
+  requirements:
+    _permission: 'administer social_comment_upload settings'

--- a/modules/social_features/social_comment_upload/src/Form/SocialCommentUploadSettingsForm.php
+++ b/modules/social_features/social_comment_upload/src/Form/SocialCommentUploadSettingsForm.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Drupal\social_comment_upload\Form;
+
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
+use Drupal\Core\Extension\ModuleHandlerInterface;
+use Drupal\Core\Form\ConfigFormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Class SocialCommentUploadSettingsForm.
+ *
+ * @package Drupal\social_comment_upload\Form
+ */
+class SocialCommentUploadSettingsForm extends ConfigFormBase implements ContainerInjectionInterface {
+
+  /**
+   * The Module Handler.
+   *
+   * @var \Drupal\Core\Extension\ModuleHandlerInterface
+   */
+  protected $moduleHandler;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct(ConfigFactoryInterface $config_factory, ModuleHandlerInterface $moduleHandler) {
+    parent::__construct($config_factory);
+    $this->moduleHandler = $moduleHandler;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('config.factory'),
+      $container->get('module_handler')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'social_comment_upload_settings';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getEditableConfigNames() {
+    return ['social_comment_upload.settings'];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+
+    // Get the configuration file.
+    $config = $this->config('social_comment_upload.settings');
+
+    $form['allow_upload_comments'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Allow file uploads in comments.'),
+      '#default_value' => $config->get('allow_upload_comments'),
+      '#required' => FALSE,
+      '#description' => $this->t("Determine wether users can upload documents to comments."),
+    ];
+
+    return parent::buildForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+
+    // Get the configuration file.
+    $config = $this->config('social_comment_upload.settings');
+    $config->set('allow_upload_comments', $form_state->getValue('allow_upload_comments'))->save();
+
+    parent::submitForm($form, $form_state);
+  }
+
+}

--- a/modules/social_features/social_comment_upload/src/SocialCommentUploadConfigOverride.php
+++ b/modules/social_features/social_comment_upload/src/SocialCommentUploadConfigOverride.php
@@ -22,6 +22,11 @@ class SocialCommentUploadConfigOverride implements ConfigFactoryOverrideInterfac
     $overrides = [];
     $config_factory = \Drupal::service('config.factory');
 
+    // Check the settings first and leave.
+    if ($config_factory->getEditable('social_comment_upload.settings')->get('allow_upload_comments') == FALSE) {
+      return $overrides;
+    }
+
     // Add field_group and field_comment_files.
     $config_name = 'core.entity_form_display.comment.comment.default';
     if (in_array($config_name, $names)) {


### PR DESCRIPTION
## Problem
When enabled we cannot disable the comment upload feature. This is needed for our SaaS product

## Solution
Added a settings form and a new permission for SM to disable this. Default it's always enabled. Also when the setting is disabled, it's no longer possible to add files to comments, nor is it possible to view them.

## Issue tracker
- https://jira.goalgorilla.com/browse/DS-4408

## HTT
- [x] Check out the code changes
- [ ] Checkout everything below from update and fresh install
- [x] Enable the module (if not yet enabled)
- [x] Try commenting on nodes and adding attachments there and notice everything works fine
- [x] Go to the setting page (under config>opensocial settings)
- [x] Disable the setting and try the above again
- [x] Notice you can't add attachments to comments anymore
- [x] Notice you don't see the attachments on the previously added comment either
