### PR TITLE
DS-4680 -Allow Travis CI test for forked repositories

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,18 +46,21 @@ before_install:
   - git clone --branch master https://github.com/goalgorilla/drupal_social.git install
   - cd install
   - export PR=https://api.github.com/repos/$TRAVIS_REPO_SLUG/pulls/$TRAVIS_PULL_REQUEST
-  - export BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_BRANCH; else echo `curl -s $PR | jq -r .head.ref`; fi)
+  - export BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_BRANCH; else echo $TRAVIS_PULL_REQUEST_BRANCH; fi)
+  - export COMMIT=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_COMMIT; else echo $TRAVIS_PULL_REQUEST_SHA; fi)
   - export COMPOSER_EXIT_ON_PATCH_FAILURE=1
-  - echo "TRAVIS_BRANCH=$TRAVIS_BRANCH, PR=$PR, BRANCH=$BRANCH"
+  - echo "TRAVIS_BRANCH=$TRAVIS_BRANCH, PR=$PR, BRANCH=$BRANCH, COMMIT=$COMMIT"
   - if [ "$TEST_SUITE" = "install_update" ]; then composer require goalgorilla/open_social:1.6.0 --prefer-dist; fi
-  - if [ "$TEST_SUITE" != "install_update" ]; then composer require goalgorilla/open_social:dev-${BRANCH}#${TRAVIS_COMMIT} --prefer-dist; fi
+  - if [ "$TRAVIS_PULL_REQUEST" != "false" ] && [ "$TRAVIS_PULL_REQUEST_SLUG" != "goalgorilla/open_social" ]; then composer config repositories.social git https://github.com/$TRAVIS_PULL_REQUEST_SLUG.git; fi
+  - if [ "$TEST_SUITE" != "install_update" ]; then composer require goalgorilla/open_social:dev-${BRANCH}#${COMMIT} --prefer-dist; fi
+
   # Install docker and our docker containers.
   - sh scripts/social/ci/install-docker.sh
   - docker-compose -f docker-compose-ci.yml up -d
 
 install:
   - if [ "$TEST_SUITE" = "install_stability_1" ] || [ "$TEST_SUITE" = "install_stability_2" ] || [ "$TEST_SUITE" = "install_stability_3-4-5" ]; then docker exec -i social_ci_web bash /var/www/scripts/social/install/install_script.sh; fi
-  - if [ "$TEST_SUITE" = "install_update" ]; then bash scripts/social/ci/build-install-update.sh $PR $BRANCH $TRAVIS_COMMIT; fi
+  - if [ "$TEST_SUITE" = "install_update" ]; then bash scripts/social/ci/build-install-update.sh $PR $BRANCH $COMMIT; fi
   - if [ "$TEST_SUITE" = "drush_make" ]; then bash scripts/social/ci/build-social-make.sh; fi
 
 script:


### PR DESCRIPTION
## Problem
Currently forks don't run automated tests due to the nature of the .travis.yml file where we hardcore `goalgorilla/open_social` as repo name.

## Solution
By setting the forked repository as a Composer git repo we can overwrite the goalgorilla/open_social package which is pulled in and build.

Also we adjusted the commit has and branch as these are different for PR's.

## HTT
- [x] See that the tests pass
- [x] See that the tests pass for https://github.com/goalgorilla/open_social/pull/716