### PR TITLE
DS-5279 by Kingdutch, bramtenhove: Better checks for moving content between groups

### DIFF
--- a/modules/social_features/social_group/src/Plugin/Field/FieldWidget/SocialGroupSelectorWidget.php
+++ b/modules/social_features/social_group/src/Plugin/Field/FieldWidget/SocialGroupSelectorWidget.php
@@ -72,8 +72,11 @@ class SocialGroupSelectorWidget extends OptionsSelectWidget {
               unset($element['#options'][$option_category_key][$option_key]);
             }
           }
+          if (empty($element['#options'][$option_category_key])) {
+            unset($element['#options'][$option_category_key]);
+          }
         }
-        if (empty($element['#options'][$option_category_key])) {
+        elseif (!in_array($option_category_key, $author_groups)) {
           unset($element['#options'][$option_category_key]);
         }
       }


### PR DESCRIPTION
## Problem
Checks for moving content between groups can be improved.

## Solution
The access checks have been improved for when there is just a single group type available on the site.

## Issue tracker
- DS-5279

## HTT
- [x] Check out the code changes
- [x] Create a single group type
- [x] Add multiple groups of that type and move content between them
- [x] Moving content works as expected

## Documentation
- [x] This item is added to the release notes