### PR TITLE
Issue #2938779 - add the PM e-mail notification setting only when module is enabled

### DIFF
--- a/modules/custom/activity_send/modules/activity_send_email/activity_send_email.module
+++ b/modules/custom/activity_send/modules/activity_send_email/activity_send_email.module
@@ -135,7 +135,6 @@ function activity_send_email_form_user_form_alter(&$form, FormStateInterface $fo
       $all_email_message_keys[4] => $all_email_message_values[4],
       $all_email_message_keys[3] => $all_email_message_values[3],
       $all_email_message_keys[2] => $all_email_message_values[2],
-      $all_email_message_keys[9] => $all_email_message_values[9],
     ];
     $what_manage = [
       $all_email_message_keys[0] => $all_email_message_values[0],
@@ -144,6 +143,10 @@ function activity_send_email_form_user_form_alter(&$form, FormStateInterface $fo
       $all_email_message_keys[1] => $all_email_message_values[1],
       $all_email_message_keys[5] => $all_email_message_values[5],
     ];
+
+    if (\Drupal::moduleHandler()->moduleExists('social_private_message') && isset($all_email_message_keys[9])) {
+      $message_to_me[$all_email_message_keys[9]] = $all_email_message_values[9];
+    }
 
     // Sort a list of email frequencies by weight.
     $emailfrequencies = sort_email_frequency_options();


### PR DESCRIPTION
## Problem
In #702 we introduced a bug that when the module private message is not enabled there would be a Notice on the account settings form:

`Notice: Undefined offset: 9 in activity_send_email_form_user_form_alter() (line 146 of /var/www/html/profiles/contrib/social/modules/custom/activity_send/modules/activity_send_email/activity_send_email.module) `

## Solution
Add a check to make sure the module exists and the key of the messages.

## Issue tracker
- N/A, but you can see pullrequest #702 

## HTT
- [x] Check out the code changes
- [x] Login as user X and go to your account settings when module is enabled and disabled
- [x] When module is enabled I see: "A user sends a private message to me" option in the notification settings

## Documentation
No changes needed since it was already added to the release notes and this bug is solved before the release.
