### PR TITLE
Issue #2964627 by Kingdutch, bramtenhove: Makes sure Mentions highlighter responds to textarea resize events

### DIFF
--- a/modules/social_features/social_mentions/js/social_mentions.js
+++ b/modules/social_features/social_mentions/js/social_mentions.js
@@ -47,6 +47,9 @@
         return item.value;
       }
     });
+
+    // Hook up the autogrow resize event to the highligher resize event handler.
+    $(element).on('autosize:resized', function () { $(element).trigger('resize.mentionsInput'); });
   };
 
   // Adds mention input config for the textarea.


### PR DESCRIPTION
## Problem
The Mentions highlighter does not respond (well) to resize events for the textarea. With multiple rows the visual indicator disappears.

## Solution
Adding the autoresize trigger for the textarea field means it again listens to resize events. From there the original code picks it up just fine.

## Issue tracker
- https://www.drupal.org/project/social/issues/2964627

## HTT
- [x] Check out the code changes
- [x] Login as user X and create a new post with multiple rows and on the last row make sure you mention someone
- [x] Notice the visual indicator is there on the mention
- [x] Do this also for comments

## Documentation
- [x] This item is added to the release notes
