### PR TITLE
Don't use deprecated RawDrupalContext property

### DIFF
--- a/tests/behat/features/bootstrap/SocialDrupalContext.php
+++ b/tests/behat/features/bootstrap/SocialDrupalContext.php
@@ -33,7 +33,8 @@ class SocialDrupalContext extends DrupalContext {
    * @Given I am viewing my :type( content):
    */
   public function assertViewingMyNode($type, TableNode $fields) {
-    if (!isset($this->user->uid)) {
+    $user = $this->getUserManager()->getCurrentUser();
+    if (!$user) {
       throw new \Exception(sprintf('There is no current logged in user to create a node for.'));
     }
 
@@ -47,7 +48,7 @@ class SocialDrupalContext extends DrupalContext {
       $node->{$field} = $value;
     }
 
-    $node->uid = $this->user->uid;
+    $node->uid = $user->uid;
 
     $saved = $this->nodeCreate($node);
 


### PR DESCRIPTION
## Problem
Interacting directly with the `RawDrupalContext::$user` property has been deprecated. Use `RawDrupalContext::getUserManager->getCurrentUser()` instead.

This causes tests to fail for some projects.

## Solution
Follow the suggestion and replace `$this->user` with `$this->getUserManager->getCurrentUser()` in SocialDrupalContext

## Issue tracker
No drupal.org issue

## HTT
- [ ] Check out the code changes
- [ ] Tests don't fail in a new way

## Documentation
No documentation change needed
