### PR TITLE
Issue #2937659 : post in a public group should always have public visibility

### DIFF
--- a/modules/social_features/social_post/src/Form/PostForm.php
+++ b/modules/social_features/social_post/src/Form/PostForm.php
@@ -71,9 +71,7 @@ class PostForm extends ContentEntityForm {
           unset($form['field_visibility']['widget'][0]['#options'][3]);
         }
         else {
-          // Remove public option from options.
           $form['field_visibility']['widget'][0]['#default_value'] = "0";
-          unset($form['field_visibility']['widget'][0]['#options'][1]);
           unset($form['field_visibility']['widget'][0]['#options'][2]);
 
           $current_group = _social_group_get_current_group();
@@ -82,14 +80,25 @@ class PostForm extends ContentEntityForm {
           }
           else {
             $group_type_id = $current_group->getGroupType()->id();
-            if ($group_type_id !== 'closed_group') {
+            $allowed_options = social_group_get_allowed_visibility_options_per_group_type($group_type_id);
+            if ($allowed_options['community'] !== TRUE) {
+              unset($form['field_visibility']['widget'][0]['#options'][0]);
+            }
+            if ($allowed_options['public'] !== TRUE) {
+              unset($form['field_visibility']['widget'][0]['#options'][1]);
+            }
+            else {
+              $form['field_visibility']['widget'][0]['#default_value'] = "1";
+            }
+            if ($allowed_options['group'] !== TRUE) {
               unset($form['field_visibility']['widget'][0]['#options'][3]);
             }
             else {
-              unset($form['field_visibility']['widget'][0]['#options'][0]);
               $form['field_visibility']['widget'][0]['#default_value'] = "3";
             }
           }
+
+
         }
       }
 

--- a/modules/social_features/social_post/src/Form/PostForm.php
+++ b/modules/social_features/social_post/src/Form/PostForm.php
@@ -98,7 +98,6 @@ class PostForm extends ContentEntityForm {
             }
           }
 
-
         }
       }
 

--- a/tests/behat/features/capabilities/group/group-create-public.feature
+++ b/tests/behat/features/capabilities/group/group-create-public.feature
@@ -74,6 +74,13 @@ Feature: Create Public Group
     And I click "Test public group"
     Then I should see the button "Joined"
 
+    # Create a post inside the public group, visible to public only
+    When I fill in "Say something to the group" with "This is a public group post."
+    And I select post visibility "Public"
+    And I press "Post"
+    Then I should see the success message "Your post has been posted."
+    And I should see "This is a public group post."
+
     When I click "Events"
     And I should see the link "Create Event" in the "Sidebar second"
     And I click "Create Event"
@@ -132,3 +139,6 @@ Feature: Create Public Group
     When I logout
     And I am on "all-groups"
     Then I should see the link "Test public group"
+
+    When I click "Test public group"
+    Then I should see "This is a public group post."


### PR DESCRIPTION

## Problem
Posts in public group are not public.

## Solution
I've improved the way we retrieve the visibility options for all the groups by using the re-usable `function social_group_get_allowed_visibility_options_per_group_type($group_type_id);` to retrieve all the allowed visibilty options for the given group type. Because I rewrote the code a bit it makes sense to test all the group types.

## Issue tracker
- https://www.drupal.org/project/social/issues/2937659

## HTT
- [x] Check out the code changes including the updated Behat test
- [x] Login as user X and create a Public Group
- [x] When you create a post you can only select Public visibility
- [x] When you create a post in a open Group you can only select Community visibility
- [x] When you create a post in a closed Group you can only select "Group members" visibility

## Documentation
- [x] This item is added to the release notes
- [x] This item is documented on LGOS
- [x] This item has been added to the feature overview
