### PR TITLE
#2932250 by bramtenhove: Remove the interval check for items in the daily digest

### DIFF
--- a/modules/custom/activity_send/modules/activity_send_email/activity_send_email.module
+++ b/modules/custom/activity_send/modules/activity_send_email/activity_send_email.module
@@ -42,7 +42,6 @@ function activity_send_email_cron() {
         $query = $db->select('user_activity_digest', 'uad')
           ->fields('uad', ['uid', 'activity'])
           ->condition('uad.frequency', $frequency['id'])
-          ->condition('uad.timestamp', time() - $interval, '<=')
           ->orderBy('uad.timestamp', 'DESC');
         $activitities = $query->execute()->fetchAll();
 


### PR DESCRIPTION
## Problem
The digest selects digest items based on if their timestamp has passed (for example) 24 hours. This is not correct as it should just select anything available.

## Solution
Simply remove the check on timestamp.

## Issue tracker
- https://www.drupal.org/project/social/issues/2932250

## HTT
- [x] Check out the code changes
- [x] Make sure the value of `digest.daily.last_run` is set to the timestamp of now
- [x] Set email notification settings to Daily for user X
- [x] As user Y post on the profile of user X
- [x] Run cron a few time, you did not receive an email
- [x] Change the value of `digest.daily.last_run` to something 24 hours ago (e.g. 1)
- [x] Run cron a few times, user X should've received a digest email

## Documentation
- [x] This item is added to the release notes