### PR TITLE
Issue #2927442 by Kingdutch: fix undefined index in social_profile_pr…

### DIFF
--- a/modules/social_features/social_profile/modules/social_profile_privacy/social_profile_privacy.install
+++ b/modules/social_features/social_profile/modules/social_profile_privacy/social_profile_privacy.install
@@ -23,10 +23,6 @@ function _social_profile_privacy_set_permissions() {
 
   /** @var \Drupal\user\Entity\Role $role */
   foreach ($roles as $role) {
-    if ($role->id() === 'administrator') {
-      continue;
-    }
-
     $permissions = _social_profile_privacy_get_permissions($role->id());
     user_role_grant_permissions($role->id(), $permissions);
   }
@@ -55,6 +51,12 @@ function _social_profile_privacy_get_permissions($role) {
   $permissions['sitemanager'] = array_merge($permissions['contentmanager'], [
     'social profile privacy view hidden fields',
   ]);
+
+  // If the requested role is not defined we return no permissions.
+  // Drupal will make them inherit the authenticated user permissions.
+  if (!isset($permissions[$role])) {
+    return [];
+  }
 
   return $permissions[$role];
 }


### PR DESCRIPTION
…ivacy.install

## Problem
Undefined index [rolename] social_profile_privacy.install line 59

This is because we don't handle the case where the social_profile_privacy module is installed in a website that has more roles than just the default Open Social roles.

## Solution
Instead of throwing an error we return an empty array for roles
that we don't want to explicitly grant permissions to. The users
with these roles will also inherit the permissions from the
"authenticated user" role.

This also removes the need for a special case for the administrator
role.

Passing an empty array to `user_role_grant_permissions` will not
modify any permissions.


## Issue tracker
- https://www.drupal.org/project/social/issues/2927442

## HTT
- [x] Check out the code changes
- [x] Ensure the social_profile_privacy module is uninstalled
- [x] Create a role not included in the Open Social (such as "randomstringrole")
- [x] Enable the social_profile_privacy and observe the mentioned error.
- [x] Ensure the social_profile_privacy module is uninstalled
- [x] Checkout to this branch
- [x] Enable the social_profile_privacy and see that it enabled successfully
