### PR TITLE
2929208 - Migrate social_user_navigation.settings > social_user.navigation.settings

### DIFF
--- a/modules/social_features/social_user/social_user.install
+++ b/modules/social_features/social_user/social_user.install
@@ -53,7 +53,6 @@ function social_user_update_8002() {
   $config->set('display_my_groups_icon', 1)->save();
 }
 
-
 /**
  * Add permissions to view and block users for site manager role.
  */

--- a/modules/social_features/social_user/social_user.install
+++ b/modules/social_features/social_user/social_user.install
@@ -18,7 +18,7 @@ function social_user_install() {
 
   // Set default value for displaying navigation icons.
   /** @var \Drupal\Core\Config\Config|\Drupal\Core\Config\ImmutableConfig $config */
-  $config = \Drupal::getContainer()->get('config.factory')->getEditable('social_user_navigation.settings');
+  $config = \Drupal::getContainer()->get('config.factory')->getEditable('social_user.navigation.settings');
   $config->set('display_social_private_message_icon', 1)->save();
   $config->set('display_my_groups_icon', 1)->save();
 }
@@ -51,6 +51,27 @@ function social_user_update_8002() {
   $config = \Drupal::getContainer()->get('config.factory')->getEditable('social_user_navigation.settings');
   $config->set('display_social_private_message_icon', 1)->save();
   $config->set('display_my_groups_icon', 1)->save();
+}
+
+
+/**
+ * Add permissions to view and block users for site manager role.
+ */
+function social_user_update_8003() {
+  $permissions = _social_user_get_permissions('sitemanager');
+  user_role_grant_permissions('sitemanager', $permissions);
+}
+
+/**
+ * Migrate navigation settings into the correct format.
+ */
+function social_user_update_8004() {
+  $old_config = \Drupal::getContainer()->get('config.factory')->getEditable('social_user_navigation.settings');
+  $new_config = \Drupal::getContainer()->get('config.factory')->getEditable('social_user.navigation.settings');
+  // Store the values.
+  $new_config->setData($old_config->getRawData());
+  // Remove the old config altogether.
+  $old_config->delete();
 }
 
 /**
@@ -104,12 +125,4 @@ function _social_user_get_permissions($role) {
     return $permissions[$role];
   }
   return [];
-}
-
-/**
- * Add permissions to view and block users for site manager role.
- */
-function social_user_update_8003() {
-  $permissions = _social_user_get_permissions('sitemanager');
-  user_role_grant_permissions('sitemanager', $permissions);
 }

--- a/modules/social_features/social_user/src/Form/SocialUserNavigationSettingsForm.php
+++ b/modules/social_features/social_user/src/Form/SocialUserNavigationSettingsForm.php
@@ -52,7 +52,7 @@ class SocialUserNavigationSettingsForm extends ConfigFormBase implements Contain
    * {@inheritdoc}
    */
   protected function getEditableConfigNames() {
-    return ['social_user_navigation.settings'];
+    return ['social_user.navigation.settings'];
   }
 
   /**
@@ -61,7 +61,7 @@ class SocialUserNavigationSettingsForm extends ConfigFormBase implements Contain
   public function buildForm(array $form, FormStateInterface $form_state) {
 
     // Get the configuration file.
-    $config = $this->config('social_user_navigation.settings');
+    $config = $this->config('social_user.navigation.settings');
 
     $form['navigation_settings'] = [
       '#type' => 'fieldset',
@@ -99,7 +99,7 @@ class SocialUserNavigationSettingsForm extends ConfigFormBase implements Contain
   public function submitForm(array &$form, FormStateInterface $form_state) {
 
     // Get the configuration file.
-    $config = $this->config('social_user_navigation.settings');
+    $config = $this->config('social_user.navigation.settings');
     $config->set('display_social_private_message_icon', $form_state->getValue('display_social_private_message_icon'))
       ->set('display_my_groups_icon', $form_state->getValue('display_my_groups_icon'))
       ->save();

--- a/modules/social_features/social_user/src/Plugin/Block/AccountHeaderBlock.php
+++ b/modules/social_features/social_user/src/Plugin/Block/AccountHeaderBlock.php
@@ -110,7 +110,7 @@ class AccountHeaderBlock extends BlockBase implements ContainerFactoryPluginInte
    */
   public function build() {
     $account = $this->getContextValue('user');
-    $navigation_settings_config = $this->configFactory->get('social_user_navigation.settings');
+    $navigation_settings_config = $this->configFactory->get('social_user.navigation.settings');
 
     if ($account->id() !== 0) {
       $account_name = $account->getAccountName();


### PR DESCRIPTION
## Problem
Using CMI with Open Social caused the following error:
`The import failed due for the following reasons:                         [error]
Configuration <em
class="placeholder">social_user_navigation.settings</em> depends on
the <em class="placeholder">social_user_navigation</em> extension
that will not be installed after import.`

Reason is that this particular piece of configuration now thinks it's part of a module called 'social_user_navigation'. This module does not exist.

## Solution
Migrated settings from social_user_navigation to social_user.navigation. Now it's part of the social_user module.

## Issue tracker
- https://www.drupal.org/project/social/issues/2929208

## HTT
- [ ] Check out the code changes
- [ ] Use the CMI interface to export a setting, (I did it with the search index: social_content)
- [ ] Re-import that setting with a minor change (not uuid or config hash of course)
- [ ] Notice you get an error about the dependency social_user_navigation
- [ ] Try the same on this branch run the update script and notice it now works.
