### PR TITLE
Issue #2969155: username in the user menu should be displayname

### DIFF
--- a/modules/social_features/social_user/src/Plugin/Block/AccountHeaderBlock.php
+++ b/modules/social_features/social_user/src/Plugin/Block/AccountHeaderBlock.php
@@ -113,7 +113,7 @@ class AccountHeaderBlock extends BlockBase implements ContainerFactoryPluginInte
     $navigation_settings_config = $this->configFactory->get('social_user.navigation.settings');
 
     if ($account->id() !== 0) {
-      $account_name = $account->getAccountName();
+      $account_name = $account->getDisplayName();
 
       $links = [
         'add' => [


### PR DESCRIPTION
## Problem
The account name in the header menu is the username, this is not handy if the username is auto-generated (e.g. with SSO solution)

## Solution
This should be the displayname instead.

## Issue tracker
- https://www.drupal.org/project/social/issues/2969155

## HTT
- [ ] Check out the code changes
- [ ] Login as user X with full name in profile
- [ ] Check the account header menu and see fullname is used
- [ ] Login as user Y without a profile
- [ ] Check the account header menu and see username is used

## Documentation
- [ ] This item is added to the release notes
- [ ] This item is documented on LGOS
- [ ] This item has been added to the feature overview
