### PR TITLE
Issue #2961977 by Makishima: Use autocomplete widget for topic authored by field

### DIFF
--- a/modules/social_features/social_topic/config/install/core.entity_form_display.node.topic.default.yml
+++ b/modules/social_features/social_topic/config/install/core.entity_form_display.node.topic.default.yml
@@ -152,9 +152,12 @@ content:
     third_party_settings: {  }
     region: content
   uid:
-    type: options_select
+    type: entity_reference_autocomplete
     weight: 3
-    settings: {  }
+    settings:
+      match_operator: CONTAINS
+      size: 60
+      placeholder: ''
     third_party_settings: {  }
     region: content
 hidden:


### PR DESCRIPTION
## Problem
On platforms with a lot of users, the select list with an unordered list of users just isn't usable.

## Solution
We have a great entity_reference_autocomplete widget that's already in use on the following content types: Book, Event, Landing Page, Basic Page

However it's not in use on the following content type: Topic

## Issue tracker
https://www.drupal.org/project/social/issues/2961977

## HTT
- [x] Check out the code changes
- [x] Login as SM or CM, create topic, start to typing user name in the Authored by field
- [x] Notice that autocomplete works for authored by field
