### PR TITLE
#2976351: Make the text align to the left for the inform block text

### DIFF
--- a/themes/socialbase/assets/css/block--informblock.css
+++ b/themes/socialbase/assets/css/block--informblock.css
@@ -49,7 +49,7 @@
   }
   .block-data-policy .card__block {
     display: block;
-    text-align: center;
+    text-align: left;
   }
   .block-data-policy .card__title {
     background-color: #1f80aa;

--- a/themes/socialbase/components/03-molecules/blocks/block--informblock/block--informblock.scss
+++ b/themes/socialbase/components/03-molecules/blocks/block--informblock/block--informblock.scss
@@ -18,7 +18,7 @@
 
     @include for-tablet-landscape-up {
       display: block;
-      text-align: center;
+      text-align: left;
     }
   }
 


### PR DESCRIPTION
## Problem
The text is currently aligned to the center. This is not looking very nice.

## Solution
Text is now aligned to the left as it should be.

## Issue tracker
https://www.drupal.org/node/2976351

## HTT
- [x] Check out the code changes
- [x] Create an data usage inform block
- [x] Check that the text is aligned to the left

## Documentation
- [x] This item is added to the release notes
