### PR TITLE
2937077 by jochemvn: Make sure 'post' link works when sending group messages

### DIFF
--- a/modules/social_features/social_group/social_group.tokens.inc
+++ b/modules/social_features/social_group/social_group.tokens.inc
@@ -104,17 +104,23 @@ function social_group_tokens($type, $tokens, array $data, array $options, Bubble
             if (is_object($entity)) {
               // If it's group content.
               if ($entity->getEntityTypeId() === 'group_content') {
-                if ($name === 'content_url') {
-                  $content_url = Url::fromRoute('entity.node.canonical',
-                    ['node' => $entity->getEntity()->id()],
-                    ['absolute' => TRUE]
-                  );
-                  $replacements[$original] = $content_url->toString();
-                }
+                $content_url = Url::fromRoute('entity.node.canonical',
+                  ['node' => $entity->getEntity()->id()],
+                  ['absolute' => TRUE]
+                );
+                $replacements[$original] = $content_url->toString();
+              }
+              // For posts, it works slightly different.
+              elseif ($entity->getEntityTypeId() === 'post') {
+                $content_url = Url::fromRoute('entity.post.canonical',
+                  ['post' => $entity->id()],
+                  ['absolute' => TRUE]
+                );
+                $replacements[$original] = $content_url->toString();
               }
             }
           }
-
+          break;
       }
     }
   }


### PR DESCRIPTION
## Problem
When you create a post in the group, the notifcation mail that is being sent has a malformed link to the 'post' entity.

## Solution
Fix the link of the post entity to its canonical

## Issue tracker
- https://www.drupal.org/project/social/issues/2937077

## HTT
- [x] Check out the code changes
- [x] Login as a group member of a certain group
- [x] Make sure the group has some members besides yourself
- [x] Create a post, a topic and an event in the group
- [x] Check the email notifications and see that the link to the post, topic and event work

## Documentation
- [x] This item is added to the release notes
- [x] This item is documented on LGOS
- [x] This item has been added to the feature overview
