### PR TITLE
DS-4344 by jaapjan: more generic terms for everything topics and message template

### DIFF
--- a/modules/social_features/social_activity/config/install/message.template.create_comment_author_node_post.yml
+++ b/modules/social_features/social_activity/config/install/message.template.create_comment_author_node_post.yml
@@ -18,7 +18,7 @@ third_party_settings:
     activity_entity_condition: comment_not_reply
 template: create_comment_author_node_post
 label: 'Create comment on authors node or post'
-description: 'A person commented on a post, topic or event created or organised by me'
+description: 'A person commented on content created or organised by me'
 text:
   -
     value: '<p><a href="[message:author:url:absolute]">[message:author:display-name]</a> commented on your <a href="[message:field_message_related_object:entity:url:absolute]">[social_comment:commented_content_type]</a></p>'

--- a/modules/social_features/social_comment/social_comment.tokens.inc
+++ b/modules/social_features/social_comment/social_comment.tokens.inc
@@ -97,7 +97,12 @@ function social_comment_tokens($type, $tokens, array $data, array $options, Bubb
                       $display_name = $entity->getDisplayName();
                     }
                     else {
-                      $display_name = $entity->bundle();
+                      if ($entity instanceof \Drupal\node\NodeInterface) {
+                        $display_name = strtolower($entity->type->entity->label());
+                      }
+                      else {
+                        $display_name = $entity->bundle();
+                      }
                     }
 
                     if (!empty($display_name)) {

--- a/modules/social_features/social_comment/social_comment.tokens.inc
+++ b/modules/social_features/social_comment/social_comment.tokens.inc
@@ -6,6 +6,7 @@
  */
 
 use Drupal\Core\Render\BubbleableMetadata;
+use Drupal\node\NodeInterface;
 
 /**
  * Implements hook_token_info().
@@ -97,7 +98,7 @@ function social_comment_tokens($type, $tokens, array $data, array $options, Bubb
                       $display_name = $entity->getDisplayName();
                     }
                     else {
-                      if ($entity instanceof \Drupal\node\NodeInterface) {
+                      if ($entity instanceof NodeInterface) {
                         $display_name = strtolower($entity->type->entity->label());
                       }
                       else {

--- a/modules/social_features/social_core/social_core.links.menu.yml
+++ b/modules/social_features/social_core/social_core.links.menu.yml
@@ -1,4 +1,4 @@
 social_core.admin.config.social:
   title: Opensocial settings
   parent: system.admin_config
-  route_name: social_core.admin_config.social
+  route_name: social_core.admin.config.social

--- a/modules/social_features/social_core/social_core.routing.yml
+++ b/modules/social_features/social_core/social_core.routing.yml
@@ -14,7 +14,7 @@ social_core.homepage:
   requirements:
     _permission: 'access content'
 
-social_core.admin_config.social:
+social_core.admin.config.social:
   path: '/admin/config/opensocial'
   defaults:
     _title: 'Open Social'

--- a/modules/social_features/social_topic/config/install/core.entity_form_display.node.topic.default.yml
+++ b/modules/social_features/social_topic/config/install/core.entity_form_display.node.topic.default.yml
@@ -38,10 +38,10 @@ third_party_settings:
         - body
       parent_name: ''
       weight: 2
-      label: 'Topic description'
+      label: 'Description'
       format_type: fieldset
       format_settings:
-        label: 'Topic description'
+        label: 'Description'
         required_fields: true
         id: description
         classes: 'card '

--- a/modules/social_features/social_topic/config/install/field.field.node.topic.field_topic_type.yml
+++ b/modules/social_features/social_topic/config/install/field.field.node.topic.field_topic_type.yml
@@ -9,7 +9,7 @@ id: node.topic.field_topic_type
 field_name: field_topic_type
 entity_type: node
 bundle: topic
-label: 'Topic type'
+label: 'Type'
 description: ''
 required: true
 translatable: false

--- a/modules/social_features/social_topic/config/install/views.view.latest_topics.yml
+++ b/modules/social_features/social_topic/config/install/views.view.latest_topics.yml
@@ -413,7 +413,7 @@ display:
           exposed: true
           expose:
             operator_id: field_topic_type_target_id_op
-            label: 'What type of topics do you want to see?'
+            label: 'is the type of'
             description: ''
             use_operator: false
             operator: field_topic_type_target_id_op


### PR DESCRIPTION
Also included a fallback in the message template for retrieving node bundle label for commented entities.

## Problem
The field labels "Topic type" and field group titles "Topic description" and filter "Topic type" were too specific on platforms where the social_renamer is used. The social_renamer does not currently support the renaming of these items.

## Solution
Propose to change this to a more generic names. See commit. In addition I've also found a way to retrieve the Node bundle's display name which can be used in the token in the comment message template.

## Issue tracker
- DS-4344

## HTT
- [ ] Check the node/add and node/edit forms for topics.
- [ ] Check the all-topics overview to verify if the filter form field label is changed accordingly.
- [ ] Check the message templates for items related to the topic node (especially commented on)
- [ ] Install social_renamer and try to rename topics to something else.
