### PR TITLE
SHN-96: Make sure the user entityreference also works with nickname

### DIFF
--- a/modules/social_features/social_profile/src/Plugin/EntityReferenceSelection/UserSelection.php
+++ b/modules/social_features/social_profile/src/Plugin/EntityReferenceSelection/UserSelection.php
@@ -36,14 +36,24 @@ class UserSelection extends UserSelectionBase {
     $query = $this->connection->select('profile', 'p')
       ->fields('p', ['uid']);
 
+    $addNickName = $this->moduleHandler->moduleExists('social_profile_fields');
+
     $query->join('profile__field_profile_first_name', 'fn', 'fn.entity_id = p.profile_id');
     $query->join('profile__field_profile_last_name', 'ln', 'ln.entity_id = p.profile_id');
+
+    if ($addNickName === TRUE) {
+      $query->join('profile__field_profile_nick_name', 'nn', 'nn.entity_id = p.profile_id');
+    }
 
     $name = $this->connection->escapeLike($match);
 
     $or = $query->orConditionGroup();
     $or->condition('fn.field_profile_first_name_value', '%' . $name . '%', 'LIKE');
     $or->condition('ln.field_profile_last_name_value', '%' . $name . '%', 'LIKE');
+
+    if ($addNickName === TRUE) {
+      $or->condition('nn.field_profile_nick_name_value', '%' . $name . '%', 'LIKE');
+    }
 
     $ids = $query->condition($or)->execute()->fetchCol();
 


### PR DESCRIPTION
## Problem
When enabling the social_profile_fields module, searching on nickname in entity references does not work.

## Solution
The new created entityreference for users is now updated with the nickname field (if it exists)

## Issue tracker
- https://jira.goalgorilla.com/browse/SHN-96

## TODO
This entityreference is now using a selectQuery instead of a entityQuery (which is normal for an entityreference). We need to reconsider this approach. One of the issues is that you cannot change this query with a hook_query_alter for instance. (the query is overriden)

## HTT
- [x] Check out the code changes
- [x] Enable the social_profile_fields module
- [x] Login as user `alisonhendrix` and change username to `vera` and nickname to `Skiire`
- [x] Try to add her to a group, by using all three names mentioned above
- [x] See that it works

## Documentation
- [x] This item is added to the release notes
- [ ] This item is documented on LGOS
- [ ] This item has been added to the feature overview
