### PR TITLE
Value for post recipient get lost

### DIFF
--- a/modules/social_features/social_post/src/Form/PostForm.php
+++ b/modules/social_features/social_post/src/Form/PostForm.php
@@ -148,6 +148,7 @@ class PostForm extends ContentEntityForm {
         }
       }
     }
+    
     $status = parent::save($form, $form_state);
 
     switch ($status) {

--- a/modules/social_features/social_post/src/Form/PostForm.php
+++ b/modules/social_features/social_post/src/Form/PostForm.php
@@ -136,20 +136,18 @@ class PostForm extends ContentEntityForm {
   public function save(array $form, FormStateInterface $form_state) {
     // Init form modes.
     $this->setFormMode();
-
     $display = $this->getFormDisplay($form_state);
-
-    if (isset($display) && ($display_id = $display->get('id'))) {
-      if ($display_id === $this->postViewProfile) {
-        $account_profile = \Drupal::routeMatch()->getParameter('user');
-        $this->entity->get('field_recipient_user')->setValue($account_profile);
-      }
-      elseif ($display_id === $this->postViewGroup) {
-        $group = \Drupal::routeMatch()->getParameter('group');
-        $this->entity->get('field_recipient_group')->setValue($group);
+    if ($this->entity->isNew()) {
+      if (isset($display) && ($display_id = $display->get('id'))) {
+        if ($display_id === $this->postViewProfile) {
+          $account_profile = \Drupal::routeMatch()->getParameter('user');
+          $this->entity->get('field_recipient_user')->setValue($account_profile);
+        } elseif ($display_id === $this->postViewGroup) {
+          $group = \Drupal::routeMatch()->getParameter('group');
+          $this->entity->get('field_recipient_group')->setValue($group);
+        }
       }
     }
-
     $status = parent::save($form, $form_state);
 
     switch ($status) {

--- a/modules/social_features/social_post/src/Form/PostForm.php
+++ b/modules/social_features/social_post/src/Form/PostForm.php
@@ -136,19 +136,22 @@ class PostForm extends ContentEntityForm {
   public function save(array $form, FormStateInterface $form_state) {
     // Init form modes.
     $this->setFormMode();
+
     $display = $this->getFormDisplay($form_state);
+
     if ($this->entity->isNew()) {
       if (isset($display) && ($display_id = $display->get('id'))) {
         if ($display_id === $this->postViewProfile) {
           $account_profile = \Drupal::routeMatch()->getParameter('user');
           $this->entity->get('field_recipient_user')->setValue($account_profile);
-        } elseif ($display_id === $this->postViewGroup) {
+        }
+        elseif ($display_id === $this->postViewGroup) {
           $group = \Drupal::routeMatch()->getParameter('group');
           $this->entity->get('field_recipient_group')->setValue($group);
         }
       }
     }
-    
+
     $status = parent::save($form, $form_state);
 
     switch ($status) {


### PR DESCRIPTION
## Problem
When editing a post that was placed on a user's timeline the value for the field_recipient_user gets lost. This causes the activity that's displayed on the users stream to display the [activity:field_activity_recipient_user_display_name] token because the activity_creator_tokens has no value to replace it with.
## Solution
Ensure the post edit form doesn't change values that are not exposed to the editing user.

## Issue tracker
https://www.drupal.org/project/social/issues/2962077#comment-12595445
## HTT
- [x] Try to edit a post on someone's user page
- [x] After saving it, you will see that the token is not replaced.
- [x] But after applying this patch, you will notice that the token is replaced by the name of the user recipient.

## Release notes copy
When editing a post that was placed on a user's timeline, the user context is gone when saving. This causes the activity that's displayed on the users stream to display the [activity:field_activity_recipient_user_display_name] token since it did not understand what user information to replace it with. 