### PR TITLE
Issue #2941204: Incorrect username when registering via social networks

### DIFF
--- a/modules/custom/social_auth_extra/social_auth_extra.module
+++ b/modules/custom/social_auth_extra/social_auth_extra.module
@@ -9,6 +9,7 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Url;
 use Drupal\social_api\Plugin\NetworkBase;
 use Drupal\Component\Render\PlainTextOutput;
+use Drupal\bootstrap\Utility\Unicode;
 
 /**
  * Implements hook_form_FORM_ID_alter().
@@ -53,7 +54,8 @@ function social_auth_extra_form_user_register_form_alter(&$form, FormStateInterf
         // first name and last name.
         if (empty($name)) {
           // Translate to lowercase and remove unnecessary symbols.
-          $name = strtolower($data_handler->get('name'));
+          $name = Unicode::strtolower($data_handler->get('name'));
+          $name = \Drupal::transliteration()->transliterate($name);
           $name = str_replace('  ', ' ', $name);
           $name = preg_replace('/[^0-9a-z]/si', '_', $name);
         }


### PR DESCRIPTION

## Problem
When users have Russian names the automated generation of a username after signup with social network does not work.

## Solution
Use the `transliterate` method from Drupal Core.

## Issue tracker
https://www.drupal.org/project/social/issues/2941204

## HTT
- [x] Check out the code changes
- [ ] Run a test-script if you are uncertain and don't want to setup an entire Social Login system.

```
<?php

use Drupal\bootstrap\Utility\Unicode;

// After patch.
$names = [
  'Александр Альберт',
  'Jochem van Nieuwenhuijsen',
];

foreach ($names as $name) {
  echo "INPUT: " . $name . "\n";

  // Translate to lowercase and remove unnecessary symbols.
  $name = Unicode::strtolower($name);
  $name = \Drupal::transliteration()->transliterate($name);
  $name = str_replace('  ', ' ', $name);
  $name = preg_replace('/[^0-9a-z]/si', '_', $name);

  echo "OUTPUT: " . $name . "\n";
}

echo "< BEFORE PATCH: > \n\n";

foreach ($names as $name) {
  echo "INPUT: " . $name . "\n";

  // Translate to lowercase and remove unnecessary symbols.
  $name = str_replace('  ', ' ', $name);
  $name = preg_replace('/[^0-9a-z]/si', '_', $name);

  echo "OUTPUT: " . $name . "\n";
}

```

After the patch it should look like this:
```
INPUT: Александр Альберт
OUTPUT: aleksandr_albert
INPUT: Jochem van Nieuwenhuijsen
OUTPUT: jochem_van_nieuwenhuijsen
```

## Documentation
- [ ] This item is added to the release notes
- [ ] This item is documented on LGOS
- [ ] This item has been added to the feature overview
