### PR TITLE
Issue #2971411 by Makishima: Fix broken spacing between featured sections

### DIFF
--- a/modules/social_features/social_landing_page/js/social_landing_page.js
+++ b/modules/social_features/social_landing_page/js/social_landing_page.js
@@ -1,11 +1,23 @@
 (function ($) {
   Drupal.behaviors.socialLandingPage = {
     attach: function (context, settings) {
-      var section = $('.paragraph--featured');
-      $(section).each(function (index, value) {
-        $(this).addClass('multiple featured_0' + index);
-        $(section).eq(0).addClass('first');
-        $(section).eq(-1).addClass('last');
+      var section = $('.paragraph--section');
+      var featured = 'paragraph--featured';
+
+      $(section).each(function () {
+        if ($(this).children(':first').hasClass(featured)) {
+          if ($(this).next().children(":first").hasClass(featured) || $(this).prev().children(':first').hasClass(featured)) {
+            $(this).children(':first').addClass('multiple');
+
+            if (!$(this).prev().children(":first").hasClass(featured)) {
+              $(this).children(':first').addClass('first');
+            }
+
+            if (!$(this).next().children(":first").hasClass(featured)) {
+              $(this).children(':first').addClass('last');
+            }
+          }
+        }
       });
     }
   };


### PR DESCRIPTION
## Problem
If you create a landing page with sections "hero" ---> "featured" ---> "hero" ---> "featured" ---> etc. then you can see that the spacing between sections is missed, only for the first sections space is set correctly

## Solution
Can be fixed by replacing with following code in social_landing_page.js :

```
(function ($) {
  Drupal.behaviors.socialLandingPage = {
    attach: function (context, settings) {
      var section = $('.paragraph--section');
      var featured = 'paragraph--featured';

      $(section).each(function () {
        if ($(this).children(':first').hasClass(featured)) {
          if ($(this).next().children(":first").hasClass(featured) || $(this).prev().children(':first').hasClass(featured)) {
            $(this).children(':first').addClass('multiple');

            if (!$(this).prev().children(":first").hasClass(featured)) {
              $(this).children(':first').addClass('first');
            }

            if (!$(this).next().children(":first").hasClass(featured)) {
              $(this).children(':first').addClass('last');
            }
          }
        }
      });
    }
  };
})(jQuery);
```

## Issue tracker
- https://www.drupal.org/project/social/issues/2971411
