### PR TITLE
ECI-702 by serhiy-chornobay: Make the user menu like dropdown on mobile

### DIFF
--- a/modules/custom/activity_creator/js/notifications.js
+++ b/modules/custom/activity_creator/js/notifications.js
@@ -23,7 +23,7 @@
                           var remaining_notifications = result['remaining_notifications'];
 
                           notification_count.html(remaining_notifications);
-                        $('.notification-bell-mobile .badge').html(remaining_notifications);
+                        $('.notification-bell.mobile .badge').html(remaining_notifications);
                       }
                     });
               });

--- a/modules/custom/activity_creator/js/notifications.js
+++ b/modules/custom/activity_creator/js/notifications.js
@@ -23,6 +23,7 @@
                           var remaining_notifications = result['remaining_notifications'];
 
                           notification_count.html(remaining_notifications);
+                        $('.notification-bell-mobile .badge').html(remaining_notifications);
                       }
                     });
               });

--- a/modules/social_features/social_user/src/Plugin/Block/AccountHeaderBlock.php
+++ b/modules/social_features/social_user/src/Plugin/Block/AccountHeaderBlock.php
@@ -170,7 +170,7 @@ class AccountHeaderBlock extends BlockBase implements ContainerFactoryPluginInte
       if ($this->moduleHandler->moduleExists('social_group')) {
         if ($navigation_settings_config->get('display_my_groups_icon') === 1) {
           $links['groups'] = [
-            'classes' => '',
+            'classes' => 'desktop',
             'link_attributes' => '',
             'icon_classes' => 'icon-group',
             'title' => $this->t('My Groups'),
@@ -198,7 +198,7 @@ class AccountHeaderBlock extends BlockBase implements ContainerFactoryPluginInte
           }
 
           $links['messages'] = [
-            'classes' => '',
+            'classes' => 'desktop',
             'link_attributes' => '',
             'icon_classes' => $message_icon,
             'title' => $this->t('Inbox'),
@@ -282,7 +282,7 @@ class AccountHeaderBlock extends BlockBase implements ContainerFactoryPluginInte
         }
 
         $links['notifications'] = [
-          'classes' => 'dropdown notification-bell',
+          'classes' => 'dropdown notification-bell desktop',
           'link_attributes' => 'data-toggle=dropdown aria-expanded=true aria-haspopup=true role=button',
           'link_classes' => 'dropdown-toggle clearfix',
           'icon_classes' => $notifications_icon,
@@ -308,6 +308,15 @@ class AccountHeaderBlock extends BlockBase implements ContainerFactoryPluginInte
             'classes' => 'dropdown-header header-nav-current-user',
             'tagline' => $this->t('Signed in as'),
             'object'  => $account_name,
+          ],
+          'divide_mobile' => [
+            'divider' => 'true',
+            'classes' => 'divider mobile',
+            'attributes' => 'role=separator',
+          ],
+          'messages_mobile' => [
+          ],
+          'notification_mobile' => [
           ],
           'divide_profile' => [
             'divider' => 'true',
@@ -431,6 +440,60 @@ class AccountHeaderBlock extends BlockBase implements ContainerFactoryPluginInte
           ],
         ],
       ];
+      if ($this->moduleHandler->moduleExists('social_private_message')) {
+        if ($navigation_settings_config->get('display_social_private_message_icon') === 1) {
+          // Fetch the amount of unread items.
+          $num_account_messages = \Drupal::service('social_private_message.service')->updateUnreadCount();
+
+          // Default icon values.
+          $label_classes = 'hidden';
+          // Override icons when there are unread items.
+          if ($num_account_messages > 0) {
+            $label_classes = 'badge badge-accent badge--pill';
+            $links['account_box']['classes'] = $links['account_box']['classes'] . ' has-alert';
+          }
+          $links['account_box']['below']['messages_mobile'] = [
+            'classes' => 'mobile',
+            'link_attributes' => '',
+            'icon_classes' => '',
+            'title' => $this->t('Inbox'),
+            'label' => $this->t('Inbox'),
+            'title_classes' => '',
+            'count_classes' => $label_classes,
+            'count_icon' => (string) $num_account_messages,
+            'url' => Url::fromRoute('social_private_message.inbox'),
+          ];
+        }
+      }
+
+      if ($this->moduleHandler->moduleExists('activity_creator')) {
+        $account_notifications = $this->activityNotifications;
+        $num_notifications = count($account_notifications->getNotifications($account, [ACTIVITY_STATUS_RECEIVED]));
+
+        if ($num_notifications === 0) {
+          $label_classes = 'hidden';
+        }
+        else {
+          $label_classes = 'badge badge-accent badge--pill';
+          $links['account_box']['classes'] = $links['account_box']['classes'] . ' has-alert';
+
+          if ($num_notifications > 99) {
+            $num_notifications = '99+';
+          }
+        }
+
+        $links['account_box']['below']['notification_mobile'] = [
+          'classes' => 'mobile',
+          'link_attributes' => '',
+          'icon_classes' => '',
+          'title' => $this->t('Notification Centre'),
+          'label' => $this->t('Notification Centre'),
+          'title_classes' => '',
+          'count_classes' => $label_classes,
+          'count_icon' => (string) $num_notifications,
+          'url' => Url::fromRoute('view.activity_stream_notifications.page_1'),
+        ];
+      }
 
       $storage = $this->entityTypeManager->getStorage('profile');
       $profile = $storage->loadByUser($account, 'profile');

--- a/modules/social_features/social_user/src/Plugin/Block/AccountHeaderBlock.php
+++ b/modules/social_features/social_user/src/Plugin/Block/AccountHeaderBlock.php
@@ -481,7 +481,7 @@ class AccountHeaderBlock extends BlockBase implements ContainerFactoryPluginInte
         }
 
         $links['account_box']['below']['notification_mobile'] = [
-          'classes' => 'mobile notification-bell-mobile',
+          'classes' => 'mobile notification-bell',
           'link_attributes' => '',
           'icon_classes' => '',
           'title' => $this->t('Notification Centre'),

--- a/modules/social_features/social_user/src/Plugin/Block/AccountHeaderBlock.php
+++ b/modules/social_features/social_user/src/Plugin/Block/AccountHeaderBlock.php
@@ -314,10 +314,8 @@ class AccountHeaderBlock extends BlockBase implements ContainerFactoryPluginInte
             'classes' => 'divider mobile',
             'attributes' => 'role=separator',
           ],
-          'messages_mobile' => [
-          ],
-          'notification_mobile' => [
-          ],
+          'messages_mobile' => [],
+          'notification_mobile' => [],
           'divide_profile' => [
             'divider' => 'true',
             'classes' => 'divider',

--- a/modules/social_features/social_user/src/Plugin/Block/AccountHeaderBlock.php
+++ b/modules/social_features/social_user/src/Plugin/Block/AccountHeaderBlock.php
@@ -481,7 +481,7 @@ class AccountHeaderBlock extends BlockBase implements ContainerFactoryPluginInte
         }
 
         $links['account_box']['below']['notification_mobile'] = [
-          'classes' => 'mobile',
+          'classes' => 'mobile notification-bell-mobile',
           'link_attributes' => '',
           'icon_classes' => '',
           'title' => $this->t('Notification Centre'),

--- a/modules/social_features/social_user/templates/account-header-links.html.twig
+++ b/modules/social_features/social_user/templates/account-header-links.html.twig
@@ -34,6 +34,9 @@
                     <li class="{{ item.classes }}">
                       <a href="{{ item.url }}" class="{{ item.link_classes }}" {{ item.link_attributes }} {% if item.title %} title="{{ item.title }}" {% endif %}>
                         <span class="{{item.title_classes}}">{{ item.label }}</span>
+                        {% if item.count_icon %}
+                          <span class="{{item.count_classes}}">{{ item.count_icon }}</span>
+                        {% endif %}
                       </a>
                     </li>
                   {% elseif item.divider %}

--- a/themes/socialbase/assets/css/dropdown.css
+++ b/themes/socialbase/assets/css/dropdown.css
@@ -5,7 +5,7 @@
   margin-left: 2px;
   vertical-align: middle;
   border-top: 4px dashed;
-  border-top: 4px solid \9;
+  border-top: 4px solid \9 ;
   border-right: 4px solid transparent;
   border-left: 4px solid transparent;
 }
@@ -49,6 +49,10 @@
   margin: 11px 0;
   overflow: hidden;
   background-color: #e5e5e5;
+}
+
+.dropdown-menu li .badge {
+  margin: 0;
 }
 
 .dropdown-menu li > a {
@@ -127,7 +131,7 @@
 .navbar-fixed-bottom .dropdown .caret {
   border-top: 0;
   border-bottom: 4px dashed;
-  border-bottom: 4px solid \9;
+  border-bottom: 4px solid \9 ;
   content: "";
 }
 
@@ -196,6 +200,12 @@
 }
 
 @media (min-width: 600px) {
+  .dropdown-menu .divider.mobile {
+    display: none;
+  }
+  .dropdown-menu li.mobile {
+    display: none;
+  }
   .dropdown-menu li > a {
     padding: 4px 10px 4px 15px;
   }
@@ -219,5 +229,19 @@
   .navbar-right .dropdown-menu-left {
     left: 0;
     right: auto;
+  }
+}
+
+@media (max-width: 599px) {
+  .dropup.has-alert > a:before,
+  .dropdown.has-alert > a:before {
+    content: '';
+    position: absolute;
+    top: 11px;
+    right: 7px;
+    width: 12px;
+    height: 12px;
+    background-color: #777777;
+    border-radius: 50%;
   }
 }

--- a/themes/socialbase/assets/css/navbar.css
+++ b/themes/socialbase/assets/css/navbar.css
@@ -385,6 +385,50 @@
   }
 }
 
+@media (max-width: 599px) {
+  .nav > li.desktop {
+    display: none;
+  }
+  .navbar-scrollable {
+    overflow: hidden;
+    position: relative;
+    width: 100%;
+    height: 46px;
+  }
+  .navbar-scrollable .navbar-nav {
+    position: absolute;
+    left: 0;
+    top: 0;
+    width: 100%;
+    -webkit-overflow-scrolling: touch;
+    -webkit-user-select: none;
+       -moz-user-select: none;
+        -ms-user-select: none;
+            user-select: none;
+    overflow-x: scroll;
+    overflow-y: hidden;
+    display: -webkit-box;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-box-pack: start;
+        -ms-flex-pack: start;
+            justify-content: flex-start;
+  }
+  .navbar-scrollable .navbar-nav::-webkit-scrollbar {
+    display: none;
+  }
+  .navbar-scrollable:after {
+    content: '';
+    display: block;
+    position: absolute;
+    width: 24px;
+    height: 100%;
+    top: 0;
+    right: 0;
+    z-index: 2;
+  }
+}
+
 @media (max-width: 899px) {
   .container--navbar {
     -ms-flex-wrap: wrap;
@@ -456,46 +500,5 @@
 @media screen and (max-height: 480px) {
   .navbar-collapse {
     max-height: 420px;
-  }
-}
-
-@media (max-width: 599px) {
-  .navbar-scrollable {
-    overflow: hidden;
-    position: relative;
-    width: 100%;
-    height: 46px;
-  }
-  .navbar-scrollable .navbar-nav {
-    position: absolute;
-    left: 0;
-    top: 0;
-    width: 100%;
-    -webkit-overflow-scrolling: touch;
-    -webkit-user-select: none;
-       -moz-user-select: none;
-        -ms-user-select: none;
-            user-select: none;
-    overflow-x: scroll;
-    overflow-y: hidden;
-    display: -webkit-box;
-    display: -ms-flexbox;
-    display: flex;
-    -webkit-box-pack: start;
-        -ms-flex-pack: start;
-            justify-content: flex-start;
-  }
-  .navbar-scrollable .navbar-nav::-webkit-scrollbar {
-    display: none;
-  }
-  .navbar-scrollable:after {
-    content: '';
-    display: block;
-    position: absolute;
-    width: 24px;
-    height: 100%;
-    top: 0;
-    right: 0;
-    z-index: 2;
   }
 }

--- a/themes/socialbase/components/03-molecules/dropdown/dropdown.scss
+++ b/themes/socialbase/components/03-molecules/dropdown/dropdown.scss
@@ -4,7 +4,6 @@
 // Dropdown menus
 // --------------------------------------------------
 
-
 // Dropdown arrow/caret
 .caret {
   display: inline-block;
@@ -12,16 +11,33 @@
   height: 0;
   margin-left: 2px;
   vertical-align: middle;
-  border-top:   $caret-width-base dashed;
-  border-top:   $caret-width-base solid \9; // IE8
+  border-top: $caret-width-base dashed;
+  border-top: $caret-width-base solid \9
+; // IE8
   border-right: $caret-width-base solid transparent;
-  border-left:  $caret-width-base solid transparent;
+  border-left: $caret-width-base solid transparent;
 }
 
 // The dropdown wrapper (div)
 .dropup,
 .dropdown {
   position: relative;
+  &.has-alert {
+    > a {
+      @include for-phone-only {
+        &:before {
+          content: '';
+          position: absolute;
+          top: 11px;
+          right: 7px;
+          width: 12px;
+          height: 12px;
+          background-color: $gray-light;
+          border-radius: 50%;
+        }
+      }
+    }
+  }
 }
 
 // Prevent the focus on the dropdown toggle when closing dropdowns
@@ -59,6 +75,21 @@
   // Dividers (basically an hr) within the dropdown
   .divider {
     @include nav-divider($dropdown-divider-bg);
+    &.mobile {
+      @include for-tablet-portrait-up {
+        display: none;
+      }
+    }
+  }
+  li {
+    &.mobile {
+      @include for-tablet-portrait-up {
+        display: none;
+      }
+    }
+    .badge {
+      margin: 0;
+    }
   }
 
   // Links within the dropdown menu
@@ -140,6 +171,7 @@
   left: auto; // Reset the default from `.dropdown-menu`
   right: 0;
 }
+
 // With v3, we enabled auto-flipping if you have a dropdown within a right
 // aligned nav component. To enable the undoing of that, we provide an override
 // to restore the default dropdown menu alignment.
@@ -188,7 +220,8 @@
   .caret {
     border-top: 0;
     border-bottom: $caret-width-base dashed;
-    border-bottom: $caret-width-base solid \9; // IE8
+    border-bottom: $caret-width-base solid \9
+  ; // IE8
     content: "";
   }
   // Different positioning for bottom up menu
@@ -199,7 +232,6 @@
   }
 }
 
-
 // Component alignment
 //
 // Reiterate per navbar.less and the modified component alignment there.
@@ -207,16 +239,17 @@
 @include for-tablet-landscape-up {
   .navbar-right {
     .dropdown-menu {
-      right: 0; left: auto;
+      right: 0;
+      left: auto;
     }
     // Necessary for overrides of the default right aligned menu.
     // Will remove come v4 in all likelihood.
     .dropdown-menu-left {
-      left: 0; right: auto;
+      left: 0;
+      right: auto;
     }
   }
 }
-
 
 .dropdown-menu {
 
@@ -271,12 +304,10 @@
 
 }
 
-
 .dropdown-header {
   padding: 7px 20px;
   background: $dropdown-header-bg;
 }
-
 
 .scrollable-menu {
 

--- a/themes/socialbase/components/03-molecules/navigation/navbar/navbar.scss
+++ b/themes/socialbase/components/03-molecules/navigation/navbar/navbar.scss
@@ -37,6 +37,11 @@
         cursor: $cursor-disabled;
       }
     }
+    &.desktop {
+      @include for-phone-only {
+        display: none;
+      }
+    }
   }
 
 }

--- a/themes/socialblue/assets/css/brand.css
+++ b/themes/socialblue/assets/css/brand.css
@@ -257,6 +257,12 @@ blockquote {
   }
 }
 
+@media (max-width: 599px) {
+  .dropdown.has-alert > a:before {
+    background-color: #ffc142;
+  }
+}
+
 @media (max-width: 899px) {
   .navbar-collapse .dropdown-menu li a {
     color: #ffffff;

--- a/themes/socialblue/assets/css/dropdown.css
+++ b/themes/socialblue/assets/css/dropdown.css
@@ -9,3 +9,9 @@
 .dropdown-menu > .disabled > a, .dropdown-menu > .disabled > a:hover, .dropdown-menu > .disabled > a:focus {
   color: #777;
 }
+
+@media (max-width: 599px) {
+  .dropdown.has-alert > a:before {
+    background-color: #ffc142;
+  }
+}

--- a/themes/socialblue/assets/css/navbar.css
+++ b/themes/socialblue/assets/css/navbar.css
@@ -85,6 +85,9 @@
 
 .navbar-default .profile img {
   border: 2px solid white;
+  width: 24px;
+  height: 24px;
+  overflow: hidden;
 }
 
 .navbar-search .form-group {

--- a/themes/socialblue/assets/css/preview.css
+++ b/themes/socialblue/assets/css/preview.css
@@ -1176,6 +1176,9 @@ html.js .input-group-addon .glyphicon.glyphicon-spin {
 
 .navbar-default .profile img {
   border: 2px solid white;
+  width: 24px;
+  height: 24px;
+  overflow: hidden;
 }
 
 .navbar-search .form-group {
@@ -1607,7 +1610,7 @@ blockquote {
   .teaser__image {
     border-top-left-radius: inherit;
     border-bottom-left-radius: inherit;
-    background: #29abe2;
+    background: #e6e6e6;
   }
   .teaser__teaser-type {
     background-color: rgba(0, 0, 0, 0.5);
@@ -1658,6 +1661,9 @@ blockquote {
   .navbar-default .navbar-nav .open .dropdown-menu > .disabled > a, .navbar-default .navbar-nav .open .dropdown-menu > .disabled > a:hover, .navbar-default .navbar-nav .open .dropdown-menu > .disabled > a:focus {
     color: #ccc;
     background-color: transparent;
+  }
+  .dropdown.has-alert > a:before {
+    background-color: #ffc142;
   }
 }
 

--- a/themes/socialblue/components/03-molecules/dropdown/dropdown.scss
+++ b/themes/socialblue/components/03-molecules/dropdown/dropdown.scss
@@ -18,3 +18,14 @@
   }
 
 }
+.dropdown {
+  &.has-alert {
+    > a {
+      @include for-phone-only {
+        &:before {
+          background-color: $brand-accent;
+        }
+      }
+    }
+  }
+}

--- a/themes/socialblue/components/03-molecules/navigation/navbar/navbar.scss
+++ b/themes/socialblue/components/03-molecules/navigation/navbar/navbar.scss
@@ -191,6 +191,9 @@
 
 .navbar-default .profile img {
   border: 2px solid white;
+  width: 24px;
+  height: 24px;
+  overflow: hidden;
 }
 
 .navbar-search {

--- a/themes/socialblue/components/brand.scss
+++ b/themes/socialblue/components/brand.scss
@@ -279,6 +279,17 @@ blockquote {
 
   }
 }
+.dropdown {
+  &.has-alert {
+    > a {
+      @include for-phone-only {
+        &:before {
+          background-color: $brand-accent;
+        }
+      }
+    }
+  }
+}
 
 @include for-tablet-landscape-down{
 


### PR DESCRIPTION
## Problem
Currently, on small screens such as iphone 5, the header menu becomes 2 rows which takes a lot of space for mobile user and the menu looks 'broken'. 

Also for enterprise team, when the add google translate icon to the header menu, on mobile the space is not enough, even for large phones. 

## Solution
When the screen is small, such as iphone 5, the user menu should become a dropdown menu. 
When there is new notification for private message or notificaiton center, the dropdown icon will reflect there is new things unread. 
There should not be a configuration interface to decide which icon will be in dropdown on mobile. (We only take care of the icons provided in distro, not other customised icons.)

## Issue tracker
https://jira.goalgorilla.com/browse/ECI-702

## HTT
- [ ] Check out the code changes
- [ ] Checkout to this branch
- [ ] Login and check User menu on mobile
- [ ] Try expand user dropdown menu and check if there are notification icon over user icon, if user have some nothification.

## Documentation
- [ ] This item is added to the release notes
- [ ] This item is documented on LGOS
- [ ] This item has been added to the feature overview
