### PR TITLE
2938779 by robertragas: Add key value of private message notification

### DIFF
--- a/modules/custom/activity_send/modules/activity_send_email/activity_send_email.module
+++ b/modules/custom/activity_send/modules/activity_send_email/activity_send_email.module
@@ -135,6 +135,7 @@ function activity_send_email_form_user_form_alter(&$form, FormStateInterface $fo
       $all_email_message_keys[4] => $all_email_message_values[4],
       $all_email_message_keys[3] => $all_email_message_values[3],
       $all_email_message_keys[2] => $all_email_message_values[2],
+      $all_email_message_keys[9] => $all_email_message_values[9],
     ];
     $what_manage = [
       $all_email_message_keys[0] => $all_email_message_values[0],


### PR DESCRIPTION
## Problem
Private message email notification configuration not rendered.

## Solution
Add the key value to the list, but needs a more flexible solution to see if all items from $email_message_templates are assigned to a category.

## Issue tracker
https://www.drupal.org/project/social/issues/2938779#comment-12445743

## HTT
- [x] Check out the code changes
- [x] Login as user X and edit your profile settings at the email notification settings
- [x] Notice that private message is messing
- [x] Checkout to this branch
- [x] Edit profile settings again and you can now set it.
