### PR TITLE
Issue #2921714 by jaapjan: add all file fields to private file system

### DIFF
--- a/modules/custom/social_file_private/src/SocialFilePrivateFieldsConfigOverride.php
+++ b/modules/custom/social_file_private/src/SocialFilePrivateFieldsConfigOverride.php
@@ -40,6 +40,8 @@ class SocialFilePrivateFieldsConfigOverride implements ConfigFactoryOverrideInte
       'field.storage.node.field_topic_image',
       'field.storage.post.field_post_image',
       'field.storage.profile.field_profile_image',
+      'field.storage.profile.field_profile_banner_image',
+      'field.storage.paragraph.field_hero_image',
     ];
     return $config_names;
   }


### PR DESCRIPTION

## Problem
field_profile_banner_image and field_hero_image are not using the private file system currently.

## Solution
Added them to the SocialFilePrivateFieldsConfigOverride class.

## Issue tracker
- https://www.drupal.org/node/2921714

## HTT
- [ ] Check out the code changes
- [ ] Turn on all the optional social modules
- [ ] Check status report to see if there is a message indicating some file fields are not using private file path.

## Documentation
- [ ] This item is added to the release notes
- [ ] This item is documented on LGOS
- [ ] This item has been added to the feature overview
