### PR TITLE
2942350: Pages and Landing page as featured in landing pages

### DIFF
--- a/modules/social_features/social_landing_page/config/install/core.entity_view_display.node.page.featured.yml
+++ b/modules/social_features/social_landing_page/config/install/core.entity_view_display.node.page.featured.yml
@@ -25,7 +25,7 @@ content:
     label: above
     settings:
       image_style: social_featured
-      image_link: ''
+      image_link: content
     third_party_settings: {  }
   groups:
     type: entity_reference_label

--- a/modules/social_features/social_landing_page/social_landing_page.module
+++ b/modules/social_features/social_landing_page/social_landing_page.module
@@ -7,9 +7,11 @@
 
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Template\Attribute;
+use Drupal\file\Entity\File;
 use Drupal\image\Entity\ImageStyle;
 use Drupal\node\NodeInterface;
 use Drupal\node\Entity\Node;
+use Drupal\paragraphs\Entity\Paragraph;
 
 /**
  * Implements hook_form_alter().
@@ -177,6 +179,14 @@ function social_landing_page_preprocess_node(&$variables) {
   /** @var \Drupal\node\Entity\Node $node */
   $node = $variables['node'];
   if ($node->getType() === 'landing_page') {
+    // If featured we need to do some magic.
+    if ($variables['view_mode'] === 'featured') {
+      $variables['content']['field_landing_page_image'] = [
+        '#type' => 'markup',
+        '#markup' => _social_landing_page_get_hero_image($node),
+      ];
+
+    }
     // Get current user.
     $account = \Drupal::currentUser();
 
@@ -195,4 +205,61 @@ function social_landing_page_preprocess_node(&$variables) {
       }
     }
   }
+}
+
+/**
+ * Fetches the first available hero section image from a landing page.
+ *
+ * @param \Drupal\node\Entity\Node $node
+ *   The landing page.
+ *
+ * @return array
+ *   Render array of the image with a link.
+ *
+ * @throws \Drupal\Core\Entity\EntityMalformedException
+ */
+function _social_landing_page_get_hero_image(Node $node) {
+  // Must be a valid node.
+  if (!$node instanceof Node) {
+    return [];
+  }
+
+  // Loop over the landing page sections of the landing page.
+  foreach ($node->get('field_landing_page_section') as $section) {
+    // Get the referenced paragraph.
+    $referenced = $section->getValue();
+    $paragraph_id = $referenced['target_id'];
+    // First paragraph is always of type section.
+    $paragraph_section = Paragraph::load($paragraph_id);
+
+    // Get the related paragraph (the one with the actual content)
+    $section_id = $paragraph_section->get('field_section_paragraph')->target_id;
+    $paragraph_content = Paragraph::load($section_id);
+
+    // Must be of type hero.
+    if ($paragraph_content->getType() === 'hero') {
+      $fid = $paragraph_content->get('field_hero_image')->target_id;
+      $file = File::load($fid);
+      // Check if it's an existing file.
+      if ($file instanceof File) {
+        // Build an image render array.
+        $image = [
+          '#theme' => 'image_style',
+          '#style_name' => 'social_featured',
+          '#uri' => $file->getFileUri(),
+        ];
+        // Build a link render array.
+        $build = [
+          '#title' => render($image),
+          '#type' => 'link',
+          '#url' => $node->toUrl('canonical'),
+        ];
+      }
+      // We immediately return the 1st found hero.
+      return render($build);
+    }
+  }
+
+  return [];
+
 }

--- a/modules/social_features/social_landing_page/templates/node--landing-page--featured.html.twig
+++ b/modules/social_features/social_landing_page/templates/node--landing-page--featured.html.twig
@@ -1,5 +1,16 @@
 {% extends 'node--featured.html.twig' %}
 
+  {% block card_hero_image %}
+    <div class="img_wrapper">
+        {% if content.field_landing_page_image|render %}
+            {{ content.field_landing_page_image }}
+        {% else %}
+          <hr class="no-feature-image">
+        {% endif %}
+    </div>
+  {% endblock %}
+
+
 {% block card_body %}
 
   <div class="card__link">


### PR DESCRIPTION
## Problem
Landing pages had no image if you'd feature them in a landing page. Pages did have an image, but it was not clickable

## Solution
Featured landing pages will now try to use the image of the first hero section (if available) and render that image with the correct link. Also featured images of pages now have a link to the content.

## Issue tracker
- https://www.drupal.org/project/social/issues/2942350
- https://jira.goalgorilla.com/browse/OSSUPPORT-493
- https://jira.goalgorilla.com/browse/ECI-799

## HTT
- [x] Check out the code changes
- [x] Turn on the social_landing_page module
- [x] Create (at least) 2 public landing pages with a hero (not necessarily on top)
- [x] Create 1 public page with a hero image
- [x] In 1 of the 2 landing pages, create a featured section, in which you feature the other landing page and the normal page.
- [x] Notice both have an image and a link to the content
- [x] Add another hero section to the landing page you've just featured
- [x] Notice the new image is not used
- [x] Move the new image above the initial image
- [x] Notice that now it IS used as featured.

## Documentation
- [ ] This item is added to the release notes
- [ ] This item is documented on LGOS
- [ ] This item has been added to the feature overview

## Release notes
When you add a featured block to a landing page, now when you choose to feature another landing page, the first hero section image will be used as the image in the featured section. 
When you feature a page, the featured image is now clickable and leads to the page content item.