### PR TITLE
ECI-706: Fix template for private's message members

### DIFF
--- a/themes/socialbase/templates/private_message/field--private-message-thread--members.html.twig
+++ b/themes/socialbase/templates/private_message/field--private-message-thread--members.html.twig
@@ -1,7 +1,7 @@
 <div{{ attributes.addClass('message__thread-members') }}>
-  {% for item in items %}
-    <div{{ item.attributes.addClass('media media-middle') }}>
+  <div{{ item.attributes.addClass('media media-middle') }}>
+    {% for item in items %}
       {{ item.content }}{% if not loop.last %},{% endif %}
-    </div>
-  {% endfor %}
+    {% endfor %}
+  </div>
 </div>


### PR DESCRIPTION
## Problem
The names are all on a new line, they should be on a single div, comma, seperated

## Solution
Fix template for private-message-thread--members.

## Issue tracker
- https://jira.goalgorilla.com/browse/ECI-706

## HTT
- [x] Check out the code changes
- [x] Checkout to this branch
- [x] Login as user site_manager and try send message to couple of peoples.
- [x] Go to private_messages page and open this message
- [x] Check if all name of the members are in one line

## Documentation
- [x] This item is added to the release notes
- [ ] This item is documented on LGOS
- [ ] This item has been added to the feature overview
