### PR TITLE
DS-4880 - Update to Drupal 8.4.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -58,7 +58,7 @@
         "composer/installers": "^1.0",
         "oomphinc/composer-installers-extender": "^1.1",
         "drupal-composer/drupal-scaffold": "^2.0.0",
-        "drupal/core": "8.4.4",
+        "drupal/core": "8.4.5",
         "drupal/crop": "1.3",
         "drupal/address": "1.3",
         "drupal/addtoany": "1.8",

--- a/drupal-org-core.make
+++ b/drupal-org-core.make
@@ -1,6 +1,6 @@
 api = 2
 core = 8.x
 projects[drupal][type] = core
-projects[drupal][version] = 8.4.4
+projects[drupal][version] = 8.4.5
 projects[drupal][patch][] = "https://www.drupal.org/files/issues/color-optional-html-preview-2844190-2.patch"
 projects[drupal][patch][] = "https://www.drupal.org/files/issues/image_restrict_image_styles-2528214-19.patch"

--- a/social.info.yml
+++ b/social.info.yml
@@ -2,7 +2,7 @@ name: Social
 type: profile
 description: 'Open Social install profile.'
 core: '8.x'
-version: '8.x-1.9'
+version: '8.x-1.10'
 project: social
 
 dependencies:


### PR DESCRIPTION
## Problem
Security update for Drupal core 8.4.5 is out, but we're on 8.4.4.

## Solution
Update Drupal Core to 8.4.5.
