### PR TITLE
Issue #2939961 by kala4ek: replace deprecated constant REQUEST_TIME

### DIFF
--- a/modules/custom/activity_send/src/Plugin/SendActivityDestinationBase.php
+++ b/modules/custom/activity_send/src/Plugin/SendActivityDestinationBase.php
@@ -85,7 +85,7 @@ class SendActivityDestinationBase extends ActivityDestinationBase {
     $last_activity_time = $query->execute()->fetchField();
 
     $offline_window = \Drupal::config('activity_send.settings')->get('activity_send_offline_window');
-    $current_time = REQUEST_TIME - $offline_window;
+    $current_time = \Drupal::time()->getRequestTime() - $offline_window;
 
     return (empty($last_activity_time) || $last_activity_time < $current_time);
   }

--- a/modules/custom/download_count/download_count.module
+++ b/modules/custom/download_count/download_count.module
@@ -32,7 +32,7 @@ function download_count_file_access($entity, $operation, $account) {
     $flood = \Drupal::flood();
     $config = \Drupal::config('download_count.settings');
     $flood_window = $config->get('download_count_flood_window');
-    $time = REQUEST_TIME;
+    $time = \Drupal::time()->getRequestTime();
 
     // Invalidate file field formatter.
     $cache_tag = 'file:' . $entity->id();

--- a/modules/custom/mentions/mentions.module
+++ b/modules/custom/mentions/mentions.module
@@ -167,7 +167,7 @@ function mentions_crud_update($type, $mentions, $id, $author) {
   // Update existing mentions.
   foreach (array_intersect($new_users, $old_users) as $uid) {
     $entity = $mentions_storage->load($old_mids[$uid]);
-    $entity->set('created', REQUEST_TIME);
+    $entity->set('created', \Drupal::time()->getRequestTime());
     $entity->save();
     $event_dispatcher->dispatch('mentions.update', new Event());
   }

--- a/modules/custom/social_demo/src/DemoComment.php
+++ b/modules/custom/social_demo/src/DemoComment.php
@@ -105,11 +105,11 @@ abstract class DemoComment extends DemoContent {
       if (!empty($item['created'])) {
         $item['created'] = $this->createDate($item['created']);
         if ($item['created'] < $entity->get('created')->value) {
-          $item['created'] = REQUEST_TIME;
+          $item['created'] = \Drupal::time()->getRequestTime();
         }
       }
       else {
-        $item['created'] = REQUEST_TIME;
+        $item['created'] = \Drupal::time()->getRequestTime();
       }
 
       $item['entity_id'] = $entity->id();

--- a/modules/custom/social_demo/src/DemoNode.php
+++ b/modules/custom/social_demo/src/DemoNode.php
@@ -95,7 +95,7 @@ abstract class DemoNode extends DemoContent {
         $item['created'] = $this->createDate($item['created']);
       }
       else {
-        $item['created'] = REQUEST_TIME;
+        $item['created'] = \Drupal::time()->getRequestTime();
       }
 
       $entry = $this->getEntry($item);

--- a/modules/custom/social_demo/src/DemoSystem.php
+++ b/modules/custom/social_demo/src/DemoSystem.php
@@ -218,7 +218,7 @@ abstract class DemoSystem extends DemoContent {
     $font = Font::create([
       'name' => $fontName,
       'user_id' => 1,
-      'created' => REQUEST_TIME,
+      'created' => \Drupal::time()->getRequestTime(),
       'field_fallback' => '0',
     ]);
     $font->save();

--- a/modules/custom/social_demo/src/DemoTaxonomyTerm.php
+++ b/modules/custom/social_demo/src/DemoTaxonomyTerm.php
@@ -76,7 +76,7 @@ abstract class DemoTaxonomyTerm extends DemoContent {
       'uuid' => $item['uuid'],
       'name' => $item['name'],
       'vid' => $item['vid'],
-      'created' => REQUEST_TIME,
+      'created' => \Drupal::time()->getRequestTime(),
     ];
 
     return $entry;

--- a/modules/custom/social_demo/src/DemoUser.php
+++ b/modules/custom/social_demo/src/DemoUser.php
@@ -153,8 +153,8 @@ abstract class DemoUser extends DemoContent {
       'init' => $item['mail'],
       'timezone' => $item['timezone'],
       'status' => $item['status'],
-      'created' => REQUEST_TIME,
-      'changed' => REQUEST_TIME,
+      'created' => \Drupal::time()->getRequestTime(),
+      'changed' => \Drupal::time()->getRequestTime(),
       'roles' => array_values($item['roles']),
     ];
 

--- a/modules/custom/social_demo/src/Plugin/DemoContent/EventEnrollment.php
+++ b/modules/custom/social_demo/src/Plugin/DemoContent/EventEnrollment.php
@@ -27,7 +27,7 @@ class EventEnrollment extends DemoEntity {
       'langcode' => $item['langcode'],
       'name' => substr($item['title'], 0, 50),
       'user_id' => $uid,
-      'created' => REQUEST_TIME,
+      'created' => \Drupal::time()->getRequestTime(),
       'field_event' => $this->loadByUuid('node', $item['field_event'])->id(),
       'field_enrollment_status' => $item['field_enrollment_status'],
       'field_account' => $uid,

--- a/modules/custom/social_demo/src/Plugin/DemoContent/Like.php
+++ b/modules/custom/social_demo/src/Plugin/DemoContent/Like.php
@@ -29,7 +29,7 @@ class Like extends DemoEntity {
       'value' => $item['value'],
       'value_type' => $item['value_type'],
       'user_id' => $this->loadByUuid('user', $item['uid'])->id(),
-      'timestamp' => REQUEST_TIME,
+      'timestamp' => \Drupal::time()->getRequestTime(),
       'vote_source' => $item['vote_source'],
     ];
   }

--- a/modules/custom/social_font/social_font.install
+++ b/modules/custom/social_font/social_font.install
@@ -16,7 +16,7 @@ function social_font_install() {
   $font = Font::create([
     'name' => 'Montserrat',
     'user_id' => 1,
-    'created' => REQUEST_TIME,
+    'created' => \Drupal::time()->getRequestTime(),
     'field_fallback' => '0',
   ]);
 

--- a/modules/social_features/social_private_message/social_private_message.services.yml
+++ b/modules/social_features/social_private_message/social_private_message.services.yml
@@ -12,3 +12,4 @@ services:
       - '@config.factory'
       - '@user.data'
       - '@database'
+      - '@datetime.time'

--- a/modules/social_features/social_private_message/src/Service/SocialPrivateMessageService.php
+++ b/modules/social_features/social_private_message/src/Service/SocialPrivateMessageService.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\social_private_message\Service;
 
+use Drupal\Component\Datetime\Time;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Database\Connection;
 use Drupal\Core\Entity\Entity;
@@ -25,11 +26,19 @@ class SocialPrivateMessageService extends PrivateMessageService {
   protected $database;
 
   /**
+   * The Time service.
+   *
+   * @var \Drupal\Component\Datetime\Time
+   */
+  protected $time;
+
+  /**
    * {@inheritdoc}
    */
-  public function __construct($mapper, AccountProxyInterface $currentUser, ConfigFactoryInterface $configFactory, UserDataInterface $userData, Connection $database) {
+  public function __construct($mapper, AccountProxyInterface $currentUser, ConfigFactoryInterface $configFactory, UserDataInterface $userData, Connection $database, Time $time) {
     parent::__construct($mapper, $currentUser, $configFactory, $userData);
     $this->database = $database;
+    $this->time = $time;
   }
 
   /**
@@ -39,7 +48,7 @@ class SocialPrivateMessageService extends PrivateMessageService {
    *   The thread entity.
    */
   public function updateLastThreadCheckTime(Entity $entity) {
-    $this->userData->set('private_message', $this->currentUser->id(), 'private_message_thread:' . $entity->id(), REQUEST_TIME);
+    $this->userData->set('private_message', $this->currentUser->id(), 'private_message_thread:' . $entity->id(), $this->time->getRequestTime());
   }
 
   /**


### PR DESCRIPTION
## Problem
As REQUEST_TIME deprecated, usage of this constant should be replaced by @datetime.time service.

## Solution
Replaced the REQUEST_TIMEs with the new service.

## Issue tracker
- https://www.drupal.org/project/social/issues/2939961
- More info: https://www.drupal.org/node/2785211

## HTT
- [x] Check out the code changes
- [x] Tests should not fail
- [x] Check with grep if there are any more REQUEST_TIME constants in use

## Documentation
- [x] This item is added to the release notes
- [x] This item is documented on LGOS
- [x] This item has been added to the feature overview
