### PR TITLE
Don't use an abbreviation for the PmAddBlock

### DIFF
--- a/modules/social_features/social_private_message/src/Plugin/Block/PmAddBlock.php
+++ b/modules/social_features/social_private_message/src/Plugin/Block/PmAddBlock.php
@@ -13,7 +13,7 @@ use Drupal\Core\Access\AccessResult;
  *
  * @Block(
  *  id = "pm_add_block",
- *  admin_label = @Translation("PM add block"),
+ *  admin_label = @Translation("Private Message add block"),
  * )
  */
 class PmAddBlock extends BlockBase {


### PR DESCRIPTION
When looking at the Private Message functionality everything is written out full, so I search for "Private Message". I have no easy way of knowing that for the "Private Message Add Block" we suddenly use the abbreviation "PM". We should just write it out in full.

We should probably also do this for the class names and ids but if we've already marked this module as stable then that would break backwards compatibility. If we haven't marked the module as stable yet it's a change still work making.

This single line change has no Drupal.org issue associated with it.