### PR TITLE
DS-5265 Socialbase theme breaks quick edit

### DIFF
--- a/themes/socialbase/templates/node/event/node--event--small-teaser.html.twig
+++ b/themes/socialbase/templates/node/event/node--event--small-teaser.html.twig
@@ -65,7 +65,7 @@
  * @ingroup themeable
  */
 #}
-<div class="card__block">
+<div class="card__block" {{ attributes }}>
 
   {% block text %}
     {{ title_prefix }}


### PR DESCRIPTION
## Problem
Socialbase theme breaks quick edit

## Solution
Add attributes for node small teasers

## Issue tracker
- https://www.drupal.org/project/social/issues/2956419

## HTT
- [x] Check out the code changes
- [x] Checkout to this branch
- [ ] Open site and check if there no JS errors.

## Documentation
- [ ] This item is added to the release notes
