### PR TITLE
Issue #2930174: Fatal error: Call to a member function id() on NULL

### DIFF
--- a/modules/social_features/social_post/src/Form/PostForm.php
+++ b/modules/social_features/social_post/src/Form/PostForm.php
@@ -168,15 +168,18 @@ class PostForm extends ContentEntityForm {
 
   /**
    * Function to set the current form modes.
+   *
+   * Retrieve the form display before it is overwritten in the parent.
    */
   protected function setFormMode() {
-    // Retrieve the form display before it is overwritten in the parent.
-    $bundle = $this->getBundleEntity()->id();
+    if ($this->getBundleEntity() !== NULL) {
+      $bundle = $this->getBundleEntity()->id();
 
-    // Set as variables, since the bundle might be different.
-    $this->postViewDefault = 'post.' . $bundle . '.default';
-    $this->postViewProfile = 'post.' . $bundle . '.profile';
-    $this->postViewGroup = 'post.' . $bundle . '.group';
+      // Set as variables, since the bundle might be different.
+      $this->postViewDefault = 'post.' . $bundle . '.default';
+      $this->postViewProfile = 'post.' . $bundle . '.profile';
+      $this->postViewGroup = 'post.' . $bundle . '.group';
+    }
   }
 
 }


### PR DESCRIPTION

## Problem
When the entitybundle is NULL the id() method shouldn't be used.

## Solution
Let's make this code a bit more defensive by adding a check for NULL.

## Issue tracker
- https://www.drupal.org/project/social/issues/2930174

## HTT
- [x] Check out the code changes

## Documentation
- [ ] This item is added to the release notes
- [ ] This item is documented on LGOS
- [ ] This item has been added to the feature overview
