### PR TITLE
Event enrollment stays open past time

### DIFF
--- a/modules/social_features/social_event/src/Form/EnrollActionForm.php
+++ b/modules/social_features/social_event/src/Form/EnrollActionForm.php
@@ -279,14 +279,14 @@ class EnrollActionForm extends FormBase implements ContainerInjectionInterface {
    *
    * @param string $remote_tz
    *   The remote timezone.
-   * @param null $origin_tz
+   * @param string $origin_tz
    *   The origin timezone.
    *
    * @return bool|int
    *   Offset in seconds.
    */
   public function getTimezoneOffset($remote_tz, $origin_tz = NULL) {
-    if($origin_tz === NULL) {
+    if ($origin_tz === NULL) {
       if (!is_string($origin_tz = date_default_timezone_get())) {
         // A UTC timestamp was returned.
         return FALSE;

--- a/modules/social_features/social_event/src/Form/EnrollActionForm.php
+++ b/modules/social_features/social_event/src/Form/EnrollActionForm.php
@@ -240,8 +240,8 @@ class EnrollActionForm extends FormBase implements ContainerInjectionInterface {
     // Get timezone of user.
     // Get offset of user from UTC time to localtime.
     $timezone = drupal_get_user_timezone();
-    //Let's get offset time from UTC.
-    $offset = $this->get_timezone_offset('UTC', $timezone);
+    // Let's get offset time from UTC.
+    $offset = $this->getTimezoneOffset('UTC', $timezone);
 
     // Use the start date when the end date is not set to determine if the
     // event is closed.
@@ -285,10 +285,11 @@ class EnrollActionForm extends FormBase implements ContainerInjectionInterface {
    * @return bool|int
    *   Offset in seconds.
    */
-  public function get_timezone_offset($remote_tz, $origin_tz = null) {
-    if($origin_tz === null) {
-      if(!is_string($origin_tz = date_default_timezone_get())) {
-        return false; // A UTC timestamp was returned
+  public function getTimezoneOffset($remote_tz, $origin_tz = NULL) {
+    if($origin_tz === NULL) {
+      if (!is_string($origin_tz = date_default_timezone_get())) {
+        // A UTC timestamp was returned.
+        return FALSE;
       }
     }
     $origin_dtz = new DateTimeZone($origin_tz);

--- a/modules/social_features/social_event/src/Form/EnrollActionForm.php
+++ b/modules/social_features/social_event/src/Form/EnrollActionForm.php
@@ -237,8 +237,8 @@ class EnrollActionForm extends FormBase implements ContainerInjectionInterface {
    *   TRUE if the evens is finished / completed.
    */
   protected function eventHasBeenFinished(Node $node) {
-    //Get timezone of user.
-    //Get offset of user from UTC time to localtime.
+    // Get timezone of user.
+    // Get offset of user from UTC time to localtime.
     $timezone = drupal_get_user_timezone();
     //Let's get offset time from UTC.
     $offset = $this->get_timezone_offset('UTC', $timezone);
@@ -254,36 +254,36 @@ class EnrollActionForm extends FormBase implements ContainerInjectionInterface {
 
     // Check to see if Event end date is in the future,
     // hence we can still "Enroll".
-    //Add offset time accordingly.
+    // Add offset time accordingly.
     if ($offset > 0) {
       if ((time() - $offset) > $event_end_timestamp) {
         return TRUE;
       }
     }
     elseif ($offset < 0) {
-     $offset = abs($offset);
-     if ((time() + $offset) > $event_end_timestamp) {
-       return TRUE;
+      $offset = abs($offset);
+      if ((time() + $offset) > $event_end_timestamp) {
+        return TRUE;
       }
-   }
-   elseif ($offset == 0) {
+    }
+    elseif ($offset == 0) {
       if (time() > $event_end_timestamp) {
         return TRUE;
       }
-   }
+    }
     return FALSE;
   }
 
   /**
    * Function to return the number of offset seconds.
    *
-   * @param $remote_tz
-   *  The remote timezone.
+   * @param string $remote_tz
+   *   The remote timezone.
    * @param null $origin_tz
-   *  The origin timezone.
+   *   The origin timezone.
    *
    * @return bool|int
-   *  Offset in seconds.
+   *   Offset in seconds.
    */
   public function get_timezone_offset($remote_tz, $origin_tz = null) {
     if($origin_tz === null) {


### PR DESCRIPTION
## Problem
Events are being marked as "passed"  prior to their start time.
## Solution
This is caused due to offset from UTC and DST, so that i made a change in timezone handling. Here we have to get offset against the UTC as event dates are stored in UTC at the database.
## Issue tracker
- https://www.drupal.org/project/social/issues/2956238#comment-12545543
## HTT
- [ ] Create a user with a different timezone than the event creator
- [ ] Checkout the event status on both the creator and user
- [ ] Then you will notice a difference
