### PR TITLE
Issue #2966841: Make time optional for events

### DIFF
--- a/modules/social_features/social_event/social_event.module
+++ b/modules/social_features/social_event/social_event.module
@@ -14,6 +14,8 @@ use Drupal\group\Entity\GroupContent;
 use Drupal\group\GroupMembershipLoaderInterface;
 use Drupal\views\Plugin\views\query\QueryPluginBase;
 use Drupal\views\ViewExecutable;
+use Drupal\Component\Utility\NestedArray;
+use Drupal\Core\Datetime\DrupalDateTime;
 
 /**
  * Implements hook_form_form_ID_alter().
@@ -232,15 +234,6 @@ function social_event_flagging_insert(EntityInterface $entity) {
 }
 
 /**
- * Implements hook_ENTITY_TYPE_delete().
- */
-function social_event_user_delete(EntityInterface $entity) {
-  $storage = \Drupal::entityTypeManager()->getStorage('event_enrollment');
-  $entities = $storage->loadByProperties(['user_id' => $entity->id()]);
-  $storage->delete($entities);
-}
-
-/**
  * Formats the event start end date.
  */
 function _social_event_format_date($event, $view_mode) {
@@ -282,28 +275,79 @@ function _social_event_format_date($event, $view_mode) {
   $time_format = 'social_time';
 
   if (!empty($start_datetime)) {
+    $start_date = $date_formatter->format($start_datetime, $date_format);
+    $start_time = $date_formatter->format($start_datetime, $time_format);
+
+    if (!empty($end_datetime)) {
+      $end_date = $date_formatter->format($end_datetime, $date_format);
+      $end_time = $date_formatter->format($end_datetime, $time_format);
+    }
+
     // Date are the same or there are no end date.
     if (empty($end_datetime) || $start_datetime == $end_datetime) {
-      $date = $date_formatter->format($start_datetime, $date_format);
-      $time = $date_formatter->format($start_datetime, $time_format);
-      $event_date = "$date - $time";
+      // Default time should not be displayed.
+      if ($start_time === '00:01') {
+        $event_date = "$start_date";
+      }
+      else {
+        $event_date = "$start_date - $start_time";
+      }
     }
     // The date is the same, the time is different.
     elseif (date('Y-m-d', $start_datetime) == date('Y-m-d', $end_datetime)) {
-      $date = $date_formatter->format($start_datetime, $date_format);
-      $start_time = $date_formatter->format($start_datetime, $time_format);
-      $end_time = $date_formatter->format($end_datetime, $time_format);
-      $event_date = "$date $start_time - $end_time";
+      $event_date = "$start_date $start_time - $end_time";
     }
     // They are not the same day (or empty?).
     elseif (!empty($end_datetime)) {
-      $start_date = $date_formatter->format($start_datetime, $date_format);
-      $end_date = $date_formatter->format($end_datetime, $date_format);
-      $start_time = $date_formatter->format($start_datetime, $time_format);
-      $end_time = $date_formatter->format($end_datetime, $time_format);
-      $event_date = "$start_date $start_time - $end_date $end_time";
+      // Default time should not be displayed.
+      if ($start_time === '00:01' && $end_time === '00:01') {
+        $event_date = "$start_date - $end_date";
+      }
+      else {
+        $event_date = "$start_date $start_time - $end_date $end_time";
+      }
     }
   }
 
   return $event_date;
+}
+
+/**
+ * Implements hook_form_alter().
+ */
+function social_event_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+  $event_forms = [
+    'node_event_form',
+    'node_event_edit_form',
+  ];
+
+  if (in_array($form_id, $event_forms)) {
+    $form['#after_build'][] = 'social_event_date_after_build';
+  }
+}
+
+/**
+ * Add custom validation to event date fields.
+ */
+function social_event_date_after_build($form, &$form_state) {
+  array_unshift($form['field_event_date']['widget'][0]['value']['#element_validate'], 'social_event_date_validate');
+  array_unshift($form['field_event_date_end']['widget'][0]['value']['#element_validate'], 'social_event_date_validate');
+  return $form;
+}
+
+/**
+ * Set default time to date field if time was not set.
+ */
+function social_event_date_validate(&$element, FormStateInterface $form_state, &$complete_form) {
+  $input = NestedArray::getValue($form_state->getValues(), $element['#parents']);
+  if (empty($input['time']) && !empty($input['date'])) {
+    $input['time'] = '00:01:01';
+    $format = 'Y-m-d H:i:s';
+    $datetime = trim($input['date'] . ' ' . $input['time']);
+    $timezone = !empty($element['#date_timezone']) ? $element['#date_timezone'] : NULL;
+    $input['object'] = DrupalDateTime::createFromFormat($format, $datetime, $timezone);
+    if ($input['object'] instanceof DrupalDateTime) {
+      $form_state->setValueForElement($element, $input);
+    }
+  }
 }


### PR DESCRIPTION
## Problem
Currently, time field is required for events, but there are events that have no specific starting time.

## Solution

- When adding a date/time - the time should not be required for events
- If no time is set event starts at 0:01 that day
- If no time is set the time should not be displayed

## Issue tracker
- https://www.drupal.org/project/social/issues/2966841
- https://jira.goalgorilla.com/browse/CBI-357

## HTT
- [ ] Check out the code changes
- [ ] Login as normal user and try to create event without time
- [ ] Notice you receive validation error about incorrect date format
- [ ] Checkout to this branch
- [ ] Try the same and check that there are no validation error
- [ ] Check event full page and teaser and see that time is not displayed
- [ ] Edit time to other value from 00:01 and check it displayed now

## Documentation
- [ ] This item is added to the release notes
- [ ] This item is documented on LGOS
- [ ] This item has been added to the feature overview
