### PR TITLE
Issue #2953182: Add ability to filter on First and Last name on Admin People view

### DIFF
--- a/modules/social_features/social_user/config/install/views.view.user_admin_people.yml
+++ b/modules/social_features/social_user/config/install/views.view.user_admin_people.yml
@@ -1,6 +1,9 @@
 langcode: en
 status: true
 dependencies:
+  config:
+    - field.storage.profile.field_profile_first_name
+    - field.storage.profile.field_profile_last_name
   module:
     - social_user
     - user
@@ -575,6 +578,132 @@ display:
           plugin_id: field
           entity_type: user
           entity_field: mail
+        field_profile_first_name:
+          id: field_profile_first_name
+          table: profile__field_profile_first_name
+          field: field_profile_first_name
+          relationship: profile
+          group_type: group
+          admin_label: ''
+          label: 'First name'
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+        field_profile_last_name:
+          id: field_profile_last_name
+          table: profile__field_profile_last_name
+          field: field_profile_last_name
+          relationship: profile
+          group_type: group
+          admin_label: ''
+          label: 'Last name'
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
       filters:
         combine:
           id: combine
@@ -601,6 +730,9 @@ display:
               authenticated: authenticated
               anonymous: '0'
               administrator: '0'
+              contentmanager: '0'
+              sitemanager: '0'
+            placeholder: ''
           is_grouped: false
           group_info:
             label: ''
@@ -616,6 +748,8 @@ display:
           fields:
             name: name
             mail: mail
+            field_profile_first_name: field_profile_first_name
+            field_profile_last_name: field_profile_last_name
           plugin_id: combine
         roles_target_id:
           id: roles_target_id
@@ -915,6 +1049,17 @@ display:
         groups:
           1: AND
       display_extenders: {  }
+      relationships:
+        profile:
+          id: profile
+          table: users_field_data
+          field: profile
+          relationship: none
+          group_type: group
+          admin_label: Profile
+          required: false
+          entity_type: user
+          plugin_id: standard
     cache_metadata:
       contexts:
         - 'languages:language_content'
@@ -922,7 +1067,9 @@ display:
         - url
         - url.query_args
       max-age: 0
-      tags: {  }
+      tags:
+        - 'config:field.storage.profile.field_profile_first_name'
+        - 'config:field.storage.profile.field_profile_last_name'
   page_1:
     display_plugin: page
     id: page_1
@@ -954,4 +1101,6 @@ display:
         - url
         - url.query_args
       max-age: 0
-      tags: {  }
+      tags:
+        - 'config:field.storage.profile.field_profile_first_name'
+        - 'config:field.storage.profile.field_profile_last_name'


### PR DESCRIPTION
## Problem
Site managers are able to look for users on the /admin/people page. The current implementation allows them to search for parts of the username and email address.

## Solution
In order to make this feature more useful, it would be good if we try to find the user also by his or her first and/or last name. Basically the same as what we do when users try to mention someone else.

## Issue tracker
- https://www.drupal.org/project/social/issues/2953182
- https://jira.goalgorilla.com/browse/ECI-733

## HTT
- [ ] Check out the code changes
- [ ] Login as SM and go to Admin People page
- [ ] Edit some profile in a way that username is different from the First and Last name
- [ ] Try to search by First or Last name and see no results
- [ ] Checkout to this branch
- [ ] Try to search again and see it works now

## Documentation
- [ ] This item is added to the release notes
- [ ] This item is documented on LGOS
- [ ] This item has been added to the feature overview
