### PR TITLE
Issue #2952190: Social Embed iFrame width consistency

### DIFF
--- a/themes/socialbase/assets/css/cards.css
+++ b/themes/socialbase/assets/css/cards.css
@@ -61,6 +61,13 @@
   padding: 1.25rem;
 }
 
+.card__body .twitter-tweet,
+.card__body .fb_iframe_widget,
+.card__body iframe {
+  max-width: 100% !important;
+  width: 100% !important;
+}
+
 .card__nested-section {
   margin-top: 0.625rem;
   margin-right: -1.25rem;

--- a/themes/socialbase/assets/css/ckeditor.css
+++ b/themes/socialbase/assets/css/ckeditor.css
@@ -446,8 +446,6 @@ th {
 .table-responsive {
   display: block;
   width: 100%;
-  overflow-x: auto;
-  -ms-overflow-style: -ms-autohiding-scrollbar;
 }
 
 .table-responsive .table-bordered {
@@ -1407,6 +1405,12 @@ body {
   }
   figure.align-left figcaption, figure.align-right figcaption, figure.align-center figcaption {
     padding: 0;
+  }
+  .table-responsive {
+    overflow-x: auto;
+    -ms-overflow-style: -ms-autohiding-scrollbar;
+    padding-bottom: 100px;
+    margin-bottom: -100px;
   }
   .hidden-for-phone-only {
     display: none;

--- a/themes/socialbase/components/02-atoms/cards/cards.scss
+++ b/themes/socialbase/components/02-atoms/cards/cards.scss
@@ -111,7 +111,12 @@
   @include for-tablet-landscape-up {
     padding: $card-spacer-xl;
   }
-
+  .twitter-tweet,
+  .fb_iframe_widget,
+  iframe {
+    max-width: 100% !important;
+    width: 100% !important;
+  }
 }
 
 // section inside card, such as comments


### PR DESCRIPTION
## Problem
Embedding for example youtube in the stream goes full width because in the templates it gets wrapped in the class "iframe-container".
When embedding the same url within a content-type using the media embed then it will not get the class resulting in not being 100%.

In the spirit of being consistent I think these 2 should have the same behaviour.

## Solution
Dublicate styles for iframe in card body

## Issue tracker
- https://www.drupal.org/project/social/issues/2952190

## HTT
- [x] Check out the code changes
- [x] Checkout to this branch
- [x] Disable social_embed module and try paste Youtube link in stream and event content type
- [x] Compare styles

## Documentation
- [x] This item is added to the release notes
- [x] This item is documented on LGOS
- [x] This item has been added to the feature overview

## Release notes
Iframes (and media objects) in nodes are now full-width as well, just like in posts.