### PR TITLE
Issue #2956718: Unavailable links in landing page hero still produce output

### DIFF
--- a/modules/social_features/social_landing_page/social_landing_page.module
+++ b/modules/social_features/social_landing_page/social_landing_page.module
@@ -98,6 +98,10 @@ function social_landing_page_theme() {
   $theme_templates['field__paragraph__field_featured_items'] = [
     'base hook' => 'field',
   ];
+  // Fields for hero buttons.
+  $theme_templates['field__paragraph__field_hero_buttons'] = [
+    'base hook' => 'field',
+  ];
   // Views.
   $theme_templates['views_view__community_activities'] = [
     'base hook' => 'views_view',

--- a/modules/social_features/social_landing_page/templates/field--paragraph--field-hero-buttons.html.twig
+++ b/modules/social_features/social_landing_page/templates/field--paragraph--field-hero-buttons.html.twig
@@ -1,0 +1,62 @@
+
+{% if bare %}
+  {% for item in items %}
+    {% if entity_type == "node" and field_name == "body" and part_of_teaser %}
+        {{ item.content|render|striptags }}
+    {% else %}
+      {{ item.content }}
+    {% endif %}
+  {% endfor %}
+
+{% else %}
+
+  {%
+    set classes = [
+      'field',
+      'field--name-' ~ field_name|clean_class,
+      'field--type-' ~ field_type|clean_class,
+      'field--label-' ~ label_display,
+    ]
+  %}
+  {%
+    set title_classes = [
+      'field--label',
+      label_display == 'visually_hidden' ? 'sr-only',
+    ]
+  %}
+
+
+  {% if label_hidden %}
+    {% if multiple %}
+      <div{{ attributes.addClass(classes, 'field--items') }}>
+        {% for item in items %}
+          {% if(item.content|render|striptags|trim) %}
+            <div{{ item.attributes.addClass('field--item') }}>{{ item.content }}</div>
+          {% endif %}
+        {% endfor %}
+      </div>
+    {% else %}
+      {% for item in items %}
+          {% if(item.content|render|striptags|trim) %}
+            <div{{ attributes.addClass(classes, 'field--item') }}>{{ item.content }}</div>
+          {% endif %}
+      {% endfor %}
+    {% endif %}
+  {% else %}
+    <div{{ attributes.addClass(classes) }}>
+      <div{{ title_attributes.addClass(title_classes) }}>{{ label }}</div>
+      {% if multiple %}
+        <div class="field__items">
+      {% endif %}
+      {% for item in items %}
+          {% if(item.content|render|striptags|trim) %}
+            <div{{ item.attributes.addClass('field--item') }}>{{ item.content }}</div>
+          {% endif %}
+      {% endfor %}
+      {% if multiple %}
+        </div>
+      {% endif %}
+    </div>
+  {% endif %}
+
+{% endif %}


### PR DESCRIPTION
## Problem
When creating a landing page with a hero and adding buttons to that hero. If you create a button that is only visible for logged in users then when anonymous users view the page there is still a field-item output with a few spaces. In some cases (for example 3 long buttons with 1 "inaccessible button" in between) this can cause an unnecessary overflow.

## Solution
Add checking if item.content is empty

## Issue tracker
- https://www.drupal.org/project/social/issues/2956718

## HTT
- [x] Check out the code changes
- [x] Checkout to this branch
- [x] Notice it doesn't work
- [x] Try add hero buttons for landing page as described in Problem

## Documentation
- [ ] This item is added to the release notes
- [ ] This item is documented on LGOS
- [ ] This item has been added to the feature overview
