### PR TITLE
Issue #2925751: add custom permission for administering navigation

### DIFF
--- a/modules/social_features/social_user/social_user.install
+++ b/modules/social_features/social_user/social_user.install
@@ -74,6 +74,19 @@ function social_user_update_8004() {
 }
 
 /**
+ * Add permissions to administer the navigation settings.
+ */
+function social_user_update_8005() {
+  $rid = 'sitemanager';
+  // Revoke permissions for the role.
+  $role = Role::load($rid);
+  if ($role) {
+    $permissions = ['administer navigation settings'];
+    user_role_grant_permissions($rid, $permissions);
+  }
+}
+
+/**
  * Function to set permissions.
  */
 function _social_user_set_permissions() {
@@ -118,6 +131,7 @@ function _social_user_get_permissions($role) {
   $permissions['sitemanager'] = array_merge($permissions['contentmanager'], [
     'view users',
     'block users',
+    'administer navigation settings',
   ]);
 
   if (isset($permissions[$role])) {

--- a/modules/social_features/social_user/social_user.permissions.yml
+++ b/modules/social_features/social_user/social_user.permissions.yml
@@ -7,3 +7,6 @@ block users:
   title: 'Block users'
   description: 'Allow to access the administration form to block some users.'
   restrict access: true
+
+administer navigation settings:
+  title: 'Administer Navigation Settings'

--- a/modules/social_features/social_user/social_user.routing.yml
+++ b/modules/social_features/social_user/social_user.routing.yml
@@ -20,4 +20,4 @@ social_user.navigation_settings:
     _form: '\Drupal\social_user\Form\SocialUserNavigationSettingsForm'
     _title: 'Navigation Settings'
   requirements:
-    _permission: 'administer site configuration'
+    _permission: 'administer navigation settings'


### PR DESCRIPTION
## Problem
SocialUserNavigationSettingsForm uses the 'administer site configuration' permission. We don't want to give this permission to the SM since it has side effects.

## Solution
This needs to be made a custom permission so it can be given to SMs.

## Issue tracker
- https://www.drupal.org/project/social/issues/2925751

## HTT
- [ ] Check out the code changes
- [ ] Run updb
- [ ] Login as SM and check out it works as expected.

## Documentation
- [ ] This item is added to the release notes
- [ ] This item is documented on LGOS
- [ ] This item has been added to the feature overview
