### PR TITLE
DS-5049 - Set a default for "empty" author tokens in stream posts when it cannot be replaced

### DIFF
--- a/modules/social_features/social_user/social_user.module
+++ b/modules/social_features/social_user/social_user.module
@@ -329,7 +329,7 @@ function social_user_menu_local_tasks_alter(&$data, $route_name) {
  * URL tokens are not filled in by the other token replacements.
  * In cases like this the account is cancelled, but the message remains behind.
  */
-function social_user_tokens_alter(array &$replacements, array $context, \Drupal\Core\Render\BubbleableMetadata $bubbleable_metadata) {
+function social_user_tokens_alter(&$replacements, $context, $bubbleable_metadata) {
   // Change the display name to that of the Anonymous user when the display name
   // token was not replaced.
   if ((isset($context['tokens']['display-name']) && empty($replacements[$context['tokens']['display-name']])) &&

--- a/modules/social_features/social_user/social_user.module
+++ b/modules/social_features/social_user/social_user.module
@@ -321,3 +321,21 @@ function social_user_menu_local_tasks_alter(&$data, $route_name) {
   }
 
 }
+
+/**
+ * Implements hook_tokens_alter().
+ */
+function social_user_tokens_alter(array &$replacements, array $context, \Drupal\Core\Render\BubbleableMetadata $bubbleable_metadata) {
+  // This is a fallback for when the user object is empty and the display name
+  // tokens are not filled in by the other token replacements.
+  // In cases like this the account is cancelled, but the message remains
+  // behind.
+  if ((isset($context['tokens']['display-name']) && empty($replacements[$context['tokens']['display-name']])) &&
+    (array_key_exists('user', $context['data']) && $context['data']['user'] === NULL)) {
+    $replacements[$context['tokens']['display-name']] = \Drupal::configFactory()->get('user.settings')->get('anonymous');
+  }
+  if ((isset($context['tokens']['url:absolute']) && empty($replacements[$context['tokens']['url:absolute']])) &&
+    (array_key_exists('user', $context['data']) && $context['data']['user'] === NULL)) {
+    $replacements[$context['tokens']['url:absolute']] = NULL;
+  }
+}

--- a/modules/social_features/social_user/social_user.module
+++ b/modules/social_features/social_user/social_user.module
@@ -324,16 +324,20 @@ function social_user_menu_local_tasks_alter(&$data, $route_name) {
 
 /**
  * Implements hook_tokens_alter().
+ *
+ * This is a fallback for when the user object is empty and the display name and
+ * URL tokens are not filled in by the other token replacements.
+ * In cases like this the account is cancelled, but the message remains behind.
  */
 function social_user_tokens_alter(array &$replacements, array $context, \Drupal\Core\Render\BubbleableMetadata $bubbleable_metadata) {
-  // This is a fallback for when the user object is empty and the display name
-  // tokens are not filled in by the other token replacements.
-  // In cases like this the account is cancelled, but the message remains
-  // behind.
+  // Change the display name to that of the Anonymous user when the display name
+  // token was not replaced.
   if ((isset($context['tokens']['display-name']) && empty($replacements[$context['tokens']['display-name']])) &&
     (array_key_exists('user', $context['data']) && $context['data']['user'] === NULL)) {
     $replacements[$context['tokens']['display-name']] = \Drupal::configFactory()->get('user.settings')->get('anonymous');
   }
+  // Empty the URL so it doesn't break rendering when the URL token was not
+  // replaced.
   if ((isset($context['tokens']['url:absolute']) && empty($replacements[$context['tokens']['url:absolute']])) &&
     (array_key_exists('user', $context['data']) && $context['data']['user'] === NULL)) {
     $replacements[$context['tokens']['url:absolute']] = NULL;


### PR DESCRIPTION
## Problem
When a user posted in the stream and then cancels his account the tokens are no longer being replaced correctly.

![screen shot 2018-05-01 at 12 30 57](https://user-images.githubusercontent.com/7124754/39469997-8c3dc83c-4d3b-11e8-88ed-fb7dd4374c10.png)

## Solution
This is part one of the solution, basically creating a fallback for when these "empty" author tokens cannot be replaced by normal token hooks.
Part two of the solution involves some more work, which is defining hooks for cancel accounts and assigning content for several entities (e.g. activities or messages) to for example the anonymous user. This is a follow-up.

![screen shot 2018-05-01 at 12 28 26](https://user-images.githubusercontent.com/7124754/39470002-959578d0-4d3b-11e8-8bc1-e313e1d1698c.png)

## Issue tracker
- DS-5049

## HTT
- [ ] Check out the code changes
- [ ] Login as user X and post something on the stream
- [ ] Cancel your account (with option to assign items to anonymous user)
- [ ] As a different user go to the stream, observe that the token is replaced by "Anonymous"
- [ ] Repeat for other streams, e.g. profile, group, explore, etc.

## Documentation
- [ ] This item is added to the release notes
