### PR TITLE
2939377 by left: replace unset with auto for top position value so it…

### DIFF
--- a/themes/socialbase/assets/css/autocomplete.css
+++ b/themes/socialbase/assets/css/autocomplete.css
@@ -8,7 +8,7 @@
 
 .ui-autocomplete.ui-widget-content.upward {
   bottom: 38px;
-  top: unset !important;
+  top: auto !important;
 }
 
 .ui-autocomplete.ui-widget-content .ui-menu-item {

--- a/themes/socialbase/components/03-molecules/form-elements/autocomplete/autocomplete.scss
+++ b/themes/socialbase/components/03-molecules/form-elements/autocomplete/autocomplete.scss
@@ -20,7 +20,7 @@
 
 	&.upward {
 		bottom: 38px; // height of textarea
-		top: unset !important;
+		top: auto !important;
 	}
 
 	.ui-menu-item {


### PR DESCRIPTION
Replace unset with auto for top position value so it works in IE

## Problem
top: unset is not supported in IE therefore the userlist is not placed above the textarea as intended

## Solution
use top: auto instead

## Issue tracker
https://www.drupal.org/project/social/issues/2939377

## HTT
- [ ] In IE, login as member+ scroll to the last comment on the stream. In the comment field start typing `@a` to get a long list of users
- [ ] Notice it exceeds the viewport height, and the background color is missing
- [ ] Checkout to this branch
- [ ] Repeat step 1. Notice the userlist being placed above the textarea and all users are visible to select

## Documentation
- [ ] This item is added to the release notes
- [ ] This item is documented on LGOS
- [ ] This item has been added to the feature overview
