### PR TITLE
Issue #2975731: Add alt text to demo content images

### DIFF
--- a/modules/custom/social_demo/content/entity/event.yml
+++ b/modules/custom/social_demo/content/entity/event.yml
@@ -14,7 +14,8 @@
     address_line1:
   field_event_date: +10 day|08:00
   field_event_date_end: +12 day|18:00
-  field_event_image:
+  image:
+  image_alt:
   field_event_location: Conference Center
   field_content_visibility: community
   field_event_type: cf6adb10-c38d-11e6-a4a6-cec0c932ce01
@@ -34,7 +35,8 @@
     address_line1:
   field_event_date: +30 day|12:30
   field_event_date_end: +30 day|23:00
-  field_event_image: aa51ee1e-dee0-11e5-b86d-9a79f06e9478
+  image: aa51ee1e-dee0-11e5-b86d-9a79f06e9478
+  image_alt: Child learns how to write
   field_event_location: Overal in the USA
   field_content_visibility: public
   field_event_type: cf6adb10-c38d-11e6-a4a6-cec0c932ce01
@@ -53,7 +55,8 @@
     address_line1: Evergreen Terrace
   field_event_date: +2 day|11:00
   field_event_date_end: +2 day|18:00
-  field_event_image: 92e8d560-da14-11e5-b5d2-0a1d41d68578
+  image: 92e8d560-da14-11e5-b5d2-0a1d41d68578
+  image_alt: Two people jogging on a bridge
   field_event_location: Springfield High School
   field_content_visibility: public
   field_event_type: cf6add72-c38d-11e6-a4a6-cec0c932ce01
@@ -72,7 +75,8 @@
     address_line1: 1109 Kinney Street
   field_event_date: -2 day|18:00
   field_event_date_end: -2 day|21:00
-  field_event_image: aa51e54a-dee0-11e5-b86d-9a79f06e9478
+  image: aa51e54a-dee0-11e5-b86d-9a79f06e9478
+  image_alt: Man thinking in front of the wall with stickers
   field_event_location: Springfield High School
   field_content_visibility: community
   group: d6e377d0-32d8-11e6-ac61-9e71128cae77
@@ -94,7 +98,8 @@
     address_line1: Emmastreet 65
   field_event_date: -14 day|12:30
   field_event_date_end: -14 day|14:30
-  field_event_image:
+  image:
+  image_alt:
   field_event_location: Texel
   field_content_visibility: public
   field_event_type: cf6ade6c-c38d-11e6-a4a6-cec0c932ce01
@@ -113,7 +118,8 @@
     address_line1: 19th street
   field_event_date: +30 day|18:30
   field_event_date_end: +30 day|23:00
-  field_event_image: c08ba9ca-3adb-11e6-ac61-9e71128cae77
+  image: c08ba9ca-3adb-11e6-ac61-9e71128cae77
+  image_alt: People discussing at the table
   field_event_location: Theater Bay Area
   field_content_visibility: public
   field_event_type: cf6ade6c-c38d-11e6-a4a6-cec0c932ce01
@@ -132,7 +138,8 @@
     address_line1: Barstreet
   field_event_date: +6 day|20:00
   field_event_date_end: +6 day|23:59
-  field_event_image: c08ba2c2-3adb-11e6-ac61-9e71128cae77
+  image: c08ba2c2-3adb-11e6-ac61-9e71128cae77
+  image_alt: People on sunset
   field_event_location: That bar there
   field_content_visibility: community
   field_event_type: cf6ae1c8-c38d-11e6-a4a6-cec0c932ce01
@@ -156,7 +163,8 @@
     address_line1: Newstreet 115
   field_event_date: +1 day|11:00
   field_event_date_end: +1 day|12:30
-  field_event_image: aa51f774-dee0-11e5-b86d-9a79f06e9478
+  image: aa51f774-dee0-11e5-b86d-9a79f06e9478
+  image_alt: People discussing at the table
   field_event_location: Utopia Experience
   field_content_visibility: public
   field_event_type: cf6ae1c8-c38d-11e6-a4a6-cec0c932ce01
@@ -179,7 +187,8 @@
     address_line1:
   field_event_date: +1 day|22:00
   field_event_date_end: +1 day|02:00
-  field_event_image: c08ba2c2-3adb-11e6-ac61-9e71128cae77
+  image: c08ba2c2-3adb-11e6-ac61-9e71128cae77
+  image_alt: People on sunset
   field_event_location: GoalGorilla Amsterdam
   field_content_visibility: public
   field_event_type: cf6ae2ae-c38d-11e6-a4a6-cec0c932ce01
@@ -202,7 +211,8 @@
     address_line1: Bulgersteyn 1
   field_event_date: -22 day|09:00
   field_event_date_end: -22 day|10:00
-  field_event_image:
+  image:
+  image_alt:
   field_event_location: Downtown
   field_content_visibility: community
   field_event_type: cf6ae2ae-c38d-11e6-a4a6-cec0c932ce01
@@ -225,7 +235,8 @@
     address_line1: Torenallee 28-20
   field_event_date: 366 day|09:00
   field_event_date_end: 366 day|22:00
-  field_event_image:
+  image:
+  image_alt:
   field_event_location: Eindhoven Startups Foundation
   field_content_visibility: public
   field_event_type: cf6ae2ae-c38d-11e6-a4a6-cec0c932ce01
@@ -248,7 +259,8 @@
     address_line1: Stationsplein 51-53
   field_event_date: 366 day|09:00
   field_event_date_end: 366 day|22:00
-  field_event_image: 7d545c0a-478d-11e7-a919-92ebcb67fe33
+  image: 7d545c0a-478d-11e7-a919-92ebcb67fe33
+  image_alt: Calculator and pen on sheet
   field_event_location: Zilveren Toren Amsterdam
   field_content_visibility: group
   field_event_type: cf6add72-c38d-11e6-a4a6-cec0c932ce01

--- a/modules/custom/social_demo/content/entity/group.yml
+++ b/modules/custom/social_demo/content/entity/group.yml
@@ -3,6 +3,7 @@
   uuid: 3bc51523-4f40-459c-887c-056432fe17cd
   langcode: und
   image: aa51f422-dee0-11e5-b86d-9a79f06e9478
+  image_alt: People writing at the table
   uid: 44fc3642-da2f-11e5-b5d2-0a1d41d68578
   created: -60 day|15:30
   label: Official Group Educational Assistance Association
@@ -20,6 +21,7 @@ d6e377d0-32d8-11e6-ac61-9e71128cae77:
   uuid: d6e377d0-32d8-11e6-ac61-9e71128cae77
   langcode: und
   image: aa51f24c-dee0-11e5-b86d-9a79f06e9478
+  image_alt: Brick building
   uid: 44fc2f3a-da2f-11e5-b5d2-0a1d41d68578
   created: -30 day|14:00
   label: Local School Group Springfield
@@ -35,6 +37,7 @@ d6e37a3c-32d8-11e6-ac61-9e71128cae77:
   uuid: d6e37a3c-32d8-11e6-ac61-9e71128cae77
   langcode: und
   image: aa51f422-dee0-11e5-b86d-9a79f06e9478
+  image_alt: People writing at the table
   uid: 44fc3642-da2f-11e5-b5d2-0a1d41d68578
   created: -4 day|11:12
   label: Board of School Topic Group
@@ -50,6 +53,7 @@ d6e37be0-32d8-11e6-ac61-9e71128cae77:
   uuid: d6e37be0-32d8-11e6-ac61-9e71128cae77
   langcode: und
   image: aa51f5d0-dee0-11e5-b86d-9a79f06e9478
+  image_alt: Man making a coffee
   uid: 44fc2f3a-da2f-11e5-b5d2-0a1d41d68578
   created: -2 day|12:12
   label: Springfield local business collaboration
@@ -65,6 +69,7 @@ da06bdb9-7ffa-4aa7-a98b-76360d8c40fd:
   uuid: da06bdb9-7ffa-4aa7-a98b-76360d8c40fd
   langcode: und
   image: 7d545872-478d-11e7-a919-92ebcb67fe33
+  image_alt: People discussing and writing at the table
   uid: 44fc3476-da2f-11e5-b5d2-0a1d41d68578
   created: -1 day|18:00
   label: Springfield board committee

--- a/modules/custom/social_demo/content/entity/page.yml
+++ b/modules/custom/social_demo/content/entity/page.yml
@@ -24,5 +24,6 @@ c0ca3235-fb0f-497c-a594-67753bdebce0:
     </ol>
     <p>We welcome code contributions, issue reports and translations. Learn how you can<a href="https://github.com/goalgorilla/drupal_social/wiki/Contributing-to-Open-Social">&nbsp;contribute in our Wiki</a>.</p>
   field_content_visibility: public
-  field_page_image: aa51f774-dee0-11e5-b86d-9a79f06e9478
+  image: aa51f774-dee0-11e5-b86d-9a79f06e9478
+  image_alt: About and contact details
   alias: /about

--- a/modules/custom/social_demo/content/entity/topic.yml
+++ b/modules/custom/social_demo/content/entity/topic.yml
@@ -23,7 +23,8 @@
     
     <p>Find out contact information. You can reach us by phone, fax, email, and after-hours cell phone number for members of the media.</p>
   field_topic_type: Blog
-  field_topic_image: aa51f918-dee0-11e5-b86d-9a79f06e9478
+  image: aa51f918-dee0-11e5-b86d-9a79f06e9478
+  image_alt: aa51f918-dee0-11e5-b86d-9a79f06e9478
   field_content_visibility: community
 92e8d86c-da14-11e5-b5d2-0a1d41d68578:
   uuid: 92e8d86c-da14-11e5-b5d2-0a1d41d68578
@@ -35,7 +36,7 @@
   body: >
     <p><span>Welcome to the community website of the Educational Assistance Association (EAA). We are very happy and proud to be able to launch this new tool to bring together people that care for education. Through the effort of all the involved People, our Sponsors and GoalGorilla it was made possible to create a new way of connecting professionals and help to spread knowledge over education. </span></p>
   field_topic_type: News
-  field_topic_image: aa51fec2-dee0-11e5-b86d-9a79f06e9478
+  image: aa51fec2-dee0-11e5-b86d-9a79f06e9478
   field_content_visibility: community
 426a6ea6-decd-11e5-b86d-9a79f06e9478:
   uuid: 426a6ea6-decd-11e5-b86d-9a79f06e9478
@@ -47,7 +48,7 @@
   body: >
     <p>We need to decide what will be the next event what we want to organize. I would propose that everybody who has an idea will post those in the comments. then we can decide which one seems the most promising.</p>
   field_topic_type: Discussion
-  field_topic_image: aa51f774-dee0-11e5-b86d-9a79f06e9478
+  image: aa51f774-dee0-11e5-b86d-9a79f06e9478
   field_content_visibility: community
 7096dc28-ded3-11e5-b86d-9a79f06e9478:
   uuid: 7096dc28-ded3-11e5-b86d-9a79f06e9478
@@ -61,7 +62,7 @@
 
     <p>I just started working in the board of schools in my town. So I saw this group here and I thought it would be a good idea to open a thread where we could exchange our most finest hours ;-). I am especially interested in successful fund raising campaigns you guys ran, but of course any input is appreciated</p>
   field_topic_type: Discussion
-  field_topic_image: aa52008e-dee0-11e5-b86d-9a79f06e9478
+  image: aa52008e-dee0-11e5-b86d-9a79f06e9478
   field_content_visibility: community
 7096de80-ded3-11e5-b86d-9a79f06e9478:
   uuid: 7096de80-ded3-11e5-b86d-9a79f06e9478
@@ -80,7 +81,7 @@
 
     <p><a href='http://loripsum.net/' target='_blank'>Verum hoc idem saepe faciamus.</a> <a href='http://loripsum.net/' target='_blank'>Sed nimis multa.</a> Conferam avum tuum Drusum cum C. <b>Dat enim intervalla et relaxat.</b> Quod si ita sit, cur opera philosophiae sit danda nescio. </p>
   field_topic_type: Blog
-  field_topic_image: aa52023c-dee0-11e5-b86d-9a79f06e9478
+  image: aa52023c-dee0-11e5-b86d-9a79f06e9478
   field_content_visibility: community
 7096df84-ded3-11e5-b86d-9a79f06e9478:
   uuid: 7096df84-ded3-11e5-b86d-9a79f06e9478
@@ -99,7 +100,7 @@
 
     <p>Praeclare hoc quidem. Quid censes in Latino fore? Cupiditates non Epicuri divisione finiebat, sed sua satietate. Nam ante Aristippus, et ille melius. <a href='http://loripsum.net/' target='_blank'>Egone quaeris, inquit, quid sentiam?</a> Nihil opus est exemplis hoc facere longius. Ita fit cum gravior, tum etiam splendidior oratio. Hoc loco tenere se Triarius non potuit. </p>
   field_topic_type: Discussion
-  field_topic_image: 
+  image: 
   field_content_visibility: community
 7096e290-ded3-11e5-b86d-9a79f06e9478:
   uuid: 7096e290-ded3-11e5-b86d-9a79f06e9478
@@ -116,7 +117,7 @@
     
     <p>Robert Andrews</p>
   field_topic_type: News
-  field_topic_image: aa51f918-dee0-11e5-b86d-9a79f06e9478
+  image: aa51f918-dee0-11e5-b86d-9a79f06e9478
   group: d6e37be0-32d8-11e6-ac61-9e71128cae77
   field_content_visibility: community
 7096e402-ded3-11e5-b86d-9a79f06e9478:
@@ -128,7 +129,7 @@
   body: >
     <p><span>As you can see Open Social is up and running. It can already help communities like this to grow. But it is still under development and new features are added regularly and existing ones are being improved constantly. If you are interested in the most recent changes you can visit us on </span><strong>https://www.drupal.org/project/social</strong><span>. There you find all updates on the project including the latest version, patch notes and much more. For more information about features and how Open Social can make your people bloom too go to <a href="https://getopensocial.com">https://getopensocial.com</a></p>
   field_topic_type: News
-  field_topic_image: c08babbe-3adb-11e6-ac61-9e71128cae77
+  image: c08babbe-3adb-11e6-ac61-9e71128cae77
   field_content_visibility: public
 7096e4f2-ded3-11e5-b86d-9a79f06e9478:
   uuid: 7096e4f2-ded3-11e5-b86d-9a79f06e9478
@@ -147,7 +148,7 @@
 
     <p>Vitae autem degendae ratio maxime quidem illis placuit quieta. Quid nunc honeste dicit? Quod cum dixissent, ille contra. <b>Gerendus est mos, modo recte sentiat.</b> Huius, Lyco, oratione locuples, rebus ipsis ielunior. </p>
   field_topic_type: Blog
-  field_topic_image: aa51fec2-dee0-11e5-b86d-9a79f06e9478
+  image: aa51fec2-dee0-11e5-b86d-9a79f06e9478
   group: 3bc51523-4f40-459c-887c-056432fe17cd
   field_content_visibility: community
 7096e5c4-ded3-11e5-b86d-9a79f06e9478:
@@ -211,7 +212,7 @@
     	<li>Qui enim existimabit posse se miserum esse beatus non erit.</li>
     </ul>
   field_topic_type: Blog
-  field_topic_image: c08b9e6c-3adb-11e6-ac61-9e71128cae77
+  image: c08b9e6c-3adb-11e6-ac61-9e71128cae77
   langcode: en
   group: 3bc51523-4f40-459c-887c-056432fe17cd
   field_content_visibility: community
@@ -239,6 +240,6 @@
         Illud enim rectum est quod katortwma dicebas contingitque sapienti soli, hoc autem inchoati cuiusdam officii est, non perfecti, quod cadere in non nullos insipientes potest.
     </blockquote>
   field_topic_type: Discussion
-  field_topic_image: aa51f058-dee0-11e5-b86d-9a79f06e9478
+  image: aa51f058-dee0-11e5-b86d-9a79f06e9478
   group: da06bdb9-7ffa-4aa7-a98b-76360d8c40fd
   field_content_visibility: group

--- a/modules/custom/social_demo/content/entity/topic.yml
+++ b/modules/custom/social_demo/content/entity/topic.yml
@@ -24,7 +24,7 @@
     <p>Find out contact information. You can reach us by phone, fax, email, and after-hours cell phone number for members of the media.</p>
   field_topic_type: Blog
   image: aa51f918-dee0-11e5-b86d-9a79f06e9478
-  image_alt: aa51f918-dee0-11e5-b86d-9a79f06e9478
+  image_alt:
   field_content_visibility: community
 92e8d86c-da14-11e5-b5d2-0a1d41d68578:
   uuid: 92e8d86c-da14-11e5-b5d2-0a1d41d68578
@@ -37,6 +37,7 @@
     <p><span>Welcome to the community website of the Educational Assistance Association (EAA). We are very happy and proud to be able to launch this new tool to bring together people that care for education. Through the effort of all the involved People, our Sponsors and GoalGorilla it was made possible to create a new way of connecting professionals and help to spread knowledge over education. </span></p>
   field_topic_type: News
   image: aa51fec2-dee0-11e5-b86d-9a79f06e9478
+  image_alt:
   field_content_visibility: community
 426a6ea6-decd-11e5-b86d-9a79f06e9478:
   uuid: 426a6ea6-decd-11e5-b86d-9a79f06e9478
@@ -49,6 +50,7 @@
     <p>We need to decide what will be the next event what we want to organize. I would propose that everybody who has an idea will post those in the comments. then we can decide which one seems the most promising.</p>
   field_topic_type: Discussion
   image: aa51f774-dee0-11e5-b86d-9a79f06e9478
+  image_alt:
   field_content_visibility: community
 7096dc28-ded3-11e5-b86d-9a79f06e9478:
   uuid: 7096dc28-ded3-11e5-b86d-9a79f06e9478
@@ -63,6 +65,7 @@
     <p>I just started working in the board of schools in my town. So I saw this group here and I thought it would be a good idea to open a thread where we could exchange our most finest hours ;-). I am especially interested in successful fund raising campaigns you guys ran, but of course any input is appreciated</p>
   field_topic_type: Discussion
   image: aa52008e-dee0-11e5-b86d-9a79f06e9478
+  image_alt:
   field_content_visibility: community
 7096de80-ded3-11e5-b86d-9a79f06e9478:
   uuid: 7096de80-ded3-11e5-b86d-9a79f06e9478
@@ -82,6 +85,7 @@
     <p><a href='http://loripsum.net/' target='_blank'>Verum hoc idem saepe faciamus.</a> <a href='http://loripsum.net/' target='_blank'>Sed nimis multa.</a> Conferam avum tuum Drusum cum C. <b>Dat enim intervalla et relaxat.</b> Quod si ita sit, cur opera philosophiae sit danda nescio. </p>
   field_topic_type: Blog
   image: aa52023c-dee0-11e5-b86d-9a79f06e9478
+  image_alt:
   field_content_visibility: community
 7096df84-ded3-11e5-b86d-9a79f06e9478:
   uuid: 7096df84-ded3-11e5-b86d-9a79f06e9478
@@ -100,7 +104,8 @@
 
     <p>Praeclare hoc quidem. Quid censes in Latino fore? Cupiditates non Epicuri divisione finiebat, sed sua satietate. Nam ante Aristippus, et ille melius. <a href='http://loripsum.net/' target='_blank'>Egone quaeris, inquit, quid sentiam?</a> Nihil opus est exemplis hoc facere longius. Ita fit cum gravior, tum etiam splendidior oratio. Hoc loco tenere se Triarius non potuit. </p>
   field_topic_type: Discussion
-  image: 
+  image:
+  image_alt:
   field_content_visibility: community
 7096e290-ded3-11e5-b86d-9a79f06e9478:
   uuid: 7096e290-ded3-11e5-b86d-9a79f06e9478
@@ -118,6 +123,7 @@
     <p>Robert Andrews</p>
   field_topic_type: News
   image: aa51f918-dee0-11e5-b86d-9a79f06e9478
+  image_alt:
   group: d6e37be0-32d8-11e6-ac61-9e71128cae77
   field_content_visibility: community
 7096e402-ded3-11e5-b86d-9a79f06e9478:
@@ -130,6 +136,7 @@
     <p><span>As you can see Open Social is up and running. It can already help communities like this to grow. But it is still under development and new features are added regularly and existing ones are being improved constantly. If you are interested in the most recent changes you can visit us on </span><strong>https://www.drupal.org/project/social</strong><span>. There you find all updates on the project including the latest version, patch notes and much more. For more information about features and how Open Social can make your people bloom too go to <a href="https://getopensocial.com">https://getopensocial.com</a></p>
   field_topic_type: News
   image: c08babbe-3adb-11e6-ac61-9e71128cae77
+  image_alt:
   field_content_visibility: public
 7096e4f2-ded3-11e5-b86d-9a79f06e9478:
   uuid: 7096e4f2-ded3-11e5-b86d-9a79f06e9478
@@ -149,6 +156,7 @@
     <p>Vitae autem degendae ratio maxime quidem illis placuit quieta. Quid nunc honeste dicit? Quod cum dixissent, ille contra. <b>Gerendus est mos, modo recte sentiat.</b> Huius, Lyco, oratione locuples, rebus ipsis ielunior. </p>
   field_topic_type: Blog
   image: aa51fec2-dee0-11e5-b86d-9a79f06e9478
+  image_alt:
   group: 3bc51523-4f40-459c-887c-056432fe17cd
   field_content_visibility: community
 7096e5c4-ded3-11e5-b86d-9a79f06e9478:
@@ -213,6 +221,7 @@
     </ul>
   field_topic_type: Blog
   image: c08b9e6c-3adb-11e6-ac61-9e71128cae77
+  image_alt:
   langcode: en
   group: 3bc51523-4f40-459c-887c-056432fe17cd
   field_content_visibility: community
@@ -241,5 +250,6 @@
     </blockquote>
   field_topic_type: Discussion
   image: aa51f058-dee0-11e5-b86d-9a79f06e9478
+  image_alt:
   group: da06bdb9-7ffa-4aa7-a98b-76360d8c40fd
   field_content_visibility: group

--- a/modules/custom/social_demo/content/entity/topic.yml
+++ b/modules/custom/social_demo/content/entity/topic.yml
@@ -10,21 +10,21 @@
     <p><strong>What We&nbsp;Do</strong></p>
 
     <p>We help to raise funds and awareness to to different topics concerning education and the educational system in America. We give our support to local groups, school boards and private persons that want to get involved.</p>
-    
+
     <p><strong>Mission, Vision, Goals </strong></p>
-    
+
     <p>Our efforts to be an important advocate for education in America, Through our work in the legislative, legal and public arenas we want to influence the politic as well as the public attitude towards education. We believe education is a civil right, and public education is America’s most vital institution.</p>
-    
+
     <p><strong>Why we created this community </strong></p>
-    
+
     <p>We think that communication and the sharing of knowledge is one of the key stones to improve our educational system. We think that through connecting professionals all over the country we can help to start a discussion about what is important in education, about new teaching methods and help local communities to learn from others.</p>
-    
+
     <p><strong>Contact Us</strong></p>
-    
+
     <p>Find out contact information. You can reach us by phone, fax, email, and after-hours cell phone number for members of the media.</p>
   field_topic_type: Blog
   image: aa51f918-dee0-11e5-b86d-9a79f06e9478
-  image_alt:
+  image_alt: A lot of books
   field_content_visibility: community
 92e8d86c-da14-11e5-b5d2-0a1d41d68578:
   uuid: 92e8d86c-da14-11e5-b5d2-0a1d41d68578
@@ -37,7 +37,7 @@
     <p><span>Welcome to the community website of the Educational Assistance Association (EAA). We are very happy and proud to be able to launch this new tool to bring together people that care for education. Through the effort of all the involved People, our Sponsors and GoalGorilla it was made possible to create a new way of connecting professionals and help to spread knowledge over education. </span></p>
   field_topic_type: News
   image: aa51fec2-dee0-11e5-b86d-9a79f06e9478
-  image_alt:
+  image_alt: Two awesome sparklets
   field_content_visibility: community
 426a6ea6-decd-11e5-b86d-9a79f06e9478:
   uuid: 426a6ea6-decd-11e5-b86d-9a79f06e9478
@@ -50,7 +50,7 @@
     <p>We need to decide what will be the next event what we want to organize. I would propose that everybody who has an idea will post those in the comments. then we can decide which one seems the most promising.</p>
   field_topic_type: Discussion
   image: aa51f774-dee0-11e5-b86d-9a79f06e9478
-  image_alt:
+  image_alt: People in a meeting
   field_content_visibility: community
 7096dc28-ded3-11e5-b86d-9a79f06e9478:
   uuid: 7096dc28-ded3-11e5-b86d-9a79f06e9478
@@ -65,7 +65,7 @@
     <p>I just started working in the board of schools in my town. So I saw this group here and I thought it would be a good idea to open a thread where we could exchange our most finest hours ;-). I am especially interested in successful fund raising campaigns you guys ran, but of course any input is appreciated</p>
   field_topic_type: Discussion
   image: aa52008e-dee0-11e5-b86d-9a79f06e9478
-  image_alt:
+  image_alt: People partying
   field_content_visibility: community
 7096de80-ded3-11e5-b86d-9a79f06e9478:
   uuid: 7096de80-ded3-11e5-b86d-9a79f06e9478
@@ -85,7 +85,7 @@
     <p><a href='http://loripsum.net/' target='_blank'>Verum hoc idem saepe faciamus.</a> <a href='http://loripsum.net/' target='_blank'>Sed nimis multa.</a> Conferam avum tuum Drusum cum C. <b>Dat enim intervalla et relaxat.</b> Quod si ita sit, cur opera philosophiae sit danda nescio. </p>
   field_topic_type: Blog
   image: aa52023c-dee0-11e5-b86d-9a79f06e9478
-  image_alt:
+  image_alt: An old typewriter
   field_content_visibility: community
 7096df84-ded3-11e5-b86d-9a79f06e9478:
   uuid: 7096df84-ded3-11e5-b86d-9a79f06e9478
@@ -115,15 +115,15 @@
   uid: 44fc3642-da2f-11e5-b5d2-0a1d41d68578
   body: >
     <p dir="ltr">Dear community,</p>
-    
+
     <p dir="ltr">over the last month we gathered books that we could acquire or were donated to us, to improve the school library. I am happy to announce, that his weekend we will hand them over to the school. We hope to have a small impact on our community and will further try to keep up the work. Thanks to all who helped to make this happen!</p>
-    
+
     <p dir="ltr">Best Wishes</p>
-    
+
     <p>Robert Andrews</p>
   field_topic_type: News
   image: aa51f918-dee0-11e5-b86d-9a79f06e9478
-  image_alt:
+  image_alt: A lot of books
   group: d6e37be0-32d8-11e6-ac61-9e71128cae77
   field_content_visibility: community
 7096e402-ded3-11e5-b86d-9a79f06e9478:
@@ -136,7 +136,7 @@
     <p><span>As you can see Open Social is up and running. It can already help communities like this to grow. But it is still under development and new features are added regularly and existing ones are being improved constantly. If you are interested in the most recent changes you can visit us on </span><strong>https://www.drupal.org/project/social</strong><span>. There you find all updates on the project including the latest version, patch notes and much more. For more information about features and how Open Social can make your people bloom too go to <a href="https://getopensocial.com">https://getopensocial.com</a></p>
   field_topic_type: News
   image: c08babbe-3adb-11e6-ac61-9e71128cae77
-  image_alt:
+  image_alt: A dasiy in a field
   field_content_visibility: public
 7096e4f2-ded3-11e5-b86d-9a79f06e9478:
   uuid: 7096e4f2-ded3-11e5-b86d-9a79f06e9478
@@ -156,7 +156,7 @@
     <p>Vitae autem degendae ratio maxime quidem illis placuit quieta. Quid nunc honeste dicit? Quod cum dixissent, ille contra. <b>Gerendus est mos, modo recte sentiat.</b> Huius, Lyco, oratione locuples, rebus ipsis ielunior. </p>
   field_topic_type: Blog
   image: aa51fec2-dee0-11e5-b86d-9a79f06e9478
-  image_alt:
+  image_alt: These are sparklets
   group: 3bc51523-4f40-459c-887c-056432fe17cd
   field_content_visibility: community
 7096e5c4-ded3-11e5-b86d-9a79f06e9478:
@@ -221,7 +221,7 @@
     </ul>
   field_topic_type: Blog
   image: c08b9e6c-3adb-11e6-ac61-9e71128cae77
-  image_alt:
+  image_alt: An organised desk
   langcode: en
   group: 3bc51523-4f40-459c-887c-056432fe17cd
   field_content_visibility: community
@@ -250,6 +250,6 @@
     </blockquote>
   field_topic_type: Discussion
   image: aa51f058-dee0-11e5-b86d-9a79f06e9478
-  image_alt:
+  image_alt: A Macbook on a desk
   group: da06bdb9-7ffa-4aa7-a98b-76360d8c40fd
   field_content_visibility: group

--- a/modules/custom/social_demo/content/entity/user.yml
+++ b/modules/custom/social_demo/content/entity/user.yml
@@ -6,7 +6,8 @@
   mail: drupal_social+susanwilliams@springfieldboard.com
   timezone: UTC
   status: 1
-  picture: 57fb675a-f04a-11e5-9ce9-5e5517507c66
+  image: 57fb675a-f04a-11e5-9ce9-5e5517507c66
+  image_alt: Susan Williams
   first_name: Susan
   last_name: Williams
   organization: Springfield School Board
@@ -25,7 +26,8 @@
   mail: drupal_social+paulharris@goalgorilla.com
   timezone: Europe/Amsterdam
   status: 1
-  picture: 57fb6390-f04a-11e5-9ce9-5e5517507c66
+  image: 57fb6390-f04a-11e5-9ce9-5e5517507c66
+  image_alt: Paul Harris
   first_name: Paul
   last_name: Harris
   organization: Springfield High School
@@ -43,7 +45,8 @@
   mail: drupal_social+michelleclark@goalgorilla.com
   timezone: Europe/Amsterdam
   status: 1
-  picture: 57fb62b4-f04a-11e5-9ce9-5e5517507c66
+  image: 57fb62b4-f04a-11e5-9ce9-5e5517507c66
+  image_alt: Michelle Clark
   first_name: Michelle
   last_name: Clark
   organization: freelance advisor
@@ -64,7 +67,8 @@
   mail: drupal_social+chrishall@goalgorilla.com
   timezone: Europe/Rome
   status: 1
-  picture: 57fb602a-f04a-11e5-9ce9-5e5517507c66
+  image: 57fb602a-f04a-11e5-9ce9-5e5517507c66
+  image_alt: Chris Hall
   first_name: Chris
   last_name: Hall
   organization: Educational Assistance Association
@@ -84,7 +88,8 @@
   mail: drupal_social+thomaswolf@goalgorilla.com
   timezone: Europe/Amsterdam
   status: 1
-  picture: 57fb6930-f04a-11e5-9ce9-5e5517507c66
+  image: 57fb6930-f04a-11e5-9ce9-5e5517507c66
+  image_alt: Thomas Wolf
   first_name: Thomas
   last_name: Wolf
   organization: Springfield Elementary School
@@ -102,7 +107,8 @@
   mail: drupal_social+EAA_officialk@goalgorilla.com
   timezone: Europe/Amsterdam
   status: 1
-  picture:
+  image:
+  image_alt:
   first_name:
   last_name:
   organization: Educational Assistance Association
@@ -122,7 +128,8 @@
   mail: drupal_social+peterkshaw@goalgorilla.com
   timezone: Europe/Amsterdam
   status: 1
-  picture: 57fb6462-f04a-11e5-9ce9-5e5517507c66
+  image: 57fb6462-f04a-11e5-9ce9-5e5517507c66
+  image_alt: Peter Shaw
   first_name: Peter
   last_name: Shaw
   organization: Board Comitee
@@ -143,7 +150,8 @@
   mail: drupal_social+anonymous@goalgorilla.com
   timezone: Europe/Amsterdam
   status: 1
-  picture:
+  image:
+  image_alt:
   first_name:
   last_name:
   organization:
@@ -161,7 +169,8 @@
   mail: drupal_social+robertandrews@goalgorilla.com
   timezone: Europe/London
   status: 1
-  picture: 57fb6692-f04a-11e5-9ce9-5e5517507c66
+  image: 57fb6692-f04a-11e5-9ce9-5e5517507c66
+  image_alt: Robert Andrews
   first_name: Robert
   last_name: Andrews
   organization:  Sax Bookstore
@@ -182,7 +191,8 @@
   mail: drupal_social+alisonhendrix@goalgorilla.com
   timezone: Europe/Berlin
   status: 1
-  picture: 57fb5c9c-f04a-11e5-9ce9-5e5517507c66
+  image: 57fb5c9c-f04a-11e5-9ce9-5e5517507c66
+  image_alt: Alison Hendrix
   first_name: Alison
   last_name: Hendrix
   organization:
@@ -200,7 +210,8 @@
   mail: drupal_social+shaunberkley@goalgorilla.com
   timezone: Europe/Berlin
   status: 1
-  picture:
+  image:
+  image_alt:
   first_name: Shaun
   last_name: Berkley
   organization:
@@ -218,7 +229,8 @@
   mail: drupal_social+darrenjohnson@goalgorilla.com
   timezone: Europe/Amsterdam
   status: 0
-  picture:
+  image:
+  image_alt: Darren Johnson
   first_name: Darren
   last_name: Johnson
   organization:
@@ -238,7 +250,8 @@ a8c4e812-ef52-11e5-9ce9-5e5517507c66:
   status: 1
   roles:
     - sitemanager
-  picture: 27764577-62d9-4db8-bb29-911236af0cfe
+  image: 27764577-62d9-4db8-bb29-911236af0cfe
+  image_alt: Ben Florez
   first_name: Ben
   last_name: Flórez
   organization: Springfield High School
@@ -259,7 +272,8 @@ a8c4ebe6-ef52-11e5-9ce9-5e5517507c66:
   status: 1
   roles:
     - contentmanager
-  picture: 92faca21-88b4-477b-87ed-f724625102a6
+  image: 92faca21-88b4-477b-87ed-f724625102a6
+  image_alt: Janna Miesner
   first_name: Janna
   last_name: Miesner
   organization: Springfield High School

--- a/modules/custom/social_demo/eaa/content/entity/book.yml
+++ b/modules/custom/social_demo/eaa/content/entity/book.yml
@@ -16,7 +16,8 @@ e154d17d-63c7-41ac-8edc-97a49e81d7c5:
     </ol>
   field_content_visibility: public
   alias: /about
-  field_book_image: Adccefcc-5c20-44cc-9944-5993c5f2f759
+  image: Adccefcc-5c20-44cc-9944-5993c5f2f759
+  image_alt: About this platform
   book:
     id: e154d17d-63c7-41ac-8edc-97a49e81d7c5
 

--- a/modules/custom/social_demo/eaa/content/entity/event.yml
+++ b/modules/custom/social_demo/eaa/content/entity/event.yml
@@ -14,7 +14,8 @@
     address_line1: 23 Putnam Road
   field_event_date: +29 day|18:00
   field_event_date_end: +29 day|21:00
-  field_event_image: 71e7af61-f4c7-4aed-bdf2-7ff3b45a7617
+  image: 71e7af61-f4c7-4aed-bdf2-7ff3b45a7617
+  image_alt:
   field_event_location: Old Bell Pub
   field_content_visibility: community
   field_event_type: c63bf60c6-a3a3-4187-9056-deded88587ae
@@ -46,7 +47,8 @@
     address_line1:
   field_event_date: +98 day|10:00
   field_event_date_end: +98 day|12:00
-  field_event_image: 86d3ac66-57c1-4400-9be4-a0048d8031e5
+  image: 86d3ac66-57c1-4400-9be4-a0048d8031e5
+  image_alt:
   field_event_location: Parliament Square
   field_content_visibility: public
   field_event_type: D27a2188-e80c-48e6-8976-f81b22c8901b
@@ -75,7 +77,8 @@
     address_line1: 16 Carlisle St
   field_event_date: +52 day|10:00
   field_event_date_end: +52 day|14:00
-  field_event_image: Cc838317-431c-47a4-86a4-5d49a621b017
+  image: Cc838317-431c-47a4-86a4-5d49a621b017
+  image_alt:
   field_event_location: SOHO BUSINESS CLUB
   field_content_visibility: community
   field_event_type: D27a2188-e80c-48e6-8976-f81b22c8901b

--- a/modules/custom/social_demo/eaa/content/entity/event.yml
+++ b/modules/custom/social_demo/eaa/content/entity/event.yml
@@ -15,7 +15,7 @@
   field_event_date: +29 day|18:00
   field_event_date_end: +29 day|21:00
   image: 71e7af61-f4c7-4aed-bdf2-7ff3b45a7617
-  image_alt:
+  image_alt: People in a meeting
   field_event_location: Old Bell Pub
   field_content_visibility: community
   field_event_type: c63bf60c6-a3a3-4187-9056-deded88587ae
@@ -48,7 +48,7 @@
   field_event_date: +98 day|10:00
   field_event_date_end: +98 day|12:00
   image: 86d3ac66-57c1-4400-9be4-a0048d8031e5
-  image_alt:
+  image_alt: People protesting
   field_event_location: Parliament Square
   field_content_visibility: public
   field_event_type: D27a2188-e80c-48e6-8976-f81b22c8901b
@@ -78,7 +78,7 @@
   field_event_date: +52 day|10:00
   field_event_date_end: +52 day|14:00
   image: Cc838317-431c-47a4-86a4-5d49a621b017
-  image_alt:
+  image_alt: Cups on a table
   field_event_location: SOHO BUSINESS CLUB
   field_content_visibility: community
   field_event_type: D27a2188-e80c-48e6-8976-f81b22c8901b

--- a/modules/custom/social_demo/eaa/content/entity/group.yml
+++ b/modules/custom/social_demo/eaa/content/entity/group.yml
@@ -3,6 +3,7 @@
   uuid: 3b2a15a0-888e-4f6a-a7e5-1a3e80cdac8a
   langcode: und
   image: 6f4fb576-a7a9-4011-b8ae-f44dbfbd9dd2
+  image_alt:
   uid: 10477c08-f850-4c1d-bbaa-13413afa7055
   created: -32 day|15:18
   label: EEA Volunteers London
@@ -20,6 +21,7 @@
   uuid: 2b7a34f1-c615-4f28-aa02-d7978553f297
   langcode: und
   image: 701479b1-eefc-469b-aa56-ed98a9492736
+  image_alt:
   uid: 42fc0a3c-5e90-44a3-bfab-8b0ea7b6dead
   created: -65 day|20:23
   label: Teacher’s lounge 
@@ -39,6 +41,7 @@
   uuid: 0f3daf2a-d36a-4e65-a6fd-77a4cc6c048f
   langcode: und
   image: C15e2f5d-186c-4a94-be20-8dab3552c40a
+  image_alt:
   uid: 4ded60a5-693b-4c64-bc84-d5f325ead6f1
   created: -9 day|07:05
   label: Student support lounge

--- a/modules/custom/social_demo/eaa/content/entity/group.yml
+++ b/modules/custom/social_demo/eaa/content/entity/group.yml
@@ -3,7 +3,7 @@
   uuid: 3b2a15a0-888e-4f6a-a7e5-1a3e80cdac8a
   langcode: und
   image: 6f4fb576-a7a9-4011-b8ae-f44dbfbd9dd2
-  image_alt:
+  image_alt: The tower bridge
   uid: 10477c08-f850-4c1d-bbaa-13413afa7055
   created: -32 day|15:18
   label: EEA Volunteers London
@@ -21,14 +21,14 @@
   uuid: 2b7a34f1-c615-4f28-aa02-d7978553f297
   langcode: und
   image: 701479b1-eefc-469b-aa56-ed98a9492736
-  image_alt:
+  image_alt: Teachers discussing and laughing
   uid: 42fc0a3c-5e90-44a3-bfab-8b0ea7b6dead
   created: -65 day|20:23
-  label: Teacher’s lounge 
+  label: Teacher’s lounge
   type: open_group
   description: >
     <p> This group is for both active and inactive teachers. In this group they can share knowledge and resources on how to best support students and their parents who require educational assistance. </p>
-  managers: 
+  managers:
     - 42fc0a3c-5e90-44a3-bfab-8b0ea7b6dead
     - 10477c08-f850-4c1d-bbaa-13413afa7055
   members:
@@ -41,14 +41,14 @@
   uuid: 0f3daf2a-d36a-4e65-a6fd-77a4cc6c048f
   langcode: und
   image: C15e2f5d-186c-4a94-be20-8dab3552c40a
-  image_alt:
+  image_alt: Random students hanging about
   uid: 4ded60a5-693b-4c64-bc84-d5f325ead6f1
   created: -9 day|07:05
   label: Student support lounge
   type: open_group
   description: >
     <p> This group is a support group for students! If you are looking for practical help and support with educational assistance (or requesting assistance!) or if you just want to vent about the issues you are facing, we are here for you! :) </p>
-  managers: 
+  managers:
     - 4ded60a5-693b-4c64-bc84-d5f325ead6f1
   members:
     - 4ded60a5-693b-4c64-bc84-d5f325ead6f1

--- a/modules/custom/social_demo/eaa/content/entity/page.yml
+++ b/modules/custom/social_demo/eaa/content/entity/page.yml
@@ -15,7 +15,7 @@ E8ffec4f-98d0-402f-8591-04e94cb59f59:
     </ol>
   field_content_visibility: public
   image: E51a60f2-cc2e-4a48-ad94-85d7c637003e
-  image_alt:
+  image_alt: A guy with a huge beard
   alias: /terms
 
 E88fd43b-bfe5-4561-b0f4-5f4c2eb0b6f2:
@@ -45,5 +45,5 @@ E88fd43b-bfe5-4561-b0f4-5f4c2eb0b6f2:
 
   field_content_visibility: community
   image: 0071ccd1-f5be-4e4d-9211-5cf4a7d759c9
-  image_alt:
+  image_alt: Someone reading a map
   alias: /guidelines

--- a/modules/custom/social_demo/eaa/content/entity/page.yml
+++ b/modules/custom/social_demo/eaa/content/entity/page.yml
@@ -14,7 +14,8 @@ E8ffec4f-98d0-402f-8591-04e94cb59f59:
         <li>The EEA aims to provide accurate information regarding educational assistance within the UK. The EEA is not responsible for inaccuracies published by EEA community members. When in doubt, please contact an EEA official to verify that the information provided by another community member is correct and can be acted upon. </li>
     </ol>
   field_content_visibility: public
-  field_page_image: E51a60f2-cc2e-4a48-ad94-85d7c637003e
+  image: E51a60f2-cc2e-4a48-ad94-85d7c637003e
+  image_alt:
   alias: /terms
 
 E88fd43b-bfe5-4561-b0f4-5f4c2eb0b6f2:
@@ -43,5 +44,6 @@ E88fd43b-bfe5-4561-b0f4-5f4c2eb0b6f2:
     <p>We reserve the right to make editorial decisions regarding submitted comments, including but not limited to removal of comments.  All comments are moderated.  They will be reviewed and posted as quickly as possible during regular business hours (Mon – Fri 8:30am – 5:30pm GMT).  Thanks for your support, for reading and for sharing.</p>
 
   field_content_visibility: community
-  field_page_image: 0071ccd1-f5be-4e4d-9211-5cf4a7d759c9
+  image: 0071ccd1-f5be-4e4d-9211-5cf4a7d759c9
+  image_alt:
   alias: /guidelines

--- a/modules/custom/social_demo/eaa/content/entity/topic.yml
+++ b/modules/custom/social_demo/eaa/content/entity/topic.yml
@@ -5,7 +5,7 @@ C1bac4d2-31d9-4173-933a-b43a7d646310:
   type: topic
   field_topic_type: News
   image: A4a52e08-5ab0-4496-8ef3-d42d48de11e9
-  image_alt:
+  image_alt: Books everywhere
   field_content_visibility: group
   langcode: und
   uid: 10477c08-f850-4c1d-bbaa-13413afa7055
@@ -25,7 +25,7 @@ C1bac4d2-31d9-4173-933a-b43a7d646310:
   type: topic
   field_topic_type: Discussion
   image: 88d9479e-44db-46f4-8f72-b61d393545ce
-  image_alt:
+  image_alt: Making a test
   field_content_visibility: community
   langcode: und
   uid: Cb92f0c9-1d34-4c05-a50b-2ea985342953
@@ -45,7 +45,7 @@ C1bac4d2-31d9-4173-933a-b43a7d646310:
   type: topic
   field_topic_type: Blog
   image: B85902d4-2127-4140-835a-35b8b3a42d83
-  image_alt:
+  image_alt: Coffee on a table
   field_content_visibility: community
   langcode: und
   uid: 10477c08-f850-4c1d-bbaa-13413afa7055
@@ -76,7 +76,7 @@ B4b25cf0-19ce-47b7-81a5-1d841c574b8d:
   type: topic
   field_topic_type: News
   image: 88e27c11-8ede-4ebe-be13-53a1ee27e744
-  image_alt:
+  image_alt: Social media everywhere
   field_content_visibility: public
   langcode: und
   uid: 6b5b2952-bec3-4dfb-982c-71ed6b271ebc

--- a/modules/custom/social_demo/eaa/content/entity/topic.yml
+++ b/modules/custom/social_demo/eaa/content/entity/topic.yml
@@ -4,7 +4,8 @@ C1bac4d2-31d9-4173-933a-b43a7d646310:
   title: 'Volunteer handbook London: Update!'
   type: topic
   field_topic_type: News
-  field_topic_image: A4a52e08-5ab0-4496-8ef3-d42d48de11e9
+  image: A4a52e08-5ab0-4496-8ef3-d42d48de11e9
+  image_alt:
   field_content_visibility: group
   langcode: und
   uid: 10477c08-f850-4c1d-bbaa-13413afa7055
@@ -23,7 +24,8 @@ C1bac4d2-31d9-4173-933a-b43a7d646310:
   title: Anybody know how to get additional test time at uni?
   type: topic
   field_topic_type: Discussion
-  field_topic_image: 88d9479e-44db-46f4-8f72-b61d393545ce
+  image: 88d9479e-44db-46f4-8f72-b61d393545ce
+  image_alt:
   field_content_visibility: community
   langcode: und
   uid: Cb92f0c9-1d34-4c05-a50b-2ea985342953
@@ -42,7 +44,8 @@ C1bac4d2-31d9-4173-933a-b43a7d646310:
   title: Monthly EEA update!
   type: topic
   field_topic_type: Blog
-  field_topic_image: B85902d4-2127-4140-835a-35b8b3a42d83
+  image: B85902d4-2127-4140-835a-35b8b3a42d83
+  image_alt:
   field_content_visibility: community
   langcode: und
   uid: 10477c08-f850-4c1d-bbaa-13413afa7055
@@ -72,7 +75,8 @@ B4b25cf0-19ce-47b7-81a5-1d841c574b8d:
   title: Social media specialist wanted
   type: topic
   field_topic_type: News
-  field_topic_image: 88e27c11-8ede-4ebe-be13-53a1ee27e744
+  image: 88e27c11-8ede-4ebe-be13-53a1ee27e744
+  image_alt:
   field_content_visibility: public
   langcode: und
   uid: 6b5b2952-bec3-4dfb-982c-71ed6b271ebc

--- a/modules/custom/social_demo/eaa/content/entity/user.yml
+++ b/modules/custom/social_demo/eaa/content/entity/user.yml
@@ -6,6 +6,7 @@
   timezone: UTC
   status: 1
   image: 5dc39cc9-04e7-4514-a267-f19927aa2be7
+  image_alt: Esther Smith
   first_name: Esther
   last_name: Smith
   organization: EAA
@@ -33,6 +34,7 @@
   roles:
     - sitemanager
   image: 63c0e520-dcf7-4ece-8496-8b13866056bd
+  image_alt: Peter Parker
   first_name: Peter
   last_name: Parker
   organization: EAA
@@ -58,6 +60,7 @@ Cb92f0c9-1d34-4c05-a50b-2ea985342953:
   timezone: UTC
   status: 1
   image: 40971751-4b75-49be-bd4c-79f8d4cbe4d5
+  image_alt: Babs Warren
   first_name: Babs
   last_name: Warren
   organization:
@@ -84,6 +87,7 @@ Cb92f0c9-1d34-4c05-a50b-2ea985342953:
   timezone: UTC
   status: 1
   image: C2f9ac2f-52dc-4de5-bc8a-d6956dc37e2e
+  image_alt: Tina Jones
   first_name: Tina
   last_name: Jones
   organization: Birmingham Secondary School
@@ -109,6 +113,7 @@ E86254ca-1c50-4f37-81f8-13aef995ae33:
   timezone: UTC
   status: 1
   image: 16200a8e-98be-4e9d-b01b-e4541f8cc524
+  image_alt: Tim Cullen
   first_name: Tim
   last_name: Cullen
   organization: Brighton College
@@ -134,6 +139,7 @@ E86254ca-1c50-4f37-81f8-13aef995ae33:
   timezone: UTC
   status: 1
   image: 9bafc7b0-9c80-4df5-8e05-a642b01dbc1d
+  image_alt: Lorelai Margrate
   first_name: Lorelai
   last_name: Margrate
   organization:

--- a/modules/custom/social_demo/eaa/content/entity/user.yml
+++ b/modules/custom/social_demo/eaa/content/entity/user.yml
@@ -5,7 +5,7 @@
   mail: esthersmith@eaa.co.uk
   timezone: UTC
   status: 1
-  picture: 5dc39cc9-04e7-4514-a267-f19927aa2be7
+  image: 5dc39cc9-04e7-4514-a267-f19927aa2be7
   first_name: Esther
   last_name: Smith
   organization: EAA
@@ -32,7 +32,7 @@
   status: 1
   roles:
     - sitemanager
-  picture: 63c0e520-dcf7-4ece-8496-8b13866056bd
+  image: 63c0e520-dcf7-4ece-8496-8b13866056bd
   first_name: Peter
   last_name: Parker
   organization: EAA
@@ -57,7 +57,7 @@ Cb92f0c9-1d34-4c05-a50b-2ea985342953:
   mail: babswarren@email.com
   timezone: UTC
   status: 1
-  picture: 40971751-4b75-49be-bd4c-79f8d4cbe4d5
+  image: 40971751-4b75-49be-bd4c-79f8d4cbe4d5
   first_name: Babs
   last_name: Warren
   organization:
@@ -83,7 +83,7 @@ Cb92f0c9-1d34-4c05-a50b-2ea985342953:
   mail: tinajones@sch.bham.uk
   timezone: UTC
   status: 1
-  picture: C2f9ac2f-52dc-4de5-bc8a-d6956dc37e2e
+  image: C2f9ac2f-52dc-4de5-bc8a-d6956dc37e2e
   first_name: Tina
   last_name: Jones
   organization: Birmingham Secondary School
@@ -108,7 +108,7 @@ E86254ca-1c50-4f37-81f8-13aef995ae33:
   mail: timcullen@brighton.edu.org.uk
   timezone: UTC
   status: 1
-  picture: 16200a8e-98be-4e9d-b01b-e4541f8cc524
+  image: 16200a8e-98be-4e9d-b01b-e4541f8cc524
   first_name: Tim
   last_name: Cullen
   organization: Brighton College
@@ -133,7 +133,7 @@ E86254ca-1c50-4f37-81f8-13aef995ae33:
   mail: lorelaimargrate@email.com
   timezone: UTC
   status: 1
-  picture: 9bafc7b0-9c80-4df5-8e05-a642b01dbc1d
+  image: 9bafc7b0-9c80-4df5-8e05-a642b01dbc1d
   first_name: Lorelai
   last_name: Margrate
   organization:

--- a/modules/custom/social_demo/src/DemoContent.php
+++ b/modules/custom/social_demo/src/DemoContent.php
@@ -242,6 +242,35 @@ abstract class DemoContent extends PluginBase implements DemoContentInterface {
   }
 
   /**
+   * Prepares data about an image.
+   *
+   * @param string $picture
+   *   The image uuid.
+   * @param string $alt
+   *   The image alt text.
+   *
+   * @return array
+   *   Returns an array for the image field.
+   */
+  protected function prepareImage($picture, $alt) {
+    $value = NULL;
+    $files = $this->fileStorage->loadByProperties([
+      'uuid' => $picture,
+    ]);
+
+    if ($files) {
+      $value = [
+        [
+          'target_id' => current($files)->id(),
+          'alt' => !empty($alt) ? $alt : 'file' . current($files)->id(),
+        ],
+      ];
+    }
+
+    return $value;
+  }
+
+  /**
    * Makes an array with data of an entity.
    *
    * @param array $item

--- a/modules/custom/social_demo/src/DemoContent.php
+++ b/modules/custom/social_demo/src/DemoContent.php
@@ -5,6 +5,7 @@ namespace Drupal\social_demo;
 use Drupal\Core\Entity\EntityStorageInterface;
 use Drupal\Core\Plugin\PluginBase;
 use Drupal\Core\Url;
+use Drupal\file\Entity\File;
 use Drupal\node\Entity\Node;
 use Drupal\profile\Entity\Profile;
 use Drupal\user\Entity\User;
@@ -252,17 +253,15 @@ abstract class DemoContent extends PluginBase implements DemoContentInterface {
    * @return array
    *   Returns an array for the image field.
    */
-  protected function prepareImage($picture, $alt) {
+  protected function prepareImage($picture, $alt = '') {
     $value = NULL;
-    $files = $this->fileStorage->loadByProperties([
-      'uuid' => $picture,
-    ]);
+    $files = $this->loadByUuid('file', $picture);
 
-    if ($files) {
+    if ($files instanceof File) {
       $value = [
         [
-          'target_id' => current($files)->id(),
-          'alt' => !empty($alt) ? $alt : 'file' . current($files)->id(),
+          'target_id' => $files->id(),
+          'alt' => $alt ?: 'file' . $files->id(),
         ],
       ];
     }

--- a/modules/custom/social_demo/src/DemoGroup.php
+++ b/modules/custom/social_demo/src/DemoGroup.php
@@ -91,7 +91,7 @@ abstract class DemoGroup extends DemoContent {
 
       // Load image by uuid and set to a group.
       if (!empty($item['image'])) {
-        $item['image'] = $this->prepareImage($item['image']);
+        $item['image'] = $this->prepareImage($item['image'], $item['image_alt']);
       }
       else {
         // Set "null" to exclude errors during saving
@@ -197,32 +197,6 @@ abstract class DemoGroup extends DemoContent {
         $entity->addMember($account, $values);
       }
     }
-  }
-
-  /**
-   * Prepares data about an image of a group.
-   *
-   * @param string $image
-   *   The uuid of the image.
-   *
-   * @return array
-   *   Returns an array.
-   */
-  protected function prepareImage($image) {
-    $value = NULL;
-    $files = $this->fileStorage->loadByProperties([
-      'uuid' => $image,
-    ]);
-
-    if ($files) {
-      $value = [
-        [
-          'target_id' => current($files)->id(),
-        ],
-      ];
-    }
-
-    return $value;
   }
 
   /**

--- a/modules/custom/social_demo/src/DemoSystem.php
+++ b/modules/custom/social_demo/src/DemoSystem.php
@@ -120,7 +120,7 @@ abstract class DemoSystem extends DemoContent {
       }
 
       // Logo.
-      $logo = $this->preparePicture($data['theme']['logo']);
+      $logo = $this->prepareImage($data['theme']['logo']);
       // Must be a valid file.
       if ($logo instanceof File) {
         $theme_logo = [
@@ -236,16 +236,16 @@ abstract class DemoSystem extends DemoContent {
   /**
    * Prepares data about an image.
    *
-   * @param string $picture
-   *   The picture by uuid.
+   * @param string $image
+   *   The image by uuid.
    *
    * @return array
    *   Returns an array.
    */
-  protected function preparePicture($picture) {
+  protected function prepareImage($image) {
     $value = NULL;
     $files = $this->fileStorage->loadByProperties([
-      'uuid' => $picture,
+      'uuid' => $image,
     ]);
 
     if ($files) {
@@ -302,7 +302,7 @@ abstract class DemoSystem extends DemoContent {
     ];
 
     /* @var \Drupal\file\Entity\File $file */
-    $file = $this->preparePicture($data['image']);
+    $file = $this->prepareImage($data['image']);
 
     $block_image = [
       'target_id' => $file->id(),

--- a/modules/custom/social_demo/src/DemoSystem.php
+++ b/modules/custom/social_demo/src/DemoSystem.php
@@ -120,7 +120,7 @@ abstract class DemoSystem extends DemoContent {
       }
 
       // Logo.
-      $logo = $this->prepareImage($data['theme']['logo']);
+      $logo = $this->fetchImage($data['theme']['logo']);
       // Must be a valid file.
       if ($logo instanceof File) {
         $theme_logo = [
@@ -242,7 +242,7 @@ abstract class DemoSystem extends DemoContent {
    * @return array
    *   Returns an array.
    */
-  protected function prepareImage($image) {
+  protected function fetchImage($image) {
     $value = NULL;
     $files = $this->fileStorage->loadByProperties([
       'uuid' => $image,
@@ -302,12 +302,8 @@ abstract class DemoSystem extends DemoContent {
     ];
 
     /* @var \Drupal\file\Entity\File $file */
-    $file = $this->prepareImage($data['image']);
-
-    $block_image = [
-      'target_id' => $file->id(),
-      'alt' => "Anonymous front page image homepage'",
-    ];
+    $block_image = $this->prepareImage($data['image'], 'Anonymous front page image homepage');
+    // Insert is in the hero image field.
     $block->field_hero_image = $block_image;
 
     // Set the links.

--- a/modules/custom/social_demo/src/DemoUser.php
+++ b/modules/custom/social_demo/src/DemoUser.php
@@ -90,13 +90,13 @@ abstract class DemoUser extends DemoContent {
       }
 
       // Load image by uuid and set to a profile.
-      if (!empty($item['picture'])) {
-        $item['picture'] = $this->preparePicture($item['picture']);
+      if (!empty($item['image'])) {
+        $item['image'] = $this->prepareImage($item['image'], $item['image_alt']);
       }
       else {
         // Set "null" to exclude errors during saving
-        // (in cases when picture will equal to "false").
-        $item['picture'] = NULL;
+        // (in cases when image will equal to "false").
+        $item['image'] = NULL;
       }
 
       if (!empty($item['expertise'])) {
@@ -162,32 +162,6 @@ abstract class DemoUser extends DemoContent {
   }
 
   /**
-   * Prepares data about an image of a profile.
-   *
-   * @param string $picture
-   *   The picture by uuid.
-   *
-   * @return array
-   *   Returns an array.
-   */
-  protected function preparePicture($picture) {
-    $value = NULL;
-    $files = $this->fileStorage->loadByProperties([
-      'uuid' => $picture,
-    ]);
-
-    if ($files) {
-      $value = [
-        [
-          'target_id' => current($files)->id(),
-        ],
-      ];
-    }
-
-    return $value;
-  }
-
-  /**
    * Returns taxonomy terms for UUIDs.
    *
    * @param array $values
@@ -224,7 +198,7 @@ abstract class DemoUser extends DemoContent {
    *   The profile field item.
    */
   protected function fillProfile(ProfileInterface $profile, array $item) {
-    $profile->field_profile_image = $item['picture'];
+    $profile->field_profile_image = $item['image'];
     $profile->field_profile_first_name = $item['first_name'];
     $profile->field_profile_last_name = $item['last_name'];
     $profile->field_profile_organization = $item['organization'];

--- a/modules/custom/social_demo/src/Plugin/DemoContent/Book.php
+++ b/modules/custom/social_demo/src/Plugin/DemoContent/Book.php
@@ -72,7 +72,7 @@ class Book extends DemoNode {
 
     // Load image by uuid and set to node.
     if (!empty($item['field_book_image'])) {
-      $entry['field_book_image'] = $this->prepareImage($item['field_book_image']);
+      $entry['field_book_image'] = $this->prepareImage($item['image'], $item['image_alt']);
     }
 
     // Load attachments to node.
@@ -115,32 +115,6 @@ class Book extends DemoNode {
       }
     }
     return $entry;
-  }
-
-  /**
-   * Prepares data about an image of node.
-   *
-   * @param string $uuid
-   *   The uuid for the image.
-   *
-   * @return array|null
-   *   Returns an array or null.
-   */
-  protected function prepareImage($uuid) {
-    $value = NULL;
-    $files = $this->fileStorage->loadByProperties([
-      'uuid' => $uuid,
-    ]);
-
-    if ($files) {
-      $value = [
-        [
-          'target_id' => current($files)->id(),
-        ],
-      ];
-    }
-
-    return $value;
   }
 
 }

--- a/modules/custom/social_demo/src/Plugin/DemoContent/Event.php
+++ b/modules/custom/social_demo/src/Plugin/DemoContent/Event.php
@@ -76,8 +76,8 @@ class Event extends DemoNode {
     $entry['field_content_visibility'] = $item['field_content_visibility'];
 
     // Load image by uuid and set to node.
-    if (!empty($item['field_event_image'])) {
-      $entry['field_event_image'] = $this->prepareImage($item['field_event_image']);
+    if (!empty($item['image'])) {
+      $entry['field_event_image'] = $this->prepareImage($item['image'], $item['image_alt']);
     }
 
     // Load attachments to node.
@@ -109,32 +109,6 @@ class Event extends DemoNode {
 
     return $date;
 
-  }
-
-  /**
-   * Prepares data about an image of node.
-   *
-   * @param string $uuid
-   *   The uuid for the image.
-   *
-   * @return array|null
-   *   Returns an array or null.
-   */
-  protected function prepareImage($uuid) {
-    $value = NULL;
-    $files = $this->fileStorage->loadByProperties([
-      'uuid' => $uuid,
-    ]);
-
-    if ($files) {
-      $value = [
-        [
-          'target_id' => current($files)->id(),
-        ],
-      ];
-    }
-
-    return $value;
   }
 
   /**

--- a/modules/custom/social_demo/src/Plugin/DemoContent/Page.php
+++ b/modules/custom/social_demo/src/Plugin/DemoContent/Page.php
@@ -60,8 +60,8 @@ class Page extends DemoNode {
     $entry['field_content_visibility'] = $item['field_content_visibility'];
 
     // Load image by uuid and set to node.
-    if (!empty($item['field_page_image'])) {
-      $entry['field_page_image'] = $this->prepareImage($item['field_page_image']);
+    if (!empty($item['image'])) {
+      $entry['field_page_image'] = $this->prepareImage($item['image'], $item['image_alt']);
     }
 
     if (!empty($item['alias'])) {
@@ -71,32 +71,6 @@ class Page extends DemoNode {
     }
 
     return $entry;
-  }
-
-  /**
-   * Prepares data about an image of node.
-   *
-   * @param string $uuid
-   *   The uuid for the image.
-   *
-   * @return array|null
-   *   Returns an array or null.
-   */
-  protected function prepareImage($uuid) {
-    $value = NULL;
-    $files = $this->fileStorage->loadByProperties([
-      'uuid' => $uuid,
-    ]);
-
-    if ($files) {
-      $value = [
-        [
-          'target_id' => current($files)->id(),
-        ],
-      ];
-    }
-
-    return $value;
   }
 
 }

--- a/modules/custom/social_demo/src/Plugin/DemoContent/Topic.php
+++ b/modules/custom/social_demo/src/Plugin/DemoContent/Topic.php
@@ -75,8 +75,8 @@ class Topic extends DemoNode {
     }
 
     // Load image by uuid and set to node.
-    if (!empty($item['field_topic_image'])) {
-      $entry['field_topic_image'] = $this->prepareImage($item['field_topic_image']);
+    if (!empty($item['image'])) {
+      $entry['field_topic_image'] = $this->prepareImage($item['image'], $item['image_alt']);
     }
 
     // Load attachments to node.
@@ -85,32 +85,6 @@ class Topic extends DemoNode {
     }
 
     return $entry;
-  }
-
-  /**
-   * Prepares data about an image of node.
-   *
-   * @param string $uuid
-   *   Type of uuid.
-   *
-   * @return array|null
-   *   Returns array|null
-   */
-  protected function prepareImage($uuid) {
-    $value = NULL;
-    $files = $this->fileStorage->loadByProperties([
-      'uuid' => $uuid,
-    ]);
-
-    if ($files) {
-      $value = [
-        [
-          'target_id' => current($files)->id(),
-        ],
-      ];
-    }
-
-    return $value;
   }
 
   /**


### PR DESCRIPTION
## Problem
Images alternative text is not present in demo content

## Solution

1. Check demo content module and add alternative text for all images.
2. Change demo content parser for this alternative text values

## Issue tracker
- https://www.drupal.org/project/social/issues/2975731
- https://jira.goalgorilla.com/browse/ECI-686

## HTT
- [x] Check out the code changes
- [x] Check that all demo content images don't have alt texts
- [x] Checkout to this branch
- [x] Reinstall the site
- [x] Check that all demo content images now have alt texts

## Documentation
- [x] This item is added to the release notes
- [ ] This item is documented on LGOS
- [ ] This item has been added to the feature overview
