### PR TITLE
Issue #2942231 by Makishima: Add year to the teaser and detail page for events

### DIFF
--- a/modules/social_features/social_core/config/install/core.date_format.social_medium_extended_date.yml
+++ b/modules/social_features/social_core/config/install/core.date_format.social_medium_extended_date.yml
@@ -1,0 +1,7 @@
+langcode: en
+status: true
+dependencies: {  }
+id: social_medium_extended_date
+label: 'Social medium extended date'
+locked: false
+pattern: 'j M ''y'

--- a/modules/social_features/social_event/social_event.module
+++ b/modules/social_features/social_event/social_event.module
@@ -226,7 +226,7 @@ function _social_event_format_date($event, $view_mode) {
 
   // Get date and time formats.
   $date_formatter = \Drupal::service('date.formatter');
-  $date_format = ($view_mode === 'hero') ? 'social_long_date' : 'social_short_date';
+  $date_format = ($view_mode === 'hero') ? 'social_long_date' : 'social_medium_extended_date';
   $time_format = 'social_time';
 
   if (!empty($start_datetime)) {


### PR DESCRIPTION
## Problem
Add year to the teaser and detail page for events

## Solution
Add new social_medium_extended_date date format. Change date format to social_medium_extended_date in the Social Event module

## Issue tracker
- https://www.drupal.org/project/social/issues/2942231

## HTT
- [ ] Check out the code changes
- [ ] Go to Events page (/events)
- [ ] Notice that date format is "j M 'y" (ex. 22 Jan '18 13:30)
- [ ] Go to event detail page. Notice that date format is "j M 'y" (ex. 22 Jan '18 13:30)