### PR TITLE
DS-4765 Interface translations should work for configuration

### DIFF
--- a/modules/social_features/social_group/src/Form/SocialGroupAddForm.php
+++ b/modules/social_features/social_group/src/Form/SocialGroupAddForm.php
@@ -109,7 +109,7 @@ class SocialGroupAddForm extends FormBase {
 
     $group_types_options = [];
     $group_types_descriptions = [];
-    $group_types = $this->entityTypeManager->getListBuilder('group_type')->load();
+    $group_types = $this->entityTypeManager->getStorage('group_type')->loadMultiple();
     /** @var \Drupal\group\Entity\GroupTypeInterface $group_type */
     foreach ($group_types as $group_type) {
       $group_types_options[$group_type->id()] = $group_type->label();


### PR DESCRIPTION
## Problem
Group type labels and group type descriptions are not translatable.

## Solution
Enable translations of this texts.

## Issue tracker
https://jira.goalgorilla.com/browse/DS-4765

## HTT
- [x] Add new language on a site and set new language as default.
- [x] Add translation for group type names for a new language.
- [x] Go to on **/group/add**.
- [x] You should see that group type names are not translated.