### PR TITLE
Issue #2965041 by bramtenhove: Change landing page block names to better reflect their function

### DIFF
--- a/modules/social_features/social_landing_page/src/Plugin/Field/FieldWidget/BlockFieldWidget.php
+++ b/modules/social_features/social_landing_page/src/Plugin/Field/FieldWidget/BlockFieldWidget.php
@@ -37,9 +37,9 @@ class BlockFieldWidget extends BlockFieldWidgetBase {
     ];
 
     $blocks = [
-      'activity_overview_block' => $this->t('Full activity stream'),
-      'views_block:activity_stream-block_stream_homepage' => $this->t('Full activity stream with post field'),
-      'views_block:community_activities-block_stream_landing' => $this->t('Latest activities'),
+      'activity_overview_block' => $this->t('Community statistics'),
+      'views_block:activity_stream-block_stream_homepage' => $this->t('Personalised activity stream'),
+      'views_block:community_activities-block_stream_landing' => $this->t('Complete community activity stream'),
       'views_block:latest_topics-block_latest_topics' => $this->t('Latest topics'),
       'views_block:newest_groups-block_newest_groups' => $this->t('Newest groups'),
       'views_block:newest_users-block_newest_users' => $this->t('Newest users'),


### PR DESCRIPTION
## Problem
We received feedback that the changed names for the landing pages blocks do not reflect their function very well. See #798.

## Solution
Changes the names for the blocks to what is suggested in the issue tracker.

## Issue tracker
- https://www.drupal.org/project/social/issues/2965041

## HTT
- [x] Check out the code changes
- [x] Login as a site manager
- [x] Create a landing page
- [x] Add blocks, notice their name reflects their function

## Documentation
- [x] This item is added to the release notes