### PR TITLE
Issue #2932356 by alex.ksis: Allow to find and fill WYSIWYG editor by…

### DIFF
--- a/tests/behat/features/bootstrap/FeatureContext.php
+++ b/tests/behat/features/bootstrap/FeatureContext.php
@@ -78,8 +78,15 @@ class FeatureContext extends RawMinkContext implements Context, SnippetAccepting
     /**
      * @When /^I fill in the "([^"]*)" WYSIWYG editor with "([^"]*)"$/
      */
-    public function iFillInTheWysiwygEditor($instanceId, $text) {
-      $instance = $this->getWysiwygInstance($instanceId);
+    public function iFillInTheWysiwygEditor($locator, $text) {
+      $field = $this->getSession()->getPage()->findField($locator);
+
+      if (null === $field) {
+        throw new ElementNotFoundException($this->getDriver(), 'form field', 'id|name|label|value|placeholder', $locator);
+      }
+
+      $id = $field->getAttribute('id');
+      $instance = $this->getWysiwygInstance($id);
       $this->getSession()->executeScript("$instance.setData(\"$text\");");
     }
 


### PR DESCRIPTION
## Problem
If the textarea has a dynamic id, it is not possible to fill WYSIWYG editor.
Textarea elements have dynamic ids within paragraph forms.

## Solution
Use Mink extension to find the element by name, label, placeholder or id, then extract id attribute and use it to get the CKEditor instance.

## Issue tracker
- https://www.drupal.org/project/social/issues/2932356