### PR TITLE
Issue #2971969 - follow-up 1 full html mails

### DIFF
--- a/modules/social_features/social_swiftmail/src/Plugin/Mail/SocialSwiftMailer.php
+++ b/modules/social_features/social_swiftmail/src/Plugin/Mail/SocialSwiftMailer.php
@@ -2,6 +2,8 @@
 
 namespace Drupal\social_swiftmail\Plugin\Mail;
 
+use Drupal\Core\Render\Markup;
+use Drupal\Core\Site\Settings;
 use Drupal\swiftmailer\Plugin\Mail\SwiftMailer;
 
 /**
@@ -15,5 +17,30 @@ use Drupal\swiftmailer\Plugin\Mail\SwiftMailer;
  * )
  */
 class SocialSwiftMailer extends SwiftMailer {
+
+  /**
+   * Massages the message body into the format expected for rendering.
+   *
+   * @param array $message
+   *   The message.
+   *
+   * @return array
+   *   The massaged message.
+   */
+  public function massageMessageBody(array $message) {
+
+    // @see: SwiftMailer::massageMessageBody()
+    $line_endings = Settings::get('mail_line_endings', PHP_EOL);
+    $message['body'] = Markup::create(implode($line_endings, array_map(function ($body) {
+      // If the field contains no html tags we can assume newlines will need be
+      // converted to <br>.
+      if (strlen(strip_tags($body)) === strlen($body)) {
+        $body = str_replace("\r", '', $body);
+        $body = str_replace("\n", '<br>', $body);
+      }
+      return check_markup($body, 'full_html');
+    }, $message['body'])));
+    return $message;
+  }
 
 }


### PR DESCRIPTION
## Problem
Will make sure html mails are rendered system notificaiotns.

## Solution
Set full html for all mails

## Issue tracker
https://github.com/goalgorilla/open_social/pull/875

## HTT
- [ ] Enable system notification for a user.
- [ ] Create a post
- [ ] Note that the full html is not rendered correctly
- [ ] Switch to this branch
- [ ] Note that the emails are now rendered successfully

## Documentation
- [ ] This item is added to the release notes
- [ ] This item is documented on LGOS
- [ ] This item has been added to the feature overview
