### PR TITLE
LU should be able to send private message to a user from their profile.

### DIFF
--- a/modules/custom/social_demo/content/entity/user.yml
+++ b/modules/custom/social_demo/content/entity/user.yml
@@ -1,6 +1,7 @@
 ---
 44fc2486-da2f-11e5-b5d2-0a1d41d68578:
   uuid: 44fc2486-da2f-11e5-b5d2-0a1d41d68578
+  created: -4 day|23:40
   name: susanwilliams
   mail: drupal_social+susanwilliams@springfieldboard.com
   timezone: UTC
@@ -19,6 +20,7 @@
    We try to create a better school environment for the children and parents. I joined this community to get into contact with other people that are also interested in this topic.
 44fc2be8-da2f-11e5-b5d2-0a1d41d68578:
   uuid: 44fc2be8-da2f-11e5-b5d2-0a1d41d68578
+  created: -11 day|12:19
   name: paulharris
   mail: drupal_social+paulharris@goalgorilla.com
   timezone: Europe/Amsterdam
@@ -36,6 +38,7 @@
     I work sinds over 20 years as a high school teacher. In this function I see the value of exchanging experiences with other professionals and involved persons.
 44fc2f3a-da2f-11e5-b5d2-0a1d41d68578:
   uuid: 44fc2f3a-da2f-11e5-b5d2-0a1d41d68578
+  created: -7 day|17:17
   name: michelleclark
   mail: drupal_social+michelleclark@goalgorilla.com
   timezone: Europe/Amsterdam
@@ -56,6 +59,7 @@
     <p><span>I worked as an advisor for different education related NGOs. The complexity &nbsp;of our educational system and its fragmentation leads in my opinion to too many avoidable problems. This is why we have to learn from each other and work together to focus knowledge resources. Only together we can grow as a community</span></p>
 44fc314c-da2f-11e5-b5d2-0a1d41d68578:
   uuid: 44fc314c-da2f-11e5-b5d2-0a1d41d68578
+  created: -60 day|17:55
   name: chrishall
   mail: drupal_social+chrishall@goalgorilla.com
   timezone: Europe/Rome
@@ -75,6 +79,7 @@
     I work as a Public Relation manager for the Educational Assistance Association. In this Function I am one of the managers of this communities.
 44fc3476-da2f-11e5-b5d2-0a1d41d68578:
   uuid: 44fc3476-da2f-11e5-b5d2-0a1d41d68578
+  created: -12 day|18:11
   name: thomaswolf
   mail: drupal_social+thomaswolf@goalgorilla.com
   timezone: Europe/Amsterdam
@@ -92,6 +97,7 @@
     As the principal of the Springfield Elementary School I joined this network to share my experiences in the educational sector.
 44fc3642-da2f-11e5-b5d2-0a1d41d68578:
   uuid: 44fc3642-da2f-11e5-b5d2-0a1d41d68578
+  created: -17 day|10:17
   name: EAA_official
   mail: drupal_social+EAA_officialk@goalgorilla.com
   timezone: Europe/Amsterdam
@@ -111,6 +117,7 @@
 
 44fc37e6-da2f-11e5-b5d2-0a1d41d68578:
   uuid: 44fc37e6-da2f-11e5-b5d2-0a1d41d68578
+  created: -12 day|13:17
   name: petershaw
   mail: drupal_social+peterkshaw@goalgorilla.com
   timezone: Europe/Amsterdam
@@ -131,6 +138,7 @@
     I am a Board Comitee member. I do this work already sinds 5 years.
 44fc398a-da2f-11e5-b5d2-0a1d41d68578:
   uuid: 44fc398a-da2f-11e5-b5d2-0a1d41d68578
+  created: -10 day|13:17
   name: student_01
   mail: drupal_social+anonymous@goalgorilla.com
   timezone: Europe/Amsterdam
@@ -148,6 +156,7 @@
 
 44fc40ec-da2f-11e5-b5d2-0a1d41d68578:
   uuid: 44fc40ec-da2f-11e5-b5d2-0a1d41d68578
+  created: -12 day|19:17
   name: robertandrews
   mail: drupal_social+robertandrews@goalgorilla.com
   timezone: Europe/London
@@ -168,6 +177,7 @@
     I am the owner of a bookstore in Springfield. I also provide a lot of the study books for the local schools and a lot of pupils come with their parents to my store. I joined here to help support our community and give a small part back to it.
 44fc433a-da2f-11e5-b5d2-0a1d41d68578:
   uuid: 44fc433a-da2f-11e5-b5d2-0a1d41d68578
+  created: -1 day|9:17
   name: alisonhendrix
   mail: drupal_social+alisonhendrix@goalgorilla.com
   timezone: Europe/Berlin
@@ -185,6 +195,7 @@
     As a parent of two children I am very interested in the topic of education. I am engaged in the community and help out a lot at the school of my children. Also I though about running next year for the election for the board of schools in my region.
 712a6044-ef52-11e5-9ce9-5e5517507c66:
   uuid: 712a6044-ef52-11e5-9ce9-5e5517507c66
+  created: -3 day|15:17
   name: shaunberkley
   mail: drupal_social+shaunberkley@goalgorilla.com
   timezone: Europe/Berlin
@@ -202,6 +213,7 @@
 
 712a6616-ef52-11e5-9ce9-5e5517507c66:
   uuid: 712a6616-ef52-11e5-9ce9-5e5517507c66
+  created: -5 day|13:17
   name: darrenjohnson
   mail: drupal_social+darrenjohnson@goalgorilla.com
   timezone: Europe/Amsterdam
@@ -219,6 +231,7 @@
 
 a8c4e812-ef52-11e5-9ce9-5e5517507c66:
   uuid: a8c4e812-ef52-11e5-9ce9-5e5517507c66
+  created: -7 day|13:12
   name: benflorez
   mail: drupal_social+benflorez@goalgorilla.com
   timezone: Europe/Amsterdam
@@ -239,6 +252,7 @@ a8c4e812-ef52-11e5-9ce9-5e5517507c66:
 
 a8c4ebe6-ef52-11e5-9ce9-5e5517507c66:
   uuid: a8c4ebe6-ef52-11e5-9ce9-5e5517507c66
+  created: -7 day|13:17
   name: jannamiesner
   mail: drupal_social+jannamiesner@goalgorilla.com
   timezone: Europe/London

--- a/modules/social_features/social_private_message/config/install/core.entity_form_display.private_message_thread.private_message_thread.default.yml
+++ b/modules/social_features/social_private_message/config/install/core.entity_form_display.private_message_thread.private_message_thread.default.yml
@@ -9,7 +9,7 @@ bundle: private_message_thread
 mode: default
 content:
   members:
-    type: options_select
+    type: social_private_message_thread_member_widget
     settings: {  }
     weight: -3
     region: content

--- a/modules/social_features/social_private_message/src/Plugin/Field/FieldWidget/SocialPrivateMessageThreadMemberWidget.php
+++ b/modules/social_features/social_private_message/src/Plugin/Field/FieldWidget/SocialPrivateMessageThreadMemberWidget.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Drupal\social_private_message\Plugin\Field\FieldWidget;
+
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Field\Plugin\Field\FieldWidget\OptionsSelectWidget;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\user\Entity\User;
+
+/**
+ * A widget to select member for private message.
+ *
+ * @FieldWidget(
+ *   id = "social_private_message_thread_member_widget",
+ *   label = @Translation("Social private message members select list"),
+ *   field_types = {
+ *     "entity_reference",
+ *     "list_integer",
+ *     "list_float",
+ *     "list_string"
+ *   },
+ *   multiple_values = TRUE
+ * )
+ */
+class SocialPrivateMessageThreadMemberWidget extends OptionsSelectWidget {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function formElement(FieldItemListInterface $items, $delta, array $element, array &$form, FormStateInterface $form_state) {
+    $element = parent::formElement($items, $delta, $element, $form, $form_state);
+
+    if (\Drupal::currentUser()->hasPermission('access user profiles')) {
+      $recipient_id = \Drupal::service('request_stack')->getCurrentRequest()->get('recipient');
+      if ($recipient_id) {
+        $recipient = User::load($recipient_id);
+        if ($recipient) {
+          $element['#default_value'] = [$recipient_id];
+        }
+      }
+    }
+
+    return $element;
+  }
+
+}

--- a/modules/social_features/social_profile/social_profile.module
+++ b/modules/social_features/social_profile/social_profile.module
@@ -196,8 +196,16 @@ function social_profile_preprocess_profile(array &$variables) {
   // See social_user_user_format_name_alter(), DisplayName is either first name
   // + last name, or username if both first and last name aren't filled out.
   $variables['profile_name'] = $user->getDisplayName();
-  $variables['profile_contact_url'] = Url::fromUserInput('/user/' . $profile->getOwnerId() . '/information');
+  $variables['profile_contact_url'] = _social_profile_get_contact_url($user);
   $variables['profile_stream_url'] = Url::fromUserInput('/user/' . $profile->getOwnerId() . '/stream');
+
+  // Set a condition for the label to show in the teaser
+  // The actual label text should be changeable in the template.
+  // Disable for the LU's own profile.
+  $variables['profile_contact_label'] = 'profile_info';
+  if (\Drupal::moduleHandler()->moduleExists('social_private_message') && $current_user->id() != $profile->getOwnerId()) {
+    $variables['profile_contact_label'] = 'private_message';
+  }
 
   // Email field.
   $global_show_email = \Drupal::config('social_profile.settings')->get('social_profile_show_email');
@@ -229,6 +237,32 @@ function social_profile_preprocess_profile(array &$variables) {
       ->buildUrl($profile->field_profile_banner_image->entity->getFileUri());
   }
 
+}
+
+/**
+ * Get the contact URL. This can be private message or other means of contact.
+ *
+ * @param \Drupal\user\Entity\User $account
+ *   The user object.
+ *
+ * @return \Drupal\Core\Url
+ *   The URL to contact the user.
+ */
+function _social_profile_get_contact_url(User $account) {
+  if (\Drupal::moduleHandler()->moduleExists('social_private_message')) {
+    $current_user = \Drupal::currentUser();
+    if ($current_user->hasPermission('use private messaging system') && $current_user->id() != $account->id()) {
+      $members = [$current_user, $account];
+      $thread_id = \Drupal::service('private_message.mapper')->getThreadIdForMembers($members);
+      if ($thread_id) {
+        return Url::fromRoute('entity.private_message_thread.canonical', ['private_message_thread' => $thread_id], ['attributes' => ['class' => ['private_message_link']]]);
+      }
+      else {
+        return Url::fromRoute('private_message.private_message_create', [], ['query' => ['recipient' => $account->id()]]);
+      }
+    }
+  }
+  return Url::fromUserInput('/user/' . $account->id() . '/information');
 }
 
 /**

--- a/modules/social_features/social_profile/social_profile.module
+++ b/modules/social_features/social_profile/social_profile.module
@@ -205,6 +205,7 @@ function social_profile_preprocess_profile(array &$variables) {
   $variables['profile_contact_label'] = 'profile_info';
   if (\Drupal::moduleHandler()->moduleExists('social_private_message') && $current_user->id() != $profile->getOwnerId()) {
     $variables['profile_contact_label'] = 'private_message';
+    $variables['#cache']['contexts'][] = 'user';
   }
 
   // Email field.

--- a/social.info.yml
+++ b/social.info.yml
@@ -2,7 +2,7 @@ name: Social
 type: profile
 description: 'Open Social install profile.'
 core: '8.x'
-version: '8.x-1.7'
+version: '8.x-1.8'
 project: social
 
 dependencies:

--- a/tests/behat/features/capabilities/private-message/create-private-message.feature
+++ b/tests/behat/features/capabilities/private-message/create-private-message.feature
@@ -18,7 +18,30 @@
     Then I should see "Create Private Message"
     And I select "PM User Two" from "edit-members"
     And I fill in "Message" with "Hi PM User Two, I heard you like pineapple on your pizza..."
-    When I press "Send"
+    And I press "Send"
+    Then I should see the following success messages:
+      | Your message has been created. |
+
+    # I want to send a new message from a user`s profile teaser
+    When I am on "/all-members"
+    Then I should see "Contact Me"
+    When I click the xth "1" link with the text "Contact Me"
+    Then I should see "PM User Two"
+    And I fill in "Message" with "Hi PM User Two, I heard you like salami on your pizza..."
+    And I press "Send"
+    Then I should see the following success messages:
+      | Your message has been created. |
+
+    # I want to send a new message from a user`s profile
+    When I am on the profile of "PM User Two"
+    Then I should see the link "Send message" in the "Hero block"
+    And I click "Send message"
+    Then I should see "PM User Two"
+    And I should see "You"
+    When I fill in "Message" with "Hi PM User Two, are we going to eat some pizza tomorrow?"
+    And I press "Send"
+    Then I should see the following success messages:
+      | Your message has been created. |
 
     # I want to see my new message and reply.
     Given I am logged in as "PM User Two"
@@ -27,8 +50,8 @@
     And I should see the link "View thread"
     And I should see "PM User One"
     When I click "View thread"
-    Then I should see "Hi PM User Two, I heard you like pineapple on your pizza..."
-    When I fill in "Message" with "Hey PM User One, ...That's correct. Ansjovis is good too!"
+    Then I should see "Hi PM User Two, are we going to eat some pizza tomorrow?"
+    When I fill in "Message" with "Hey PM User One, ...That's fine. I will order!"
     And I press "Send"
     Then I should see the following success messages:
       | Your message has been created. |
@@ -92,6 +115,7 @@
     And I select "PM User Four" from "edit-members"
     And I fill in "Message" with "Be strict on the pizza toppings, user two likes it weird!"
     When I press "Send"
+
     # Check the two messages.
     Given I am logged in as "PM User Four"
     When I click the xth "0" element with the css ".icon-mail"

--- a/tests/behat/features/capabilities/private-message/create-private-message.feature
+++ b/tests/behat/features/capabilities/private-message/create-private-message.feature
@@ -24,8 +24,8 @@
 
     # I want to send a new message from a user`s profile teaser
     When I am on "/all-members"
-    Then I should see "Contact Me"
-    When I click the xth "1" link with the text "Contact Me"
+    Then I should see "Private message"
+    When I click the xth "1" link with the text "Private message"
     Then I should see "PM User Two"
     And I fill in "Message" with "Hi PM User Two, I heard you like salami on your pizza..."
     And I press "Send"

--- a/tests/behat/features/capabilities/private-message/create-private-message.feature
+++ b/tests/behat/features/capabilities/private-message/create-private-message.feature
@@ -34,8 +34,8 @@
 
     # I want to send a new message from a user`s profile
     When I am on the profile of "PM User Two"
-    Then I should see the link "Send message" in the "Hero block"
-    And I click "Send message"
+    Then I should see the link "Private message" in the "Hero block"
+    And I click "Private message"
     Then I should see "PM User Two"
     And I should see "You"
     When I fill in "Message" with "Hi PM User Two, are we going to eat some pizza tomorrow?"

--- a/themes/socialbase/templates/profile/profile--profile--hero.html.twig
+++ b/themes/socialbase/templates/profile/profile--profile--hero.html.twig
@@ -22,10 +22,11 @@
 {{ attach_library('socialbase/hero')}}
 
 {% if profile_hero_styled_image_url %}
-<div style="background-image: url('{{ profile_hero_styled_image_url }}')" class="cover cover-img cover-img-gradient">
+  <div style="background-image: url('{{ profile_hero_styled_image_url }}')" class="cover cover-img cover-img-gradient">
 {% else %}
-<div class="cover">
+  <div class="cover">
 {% endif %}
+
 {% if profile_edit_url %}
   <div class="hero-action-button">
     <a href="{{ profile_edit_url }}" title="Edit profile information" class="btn btn-raised btn-default btn-floating">
@@ -37,6 +38,7 @@
 {% endif %}
 
   <div class="cover-wrap">
+
     <header>
       <h1 class="page-title">
         {{ profile_name }}
@@ -44,24 +46,35 @@
       {{ content.field_profile_image }}
     </header>
 
-    {% if (content.field_profile_function|render or content.field_profile_organization|render) %}
-      <footer class="hero-footer">
-        <div class="hero-footer__text">
-          {% if content.field_profile_function|render %}
-            <strong>{{ content.field_profile_function|render }}</strong>
-          {% endif %}
-          {% if (content.field_profile_function|render and content.field_profile_organization|render) %}
-          &nbsp;-&nbsp;
-          {% endif %}
-          {% if content.field_profile_organization|render %}
-            {{ content.field_profile_organization|render }}
-          {% endif %}
-        </div>
 
-      </footer>
+  {% if (content.field_profile_function|render or content.field_profile_organization|render) or profile_contact_label == 'private_message' %}
+    <footer class="hero-footer">
+  {% endif %}
+
+    <div class="hero-footer__text">
+      {% if content.field_profile_function|render %}
+        <strong>{{ content.field_profile_function|render }}</strong>
+      {% endif %}
+      {% if (content.field_profile_function|render and content.field_profile_organization|render) %}
+      &nbsp;-&nbsp;
+      {% endif %}
+        {{ content.field_profile_organization|render }}
+    </div>
+
+    {% if profile_contact_label == 'private_message' %}
+      <div class="hero-footer__cta">
+        <a href="{{ profile_contact_url }}" class="btn btn-accent btn-lg btn-raised">
+          {% trans %} Send message {% endtrans %}
+        </a>
+      </div>
     {% endif %}
+
+  {% if (content.field_profile_function|render or content.field_profile_organization|render) or profile_contact_label == 'private_message' %}
+    </footer>
+  {% endif %}
 
     {# render other fields that developers might add #}
     {{ content|without('field_profile_first_name', 'field_profile_last_name', 'field_profile_image', 'field_profile_function', 'field_profile_organization') }}
   </div>
+
 </div>

--- a/themes/socialbase/templates/profile/profile--profile--hero.html.twig
+++ b/themes/socialbase/templates/profile/profile--profile--hero.html.twig
@@ -64,7 +64,7 @@
     {% if profile_contact_label == 'private_message' %}
       <div class="hero-footer__cta">
         <a href="{{ profile_contact_url }}" class="btn btn-accent btn-lg btn-raised">
-          {% trans %} Send message {% endtrans %}
+          {% trans %} Private message {% endtrans %}
         </a>
       </div>
     {% endif %}

--- a/themes/socialbase/templates/profile/profile--profile--teaser.html.twig
+++ b/themes/socialbase/templates/profile/profile--profile--teaser.html.twig
@@ -65,7 +65,7 @@
     <div class="card__actionbar">
       <a href="{{ profile_contact_url }}" class="card__link">
         {% if profile_contact_label == 'private_message' %}
-          {% trans %}Contact Me{% endtrans %}
+          {% trans %}Private message{% endtrans %}
         {% else %}
           {% trans %}View profile{% endtrans %}
         {% endif %}

--- a/themes/socialbase/templates/profile/profile--profile--teaser.html.twig
+++ b/themes/socialbase/templates/profile/profile--profile--teaser.html.twig
@@ -64,7 +64,11 @@
 
     <div class="card__actionbar">
       <a href="{{ profile_contact_url }}" class="card__link">
-        {% trans %}View profile{% endtrans %}
+        {% if profile_contact_label == 'private_message' %}
+          {% trans %}Contact Me{% endtrans %}
+        {% else %}
+          {% trans %}View profile{% endtrans %}
+        {% endif %}
       </a>
       <a href="{{ profile_stream_url }}" class="card__link hidden-for-phone-only">
         {% trans %}View activities{% endtrans %}


### PR DESCRIPTION
## Problem
I should be able to send a user private message directly from his/her profile without having to go first to my inbox. 
I should be able to send a user private message directly from teaser. 

## Solution
Change one link in profile teaser, only when PM module is enabled.
Add button to profile hero, only when PM module is enabled

## HTT
- [x] Login as admin, enabled private message module, rebuild cache
- [x] Login as chrishall, go to all members page
- [x] You see a "contact me" button in all teasers
- [x] Click on any contact me button of a user you haven't PM-ed before.
- [x] You land on create private message form
- [x] Send him/her a message
- [x] Return to all members overview, click the same link again
- [x] Now you land on the thread page, not create new message form
- [x] Return to all members, click on "view actities" of any user.
- [x] On his/her profile you see a "send message" button in the hero
- [x] The link brings you to the create private message page / thread
- [x] Go to your own profile -> There is no "send message" button in the hero.
