### PR TITLE
2949116: Filter out blocked users from the search

### DIFF
--- a/modules/social_features/social_search/config/install/search_api.index.social_all.yml
+++ b/modules/social_features/social_search/config/install/search_api.index.social_all.yml
@@ -20,7 +20,7 @@ dependencies:
     - profile
 id: social_all
 name: 'Social all'
-description: ''
+description: 'All content index created for the Social distribution.'
 read_only: false
 field_settings:
   rendered_item:
@@ -146,6 +146,14 @@ field_settings:
     dependencies:
       module:
         - user
+  user_status:
+    label: 'Owner » User » User status'
+    datasource_id: 'entity:profile'
+    property_path: 'uid:entity:status'
+    type: boolean
+    dependencies:
+      module:
+        - user
 datasource_settings:
   'entity:node':
     bundles:
@@ -172,6 +180,7 @@ processor_settings:
     weights:
       preprocess_query: -30
   html_filter:
+    all_fields: false
     fields:
       - rendered_item
       - type
@@ -193,8 +202,8 @@ processor_settings:
     weights:
       preprocess_index: -15
       preprocess_query: -15
-    all_fields: false
   ignorecase:
+    all_fields: false
     fields:
       - rendered_item
       - type
@@ -206,9 +215,9 @@ processor_settings:
     weights:
       preprocess_index: -20
       preprocess_query: -20
-    all_fields: false
   rendered_item: {  }
   stopwords:
+    all_fields: false
     fields:
       - rendered_item
       - field_group_description
@@ -251,8 +260,8 @@ processor_settings:
     weights:
       preprocess_index: -5
       preprocess_query: -2
-    all_fields: false
   tokenizer:
+    all_fields: false
     fields:
       - rendered_item
       - field_group_description
@@ -262,8 +271,8 @@ processor_settings:
     weights:
       preprocess_index: -6
       preprocess_query: -6
-    all_fields: false
   transliteration:
+    all_fields: false
     fields:
       - rendered_item
       - type
@@ -275,10 +284,12 @@ processor_settings:
     weights:
       preprocess_index: -20
       preprocess_query: -20
-    all_fields: false
   super_user:
     weights:
       preprocess_query: 30
+  blocked_users:
+    weights:
+      preprocess_query: -30
 tracker_settings:
   default:
     indexing_order: fifo

--- a/modules/social_features/social_search/config/install/search_api.index.social_users.yml
+++ b/modules/social_features/social_search/config/install/search_api.index.social_users.yml
@@ -65,6 +65,14 @@ field_settings:
     dependencies:
       module:
         - user
+  user_status:
+    label: 'Owner » User » User status'
+    datasource_id: 'entity:profile'
+    property_path: 'uid:entity:status'
+    type: boolean
+    dependencies:
+      module:
+        - user
 datasource_settings:
   'entity:profile':
     plugin_id: 'entity:profile'
@@ -241,6 +249,9 @@ processor_settings:
   super_user:
     weights:
       preprocess_query: 30
+  blocked_users:
+    weights:
+      preprocess_query: -30
 tracker_settings:
   default:
     plugin_id: default

--- a/modules/social_features/social_search/src/Plugin/search_api/processor/BlockedUsers.php
+++ b/modules/social_features/social_search/src/Plugin/search_api/processor/BlockedUsers.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Drupal\social_search\Plugin\search_api\processor;
+
+use Drupal\search_api\IndexInterface;
+use Drupal\search_api\Processor\ProcessorPluginBase;
+use Drupal\profile\Entity\ProfileInterface;
+use Drupal\user\UserInterface;
+use Drupal\search_api\Query\QueryInterface;
+
+/**
+ * Ignores blocked users in index and queries.
+ *
+ * Makes sure blocked users are no longer indexed AND
+ * also filters out blocked users from queries.
+ *
+ * @SearchApiProcessor(
+ *   id = "blocked_users",
+ *   label = @Translation("Skip Blocked users"),
+ *   description = @Translation("Makes sure that blocked users are not added to the index."),
+ *   stages = {
+ *     "alter_items" = 0,
+ *     "preprocess_query" = -30,
+ *   },
+ * )
+ */
+class BlockedUsers extends ProcessorPluginBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function supportsIndex(IndexInterface $index) {
+    $entity_types = ['profile'];
+    foreach ($index->getDatasources() as $datasource) {
+      if (in_array($datasource->getEntityTypeId(), $entity_types)) {
+        return TRUE;
+      }
+    }
+    return FALSE;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function alterIndexedItems(array &$items) {
+    foreach ($items as $item_id => $item) {
+      $object = $item->getOriginalObject()->getValue();
+      if ($object instanceof ProfileInterface) {
+        // Profile ownedId is the userId.
+        if ($object->getOwner()->isBlocked() === TRUE) {
+          unset($items[$item_id]);
+        }
+      }
+      elseif ($object instanceof UserInterface) {
+        if ($object->isBlocked() === TRUE) {
+          unset($items[$item_id]);
+        }
+      }
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function preprocessSearchQuery(QueryInterface $query) {
+    if (!$query->getOption('search_api_bypass_access')) {
+      // Add a condition to filter out users through the status field.
+      $conditions = $query->createConditionGroup('AND');
+      $conditions->addCondition('user_status', 0, '<>');
+      // Add the conditions.
+      $query->addConditionGroup($conditions);
+    }
+  }
+
+}


### PR DESCRIPTION
## Problem
Blocked users show up in the search and when you click on them you get an access denied page.

## Solution
A plugin that does 2 things:
1. Make sure blocked user are no longer indexed
2. Filter out blocked users on query level. 


## Issue tracker
- https://www.drupal.org/node/2949116
- https://jira.goalgorilla.com/browse/ECI-735

## HTT
- [ ] Check out the code changes
- [ ] Login as user X and do this and this and that
- [ ] Notice it doesn't work
- [ ] Checkout to this branch
- [ ] Try this and this and that and see that it works now

## Documentation
- [ ] This item is added to the release notes
- [ ] This item is documented on LGOS
- [ ] This item has been added to the feature overview
