### PR TITLE
DS-4886 As a LU I want to see a clear activity stream without duplicate info regarding posts + comments

### DIFF
--- a/modules/social_features/social_activity/config/install/message.template.create_comment_group_node.yml
+++ b/modules/social_features/social_activity/config/install/message.template.create_comment_group_node.yml
@@ -11,7 +11,6 @@ third_party_settings:
     activity_context: group_activity_context
     activity_destinations:
       stream_explore: stream_explore
-      stream_group: stream_group
       stream_home: stream_home
       stream_profile: stream_profile
     activity_create_direct: 1

--- a/modules/social_features/social_activity/config/install/message.template.create_comment_group_post.yml
+++ b/modules/social_features/social_activity/config/install/message.template.create_comment_group_post.yml
@@ -11,7 +11,6 @@ third_party_settings:
     activity_context: group_activity_context
     activity_destinations:
       stream_explore: stream_explore
-      stream_group: stream_group
       stream_profile: stream_profile
     activity_create_direct: 1
     activity_aggregate: 1

--- a/modules/social_features/social_activity/config/install/views.view.activity_stream_group.yml
+++ b/modules/social_features/social_activity/config/install/views.view.activity_stream_group.yml
@@ -241,42 +241,6 @@ display:
           entity_type: activity
           entity_field: status
           plugin_id: boolean
-        field_activity_entity_target_type:
-          id: field_activity_entity_target_type
-          table: activity__field_activity_entity
-          field: field_activity_entity_target_type
-          relationship: none
-          group_type: group
-          admin_label: ''
-          operator: '!='
-          value: comment
-          group: 1
-          exposed: false
-          expose:
-            operator_id: ''
-            label: ''
-            description: ''
-            use_operator: false
-            operator: ''
-            identifier: ''
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
-          plugin_id: string
       sorts:
         created:
           id: created

--- a/modules/social_features/social_activity/config/install/views.view.activity_stream_group.yml
+++ b/modules/social_features/social_activity/config/install/views.view.activity_stream_group.yml
@@ -241,6 +241,42 @@ display:
           entity_type: activity
           entity_field: status
           plugin_id: boolean
+        field_activity_entity_target_type:
+          id: field_activity_entity_target_type
+          table: activity__field_activity_entity
+          field: field_activity_entity_target_type
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: '!='
+          value: comment
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          plugin_id: string
       sorts:
         created:
           id: created

--- a/tests/behat/features/capabilities/activity-stream/activity-stream-comments.feature
+++ b/tests/behat/features/capabilities/activity-stream/activity-stream-comments.feature
@@ -1,4 +1,4 @@
-@api @stability @activity_stream @comment @DS-1394 @DS-4211 @stability-2
+@api @stability @activity_stream @comment @DS-1394 @DS-4211 @DS-4886 @stability-2
 Feature: See comments in activity stream
   Benefit: Participate in discussions on the platform
   Role: As a LU
@@ -114,7 +114,7 @@ Feature: See comments in activity stream
     And I am on the stream of group "Test open group"
     Then I should see "CreateUser created an event in Test open group"
     And I should see "Test group event"
-    And I should see "This is a third event comment"
+    And I should not see "This is a third event comment"
     And I should not see "This is a first event comment"
     And I should not see "This is a reply event comment"
 


### PR DESCRIPTION
## Problem
The problem is that there is a lot of duplicate information when people comment on a post in a group stream.

## Solution
Hide all activities about the commented post on group stream page.

## Issue tracker
https://jira.goalgorilla.com/browse/DS-4886

## HTT
- [ ] Go to stream page of some group
- [ ] Create comment on some post
- [ ] You should see your comment in the first position of a stream and you can see second time your comment after activity about creating a commented post
- [ ] Checkout to this branch
- [ ] You should not see your comment in the first position of a stream