### PR TITLE
DS-4503: enable inline form errors for new installs

### DIFF
--- a/social.profile
+++ b/social.profile
@@ -140,6 +140,7 @@ function social_form_install_configure_form_alter(&$form, FormStateInterface $fo
     'social_event_type' => t('Categorize events in event types'),
     'social_sso' => t('Registration with social networks'),
     'social_file_private' => t('Use the private file system for uploaded files (highly recommended)'),
+    'inline_form_errors' => t('Inline Form Errors'),
   ];
 
   // Checkboxes to enable Optional modules.
@@ -149,6 +150,7 @@ function social_form_install_configure_form_alter(&$form, FormStateInterface $fo
     '#options' => $social_optional_modules,
     '#default_value' => [
       'social_file_private',
+      'inline_form_errors',
     ],
   ];
 


### PR DESCRIPTION
## Problem
Drupal Core has the awesome inline form error module which makes it much easier to notice within a form which form elements need direct attention.

## Solution
Let's enable it for all new Open Social instances but leave it like it is for existing distro & enterprise installs.

As @left23 pointed out already:
1. Inline form errors are not visible until the form is being sent. HTML5 errors come before Inline Form Errors and this may cause confusion.
2. Loss of uniform and exhaustive error representation. Some elements have HTML5 validation and others don’t.

## Issue tracker
- DS-4503

## HTT
- [x] Check out the code changes
- [x] Re-install and notice that inline form errors is enabled

## Documentation
- [ ] This item is added to the release notes
- [ ] This item is documented on LGOS
- [ ] This item has been added to the feature overview
