### PR TITLE
2936738: Make sure the local actions block is not displayed on admin/reports pages

### DIFF
--- a/modules/social_features/social_core/config/optional/block.block.socialblue_local_actions.yml
+++ b/modules/social_features/social_core/config/optional/block.block.socialblue_local_actions.yml
@@ -1,6 +1,8 @@
 langcode: en
 status: true
 dependencies:
+  module:
+    - system
   theme:
     - socialblue
 id: socialblue_local_actions

--- a/modules/social_features/social_core/config/optional/block.block.socialblue_local_actions.yml
+++ b/modules/social_features/social_core/config/optional/block.block.socialblue_local_actions.yml
@@ -14,4 +14,9 @@ settings:
   label: 'Primary admin actions'
   provider: core
   label_display: '0'
-visibility: {  }
+visibility:
+  request_path:
+    id: request_path
+    pages: 'admin/reports/*'
+    negate: true
+    context_mapping: {  }

--- a/modules/social_features/social_core/config/optional/block.block.socialblue_local_actions.yml
+++ b/modules/social_features/social_core/config/optional/block.block.socialblue_local_actions.yml
@@ -17,6 +17,6 @@ settings:
 visibility:
   request_path:
     id: request_path
-    pages: 'admin/reports/*'
+    pages: '/admin/reports/*'
     negate: true
     context_mapping: {  }


### PR DESCRIPTION
## Problem
The local actions block is displayed on admin/reports. In some cases (analytics) a sidebar second is being rendered, but only if both complementary area's are empty. Since this block was always rendered, those blocks were never considered empty

## Solution
Make sure the block is not rendered on admin/reports pages

## Issue tracker
- https://www.drupal.org/project/social/issues/2936738
- https://jira.goalgorilla.com/browse/DS-4662
- https://jira.goalgorilla.com/browse/SHN-141

## HTT
- [x] Check out the code changes
- [x] Install the social_kpi_analytics module
- [x] Go to the analytics page
- [x] Notice the layout is correct now (both on update and on fresh install)
- [x] Remove this function from saas: `_social_saas_core_fix_analytics_blocks`

## Documentation
- [x] This item is added to the release notes
- [x] This item is documented on LGOS
- [x] This item has been added to the feature overview

## Release notes
The Primary admin actions block is always shown in the 'Complementary Top' region. Most of the times it's empty and that's the issue. Some pages use the 'Sidebar first' and 'Sidebar second' layout. However when there are blocks shown in the 'Complementary Top', the 'Sidebar Second' region will not show up. We’ve made sure to have great default setting so it works with the Social KPI Analytics module as well.