### PR TITLE
Issue #2954924: lazy_builder in social_admin_menu_toolbar_alter causes DomainException

### DIFF
--- a/modules/custom/social_admin_menu/social_admin_menu.module
+++ b/modules/custom/social_admin_menu/social_admin_menu.module
@@ -9,5 +9,10 @@
  * Implements hook_toolbar_alter().
  */
 function social_admin_menu_toolbar_alter(&$items) {
-  $items['administration']['tray']['toolbar_administration']['#lazy_builder'] = ['social_admin_menu.administrator_menu_tree_manipulators:renderForm', []];
+  $items['administration']['tray']['toolbar_administration'] = [
+    '#lazy_builder' => [
+      'social_admin_menu.administrator_menu_tree_manipulators:renderForm',
+      [],
+    ],
+  ];
 }


### PR DESCRIPTION
Originally reported by @Kingdutch 

## Problem
PHP Error in Social admin Menu when social_admin_menu is enabled.

## Solution
We have to "nuke" the array.

## Issue tracker
https://www.drupal.org/project/social/issues/2954924

## HTT
- [x] Check out the code changes
- [x] Login as admin
- [x] Enable social_admin_menu
- [x] You should not see an error after a cache-clear.

## Documentation
- [x] This item is added to the release notes
- [ ] This item is documented on LGOS
- [ ] This item has been added to the feature overview
