### PR TITLE
Issue #2936748 : prevent warning when adding node from group page with tagging

### DIFF
--- a/modules/social_features/social_tagging/social_tagging.module
+++ b/modules/social_features/social_tagging/social_tagging.module
@@ -14,7 +14,6 @@ use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\Render\Element;
 use Drupal\Core\Url;
 use Drupal\node\Entity\Node;
-use Drupal\node\Entity\NodeType;
 use Drupal\taxonomy\Entity\Term;
 
 /**

--- a/modules/social_features/social_tagging/social_tagging.module
+++ b/modules/social_features/social_tagging/social_tagging.module
@@ -106,21 +106,12 @@ function social_tagging_form_taxonomy_overview_terms_alter(&$form, FormStateInte
  */
 function social_tagging_form_node_form_alter(&$form, FormStateInterface $form_state, $form_id) {
 
-  /** @var \Drupal\node\Entity\NodeType $node_type */
-  $node_type = \Drupal::routeMatch()->getParameter('node_type');
-  /** @var \Drupal\node\Entity\Node $node */
-  $node = \Drupal::routeMatch()->getParameter('node');
-
-  // On node edit we need to do this.
-  if (!$node_type) {
-    $node_type = NodeType::load($node->bundle());
-  }
-
+  $node = $form_state->getFormObject()->getEntity();
   $node_type_tagging = TRUE;
-  if ($node_type instanceof NodeType) {
+  if ($node_type = $node->type->entity->id()) {
 
     $config = \Drupal::getContainer()->get('config.factory')->getEditable('social_tagging.settings');
-    $config_value = $config->get('tag_node_type_' . $node_type->id());
+    $config_value = $config->get('tag_node_type_' . $node_type);
 
     if ($config_value === FALSE || $config_value === 0) {
       $node_type_tagging = FALSE;


### PR DESCRIPTION

## Problem
When social tagging is enabled and you create a topic from a group Topics overview page you will see this error:
`The website encountered an unexpected error. Please try again later.
Error: Call to a member function bundle() on null in social_tagging_form_node_form_alter() (line 116 of profiles/contrib/social/modules/social_features/social_tagging/social_tagging.module).`

The bug was introduced in https://github.com/goalgorilla/open_social/pull/706 so no reason to create a new bugreport on d.o just yet.

## Solution
Find a better way to retrieve the node_type. There is no reason to depend on the route parameters when you can get the node object from the form state directly.

## Issue tracker
- https://github.com/goalgorilla/open_social/pull/706

## HTT
- [ ] Login as user X and go to a group you are member of.
- [ ] When you go to to Topics > Create topic (url should be: /group/[id]/content/create/group_node%3Atopic) you should not see the error above. If you compare it with 8.x-1.x you will see that the error is there.
- [ ] Check the way I retrieve the node-type now and see if this is ok.

## Documentation
- [x] This item is added to the release notes (not needed)
- [x] This item is documented on LGOS (not needed)
- [x] This item has been added to the feature overview (not needed)
