### PR TITLE
Issue #2840694: update activity stream pager types to mini pagers

### DIFF
--- a/modules/social_features/social_activity/config/install/views.view.activity_stream_group.yml
+++ b/modules/social_features/social_activity/config/install/views.view.activity_stream_group.yml
@@ -49,17 +49,15 @@ display:
           sort_asc_label: Asc
           sort_desc_label: Desc
       pager:
-        type: full
+        type: mini
         options:
           items_per_page: 10
           offset: 0
           id: 0
           total_pages: null
           tags:
-            previous: '‹ Previous'
-            next: 'Next ›'
-            first: '« First'
-            last: 'Last »'
+            previous: ‹‹
+            next: ››
           expose:
             items_per_page: false
             items_per_page_label: 'Items per page'
@@ -68,7 +66,6 @@ display:
             items_per_page_options_all_label: '- All -'
             offset: false
             offset_label: Offset
-          quantity: 9
       style:
         type: default
       row:

--- a/modules/social_features/social_activity/config/install/views.view.activity_stream_notifications.yml
+++ b/modules/social_features/social_activity/config/install/views.view.activity_stream_notifications.yml
@@ -251,7 +251,7 @@ display:
           entity_type: activity
           entity_field: created
           plugin_id: date
-      title: 'Notifications'
+      title: Notifications
       header: {  }
       footer: {  }
       empty:
@@ -360,17 +360,15 @@ display:
       display_extenders: {  }
       path: notifications
       pager:
-        type: full
+        type: mini
         options:
-          items_per_page: 10
+          items_per_page: 30
           offset: 0
           id: 0
           total_pages: null
           tags:
-            previous: '‹ Previous'
-            next: 'Next ›'
-            first: '« First'
-            last: 'Last »'
+            previous: ‹‹
+            next: ››
           expose:
             items_per_page: false
             items_per_page_label: 'Items per page'
@@ -379,7 +377,6 @@ display:
             items_per_page_options_all_label: '- All -'
             offset: false
             offset_label: Offset
-          quantity: 9
       defaults:
         pager: false
         css_class: false

--- a/modules/social_features/social_activity/config/install/views.view.activity_stream_profile.yml
+++ b/modules/social_features/social_activity/config/install/views.view.activity_stream_profile.yml
@@ -51,17 +51,15 @@ display:
           sort_asc_label: Asc
           sort_desc_label: Desc
       pager:
-        type: full
+        type: mini
         options:
           items_per_page: 10
           offset: 0
           id: 0
           total_pages: null
           tags:
-            previous: '‹ Previous'
-            next: 'Next ›'
-            first: '« First'
-            last: 'Last »'
+            previous: ‹‹
+            next: ››
           expose:
             items_per_page: false
             items_per_page_label: 'Items per page'
@@ -70,7 +68,6 @@ display:
             items_per_page_options_all_label: '- All -'
             offset: false
             offset_label: Offset
-          quantity: 9
       style:
         type: default
       row:


### PR DESCRIPTION
## Problem
Pagers are not consistent across the activity streams.  There are currently 2 different pagers on 5 'stream' pages:

- group stream
- profile stream
- explore stream
- homepage stream
- all notifications (stream)

Homepage and explore have the 1 button 'older items', while the other 3 still have a numbered pager. 

## Solution
I suggest we change the all notifications, group and profile to use the same pager as the 2 other pages.

## Issue tracker
- https://www.drupal.org/node/2840694

## HTT
- [x] Check out the code changes
- [x] Login as user chrishall and create lots of content in one of your groups
- [x] Check the group stream and verify it has the right pager (Older items >>, Newer items <<)
- [x] Check the profile stream and verify it has the right pager
- [x] Check the all notifications `/notifications` stream and verify it has the right pager
- [x] Check the homepage stream and verify it has the right pager
- [x] Check the explore stream and verify it has the right pager
- [x] Verify all the tests are still passing

## Documentation
- [x] This item is added to the release notes
- [x] This item is documented on LGOS
- [x] This item has been added to the feature overview
