### PR TITLE
Added extra handling for hero images on custom content types fixes is…

### DIFF
--- a/modules/social_features/social_core/social_core.module
+++ b/modules/social_features/social_core/social_core.module
@@ -101,8 +101,10 @@ function template_preprocess_page_hero_data(array &$variables) {
         $field = reset($image_fields);
         if ($field != NULL){
           if ($field->getFieldDefinition()->get("field_type") == "image") {
-            $variables['hero_styled_image_url'] = ImageStyle::load('social_xx_large')
-              ->buildUrl($node->get($field->getName())->entity->getFileUri());
+            if (!empty(($node->get($field->getName())->entity))) {
+              $variables['hero_styled_image_url'] = ImageStyle::load('social_xx_large')
+                ->buildUrl($node->get($field->getName())->entity->getFileUri());
+            }
           }
         }
       }

--- a/modules/social_features/social_core/social_core.module
+++ b/modules/social_features/social_core/social_core.module
@@ -94,11 +94,26 @@ function template_preprocess_page_hero_data(array &$variables) {
     if (!empty($node->{$image_field}->entity)) {
       $variables['hero_styled_image_url'] = ImageStyle::load('social_xx_large')
         ->buildUrl($node->{$image_field}->entity->getFileUri());
+      } else { // If machine name too long or using another image field
+        $node_fields = $node->getFields();
+        $image_fields = array_filter($node_fields, "findImageField");
+        // Get the first image field of all the fields
+        $field = reset($image_fields);
+        if ($field != NULL){
+          if ($field->getFieldDefinition()->get("field_type") == "image") {
+            $variables['hero_styled_image_url'] = ImageStyle::load('social_xx_large')
+              ->buildUrl($node->get($field->getName())->entity->getFileUri());
+          }
+        }
+      }
     }
-
   }
-
-}
+  
+  function findImageField($field){
+    if (strpos($field->getName(), 'image') !== false) {
+      return $field;
+    }
+  }
 
 /**
  * Implements hook_form_FORM_ID_alter().


### PR DESCRIPTION
Issue #726

## Problem
If you use a custom content type (not provided by Open Social) and happens to have a long name, the validation above will fail because machine names can only be 26 characters long.
In order to at least have the possibility of having an image set, new code needs to load an image field as hero, as long as it has the word "image" on its field name and it is an image field.

## Solution
I've written code to handle this special case

## Issue tracker
Created the issue directly on GitHub

## HTT
- [ ] Check out the code changes
- [ ] Login as user admin and create a content type with a "long" name (21 chars or more), then assign an image field following convention "<content type name> image" so machine name would be field_<content_type_name>_image, create a new node based on that content type including uploading an image.
- [ ] Notice it doesn't work, hero image won't load
- [ ] Checkout to this branch
- [ ] On the content type you just created, if you add an image field that has the word "image" in its machine name (you can even re-use one of the image fields established for the default content types) and is an image field, the hero image will load.

## Documentation
- [ ] This item is added to the release notes
- [ ] This item is documented on LGOS
- [ ] This item has been added to the feature overview