### PR TITLE
DS-5042 by bramtenhove: Fix incompatibility issue with Social Profile Privacy and Social Profile Fields

### DIFF
--- a/modules/social_features/social_profile/modules/social_profile_fields/src/Form/SocialProfileFieldsSettingsForm.php
+++ b/modules/social_features/social_profile/modules/social_profile_fields/src/Form/SocialProfileFieldsSettingsForm.php
@@ -62,7 +62,7 @@ class SocialProfileFieldsSettingsForm extends ConfigFormBase implements Containe
    * {@inheritdoc}
    */
   public function getFormId() {
-    return 'social_profile_admin_settings_form';
+    return 'social_profile_fields_admin_settings_form';
   }
 
   /**


### PR DESCRIPTION
## Problem
When having both Social Profile Privacy and Social Profile Fields modules enabled the config page of Social Profile Fields breaks.

## Solution
Fix the wrong ID for the settings form.

## HTT
- [x] Check out the code changes
- [x] Enable both modules and go to /admin/config/opensocial/profile-fields
- [x] Notice it doesn't work
- [x] Checkout to this branch
- [x] Try it again, works now.

## Documentation
- [x] This item is added to the release notes
- [x] This item is documented on LGOS
- [x] This item has been added to the feature overview
