### PR TITLE
DS-4405 - Fix singular translation for amount of likes

### DIFF
--- a/themes/socialbase/templates/like/like-and-dislike-icons.html.twig
+++ b/themes/socialbase/templates/like/like-and-dislike-icons.html.twig
@@ -34,10 +34,10 @@
     <div class="vote__count">
       {% if logged_in %}
       <a class="use-ajax" data-dialog-options='{"title":"{{ modal_title }}","width":"auto"}' data-dialog-type="modal" href="/wholiked/{{ entity_type }}/{{ entity_id }}">
-        {% trans %}1 like {% plural likes %} {{ likes }} likes{% endtrans %}
+        {% trans %}{{ likes }} like {% plural likes %} {{ likes }} likes{% endtrans %}
       </a>
       {% else %}
-        {% trans %}1 like {% plural likes %} {{ likes }} likes{% endtrans %}
+        {% trans %}{{ likes }} like {% plural likes %} {{ likes }} likes{% endtrans %}
       {% endif %}
     </div>
   </div>


### PR DESCRIPTION
## Problem
When using Open Social in Dutch the like counter shows 1 like when there are 0 likes. 

## Solution
The main problem was that the plural-forms was not correct for the Dutch translation.

It was set to:
`"Plural-Forms: nplurals=2; plural=(n > 1);\n"`

And it should be:
`"Plural-Forms: nplurals=2; plural=(n != 1);\n"`

According to these specs: http://docs.translatehouse.org/projects/localization-guide/en/latest/l10n/pluralforms.html?id=l10n/pluralforms Also we should include the amount of likes in the singular translation to accommodate for languages wo use the plural=(n > 1) setting.

## Issue tracker
- DS-4405

## HTT
- [x] Check out the code changes
- [x] Add Dutch language and make that the default
- [ ] Add translation file for Dutch
- [x] Notice that the amount of likes is always shown correctly
