### PR TITLE
DS-4637 - Use Landingpage as replacement of homepage

### DIFF
--- a/modules/custom/alternative_frontpage/alternative_frontpage.info.yml
+++ b/modules/custom/alternative_frontpage/alternative_frontpage.info.yml
@@ -1,0 +1,7 @@
+name: 'Alternative frontpage'
+description: 'Provides an alternative frontpage option for authenticated users via redirect.'
+type: module
+core: 8.x
+dependencies:
+  - drupal:system
+  - drupal:user

--- a/modules/custom/alternative_frontpage/alternative_frontpage.links.menu.yml
+++ b/modules/custom/alternative_frontpage/alternative_frontpage.links.menu.yml
@@ -1,0 +1,6 @@
+alternative_frontpage.settings:
+  title: 'Alternative Frontpage Settings'
+  route_name: alternative_frontpage.settings
+  description: 'Set an alternative frontpage for authenticated users.'
+  parent: system.admin_config_system
+  weight: 99

--- a/modules/custom/alternative_frontpage/alternative_frontpage.routing.yml
+++ b/modules/custom/alternative_frontpage/alternative_frontpage.routing.yml
@@ -1,0 +1,9 @@
+alternative_frontpage.settings:
+  path: '/admin/config/alternative_frontpage'
+  defaults:
+    _form: '\Drupal\alternative_frontpage\Form\AlternativeFrontpageSettings'
+    _title: 'Alternative Frontpage Settings'
+  requirements:
+    _permission: 'access administration pages'
+  options:
+    _admin_route: TRUE

--- a/modules/custom/alternative_frontpage/alternative_frontpage.services.yml
+++ b/modules/custom/alternative_frontpage/alternative_frontpage.services.yml
@@ -1,0 +1,6 @@
+services:
+  alternative_frontpage.redirect_homepage:
+    class: Drupal\alternative_frontpage\EventSubscriber\RedirectHomepageSubscriber
+    arguments: ['@user.data', '@config.factory', '@current_user', '@path.matcher']
+    tags:
+      - { name: event_subscriber }

--- a/modules/custom/alternative_frontpage/config/install/alternative_frontpage.alternativefrontpagesettings.yml
+++ b/modules/custom/alternative_frontpage/config/install/alternative_frontpage.alternativefrontpagesettings.yml
@@ -1,0 +1,1 @@
+alternative_frontpage:

--- a/modules/custom/alternative_frontpage/src/EventSubscriber/RedirectHomepageSubscriber.php
+++ b/modules/custom/alternative_frontpage/src/EventSubscriber/RedirectHomepageSubscriber.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Drupal\alternative_frontpage\EventSubscriber;
+
+use Drupal\Core\Path\PathMatcher;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\EventDispatcher\Event;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Drupal\user\UserData;
+use Drupal\Core\Session\AccountProxy;
+use Drupal\Core\Config\ConfigFactory;
+
+/**
+ * Class RedirectHomepageSubscriber.
+ */
+class RedirectHomepageSubscriber implements EventSubscriberInterface {
+
+  /**
+   * Protected var UserData.
+   *
+   * @var \Drupal\user\UserData
+   */
+  protected $userData;
+
+  /**
+   * Protected var ConfigFactory.
+   *
+   * @var \Drupal\Core\Config\ConfigFactory
+   */
+  protected $configFactory;
+
+  /**
+   * Protected var for the current user.
+   *
+   * @var \Drupal\Core\Session\AccountProxy
+   */
+  protected $currentUser;
+
+  /**
+   * Protected var for the path matcher.
+   *
+   * @var \Drupal\Core\Path\PathMatcher
+   */
+  protected $pathMatcher;
+
+  /**
+   * Constructor for the RedirectHomepageSubscriber.
+   */
+  public function __construct(UserData $user_data, ConfigFactory $config_factory, AccountProxy $current_user, PathMatcher $path_matcher) {
+    // We needs it.
+    $this->userData = $user_data;
+    $this->configFactory = $config_factory->get('alternative_frontpage.settings');
+    $this->currentUser = $current_user;
+    $this->pathMatcher = $path_matcher;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents() {
+    // 280 priority is higher than the dynamic and static page cache.
+    $events[KernelEvents::REQUEST][] = ['checkForHomepageRedirect'];
+    return $events;
+  }
+
+  /**
+   * This method is called whenever the request event is dispatched.
+   *
+   * @param \Symfony\Component\EventDispatcher\Event $event
+   *   Triggering event.
+   */
+  public function checkForHomepageRedirect(Event $event) {
+
+    // Make sure front page module is not run when using cli or doing install.
+    if (PHP_SAPI === 'cli' || drupal_installation_attempted()) {
+      return;
+    }
+    // Don't run when site is in maintenance mode.
+    if (\Drupal::state()->get('system.maintenance_mode')) {
+      return;
+    }
+
+    // Ignore non index.php requests (like cron).
+    if (!empty($_SERVER['SCRIPT_FILENAME']) && realpath(DRUPAL_ROOT . '/index.php') != realpath($_SERVER['SCRIPT_FILENAME'])) {
+      return;
+    }
+
+    $isFrontPage = $this->pathMatcher->isFrontPage();
+    if ($isFrontPage) {
+      // Get the current user.
+      $front_page = $this->configFactory->get('frontpage_for_authenticated_user');
+      if ($front_page && $this->currentUser->isAuthenticated()) {
+        $event->setResponse(new RedirectResponse($front_page));
+      }
+    }
+  }
+
+}

--- a/modules/custom/alternative_frontpage/src/EventSubscriber/RedirectHomepageSubscriber.php
+++ b/modules/custom/alternative_frontpage/src/EventSubscriber/RedirectHomepageSubscriber.php
@@ -69,7 +69,7 @@ class RedirectHomepageSubscriber implements EventSubscriberInterface {
    */
   public static function getSubscribedEvents() {
     // 280 priority is higher than the dynamic and static page cache.
-    $events[KernelEvents::REQUEST][] = ['checkForHomepageRedirect'];
+    $events[KernelEvents::REQUEST][] = ['checkForHomepageRedirect', '280'];
     return $events;
   }
 

--- a/modules/custom/alternative_frontpage/src/Form/AlternativeFrontpageSettings.php
+++ b/modules/custom/alternative_frontpage/src/Form/AlternativeFrontpageSettings.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Drupal\alternative_frontpage\Form;
+
+use Drupal\Core\Form\ConfigFormBase;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Class AlternativeFrontpageSettings.
+ */
+class AlternativeFrontpageSettings extends ConfigFormBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getEditableConfigNames() {
+    return [
+      'alternative_frontpage.settings',
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'alternative_frontpage_settings';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    $config = $this->config('alternative_frontpage.settings');
+    $site_config = $this->config('system.site');
+    $form['frontpage_for_anonymous_users'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Frontpage for anonymous users'),
+      '#description' => $this->t('Enter the frontpage for anonymous users. This setting will override the homepage which is set in the Site Configuration form.'),
+      '#maxlength' => 64,
+      '#size' => 64,
+      '#default_value' => $site_config->get('page.front'),
+    ];
+    $form['frontpage_for_authenticated_user'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Frontpage for authenticated users'),
+      '#description' => $this->t('Enter the frontpage for authenticated users. When the value is left empty it will use the anonymous homepage for authenticated users as well.'),
+      '#maxlength' => 64,
+      '#size' => 64,
+      '#default_value' => $config->get('frontpage_for_authenticated_user'),
+    ];
+    return parent::buildForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    parent::submitForm($form, $form_state);
+
+    $this->config('alternative_frontpage.settings')
+      ->set('frontpage_for_authenticated_user', $form_state->getValue('frontpage_for_authenticated_user'))
+      ->save();
+
+    $this->configFactory->getEditable('system.site')->set('page.front', $form_state->getValue('frontpage_for_anonymous_users'))->save();
+  }
+
+}

--- a/modules/custom/alternative_frontpage/src/Form/AlternativeFrontpageSettings.php
+++ b/modules/custom/alternative_frontpage/src/Form/AlternativeFrontpageSettings.php
@@ -2,13 +2,47 @@
 
 namespace Drupal\alternative_frontpage\Form;
 
+use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Form\ConfigFormBase;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Path\PathValidatorInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Class AlternativeFrontpageSettings.
  */
 class AlternativeFrontpageSettings extends ConfigFormBase {
+
+  /**
+   * Path validator.
+   *
+   * @var \Drupal\Core\Path\PathValidatorInterface
+   */
+  protected $pathValidator;
+
+  /**
+   * Class constructor.
+   *
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   The factory for configuration objects.
+   * @param \Drupal\Core\Path\PathValidatorInterface $path_validator
+   *   The factory for configuration objects.
+   */
+  public function __construct(ConfigFactoryInterface $config_factory, PathValidatorInterface $path_validator) {
+    parent::__construct($config_factory);
+    $this->pathValidator = $path_validator;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    // Instantiates this form class.
+    return new static(
+      $container->get('config.factory'),
+      $container->get('path.validator')
+    );
+  }
 
   /**
    * {@inheritdoc}
@@ -35,7 +69,7 @@ class AlternativeFrontpageSettings extends ConfigFormBase {
     $form['frontpage_for_anonymous_users'] = [
       '#type' => 'textfield',
       '#title' => $this->t('Frontpage for anonymous users'),
-      '#description' => $this->t('Enter the frontpage for anonymous users. This setting will override the homepage which is set in the Site Configuration form.'),
+      '#description' => $this->t('Enter the frontpage for anonymous users. This setting will override the homepage which is set in the Site Configuration form. Enter the path starting with a forward slash. Default: /stream.'),
       '#maxlength' => 64,
       '#size' => 64,
       '#default_value' => $site_config->get('page.front'),
@@ -43,12 +77,75 @@ class AlternativeFrontpageSettings extends ConfigFormBase {
     $form['frontpage_for_authenticated_user'] = [
       '#type' => 'textfield',
       '#title' => $this->t('Frontpage for authenticated users'),
-      '#description' => $this->t('Enter the frontpage for authenticated users. When the value is left empty it will use the anonymous homepage for authenticated users as well.'),
+      '#description' => $this->t('Enter the frontpage for authenticated users. When the value is left empty it will use the anonymous homepage for authenticated users as well. Enter the path starting with a forward slash. Default: /stream.'),
       '#maxlength' => 64,
       '#size' => 64,
       '#default_value' => $config->get('frontpage_for_authenticated_user'),
     ];
     return parent::buildForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function validateForm(array &$form, FormStateInterface $form_state) {
+    $frontpage_for_anonymous_user = $form_state->getValue('frontpage_for_anonymous_users');
+    $frontpage_for_authenticated_user = $form_state->getValue('frontpage_for_authenticated_user');
+
+    if ($frontpage_for_anonymous_user) {
+      if (!$this->pathValidator->getUrlIfValidWithoutAccessCheck($frontpage_for_anonymous_user)) {
+        $form_state->setErrorByName('frontpage_for_anonymous_users', $this->t('The path for the anonymous frontpage is not valid.'));
+      }
+      elseif (substr($frontpage_for_anonymous_user, 0, 1) !== '/') {
+        $form_state->setErrorByName('frontpage_for_anonymous_users', $this->t('The path for the anonymous frontpage should start with a forward slash.'));
+      }
+      elseif (!$this->isAllowedPath($frontpage_for_anonymous_user)) {
+        $form_state->setErrorByName('frontpage_for_anonymous_users', $this->t('The path for the anonymous frontpage is not allowed.'));
+      }
+    }
+    else {
+      $form_state->setErrorByName('frontpage_for_anonymous_users', $this->t('The path for the anonymous frontpage cannot be empty.'));
+    }
+    if ($frontpage_for_authenticated_user) {
+      if (!$this->pathValidator->getUrlIfValidWithoutAccessCheck($frontpage_for_authenticated_user)) {
+        $form_state->setErrorByName('frontpage_for_authenticated_user', $this->t('The path for the authenticated frontpage is not valid.'));
+      }
+      elseif (substr($frontpage_for_authenticated_user, 0, 1) !== '/') {
+        $form_state->setErrorByName('frontpage_for_authenticated_user', $this->t('The path for the authenticated frontpage should start with a forward slash.'));
+      }
+      elseif (!$this->isAllowedPath($frontpage_for_authenticated_user)) {
+        $form_state->setErrorByName('frontpage_for_authenticated_user', $this->t('The path for the authenticated frontpage is not allowed.'));
+      }
+    }
+  }
+
+  /**
+   * Checks if a path is allowed.
+   *
+   * Some paths are not allowed, e.g.:
+   *  - /user/login?destination=
+   *  - /user/login
+   *  - /user
+   *  - /user/register/
+   *
+   * @param string $path
+   *   Path to check.
+   *
+   * @return bool
+   *   Returns true when path is allowed.
+   */
+  private function isAllowedPath($path) {
+    $unallowed_paths = [
+      '/user/login',
+      '/user/register',
+      '/user',
+    ];
+    foreach ($unallowed_paths as $unallowed_path) {
+      if ($unallowed_path === substr($path, 0, strlen($unallowed_path))) {
+        return FALSE;
+      }
+    }
+    return TRUE;
   }
 
   /**

--- a/modules/custom/alternative_frontpage/src/Form/AlternativeFrontpageSettings.php
+++ b/modules/custom/alternative_frontpage/src/Form/AlternativeFrontpageSettings.php
@@ -122,11 +122,7 @@ class AlternativeFrontpageSettings extends ConfigFormBase {
   /**
    * Checks if a path is allowed.
    *
-   * Some paths are not allowed, e.g.:
-   *  - /user/login?destination=
-   *  - /user/login
-   *  - /user
-   *  - /user/register/
+   * Some paths are not allowed, e.g. /user/logout or /ajax.
    *
    * @param string $path
    *   Path to check.
@@ -136,9 +132,8 @@ class AlternativeFrontpageSettings extends ConfigFormBase {
    */
   private function isAllowedPath($path) {
     $unallowed_paths = [
-      '/user/login',
-      '/user/register',
-      '/user',
+      '/user/logout',
+      '/ajax',
     ];
     foreach ($unallowed_paths as $unallowed_path) {
       if ($unallowed_path === substr($path, 0, strlen($unallowed_path))) {

--- a/modules/social_features/social_activity/config/install/views.view.activity_stream.yml
+++ b/modules/social_features/social_activity/config/install/views.view.activity_stream.yml
@@ -7,6 +7,7 @@ dependencies:
     - activity_creator
     - activity_viewer
     - options
+    - social_post
 id: activity_stream
 label: 'Activity Stream'
 module: views
@@ -216,19 +217,16 @@ display:
           plugin_id: date
       title: Stream
       header:
-        entity_block:
-          id: entity_block
+        post_form:
+          id: post_form
           table: views
-          field: entity_block
+          field: post_form
           relationship: none
           group_type: group
-          admin_label: header_postblock
+          admin_label: ''
           empty: true
-          tokenize: false
-          target: postblock
-          view_mode: default
-          bypass_access: false
-          plugin_id: entity
+          block_id: post_block
+          plugin_id: social_post_post_form
       defaults:
         header: false
       footer: {  }
@@ -247,9 +245,9 @@ display:
         - 'languages:language_interface'
         - url.query_args
       tags:
+        - 'config:core.entity_view_display.activity.activity.notification_archive'
         - 'config:core.entity_view_display.activity.activity.default'
         - 'config:core.entity_view_display.activity.activity.notification'
-        - 'config:core.entity_view_display.activity.activity.notification_archive'
   block_stream_homepage:
     display_plugin: block
     id: block_stream_homepage

--- a/modules/social_features/social_activity/config/install/views.view.activity_stream.yml
+++ b/modules/social_features/social_activity/config/install/views.view.activity_stream.yml
@@ -245,9 +245,9 @@ display:
         - 'languages:language_interface'
         - url.query_args
       tags:
-        - 'config:core.entity_view_display.activity.activity.notification_archive'
         - 'config:core.entity_view_display.activity.activity.default'
         - 'config:core.entity_view_display.activity.activity.notification'
+        - 'config:core.entity_view_display.activity.activity.notification_archive'
   block_stream_homepage:
     display_plugin: block
     id: block_stream_homepage

--- a/modules/social_features/social_landing_page/config/install/core.entity_view_display.node.event.featured.yml
+++ b/modules/social_features/social_landing_page/config/install/core.entity_view_display.node.event.featured.yml
@@ -71,6 +71,14 @@ content:
       link: true
     third_party_settings: {  }
     type: entity_reference_label
+  groups_type_public_group:
+    label: above
+    weight: -5
+    region: content
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
 hidden:
   body: true
   field_content_visibility: true

--- a/modules/social_features/social_landing_page/config/install/core.entity_view_display.node.landing_page.default.yml
+++ b/modules/social_features/social_landing_page/config/install/core.entity_view_display.node.landing_page.default.yml
@@ -2,6 +2,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.node.landing_page.field_content_visibility
     - field.field.node.landing_page.field_landing_page_section
     - node.type.landing_page
   module:
@@ -50,9 +51,18 @@ content:
       link: true
     third_party_settings: {  }
     type: entity_reference_label
+  groups_type_public_group:
+    label: above
+    weight: -5
+    region: content
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
   links:
     weight: 100
     region: content
     settings: {  }
     third_party_settings: {  }
-hidden: {  }
+hidden:
+  field_content_visibility: true

--- a/modules/social_features/social_landing_page/config/install/core.entity_view_display.node.landing_page.teaser.yml
+++ b/modules/social_features/social_landing_page/config/install/core.entity_view_display.node.landing_page.teaser.yml
@@ -3,6 +3,7 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.node.teaser
+    - field.field.node.landing_page.field_content_visibility
     - field.field.node.landing_page.field_landing_page_section
     - node.type.landing_page
   module:
@@ -39,8 +40,17 @@ content:
       link: true
     third_party_settings: {  }
     type: entity_reference_label
+  groups_type_public_group:
+    label: above
+    weight: -5
+    region: content
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
   links:
     weight: 100
     region: content
 hidden:
+  field_content_visibility: true
   field_landing_page_section: true

--- a/modules/social_features/social_landing_page/config/install/core.entity_view_display.node.topic.featured.yml
+++ b/modules/social_features/social_landing_page/config/install/core.entity_view_display.node.topic.featured.yml
@@ -60,6 +60,14 @@ content:
       link: true
     third_party_settings: {  }
     type: entity_reference_label
+  groups_type_public_group:
+    label: above
+    weight: -5
+    region: content
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
 hidden:
   body: true
   field_content_visibility: true

--- a/modules/social_features/social_landing_page/config/install/field.field.node.landing_page.field_content_visibility.yml
+++ b/modules/social_features/social_landing_page/config/install/field.field.node.landing_page.field_content_visibility.yml
@@ -3,10 +3,10 @@ status: true
 dependencies:
   config:
     - field.storage.node.field_content_visibility
-    - node.type.topic
+    - node.type.landing_page
   module:
     - entity_access_by_field
-id: node.topic.field_content_visibility
+id: node.landing_page.field_content_visibility
 field_name: field_content_visibility
 entity_type: node
 bundle: landing_page

--- a/modules/social_features/social_landing_page/config/install/field.field.paragraph.block.field_block_reference.yml
+++ b/modules/social_features/social_landing_page/config/install/field.field.paragraph.block.field_block_reference.yml
@@ -18,5 +18,7 @@ default_value: {  }
 default_value_callback: ''
 settings:
   plugin_ids:
+    'views_block:activity_stream-block_stream_homepage': 'views_block:activity_stream-block_stream_homepage'
     'views_block:community_activities-block_stream_landing': 'views_block:community_activities-block_stream_landing'
+    activity_overview_block: activity_overview_block
 field_type: block_field

--- a/modules/social_features/social_landing_page/config/install/field.field.paragraph.block.field_block_reference_secondary.yml
+++ b/modules/social_features/social_landing_page/config/install/field.field.paragraph.block.field_block_reference_secondary.yml
@@ -18,11 +18,9 @@ default_value: {  }
 default_value_callback: ''
 settings:
   plugin_ids:
-    'views_block:latest_topics-group_topics_block': 'views_block:latest_topics-group_topics_block'
+    'views_block:upcoming_events-block_community_events': 'views_block:upcoming_events-block_community_events'
     'views_block:latest_topics-block_latest_topics': 'views_block:latest_topics-block_latest_topics'
     'views_block:newest_groups-block_newest_groups': 'views_block:newest_groups-block_newest_groups'
     'views_block:newest_users-block_newest_users': 'views_block:newest_users-block_newest_users'
-    'views_block:topics-block_user_topics': 'views_block:topics-block_user_topics'
-    'views_block:upcoming_events-upcoming_events_group': 'views_block:upcoming_events-upcoming_events_group'
     activity_overview_block: activity_overview_block
 field_type: block_field

--- a/modules/social_features/social_landing_page/config/install/field.storage.paragraph.field_block_reference.yml
+++ b/modules/social_features/social_landing_page/config/install/field.storage.paragraph.field_block_reference.yml
@@ -11,7 +11,7 @@ type: block_field
 settings: {  }
 module: block_field
 locked: false
-cardinality: 1
+cardinality: -1
 translatable: true
 indexes: {  }
 persist_with_no_fields: false

--- a/modules/social_features/social_landing_page/config/install/field.storage.paragraph.field_block_reference_secondary.yml
+++ b/modules/social_features/social_landing_page/config/install/field.storage.paragraph.field_block_reference_secondary.yml
@@ -11,7 +11,7 @@ type: block_field
 settings: {  }
 module: block_field
 locked: false
-cardinality: 1
+cardinality: -1
 translatable: true
 indexes: {  }
 persist_with_no_fields: false

--- a/modules/social_features/social_landing_page/config/install/views.view.community_activities.yml
+++ b/modules/social_features/social_landing_page/config/install/views.view.community_activities.yml
@@ -236,9 +236,9 @@ display:
       contexts:
         - 'languages:language_interface'
       tags:
+        - 'config:core.entity_view_display.activity.activity.notification_archive'
         - 'config:core.entity_view_display.activity.activity.default'
         - 'config:core.entity_view_display.activity.activity.notification'
-        - 'config:core.entity_view_display.activity.activity.notification_archive'
   block_stream_landing:
     display_plugin: block
     id: block_stream_landing

--- a/modules/social_features/social_landing_page/config/install/views.view.community_activities.yml
+++ b/modules/social_features/social_landing_page/config/install/views.view.community_activities.yml
@@ -236,9 +236,9 @@ display:
       contexts:
         - 'languages:language_interface'
       tags:
-        - 'config:core.entity_view_display.activity.activity.notification_archive'
         - 'config:core.entity_view_display.activity.activity.default'
         - 'config:core.entity_view_display.activity.activity.notification'
+        - 'config:core.entity_view_display.activity.activity.notification_archive'
   block_stream_landing:
     display_plugin: block
     id: block_stream_landing

--- a/modules/social_features/social_post/modules/social_post_photo/src/Plugin/Block/PostPhotoBlock.php
+++ b/modules/social_features/social_post/modules/social_post_photo/src/Plugin/Block/PostPhotoBlock.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\social_post_photo\Plugin\Block;
 
+use Drupal\Core\Extension\ModuleHandler;
 use Drupal\social_post\Plugin\Block\PostBlock;
 
 /**
@@ -14,34 +15,11 @@ use Drupal\social_post\Plugin\Block\PostBlock;
  */
 class PostPhotoBlock extends PostBlock {
 
-  public $bundle;
-
-  /**
-   * The entity type manager.
-   *
-   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
-   */
-  protected $entityTypeManager;
-
-  /**
-   * The current user.
-   *
-   * @var \Drupal\Core\Session\AccountProxy
-   */
-  protected $currentUser;
-
-  /**
-   * The form builder.
-   *
-   * @var \Drupal\Core\Form\FormBuilderInterface
-   */
-  protected $formBuilder;
-
   /**
    * {@inheritdoc}
    */
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, $entityTypeManager, $currentUser, $formBuilder) {
-    parent::__construct($configuration, $plugin_id, $plugin_definition, $entityTypeManager, $currentUser, $formBuilder);
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, $entityTypeManager, $currentUser, $formBuilder, ModuleHandler $moduleHandler) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition, $entityTypeManager, $currentUser, $formBuilder, $moduleHandler);
     // Override the bundle type.
     $this->bundle = 'photo';
   }

--- a/modules/social_features/social_post/modules/social_post_photo/src/Plugin/Block/PostPhotoGroupBlock.php
+++ b/modules/social_features/social_post/modules/social_post_photo/src/Plugin/Block/PostPhotoGroupBlock.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\social_post_photo\Plugin\Block;
 
+use Drupal\Core\Extension\ModuleHandler;
 use Drupal\social_post\Plugin\Block\PostGroupBlock;
 
 /**
@@ -14,34 +15,11 @@ use Drupal\social_post\Plugin\Block\PostGroupBlock;
  */
 class PostPhotoGroupBlock extends PostGroupBlock {
 
-  public $bundle;
-
-  /**
-   * The entity type manager.
-   *
-   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
-   */
-  protected $entityTypeManager;
-
-  /**
-   * The current user.
-   *
-   * @var \Drupal\Core\Session\AccountProxy
-   */
-  protected $currentUser;
-
-  /**
-   * The form builder.
-   *
-   * @var \Drupal\Core\Form\FormBuilderInterface
-   */
-  protected $formBuilder;
-
   /**
    * {@inheritdoc}
    */
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, $entityTypeManager, $currentUser, $formBuilder) {
-    parent::__construct($configuration, $plugin_id, $plugin_definition, $entityTypeManager, $currentUser, $formBuilder);
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, $entityTypeManager, $currentUser, $formBuilder, ModuleHandler $moduleHandler) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition, $entityTypeManager, $currentUser, $formBuilder, $moduleHandler);
     // Override the bundle type.
     $this->bundle = 'photo';
   }

--- a/modules/social_features/social_post/modules/social_post_photo/src/Plugin/Block/PostPhotoProfileBlock.php
+++ b/modules/social_features/social_post/modules/social_post_photo/src/Plugin/Block/PostPhotoProfileBlock.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\social_post_photo\Plugin\Block;
 
+use Drupal\Core\Extension\ModuleHandler;
 use Drupal\social_post\Plugin\Block\PostProfileBlock;
 
 /**
@@ -14,34 +15,11 @@ use Drupal\social_post\Plugin\Block\PostProfileBlock;
  */
 class PostPhotoProfileBlock extends PostProfileBlock {
 
-  public $bundle;
-
-  /**
-   * The entity type manager.
-   *
-   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
-   */
-  protected $entityTypeManager;
-
-  /**
-   * The current user.
-   *
-   * @var \Drupal\Core\Session\AccountProxy
-   */
-  protected $currentUser;
-
-  /**
-   * The form builder.
-   *
-   * @var \Drupal\Core\Form\FormBuilderInterface
-   */
-  protected $formBuilder;
-
   /**
    * {@inheritdoc}
    */
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, $entityTypeManager, $currentUser, $formBuilder) {
-    parent::__construct($configuration, $plugin_id, $plugin_definition, $entityTypeManager, $currentUser, $formBuilder);
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, $entityTypeManager, $currentUser, $formBuilder, ModuleHandler $moduleHandler) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition, $entityTypeManager, $currentUser, $formBuilder, $moduleHandler);
     // Override the bundle type.
     $this->bundle = 'photo';
   }

--- a/modules/social_features/social_post/social_post.views.inc
+++ b/modules/social_features/social_post/social_post.views.inc
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @file
  * Provide views data for social_post module.

--- a/modules/social_features/social_post/social_post.views.inc
+++ b/modules/social_features/social_post/social_post.views.inc
@@ -1,0 +1,20 @@
+<?php
+/**
+ * @file
+ * Provide views data for social_post module.
+ */
+
+/**
+ * Implements hook_views_data().
+ */
+function social_post_views_data() {
+  $data = [];
+  $data['views']['post_form'] = [
+    'title' => t('Sitewide Post form'),
+    'help' => t('Adds a sitewide post form.'),
+    'area' => [
+      'id' => 'social_post_post_form',
+    ],
+  ];
+  return $data;
+}

--- a/modules/social_features/social_post/src/Plugin/Block/PostBlock.php
+++ b/modules/social_features/social_post/src/Plugin/Block/PostBlock.php
@@ -4,6 +4,7 @@ namespace Drupal\social_post\Plugin\Block;
 
 use Drupal\Core\Block\BlockBase;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Extension\ModuleHandler;
 use Drupal\Core\Form\FormBuilderInterface;
 use Drupal\Core\Form\FormState;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
@@ -48,9 +49,16 @@ class PostBlock extends BlockBase implements ContainerFactoryPluginInterface {
   protected $formBuilder;
 
   /**
+   * Module handler.
+   *
+   * @var \Drupal\Core\Extension\ModuleHandler
+   */
+  protected $moduleHandler;
+
+  /**
    * {@inheritdoc}
    */
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entityTypeManager, AccountProxy $currentUser, FormBuilderInterface $formBuilder) {
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entityTypeManager, AccountProxy $currentUser, FormBuilderInterface $formBuilder, ModuleHandler $moduleHandler) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
     $this->entityType = 'post';
     $this->bundle = 'post';
@@ -58,6 +66,10 @@ class PostBlock extends BlockBase implements ContainerFactoryPluginInterface {
     $this->entityTypeManager = $entityTypeManager;
     $this->currentUser = $currentUser;
     $this->formBuilder = $formBuilder;
+    $this->moduleHandler = $moduleHandler;
+    if ($moduleHandler->moduleExists('social_post_photo')){
+      $this->bundle = 'photo';
+    }
   }
 
   /**
@@ -70,7 +82,8 @@ class PostBlock extends BlockBase implements ContainerFactoryPluginInterface {
       $plugin_definition,
       $container->get('entity_type.manager'),
       $container->get('current_user'),
-      $container->get('form_builder')
+      $container->get('form_builder'),
+      $container->get('module_handler')
     );
   }
 

--- a/modules/social_features/social_post/src/Plugin/Block/PostBlock.php
+++ b/modules/social_features/social_post/src/Plugin/Block/PostBlock.php
@@ -67,7 +67,7 @@ class PostBlock extends BlockBase implements ContainerFactoryPluginInterface {
     $this->currentUser = $currentUser;
     $this->formBuilder = $formBuilder;
     $this->moduleHandler = $moduleHandler;
-    if ($moduleHandler->moduleExists('social_post_photo')){
+    if ($moduleHandler->moduleExists('social_post_photo')) {
       $this->bundle = 'photo';
     }
   }

--- a/modules/social_features/social_post/src/Plugin/Block/PostGroupBlock.php
+++ b/modules/social_features/social_post/src/Plugin/Block/PostGroupBlock.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\social_post\Plugin\Block;
 
+use Drupal\Core\Extension\ModuleHandler;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\Access\AccessResult;
 
@@ -15,36 +16,11 @@ use Drupal\Core\Access\AccessResult;
  */
 class PostGroupBlock extends PostBlock {
 
-  public $entityType;
-  public $bundle;
-  public $formDisplay;
-
-  /**
-   * The entity type manager.
-   *
-   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
-   */
-  protected $entityTypeManager;
-
-  /**
-   * The current user.
-   *
-   * @var \Drupal\Core\Session\AccountProxy
-   */
-  protected $currentUser;
-
-  /**
-   * The form builder.
-   *
-   * @var \Drupal\Core\Form\FormBuilderInterface
-   */
-  protected $formBuilder;
-
   /**
    * {@inheritdoc}
    */
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, $entityTypeManager, $currentUser, $formBuilder) {
-    parent::__construct($configuration, $plugin_id, $plugin_definition, $entityTypeManager, $currentUser, $formBuilder);
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, $entityTypeManager, $currentUser, $formBuilder, ModuleHandler $moduleHandler) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition, $entityTypeManager, $currentUser, $formBuilder, $moduleHandler);
     $this->entityType = 'post';
     $this->bundle = 'post';
     $this->formDisplay = 'group';

--- a/modules/social_features/social_post/src/Plugin/Block/PostProfileBlock.php
+++ b/modules/social_features/social_post/src/Plugin/Block/PostProfileBlock.php
@@ -2,6 +2,8 @@
 
 namespace Drupal\social_post\Plugin\Block;
 
+use Drupal\Core\Extension\ModuleHandler;
+
 /**
  * Provides a 'PostProfileBlock' block.
  *
@@ -12,36 +14,11 @@ namespace Drupal\social_post\Plugin\Block;
  */
 class PostProfileBlock extends PostBlock {
 
-  public $entityType;
-  public $bundle;
-  public $formDisplay;
-
-  /**
-   * The entity type manager.
-   *
-   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
-   */
-  protected $entityTypeManager;
-
-  /**
-   * The current user.
-   *
-   * @var \Drupal\Core\Session\AccountProxy
-   */
-  protected $currentUser;
-
-  /**
-   * The form builder.
-   *
-   * @var \Drupal\Core\Form\FormBuilderInterface
-   */
-  protected $formBuilder;
-
   /**
    * {@inheritdoc}
    */
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, $entityTypeManager, $currentUser, $formBuilder) {
-    parent::__construct($configuration, $plugin_id, $plugin_definition, $entityTypeManager, $currentUser, $formBuilder);
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, $entityTypeManager, $currentUser, $formBuilder, ModuleHandler $moduleHandler) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition, $entityTypeManager, $currentUser, $formBuilder, $moduleHandler);
     $this->entityType = 'post';
     $this->bundle = 'post';
     $this->formDisplay = 'profile';

--- a/modules/social_features/social_post/src/Plugin/views/area/SocialPostPostForm.php
+++ b/modules/social_features/social_post/src/Plugin/views/area/SocialPostPostForm.php
@@ -1,7 +1,4 @@
 <?php
-/**
- * @file
- */
 
 namespace Drupal\social_post\Plugin\views\area;
 
@@ -163,4 +160,5 @@ class SocialPostPostForm extends AreaPluginBase {
 
     return $block_instance;
   }
+
 }

--- a/modules/social_features/social_post/src/Plugin/views/area/SocialPostPostForm.php
+++ b/modules/social_features/social_post/src/Plugin/views/area/SocialPostPostForm.php
@@ -1,0 +1,166 @@
+<?php
+/**
+ * @file
+ */
+
+namespace Drupal\social_post\Plugin\views\area;
+
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\views\Plugin\views\area\AreaPluginBase;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Drupal\Core\Block\BlockManagerInterface;
+
+/**
+ * Provides an area handler which renders a block entity in a certain view mode.
+ *
+ * TODO Replace with code from views_block_area when module is ported.
+ *
+ * @ingroup views_area_handlers
+ *
+ * @ViewsArea("social_post_post_form")
+ */
+class SocialPostPostForm extends AreaPluginBase {
+
+  /**
+   * The block plugin manager.
+   *
+   * @var \Drupal\Core\Block\BlockManagerInterface
+   */
+  protected $blockManager;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static($configuration, $plugin_id, $plugin_definition, $container->get('plugin.manager.block'));
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, BlockManagerInterface $block_manager) {
+    $this->blockManager = $block_manager;
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function defineOptions() {
+    $options = parent::defineOptions();
+
+    $options['block_id'] = ['default' => 'post_photo_block'];
+
+    return $options;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildOptionsForm(&$form, FormStateInterface $form_state) {
+    parent::buildOptionsForm($form, $form_state);
+
+    $options = [];
+    /** @var \Drupal\block_field\BlockFieldManagerInterface $block_field_manager */
+    $definitions = $this->getBlockDefinitions();
+    foreach ($definitions as $id => $definition) {
+      // If allowed plugin ids are set then check that this block should be
+      // included.
+      $category = (string) $definition['category'];
+      $options[$category][$id] = $definition['admin_label'];
+    }
+
+    $form['block_id'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Block'),
+      '#options' => $options,
+      '#empty_option' => $this->t('Please select'),
+      '#default_value' => $this->options['block_id'],
+    ];
+  }
+
+  /**
+   * Get sorted listed of supported block definitions.
+   *
+   * @return array
+   *   An associative array of supported block definitions.
+   */
+  protected function getBlockDefinitions() {
+    $definitions = $this->blockManager->getSortedDefinitions();
+    $block_definitions = [];
+    foreach ($definitions as $plugin_id => $definition) {
+      // Context aware plugins are not currently supported.
+      // Core and component plugins can be context-aware
+      // https://www.drupal.org/node/1938688
+      // @see \Drupal\ctools\Plugin\Block\EntityView
+      if (isset($definition['context'])) {
+        continue;
+      }
+
+      $block_definitions[$plugin_id] = $definition;
+    }
+    return $block_definitions;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function render($empty = FALSE) {
+
+    /** @var \Drupal\block_field\BlockFieldItemInterface $item */
+    $block_instance = $this->getBlock();
+    // Make sure the block exists and is accessible.
+    if (!$block_instance || !$block_instance->access(\Drupal::currentUser())) {
+      return NULL;
+    }
+
+    // @see \Drupal\block\BlockViewBuilder::buildPreRenderableBlock
+    // @see template_preprocess_block()
+    $element = [
+      '#theme' => 'block',
+      '#attributes' => [],
+      '#configuration' => $block_instance->getConfiguration(),
+      '#plugin_id' => $block_instance->getPluginId(),
+      '#base_plugin_id' => $block_instance->getBaseId(),
+      '#derivative_plugin_id' => $block_instance->getDerivativeId(),
+      '#id' => $block_instance->getPluginId(),
+      'content' => $block_instance->build(),
+    ];
+    /** @var \Drupal\Core\Render\RendererInterface $renderer */
+    $renderer = \Drupal::service('renderer');
+    $renderer->addCacheableDependency($element, $block_instance);
+    return $element;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getBlock() {
+    if (empty($this->options['block_id'])) {
+      return NULL;
+    }
+
+    /** @var \Drupal\Core\Block\BlockManagerInterface $block_manager */
+    $block_manager = \Drupal::service('plugin.manager.block');
+
+    /** @var \Drupal\Core\Block\BlockPluginInterface $block_instance */
+    $block_instance = $block_manager->createInstance($this->options['block_id'], []);
+
+    $plugin_definition = $block_instance->getPluginDefinition();
+
+    // Don't return broken block plugin instances.
+    if ($plugin_definition['id'] == 'broken') {
+      return NULL;
+    }
+
+    // Don't return broken block content instances.
+    if ($plugin_definition['id'] == 'block_content') {
+      $uuid = $block_instance->getDerivativeId();
+      if (!\Drupal::entityManager()->loadEntityByUuid('block_content', $uuid)) {
+        return NULL;
+      }
+    }
+
+    return $block_instance;
+  }
+}

--- a/social.info.yml
+++ b/social.info.yml
@@ -2,7 +2,7 @@ name: Social
 type: profile
 description: 'Open Social install profile.'
 core: '8.x'
-version: '8.x-1.8'
+version: '8.x-1.9'
 project: social
 
 dependencies:

--- a/tests/behat/features/bootstrap/SocialDrupalContext.php
+++ b/tests/behat/features/bootstrap/SocialDrupalContext.php
@@ -89,7 +89,10 @@ class SocialDrupalContext extends DrupalContext {
       if (isset($node->field_event_date)) {
         $node->field_event_date = date('Y-m-d H:i:s', strtotime($node->field_event_date));
       }
-      $this->nodeCreate($node);
+      $entity = $this->nodeCreate($node);
+      if (isset($node->alias)) {
+        \Drupal::service('path.alias_storage')->save("/node/" . $entity->nid, $node->alias);
+      }
     }
   }
 

--- a/tests/behat/features/capabilities/alternative-frontpage/alternative-frontpage.feature
+++ b/tests/behat/features/capabilities/alternative-frontpage/alternative-frontpage.feature
@@ -16,8 +16,8 @@ Feature: Set alternative frontpage
     When I am on "admin/config/alternative_frontpage"
     # Error validation
     And I fill in the following:
-      | Frontpage for anonymous users     |       |
-      | Frontpage for authenticated users | /user |
+      | Frontpage for anonymous users     |              |
+      | Frontpage for authenticated users | /user/logout |
     And I press "Save configuration"
     Then I should see "The path for the anonymous frontpage cannot be empty."
     And I should see "The path for the authenticated frontpage is not allowed."
@@ -37,3 +37,4 @@ Feature: Set alternative frontpage
     # See as AN
     Given I logout
     And I click "Home"
+    Then I should see "Frontpage AN"

--- a/tests/behat/features/capabilities/alternative-frontpage/alternative-frontpage.feature
+++ b/tests/behat/features/capabilities/alternative-frontpage/alternative-frontpage.feature
@@ -1,0 +1,39 @@
+@api @alternative-frontpage @stability @perfect @critical @DS-4638 @stability-4
+Feature: Set alternative frontpage
+  Benefit: In order to improve the Look and Feel for LU
+  Role: AN
+  Goal/desire: I want to set a different frontpage for Anonymous and Logged-in users
+
+  Scenario: Successfully set alternative frontpage
+
+    Given I enable the module "alternative_frontpage"
+    Given page content:
+      | title          | status | field_content_visibility | alias         |
+      | Frontpage AN   | 1      | public                   | /frontpage-an |
+      | Frontpage LU   | 1      | community                | /frontpage-lu |
+    # Configure the settings
+    Given I am logged in as an "sitemanager"
+    When I am on "admin/config/alternative_frontpage"
+    # Error validation
+    And I fill in the following:
+      | Frontpage for anonymous users     |       |
+      | Frontpage for authenticated users | /user |
+    And I press "Save configuration"
+    Then I should see "The path for the anonymous frontpage cannot be empty."
+    And I should see "The path for the authenticated frontpage is not allowed."
+    When I fill in the following:
+      | Frontpage for anonymous users     | stream       |
+      | Frontpage for authenticated users | invalid page |
+    And I press "Save configuration"
+    Then I should see "The path for the anonymous frontpage should start with a forward slash."
+    And I should see "The path for the authenticated frontpage is not valid."
+    # Fill in the correct settings.
+    When I fill in the following:
+      | Frontpage for anonymous users     | /frontpage-an |
+      | Frontpage for authenticated users | /frontpage-lu |
+    And I press "Save configuration"
+    And I am on "frontpage-an"
+    Then I should see "Frontpage LU"
+    # See as AN
+    Given I logout
+    And I click "Home"

--- a/tests/behat/features/capabilities/alternative-frontpage/alternative-frontpage.feature
+++ b/tests/behat/features/capabilities/alternative-frontpage/alternative-frontpage.feature
@@ -36,5 +36,19 @@ Feature: Set alternative frontpage
     Then I should see "Frontpage LU"
     # See as AN
     Given I logout
-    And I click "Home"
+    When I click "Home"
     Then I should see "Frontpage AN"
+
+    # Restore the settings
+    Given I am on "user/login"
+    When I fill in the following:
+      | Username or email address | admin |
+      | Password                  | admin |
+    And I press "Log in"
+    Given I am on "admin/config/alternative_frontpage"
+    # Error validation
+    When I fill in the following:
+      | Frontpage for anonymous users     | /stream |
+      | Frontpage for authenticated users |         |
+    And I press "Save configuration"
+    Then I should see "The configuration options have been saved."

--- a/themes/socialbase/src/Plugin/Preprocess/Block.php
+++ b/themes/socialbase/src/Plugin/Preprocess/Block.php
@@ -36,7 +36,11 @@ class Block extends PreprocessBase {
     $route_name = \Drupal::routeMatch()->getRouteName();
 
     // Get the region of a block.
-    $region = BlockEntity::load($variables['elements']['#id'])->getRegion();
+    $region = '';
+    $block_entity = BlockEntity::load($variables['elements']['#id']);
+    if ($block_entity) {
+      $region = $block_entity->getRegion();
+    }
 
     $prefix = '';
     // If socialbase is one of the basetheme, we need a prefix for block ids.
@@ -52,6 +56,7 @@ class Block extends PreprocessBase {
       'complementary_bottom',
       'content_top',
       'content_bottom',
+      '',
     ];
 
     if (in_array($region, $regions_card)) {


### PR DESCRIPTION
## Problem
Anonymous and logged-in users frontpages are currently not very flexible. It is virtually impossible to feature content. It would be an option to be able to use the landingpage feature for this since it will give the SM the possibility to create a visually appealing site and feature content, groups.

## Solution
The landingpage can not be set as the homepage on "/stream" currently since it will add new blocks automatically. Actually when using a landingpage it should not add any blocks to the hero, content area or sidebars. 

## Issue tracker
DS-4638
https://www.drupal.org/project/social/issues/2931507

## HTT
- [x] Check out the code changes and especially the refactoring of the Post blocks and the Views plugin code
- [x] Login as user with SM rights and create a landingpage and use an alias which is NOT "/stream" but something else like "/frontpage"
- [x] Try to recreate the homepage by making a hero, adding activity stream and adding the correct blocks on the right
- [x] Notice it looks like the homepage and you can even add new blocks (unlimited) to any region
- [x] Set the page alias as the Homepage on Site Configuration administration page
- [x] Verify that the page looks good as LU
- [x] Try to recreate the Anonymous Homepage as well and set the visibility of the content to AN