### PR TITLE
by ribel: Fix homepage events behat test

### DIFF
--- a/tests/behat/features/capabilities/event/lu-homepage-my-events.feature
+++ b/tests/behat/features/capabilities/event/lu-homepage-my-events.feature
@@ -26,7 +26,7 @@ Feature: See my upcoming events
     Then I should see "Enrolled"
 
     When I go to the homepage
-    Then I should not see "My Behat Event created" in the "Sidebar second"
+    Then I should see "My Behat Event created" in the "Sidebar second"
     And I should see "My Behat Event enrolled" in the "Sidebar second"
     And I should see "Enrolled" in the "Sidebar second"
 


### PR DESCRIPTION
## Problem
Behat test with tags @DS-1053 See my upcoming events is failing on step:
```
Then I should not see "My Behat Event created" in the "Sidebar second"  
      The text "My Behat Event created" was found in the region "Sidebar second" on the page 
```
Test assume that we should not see it in block **My Upcoming events**, which is still true, but this event is also displayed in **Upcoming events** block. See: http://prntscr.com/hjct6i

## Solution
Fix behat test by assuming that both enrolled and created events should be visible on homage sidebar

## Issue tracker
- none

## HTT
- [ ] Check out the code changes
- [ ] Try to reproduce steps from test manually or by running test
- [ ] Changed test should pass
