### PR TITLE
DS-4351 - As SM I want to be able to administer the tags on the platform.

### DIFF
--- a/modules/social_features/social_tagging/config/install/taxonomy.vocabulary.social_tagging.yml
+++ b/modules/social_features/social_tagging/config/install/taxonomy.vocabulary.social_tagging.yml
@@ -1,0 +1,8 @@
+langcode: en
+status: true
+dependencies: {  }
+name: 'Content tags'
+vid: social_tagging
+description: ''
+hierarchy: 0
+weight: 0

--- a/modules/social_features/social_tagging/config/install/taxonomy.vocabulary.social_tagging.yml
+++ b/modules/social_features/social_tagging/config/install/taxonomy.vocabulary.social_tagging.yml
@@ -3,6 +3,6 @@ status: true
 dependencies: {  }
 name: 'Content tags'
 vid: social_tagging
-description: ''
+description: 'Categories and terms for tagging nodes'
 hierarchy: 0
 weight: 0

--- a/modules/social_features/social_tagging/social_tagging.features.yml
+++ b/modules/social_features/social_tagging/social_tagging.features.yml
@@ -1,0 +1,2 @@
+bundle: social
+required: true

--- a/modules/social_features/social_tagging/social_tagging.info.yml
+++ b/modules/social_features/social_tagging/social_tagging.info.yml
@@ -1,0 +1,5 @@
+name: Social Tagging
+type: module
+description: Content tagging module
+core: 8.x
+package: social

--- a/modules/social_features/social_tagging/social_tagging.install
+++ b/modules/social_features/social_tagging/social_tagging.install
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * @file
+ * Installation file for Social Tagging.
+ */
+
+/**
+ * Install the module.
+ */
+function social_tagging_install() {
+  _social_tagging_set_defaults();
+}
+
+/**
+ * Function that sets the default configuration value(s) for this module.
+ */
+function _social_tagging_set_defaults() {
+  $permissions = [
+    'administer social_tagging',
+    'delete terms in social_tagging',
+    'edit terms in social_tagging',
+  ];
+
+  // Set allow to true, since that's the case by default.
+  \Drupal::getContainer()->get('config.factory')->getEditable('social_tagging.settings')->set('enable_content_tagging', 1)->save();
+  // SM should be able to change the permissions.
+  user_role_grant_permissions('sitemanager', $permissions);
+}

--- a/modules/social_features/social_tagging/social_tagging.links.menu.yml
+++ b/modules/social_features/social_tagging/social_tagging.links.menu.yml
@@ -1,0 +1,5 @@
+social_tagging.settings:
+  title: 'Tagging settings'
+  description: 'Administer settings for the social tagging module.'
+  parent: social_core.admin.config.social
+  route_name: social_tagging.settings

--- a/modules/social_features/social_tagging/social_tagging.module
+++ b/modules/social_features/social_tagging/social_tagging.module
@@ -21,6 +21,13 @@ function social_tagging_help($route_name, RouteMatchInterface $route_match) {
       $output .= '<p>' . t('Content tagging module') . '</p>';
       return $output;
 
+    case 'entity.taxonomy_vocabulary.overview_form':
+      /* @var \Drupal\taxonomy\Entity\Vocabulary $vocabulary */
+      $vocabulary = $route_match->getParameter('taxonomy_vocabulary');
+      if ($vocabulary->id() === 'social_tagging') {
+        return '<p><strong>' . t('Notice: Drag and drop has intentionally been disabled for this vocabulary.') . '</strong></p>';
+      }
+
     default:
   }
 }

--- a/modules/social_features/social_tagging/social_tagging.module
+++ b/modules/social_features/social_tagging/social_tagging.module
@@ -39,7 +39,6 @@ function social_tagging_form_taxonomy_term_social_tagging_form_alter(&$form, For
 
   // Make some changes.
   $form['weight']['#access'] = FALSE;
-  $form['parent']['#multiple'] = FALSE;
   $form['parent']['#title'] = t('Placement');
 
   // Load all taxonomy terms from the top level.

--- a/modules/social_features/social_tagging/social_tagging.module
+++ b/modules/social_features/social_tagging/social_tagging.module
@@ -70,8 +70,8 @@ function social_tagging_form_taxonomy_overview_terms_alter(&$form, FormStateInte
       unset($form['terms'][$name]['weight']);
     }
 
-    // Hide Save and Reset buttons.
-    $form['actions']['#access'] = FALSE;
+    // Hide Save button.
+    $form['actions']['submit']['#access'] = FALSE;
 
     // Remove tableDrag.
     unset($form['terms']['#tabledrag']);

--- a/modules/social_features/social_tagging/social_tagging.module
+++ b/modules/social_features/social_tagging/social_tagging.module
@@ -5,6 +5,7 @@
  * Contains social_tagging.module.
  */
 
+use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
 
 /**
@@ -21,4 +22,35 @@ function social_tagging_help($route_name, RouteMatchInterface $route_match) {
 
     default:
   }
+}
+
+/**
+ * Implements hook_form_FORM_ID_alter().
+ */
+function social_tagging_form_taxonomy_term_social_tagging_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+  // Remove these fields.
+  $form['path']['#access'] = FALSE;
+  $form['relations']['#access'] = FALSE;
+  $form['description']['#access'] = FALSE;
+
+  // Move it outside the details.
+  $form['parent'] = $form['relations']['parent'];
+  unset($form['relations']['parent']);
+
+  // Make some changes.
+  $form['weight']['#access'] = FALSE;
+  $form['parent']['#multiple'] = FALSE;
+  $form['parent']['#title'] = t('Placement');
+
+  // Load all taxonomy terms from the top level.
+  $tag_service = Drupal::getContainer()->get('social_tagging.terms');
+
+  // Fetch all top level items.
+  $options = $tag_service->getCategories();
+  // Add the 0 option for a new toplevel item.
+  $options[0] = t('Main category');
+  // Sort the array.
+  ksort($options);
+  // Add it to the select.
+  $form['parent']['#options'] = $options;
 }

--- a/modules/social_features/social_tagging/social_tagging.module
+++ b/modules/social_features/social_tagging/social_tagging.module
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * @file
+ * Contains social_tagging.module.
+ */
+
+use Drupal\Core\Routing\RouteMatchInterface;
+
+/**
+ * Implements hook_help().
+ */
+function social_tagging_help($route_name, RouteMatchInterface $route_match) {
+  switch ($route_name) {
+    // Main module help for the social_tagging module.
+    case 'help.page.social_tagging':
+      $output = '';
+      $output .= '<h3>' . t('About') . '</h3>';
+      $output .= '<p>' . t('Content tagging module') . '</p>';
+      return $output;
+
+    default:
+  }
+}

--- a/modules/social_features/social_tagging/social_tagging.module
+++ b/modules/social_features/social_tagging/social_tagging.module
@@ -7,6 +7,7 @@
 
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\Core\Render\Element;
 
 /**
  * Implements hook_help().
@@ -52,4 +53,31 @@ function social_tagging_form_taxonomy_term_social_tagging_form_alter(&$form, For
   ksort($options);
   // Add it to the select.
   $form['parent']['#options'] = $options;
+}
+
+/**
+ * Implements hook_form_FORM_ID_alter().
+ */
+function social_tagging_form_taxonomy_overview_terms_alter(&$form, FormStateInterface $form_state, $form_id) {
+
+  $storage = $form_state->getStorage();
+  /* @var \Drupal\taxonomy\Entity\Vocabulary $vocabulary */
+  $vocabulary = $storage['taxonomy']['vocabulary'];
+
+  if ($vocabulary->id() === 'social_tagging') {
+    // Remove edit/delete links.
+    foreach (Element::children($form['terms']) as $name) {
+      unset($form['terms'][$name]['weight']);
+    }
+
+    // Hide Save and Reset buttons.
+    $form['actions']['#access'] = FALSE;
+
+    // Remove tableDrag.
+    unset($form['terms']['#tabledrag']);
+
+    // Remove Weight column.
+    unset($form['terms']['#header'][1]);
+  }
+
 }

--- a/modules/social_features/social_tagging/social_tagging.permissions.yml
+++ b/modules/social_features/social_tagging/social_tagging.permissions.yml
@@ -1,0 +1,2 @@
+administer social_tagging:
+  title: 'Administer social tagging settings'

--- a/modules/social_features/social_tagging/social_tagging.routing.yml
+++ b/modules/social_features/social_tagging/social_tagging.routing.yml
@@ -1,0 +1,7 @@
+social_tagging.settings:
+  path: '/admin/config/opensocial/tagging-settings'
+  defaults:
+    _form: '\Drupal\social_tagging\Form\SocialTaggingSettingsForm'
+    _title: 'Tagging settings'
+  requirements:
+    _permission: 'administer social_tagging'

--- a/modules/social_features/social_tagging/social_tagging.services.yml
+++ b/modules/social_features/social_tagging/social_tagging.services.yml
@@ -1,0 +1,4 @@
+services:
+  social_tagging.terms:
+    class: Drupal\social_tagging\SocialTaggingService
+    arguments: ['@entity.manager']

--- a/modules/social_features/social_tagging/src/Form/SocialTaggingSettingsForm.php
+++ b/modules/social_features/social_tagging/src/Form/SocialTaggingSettingsForm.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Drupal\social_tagging\Form;
+
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
+use Drupal\Core\Extension\ModuleHandlerInterface;
+use Drupal\Core\Form\ConfigFormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Class SocialTaggingSettingsForm.
+ *
+ * @package Drupal\social_tagging\Form
+ */
+class SocialTaggingSettingsForm extends ConfigFormBase implements ContainerInjectionInterface {
+
+  /**
+   * The Module Handler.
+   *
+   * @var \Drupal\Core\Extension\ModuleHandlerInterface
+   */
+  protected $moduleHandler;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct(ConfigFactoryInterface $config_factory, ModuleHandlerInterface $moduleHandler) {
+    parent::__construct($config_factory);
+    $this->moduleHandler = $moduleHandler;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('config.factory'),
+      $container->get('module_handler')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'social_tagging_settings';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getEditableConfigNames() {
+    return ['social_tagging.settings'];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+
+    // Get the configuration file.
+    $config = $this->config('social_tagging.settings');
+
+    $form['enable_content_tagging'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Allow users to user tags in all node types.'),
+      '#default_value' => $config->get('enable_content_tagging'),
+      '#required' => FALSE,
+      '#description' => $this->t("Determine wether users are allowed tag content and to view tags in content."),
+    ];
+
+    return parent::buildForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+
+    // Get the configuration file.
+    $config = $this->config('social_tagging.settings');
+    $config->set('enable_content_tagging', $form_state->getValue('enable_content_tagging'))->save();
+
+    parent::submitForm($form, $form_state);
+  }
+
+}

--- a/modules/social_features/social_tagging/src/SocialTaggingService.php
+++ b/modules/social_features/social_tagging/src/SocialTaggingService.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Drupal\social_tagging;
+
+use Drupal\Core\Entity\EntityManagerInterface;
+
+/**
+ * Provides a custom tagging service.
+ */
+class SocialTaggingService {
+
+  /**
+   * The entity manager.
+   *
+   * @var \Drupal\Core\Entity\EntityManagerInterface
+   */
+  protected $entityManager;
+
+  /**
+   * The taxonomy storage.
+   *
+   * @var \Drupal\Taxonomy\TermStorageInterface
+   */
+  protected $termStorage;
+
+  /**
+   * SocialTaggingService constructor.
+   *
+   * @param \Drupal\Core\Entity\EntityManagerInterface $entityManager
+   *   Injection of the entitymanager.
+   *
+   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
+   */
+  public function __construct(EntityManagerInterface $entityManager) {
+    $this->entityManager = $entityManager;
+    $this->termStorage = $entityManager->getStorage('taxonomy_term');
+  }
+
+  /**
+   * Returns all the top level term items, that are considered categories.
+   *
+   * @return array
+   *   An array of top level category items.
+   */
+  public function getCategories() {
+    // Define as array.
+    $options = [];
+    // Fetch main categories.
+    foreach ($this->termStorage->loadTree('social_tagging', 0, 1) as $category) {
+      $options[$category->tid] = $category->name;
+    }
+    // Return array.
+    return $options;
+  }
+
+}


### PR DESCRIPTION
## Problem
This is a new feature

## Solution
Created a taxonomy where you can only go 2 levels deep (main items and sub items)

## Issue tracker
- https://jira.goalgorilla.com/browse/DS-4351

## HTT
- [x] Check out the code changes
- [x] Login as an admin and enable the social_tagging module
- [x] Notice you can administer the tags (structure > taxonomy)
- [x] Notice you can only go 1 level deep (main / sub)
- [x] Notice only the SM can administer these terms

- [x] Check the story and see the acceptance criteria are matched

- [x] Also try it in Saas and notice it works: (PR: [here](https://bitbucket.org/goalgorilla/saas/pull-requests/100))
