### PR TITLE
Issue #2975745 : Add possibility to edit profile directly from People overview

### DIFF
--- a/modules/social_features/social_profile/social_profile.module
+++ b/modules/social_features/social_profile/social_profile.module
@@ -543,7 +543,7 @@ function _social_profile_form_pre_render($element) {
 /**
  * Implements hook_entity_operation_alter().
  */
-function social_profile_entity_operation_alter(array &$operations, \Drupal\Core\Entity\EntityInterface $entity) {
+function social_profile_entity_operation_alter(array &$operations, EntityInterface $entity) {
   if ($entity->getEntityTypeId() === 'user') {
     if (isset($operations['edit'])) {
       $operations['edit']['title'] = t('Edit account');

--- a/modules/social_features/social_profile/social_profile.module
+++ b/modules/social_features/social_profile/social_profile.module
@@ -539,3 +539,19 @@ function _social_profile_form_pre_render($element) {
   $element['group_locale_settings']['timezone']['#title'] = NULL;
   return $element;
 }
+
+/**
+ * Implements hook_entity_operation_alter().
+ */
+function social_profile_entity_operation_alter(array &$operations, \Drupal\Core\Entity\EntityInterface $entity) {
+  if ($entity->getEntityTypeId() === 'user') {
+    if (isset($operations['edit'])) {
+      $operations['edit']['title'] = t('Edit account');
+      $operations['edit_profile'] = [
+        'title' => t('Edit profile'),
+        'weight' => (isset($operations['edit']['weight'])) ? $operations['edit']['weight']-- : 0,
+        'url' => Url::fromUserInput('/user/' . $entity->id() . '/profile'),
+      ];
+    }
+  }
+}


### PR DESCRIPTION
## Problem
Currently the admin/people overview does not make a distinction between the edit account page and the edit profile page. On the account settings form you can edit the username, e-mail and user's settings. On the edit profile page you can edit the profile information including the first name, last name and organisation.

A site manager now has to click on the profile first and then on the pencil to edit the profile and this breaks the flow since the ?destination=admin/people is not added to the link.

## Solution
Add the "Edit profile" link to the operations and change the current edit link title to "Edit account".

## Issue tracker
- https://www.drupal.org/project/social/issues/2975745

## HTT
- [x] Check out the code changes
- [x] Login as site manager
- [x] Go to the people overview
- [x] Note that there are now two operations (Edit account and Edit profile) and verify those work
- [x] Check for other occurrences where these operations might be displayed, but shouldn't

## Documentation
- [ ] This item is added to the release notes
- [ ] This item is documented on LGOS
- [ ] This item has been added to the feature overview
- [ ] Check if screenshots need to be adjusted on LGOS (I couldn't find any)