### PR TITLE
Issue #2964693: update Bootstrap from 3.9 to 3.11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,9 +48,6 @@
             "drupal/private_message": {
                 "Email notification settings are not taken into account": "https://www.drupal.org/files/issues/2910537-2.patch"
             },
-            "drupal/bootstrap": {
-                "Not possible to select vertical tabs menu items with keyboard": "https://www.drupal.org/files/issues/bootstrap-vertical-tabs-menu-items-accessibility-2949112-2.patch"
-            },
             "drupal/url_embed": {
                 "WSOD if wrong url or network unavailable": "https://www.drupal.org/files/issues/url_embed_WSOD_convert_url_to_embed-2871744-5.patch",
                 "Improve performance for embeds": "https://www.drupal.org/files/issues/caching_layer_url_embed_2867668-14.patch",
@@ -102,7 +99,7 @@
         "drupal/url_embed": "1.0-alpha1",
         "drupal/views_infinite_scroll": "1.5",
         "drupal/votingapi": "3.0-alpha5",
-        "drupal/bootstrap": "3.9",
+        "drupal/bootstrap": "3.11",
         "league/csv": "^8",
         "facebook/graph-sdk": "^5.4",
         "google/apiclient": "^2.1",

--- a/drupal-org.make
+++ b/drupal-org.make
@@ -82,5 +82,4 @@ projects[votingapi][type] = module
 projects[votingapi][version] = 3.0-alpha5
 projects[votingapi][patch][] = "https://www.drupal.org/files/issues/2018-03-29/delete-everywhere-2957067-2.patch"
 projects[bootstrap][type] = theme
-projects[bootstrap][version] = 3.9
-projects[bootstrap][patch][] = "https://www.drupal.org/files/issues/bootstrap-vertical-tabs-menu-items-accessibility-2949112-2.patch"
+projects[bootstrap][version] = 3.11


### PR DESCRIPTION

## Problem
Updating Bootstrap from 3.9 to 3.11. Some more work is required to mark this as done. See the release notes here:
https://www.drupal.org/project/bootstrap/releases/8.x-3.10
https://www.drupal.org/project/bootstrap/releases/8.x-3.11

## Solution
Updated the composer.json and drupal-org.make files.

We still need to test the changes and see if they are implemented in our (sub)themes correctly. cc @Crazylord 

## Issue tracker
- https://www.drupal.org/project/social/issues/2964693

## HTT
- [ ] Check out the code changes
- [ ] Check the release notes and changelogs
- [ ] Verify if everything still works as expected.

## Documentation
- [ ] This item is added to the release notes
- [ ] This item is documented on LGOS
- [ ] This item has been added to the feature overview
