### PR TITLE
DS-4058 As a LU, I want to be more likely to receive my email notification which is set to 'immediately'

### DIFF
--- a/modules/custom/activity_creator/src/ActivityInterface.php
+++ b/modules/custom/activity_creator/src/ActivityInterface.php
@@ -61,4 +61,12 @@ interface ActivityInterface extends ContentEntityInterface, EntityChangedInterfa
    */
   public function getRelatedEntityUrl();
 
+  /**
+   * Get destinations.
+   *
+   * @return array
+   *   The list of destinations.
+   */
+  public function getDestinations();
+
 }

--- a/modules/custom/activity_creator/src/Entity/Activity.php
+++ b/modules/custom/activity_creator/src/Entity/Activity.php
@@ -232,7 +232,7 @@ class Activity extends ContentEntityBase implements ActivityInterface {
   }
 
   /**
-   * Get destinations.
+   * {@inheritdoc}
    */
   public function getDestinations() {
     $values = [];

--- a/modules/custom/activity_send/activity_send.info.yml
+++ b/modules/custom/activity_send/activity_send.info.yml
@@ -3,5 +3,6 @@ type: module
 description: Used to store and manage external notifications
 core: 8.x
 package: Social
+configure: activity_send.settings
 dependencies:
   - activity_basics:activity_basics

--- a/modules/custom/activity_send/activity_send.install
+++ b/modules/custom/activity_send/activity_send.install
@@ -118,3 +118,14 @@ function activity_send_update_8001() {
   $schema->dropField('user_activity_send', 'status');
   $schema->dropIndex('user_activity_send', 'uasstatus');
 }
+
+/**
+ * Reduce delay time for immediate email notification to 90 seconds.
+ */
+function activity_send_update_8002() {
+  $config = \Drupal::configFactory()->getEditable('activity_send.settings');
+
+  if ($config->get('activity_send_offline_window') == 900) {
+    $config->set('activity_send_offline_window', 90)->save();
+  }
+}

--- a/modules/custom/activity_send/config/install/activity_send.settings.yml
+++ b/modules/custom/activity_send/config/install/activity_send.settings.yml
@@ -1,1 +1,1 @@
-activity_send_offline_window: 900
+activity_send_offline_window: 90

--- a/modules/custom/activity_send/modules/activity_send_email/activity_send_email.module
+++ b/modules/custom/activity_send/modules/activity_send_email/activity_send_email.module
@@ -277,15 +277,15 @@ function activity_send_email_mail($key, &$message, $params) {
  * Implements hook_ENTITY_TYPE_insert().
  */
 function activity_send_email_activity_insert(ActivityInterface $activity) {
-
-  $destinations = $activity->getDestinations();
-  if (in_array('email', $destinations)) {
-    /* @var $activity_send_factory Drupal\activity_send\Plugin\ActivitySendManager */
-    $activity_send_factory = \Drupal::service('plugin.manager.activity_send.processor');
-    // Trigger the create action for entities.
-    /* @var $create_action Drupal\activity_send\Plugin\ActivitySend\CreateActivitySend */
-    $create_action = $activity_send_factory->createInstance('email_activity_send');
-    $create_action->create($activity);
+  if (!in_array('email', $activity->getDestinations())) {
+    return;
   }
 
+  /* @var \Drupal\activity_send\Plugin\ActivitySendManager $activity_send_factory */
+  $activity_send_factory = \Drupal::service('plugin.manager.activity_send.processor');
+
+  // Trigger the create action for entities.
+  /* @var \Drupal\activity_send_email\Plugin\ActivitySend\EmailActivitySend $create_action */
+  $create_action = $activity_send_factory->createInstance('email_activity_send');
+  $create_action->create($activity);
 }


### PR DESCRIPTION
## Problem
A recipient should wait 15 minutes for E-mail notification about some activity after the last visit of a website.

## Solution
Reduce delay time for immediate email notification from 900 seconds to 90 seconds.

## Issue tracker
- https://jira.goalgorilla.com/browse/DS-4058

## HTT
- [ ] Login as user X and create a post on somewhere
- [ ] Login as user Y and add a comment to X's post
- [ ] User X should wait 15 minutes when he receives E-mail notification about post commenting
- [ ] Checkout to this branch
- [ ] Do first two steps again and user X receive an E-mail notification after one and half minutes