### PR TITLE
#2944419 - Hero images for custom content types when machine name is too long

### DIFF
--- a/modules/social_features/social_core/social_core.module
+++ b/modules/social_features/social_core/social_core.module
@@ -101,8 +101,10 @@ function template_preprocess_page_hero_data(array &$variables) {
         $field = reset($image_fields);
         if ($field != NULL){
           if ($field->getFieldDefinition()->get("field_type") == "image") {
-            $variables['hero_styled_image_url'] = ImageStyle::load('social_xx_large')
-              ->buildUrl($node->get($field->getName())->entity->getFileUri());
+            if (!empty(($node->get($field->getName())->entity))) {
+              $variables['hero_styled_image_url'] = ImageStyle::load('social_xx_large')
+                ->buildUrl($node->get($field->getName())->entity->getFileUri());
+            }
           }
         }
       }

--- a/modules/social_features/social_core/social_core.module
+++ b/modules/social_features/social_core/social_core.module
@@ -94,11 +94,26 @@ function template_preprocess_page_hero_data(array &$variables) {
     if (!empty($node->{$image_field}->entity)) {
       $variables['hero_styled_image_url'] = ImageStyle::load('social_xx_large')
         ->buildUrl($node->{$image_field}->entity->getFileUri());
+      } else { // If machine name too long or using another image field
+        $node_fields = $node->getFields();
+        $image_fields = array_filter($node_fields, "findImageField");
+        // Get the first image field of all the fields
+        $field = reset($image_fields);
+        if ($field != NULL){
+          if ($field->getFieldDefinition()->get("field_type") == "image") {
+            $variables['hero_styled_image_url'] = ImageStyle::load('social_xx_large')
+              ->buildUrl($node->get($field->getName())->entity->getFileUri());
+          }
+        }
+      }
     }
-
   }
-
-}
+  
+  function findImageField($field){
+    if (strpos($field->getName(), 'image') !== false) {
+      return $field;
+    }
+  }
 
 /**
  * Implements hook_form_FORM_ID_alter().

--- a/modules/social_features/social_core/social_core.module
+++ b/modules/social_features/social_core/social_core.module
@@ -16,6 +16,7 @@ use Drupal\path\Plugin\Field\FieldWidget\PathWidget;
 use Drupal\user\Entity\User;
 use Drupal\group\Entity\Group;
 use Drupal\user\UserInterface;
+use Drupal\Core\Field\FieldItemList;
 
 /**
  * Implements hook_theme().
@@ -94,28 +95,40 @@ function template_preprocess_page_hero_data(array &$variables) {
     if (!empty($node->{$image_field}->entity)) {
       $variables['hero_styled_image_url'] = ImageStyle::load('social_xx_large')
         ->buildUrl($node->{$image_field}->entity->getFileUri());
-      } else { // If machine name too long or using another image field
-        $node_fields = $node->getFields();
-        $image_fields = array_filter($node_fields, "findImageField");
-        // Get the first image field of all the fields
-        $field = reset($image_fields);
-        if ($field != NULL){
-          if ($field->getFieldDefinition()->get("field_type") == "image") {
-            if (!empty(($node->get($field->getName())->entity))) {
-              $variables['hero_styled_image_url'] = ImageStyle::load('social_xx_large')
-                ->buildUrl($node->get($field->getName())->entity->getFileUri());
-            }
+    }
+    else {
+      // If machine name too long or using another image field.
+      $node_fields = $node->getFields();
+      $image_fields = array_filter($node_fields, '_social_core_find_image_field');
+      // Get the first image field of all the fields.
+      $field = reset($image_fields);
+      if ($field !== NULL) {
+        if ($field->getFieldDefinition()->get("field_type") === 'image') {
+          if (!empty(($node->get($field->getName())->entity))) {
+            $variables['hero_styled_image_url'] = ImageStyle::load('social_xx_large')
+              ->buildUrl($node->get($field->getName())->entity->getFileUri());
           }
         }
       }
     }
   }
-  
-  function findImageField($field){
-    if (strpos($field->getName(), 'image') !== false) {
-      return $field;
-    }
+}
+
+/**
+ * Tries to determine if a field is an image field based on a field name.
+ *
+ * @param \Drupal\Core\Field\FieldItemList $field
+ *   A field object.
+ *
+ * @return \Drupal\Core\Field\FieldItemList|null
+ *   Will return the FieldItemList or null if its not an image field.
+ */
+function _social_core_find_image_field(FieldItemList $field) {
+  if (strpos($field->getName(), 'image') !== FALSE) {
+    return $field;
   }
+  return NULL;
+}
 
 /**
  * Implements hook_form_FORM_ID_alter().


### PR DESCRIPTION
This is a copy of the original pullrequest #727 and the issue can be found here: https://www.drupal.org/project/social/issues/2944419

## Problem
If you use a custom content type (not provided by Open Social) and happens to have a long name, the validation above will fail because machine names can only be 26 characters long.
In order to at least have the possibility of having an image set, new code needs to load an image field as hero, as long as it has the word "image" on its field name and it is an image field.

## Solution
I've written code to handle this special case

## Issue tracker
Created the issue directly on GitHub

## HTT
- [x] Check out the code changes
- [x] Login as user admin and create a content type with a "long" name (21 chars or more), then assign an image field following convention "<content type name> image" so machine name would be field_<content_type_name>_image, create a new node based on that content type including uploading an image.
- [x] Notice it doesn't work, hero image won't load
- [x] Checkout to this branch
- [x] On the content type you just created, if you add an image field that has the word "image" in its machine name (you can even re-use one of the image fields established for the default content types) and is an image field, the hero image will load.

## Documentation
- [x] This item is added to the release notes
- [x] This item is documented on LGOS
- [x] This item has been added to the feature overview