### PR TITLE
DS-4891 by bramtenhove: Add default styling for the GDPR inform block

### DIFF
--- a/themes/socialbase/assets/css/block--informblock.css
+++ b/themes/socialbase/assets/css/block--informblock.css
@@ -19,6 +19,7 @@
       -ms-flex: 2;
           flex: 2;
   padding: 0 0.75rem 0 0;
+  text-align: left !important;
 }
 
 .block-gdpr-consent footer {
@@ -60,6 +61,7 @@
         -ms-flex: none;
             flex: none;
     padding: 15px 1.25rem;
+    text-align: center !important;
   }
   .block-gdpr-consent footer {
     border-left: none;

--- a/themes/socialbase/assets/css/block--informblock.css
+++ b/themes/socialbase/assets/css/block--informblock.css
@@ -1,0 +1,75 @@
+.block-gdpr-consent {
+  -webkit-box-align: center;
+      -ms-flex-align: center;
+          align-items: center;
+  cursor: pointer;
+  -webkit-box-orient: unset;
+  -webkit-box-direction: unset;
+      -ms-flex-direction: unset;
+          flex-direction: unset;
+  padding: 1rem;
+}
+
+.block-gdpr-consent .card__block {
+  display: none;
+}
+
+.block-gdpr-consent .card__title {
+  -webkit-box-flex: 2;
+      -ms-flex: 2;
+          flex: 2;
+  padding: 0 0.75rem 0 0;
+}
+
+.block-gdpr-consent footer {
+  border-left: 2px solid #e6e6e6;
+  -webkit-box-flex: fit-content;
+      -ms-flex: fit-content;
+          flex: fit-content;
+  padding: 0 0 0 0.75rem;
+  margin-top: 0;
+}
+
+.block-gdpr-consent footer a {
+  padding: 0;
+}
+
+@media (min-width: 900px) {
+  .block-gdpr-consent {
+    -webkit-box-align: normal;
+        -ms-flex-align: normal;
+            align-items: normal;
+    cursor: default;
+    -webkit-box-orient: vertical;
+    -webkit-box-direction: normal;
+        -ms-flex-direction: column;
+            flex-direction: column;
+    padding: inherit;
+  }
+  .block-gdpr-consent .card__block {
+    display: block;
+    text-align: center;
+  }
+  .block-gdpr-consent .card__title {
+    background-color: #1f80aa;
+    border-radius: inherit;
+    border-bottom-left-radius: 0;
+    border-bottom-right-radius: 0;
+    color: white;
+    -webkit-box-flex: 0;
+        -ms-flex: none;
+            flex: none;
+    padding: 15px 1.25rem;
+  }
+  .block-gdpr-consent footer {
+    border-left: none;
+    -webkit-box-flex: 0;
+        -ms-flex: none;
+            flex: none;
+    padding: 1.25rem;
+    margin-top: -1.25rem;
+  }
+  .block-gdpr-consent footer a {
+    padding: 6px 12px;
+  }
+}

--- a/themes/socialbase/assets/js/informblock.min.js
+++ b/themes/socialbase/assets/js/informblock.min.js
@@ -1,0 +1,1 @@
+!function(i,n){window.informBlockClick=void i(".block-gdpr-consent").on("click",function(){window.innerWidth<900&&i(this).find("footer a").click()})}(jQuery,Drupal);

--- a/themes/socialbase/components/03-molecules/blocks/block--informblock/block--informblock.scss
+++ b/themes/socialbase/components/03-molecules/blocks/block--informblock/block--informblock.scss
@@ -25,6 +25,7 @@
   .card__title {
     flex: 2;
     padding: 0 0.75rem 0 0;
+    text-align: left !important;
 
     @include for-tablet-landscape-up {
       background-color: #1f80aa;
@@ -34,6 +35,7 @@
       color: white;
       flex: none;
       padding: 15px $card-spacer-x;
+      text-align: center !important;
     }
   }
 

--- a/themes/socialbase/components/03-molecules/blocks/block--informblock/block--informblock.scss
+++ b/themes/socialbase/components/03-molecules/blocks/block--informblock/block--informblock.scss
@@ -1,0 +1,61 @@
+@import 'settings';
+
+.block-gdpr-consent {
+  align-items: center;
+  cursor: pointer;
+  flex-direction: unset;
+  padding: 1rem;
+
+  @include for-tablet-landscape-up {
+    align-items: normal;
+    cursor: default;
+    flex-direction: column;
+    padding: inherit;
+  }
+
+  .card__block {
+    display: none;
+
+    @include for-tablet-landscape-up {
+      display: block;
+      text-align: center;
+    }
+  }
+
+  .card__title {
+    flex: 2;
+    padding: 0 0.75rem 0 0;
+
+    @include for-tablet-landscape-up {
+      background-color: #1f80aa;
+      border-radius: inherit;
+      border-bottom-left-radius: 0;
+      border-bottom-right-radius: 0;
+      color: white;
+      flex: none;
+      padding: 15px $card-spacer-x;
+    }
+  }
+
+  footer {
+    border-left: 2px solid $gray-lighter;
+    flex: fit-content;
+    padding: 0 0 0 0.75rem;
+    margin-top: 0;
+
+    @include for-tablet-landscape-up {
+      border-left: none;
+      flex: none;
+      padding: 1.25rem;
+      margin-top: -1.25rem;
+    }
+
+    a {
+      padding: 0;
+
+      @include for-tablet-landscape-up {
+        padding: 6px 12px;
+      }
+    }
+  }
+}

--- a/themes/socialbase/components/03-molecules/blocks/block--informblock/informblock.js
+++ b/themes/socialbase/components/03-molecules/blocks/block--informblock/informblock.js
@@ -1,0 +1,19 @@
+/**
+ * @file
+ * Inform block click behaviour.
+ */
+(function ($, Drupal) {
+
+  window.informBlockClick = (function() {
+    $('.block-gdpr-consent').on('click', function() {
+
+      var viewportWidth = window.innerWidth;
+      var tabletLandscapeUpBreakpoint = 900;
+
+      if (viewportWidth < tabletLandscapeUpBreakpoint) {
+        $(this).find('footer a').click();
+      }
+    });
+  })();
+
+})(jQuery, Drupal);

--- a/themes/socialbase/socialbase.libraries.yml
+++ b/themes/socialbase/socialbase.libraries.yml
@@ -72,6 +72,13 @@ block--introtext:
     component:
       assets/css/block--introtext.css: {}
 
+block--informblock:
+  css:
+    component:
+      assets/css/block--informblock.css: {}
+  js:
+    assets/js/informblock.min.js: { minified: true }
+
 breadcrumb:
   css:
     component:

--- a/themes/socialbase/templates/block/block--gdpr-consent.html.twig
+++ b/themes/socialbase/templates/block/block--gdpr-consent.html.twig
@@ -1,0 +1,26 @@
+{#
+/**
+ * @file
+ * Theme implementation to display a GDPR Inform and Consent block.
+ *
+ * @ingroup templates
+ *
+ * @see bootstrap_preprocess_block()
+ * @see template_preprocess()
+ * @see template_preprocess_block()
+ * @see bootstrap_process_block()
+ * @see template_process()
+ */
+#}
+{% extends 'block.html.twig' %}
+
+{% block content %}
+    {{ attach_library('socialbase/block--informblock') }}
+    <div class="card__block">
+        {{ content|without('link') }}
+    </div>
+
+    <footer class="card__actionbar">
+        {{ content.link }}
+    </footer>
+{% endblock %}

--- a/themes/socialbase/templates/block/block--gdpr-consent.html.twig
+++ b/themes/socialbase/templates/block/block--gdpr-consent.html.twig
@@ -20,7 +20,9 @@
         {{ content|without('link') }}
     </div>
 
+    {% if content.link|render %}
     <footer class="card__actionbar">
         {{ content.link }}
     </footer>
+    {% endif %}
 {% endblock %}


### PR DESCRIPTION
## Problem
The new [GDPR inform & consent module](https://github.com/goalgorilla/gdpr_consent) is blank of styling by default. But for Open Social we require it to have styling that fits the Distribution.

## Solution
Added a custom template and styling for the Inform blocks provided by the module.

## HTT
- [ ] Check out the code changes
- [ ] Make sure you have inform blocks configured (for example for the `/user/register` page)
- [ ] Visit the `/user/register` page
- [ ] Check out that the styling is as designed and expected

## Documentation
- [ ] This item is added to the release notes
