### PR TITLE
Issue #2978155 by Makishima: Add alter hook for the ActivityOverviewBlock content

### DIFF
--- a/modules/social_features/social_landing_page/social_landing_page.api.php
+++ b/modules/social_features/social_landing_page/social_landing_page.api.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * @file
+ * Hooks provided by the Social Landing Page module.
+ */
+
+/**
+ * Alter ActivityOverviewBlock.
+ * @param array $content
+ *   Block content.
+ */
+function hook_social_landing_page_activity_overview_alter(array &$content) {
+
+}

--- a/modules/social_features/social_landing_page/src/Plugin/Block/ActivityOverviewBlock.php
+++ b/modules/social_features/social_landing_page/src/Plugin/Block/ActivityOverviewBlock.php
@@ -53,7 +53,7 @@ class ActivityOverviewBlock extends BlockBase implements ContainerFactoryPluginI
    * {@inheritdoc}
    */
   public function build() {
-    return [
+    $content = [
       [
         '#type' => 'container',
         '#attributes' => [
@@ -274,6 +274,9 @@ class ActivityOverviewBlock extends BlockBase implements ContainerFactoryPluginI
       ],
     ];
 
+    \Drupal::moduleHandler()->alter('social_landing_page_activity_overview', $content);
+
+    return $content;
   }
 
   /**


### PR DESCRIPTION
## Problem

Unable to rename elements of the activity overview block which is rendered as a paragraph on the landing page using the renaming module (which based on social_renamer module).
(This changes needed to rename groups to initiatives in the according to task https://jira.goalgorilla.com/browse/OSSUPPORT-915) 

## Solutions

Provide an alter hook for the ActivityOverviewBlock content in the ActivityOverviewBlock.php of social_landing_page module that allows other modules to change the block content.

## Issue tracker
- https://www.drupal.org/project/social/issues/2978155

## HTT
- [ ] Check out the code changes
