### PR TITLE
2980692 by robertragas: Use label of content-type so it takes transla…

### DIFF
--- a/modules/social_features/social_like/social_like.tokens.inc
+++ b/modules/social_features/social_like/social_like.tokens.inc
@@ -63,7 +63,13 @@ function social_like_tokens($type, $tokens, array $data, array $options, Bubblea
             // Check if the content type is node.
             if ($content_type === 'node') {
               // Then get the bundle name.
-              $content_type = $entity->bundle();
+              $content_type = Unicode::strtolower(\Drupal::entityTypeManager()
+                ->getStorage('node_type')
+                ->load($entity->bundle())
+                ->label());
+            }
+            if ($content_type === 'post' || $content_type === 'photo' || $content_type === 'comment') {
+              $content_type = Unicode::strtolower($entity->getEntityType()->getLabel());
             }
 
             $replacements[$original] = $content_type;

--- a/modules/social_features/social_like/social_like.tokens.inc
+++ b/modules/social_features/social_like/social_like.tokens.inc
@@ -5,6 +5,7 @@
  * Builds placeholder replacement tokens for Social Like module.
  */
 
+use Drupal\Component\Utility\Unicode;
 use Drupal\Core\Render\BubbleableMetadata;
 use Drupal\votingapi\Entity\Vote;
 


### PR DESCRIPTION
…tion

## Problem
In the notification stream of a user it does not translate the content-type ,content from posts / photo's and comments.

## Solution
Use the bundle label instead of the bundle machine name and created exceptions for the other types just like social_group module does.

## Issue tracker
- https://www.drupal.org/project/social/issues/2980692

## HTT
- [ ] Check out the code changes
- [ ] Login / add a content-type translation and like your own content of this type
- [ ] Notice that the notification is not translated
- [ ] Checkout to this branch
- [ ] Reload the notification stream and see it's translated

## Documentation
- [ ] This item is added to the release notes
- [ ] This item is documented on LGOS
- [ ] This item has been added to the feature overview
