### PR TITLE
IE11 by serhiy-chornobay: Fix styles for hero in IE11

### DIFF
--- a/themes/socialbase/assets/css/base.css
+++ b/themes/socialbase/assets/css/base.css
@@ -131,7 +131,7 @@ optgroup {
 
 html {
   font-size: 16px;
-  -webkit-tap-highlight-color: transparent;
+  -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
   font-family: sans-serif;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;

--- a/themes/socialbase/assets/css/ckeditor.css
+++ b/themes/socialbase/assets/css/ckeditor.css
@@ -44,7 +44,7 @@ pre code {
 
 html {
   font-size: 16px;
-  -webkit-tap-highlight-color: transparent;
+  -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
   font-family: sans-serif;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;

--- a/themes/socialbase/assets/css/hero.css
+++ b/themes/socialbase/assets/css/hero.css
@@ -266,3 +266,10 @@
     max-width: 66.66667%;
   }
 }
+
+@media all and (-ms-high-contrast: none) {
+  *::-ms-backdrop, .cover-wrap {
+    height: 410px;
+  }
+  /* IE11 */
+}

--- a/themes/socialbase/assets/css/nav-tabs.css
+++ b/themes/socialbase/assets/css/nav-tabs.css
@@ -16,7 +16,7 @@
       -ms-user-select: none;
           user-select: none;
   -webkit-touch-callout: none;
-  -webkit-tap-highlight-color: transparent;
+  -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
 }
 
 .nav-tabs > li > a:hover, .nav-tabs > li > a:focus {

--- a/themes/socialbase/assets/css/teaser.css
+++ b/themes/socialbase/assets/css/teaser.css
@@ -161,8 +161,8 @@
     display: block;
     position: absolute;
     content: '';
-    background-image: -webkit-gradient(linear, left top, left bottom, color-stop(40%, transparent), color-stop(70%, rgba(0, 0, 0, 0.1)), to(rgba(34, 34, 34, 0.5)));
-    background-image: linear-gradient(transparent 40%, rgba(0, 0, 0, 0.1) 70%, rgba(34, 34, 34, 0.5) 100%);
+    background-image: -webkit-gradient(linear, left top, left bottom, color-stop(40%, rgba(0, 0, 0, 0)), color-stop(70%, rgba(0, 0, 0, 0.1)), to(rgba(34, 34, 34, 0.5)));
+    background-image: linear-gradient(rgba(0, 0, 0, 0) 40%, rgba(0, 0, 0, 0.1) 70%, rgba(34, 34, 34, 0.5) 100%);
     height: 100%;
     width: 100%;
     left: 0;

--- a/themes/socialbase/components/04-organisms/hero/hero.scss
+++ b/themes/socialbase/components/04-organisms/hero/hero.scss
@@ -64,6 +64,9 @@
   }
 
 }
+@media all and (-ms-high-contrast:none) {
+  *::-ms-backdrop, .cover-wrap { height: 410px; } /* IE11 */
+}
 
 // anon homepage hero
 .cover-with-canvas .cover-wrap {


### PR DESCRIPTION
## Problem
There is the bug with vertical alignment for text in hero banner.

## Solution
Set height for bannet text only for IE11

## HTT
- [x] Check out the code changes
- [x] Checkout to this branch
- [x] Check hero banner in IE11

## Documentation
- [x] This item is added to the release notes

## Release notes
..