### PR TITLE
Issue #2968895 by Kingdutch: Provide alter hook for notification settings on user profile

### DIFF
--- a/modules/custom/activity_send/modules/activity_send_email/activity_send_email.api.php
+++ b/modules/custom/activity_send/modules/activity_send_email/activity_send_email.api.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * @file
+ * Hooks provided by the Activity Send Email module.
+ */
+
+/**
+ * @addtogroup hooks
+ * @{
+ */
+
+/**
+ * Alter notification settings display.
+ *
+ * @param array &$items
+ *   An array of groups that contain a title and an array of templates that are
+ *   contained in this settings group.
+ * @param array $email_message_templates
+ *   Message templates enabled for sending by email.
+ *
+ * @see activity_send_email_form_user_form_alter().
+ */
+function hook_activity_send_email_notifications_alter(array &$items, array $email_message_templates) {
+  // If a create_private_message template is enabled then we add it in the
+  // "Message to Me" section.
+  if (isset($email_message_templates['create_private_message'])) {
+    $items['message_to_me']['templates'][] = 'create_private_message';
+  }
+}
+
+/**
+ * @} End of "addtogroup hooks".
+ */

--- a/modules/custom/activity_send/modules/activity_send_email/activity_send_email.module
+++ b/modules/custom/activity_send/modules/activity_send_email/activity_send_email.module
@@ -160,9 +160,11 @@ function activity_send_email_form_user_form_alter(&$form, FormStateInterface $fo
 
   $email_message_templates = EmailActivityDestination::getSendEmailMessageTemplates();
 
-  if (\Drupal::moduleHandler()->moduleExists('social_private_message') && isset($email_message_templates['create_private_message'])) {
-    $items['message_to_me']['templates'][] = 'create_private_message';
-  }
+  // Give other modules the chance to add their own email notifications or
+  // change the title or order of the e-mail notifications on this form.
+  // Copy templates so that they can't be altered (arrays are assigned by copy).
+  $context = $email_message_templates;
+  \Drupal::moduleHandler()->alter('activity_send_email_notifications', $items, $context);
 
   // Sort a list of email frequencies by weight.
   $email_frequencies = sort_email_frequency_options();

--- a/modules/custom/activity_send/modules/activity_send_email/activity_send_email.module
+++ b/modules/custom/activity_send/modules/activity_send_email/activity_send_email.module
@@ -107,95 +107,100 @@ function activity_send_email_theme() {
  * Implements hook_form_FORM_ID_alter() for user_form().
  */
 function activity_send_email_form_user_form_alter(&$form, FormStateInterface $form_state) {
-  $account = \Drupal::routeMatch()->getParameter('user');
-  if (is_object($account)) {
-    $form['email_notifications'] = [
-      '#type' => 'fieldset',
-      '#title' => t('Email notifications'),
-      '#tree' => TRUE,
-      '#attributes' => [
-        'class' => ['form-horizontal'],
-      ],
-    ];
+  $account = $form_state->getFormObject()->getEntity();
 
-    $form['email_notifications']['description'] = [
-      '#type' => 'html_tag',
-      '#tag' => 'p',
-      '#value' => t('For each email notification below, you can choose to turn it off, receive it immediately or in a daily or weekly digest. Email notifications will only be sent when you are not active in the platform.'),
-    ];
-
-    $items = [
-      'message_to_me' => [
-        'title' => t('Message to me'),
-        'templates' => [
-          'create_post_profile',
-          'create_mention_post',
-          'create_mention_comment',
-          'create_comment_reply_mention',
-          'create_comment_reply',
-          'create_comment_post_profile',
-          'create_like_node_or_post',
-        ],
-      ],
-      'what_manage' => [
-        'title' => t('What I manage'),
-        'templates' => [
-          'create_comment_author_node_post',
-        ],
-      ],
-      'what_follow' => [
-        'title' => t('What I follow'),
-        'templates' => [
-          'create_comment_following_node',
-          'create_content_in_joined_group',
-        ],
-      ],
-    ];
-
-    $email_message_templates = EmailActivityDestination::getSendEmailMessageTemplates();
-
-    if (\Drupal::moduleHandler()->moduleExists('social_private_message') && isset($email_message_templates['create_private_message'])) {
-      $items['message_to_me']['templates'][] = 'create_private_message';
-    }
-
-    // Sort a list of email frequencies by weight.
-    $email_frequencies = sort_email_frequency_options();
-
-    $notification_options = [];
-
-    // Place the sorted data in an actual form option.
-    foreach ($email_frequencies as $option) {
-      $notification_options[$option['id']] = $option['name'];
-    }
-
-    $user_email_settings = EmailActivityDestination::getSendEmailUserSettings($account);
-
-    foreach ($items as $item_id => $item) {
-      $form['email_notifications'][$item_id] = [
-        '#type' => 'details',
-        '#title' => [
-          '#type' => 'html_tag',
-          '#tag' => 'h5',
-          '#value' => $item['title'],
-        ],
-        '#attributes' => [
-          'class' => ['form-fieldset'],
-        ],
-      ];
-
-      foreach ($item['templates'] as $template) {
-        $form['email_notifications'][$item_id][$template] = [
-          '#type' => 'select',
-          '#title' => $email_message_templates[$template],
-          '#options' => $notification_options,
-          '#default_value' => isset($user_email_settings[$template]) ? $user_email_settings[$template] : 'immediately',
-        ];
-      }
-    }
-
-    // Submit function to save send email settings.
-    $form['actions']['submit']['#submit'][] = '_activity_send_email_form_user_form_submit';
+  // Only expose these settings to existing users so it's not shown on the
+  // user create form.
+  if ($account->isNew()) {
+    return;
   }
+
+  $form['email_notifications'] = [
+    '#type' => 'fieldset',
+    '#title' => t('Email notifications'),
+    '#tree' => TRUE,
+    '#attributes' => [
+      'class' => ['form-horizontal'],
+    ],
+  ];
+
+  $form['email_notifications']['description'] = [
+    '#type' => 'html_tag',
+    '#tag' => 'p',
+    '#value' => t('For each email notification below, you can choose to turn it off, receive it immediately or in a daily or weekly digest. Email notifications will only be sent when you are not active in the platform.'),
+  ];
+
+  $items = [
+    'message_to_me' => [
+      'title' => t('Message to me'),
+      'templates' => [
+        'create_post_profile',
+        'create_mention_post',
+        'create_mention_comment',
+        'create_comment_reply_mention',
+        'create_comment_reply',
+        'create_comment_post_profile',
+        'create_like_node_or_post',
+      ],
+    ],
+    'what_manage' => [
+      'title' => t('What I manage'),
+      'templates' => [
+        'create_comment_author_node_post',
+      ],
+    ],
+    'what_follow' => [
+      'title' => t('What I follow'),
+      'templates' => [
+        'create_comment_following_node',
+        'create_content_in_joined_group',
+      ],
+    ],
+  ];
+
+  $email_message_templates = EmailActivityDestination::getSendEmailMessageTemplates();
+
+  if (\Drupal::moduleHandler()->moduleExists('social_private_message') && isset($email_message_templates['create_private_message'])) {
+    $items['message_to_me']['templates'][] = 'create_private_message';
+  }
+
+  // Sort a list of email frequencies by weight.
+  $email_frequencies = sort_email_frequency_options();
+
+  $notification_options = [];
+
+  // Place the sorted data in an actual form option.
+  foreach ($email_frequencies as $option) {
+    $notification_options[$option['id']] = $option['name'];
+  }
+
+  $user_email_settings = EmailActivityDestination::getSendEmailUserSettings($account);
+
+  foreach ($items as $item_id => $item) {
+    $form['email_notifications'][$item_id] = [
+      '#type' => 'details',
+      '#title' => [
+        '#type' => 'html_tag',
+        '#tag' => 'h5',
+        '#value' => $item['title'],
+      ],
+      '#attributes' => [
+        'class' => ['form-fieldset'],
+      ],
+    ];
+
+    foreach ($item['templates'] as $template) {
+      $form['email_notifications'][$item_id][$template] = [
+        '#type' => 'select',
+        '#title' => $email_message_templates[$template],
+        '#options' => $notification_options,
+        '#default_value' => isset($user_email_settings[$template]) ? $user_email_settings[$template] : 'immediately',
+      ];
+    }
+  }
+
+  // Submit function to save send email settings.
+  $form['actions']['submit']['#submit'][] = '_activity_send_email_form_user_form_submit';
 }
 
 /**

--- a/modules/social_features/social_private_message/social_private_message.module
+++ b/modules/social_features/social_private_message/social_private_message.module
@@ -314,3 +314,14 @@ function social_private_message_entity_view_display_alter(EntityViewDisplayInter
     }
   }
 }
+
+/**
+ * Implements hook_activity_send_email_notifications_alter().
+ */
+function social_private_message_activity_send_email_notifications_alter(array &$items, array $email_message_templates) {
+  // If our create_private_message template is enabled for email then we add it
+  // to the "Message to Me" section.
+  if (isset($email_message_templates['create_private_message'])) {
+    $items['message_to_me']['templates'][] = 'create_private_message';
+  }
+}


### PR DESCRIPTION
## Problem
If a platform has custom notifications, then there's currently no way to add these to the settings screen on the user profile without patching Open Social. There's also no way to change the grouping of the notification settings if a grouping more appropriate for the platform is thought of.

## Solution
Provide an alter hook for the `$items` object of `activity_send_email_form_user_form_alter` in the `activity_send_email.module` that allows other modules to add/move/remove templates or change the title.

## Issue tracker
- https://www.drupal.org/project/social/issues/2968895

## HTT
- [ ] Check out the code changes
- [ ] Login as admin and enable the private_message module
- [ ] Check that the private message notification setting is still present

## Documentation
- [ ] This item is added to the release notes
