### PR TITLE
#2976036 - Add comment on node in group to activity stream (again)

### DIFF
--- a/modules/social_features/social_activity/config/install/message.template.create_comment_group_node.yml
+++ b/modules/social_features/social_activity/config/install/message.template.create_comment_group_node.yml
@@ -11,6 +11,7 @@ third_party_settings:
     activity_context: group_activity_context
     activity_destinations:
       stream_explore: stream_explore
+      stream_group: stream_group
       stream_home: stream_home
       stream_profile: stream_profile
     activity_create_direct: 1

--- a/tests/behat/features/capabilities/activity-stream/activity-stream-comments.feature
+++ b/tests/behat/features/capabilities/activity-stream/activity-stream-comments.feature
@@ -114,7 +114,7 @@ Feature: See comments in activity stream
     And I am on the stream of group "Test open group"
     Then I should see "CreateUser created an event in Test open group"
     And I should see "Test group event"
-    And I should not see "This is a third event comment"
+    And I should see "This is a third event comment"
     And I should not see "This is a first event comment"
     And I should not see "This is a reply event comment"
 


### PR DESCRIPTION
## Problem
Currently when someone comments on a node in the group this is not showing in the activity stream of that group. This is not correct and it should always display in the group stream.

## Solution
In https://github.com/goalgorilla/open_social/pull/803/files this template was also changed:
message.template.create_comment_group_node.yml this was a mistake and that change should be reverted.

## Issue tracker
- https://www.drupal.org/project/social/issues/2976036

## HTT
- [x] Check out the code changes
- [x] Login as user X and create a node in a group
- [x] Comment on this node once and a few times
- [x] Note that the comment is visible in the activity stream of the group

## Documentation
- [x] This item is added to the release notes
- [ ] This item is documented on LGOS
- [ ] This item has been added to the feature overview
