### PR TITLE
Issue #2965666: SocialLikeConfigOverride is overly broad

### DIFF
--- a/modules/social_features/social_like/src/SocialLikeConfigOverride.php
+++ b/modules/social_features/social_like/src/SocialLikeConfigOverride.php
@@ -21,8 +21,6 @@ class SocialLikeConfigOverride implements ConfigFactoryOverrideInterface {
   public function loadOverrides($names) {
     $overrides = [];
 
-    $config_factory = \Drupal::service('config.factory');
-
     // Override post photo default.
     $config_names = [
       'core.entity_view_display.post.photo.activity',
@@ -31,17 +29,14 @@ class SocialLikeConfigOverride implements ConfigFactoryOverrideInterface {
 
     foreach ($config_names as $config_name) {
       if (in_array($config_name, $names)) {
-        $config = $config_factory->getEditable($config_name);
-        $content = $config->get('content');
-
-        $content['like_and_dislike'] = [
-          'weight' => 2,
-          'settings' => [],
-          'third_party_settings' => [],
-        ];
-
         $overrides[$config_name] = [
-          'content' => $content,
+          'content' => [
+            'like_and_dislike' => [
+              'weight' => 2,
+              'settings' => [],
+              'third_party_settings' => [],
+            ],
+          ],
         ];
       }
     }


### PR DESCRIPTION
## Problem
The SocialLikeConfigOverride class in the social_like module
specifies the entire configuration as an override. This causes
other overrides (such as the comment order for posts) to no longer
work.

## Solution
This commit only overrides the part that actually needs overriding.
In this case to add the field under content.

## Issue tracker
- https://www.drupal.org/project/social/issues/2965666

## HTT
- [ ] Check out the code changes
- [ ] Ensure the tests still work
- [ ] Ensure the social_like module still adds the like count to posts

## Documentation
- [ ] This item is added to the release notes