### PR TITLE
Issue #2940839 : Call to a member function hasPermission() on string in social_post_comment_create_access()

### DIFF
--- a/modules/social_features/social_post/social_post.module
+++ b/modules/social_features/social_post/social_post.module
@@ -12,6 +12,8 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Url;
 use Drupal\Core\Access\AccessResult;
 use Drupal\user\Entity\User;
+use Drupal\group\Entity\GroupInterface;
+use Drupal\group\Entity\Group;
 
 /**
  * Implements hook_form_FORM_ID_alter().
@@ -197,6 +199,9 @@ function social_post_preprocess_field(array &$variables) {
 function social_post_comment_create_access(AccountInterface $account, array $context, $entity_bundle) {
   if ($entity_bundle === 'post_comment') {
     $group = \Drupal::routeMatch()->getParameter('group');
+    if (is_numeric($group) && !$group instanceof GroupInterface) {
+      $group = Group::load($group);
+    }
     if ($group) {
       if ($group->hasPermission('add post entities in group', $account)) {
         return AccessResult::allowed()->cachePerUser();


### PR DESCRIPTION
This patch was delivered by Namzhilma Zhambalova in https://www.drupal.org/project/social/issues/2940839

## Problem
When creating a custom view with URL '/group/%group/photos' with posts you will see the mentioned warning. It is also reproducible by going to /admin/group/types/manage/open_group/permissions as user 1.

## Solution
Check if the group is an id or a Group object, if it's an id load the group before calling the hasPermission() method.

## Issue tracker
- https://www.drupal.org/project/social/issues/2940839

## HTT
- [x] Stay on the 8.x-1.x branch first
- [x] Login as admin
- [x] Go to /admin/group/types/manage/open_group/permissions
- [x] Notice you are getting an error
- [x] Switch to this branch and refresh
- [x] Notice the error is gone

## Documentation
- [ ] This item is added to the release notes
- [x] This item is documented on LGOS
- [x] This item has been added to the feature overview
