### PR TITLE
#2921723 by maikelkoopman: show custom fields for posts by default

### DIFF
--- a/themes/socialbase/templates/post/post--activity-comment.html.twig
+++ b/themes/socialbase/templates/post/post--activity-comment.html.twig
@@ -1,20 +1,21 @@
-  {#
-  /**
-  * @file post.html.twig
-  * Default theme implementation to present Post data.
-  *
-  * This template is used when viewing Post pages.
-  *
-  *
-  * Available variables:
-  * - content: A list of content items. Use 'content' to print all content, or
-  * - attributes: HTML attributes for the container element.
-  *
-  * @see template_preprocess_post()
-  *
-  * @ingroup themeable
-  */
-  #}
+{#
+/**
+* @file post-activity-comment.html.twig
+* @deprecated
+*
+* The template is not used anymore since comments are aggegrated with
+* the post itself. If a developer disables aggegration of comments
+* this template will be used again.
+*
+* Available variables:
+* - content: A list of content items. Use 'content' to print all content, or
+* - attributes: HTML attributes for the container element.
+*
+* @see template_preprocess_post()
+*
+* @ingroup themeable
+*/
+#}
 {{ attach_library('socialbase/comment') }}
 
 {%

--- a/themes/socialbase/templates/post/post--activity.html.twig
+++ b/themes/socialbase/templates/post/post--activity.html.twig
@@ -1,20 +1,21 @@
-  {#
-  /**
-  * @file post.html.twig
-  * Default theme implementation to present Post data.
-  *
-  * This template is used when viewing Post pages.
-  *
-  *
-  * Available variables:
-  * - content: A list of content items. Use 'content' to print all content, or
-  * - attributes: HTML attributes for the container element.
-  *
-  * @see template_preprocess_post()
-  *
-  * @ingroup themeable
-  */
-  #}
+{#
+/**
+* @file post.html.twig
+* Default theme implementation to present Post data.
+*
+* This template is used when viewing Post pages.
+*
+*
+* Available variables:
+* - content: A list of content items. Use 'content' to print all content, or
+* - attributes: HTML attributes for the container element.
+*
+* @see template_preprocess_post()
+*
+* @ingroup themeable
+*/
+#}
+
 {{ attach_library('socialbase/comment') }}
 
 {%
@@ -25,31 +26,23 @@
   ]
 %}
 
-
-{% if content.links|render %}
-  {{ content.links }}
-{% endif %}
+{{ content.links }}
 
 <div{{ attributes.addClass(classes) }}>
 
-  {% if content.field_post %}
-    {{ content.field_post }}
-  {% endif %}
+  {{ content|without('links', 'field_post_comments', 'like_and_dislike', 'field_post_image', 'user_id') }}
 
   {% if content.field_post_image|render %}
     <p>{{ content.field_post_image }}</p>
   {% endif %}
 
-  {% if content.like_and_dislike %}
-    {{ content.like_and_dislike }}
-  {% endif %}
+  <div class="clearfix"></div>
+  {{ content.like_and_dislike }}
 
 </div>
 
 {% if logged_in %}
   <div class="card__nested-section">
-    {% if content.field_post_comments %}
-      {{ content.field_post_comments }}
-    {% endif %}
+    {{ content.field_post_comments }}
   </div>
 {% endif %}

--- a/themes/socialbase/templates/post/post.html.twig
+++ b/themes/socialbase/templates/post/post.html.twig
@@ -1,20 +1,20 @@
-  {#
-  /**
-  * @file post.html.twig
-  * Default theme implementation to present Post data.
-  *
-  * This template is used when viewing Post pages.
-  *
-  *
-  * Available variables:
-  * - content: A list of content items. Use 'content' to print all content, or
-  * - attributes: HTML attributes for the container element.
-  *
-  * @see template_preprocess_post()
-  *
-  * @ingroup themeable
-  */
-  #}
+{#
+/**
+* @file post.html.twig
+* Default theme implementation to present Post data.
+*
+* This template is used when viewing Post pages.
+*
+*
+* Available variables:
+* - content: A list of content items. Use 'content' to print all content, or
+* - attributes: HTML attributes for the container element.
+*
+* @see template_preprocess_post()
+*
+* @ingroup themeable
+*/
+#}
 
 {{ attach_library('socialbase/comment') }}
 <div class="card">
@@ -42,25 +42,20 @@
 
     <div class="margin-top-s iframe-container">
 
-      {% if content.field_post %}
-        {{ content.field_post }}
-      {% endif %}
+      {{ content|without('links', 'field_post_comments', 'like_and_dislike', 'field_post_image', 'user_id') }}
 
       {% if content.field_post_image|render %}
         <p>{{ content.field_post_image }}</p>
       {% endif %}
 
-      {% if content.like_and_dislike %}
-        {{ content.like_and_dislike }}
-      {% endif %}
+      <div class="clearfix"></div>
+      {{ content.like_and_dislike }}
     </div>
 
 
     {% if logged_in %}
       <div class="card__nested-section">
-        {% if content.field_post_comments %}
-          {{ content.field_post_comments }}
-        {% endif %}
+        {{ content.field_post_comments }}
       </div>
     {% endif %}
 


### PR DESCRIPTION
## Problem
Custom fields not showing up in custom post type

## Solution
In template replace exact fields to print with all fields to print. Then exclude the fields that are printed on other places in the template

## Issue tracker
https://www.drupal.org/project/social/issues/2921723


## HTT
- [x] Login as admin
- [x] Go to /admin/structure/post/photo/edit/fields and Add a new field 
- [x] Make it display in the form and all 3 displays
- [x] See the post create form has your new field
- [x] Post something with your new field. 
- [x] It shows on the stream and post detail page

- This doesn't include theming of course. If a developer add new fields, they need to add theming for it in a subtheme.
