### PR TITLE
DS-4491 activity stream multilingual

### DIFF
--- a/modules/custom/activity_creator/activity_creator.module
+++ b/modules/custom/activity_creator/activity_creator.module
@@ -209,6 +209,7 @@ function activity_creator_entity_view(array &$build, EntityInterface $entity, En
   }
 
   // Generate the output text for the user in his selected language.
+  // Get language van recipient user.
   if ($entity instanceof \Drupal\activity_creator\Entity\Activity) {
     $message = Message::load($entity->get('field_activity_message')->target_id);
     if ($message instanceof Message) {
@@ -216,6 +217,8 @@ function activity_creator_entity_view(array &$build, EntityInterface $entity, En
       $output = \Drupal::service('activity_creator.activity_factory')->getMessageText($message);
       // Replace the old text with the correct one.
       $build['field_activity_output_text'][0]['#text'] = $output[0];
+
+      // Caching context met current language toevoegen als nodig (build array).
     }
   }
 }

--- a/modules/custom/activity_creator/activity_creator.module
+++ b/modules/custom/activity_creator/activity_creator.module
@@ -210,7 +210,7 @@ function activity_creator_entity_view(array &$build, EntityInterface $entity, En
   }
 
   // Generate the output text for the user in his selected language.
-  if ($entity instanceof Activity) {
+  if ($entity instanceof Activity && !empty($entity->get('field_activity_message')->target_id)) {
     $message = Message::load($entity->get('field_activity_message')->target_id);
     if ($message instanceof Message) {
       // Get the text in the users language.

--- a/modules/custom/activity_creator/activity_creator.module
+++ b/modules/custom/activity_creator/activity_creator.module
@@ -9,6 +9,7 @@ use Drupal\message\Entity\Message;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\Display\EntityViewDisplayInterface;
 use Drupal\Core\Url;
+use Drupal\activity_creator\Entity\Activity;
 
 /**
  * Activity statuses.
@@ -209,16 +210,13 @@ function activity_creator_entity_view(array &$build, EntityInterface $entity, En
   }
 
   // Generate the output text for the user in his selected language.
-  // Get language van recipient user.
-  if ($entity instanceof \Drupal\activity_creator\Entity\Activity) {
+  if ($entity instanceof Activity) {
     $message = Message::load($entity->get('field_activity_message')->target_id);
     if ($message instanceof Message) {
       // Get the text in the users language.
       $output = \Drupal::service('activity_creator.activity_factory')->getMessageText($message);
       // Replace the old text with the correct one.
       $build['field_activity_output_text'][0]['#text'] = $output[0];
-
-      // Caching context met current language toevoegen als nodig (build array).
     }
   }
 }

--- a/modules/custom/activity_creator/activity_creator.module
+++ b/modules/custom/activity_creator/activity_creator.module
@@ -207,6 +207,17 @@ function activity_creator_entity_view(array &$build, EntityInterface $entity, En
     // @TODO Check if this entity is even specified in ActivityLoggerFactory
     \Drupal::service('activity_creator.activity_notifications')->markEntityNotificationsAsRead($account, $entity);
   }
+
+  // Generate the output text for the user in his selected language.
+  if ($entity instanceof \Drupal\activity_creator\Entity\Activity) {
+    $message = Message::load($entity->get('field_activity_message')->target_id);
+    if ($message instanceof Message) {
+      // Get the text in the users language.
+      $output = \Drupal::service('activity_creator.activity_factory')->getMessageText($message);
+      // Replace the old text with the correct one.
+      $build['field_activity_output_text'][0]['#text'] = $output[0];
+    }
+  }
 }
 
 /**

--- a/modules/custom/activity_logger/activity_logger.tokens.inc
+++ b/modules/custom/activity_logger/activity_logger.tokens.inc
@@ -115,7 +115,10 @@ function activity_logger_tokens($type, $tokens, array $data, array $options, Bub
                   $replacements[$original] = $group->label();
                 }
                 if ($name === 'gurl') {
-                  $gurl = Url::fromRoute('entity.group.canonical', ['group' => $group->id()]);
+                  $gurl = Url::fromRoute('entity.group.canonical',
+                    ['group' => $group->id()],
+                    ['absolute' => TRUE]
+                  );
                   $replacements[$original] = $gurl->toString();
                 }
               }

--- a/modules/custom/activity_send/modules/activity_send_email/src/Plugin/ActivityDestination/EmailActivityDestination.php
+++ b/modules/custom/activity_send/modules/activity_send_email/src/Plugin/ActivityDestination/EmailActivityDestination.php
@@ -43,15 +43,18 @@ class EmailActivityDestination extends SendActivityDestinationBase {
    *
    * @param \Drupal\message\Entity\Message $message
    *   The Message object.
+   * @param string $langcode
+   *   The language in which we need to get the email text.
    *
    * @return string|null
    *   If we have message text we return the text, otherwise null.
    */
-  public static function getSendEmailOutputText(Message $message) {
+  public static function getSendEmailOutputText(Message $message, $langcode = '') {
     $text = NULL;
     if (isset($message)) {
       $activity_factory = \Drupal::service('activity_creator.activity_factory');
-      $value = $activity_factory->getMessageText($message);
+      $value = $activity_factory->getMessageText($message, $langcode);
+
       // Text for email.
       if (!empty($value[2])) {
         $text = $value[2];

--- a/modules/custom/activity_send/modules/activity_send_email/src/Plugin/EmailFrequency/Immediately.php
+++ b/modules/custom/activity_send/modules/activity_send_email/src/Plugin/EmailFrequency/Immediately.php
@@ -29,7 +29,7 @@ class Immediately extends EmailFrequencyBase {
     // Continue if we have text to send and the user is currently offline.
     if (isset($activity->field_activity_output_text) && EmailActivityDestination::isUserOffline($target)) {
       $langcode = $target->getPreferredLangcode();
-      $body_text = EmailActivityDestination::getSendEmailOutputText($message);
+      $body_text = EmailActivityDestination::getSendEmailOutputText($message, $langcode);
 
       if ($langcode && !empty($body_text)) {
         $this->sendEmail($body_text, $langcode, $target);

--- a/modules/custom/activity_send/modules/activity_send_email/src/Plugin/EmailFrequency/Immediately.php
+++ b/modules/custom/activity_send/modules/activity_send_email/src/Plugin/EmailFrequency/Immediately.php
@@ -53,9 +53,10 @@ class Immediately extends EmailFrequencyBase {
       '#theme' => 'directmail',
       '#notification' => $body_text,
       '#notification_settings' => t('Based on your @settings, the notification above is sent to you <strong>:frequency</strong>', [
-        '@settings' => Link::fromTextAndUrl(t('email notification settings'), Url::fromRoute('entity.user.edit_form', ['user' => $target->id()])->setAbsolute())->toString(),
+        '@settings' => Link::fromTextAndUrl(t('email notification settings', [], ['langcode' => $langcode]), Url::fromRoute('entity.user.edit_form', ['user' => $target->id()])->setAbsolute())->toString(),
         ':frequency' => $this->getName(),
-      ]),
+      ],
+      ['langcode' => $langcode]),
     ];
 
     $params['body'] = \Drupal::service('renderer')->renderRoot($notification);

--- a/modules/custom/activity_send/modules/activity_send_email/src/Plugin/EmailFrequency/Immediately.php
+++ b/modules/custom/activity_send/modules/activity_send_email/src/Plugin/EmailFrequency/Immediately.php
@@ -48,13 +48,18 @@ class Immediately extends EmailFrequencyBase {
    *   The target account to send the email to.
    */
   protected function sendEmail($body_text, $langcode, User $target) {
+    // Translating frequency instance in the language of the user.
+    // @codingStandardsIgnoreStart
+    $frequency_translated = t($this->getName()->getUntranslatedString(), [], ['langcode' => $langcode]);
+    // @codingStandardsIgnoreEnd
+
     // Construct the render array.
     $notification = [
       '#theme' => 'directmail',
       '#notification' => $body_text,
       '#notification_settings' => t('Based on your @settings, the notification above is sent to you <strong>:frequency</strong>', [
         '@settings' => Link::fromTextAndUrl(t('email notification settings', [], ['langcode' => $langcode]), Url::fromRoute('entity.user.edit_form', ['user' => $target->id()])->setAbsolute())->toString(),
-        ':frequency' => t($this->getName()->getUntranslatedString(), [], ['langcode' => $langcode]),
+        ':frequency' => $frequency_translated,
       ],
       ['langcode' => $langcode]),
     ];

--- a/modules/custom/activity_send/modules/activity_send_email/src/Plugin/EmailFrequency/Immediately.php
+++ b/modules/custom/activity_send/modules/activity_send_email/src/Plugin/EmailFrequency/Immediately.php
@@ -54,7 +54,7 @@ class Immediately extends EmailFrequencyBase {
       '#notification' => $body_text,
       '#notification_settings' => t('Based on your @settings, the notification above is sent to you <strong>:frequency</strong>', [
         '@settings' => Link::fromTextAndUrl(t('email notification settings', [], ['langcode' => $langcode]), Url::fromRoute('entity.user.edit_form', ['user' => $target->id()])->setAbsolute())->toString(),
-        ':frequency' => $this->getName(),
+        ':frequency' => t($this->getName()->getUntranslatedString(), [], ['langcode' => $langcode]),
       ],
       ['langcode' => $langcode]),
     ];

--- a/modules/custom/activity_send/modules/activity_send_email/src/Plugin/QueueWorker/ActivityDigestWorker.php
+++ b/modules/custom/activity_send/modules/activity_send_email/src/Plugin/QueueWorker/ActivityDigestWorker.php
@@ -58,7 +58,7 @@ class ActivityDigestWorker extends ActivitySendWorkerBase {
           $notification_count = count($digest_notifications['#notifications']);
 
           // Get the notification count for the email template.
-          $digest_notifications['#notification_count'] = \Drupal::translation()->formatPlural($notification_count, 'You have received <strong>:count</strong> notification', 'You have received <strong>:count</strong> notifications', [':count' => $notification_count]);
+          $digest_notifications['#notification_count'] = \Drupal::translation()->formatPlural($notification_count, 'You have received <strong>:count</strong> notification', 'You have received <strong>:count</strong> notifications', [':count' => $notification_count], ['langcode' => $langcode]);
 
           $emailfrequencymanager = \Drupal::service('plugin.manager.emailfrequency');
           /* @var \Drupal\activity_send_email\EmailFrequencyInterface $instance */
@@ -68,7 +68,8 @@ class ActivityDigestWorker extends ActivitySendWorkerBase {
           $digest_notifications['#notification_settings'] = \Drupal::translation()->formatPlural($notification_count, 'Based on your @settings, the notification above is sent to you as a <strong>:frequency mail</strong>', 'Based on your @settings, the notifications above are sent to you as a <strong>:frequency mail</strong>', [
             '@settings' => Link::fromTextAndUrl(t('email notification settings'), Url::fromRoute('entity.user.edit_form', ['user' => $target->id()])->setAbsolute())->toString(),
             ':frequency' => $instance->getName(),
-          ]);
+          ],
+          ['langcode' => $langcode]);
 
           // Render the notifications using the digestmail.html.twig template.
           $params['body'] = \Drupal::service('renderer')->renderRoot($digest_notifications);

--- a/modules/custom/activity_send/modules/activity_send_email/src/Plugin/QueueWorker/ActivityDigestWorker.php
+++ b/modules/custom/activity_send/modules/activity_send_email/src/Plugin/QueueWorker/ActivityDigestWorker.php
@@ -67,7 +67,7 @@ class ActivityDigestWorker extends ActivitySendWorkerBase {
           // Get the notification settings for the email template.
           $digest_notifications['#notification_settings'] = \Drupal::translation()->formatPlural($notification_count, 'Based on your @settings, the notification above is sent to you as a <strong>:frequency mail</strong>', 'Based on your @settings, the notifications above are sent to you as a <strong>:frequency mail</strong>', [
             '@settings' => Link::fromTextAndUrl(t('email notification settings'), Url::fromRoute('entity.user.edit_form', ['user' => $target->id()])->setAbsolute())->toString(),
-            ':frequency' => $instance->getName(),
+            ':frequency' => t($instance->getName()->getUntranslatedString(), [], ['langcode' => $langcode]),
           ],
           ['langcode' => $langcode]);
 

--- a/modules/custom/activity_send/modules/activity_send_email/src/Plugin/QueueWorker/ActivityDigestWorker.php
+++ b/modules/custom/activity_send/modules/activity_send_email/src/Plugin/QueueWorker/ActivityDigestWorker.php
@@ -45,7 +45,7 @@ class ActivityDigestWorker extends ActivitySendWorkerBase {
           if (isset($activity->field_activity_output_text)) {
             // Load the message.
             $message = Message::load($activity->field_activity_message->target_id);
-            $body_text = EmailActivityDestination::getSendEmailOutputText($message);
+            $body_text = EmailActivityDestination::getSendEmailOutputText($message, $langcode);
 
             if ($langcode && !empty($body_text)) {
               $digest_notifications['#notifications'][] = $body_text;

--- a/modules/custom/activity_send/modules/activity_send_email/src/Plugin/QueueWorker/ActivityDigestWorker.php
+++ b/modules/custom/activity_send/modules/activity_send_email/src/Plugin/QueueWorker/ActivityDigestWorker.php
@@ -64,10 +64,15 @@ class ActivityDigestWorker extends ActivitySendWorkerBase {
           /* @var \Drupal\activity_send_email\EmailFrequencyInterface $instance */
           $instance = $emailfrequencymanager->createInstance($data['frequency']);
 
+          // Translating frequency instance in the language of the user.
+          // @codingStandardsIgnoreStart
+          $frequency_translated = t($instance->getName()->getUntranslatedString(), [], ['langcode' => $langcode]);
+          // @codingStandardsIgnoreEnd
+
           // Get the notification settings for the email template.
           $digest_notifications['#notification_settings'] = \Drupal::translation()->formatPlural($notification_count, 'Based on your @settings, the notification above is sent to you as a <strong>:frequency mail</strong>', 'Based on your @settings, the notifications above are sent to you as a <strong>:frequency mail</strong>', [
             '@settings' => Link::fromTextAndUrl(t('email notification settings'), Url::fromRoute('entity.user.edit_form', ['user' => $target->id()])->setAbsolute())->toString(),
-            ':frequency' => t($instance->getName()->getUntranslatedString(), [], ['langcode' => $langcode]),
+            ':frequency' => $frequency_translated,
           ],
           ['langcode' => $langcode]);
 


### PR DESCRIPTION
## Problem
In the activity stream it is currently not possible to have the message displayed in the language of the user. If an user has selected the Dutch language or is visiting the Dutch website the notification is still shown in English (e.g. "User x created an event in group Y").

In emails there is a similar problem, but other texts are also not translated in the language of the recipient user.

## Solution
Translating the message template text upon **display** of the item. Basically this means we retrieve the message template and generate the output text (with tokens replaced) on an entity view. And the same happens when sending notifications in emails.

_As an added bonus I fixed the URL in email notifications for groups. This was, as far as I could tell, the only item which was using a relative URL (which doesn't work well in emails). I changed it to an absolute URL like was done in other places._

The output text is saved in the database when creating the activity object. We don't really need it anymore, and thus we should remove it at some point.

## HTT
- [x] Check out the code changes.
- [x] Install the site, enable Interface Translation, set-up the Dutch language and import the Open Social translations.
- [x] Configure Language detection to use (at least) the users language.
- [x] Set the user language for user X to Dutch.
- [x] _You may choose to generate demo content again now._
- [x] Post some stuff which user X will receive, mention user X and create a topic in the group of user X.
- [x] As user X login to the platform, observe that activities are now shown in Dutch in the homepage stream.
- [x] Observe that activities are now shown in Dutch in the group stream.
- [x] Observe that activities are now shown in Dutch in the profile stream.
- [x] Observe that activities are now shown in Dutch in the notification centre.
- [x] Check the email of user X and see that the notification(s) he received are in Dutch.
- [x] Configure some notifications to be shown in a digest email (e.g. daily) for user X.
- [x] Logout user X and create some activities that will generate a digest email for user X.
- [x] Wait or force the digest to be send.
- [x] Check the digest mail to see that the notifications are translated there as well.
- [x] Verify that other languages (e.g. Spanish) work just as described for Dutch.

When adding another language, next to Dutch, be sure to translate the message template notification messages via the UI translation page!