### PR TITLE
Issue #2946460: Styling of the text buttons is not complies with WCAG AA

### DIFF
--- a/themes/socialblue/assets/css/brand.css
+++ b/themes/socialblue/assets/css/brand.css
@@ -158,18 +158,6 @@ fieldset[disabled] .btn-accent.focus {
   fill: #29abe2;
 }
 
-.nav-tabs > li.active > a,
-.nav-tabs > li.active > a:hover,
-.nav-tabs > li.active > a:focus,
-.card__link:focus,
-.card__link:hover,
-.btn-link:hover,
-.btn-flat:hover,
-.btn-link:focus,
-.btn-flat:focus {
-  text-shadow: 0 0 1px rgba(0, 0, 0, 0.2);
-}
-
 .list-item--active,
 .list-item--active:hover,
 .list-item--active:focus,

--- a/themes/socialblue/assets/css/button.css
+++ b/themes/socialblue/assets/css/button.css
@@ -121,9 +121,50 @@ fieldset[disabled] .btn-flat.focus {
 
 .btn-flat:hover, .btn-flat:focus,
 .open .dropdown-toggle .btn-flat {
-  border-color: transparent;
+  color: inherit;
+  background-color: #ffffff;
+  border-color: #adadad;
+  fill: inherit;
   color: #1a8dbe;
   fill: #1a8dbe;
+}
+
+.btn-flat:hover:focus, .btn-flat:hover.focus, .btn-flat:hover:hover, .btn-flat:hover:active, .btn-flat:hover.active,
+.open > .btn-flat:hover.dropdown-toggle, .btn-flat:focus:focus, .btn-flat:focus.focus, .btn-flat:focus:hover, .btn-flat:focus:active, .btn-flat:focus.active,
+.open > .btn-flat:focus.dropdown-toggle,
+.open .dropdown-toggle .btn-flat:focus,
+.open .dropdown-toggle .btn-flat.focus,
+.open .dropdown-toggle .btn-flat:hover,
+.open .dropdown-toggle .btn-flat:active,
+.open .dropdown-toggle .btn-flat.active,
+.open >
+.open .dropdown-toggle .btn-flat.dropdown-toggle {
+  background-color: #e6e6e6;
+  border-color: #8e8e8e;
+  color: inherit;
+}
+
+.btn-flat:hover.disabled:hover, .btn-flat:hover.disabled:focus, .btn-flat:hover.disabled.focus, .btn-flat:hover[disabled]:hover, .btn-flat:hover[disabled]:focus, .btn-flat:hover[disabled].focus,
+fieldset[disabled] .btn-flat:hover:hover,
+fieldset[disabled] .btn-flat:hover:focus,
+fieldset[disabled] .btn-flat:hover.focus, .btn-flat:focus.disabled:hover, .btn-flat:focus.disabled:focus, .btn-flat:focus.disabled.focus, .btn-flat:focus[disabled]:hover, .btn-flat:focus[disabled]:focus, .btn-flat:focus[disabled].focus,
+fieldset[disabled] .btn-flat:focus:hover,
+fieldset[disabled] .btn-flat:focus:focus,
+fieldset[disabled] .btn-flat:focus.focus,
+.open .dropdown-toggle .btn-flat.disabled:hover,
+.open .dropdown-toggle .btn-flat.disabled:focus,
+.open .dropdown-toggle .btn-flat.disabled.focus,
+.open .dropdown-toggle .btn-flat[disabled]:hover,
+.open .dropdown-toggle .btn-flat[disabled]:focus,
+.open .dropdown-toggle .btn-flat[disabled].focus,
+fieldset[disabled]
+.open .dropdown-toggle .btn-flat:hover,
+fieldset[disabled]
+.open .dropdown-toggle .btn-flat:focus,
+fieldset[disabled]
+.open .dropdown-toggle .btn-flat.focus {
+  background-color: #ffffff;
+  border-color: #adadad;
 }
 
 .btn-flat:hover .icon-inline, .btn-flat:focus .icon-inline,

--- a/themes/socialblue/assets/css/ckeditor.css
+++ b/themes/socialblue/assets/css/ckeditor.css
@@ -121,9 +121,50 @@ fieldset[disabled] .btn-flat.focus {
 
 .btn-flat:hover, .btn-flat:focus,
 .open .dropdown-toggle .btn-flat {
-  border-color: transparent;
+  color: inherit;
+  background-color: #ffffff;
+  border-color: #adadad;
+  fill: inherit;
   color: #1a8dbe;
   fill: #1a8dbe;
+}
+
+.btn-flat:hover:focus, .btn-flat:hover.focus, .btn-flat:hover:hover, .btn-flat:hover:active, .btn-flat:hover.active,
+.open > .btn-flat:hover.dropdown-toggle, .btn-flat:focus:focus, .btn-flat:focus.focus, .btn-flat:focus:hover, .btn-flat:focus:active, .btn-flat:focus.active,
+.open > .btn-flat:focus.dropdown-toggle,
+.open .dropdown-toggle .btn-flat:focus,
+.open .dropdown-toggle .btn-flat.focus,
+.open .dropdown-toggle .btn-flat:hover,
+.open .dropdown-toggle .btn-flat:active,
+.open .dropdown-toggle .btn-flat.active,
+.open >
+.open .dropdown-toggle .btn-flat.dropdown-toggle {
+  background-color: #e6e6e6;
+  border-color: #8e8e8e;
+  color: inherit;
+}
+
+.btn-flat:hover.disabled:hover, .btn-flat:hover.disabled:focus, .btn-flat:hover.disabled.focus, .btn-flat:hover[disabled]:hover, .btn-flat:hover[disabled]:focus, .btn-flat:hover[disabled].focus,
+fieldset[disabled] .btn-flat:hover:hover,
+fieldset[disabled] .btn-flat:hover:focus,
+fieldset[disabled] .btn-flat:hover.focus, .btn-flat:focus.disabled:hover, .btn-flat:focus.disabled:focus, .btn-flat:focus.disabled.focus, .btn-flat:focus[disabled]:hover, .btn-flat:focus[disabled]:focus, .btn-flat:focus[disabled].focus,
+fieldset[disabled] .btn-flat:focus:hover,
+fieldset[disabled] .btn-flat:focus:focus,
+fieldset[disabled] .btn-flat:focus.focus,
+.open .dropdown-toggle .btn-flat.disabled:hover,
+.open .dropdown-toggle .btn-flat.disabled:focus,
+.open .dropdown-toggle .btn-flat.disabled.focus,
+.open .dropdown-toggle .btn-flat[disabled]:hover,
+.open .dropdown-toggle .btn-flat[disabled]:focus,
+.open .dropdown-toggle .btn-flat[disabled].focus,
+fieldset[disabled]
+.open .dropdown-toggle .btn-flat:hover,
+fieldset[disabled]
+.open .dropdown-toggle .btn-flat:focus,
+fieldset[disabled]
+.open .dropdown-toggle .btn-flat.focus {
+  background-color: #ffffff;
+  border-color: #adadad;
 }
 
 .btn-flat:hover .icon-inline, .btn-flat:focus .icon-inline,

--- a/themes/socialblue/assets/css/preview.css
+++ b/themes/socialblue/assets/css/preview.css
@@ -712,9 +712,50 @@ fieldset[disabled] .btn-flat.focus {
 
 .btn-flat:hover, .btn-flat:focus,
 .open .dropdown-toggle .btn-flat {
-  border-color: transparent;
+  color: inherit;
+  background-color: #ffffff;
+  border-color: #adadad;
+  fill: inherit;
   color: #1a8dbe;
   fill: #1a8dbe;
+}
+
+.btn-flat:hover:focus, .btn-flat:hover.focus, .btn-flat:hover:hover, .btn-flat:hover:active, .btn-flat:hover.active,
+.open > .btn-flat:hover.dropdown-toggle, .btn-flat:focus:focus, .btn-flat:focus.focus, .btn-flat:focus:hover, .btn-flat:focus:active, .btn-flat:focus.active,
+.open > .btn-flat:focus.dropdown-toggle,
+.open .dropdown-toggle .btn-flat:focus,
+.open .dropdown-toggle .btn-flat.focus,
+.open .dropdown-toggle .btn-flat:hover,
+.open .dropdown-toggle .btn-flat:active,
+.open .dropdown-toggle .btn-flat.active,
+.open >
+.open .dropdown-toggle .btn-flat.dropdown-toggle {
+  background-color: #e6e6e6;
+  border-color: #8e8e8e;
+  color: inherit;
+}
+
+.btn-flat:hover.disabled:hover, .btn-flat:hover.disabled:focus, .btn-flat:hover.disabled.focus, .btn-flat:hover[disabled]:hover, .btn-flat:hover[disabled]:focus, .btn-flat:hover[disabled].focus,
+fieldset[disabled] .btn-flat:hover:hover,
+fieldset[disabled] .btn-flat:hover:focus,
+fieldset[disabled] .btn-flat:hover.focus, .btn-flat:focus.disabled:hover, .btn-flat:focus.disabled:focus, .btn-flat:focus.disabled.focus, .btn-flat:focus[disabled]:hover, .btn-flat:focus[disabled]:focus, .btn-flat:focus[disabled].focus,
+fieldset[disabled] .btn-flat:focus:hover,
+fieldset[disabled] .btn-flat:focus:focus,
+fieldset[disabled] .btn-flat:focus.focus,
+.open .dropdown-toggle .btn-flat.disabled:hover,
+.open .dropdown-toggle .btn-flat.disabled:focus,
+.open .dropdown-toggle .btn-flat.disabled.focus,
+.open .dropdown-toggle .btn-flat[disabled]:hover,
+.open .dropdown-toggle .btn-flat[disabled]:focus,
+.open .dropdown-toggle .btn-flat[disabled].focus,
+fieldset[disabled]
+.open .dropdown-toggle .btn-flat:hover,
+fieldset[disabled]
+.open .dropdown-toggle .btn-flat:focus,
+fieldset[disabled]
+.open .dropdown-toggle .btn-flat.focus {
+  background-color: #ffffff;
+  border-color: #adadad;
 }
 
 .btn-flat:hover .icon-inline, .btn-flat:focus .icon-inline,
@@ -1524,18 +1565,6 @@ fieldset[disabled] .btn-accent.focus {
 .nav-book .menu-item--active-trail > a {
   color: #29abe2;
   fill: #29abe2;
-}
-
-.nav-tabs > li.active > a,
-.nav-tabs > li.active > a:hover,
-.nav-tabs > li.active > a:focus,
-.card__link:focus,
-.card__link:hover,
-.btn-link:hover,
-.btn-flat:hover,
-.btn-link:focus,
-.btn-flat:focus {
-  text-shadow: 0 0 1px rgba(0, 0, 0, 0.2);
 }
 
 .list-item--active,

--- a/themes/socialblue/components/02-atoms/button/button.scss
+++ b/themes/socialblue/components/02-atoms/button/button.scss
@@ -106,7 +106,8 @@
   &:hover,
   &:focus,
   .open .dropdown-toggle & {
-    border-color: transparent;
+    //border-color: transparent;
+    @include button-variant(inherit, $btn-default-bg, $btn-default-border);
     color: darken($brand-primary, 10%);
     fill: darken($brand-primary, 10%);
 

--- a/themes/socialblue/components/brand.scss
+++ b/themes/socialblue/components/brand.scss
@@ -185,17 +185,6 @@
   fill: $brand-primary;
 }
 
-.nav-tabs > li.active > a,
-.nav-tabs > li.active > a:hover,
-.nav-tabs > li.active > a:focus,
-.card__link:focus,
-.card__link:hover,
-.btn-link:hover,
-.btn-flat:hover,
-.btn-link:focus,
-.btn-flat:focus {
-  text-shadow: 0 0 1px rgba(black,0.2);
-}
 .list-item--active,
 .list-item--active:hover,
 .list-item--active:focus,


### PR DESCRIPTION
## Problem
Styling of the text buttons is not complies with WCAG AA. See issue for more details and discussion

## Solution
1. Add border and background colour like btn-default on focus and hover, to provide visual feedback for keyboard users
2. In discussion with @basvanos regarding colour contrast

## Issue tracker
https://www.drupal.org/project/social/issues/2946460

## HTT - coming soon
- [ ] Check out the code changes
- [ ] Login as user X and do this and this and that
- [ ] Notice it doesn't work
- [ ] Checkout to this branch
- [ ] Try this and this and that and see that it works now

## Documentation
- [ ] This item is added to the release notes
- [ ] This item is documented on LGOS
- [ ] This item has been added to the feature overview
