### PR TITLE
#2919653 Comment anchors obscured by main navigation

### DIFF
--- a/themes/socialbase/assets/css/comment.css
+++ b/themes/socialbase/assets/css/comment.css
@@ -1,3 +1,10 @@
+#section-comments a[id^="comment-"] {
+  display: block;
+  position: relative;
+  top: -70px;
+  visibility: hidden;
+}
+
 .comment {
   position: relative;
   margin-top: 1em;

--- a/themes/socialbase/components/04-organisms/comment/comment.scss
+++ b/themes/socialbase/components/04-organisms/comment/comment.scss
@@ -1,5 +1,14 @@
 @import 'settings';
 
+// Make sure comment anachors are not hidden
+// behind fixed navigation (which is 50px tall).
+#section-comments a[id^="comment-"] {
+  display: block;
+  position: relative;
+  top: -70px;
+  visibility: hidden;
+}
+
 .comment {
   position: relative;
   margin-top: 1em;

--- a/themes/socialbase/components/04-organisms/comment/comment.scss
+++ b/themes/socialbase/components/04-organisms/comment/comment.scss
@@ -5,7 +5,7 @@
 #section-comments a[id^="comment-"] {
   display: block;
   position: relative;
-  top: -70px;
+  top: -($navbar-height + 20px);
   visibility: hidden;
 }
 


### PR DESCRIPTION
## Problem
When you click a link that goes to a comment (for example in an e-mail notification) then the top of the comment (its author) will be obscured by fixed navigation. This is because the anchor is moved to the top of the screen by the browser.

## Solution
Add an offset to all comment anchors to compensate for the navigation. 

## Issue tracker
https://www.drupal.org/project/social/issues/2919653

## HTT
- [ ] Login as thomaswolf
- [ ] Navigate to node/10
- [ ] Add at least 5 long comments (so we get a long page that needs scrolling)
- [ ] Login as chrishall, you have notifications that there are comments by thomaswolf
- [ ] Click on the oldest notification
- [ ] You see the whole comment, including the name and avatar below the fixed navbar.
