### PR TITLE
Issue #2948237: "Edit profile information" is not translatable

### DIFF
--- a/themes/socialbase/templates/profile/profile--profile--hero.html.twig
+++ b/themes/socialbase/templates/profile/profile--profile--hero.html.twig
@@ -29,7 +29,7 @@
     <div class="hero__bgimage-overlay"></div>
 {% if profile_edit_url %}
   <div class="hero-action-button">
-    <a href="{{ profile_edit_url }}" title="Edit profile information" class="btn btn-raised btn-default btn-floating">
+    <a href="{{ profile_edit_url }}" title="{% trans %}Edit profile information{% endtrans %}" class="btn btn-raised btn-default btn-floating">
       <svg class="icon-medium">
         <use xlink:href="#icon-edit"></use>
       </svg>


### PR DESCRIPTION
## Problem
The text "Edit profile information" in the profile hero is not translatable currently.

## Solution
Let's make it translatable with Twig!

## Issue tracker
- https://www.drupal.org/project/social/issues/2948237

## HTT
- [x] Check out the code changes
- [x] Enable language
- [x] Translate "Edit profile information" and notice that it is translated in the hero are of the profile.

## Documentation
- [ ] This item is added to the release notes
- [ ] This item is documented on LGOS
- [ ] This item has been added to the feature overview
