### PR TITLE
2935632 Fail to build inline form for an entity with a field for controlling visibility

### DIFF
--- a/modules/custom/entity_access_by_field/entity_access_by_field.module
+++ b/modules/custom/entity_access_by_field/entity_access_by_field.module
@@ -197,6 +197,11 @@ function entity_access_by_field_field_widget_form_alter(&$element, FormStateInte
   // Set public visibility by default.
   $entity = $form_object->getEntity();
   $field_name = $field_definition->getName();
+
+  if (!$entity->hasField($field_name)) {
+    return;
+  }
+
   // Do not check if visibility already set and user has access to override
   // this option because SM can change the visibility.
   if (!$entity->get($field_name) || (!$entity->get($field_name)->isEmpty() && $account->hasPermission('override disabled public visibility'))) {


### PR DESCRIPTION
## Problem
Fail to build inline form for an entity with a field for controlling visibility.

## Solution
Check if a referenced entity has a field for controlling visibility.

## Issue tracker
https://www.drupal.org/project/social/issues/2935632

## HTT
- [x] Install [Inline Entity Form](https://drupal.org/project/inline_entity_form) module.
- [x] Add **Entity reference** field to open group and set **Inline entity form - Complex widget** for this field. This field should be referenced with some content type which has **Visibility** field (for example it can be **Topic** content type).
- [x] Go to the page for creating an open group.
- [x] When press **Add new node** then you shouldn't see inline form and you should see following log message:

> InvalidArgumentException: Field field_content_visibility is unknown. in Drupal\Core\Entity\ContentEntityBase->getTranslatedField() (line 509 of /var/www/html/core/lib/Drupal/Core/Entity/ContentEntityBase.php).
