### PR TITLE
Create update hook to reset the existing theme setting colors to the new layout

### DIFF
--- a/modules/custom/improved_theme_settings/improved_theme_settings.install
+++ b/modules/custom/improved_theme_settings/improved_theme_settings.install
@@ -14,3 +14,51 @@ function improved_theme_settings_install() {
   // Set weight.
   module_set_weight('improved_theme_settings', 50);
 }
+
+/**
+ * Migrate old theme settings to the new settings.
+ */
+function improved_theme_settings_update_8001() {
+  // Get the current default theme.
+  $theme = \Drupal::configFactory()->get('system.theme')->get('default');
+  // Get the color values.
+  $config = \Drupal::configFactory()->getEditable('color.theme.' . $theme);
+  $colors = $config->getRawData();
+
+  // Create an array for the new color values.
+  $new_colors = [
+    'brand-primary' => '#29abe2',
+    'brand-secondary' => '#1f80aa',
+    'brand-accent' => '#ffc142',
+    'brand-link' => '#33b5e5',
+    'navbar-bg' => '#333333',
+    'navbar-text' => '#ffffff',
+    'navbar-active-bg' => '#1f1f1f',
+    'navbar-active-text' => '#f3f3f3',
+    'navbar-sec-bg' => '#1f7ea7',
+    'navbar-sec-text' => '#f9f9f9',
+  ];
+
+  // Fetch values from the old theme and overrode em.
+  if (isset($colors['palette']['brand-bg-primary'])) {
+    $new_colors['brand-primary'] = $colors['palette']['brand-bg-primary'];
+  }
+
+  if (isset($colors['palette']['brand-bg-secondary'])) {
+    $new_colors['brand-secondary'] = $colors['palette']['brand-bg-secondary'];
+  }
+
+  if (isset($colors['palette']['brand-bg-accent'])) {
+    $new_colors['brand-accent'] = $colors['palette']['brand-bg-accent'];
+  }
+
+  if (isset($colors['palette']['brand-text-primary'])) {
+    $new_colors['brand-link'] = $colors['palette']['brand-text-primary'];
+  }
+
+  // overwrite.
+  $colors['palette'] = $new_colors;
+
+  // Save the new config.
+  $config->setData($colors)->save();
+}

--- a/modules/custom/social_demo/eaa/content/entity/system.yml
+++ b/modules/custom/social_demo/eaa/content/entity/system.yml
@@ -5,6 +5,12 @@ theme:
   color_secondary: '#c63f17'
   color_accents: '#e3f2fd'
   color_link: '#ffa270'
+  navbar-bg: '#333333'
+  navbar-text: '#ffffff'
+  navbar-active-bg: '#000000'
+  navbar-active-text: '#ffffff'
+  navbar-sec-bg: '#c63f17'
+  navbar-sec-text: '#e3f2fd'
   card_radius: 5
   form_control_radius: 2
   button_radius: 5

--- a/modules/custom/social_demo/src/DemoSystem.php
+++ b/modules/custom/social_demo/src/DemoSystem.php
@@ -141,10 +141,16 @@ abstract class DemoSystem extends DemoContent {
       $color = $this->configFactory->getEditable('color.theme.' . $active_theme);
       // Set as a palette.
       $palette = [
-        'brand-bg-primary' => $data['theme']['color_primary'],
-        'brand-bg-secondary' => $data['theme']['color_secondary'],
-        'brand-bg-accent' => $data['theme']['color_accents'],
-        'brand-text-primary' => $data['theme']['color_link'],
+        'brand-primary'  => $data['theme']['color_primary'],
+        'brand-secondary'  => $data['theme']['color_secondary'],
+        'brand-accent'  => $data['theme']['color_accents'],
+        'brand-link'  => $data['theme']['color_link'],
+        'navbar-bg' => $data['theme']['navbar-bg'],
+        'navbar-text' => $data['theme']['navbar-text'],
+        'navbar-active-bg' => $data['theme']['navbar-active-bg'],
+        'navbar-active-text' => $data['theme']['navbar-active-text'],
+        'navbar-sec-bg' => $data['theme']['navbar-sec-bg'],
+        'navbar-sec-text' => $data['theme']['navbar-sec-text'],
       ];
 
       // Save the palette.


### PR DESCRIPTION
## Problem
When updating form OS 1.7 to 1.8 with custom colors in your DEFAULT theme. The colors are not migrated. This causes the new settingsform not to load any of the color fields.

## Solution
Migrate the settings in an update hook

## HTT
- [x] Check out the code changes
- [x] Install SaaS 1.12 (with open_social "1.7" and socialsaas "dev-master#bc7cc90")
- [x] Change colors in theme settings to some custom values
- [x] git checkout 1.13 (first checkout composer.lock)
- [x] set this PR as patch in composer.
- [x] run composer update and run the update.sh script.
- [x] See that the colors are now properly migrated and that there's a nice new preview.
