### PR TITLE
Issue #2976549 by Kingdutch, bramtenhove, robertragas: Page title block should not be shown on landing page 404 or 403 pages

### DIFF
--- a/modules/social_features/social_core/src/Plugin/Block/SocialPageTitleBlock.php
+++ b/modules/social_features/social_core/src/Plugin/Block/SocialPageTitleBlock.php
@@ -2,10 +2,18 @@
 
 namespace Drupal\social_core\Plugin\Block;
 
+use Drupal\Core\Controller\TitleResolverInterface;
+use Drupal\Core\Entity\EntityRepositoryInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\Routing\RouteMatchInterface;
 use Symfony\Cmf\Component\Routing\RouteObjectInterface;
 use Drupal\node\Entity\Node;
 use Drupal\Core\Block\Plugin\Block\PageTitleBlock;
 use Drupal\Core\Url;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 /**
  * Provides a 'SocialPageTitleBlock' block.
@@ -15,14 +23,83 @@ use Drupal\Core\Url;
  *  admin_label = @Translation("Page title block"),
  * )
  */
-class SocialPageTitleBlock extends PageTitleBlock {
+class SocialPageTitleBlock extends PageTitleBlock implements ContainerFactoryPluginInterface {
+
+  /**
+   * The route match.
+   *
+   * @var \Drupal\Core\Routing\RouteMatchInterface
+   */
+  protected $routeMatch;
+
+  /**
+   * The route match.
+   *
+   * @var \Drupal\social_tagging\SocialTaggingService
+   */
+  protected $requestStack;
+
+  /**
+   * The entity repository.
+   *
+   * @var \Drupal\Core\Entity\EntityRepositoryInterface
+   */
+  protected $entityRepository;
+
+  /**
+   * The title resolver service.
+   *
+   * @var \Drupal\Core\Controller\TitleResolverInterface
+   */
+  protected $titleResolver;
+
+  /**
+   * EventAddBlock constructor.
+   *
+   * @param array $configuration
+   *   The given configuration.
+   * @param string $plugin_id
+   *   The given plugin id.
+   * @param mixed $plugin_definition
+   *   The given plugin definition.
+   * @param \Drupal\Core\Routing\RouteMatchInterface $route_match
+   *   The route match.
+   * @param \Symfony\Component\HttpFoundation\RequestStack $request_stack
+   *   The current request stack.
+   * @param \Drupal\Core\Entity\EntityRepositoryInterface $entity_repository
+   *   The entity repository.
+   * @param \Drupal\Core\Controller\TitleResolverInterface $title_resolver
+   *   The title resolver.
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, RouteMatchInterface $route_match, RequestStack $request_stack, EntityRepositoryInterface $entity_repository, TitleResolverInterface $title_resolver) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->routeMatch = $route_match;
+    $this->requestStack = $request_stack;
+    $this->entityRepository = $entity_repository;
+    $this->titleResolver = $title_resolver;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('current_route_match'),
+      $container->get('request_stack'),
+      $container->get('entity.repository'),
+      $container->get('title_resolver')
+    );
+  }
 
   /**
    * {@inheritdoc}
    */
   public function build() {
     // Take the raw parameter. We'll load it ourselves.
-    $nid = \Drupal::routeMatch()->getRawParameter('node');
+    $nid = $this->routeMatch->getRawParameter('node');
     $node = FALSE;
     $current_url = Url::fromRoute('<current>');
     $current_path = $current_url->toString();
@@ -33,8 +110,23 @@ class SocialPageTitleBlock extends PageTitleBlock {
       $node = Node::load($nid);
     }
 
+    $request = $this->requestStack->getCurrentRequest();
+
     if ($node) {
-      $translation = \Drupal::service('entity.repository')->getTranslationFromContext($node);
+      // Landing pages have their own heroes. Usually we're not displayed for
+      // landing page. However, when a landing page is used as a 404 or 403 page
+      // then this block is still rendered. Therefor if we're asked to render
+      // for a landing page we check if we're not in a 404 or 403. If we are
+      // then we can quickly determine we won't render anything.
+      if ($node->getType() === "landing_page") {
+        $exception = $request->attributes->get('exception');
+
+        if ($exception instanceof NotFoundHttpException || $exception instanceof AccessDeniedHttpException) {
+          return [];
+        }
+      }
+
+      $translation = $this->entityRepository->getTranslationFromContext($node);
 
       if (!empty($translation)) {
         $node->setTitle($translation->getTitle());
@@ -72,10 +164,8 @@ class SocialPageTitleBlock extends PageTitleBlock {
     }
     else {
 
-      $request = \Drupal::request();
-
       if ($route = $request->attributes->get(RouteObjectInterface::ROUTE_OBJECT)) {
-        $title = \Drupal::service('title_resolver')->getTitle($request, $route);
+        $title = $this->titleResolver->getTitle($request, $route);
         return [
           '#type' => 'page_title',
           '#title' => $title,

--- a/tests/behat/config/behat.yml
+++ b/tests/behat/config/behat.yml
@@ -17,6 +17,7 @@ default:
         - SocialDrupalContext
         - SocialMinkContext
         - Drupal\DrupalExtension\Context\BatchContext
+        - Drupal\DrupalExtension\Context\ConfigContext
         - Drupal\DrupalExtension\Context\MessageContext
         - PostContext
         - EmailContext

--- a/tests/behat/features/capabilities/landing-page/landing-page-as-404.feature
+++ b/tests/behat/features/capabilities/landing-page/landing-page-as-404.feature
@@ -25,12 +25,9 @@ Feature: Use a landing page as 404 page
     And I fill in "URL alias" with "page-not-found"
     And I press "Save"
     And I wait for "3" seconds
-    # Ses as LU
+    # See as LU
     Then I should see "Landing page Page not found has been created."
-    When I am on "/admin/config/system/site-information"
-    And I fill in the following:
-      | edit-site-404 | /page-not-found |
-    And I press "Save configuration"
-    Given I am on "this-is-a-page-that-should-never-exist-thats-why-its-so-long-if-this-does-exist-then-this-test-breaks"
+    Given I set the configuration item "system.site" with key "page.404" to "/page-not-found"
+    And I am on "this-is-a-page-that-should-never-exist-thats-why-its-so-long-if-this-does-exist-then-this-test-breaks"
     Then I should see "Hero title"
     And I should not see an ".block-social-page-title-block" element

--- a/tests/behat/features/capabilities/landing-page/landing-page-as-404.feature
+++ b/tests/behat/features/capabilities/landing-page/landing-page-as-404.feature
@@ -1,0 +1,36 @@
+@api @landing-page @stability @perfect @critical @stability-4
+Feature: Use a landing page as 404 page
+  Benefit: Provide a customisable visually pleasing 404 page
+  Role: LU
+  Goal/desire: I want to use a landing page as not found page
+
+  Scenario: Create a landing page and configure it as 404 page
+
+    Given I enable the module "social_landing_page"
+    # Create Landing Page Hero
+    Given I am logged in as an "sitemanager"
+    When I am on "node/add/landing_page"
+    And I fill in the following:
+      | Title | Page not found |
+    And I click radio button "Public - visible to everyone including people who are not a member" with the id "edit-field-content-visibility-public"
+    And I press "Add Section"
+    And I wait for AJAX to finish
+    And I press "Add Hero"
+    And I wait for AJAX to finish
+    And I fill in the following:
+      | field_landing_page_section[0][subform][field_section_paragraph][0][subform][field_hero_title][0][value]                                     | Hero title    |
+      | field_landing_page_section[0][subform][field_section_paragraph][0][subform][field_hero_subtitle][0][value]                                  | Hero subtitle |
+    # Set URL Alias
+    And I click "URL path settings"
+    And I fill in "URL alias" with "page-not-found"
+    And I press "Save"
+    And I wait for "3" seconds
+    # Ses as LU
+    Then I should see "Landing page Page not found has been created."
+    When I am on "/admin/config/system/site-information"
+    And I fill in the following:
+      | edit-site-404 | /page-not-found |
+    And I press "Save configuration"
+    Given I am on "this-is-a-page-that-should-never-exist-thats-why-its-so-long-if-this-does-exist-then-this-test-breaks"
+    Then I should see "Hero title"
+    And I should not see an ".block-social-page-title-block" element


### PR DESCRIPTION
## Problem
When a landing page is used as a 404 or 403 page then the page title block is shown but this conflicts with landing page's own heroes.

## Solution
Let the page title block check if it's being rendered in a 404 or 403 context that uses a landing page.

## Issue tracker
- https://www.drupal.org/project/social/issues/2976549

## HTT
- [x] Check out the code changes
- [x] Create a landing page
- [x] In basic site settings set the landing page as 404 page
- [x] Go to a non-existent page and see that the page title block is not there
- [x] See that the included test fails before the fix and is green after the fix

## Documentation
Landing pages can now be used to retain users on Page not found pages!

- [x] This item is added to the release notes
- [ ] This item is documented on LGOS
- [ ] This item has been added to the feature overview
