### PR TITLE
OSSUPPORT-904: Use RawDrupalContext::getUserManager->getCurrentUser() 

### DIFF
--- a/tests/behat/features/bootstrap/SocialDrupalContext.php
+++ b/tests/behat/features/bootstrap/SocialDrupalContext.php
@@ -33,7 +33,10 @@ class SocialDrupalContext extends DrupalContext {
    * @Given I am viewing my :type( content):
    */
   public function assertViewingMyNode($type, TableNode $fields) {
-    if (!$this->getUserManager->getCurrentUser()) {
+
+    $user_manager = $this->getUserManager();
+    $user = $user_manager->getCurrentUser();
+    if (!$user) {
       throw new \Exception(sprintf('There is no current logged in user to create a node for.'));
     }
 
@@ -47,8 +50,7 @@ class SocialDrupalContext extends DrupalContext {
       $node->{$field} = $value;
     }
 
-    $node->uid = $this->getUserManager->getCurrentUser()->uid;
-
+    $node->uid = $user->uid;
     $saved = $this->nodeCreate($node);
 
     // Set internal browser on the node.

--- a/tests/behat/features/bootstrap/SocialDrupalContext.php
+++ b/tests/behat/features/bootstrap/SocialDrupalContext.php
@@ -33,7 +33,7 @@ class SocialDrupalContext extends DrupalContext {
    * @Given I am viewing my :type( content):
    */
   public function assertViewingMyNode($type, TableNode $fields) {
-    if (!isset($this->getUserManager->getCurrentUser())) {
+    if (!$this->getUserManager->getCurrentUser()) {
       throw new \Exception(sprintf('There is no current logged in user to create a node for.'));
     }
 

--- a/tests/behat/features/bootstrap/SocialDrupalContext.php
+++ b/tests/behat/features/bootstrap/SocialDrupalContext.php
@@ -33,7 +33,7 @@ class SocialDrupalContext extends DrupalContext {
    * @Given I am viewing my :type( content):
    */
   public function assertViewingMyNode($type, TableNode $fields) {
-    if (!isset($this->user->uid)) {
+    if (!isset($this->getUserManager->getCurrentUser())) {
       throw new \Exception(sprintf('There is no current logged in user to create a node for.'));
     }
 
@@ -47,7 +47,7 @@ class SocialDrupalContext extends DrupalContext {
       $node->{$field} = $value;
     }
 
-    $node->uid = $this->user->uid;
+    $node->uid = $this->getUserManager->getCurrentUser()->uid;
 
     $saved = $this->nodeCreate($node);
 


### PR DESCRIPTION
## Problem
Got this warning when running tests:
`Interacting directly with the RawDrupalContext::$user property has been deprecated. Use RawDrupalContext::getUserManager->getCurrentUser() instead.`

## Solution
Use RawDrupalContext::getUserManager->getCurrentUser() instead.

## Issue tracker
- OSSUPPORT-904

## HTT
- [ ] Just see if the tests are passing.

## Documentation
- [ ] This item is added to the release notes
- [ ] This item is documented on LGOS
- [ ] This item has been added to the feature overview
