### PR TITLE
#2975145 by bramtenhove: Enable Page Cache and Dynamic Page Cache by default

### DIFF
--- a/social.profile
+++ b/social.profile
@@ -141,6 +141,8 @@ function social_form_install_configure_form_alter(&$form, FormStateInterface $fo
     'social_sso' => t('Registration with social networks'),
     'social_file_private' => t('Use the private file system for uploaded files (highly recommended)'),
     'inline_form_errors' => t('Inline Form Errors'),
+    'page_cache' => t('Cache page for anonymous users (highly recommended)'),
+    'dynamic_page_cache' => t('Cache pages for any user (highly recommended)'),
   ];
 
   // Checkboxes to enable Optional modules.
@@ -151,6 +153,8 @@ function social_form_install_configure_form_alter(&$form, FormStateInterface $fo
     '#default_value' => [
       'social_file_private',
       'inline_form_errors',
+      'page_cache',
+      'dynamic_page_cache',
     ],
   ];
 


### PR DESCRIPTION
## Problem
Page Cache and Dynamic Page Cache modules are not enabled by default for Open Social. Enabling them instantly gives a better site performance.

## Solution
Enable the two modules on install.

## Issue tracker
- https://www.drupal.org/project/social/issues/2975145

## HTT
- [ ] Check out the code changes
- [ ] Reinstall the site
- [ ] Notice Page Cache and Dynamic Page Cache modules are turned on

## Documentation
- [x] This item is added to the release notes