### PR TITLE
Issue #2936477: fix dependency declaration in social.info.yml

### DIFF
--- a/social.info.yml
+++ b/social.info.yml
@@ -6,11 +6,11 @@ version: '8.x-1.11'
 project: social
 
 dependencies:
-  - config
-  - system
-  - user
-  - breakpoint
-  - features
+  - drupal:config
+  - drupal:system
+  - drupal:user
+  - drupal:breakpoint
+  - features:features
 themes:
   - seven
   - socialbase


### PR DESCRIPTION
## Problem
The info file contains dependencies without the drupal: declaration. 

## Solution
All dependencies must be prefixed with the project name.

## Issue tracker
- https://www.drupal.org/project/social/issues/2936477

## HTT
- [x] Check out the code changes
- [ ] Do a new install, check that it works and the modules are enabled.

## Documentation
- [ ] This item is added to the release notes
- [ ] This item is documented on LGOS
- [ ] This item has been added to the feature overview
