### PR TITLE
Issue #2925994 temporal fields ios

### DIFF
--- a/themes/socialbase/assets/css/form-controls.css
+++ b/themes/socialbase/assets/css/form-controls.css
@@ -539,5 +539,9 @@ input[type=checkbox]:not(:disabled) ~ .lever:active:after {
   input[type="datetime-local"].form-control,
   input[type="month"].form-control {
     line-height: 24px;
+    background: url(data:image/svg+xml;base64,PHN2ZyBpZD0iTGF5ZXJfMSIgZGF0YS1uYW1lPSJMYXllciAxIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA0Ljk1IDEwIj48ZGVmcz48c3R5bGU+LmNscy0xe2ZpbGw6I2ZmZjt9LmNscy0ye2ZpbGw6IzQ0NDt9PC9zdHlsZT48L2RlZnM+PHRpdGxlPmFycm93czwvdGl0bGU+PHJlY3QgY2xhc3M9ImNscy0xIiB3aWR0aD0iNC45NSIgaGVpZ2h0PSIxMCIvPjxwb2x5Z29uIGNsYXNzPSJjbHMtMiIgcG9pbnRzPSIxLjQxIDQuNjcgMi40OCAzLjE4IDMuNTQgNC42NyAxLjQxIDQuNjciLz48cG9seWdvbiBjbGFzcz0iY2xzLTIiIHBvaW50cz0iMy41NCA1LjMzIDIuNDggNi44MiAxLjQxIDUuMzMgMy41NCA1LjMzIi8+PC9zdmc+) no-repeat 95% 50%;
+    -webkit-appearance: none;
+       -moz-appearance: none;
+            appearance: none;
   }
 }

--- a/themes/socialbase/assets/css/form-controls.css
+++ b/themes/socialbase/assets/css/form-controls.css
@@ -544,4 +544,10 @@ input[type=checkbox]:not(:disabled) ~ .lever:active:after {
        -moz-appearance: none;
             appearance: none;
   }
+  input[type="date"].form-control:focus,
+  input[type="time"].form-control:focus,
+  input[type="datetime-local"].form-control:focus,
+  input[type="month"].form-control:focus {
+    background: inherit;
+  }
 }

--- a/themes/socialbase/components/02-atoms/form-controls/_input.scss
+++ b/themes/socialbase/components/02-atoms/form-controls/_input.scss
@@ -89,6 +89,8 @@ input[type="search"] {
   input[type="month"] {
     &.form-control {
       line-height: $line-height-computed;
+      background: url(data:image/svg+xml;base64,PHN2ZyBpZD0iTGF5ZXJfMSIgZGF0YS1uYW1lPSJMYXllciAxIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA0Ljk1IDEwIj48ZGVmcz48c3R5bGU+LmNscy0xe2ZpbGw6I2ZmZjt9LmNscy0ye2ZpbGw6IzQ0NDt9PC9zdHlsZT48L2RlZnM+PHRpdGxlPmFycm93czwvdGl0bGU+PHJlY3QgY2xhc3M9ImNscy0xIiB3aWR0aD0iNC45NSIgaGVpZ2h0PSIxMCIvPjxwb2x5Z29uIGNsYXNzPSJjbHMtMiIgcG9pbnRzPSIxLjQxIDQuNjcgMi40OCAzLjE4IDMuNTQgNC42NyAxLjQxIDQuNjciLz48cG9seWdvbiBjbGFzcz0iY2xzLTIiIHBvaW50cz0iMy41NCA1LjMzIDIuNDggNi44MiAxLjQxIDUuMzMgMy41NCA1LjMzIi8+PC9zdmc+) no-repeat 95% 50%;
+      appearance: none;
     }
   }
 }

--- a/themes/socialbase/components/02-atoms/form-controls/_input.scss
+++ b/themes/socialbase/components/02-atoms/form-controls/_input.scss
@@ -91,6 +91,9 @@ input[type="search"] {
       line-height: $line-height-computed;
       background: url(data:image/svg+xml;base64,PHN2ZyBpZD0iTGF5ZXJfMSIgZGF0YS1uYW1lPSJMYXllciAxIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA0Ljk1IDEwIj48ZGVmcz48c3R5bGU+LmNscy0xe2ZpbGw6I2ZmZjt9LmNscy0ye2ZpbGw6IzQ0NDt9PC9zdHlsZT48L2RlZnM+PHRpdGxlPmFycm93czwvdGl0bGU+PHJlY3QgY2xhc3M9ImNscy0xIiB3aWR0aD0iNC45NSIgaGVpZ2h0PSIxMCIvPjxwb2x5Z29uIGNsYXNzPSJjbHMtMiIgcG9pbnRzPSIxLjQxIDQuNjcgMi40OCAzLjE4IDMuNTQgNC42NyAxLjQxIDQuNjciLz48cG9seWdvbiBjbGFzcz0iY2xzLTIiIHBvaW50cz0iMy41NCA1LjMzIDIuNDggNi44MiAxLjQxIDUuMzMgMy41NCA1LjMzIi8+PC9zdmc+) no-repeat 95% 50%;
       appearance: none;
+      &:focus {
+        background: inherit;
+      }
     }
   }
 }


### PR DESCRIPTION
## Problem
Event date and time field has gradient on mobile on iOS. This is default behaviour but is inconsistent with the design.

## Solution
For iOS temporal fields only, set appearance to none, and add background svg icons to indicate it is a select element

## Issue tracker
https://www.drupal.org/project/social/issues/2925994

## HTT - coming soon
- [ ] Check out the code changes
- [ ] Login as user X and do this and this and that
- [ ] Notice it doesn't work
- [ ] Checkout to this branch
- [ ] Try this and this and that and see that it works now

## Documentation
- [x] This item is added to the release notes
- [ ] This item is documented on LGOS
- [ ] This item has been added to the feature overview
