### PR TITLE
Number of likes to be added to the CSV export

### DIFF
--- a/modules/social_features/social_user_export/social_user_export.module
+++ b/modules/social_features/social_user_export/social_user_export.module
@@ -6,6 +6,7 @@
  */
 
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Session\AccountInterface;
 use Drupal\user\UserInterface;
 use Drupal\views\Views;
 
@@ -187,6 +188,24 @@ function social_user_export_groups_count(UserInterface $account) {
     ->countQuery()
     ->execute()
     ->fetchField();
+}
+
+/**
+ * Returns the quantity of likes by a user.
+ *
+ * @param UserInterface $account
+ * @return int
+ * number of likes
+ */
+function social_user_export_likes_count(AccountInterface $account) {
+    $query = \Drupal::database()->select('votingapi_vote', 'v');
+    $query->addField('v', 'type');
+    $query->condition('v.user_id', $account->id());
+
+    return(int) $query
+        ->countQuery()
+        ->execute()
+        ->fetchField();
 }
 
 /**

--- a/modules/social_features/social_user_export/src/ExportUser.php
+++ b/modules/social_features/social_user_export/src/ExportUser.php
@@ -46,6 +46,7 @@ class ExportUser {
         t('Events enrollments'),
         t('Events created'),
         t('Groups created'),
+        t('Number of Likes'),
       ];
       $csv->insertOne($headers);
     }
@@ -91,6 +92,7 @@ class ExportUser {
       social_user_export_events_enrollments_count($entity),
       social_user_export_nodes_count($entity, 'event'),
       social_user_export_groups_count($entity),
+      social_user_export_likes_count($entity),
     ]);
 
     $context['message'] = t('Exporting: @name', [


### PR DESCRIPTION
## Problem
Number of Likes to be added as a column when exporting user to CSV

## HTT
- [ ] Try to export a user or users to CSV(using the user_export module)
- [ ] Then you will not have a column heading "Likes with a number of likes a user did"
- [ ] Adding such a feature may be useful to track the activity of a user

