### PR TITLE
#2950337 by kala4ek: checkCreateAccess failed at PostAccessControlHandler

### DIFF
--- a/modules/social_features/social_post/src/PostAccessControlHandler.php
+++ b/modules/social_features/social_post/src/PostAccessControlHandler.php
@@ -6,6 +6,7 @@ use Drupal\Core\Entity\EntityAccessControlHandler;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\Access\AccessResult;
+use Drupal\group\Entity\GroupInterface;
 
 /**
  * Access controller for the Post entity.
@@ -130,8 +131,8 @@ class PostAccessControlHandler extends EntityAccessControlHandler {
    */
   protected function checkCreateAccess(AccountInterface $account, array $context, $entity_bundle = NULL) {
     // If group context is active.
-    $group = \Drupal::routeMatch()->getParameter('group');
-    if ($group) {
+    $group = _social_group_get_current_group();
+    if ($group instanceof GroupInterface) {
       if ($group->hasPermission('add post entities in group', $account)) {
         return AccessResult::allowed();
       }


### PR DESCRIPTION
## Problem
`PostGroupBlock` placed at the pages like this `group/[group-id]/anything` cause the error:
> Error: Call to a member function hasPermission() on string in Drupal\social_post\PostAccessControlHandler->checkCreateAccess() (line 135 of profiles/contrib/social/modules/social_features/social_post/src/PostAccessControlHandler.php).

## Solution
Replace direct execute of `\Drupal::routeMatch()->getParameter('group');` by `_social_group_get_current_group();`

## Issue tracker
- https://www.drupal.org/project/social/issues/2950337

## HTT
- [x] Check out the code changes
- [x] Login as admin user and create new page `group/[group-id]/anything` and place `PostGroupBlock` to this page
- [x] Notice it doesn't work
- [x] Checkout to this branch
- [x] Try to open `group/[group-id]/anything` again and see that it works now

