### PR TITLE
#2929953 Waves: JS errors in IE11 for menus

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,7 @@
                 "Email notification settings are not taken into account": "https://www.drupal.org/files/issues/2910537-2.patch"
             },
             "bower-asset/waves": {
-                "getWavesEffectElement iterates over parentElement - should use parentNode instead": "https://www.drupal.org/files/issues/2929953-waves-error-ie11-3.patch"
+                "getWavesEffectElement iterates over parentElement - should use parentNode instead": "https://www.drupal.org/files/issues/2929953-waves-error-ie11-5.patch"
             }
         }
     },


### PR DESCRIPTION
## Problem
Clicking on profile menu or plus button not working in IE11.

## Solution
in waves.js function getWavesEffectElement iterates over target.parentElement recursively. This leads to problems in IE11 SVG-Elements where parentElement is undefined. Changing this to target.parentNode works as expected in all browsers.

## Issue tracker
https://www.drupal.org/project/social/issues/2929953

## HTT
- [ ]  Check out the code changes
- [ ]  Composer update
- [ ]  Test in IE11
- [ ]  Login as chrishall
- [ ]  Click on plus icon or user profile (both in user menu). No errors should show in Inspector
