### PR TITLE
Issue #2950411 by jaapjan: make state field available for closed group location

### DIFF
--- a/modules/social_features/social_group/config/install/field.field.group.closed_group.field_group_address.yml
+++ b/modules/social_features/social_group/config/install/field.field.group.closed_group.field_group_address.yml
@@ -19,10 +19,10 @@ default_value_callback: ''
 settings:
   available_countries: {  }
   fields:
+    administrativeArea: administrativeArea
     locality: locality
     postalCode: postalCode
     addressLine1: addressLine1
-    administrativeArea: '0'
     dependentLocality: '0'
     sortingCode: '0'
     addressLine2: '0'


### PR DESCRIPTION
## Problem
State field is not available for Closed Group Location field.

## Solution
Let's add it to the field.field.group.closed_group.field_group_address.yml file.

## Issue tracker
- https://www.drupal.org/project/social/issues/2950411

## HTT
- [x] Check out the code changes
- [x] Login as user X and create closed group
- [x] Notice that now you can select a state for closed group

## Documentation
- [ ] This item is added to the release notes
- [ ] This item is documented on LGOS (not needed)
- [ ] This item has been added to the feature overview (not needed)
