### PR TITLE
Issue #2960310: Post comment anchors obscured by main navigation

### DIFF
--- a/themes/socialbase/assets/css/comment.css
+++ b/themes/socialbase/assets/css/comment.css
@@ -1,4 +1,4 @@
-#section-comments a[id^="comment-"] {
+a[id^="comment-"] {
   display: block;
   position: relative;
   top: -70px;

--- a/themes/socialbase/components/04-organisms/comment/comment.scss
+++ b/themes/socialbase/components/04-organisms/comment/comment.scss
@@ -2,7 +2,7 @@
 
 // Make sure comment anachors are not hidden
 // behind fixed navigation (which is 50px tall).
-#section-comments a[id^="comment-"] {
+a[id^="comment-"] {
   display: block;
   position: relative;
   top: -($navbar-height + 20px);


### PR DESCRIPTION
## Problem
When you click a link that goes to a comment (for example in an e-mail notification) then the top of the comment (its author) will be obscured by fixed navigation. This is because the anchor is moved to the top of the screen by the browser.

## Solution
Extend styles for comment anchors as are for node comments.

## Issue tracker
- https://www.drupal.org/project/social/issues/2960310

## HTT
- [x] Check out the code changes
- [x] Checkout to this branch
- [x] Try use link to home page with comment anchor

## Documentation
- [ ] This item is added to the release notes
