### PR TITLE
Issue #2956238 by Brhane, Kingdutch: Incorrect "event has passed" mes…

### DIFF
--- a/modules/social_features/social_event/src/Form/EnrollActionForm.php
+++ b/modules/social_features/social_event/src/Form/EnrollActionForm.php
@@ -4,6 +4,7 @@ namespace Drupal\social_event\Form;
 
 use Drupal\Core\Cache\Cache;
 use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Datetime\DrupalDateTime;
 use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
 use Drupal\Core\Entity\EntityStorageInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
@@ -237,17 +238,17 @@ class EnrollActionForm extends FormBase implements ContainerInjectionInterface {
   protected function eventHasBeenFinished(Node $node) {
     // Use the start date when the end date is not set to determine if the
     // event is closed.
-    $check_end_date = $node->field_event_date->value;
+    /** @var \Drupal\Core\Datetime\DrupalDateTime $check_end_date */
+    $check_end_date = $node->field_event_date->date;
 
-    if (isset($node->field_event_date_end->value)) {
-      $check_end_date = $node->field_event_date_end->value;
+    if (isset($node->field_event_date_end->date)) {
+      $check_end_date = $node->field_event_date_end->date;
     }
-    // Get Event end date to compare w/ current timestamp.
-    $event_end_timestamp = strtotime($check_end_date);
 
-    // Check to see if Event end date is in the future,
-    // hence we can still "Enroll".
-    if (time() > $event_end_timestamp) {
+    $current_time = new DrupalDateTime();
+
+    // The event has finished if the end date is smaller than the current date.
+    if ($current_time > $check_end_date) {
       return TRUE;
     }
     return FALSE;


### PR DESCRIPTION
…sage

## Problem
When changing a date from a string to a time PHP uses the timezone
that's returned by `date_default_timezone_get`. However, this is
set by Drupal to be set to the timezone of the user that is making
the current request. This causes a time that is stored as UTC to
be treated in a different timezone. If a `time()` call is then used
to compare against this timezone then in timezones that are behind
`UTC` they'll be able to enroll to events that have passed while
in timezones ahead of `UTC` events will close early.

## Solution
DateTime fields also have a `date` property which stores the time-
zone aware value. We then use `new DrupalDateTime` which defaults
to `time()` in server time and creates another proper timezone
aware value. Those values can then be compared and the values will
be modified so that comparison takes place in the same timezone.

This results in the proper timezone aware closing of events where
the event enrollment closes for all users around the globe at the
same moment.

## Issue tracker
- https://www.drupal.org/project/social/issues/2956238

## HTT
- [ ] Check out the code changes
- [ ] Login as user X and set the timezone to Amsterdam
- [ ] Create an event that started two hours ago and ended one hour ago
- [ ] Observe that you can no longer enroll for that event
- [ ] Login as user Y and set the timezone to Edmonton (this is -X offset of UTC)
- [ ] Observe that you can now still enroll for the event
- [ ] Checkout to this branch
- [ ] Login as user X and observe that you still can not enroll to the event
- [ ] Login as user Y and observe that you can also no longer enroll in the event
- [ ] Create a new event as user X that starts in the future and observe that both users can enroll to the event

## Documentation
- [ ] This item is added to the release notes

This PR makes #810 unnecessary.