### PR TITLE
ECI-737 by jochemvn: Make sure apostrophe's are displayed correctly in a name

### DIFF
--- a/modules/social_features/social_user/social_user.module
+++ b/modules/social_features/social_user/social_user.module
@@ -296,6 +296,8 @@ function social_user_user_format_name_alter(&$name, $account) {
     }
   }
   $name = ($accountname !== '') ? $accountname : $name;
+  // Make sure weird chars are displayed normally.
+  $name = html_entity_decode($name, ENT_QUOTES);
 }
 
 /**


### PR DESCRIPTION
## Problem
User that have an apostrophe in their name are not displayed correctly

## Solution
Make sure it's displayed correctly

## Issue tracker
- https://jira.goalgorilla.com/browse/ECI-737

## HTT
- [ ] Check out the code changes
- [ ] Login as a user and change your name to "Shenanigans O'Toole"
- [ ] See that it's display with the ampersand code
- [ ] Checkout to this branch
- [ ] Clear caches and reload the page
- [ ] You now see your name correctly

## Documentation
- [ ] This item is added to the release notes
- [ ] This item is documented on LGOS
- [ ] This item has been added to the feature overview
