### PR TITLE
Issue #2962434: Not able to click on a post image on the post detail page

### DIFF
--- a/modules/social_features/social_post/modules/social_post_photo/config/install/core.entity_view_display.post.photo.default.yml
+++ b/modules/social_features/social_post/modules/social_post_photo/config/install/core.entity_view_display.post.photo.default.yml
@@ -41,7 +41,7 @@ content:
     label: hidden
     settings:
       image_style: social_post_photo
-      image_link: file
+      image_link: ''
     third_party_settings: {  }
     type: image
     region: content


### PR DESCRIPTION
## Problem
On post detail page the image does not enlarge when clicking on it.

## Solution
Because there is a double `a` the library does not work. Remove that link to the image and it should work.

## Issue tracker
- https://www.drupal.org/project/social/issues/2962434

## HTT
- [x] Check out the code changes
- [x] On 8.x-1.x go to a post detail page with an image and notice that you can not open a bigger version of the image (JS error in console)
- [x] Switch to this branch and retest. Note it should work (after running update.sh with the feature revert).
- [x] Test all the other places this image occurs as well.

## Documentation
- [x] This item is added to the release notes
- [ ] This item is documented on LGOS
- [ ] This item has been added to the feature overview
