### PR TITLE
Issue #2956971: TranslatableMarkup::toString - undefined function

### DIFF
--- a/modules/custom/activity_creator/activity.page.inc
+++ b/modules/custom/activity_creator/activity.page.inc
@@ -41,7 +41,7 @@ function template_preprocess_activity(array &$variables) {
     $variables['date'] = $date;
   }
   else {
-    $variables['date'] = Link::fromTextAndUrl($date, $full_url);
+    $variables['date'] = Link::fromTextAndUrl($date, $full_url)->toString()->getGeneratedLink();
   }
   $variables['#cache']['max-age'] = $created_time_ago->getMaxAge();
 

--- a/modules/custom/activity_creator/activity.page.inc
+++ b/modules/custom/activity_creator/activity.page.inc
@@ -37,7 +37,10 @@ function template_preprocess_activity(array &$variables) {
   $created_time_ago = \Drupal::service('date.formatter')
     ->formatTimeDiffSince($activity->getCreatedTime(), ['granularity' => 1, 'return_as_object' => TRUE]);
   $date = t('@time ago', ['@time' => $created_time_ago->getString()]);
-  if (isset($variables['elements']['#view_mode']) && ($variables['elements']['#view_mode'] === 'notification_archive' || $variables['elements']['#view_mode'] === 'notification')) {
+  if (isset($variables['elements']['#view_mode']) && in_array($variables['content']['field_activity_output_text']['#view_mode'], [
+    'notification',
+    'notification_archive',
+  ])) {
     $variables['date'] = $date;
   }
   else {

--- a/modules/custom/activity_creator/activity.page.inc
+++ b/modules/custom/activity_creator/activity.page.inc
@@ -37,7 +37,7 @@ function template_preprocess_activity(array &$variables) {
   $created_time_ago = \Drupal::service('date.formatter')
     ->formatTimeDiffSince($activity->getCreatedTime(), ['granularity' => 1, 'return_as_object' => TRUE]);
   $date = t('@time ago', ['@time' => $created_time_ago->getString()]);
-  if ($full_url == '') {
+  if (isset($variables['elements']['#view_mode']) && ($variables['elements']['#view_mode'] === 'notification_archive' || $variables['elements']['#view_mode'] === 'notification')) {
     $variables['date'] = $date;
   }
   else {

--- a/modules/custom/activity_creator/activity.page.inc
+++ b/modules/custom/activity_creator/activity.page.inc
@@ -36,12 +36,12 @@ function template_preprocess_activity(array &$variables) {
   // Display activity created date in format 'time ago'.
   $created_time_ago = \Drupal::service('date.formatter')
     ->formatTimeDiffSince($activity->getCreatedTime(), ['granularity' => 1, 'return_as_object' => TRUE]);
-  $date = t('%time ago', ['%time' => $created_time_ago->getString()]);
+  $date = t('@time ago', ['@time' => $created_time_ago->getString()]);
   if ($full_url == '') {
     $variables['date'] = $date;
   }
   else {
-    $variables['date'] = Link::fromTextAndUrl($date, $full_url)->toString()->getGeneratedLink();
+    $variables['date'] = Link::fromTextAndUrl($date, $full_url)->toRenderable();
   }
   $variables['#cache']['max-age'] = $created_time_ago->getMaxAge();
 

--- a/themes/socialbase/src/Plugin/Preprocess/Activity.php
+++ b/themes/socialbase/src/Plugin/Preprocess/Activity.php
@@ -25,7 +25,7 @@ class Activity extends PreprocessBase {
       'notification_archive',
     ])) {
       // Remove href from date.
-      $variables['date'] = strip_tags($variables['date']->toString()->getGeneratedLink());
+      $variables['date'] = strip_tags($variables['date']);
       // Remove href from output text.
       $variables['content']['field_activity_output_text'][0]['#text'] = strip_tags($variables['content']['field_activity_output_text'][0]['#text']);
       // Remove href from profile image.

--- a/themes/socialbase/src/Plugin/Preprocess/Activity.php
+++ b/themes/socialbase/src/Plugin/Preprocess/Activity.php
@@ -24,8 +24,6 @@ class Activity extends PreprocessBase {
       'notification',
       'notification_archive',
     ])) {
-      // Remove href from date.
-      $variables['date'] = strip_tags($variables['date']);
       // Remove href from output text.
       $variables['content']['field_activity_output_text'][0]['#text'] = strip_tags($variables['content']['field_activity_output_text'][0]['#text']);
       // Remove href from profile image.


### PR DESCRIPTION
## Problem
I have the fatal error after creating messages (notifications):

```
The website encountered an unexpected error. Please try again later.
Error: Call to undefined method Drupal\Core\StringTranslation\TranslatableMarkup::toString() in Drupal\socialbase\Plugin\Preprocess\Activity->preprocess() (line 28 of profiles/contrib/social/themes/socialbase/src/Plugin/Preprocess/Activity.php).
```
See: https://www.drupal.org/project/social/issues/2956971

## Solution
As I see, `$variables['date'] `will have different types - string or object, which needs special methods before rendering.
The patch from the current issue creates `$variables['date']` with renderable data.

## Issue tracker
- https://www.drupal.org/project/social/issues/2956971

## HTT
- [x] Check out the code changes
- [x] Follow steps how to reproduce

## Documentation
- [ ] This item is added to the release notes
- [x] This item is documented on LGOS
- [x] This item has been added to the feature overview
