### PR TITLE
2528214 by robertragas: add new patch number for restrict image text-…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "patches": {
             "drupal/core": {
                 "Color module html preview optional": "https://www.drupal.org/files/issues/color-optional-html-preview-2844190-2.patch",
-                "Restrict images to this site blocks image style derivatives": "https://www.drupal.org/files/issues/image_restrict_image_styles-2528214-19.patch",
+                "Restrict images to this site blocks image style derivatives": "https://www.drupal.org/files/issues/image_restrict_image_styles-2528214-24.patch",
                 "Fix SQL error when importing translations": "https://www.drupal.org/files/issues/2599228-31.patch",
                 "Optimize getCommentedEntity()": "https://www.drupal.org/files/issues/get-commented-entity-2580551.52.patch"
             },

--- a/drupal-org-core.make
+++ b/drupal-org-core.make
@@ -3,6 +3,6 @@ core = 8.x
 projects[drupal][type] = core
 projects[drupal][version] = 8.5.3
 projects[drupal][patch][] = "https://www.drupal.org/files/issues/color-optional-html-preview-2844190-2.patch"
-projects[drupal][patch][] = "https://www.drupal.org/files/issues/image_restrict_image_styles-2528214-19.patch"
+projects[drupal][patch][] = "https://www.drupal.org/files/issues/image_restrict_image_styles-2528214-24.patch"
 projects[drupal][patch][] = "https://www.drupal.org/files/issues/2599228-31.patch"
 projects[drupal][patch][] = "https://www.drupal.org/files/issues/get-commented-entity-2580551.52.patch"


### PR DESCRIPTION
## Problem
When restrict images is checked in a text format in some cases it gives a wsod like the following:

Error: Call to undefined method Drupal\Core\Image\Image::setAttribute() in filter_filter_secure_image_alter() (line 835 of /app/html/core/modules/filter/filter.module) #0 /app/html/core/lib/Drupal/Core/Extension/ModuleHandler.php(501): filter_filter_secure_image_alter(Object(Drupal\Core\Image\Image), NULL, NULL) #1 /app/html/core/modules/filter/filter.module(817): Drupal\Core\Extension\ModuleHandler->alter(‘filter_secure_i...‘, Object(Drupal\Core\Image\Image)) #2 /app/html/core/modules/filter/src/Plugin/Filter/FilterHtmlImageSecure.php(25): _filter_html_image_secure_process(‘<p>In dit inter...‘) #3

## Solution
Update the patch number. See comment #24 for the solution.
https://www.drupal.org/node/2528214

## Issue tracker
- https://www.drupal.org/node/2528214

## HTT
Not sure how to reproduce it. I always test it on a client where this goes wrong.
