### PR TITLE
Issue 2938820 by brhane: Title as Profile Name for a Profile Image in…

### DIFF
--- a/themes/socialbase/templates/profile/profile--compact.html.twig
+++ b/themes/socialbase/templates/profile/profile--compact.html.twig
@@ -19,6 +19,6 @@
  * @ingroup themeable
  */
 #}
-<div class="avatar">
+<div class="avatar" title="{{ profile_name|render }}">
   {{ content }}
 </div>


### PR DESCRIPTION
… an event Block

## Problem
Currently if someone is enrolled for an event their picture is shown. However, these profile pictures are surrounded with links that don't have a title which means that if someone doesn't have an image or a sight impaired user is viewing the page there's no way to know without clicking the "All enrollments" button, who has enrolled.
## Solution
Adjust the output of the link surrounding the user image to have a title with their user/profile name with the following patch file.

## HTT
- [ ] create an event
- [ ] enroll a user with a default profile image
- [ ] notice that it displays "User name" as title surrounding the profile image
- [ ] So able to identify the user who is enrolled without going to the "All Enrolments"
