### PR TITLE
Issue #2978381: SocialPageTitleBlock::build use of the title_resolver service

### DIFF
--- a/modules/social_features/social_core/src/Plugin/Block/SocialPageTitleBlock.php
+++ b/modules/social_features/social_core/src/Plugin/Block/SocialPageTitleBlock.php
@@ -54,7 +54,7 @@ class SocialPageTitleBlock extends PageTitleBlock implements ContainerFactoryPlu
   protected $titleResolver;
 
   /**
-   * EventAddBlock constructor.
+   * SocialPageTitleBlock constructor.
    *
    * @param array $configuration
    *   The given configuration.
@@ -165,7 +165,8 @@ class SocialPageTitleBlock extends PageTitleBlock implements ContainerFactoryPlu
     else {
 
       if ($route = $request->attributes->get(RouteObjectInterface::ROUTE_OBJECT)) {
-        $title = $this->titleResolver->getTitle($request, $route);
+        $title = $this->title;
+
         return [
           '#type' => 'page_title',
           '#title' => $title,


### PR DESCRIPTION
## Problem
The else clause in SocialPageTitleBlock::build uses the title resolver service to get the page title. Is there a reason to prefer this resolver vs using $this->title from the parent PageTitleBlock? The service won't have information on eg dynamic views titles, whereas $this->title will contain the dynamic title.

## Solution
Use the original title from `\Drupal\Core\Block\Plugin\Block\PageTitleBlock::$title`.

## Issue tracker
- https://www.drupal.org/project/social/issues/2978381

## HTT
- [ ] Check out the code changes
- [ ] Login as user X and open a few pages
- [ ] Check titles of overviews, nodes, profiles, posts, forms, etc.

## Documentation
- [ ] This item is added to the release notes
- [ ] This item is documented on LGOS
- [ ] This item has been added to the feature overview
