### PR TITLE
#2960382: Make features profiles in landing page link to the user not the profile

### DIFF
--- a/modules/social_features/social_landing_page/config/install/core.entity_view_display.profile.profile.featured.yml
+++ b/modules/social_features/social_landing_page/config/install/core.entity_view_display.profile.profile.featured.yml
@@ -38,7 +38,7 @@ content:
     label: hidden
     settings:
       image_style: social_featured
-      image_link: content
+      image_link: ''
     third_party_settings: {  }
     type: image
     region: content

--- a/modules/social_features/social_landing_page/templates/profile--featured.html.twig
+++ b/modules/social_features/social_landing_page/templates/profile--featured.html.twig
@@ -1,7 +1,11 @@
 {% extends 'node--featured.html.twig' %}
 
 {% block card_hero_image %}
-  <div class="img_wrapper">{{ content.field_profile_image }}</div>
+  <div class="img_wrapper">
+    <a href="{{ profile_stream_url }}">
+      {{ content.field_profile_image }}
+    </a>
+  </div>
 {% endblock %}
 
 {% block card_teaser_type %}


### PR DESCRIPTION
## Problem
Whenever you feature users in the landing page, the picture links to the profile entity rather then the user entity. In OS we don't really user the profile page.

## Solution
Make sure we don't link the profile picture to the entity and make a link in the template to the user

## Issue tracker
- https://www.drupal.org/project/social/issues/2960382
- https://jira.goalgorilla.com/browse/ECI-738

## HTT
- [x] Check out the code changes
- [x] Login as a SM and create landing page with some featured users
- [x] Notice the pictures link to the profile, but the name to the user
- [x] Checkout this branch, revert features and clear caches
- [x] Notice that the pictures now also link to the user

## Documentation
- [ ] This item is added to the release notes
- [ ] This item is documented on LGOS
- [ ] This item has been added to the feature overview
