### PR TITLE
Issue #2942747 by ribel: Improve messages on failed login, and password reset

### DIFF
--- a/modules/social_features/social_user/social_user.module
+++ b/modules/social_features/social_user/social_user.module
@@ -11,6 +11,8 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\user\Plugin\Action\BlockUser;
 use Drupal\social_user\Plugin\Action\SocialBlockUser;
+use Drupal\Core\Url;
+use Drupal\Core\Link;
 
 /**
  * Implements hook_action_info_alter().
@@ -55,8 +57,11 @@ function social_user_register_validate(&$form, FormStateInterface $form_state) {
     // existing messages, making sure nothing about this is being disclosed.
     $form_state->clearErrors();
     // Set a new more general error.
+    $site_config = \Drupal::config('system.site');
+    $site_mail = $site_config->get('mail');
+    $admin_link = empty($site_mail) ? t('site administrator') : Link::fromTextAndUrl(t('site administrator'), Url::fromUri('mailto:' . $site_mail))->toString();
     $form_state->setErrorByName('mail', t('Due to privacy concerns, the policy of this web site is not to disclose the existence of registered email addresses or usernames. However, if you entered an email address or username that already exists, you will not be able to continue.
-    Please try again, or request a new password. Contact the site administrator if there are any problems.'));
+    Please try again, or request a new password. Contact the @admin_link if there are any problems.', ['@admin_link' => $admin_link]));
   }
 }
 

--- a/modules/social_features/social_user/src/Form/SocialUserLoginForm.php
+++ b/modules/social_features/social_user/src/Form/SocialUserLoginForm.php
@@ -218,11 +218,11 @@ class SocialUserLoginForm extends UserLoginForm {
    */
   protected function setGeneralErrorMessage(array &$form, FormStateInterface $form_state) {
     $form_state->setErrorByName('name_or_mail', $this->t('
-        There was an error :( This could happen for one of for the following reasons: <br>
-        - Unrecognized username/email and password combination. <br>
+        Oops, there was an error. This may have happened for the following reasons: <br>
+        - Invalid username/email and password combination. <br>
         - There has been more than one failed login attempt for this account. It is temporarily blocked. <br>
-        - Too many failed login attempts from your IP address. This IP address is temporarily blocked. <br> <br>
-        To solve the issue try other credentials, try again later or <a href=":url">request a new password</a>',
+        - Too many failed login attempts from your computer (IP address). This IP address is temporarily blocked. <br> <br>
+        To solve the issue, try using different login information, try again later, or <a href=":url">request a new password</a>',
       ['%name_or_email' => $form_state->getValue('name_or_mail'), ':url' => $this->url('user.pass')]));
   }
 

--- a/modules/social_features/social_user/src/Form/SocialUserPasswordForm.php
+++ b/modules/social_features/social_user/src/Form/SocialUserPasswordForm.php
@@ -4,6 +4,8 @@ namespace Drupal\social_user\Form;
 
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\user\Form\UserPasswordForm;
+use Drupal\Core\Url;
+use Drupal\Core\Link;
 
 /**
  * Class SocialUserPasswordForm.
@@ -51,10 +53,12 @@ class SocialUserPasswordForm extends UserPasswordForm {
           ]);
       }
     }
-    drupal_set_message(t('Due to privacy concerns, the policy of this web site is not to disclose the existence of registered email addresses.
-     Hence, if you entered a valid email address or username, a password reset link is now being sent to it.
-     If the email address or username you entered does not exist, you will not get a reset link, and will neither get any confirmation or warning about that here.
-     Contact the site administrator if there are any problems.'));
+    $site_config = $this->config('system.site');
+    $site_mail = $site_config->get('mail');
+    $admin_link = empty($site_mail) ? t('site administrator') : Link::fromTextAndUrl(t('site administrator'), Url::fromUri('mailto:' . $site_mail))->toString();
+    drupal_set_message(t('Due to privacy concerns, the identity of registered email addresses will not be disclosed. Therefore, a password reset link has been sent to you only if you have entered a valid email address or username.
+<br>If the email address or username you entered does not exist, you will not get a reset link or a confirmation/warning about that here. Please contact the @admin_link if there are any problems.',
+      ['@admin_link' => $admin_link]));
 
     $form_state->setRedirect('user.page');
   }


### PR DESCRIPTION
## Problem
See drupal.org issue

## Solution
See drupal.org issue

## Issue tracker
- https://www.drupal.org/project/social/issues/2942747

## HTT
- [ ] Check out the code changes
- [ ] Try to reset password or login with not existing users
- [ ] Check how current messages look
- [ ] Checkout to this branch
- [ ] Try to reset password or login with not existing users and check new messages

## Documentation
- [ ] This item is added to the release notes
- [ ] This item is documented on LGOS
- [ ] This item has been added to the feature overview
