### PR TITLE
Issue #2949847 by ribel: Remove not needed |render filters in twig templates

### DIFF
--- a/modules/social_features/social_landing_page/templates/profile--featured.html.twig
+++ b/modules/social_features/social_landing_page/templates/profile--featured.html.twig
@@ -15,7 +15,7 @@
 {% block card_title %}
   <h4 class="teaser__title">
     <a href="{{ profile_stream_url }}">
-      {{ profile_name|render }}
+      {{ profile_name }}
     </a>
   </h4>
 {% endblock %}

--- a/modules/social_features/social_mentions/templates/profile--profile--autocomplete_item.html.twig
+++ b/modules/social_features/social_mentions/templates/profile--profile--autocomplete_item.html.twig
@@ -21,4 +21,4 @@
 #}
 
 <span class="avatar mention__avatar"> {{ content.field_profile_image }} </span>
-<span class="mention__name"> {{ profile_name|render }} </span>
+<span class="mention__name"> {{ profile_name }} </span>

--- a/themes/socialbase/templates/profile/profile--profile--compact_teaser.html.twig
+++ b/themes/socialbase/templates/profile/profile--profile--compact_teaser.html.twig
@@ -28,7 +28,7 @@
     </a>
 
     <div class="list-item__text">
-      <a href="{{ profile_stream_url }}" title="{{ 'View Profile'|t }}">{{ profile_name|render }}</a>
+      <a href="{{ profile_stream_url }}" title="{{ 'View Profile'|t }}">{{ profile_name }}</a>
 
       {% if content.field_profile_function|render and content.field_profile_organization|render %} <br /> {% endif %}
       {{content.field_profile_function}}

--- a/themes/socialbase/templates/profile/profile--profile--hero.html.twig
+++ b/themes/socialbase/templates/profile/profile--profile--hero.html.twig
@@ -53,12 +53,12 @@
 
     <div class="hero-footer__text">
       {% if content.field_profile_function|render %}
-        <strong>{{ content.field_profile_function|render }}</strong>
+        <strong>{{ content.field_profile_function }}</strong>
       {% endif %}
       {% if (content.field_profile_function|render and content.field_profile_organization|render) %}
       &nbsp;-&nbsp;
       {% endif %}
-        {{ content.field_profile_organization|render }}
+        {{ content.field_profile_organization }}
     </div>
 
     {% if profile_contact_label == 'private_message' %}

--- a/themes/socialbase/templates/profile/profile--profile--medium_teaser.html.twig
+++ b/themes/socialbase/templates/profile/profile--profile--medium_teaser.html.twig
@@ -29,7 +29,7 @@
     </span>
 
     <span class="list-item__text">
-      {{ profile_name|render }}
+      {{ profile_name }}
     </span>
 
   </a>

--- a/themes/socialbase/templates/profile/profile--profile--small_teaser.html.twig
+++ b/themes/socialbase/templates/profile/profile--profile--small_teaser.html.twig
@@ -29,7 +29,7 @@
     </span>
 
     <span class="list-item__text">
-      {{ profile_name|render }}
+      {{ profile_name }}
     </span>
 
   </a>

--- a/themes/socialbase/templates/profile/profile--profile--table.html.twig
+++ b/themes/socialbase/templates/profile/profile--profile--table.html.twig
@@ -33,7 +33,7 @@
   <div class="media-body">
     <h6 class="list-group-item-heading no-margin">
       <a href="{{ profile_stream_url }}">
-        {{ profile_name|render }}
+        {{ profile_name }}
       </a>
     </h6>
   </div>

--- a/themes/socialbase/templates/profile/profile--profile--teaser--anonymous.html.twig
+++ b/themes/socialbase/templates/profile/profile--profile--teaser--anonymous.html.twig
@@ -29,7 +29,7 @@
   <div class="teaser__body">
     <div class="teaser__content">
       <h4 class="teaser__title">
-        {{ profile_name|render }}
+        {{ profile_name }}
       </h4>
       {% if content.field_profile_function|render or content.field_profile_organization|render %}
         <div class="teaser__content-line">

--- a/themes/socialbase/templates/profile/profile--profile--teaser.html.twig
+++ b/themes/socialbase/templates/profile/profile--profile--teaser.html.twig
@@ -30,7 +30,7 @@
     <div class="teaser__content">
       <h4 class="teaser__title">
        <a href="{{ profile_stream_url }}">
-          {{ profile_name|render }}
+          {{ profile_name }}
         </a>
       </h4>
         {% if content.field_profile_function|render or content.field_profile_organization|render %}


### PR DESCRIPTION
## Problem
There are multiple places with code `{{ profile_name|render }}`. Render filter in twig templates is useful for if statements, but it's redundant in normal output cases.
It could cause issues like this if you want for example use tags in username output: http://prntscr.com/imrp67

## Solution
Remove not needed `|render` filter after profile_name in twig templates.
Profile names with additional tags will look like this after that: http://prntscr.com/imrowl

## Issue tracker
- https://www.drupal.org/project/social/issues/2949847
- https://jira.goalgorilla.com/browse/ECI-691

## Example for HTT

```
function user_hooks_test_user_format_name_alter(&$name, $account) {
  if (\Drupal::state()
    ->get('user_hooks_test_user_format_name_alter', FALSE)) {
    if (\Drupal::state()
      ->get('user_hooks_test_user_format_name_alter_safe', FALSE)) {
      $name = SafeMarkup::format('<em>@uid</em>', array(
        '@uid' => $account
          ->id(),
      ));
    }
    else {
      $name = '<em>' . $account
        ->id() . '</em>';
    }
  }
}
```

## HTT
- [ ] Check out the code changes
- [ ] Implement hook as from example above
- [ ] Notice tags are displayed like in problem description screenshot
- [ ] Checkout to this branch
- [ ] Notice tags are displayed like in problem solution screenshot

## Documentation
- [x] This item is added to the release notes
- [ ] This item is documented on LGOS
- [ ] This item has been added to the feature overview
