### PR TITLE
Issue #2968962: operator not supported in landing page module

### DIFF
--- a/modules/social_features/social_landing_page/social_landing_page.module
+++ b/modules/social_features/social_landing_page/social_landing_page.module
@@ -15,7 +15,10 @@ use Drupal\node\Entity\Node;
  * Implements hook_form_alter().
  */
 function social_landing_page_form_alter(array &$form, FormStateInterface $form_state, $form_id) {
-  if ('node_landing_page_edit_form' || 'node_landing_page_form' === $form_id) {
+  if (in_array($form_id, [
+    'node_landing_page_edit_form',
+    'node_landing_page_form',
+  ])) {
     $form['#attached']['library'][] = 'social_landing_page/admin';
   }
 }


### PR DESCRIPTION
## Problem
On Landing Page forms it checks for `node_landing_page_edit_form` but it does not compare it to an actual `$form_id` so it's always attaching the library to every form. 

## Solution
Rewrite the code to check for in_array for both values.

## Issue tracker
https://www.drupal.org/project/social/issues/2968962

## HTT
- [ ] Check out the code changes
- [ ] Go to node/add/landing_page
- [ ] Go to node/x/edit (edit landing page)
- [ ] Verify that the library is attached

## Documentation
- [ ] This item is added to the release notes
- [ ] This item is documented on LGOS
- [ ] This item has been added to the feature overview
