### PR TITLE
#2949101: Fix missing profile images for anonymous visitors

### DIFF
--- a/modules/social_features/social_profile/social_profile.module
+++ b/modules/social_features/social_profile/social_profile.module
@@ -420,9 +420,10 @@ function social_profile_profile_view_alter(array &$build, EntityInterface $entit
 
   /** @var \Drupal\Core\Session\AccountProxy $current_user */
   $current_user = \Drupal::currentUser();
+
   // If the current user has no access to viewing user profiles, he might not
   // have access to the users profile.
-  if (!$current_user->hasPermission('view any profile profile') && ($display->getMode() === 'compact' || $display->getMode() === 'compact_notification')) {
+  if (!$current_user->hasPermission('view any profile profile') && isset($display->get('content')['field_profile_image'])) {
     // Try to load the profile picture.
     $fid = $entity->get('field_profile_image')->target_id;
     // Must have a value and not be NULL.


### PR DESCRIPTION
## Problem
With Social Private Files turned on the profile images are saved in the private files folder. This works ok, but for some display modes the profile image is not replaced by the default image.

When it is not replaced with the default image a request is done for the normal image. But this one is not accessible and thus results in a missing image.

The check is currently on `compact` and `compact_notification` display modes. However we already have `small_teaser` display mode and possibly more in the future.

## Solution
By adding a check for the `field_profile_image` being used in a display mode, instead of checking for specific display modes this is easily solved.

## Issue tracker
- https://www.drupal.org/project/social/issues/2949101

## HTT
- [x] Check out the code changes and make sure Social Private Files is enabled
- [x] Register a new account, upload an image
- [x] Create a public group
- [x] Post something in the stream and create a topic in the public group
- [x] As an anonymous visitor check out the public group, observe that the image is replaced by the default one (check activity stream and newest members)
- [x] As a logged in user visit the public group, verify you can see the image the user uploaded

## Documentation
- [ ] This item is added to the release notes
- [x] This item is documented on LGOS
- [x] This item has been added to the feature overview
