### PR TITLE
Issue #2931336 replace string for page title and config description

### DIFF
--- a/modules/social_features/social_activity/config/install/views.view.activity_stream_notifications.yml
+++ b/modules/social_features/social_activity/config/install/views.view.activity_stream_notifications.yml
@@ -13,7 +13,7 @@ dependencies:
 id: activity_stream_notifications
 label: 'Activity stream notifications'
 module: views
-description: 'Activity stream on a profile'
+description: 'Activity stream notifications on a profile'
 tag: ''
 base_table: activity_field_data
 base_field: id
@@ -251,7 +251,7 @@ display:
           entity_type: activity
           entity_field: created
           plugin_id: date
-      title: 'Activity stream'
+      title: 'Notifications'
       header: {  }
       footer: {  }
       empty:


### PR DESCRIPTION
## Problem
The title of the "Notifications" page (/notifications) is now "Activity Stream". 

I think this is due to the configuration yml having being copied and these strings were overlooked

## Solution
Title should be "Notifications" 

## Issue tracker
https://www.drupal.org/project/social/issues/2931336

## HTT
- [ ] Login as LU + and go to /notifications
- [ ] Notice the page title reads "activity stream"
- [ ] Checkout to this branch
- [ ] *I am not sure how you load this new configuration - I uninstalled social_activity module and reinstalled it
- [ ] Notice the page title reads "Notifications"

## Documentation
- [ ] This item is added to the release notes
- [ ] This item is documented on LGOS
- [ ] This item has been added to the feature overview
