### PR TITLE
DS-5713:make sure embed for LU works for all combinations of modules

### DIFF
--- a/modules/social_features/social_embed/social_embed.services.yml
+++ b/modules/social_features/social_embed/social_embed.services.yml
@@ -2,8 +2,8 @@ services:
   social_embed.overrider:
     class: \Drupal\social_embed\SocialEmbedConfigOverride
     tags:
-      - {name: config.factory.override, priority: 5}
+      - {name: config.factory.override, priority: 50}
   social_embed_editor.overrider:
     class: \Drupal\social_embed\SocialEmbedEditorConfigOverride
     tags:
-      - {name: config.factory.override, priority: 5}
+      - {name: config.factory.override, priority: 51}

--- a/modules/social_features/social_profile/modules/social_profile_fields/src/SocialProfileFieldsOverride.php
+++ b/modules/social_features/social_profile/modules/social_profile_fields/src/SocialProfileFieldsOverride.php
@@ -53,7 +53,7 @@ class SocialProfileFieldsOverride implements ConfigFactoryOverrideInterface {
    * {@inheritdoc}
    */
   public function getCacheSuffix() {
-    return 'SocialCommentUploadConfigOverride';
+    return 'SocialProfileFieldsOverride';
   }
 
   /**


### PR DESCRIPTION
## Problem
HTT:

Login as LU on the SaaS environment
Go to `node/add/topic`
Click on the Embed button
Note that nothing happens

Apparently this happens when some other modules are enabled with the same config override priority. E.g. `SocialMentionsConfigOverride`

## Solution
I've increased the priority of this module's configoverrides. 

## Issue tracker
- DS-5713

## HTT
- [x] Check out the code changes
- [ ] Login as LU
- [ ] Go to `node/add/topic` 
- [ ] Click on the 'media' button to add Embed URL.
- [ ] Save node
- [ ] See that it works!

## Documentation
- [ ] This item is added to the release notes
- [ ] This item is documented on LGOS
- [ ] This item has been added to the feature overview
