### PR TITLE
Issue #2950391 by jaapjan: user export should use offset method instead

### DIFF
--- a/modules/social_features/social_user_export/src/ExportUser.php
+++ b/modules/social_features/social_user_export/src/ExportUser.php
@@ -109,7 +109,6 @@ class ExportUser {
   public static function exportUsersAllOperation(array $conditions, array &$context) {
     if (empty($context['sandbox'])) {
       $context['sandbox']['progress'] = 0;
-      $context['sandbox']['current_id'] = 0;
 
       // Get max uid.
       $view = _social_user_export_get_view($conditions);
@@ -124,9 +123,8 @@ class ExportUser {
         'direction' => 'ASC',
       ],
     ];
-    $view->setOffset(0);
+    $view->setOffset($context['sandbox']['progress']);
     $view->setItemsPerPage(1);
-    $view->query->addWhere(1, 'users_field_data.uid', $context['sandbox']['current_id'], '>');
     $view->preExecute();
     $view->execute();
 
@@ -139,7 +137,6 @@ class ExportUser {
 
     if ($account) {
       self::exportUserOperation($account, $context);
-      $context['sandbox']['current_id'] = $account->id();
     }
 
     $context['sandbox']['progress']++;


### PR DESCRIPTION
## Problem
The social_user_export module gives the ability to export all users over all pages on /admin/people. The code for that functionality is in src/ExportUser.php. It uses the uid to determine the next user to export in the batch. However this does not work when the view query is already altered in another hook. 

## Solution
Let's use the offset method instead.

## Issue tracker
- https://www.drupal.org/project/social/issues/2950391

## HTT
- [x] Check out the code changes
- [x] Create custom module with the hook described in the issue tracker.
- [x] Login as user with SM role and go to /admin/people
- [x] Make export of users and make sure you click "Select all users over all pages" button
- [x] Notice the .csv only contains duplicate users
- [x] Checkout to this branch
- [x] Try again and notice it works now.

## Documentation
- [ ] This item is added to the release notes
- [x] This item is documented on LGOS
- [x] This item has been added to the feature overview
