### PR TITLE
Issue 2934118 After editing a comment on a post, upon save you are direct to the edit screen.

### DIFF
--- a/modules/social_features/social_post/social_post.module
+++ b/modules/social_features/social_post/social_post.module
@@ -67,19 +67,30 @@ function social_post_form_post_form_alter(&$form, FormStateInterface $form_state
  */
 function social_post_form_comment_post_comment_form_alter(&$form, FormStateInterface $form_state, $form_id) {
   // Reset title display.
-  $form['field_comment_body']['widget'][0]['#title_display'] = 'invisible';
-
-  // Set the action of the form to the current uri.
-  // This needs to be done, because we cannot override $form['#action']
-  // without breaking functionality.
-  $uri = Url::fromRoute('<current>')->toString();
-  // Store in a hidden field.
-  $form['redirect_after_save'] = [
-    '#type' => 'hidden',
-    '#title' => t('Redir'),
-    '#default_value' => $uri,
-  ];
-
+  $from['field_comment_body']['widget'][0]['#title_display'] = 'invisible';
+  // For redirecting the comment_edit_form page.
+  $route_name = \Drupal::routeMatch()->getRouteName();
+  // Check if we are on editing comment.
+  if ($route_name == 'entity.comment.edit_form') {
+    $uri = Url::fromRoute('<current>')->toUriString();
+    $form['redirect_after_save'] = [
+      '#type' => 'hidden',
+      '#title' => t('Redir'),
+      '#defautl_value' => $uri,
+    ];
+  }
+  else {
+    // Set the action of the form to the current uri.
+    // This needs to be done, because we cannot override $form['#action']
+    // Without breaking functionality.
+    $uri = Url::fromRoute('<current>')->toString();
+    // Store in a hidden field.
+    $form['redirect_after_save'] = [
+      '#type' => 'hidden',
+      '#title' => t('Redir'),
+      '#default_value' => $uri,
+    ];
+  }
   // Submit function to retrieve the action uri and redirect to it.
   $form['actions']['submit']['#submit'][] = '_social_post_comment_post_comment_form_submit';
 }
@@ -93,29 +104,6 @@ function social_post_form_comment_post_comment_form_alter(&$form, FormStateInter
  *   Form state interface.
  */
 function _social_post_comment_post_comment_form_submit(array $form, FormStateInterface $form_state) {
-  // For redirecting the comment_edit_form page.
-  $route_name = \Drupal::routeMatch()->getRouteName();
-  // We only change it for editing a comment on a Post.
-  if ($route_name === 'entity.comment.edit_form') {
-    // Get comment from URL.
-    foreach (\Drupal::routeMatch()->getParameters() as $comment) {
-      if ($comment instanceof \Drupal\comment\Entity\Comment) {
-        // Get the Post the comment was placed on.
-        $post = $comment->getCommentedEntity();
-        /** @var \Drupal\Core\Url $url */
-        $url = $post->toUrl('canonical');
-        $options = [
-          'fragment' => 'comment-' . $comment->id(),
-        ];
-        // Redirect to the canonical URL of the post
-        // and add the comment as a fragment.
-        // This to ensure we scroll directly to
-        // the comment by using #-commentid.
-        $form_state->setRedirectUrl($url, $options);
-      }
-    }
-  }
-
   // Fetch from the form.
   $uri = $form_state->getValue('redirect_after_save');
   // Let's not trust this.

--- a/modules/social_features/social_post/social_post.module
+++ b/modules/social_features/social_post/social_post.module
@@ -93,6 +93,29 @@ function social_post_form_comment_post_comment_form_alter(&$form, FormStateInter
  *   Form state interface.
  */
 function _social_post_comment_post_comment_form_submit(array $form, FormStateInterface $form_state) {
+  // For redirecting the comment_edit_form page.
+  $route_name = \Drupal::routeMatch()->getRouteName();
+  // We only change it for editing a comment on a Post.
+  if ($route_name === 'entity.comment.edit_form') {
+    // Get comment from URL.
+    foreach (\Drupal::routeMatch()->getParameters() as $comment) {
+      if ($comment instanceof \Drupal\comment\Entity\Comment) {
+        // Get the Post the comment was placed on.
+        $post = $comment->getCommentedEntity();
+        /** @var \Drupal\Core\Url $url */
+        $url = $post->toUrl('canonical');
+        $options = [
+          'fragment' => 'comment-' . $comment->id(),
+        ];
+        // Redirect to the canonical URL of the post
+        // and add the comment as a fragment.
+        // This to ensure we scroll directly to
+        // the comment by using #-commentid.
+        $form_state->setRedirectUrl($url, $options);
+      }
+    }
+  }
+
   // Fetch from the form.
   $uri = $form_state->getValue('redirect_after_save');
   // Let's not trust this.


### PR DESCRIPTION
## Problem
After editing a comment on a post, upon save you are direct to the edit screen. This is not correct.
When editing a comment on a topic, it does work correct: you return to the topic detail page. Same for reply on a comment: works like a charm!

## Solution
Expected result:
- I think best is to return to the post detail page, scrolled down to your comment.

## Issue tracker
- https://www.drupal.org/project/social/issues/2934118

## HTT
Steps to reproduce the issue:
- [ ] create a comment on a post
- [ ] edit the comment, press save
- [ ] observe that you end up on the edit comment screen.
- [ ] You do get a message that your comment has been posted. 

Steps to reproduce the fix:
- [ ] create a comment on a post
- [ ] edit the comment, press save
- [ ] observe that you end up on the post screen and you scroll down to edited comment.
- [ ] You do get a message that your comment has been posted. 

