### PR TITLE
Issue #2939371 by Kingdutch: Boost user names in all search

### DIFF
--- a/modules/social_features/social_search/config/install/search_api.index.social_all.yml
+++ b/modules/social_features/social_search/config/install/search_api.index.social_all.yml
@@ -142,6 +142,7 @@ field_settings:
     datasource_id: 'entity:profile'
     property_path: 'uid:entity:name'
     type: text
+    boost: !!float 2
     dependencies:
       module:
         - user


### PR DESCRIPTION
## Problem
When you search for a user in the "All" tab then a user name bears no more importance than other content (that might be published by this user). This causes the user searched for to end up on the last page of "Search All". This was experienced by one of our enterprise clients.

## Solution
Boost the username importance from 1 to 2. This ensures that if a user is matched in a "Search All" search it is displayed first. (User)names are usually quite unique and when searched for they are usually the goal (if searching for an article, other terms would be used). Therefor having any users come up first in a query has probably no or little downside and a lot of upside

## Issue tracker
https://www.drupal.org/project/social/issues/2939371

## HTT
- [x] Make sure you're logged in so user search works
- [x] In the all tab search for a user such as "Chris" or "Robert"
- [x] See that "Chris Hall" and "Robert Andrews" are at the bottom of the search results
- [x] Apply the change in this PR
- [x] See that "Chris Hall" and "Robert Andres" now show up first when searching for "Chris" and "Robert" respectively. They show up before content that they've authored.
