### PR TITLE
Issue #2972959: disable public group permissions when public visibility is turned off

### DIFF
--- a/modules/social_features/social_group/social_group.install
+++ b/modules/social_features/social_group/social_group.install
@@ -91,7 +91,7 @@ function _social_group_get_permissions($role) {
   $permissions['authenticated'] = array_merge($permissions['anonymous'], [
     'create open_group group',
     'create closed_group group',
-    'create public_group group',
+    'create public_group group', // Note: this is depedendent on settings!
     'view group stream page',
   ]);
 

--- a/modules/social_features/social_group/social_group.install
+++ b/modules/social_features/social_group/social_group.install
@@ -91,9 +91,14 @@ function _social_group_get_permissions($role) {
   $permissions['authenticated'] = array_merge($permissions['anonymous'], [
     'create open_group group',
     'create closed_group group',
-    'create public_group group', // Note: this is depedendent on settings!
     'view group stream page',
   ]);
+
+  $config = \Drupal::config('entity_access_by_field.settings');
+  $disable_public_visibility = $config->get('disable_public_visibility');
+  if ($disable_public_visibility === 0) {
+    $permissions['authenticated'][] = 'create public_group group';
+  }
 
   // Content manager.
   $permissions['contentmanager'] = array_merge($permissions['authenticated'], [

--- a/modules/social_features/social_group/social_group.module
+++ b/modules/social_features/social_group/social_group.module
@@ -27,6 +27,7 @@ use Drupal\Core\Url;
 use Drupal\Core\Cache\Cache;
 use Drupal\image\Entity\ImageStyle;
 use Drupal\Core\Block\BlockPluginInterface;
+use Drupal\user\Entity\Role;
 use Drupal\user\Entity\User;
 use Drupal\profile\Entity\Profile;
 use Drupal\Core\Entity\EntityTypeInterface;
@@ -143,6 +144,47 @@ function _social_group_edit_submit_redirect(array $form, FormStateInterface $for
     'view.group_information.page_group_about',
     $form_state->getRedirect()->getRouteParameters()
   );
+}
+
+/**
+ * Implements hook_form_FORM_ID_alter().
+ */
+function social_group_form_entity_access_by_field_visibility_form_alter(&$form, \Drupal\Core\Form\FormStateInterface $form_state, $form_id) {
+  // Add option to disable public group creation.
+  $form['#submit'][] = '_social_group_visibility_settings_submit';
+}
+
+/**
+ * Form submit for visibility settings.
+ *
+ * @param array $form
+ *   Group add or group edit form.
+ * @param \Drupal\Core\Form\FormStateInterface $form_state
+ *   Form state interface.
+ */
+function _social_group_visibility_settings_submit(array $form, FormStateInterface $form_state) {
+
+  /** @var \Drupal\user\Entity\Role $role */
+  $role = Role::load('authenticated');
+  if (in_array('create public_group group', $role->getPermissions())) {
+    $current_permission = TRUE;
+  }
+  else {
+    $current_permission = FALSE;
+  }
+  $disable_public_visibility = $form_state->getValue('disable_public_visibility');
+
+  if ($disable_public_visibility === 1 && $current_permission === TRUE) {
+    user_role_revoke_permissions($role->id(), [
+      'create public_group group',
+    ]);
+  }
+  if ($disable_public_visibility === 0 && $current_permission === FALSE) {
+    user_role_grant_permissions($role->id(), [
+      'create public_group group',
+    ]);
+  }
+
 }
 
 /**

--- a/modules/social_features/social_group/social_group.module
+++ b/modules/social_features/social_group/social_group.module
@@ -149,7 +149,7 @@ function _social_group_edit_submit_redirect(array $form, FormStateInterface $for
 /**
  * Implements hook_form_FORM_ID_alter().
  */
-function social_group_form_entity_access_by_field_visibility_form_alter(&$form, \Drupal\Core\Form\FormStateInterface $form_state, $form_id) {
+function social_group_form_entity_access_by_field_visibility_form_alter(&$form, FormStateInterface $form_state, $form_id) {
   // Add option to disable public group creation.
   $form['#submit'][] = '_social_group_visibility_settings_submit';
 }

--- a/modules/social_features/social_group/social_group.module
+++ b/modules/social_features/social_group/social_group.module
@@ -166,12 +166,8 @@ function _social_group_visibility_settings_submit(array $form, FormStateInterfac
 
   /** @var \Drupal\user\Entity\Role $role */
   $role = Role::load('authenticated');
-  if (in_array('create public_group group', $role->getPermissions())) {
-    $current_permission = TRUE;
-  }
-  else {
-    $current_permission = FALSE;
-  }
+  $current_permission = $role->hasPermission('create public_group group');
+
   $disable_public_visibility = $form_state->getValue('disable_public_visibility');
 
   if ($disable_public_visibility === 1 && $current_permission === TRUE) {

--- a/modules/social_features/social_group/src/Plugin/Block/GroupAddEventBlock.php
+++ b/modules/social_features/social_group/src/Plugin/Block/GroupAddEventBlock.php
@@ -28,6 +28,12 @@ class GroupAddEventBlock extends BlockBase {
 
     if (is_object($group)) {
       if ($group->hasPermission('create group_node:event entity', $account)) {
+        if ($group->getGroupType()->id() === 'public_group') {
+          $config = \Drupal::config('entity_access_by_field.settings');
+          if ($config->get('disable_public_visibility') === 1 && !$account->hasPermission('override disabled public visibility')) {
+            return AccessResult::forbidden();
+          }
+        }
         return AccessResult::allowed();
       }
     }

--- a/modules/social_features/social_group/src/Plugin/Block/GroupAddTopicBlock.php
+++ b/modules/social_features/social_group/src/Plugin/Block/GroupAddTopicBlock.php
@@ -28,6 +28,12 @@ class GroupAddTopicBlock extends BlockBase {
 
     if (is_object($group)) {
       if ($group->hasPermission('create group_node:topic entity', $account)) {
+        if ($group->getGroupType()->id() === 'public_group') {
+          $config = \Drupal::config('entity_access_by_field.settings');
+          if ($config->get('disable_public_visibility') === 1 && !$account->hasPermission('override disabled public visibility')) {
+            return AccessResult::forbidden();
+          }
+        }
         return AccessResult::allowed();
       }
     }

--- a/modules/social_features/social_group/src/Plugin/Field/FieldWidget/SocialGroupSelectorWidget.php
+++ b/modules/social_features/social_group/src/Plugin/Field/FieldWidget/SocialGroupSelectorWidget.php
@@ -260,6 +260,12 @@ class SocialGroupSelectorWidget extends OptionsSelectWidget implements Container
     $group = Group::load($gid);
 
     if ($group->hasPermission('create group_' . $entity->getEntityTypeId() . ':' . $entity->bundle() . ' entity', $account)) {
+      if ($group->getGroupType()->id() === 'public_group') {
+        $config = \Drupal::config('entity_access_by_field.settings');
+        if ($config->get('disable_public_visibility') === 1 && !$account->hasPermission('override disabled public visibility')) {
+          return FALSE;
+        }
+      }
       return TRUE;
     }
     return FALSE;

--- a/modules/social_features/social_group/src/Plugin/Field/FieldWidget/SocialGroupSelectorWidget.php
+++ b/modules/social_features/social_group/src/Plugin/Field/FieldWidget/SocialGroupSelectorWidget.php
@@ -176,7 +176,7 @@ class SocialGroupSelectorWidget extends OptionsSelectWidget implements Container
       }
     }
     else {
-      $config = \Drupal::config('entity_access_by_field.settings');
+      $config = $this->configFactory->get('entity_access_by_field.settings');
       $default_visibility = $config->get('default_visibility');
       $entity = $form_state->getFormObject()->getEntity();
 
@@ -261,7 +261,7 @@ class SocialGroupSelectorWidget extends OptionsSelectWidget implements Container
 
     if ($group->hasPermission('create group_' . $entity->getEntityTypeId() . ':' . $entity->bundle() . ' entity', $account)) {
       if ($group->getGroupType()->id() === 'public_group') {
-        $config = \Drupal::config('entity_access_by_field.settings');
+        $config = $this->configFactory->get('entity_access_by_field.settings');
         if ($config->get('disable_public_visibility') === 1 && !$account->hasPermission('override disabled public visibility')) {
           return FALSE;
         }

--- a/modules/social_features/social_post/src/PostAccessControlHandler.php
+++ b/modules/social_features/social_post/src/PostAccessControlHandler.php
@@ -134,6 +134,12 @@ class PostAccessControlHandler extends EntityAccessControlHandler {
     $group = _social_group_get_current_group();
     if ($group instanceof GroupInterface) {
       if ($group->hasPermission('add post entities in group', $account)) {
+        if ($group->getGroupType()->id() === 'public_group') {
+          $config = \Drupal::config('entity_access_by_field.settings');
+          if ($config->get('disable_public_visibility') === 1 && !$account->hasPermission('override disabled public visibility')) {
+            return AccessResult::forbidden();
+          }
+        }
         return AccessResult::allowed();
       }
       else {


### PR DESCRIPTION
## Problem
See issue: https://www.drupal.org/project/social/issues/2972959

## Solution
When public visibility is disabled we need to make sure that users can not create public groups, public content in public groups anymore. I've added all the necessary access hooks and made sure that public groups are not shown for LU anymore in the create content group selector widget.

## Issue tracker
- https://www.drupal.org/project/social/issues/2972959

## HTT
- [x] Check out the code changes
- [x] Login as SM and go to /admin/config/opensocial/visibility and disable public visibility.
- [x] Logout and login as LU
- [x] Note that you can not create a public group
- [x] Note that you can not create posts in public groups (the form is also not shown)
- [x] Note that you can not create topics and events in public groups you are a member of

## Documentation
- [x] This item is added to the release notes
- [ ] This item is documented on LGOS
- [ ] This item has been added to the feature overview
 