### PR TITLE
2925592 Disable e-mail notifications of people liking my comments

### DIFF
--- a/modules/custom/activity_send/modules/activity_send_email/activity_send_email.install
+++ b/modules/custom/activity_send/modules/activity_send_email/activity_send_email.install
@@ -8,24 +8,6 @@
 use Drupal\Core\Database\Database;
 
 /**
- * Implements hook_install().
- *
- * Perform actions related to the installation of activity_send_email.
- */
-function activity_send_email_install() {
-  // Set email destination to given message templates.
-  $message_templates = ['create_post_profile'];
-  foreach ($message_templates as $message_template) {
-    $config_name = "message.template.{$message_template}";
-    $config = \Drupal::service('config.factory')->getEditable($config_name);
-    $activity_destinations = $config->get('third_party_settings.activity_logger.activity_destinations');
-    $activity_destinations['email'] = 'email';
-    $config->set('third_party_settings.activity_logger.activity_destinations', $activity_destinations);
-    $config->save();
-  }
-}
-
-/**
  * Implements hook_uninstall().
  *
  * Removes keys from the State API.

--- a/modules/custom/activity_send/modules/activity_send_email/activity_send_email.module
+++ b/modules/custom/activity_send/modules/activity_send_email/activity_send_email.module
@@ -119,96 +119,78 @@ function activity_send_email_form_user_form_alter(&$form, FormStateInterface $fo
     ];
 
     $form['email_notifications']['description'] = [
-      '#markup' => '<p>' . t('For each email notification below, you can choose to turn it off, receive it immediately or in a daily or weekly digest. Email notifications will only be sent when you are not active in the platform.') . '</p>',
+      '#type' => 'html_tag',
+      '#tag' => 'p',
+      '#value' => t('For each email notification below, you can choose to turn it off, receive it immediately or in a daily or weekly digest. Email notifications will only be sent when you are not active in the platform.'),
+    ];
+
+    $items = [
+      'message_to_me' => [
+        'title' => t('Message to me'),
+        'templates' => [
+          'create_post_profile',
+          'create_mention_post',
+          'create_mention_comment',
+          'create_comment_reply_mention',
+          'create_comment_reply',
+          'create_comment_post_profile',
+          'create_like_node_or_post',
+        ],
+      ],
+      'what_manage' => [
+        'title' => t('What I manage'),
+        'templates' => [
+          'create_comment_author_node_post',
+        ],
+      ],
+      'what_follow' => [
+        'title' => t('What I follow'),
+        'templates' => [
+          'create_comment_following_node',
+          'create_content_in_joined_group',
+        ],
+      ],
     ];
 
     $email_message_templates = EmailActivityDestination::getSendEmailMessageTemplates();
-    $user_email_settings = EmailActivityDestination::getSendEmailUserSettings($account);
 
-    $all_email_message_keys = array_keys($email_message_templates);
-    $all_email_message_values = array_values($email_message_templates);
-
-    $message_to_me = [
-      $all_email_message_keys[8] => $all_email_message_values[8],
-      $all_email_message_keys[7] => $all_email_message_values[7],
-      $all_email_message_keys[6] => $all_email_message_values[6],
-      $all_email_message_keys[4] => $all_email_message_values[4],
-      $all_email_message_keys[3] => $all_email_message_values[3],
-      $all_email_message_keys[2] => $all_email_message_values[2],
-    ];
-    $what_manage = [
-      $all_email_message_keys[0] => $all_email_message_values[0],
-    ];
-    $what_follow = [
-      $all_email_message_keys[1] => $all_email_message_values[1],
-      $all_email_message_keys[5] => $all_email_message_values[5],
-    ];
-
-    if (\Drupal::moduleHandler()->moduleExists('social_private_message') && isset($all_email_message_keys[9])) {
-      $message_to_me[$all_email_message_keys[9]] = $all_email_message_values[9];
+    if (\Drupal::moduleHandler()->moduleExists('social_private_message') && isset($email_message_templates['create_private_message'])) {
+      $items['message_to_me']['templates'][] = 'create_private_message';
     }
 
     // Sort a list of email frequencies by weight.
-    $emailfrequencies = sort_email_frequency_options();
+    $email_frequencies = sort_email_frequency_options();
 
     $notification_options = [];
 
     // Place the sorted data in an actual form option.
-    foreach ($emailfrequencies as $option) {
+    foreach ($email_frequencies as $option) {
       $notification_options[$option['id']] = $option['name'];
     }
 
-    // The email notification settings for Message to me.
-    $form['email_notifications']['message_to_me'] = [
-      '#type' => 'details',
-      '#title' => t('<h5>Message to me</h5>'),
-      '#attributes' => [
-        'class' => ['form-fieldset'],
-      ],
-    ];
-    // Build the message to me section.
-    foreach ($message_to_me as $key => $title) {
-      $form['email_notifications']['message_to_me'][$key] = [
-        '#type' => 'select',
-        '#title' => $title,
-        '#options' => $notification_options,
-        '#default_value' => isset($user_email_settings[$key]) ? $user_email_settings[$key] : 'immediately',
-      ];
-    }
-    // The email notification settings for What I manage.
-    $form['email_notifications']['what_manage'] = [
-      '#type' => 'details',
-      '#title' => t('<h5>What I manage</h5>'),
-      '#attributes' => [
-        'class' => ['form-fieldset'],
-      ],
-    ];
-    // Build the what I manage section.
-    foreach ($what_manage as $key => $title) {
-      $form['email_notifications']['what_manage'][$key] = [
-        '#type' => 'select',
-        '#title' => $title,
-        '#options' => $notification_options,
-        '#default_value' => isset($user_email_settings[$key]) ? $user_email_settings[$key] : 'immediately',
-      ];
-    }
+    $user_email_settings = EmailActivityDestination::getSendEmailUserSettings($account);
 
-    // The email notification settings for What I follow.
-    $form['email_notifications']['what_follow'] = [
-      '#type' => 'details',
-      '#title' => t('<h5>What I follow</h5>'),
-      '#attributes' => [
-        'class' => ['form-fieldset'],
-      ],
-    ];
-    // Build the what I follow section.
-    foreach ($what_follow as $key => $title) {
-      $form['email_notifications']['what_follow'][$key] = [
-        '#type' => 'select',
-        '#title' => $title,
-        '#options' => $notification_options,
-        '#default_value' => isset($user_email_settings[$key]) ? $user_email_settings[$key] : 'immediately',
+    foreach ($items as $item_id => $item) {
+      $form['email_notifications'][$item_id] = [
+        '#type' => 'details',
+        '#title' => [
+          '#type' => 'html_tag',
+          '#tag' => 'h5',
+          '#value' => $item['title'],
+        ],
+        '#attributes' => [
+          'class' => ['form-fieldset'],
+        ],
       ];
+
+      foreach ($item['templates'] as $template) {
+        $form['email_notifications'][$item_id][$template] = [
+          '#type' => 'select',
+          '#title' => $email_message_templates[$template],
+          '#options' => $notification_options,
+          '#default_value' => isset($user_email_settings[$template]) ? $user_email_settings[$template] : 'immediately',
+        ];
+      }
     }
 
     // Submit function to save send email settings.

--- a/modules/social_features/social_like/config/install/message.template.create_like_node_or_post.yml
+++ b/modules/social_features/social_like/config/install/message.template.create_like_node_or_post.yml
@@ -11,6 +11,7 @@ third_party_settings:
     activity_context: vote_activity_context
     activity_destinations:
       notifications: notifications
+      email: email
     activity_create_direct: 1
     activity_aggregate: 0
     activity_entity_condition: ''


### PR DESCRIPTION
## Problem
User settings page does not have a field for controlling e-mail notification which you received when someone liking your post, comment, etc.

## Solution
Implement possibility to control e-mail notifications about liking my stuff.

## Issue tracker
- https://www.drupal.org/project/social/issues/2925592
- https://jira.goalgorilla.com/browse/DS-4477

## HTT
- [x] Login and go to user settings page for user X
- [x] You should see an option for control liking in **Email notifications** section
- [x] Select `None` and as user Y like a post of user X
- [x] User X should not have received any notifications regarding the like
- [x] Select `Immediately` and as user Y like a post of user X
- [x] User X should receive a notifications regarding the like
- [x] Select `Daily` or `Weekly` and as user Y like a post of user X
- [x] Wait a day or a week, or force the digest cron to run
- [x] User X should receive a digest notification regarding the like

## Documentation
- [ ] This item is added to the release notes
- [ ] This item is documented on LGOS
- [ ] This item has been added to the feature overview
