### PR TITLE
Redirect to post comment after editing

### DIFF
--- a/modules/social_features/social_post/social_post.module
+++ b/modules/social_features/social_post/social_post.module
@@ -67,25 +67,36 @@ function social_post_form_post_form_alter(&$form, FormStateInterface $form_state
  *
  * Alter the comment_post_comment_form form.
  */
-function social_post_form_comment_post_comment_form_alter(&$form, FormStateInterface $form_state, $form_id) {
-  // Reset title display.
-  $form['field_comment_body']['widget'][0]['#title_display'] = 'invisible';
-
-  // Set the action of the form to the current uri.
-  // This needs to be done, because we cannot override $form['#action']
-  // without breaking functionality.
-  $uri = Url::fromRoute('<current>')->toString();
-  // Store in a hidden field.
-  $form['redirect_after_save'] = [
-    '#type' => 'hidden',
-    '#title' => t('Redir'),
-    '#default_value' => $uri,
-  ];
-
-  // Submit function to retrieve the action uri and redirect to it.
-  $form['actions']['submit']['#submit'][] = '_social_post_comment_post_comment_form_submit';
+function social_post_form_comment_post_comment_form_alter(&$form, FormStateInterface $form_state, $form_id)
+{
+    // Reset title display.
+    $form['field_comment_body']['widget'][0]['#title_display'] = 'invisible';
+    //for redirecting the comment_edit_form page
+    $route_name = \Drupal::routeMatch()->getRouteName();
+    //check if on editing comment
+    if ($route_name == 'entity.comment.edit_form') {
+        $uri = Url::fromRoute('<current>')->toUriString();
+        $form['redirect_after_save'] = [
+            '#type' => 'hidden',
+            '#title' => t('Redir'),
+            '#defautl_value' => $uri,
+        ];
+    }
+    else {
+        // Set the action of the form to the current uri.
+        // This needs to be done, because we cannot override $form['#action']
+        // without breaking functionality.
+        $uri = Url::fromRoute('<current>')->toString();
+        // Store in a hidden field.
+        $form['redirect_after_save'] = [
+            '#type' => 'hidden',
+            '#title' => t('Redir'),
+            '#default_value' => $uri,
+        ];
+    }
+    // Submit function to retrieve the action uri and redirect to it.
+    $form['actions']['submit']['#submit'][] = '_social_post_comment_post_comment_form_submit';
 }
-
 /**
  * Form submit for comment_post_comment_form.
  *

--- a/modules/social_features/social_post/social_post.module
+++ b/modules/social_features/social_post/social_post.module
@@ -70,29 +70,21 @@ function social_post_form_post_form_alter(&$form, FormStateInterface $form_state
 function social_post_form_comment_post_comment_form_alter(&$form, FormStateInterface $form_state, $form_id) {
   // Reset title display.
   $from['field_comment_body']['widget'][0]['#title_display'] = 'invisible';
+
   // For redirecting the comment_edit_form page.
   $route_name = \Drupal::routeMatch()->getRouteName();
   // Check if we are on editing comment.
+  $uri = Url::fromRoute('<current>')->toString();
   if ($route_name == 'entity.comment.edit_form') {
     $uri = Url::fromRoute('<current>')->toUriString();
-    $form['redirect_after_save'] = [
-      '#type' => 'hidden',
-      '#title' => t('Redir'),
-      '#defautl_value' => $uri,
-    ];
   }
-  else {
-    // Set the action of the form to the current uri.
-    // This needs to be done, because we cannot override $form['#action']
-    // Without breaking functionality.
-    $uri = Url::fromRoute('<current>')->toString();
-    // Store in a hidden field.
-    $form['redirect_after_save'] = [
-      '#type' => 'hidden',
-      '#title' => t('Redir'),
-      '#default_value' => $uri,
-    ];
-  }
+
+  $form['redirect_after_save'] = [
+    '#type' => 'hidden',
+    '#title' => t('Redir'),
+    '#defautl_value' => $uri,
+  ];
+
   // Submit function to retrieve the action uri and redirect to it.
   $form['actions']['submit']['#submit'][] = '_social_post_comment_post_comment_form_submit';
 }
@@ -115,6 +107,7 @@ function _social_post_comment_post_comment_form_submit(array $form, FormStateInt
   if (UrlHelper::isValid($uri)) {
     // Get the Url from the Form value and redirect to this url.
     $url = Url::fromUserInput($uri);
+    var_dump($url);
     // Set redirect.
     $form_state->setRedirectUrl($url);
   }

--- a/modules/social_features/social_post/social_post.module
+++ b/modules/social_features/social_post/social_post.module
@@ -69,20 +69,26 @@ function social_post_form_post_form_alter(&$form, FormStateInterface $form_state
  */
 function social_post_form_comment_post_comment_form_alter(&$form, FormStateInterface $form_state, $form_id) {
   // Reset title display.
-  $from['field_comment_body']['widget'][0]['#title_display'] = 'invisible';
+  $form['field_comment_body']['widget'][0]['#title_display'] = 'invisible';
 
-  // For redirecting the comment_edit_form page.
+  // For redirecting the comment.edit_form page.
   $route_name = \Drupal::routeMatch()->getRouteName();
-  // Check if we are on editing comment.
-  $uri = Url::fromRoute('<current>')->toString();
-  if ($route_name == 'entity.comment.edit_form') {
-    $uri = Url::fromRoute('<current>')->toUriString();
-  }
 
+  // Set the action of the form to the current uri.
+  // This needs to be done, because we cannot override $form['#action']
+  // without breaking functionality.
+  $uri = Url::fromRoute('<current>')->toString();
+
+  // Check if we are on editing comment.
+  if ($route_name == 'entity.comment.edit_form') {
+    $uri = Url::fromRoute('<current>')->toString();
+  }
+  
+  // Store in a hidden field.
   $form['redirect_after_save'] = [
     '#type' => 'hidden',
     '#title' => t('Redir'),
-    '#defautl_value' => $uri,
+    '#default_value' => $uri,
   ];
 
   // Submit function to retrieve the action uri and redirect to it.

--- a/modules/social_features/social_post/social_post.module
+++ b/modules/social_features/social_post/social_post.module
@@ -107,7 +107,6 @@ function _social_post_comment_post_comment_form_submit(array $form, FormStateInt
   if (UrlHelper::isValid($uri)) {
     // Get the Url from the Form value and redirect to this url.
     $url = Url::fromUserInput($uri);
-    var_dump($url);
     // Set redirect.
     $form_state->setRedirectUrl($url);
   }

--- a/modules/social_features/social_post/social_post.module
+++ b/modules/social_features/social_post/social_post.module
@@ -73,17 +73,14 @@ function social_post_form_comment_post_comment_form_alter(&$form, FormStateInter
 
   // For redirecting the comment.edit_form page.
   $route_name = \Drupal::routeMatch()->getRouteName();
-
   // Set the action of the form to the current uri.
   // This needs to be done, because we cannot override $form['#action']
   // without breaking functionality.
   $uri = Url::fromRoute('<current>')->toString();
-
   // Check if we are on editing comment.
   if ($route_name == 'entity.comment.edit_form') {
     $uri = Url::fromRoute('<current>')->toString();
   }
-  
   // Store in a hidden field.
   $form['redirect_after_save'] = [
     '#type' => 'hidden',

--- a/modules/social_features/social_post/social_post.module
+++ b/modules/social_features/social_post/social_post.module
@@ -76,10 +76,10 @@ function social_post_form_comment_post_comment_form_alter(&$form, FormStateInter
   if ($route_name == 'entity.comment.edit_form') {
     $uri = Url::fromRoute('<current>')->toUriString();
     $form['redirect_after_save'] = [
-    '#type' => 'hidden',
-    '#title' => t('Redir'),
-    '#defautl_value' => $uri,
-      ];
+      '#type' => 'hidden',
+      '#title' => t('Redir'),
+      '#defautl_value' => $uri,
+    ];
   }
   else {
     // Set the action of the form to the current uri.
@@ -87,15 +87,16 @@ function social_post_form_comment_post_comment_form_alter(&$form, FormStateInter
     // Without breaking functionality.
     $uri = Url::fromRoute('<current>')->toString();
     // Store in a hidden field.
-      $form['redirect_after_save'] = [
+    $form['redirect_after_save'] = [
       '#type' => 'hidden',
       '#title' => t('Redir'),
       '#default_value' => $uri,
-        ];
+    ];
   }
-    // Submit function to retrieve the action uri and redirect to it.
-    $form['actions']['submit']['#submit'][] = '_social_post_comment_post_comment_form_submit';
+  // Submit function to retrieve the action uri and redirect to it.
+  $form['actions']['submit']['#submit'][] = '_social_post_comment_post_comment_form_submit';
 }
+
 /**
  * Form submit for comment_post_comment_form.
  *

--- a/modules/social_features/social_post/social_post.module
+++ b/modules/social_features/social_post/social_post.module
@@ -67,33 +67,32 @@ function social_post_form_post_form_alter(&$form, FormStateInterface $form_state
  *
  * Alter the comment_post_comment_form form.
  */
-function social_post_form_comment_post_comment_form_alter(&$form, FormStateInterface $form_state, $form_id)
-{
-    // Reset title display.
-    $form['field_comment_body']['widget'][0]['#title_display'] = 'invisible';
-    //for redirecting the comment_edit_form page
-    $route_name = \Drupal::routeMatch()->getRouteName();
-    //check if on editing comment
-    if ($route_name == 'entity.comment.edit_form') {
-        $uri = Url::fromRoute('<current>')->toUriString();
-        $form['redirect_after_save'] = [
-            '#type' => 'hidden',
-            '#title' => t('Redir'),
-            '#defautl_value' => $uri,
+function social_post_form_comment_post_comment_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+  // Reset title display.
+  $from['field_comment_body']['widget'][0]['#title_display'] = 'invisible';
+  // For redirecting the comment_edit_form page.
+  $route_name = \Drupal::routeMatch()->getRouteName();
+  // Check if we are on editing comment.
+  if ($route_name == 'entity.comment.edit_form') {
+    $uri = Url::fromRoute('<current>')->toUriString();
+    $form['redirect_after_save'] = [
+    '#type' => 'hidden',
+    '#title' => t('Redir'),
+    '#defautl_value' => $uri,
+      ];
+  }
+  else {
+    // Set the action of the form to the current uri.
+    // This needs to be done, because we cannot override $form['#action']
+    // Without breaking functionality.
+    $uri = Url::fromRoute('<current>')->toString();
+    // Store in a hidden field.
+      $form['redirect_after_save'] = [
+      '#type' => 'hidden',
+      '#title' => t('Redir'),
+      '#default_value' => $uri,
         ];
-    }
-    else {
-        // Set the action of the form to the current uri.
-        // This needs to be done, because we cannot override $form['#action']
-        // without breaking functionality.
-        $uri = Url::fromRoute('<current>')->toString();
-        // Store in a hidden field.
-        $form['redirect_after_save'] = [
-            '#type' => 'hidden',
-            '#title' => t('Redir'),
-            '#default_value' => $uri,
-        ];
-    }
+  }
     // Submit function to retrieve the action uri and redirect to it.
     $form['actions']['submit']['#submit'][] = '_social_post_comment_post_comment_form_submit';
 }


### PR DESCRIPTION
## Problem
After editing a comment on a post, upon save you are direct to the edit screen. This is not correct.
When editing a comment on a topic, it does work correct: you return to the topic detail page. Same for reply on a comment: works like a charm!
## Solution
I think best is to return to the post detail page, scrolled down to your comment.
## Issue tracker
- https://www.drupal.org/project/social/issues/2934118

## HTT
 - [ ] create a comment on a post
 - [ ] edit the comment, press save
 - [ ] observe that you end up on the edit comment screen.
 - [ ] You do get a message that your comment has been posted.

Steps to reproduce the fix:

 - [ ] create a comment on a post
 - [ ] edit the comment, press save
 - [ ] observe that you end up on the post screen and you scroll down to edited comment.
 - [ ] You do get a message that your comment has been posted.