### PR TITLE
removed #pre_render

### DIFF
--- a/modules/custom/social_admin_menu/social_admin_menu.module
+++ b/modules/custom/social_admin_menu/social_admin_menu.module
@@ -11,36 +11,5 @@ use Drupal\Core\Menu\MenuTreeParameters;
  * Implements hook_toolbar_alter().
  */
 function social_admin_menu_toolbar_alter(&$items) {
-  $items['administration']['tray']['toolbar_administration']['#pre_render'] = ['social_admin_menu_prerender_toolbar_administration_tray'];
-}
-
-/**
- * Renders the toolbar's administration tray.
- *
- * This is a clone of core's toolbar_prerender_toolbar_administration_tray()
- * function, which uses setMaxDepth(4) instead of setTopLevelOnly()
- *
- * @param array $element
- *   A renderable array.
- *
- * @return array
- *   The updated renderable array.
- *
- * @see admin_toolbar_prerender_toolbar_administration_tray()
- */
-function social_admin_menu_prerender_toolbar_administration_tray(array $element) {
-  $menu_tree = \Drupal::service('toolbar.menu_tree');
-  $parameters = new MenuTreeParameters();
-  $parameters->setRoot('system.admin')->excludeRoot()->setMaxDepth(4)->onlyEnabledLinks();
-  $tree = $menu_tree->load(NULL, $parameters);
-  $manipulators = [
-    ['callable' => 'menu.default_tree_manipulators:checkAccess'],
-    ['callable' => 'menu.default_tree_manipulators:generateIndexAndSort'],
-    ['callable' => 'toolbar_tools_menu_navigation_links'],
-    ['callable' => 'social_admin_menu.administrator_menu_tree_manipulators:checkAccess'],
-  ];
-  $tree = $menu_tree->transform($tree, $manipulators);
-  $element['administration_menu'] = $menu_tree->build($tree);
-  $element['administration_menu']['#cache']['contexts'][] = 'user.roles';
-  return $element;
+  $items['administration']['tray']['toolbar_administration']['#lazy_builder'] = ['social_admin_menu.administrator_menu_tree_manipulators:renderForm',[]];
 }

--- a/modules/custom/social_admin_menu/social_admin_menu.module
+++ b/modules/custom/social_admin_menu/social_admin_menu.module
@@ -5,11 +5,9 @@
  * The Social Admin Menu module.
  */
 
-use Drupal\Core\Menu\MenuTreeParameters;
-
 /**
  * Implements hook_toolbar_alter().
  */
 function social_admin_menu_toolbar_alter(&$items) {
-  $items['administration']['tray']['toolbar_administration']['#lazy_builder'] = ['social_admin_menu.administrator_menu_tree_manipulators:renderForm',[]];
+  $items['administration']['tray']['toolbar_administration']['#lazy_builder'] = ['social_admin_menu.administrator_menu_tree_manipulators:renderForm', []];
 }

--- a/modules/custom/social_admin_menu/src/Menu/SocialAdminMenuAdministratorMenuLinkTreeManipulators.php
+++ b/modules/custom/social_admin_menu/src/Menu/SocialAdminMenuAdministratorMenuLinkTreeManipulators.php
@@ -98,33 +98,33 @@ class SocialAdminMenuAdministratorMenuLinkTreeManipulators extends DefaultMenuLi
     return $tree;
   }
 
-    /**
-     * Renders the toolbar's administration tray.
-     *
-     * This is a adoption of core's toolbar_prerender_toolbar_administration_tray()
-     * function, which uses setMaxDepth(4) instead of setTopLevelOnly()
-     *
-     * @param NULL
-     *
-     * @return array
-     *   The updated renderable array.
-     *
-     * @see admin_toolbar_prerender_toolbar_administration_tray()
-     */
+  /**
+   * Renders the toolbar's administration tray.
+   *
+   * This is a adoption of core's
+   * toolbar_prerender_toolbar_administration_tray() function,
+   * which uses setMaxDepth(4) instead of setTopLevelOnly()
+   *
+   * @return array
+   *   The updated renderable array.
+   *
+   * @see admin_toolbar_prerender_toolbar_administration_tray()
+   */
   public function renderForm() {
-      $menu_tree = \Drupal::service('toolbar.menu_tree');
-      $parameters = new MenuTreeParameters();
-      $parameters->setRoot('system.admin')->excludeRoot()->setMaxDepth(4)->onlyEnabledLinks();
-      $manipulators = [
-          ['callable' => 'menu.default_tree_manipulators:checkAccess'],
-          ['callable' => 'menu.default_tree_manipulators:generateIndexAndSort'],
-          ['callable' => 'toolbar_tools_menu_navigation_links'],
-          ['callable' => 'social_admin_menu.administrator_menu_tree_manipulators:checkAccess'],
-      ];
-      $tree = $menu_tree->load(NULL, $parameters);
-      $tree = $menu_tree->transform($tree, $manipulators);
-      $element['administration_menu'] = $menu_tree->build($tree);
-      $element['administration_menu']['#cache']['contexts'][] = 'user.roles';
-      return $element;
+    $menu_tree = \Drupal::service('toolbar.menu_tree');
+    $parameters = new MenuTreeParameters();
+    $parameters->setRoot('system.admin')->excludeRoot()->setMaxDepth(4)->onlyEnabledLinks();
+    $manipulators = [
+        ['callable' => 'menu.default_tree_manipulators:checkAccess'],
+        ['callable' => 'menu.default_tree_manipulators:generateIndexAndSort'],
+        ['callable' => 'toolbar_tools_menu_navigation_links'],
+        ['callable' => 'social_admin_menu.administrator_menu_tree_manipulators:checkAccess'],
+    ];
+    $tree = $menu_tree->load(NULL, $parameters);
+    $tree = $menu_tree->transform($tree, $manipulators);
+    $element['administration_menu'] = $menu_tree->build($tree);
+    $element['administration_menu']['#cache']['contexts'][] = 'user.roles';
+    return $element;
   }
+
 }

--- a/modules/custom/social_admin_menu/src/Menu/SocialAdminMenuAdministratorMenuLinkTreeManipulators.php
+++ b/modules/custom/social_admin_menu/src/Menu/SocialAdminMenuAdministratorMenuLinkTreeManipulators.php
@@ -3,6 +3,7 @@
 namespace Drupal\social_admin_menu\Menu;
 
 use Drupal\Core\Menu\DefaultMenuLinkTreeManipulators;
+use Drupal\Core\Menu\MenuTreeParameters;
 
 /**
  * Provides a couple of menu link tree manipulators.
@@ -97,4 +98,33 @@ class SocialAdminMenuAdministratorMenuLinkTreeManipulators extends DefaultMenuLi
     return $tree;
   }
 
+    /**
+     * Renders the toolbar's administration tray.
+     *
+     * This is a adoption of core's toolbar_prerender_toolbar_administration_tray()
+     * function, which uses setMaxDepth(4) instead of setTopLevelOnly()
+     *
+     * @param NULL
+     *
+     * @return array
+     *   The updated renderable array.
+     *
+     * @see admin_toolbar_prerender_toolbar_administration_tray()
+     */
+  public function renderForm() {
+      $menu_tree = \Drupal::service('toolbar.menu_tree');
+      $parameters = new MenuTreeParameters();
+      $parameters->setRoot('system.admin')->excludeRoot()->setMaxDepth(4)->onlyEnabledLinks();
+      $manipulators = [
+          ['callable' => 'menu.default_tree_manipulators:checkAccess'],
+          ['callable' => 'menu.default_tree_manipulators:generateIndexAndSort'],
+          ['callable' => 'toolbar_tools_menu_navigation_links'],
+          ['callable' => 'social_admin_menu.administrator_menu_tree_manipulators:checkAccess'],
+      ];
+      $tree = $menu_tree->load(NULL, $parameters);
+      $tree = $menu_tree->transform($tree, $manipulators);
+      $element['administration_menu'] = $menu_tree->build($tree);
+      $element['administration_menu']['#cache']['contexts'][] = 'user.roles';
+      return $element;
+  }
 }


### PR DESCRIPTION
## Problem
After update from 8.x-1.7 to 8.x-1.8 the social_admin_menu causes an error using #pre_render.

## Solution
Replaced #pre_render syntax with #lazy_builder

## Issue tracker
- https://www.drupal.org/project/social/issues/2930298

## HTT
- [x] Check out the code changes
- [x] Make sure social_admin_menu is enabled
- [x] login as Content Manager -> check Admin Toolbar (config, reports, help) should be removed
- [x] login as Site Manager -> check Admin Toolbar (help) should be removed
- [x] Uninstall the module -> Menu items should be visible to the roles above
