### PR TITLE
Only create Travis screenshots if the directory exists

### DIFF
--- a/tests/behat/features/bootstrap/SocialMinkContext.php
+++ b/tests/behat/features/bootstrap/SocialMinkContext.php
@@ -54,8 +54,9 @@ class SocialMinkContext extends MinkContext{
    */
   public function iMakeAScreenshotWithFileName($filename) {
     $screenshot = $this->getSession()->getDriver()->getScreenshot();
-    if (is_dir('/var/www/travis_artifacts')) {
-      $file_and_path = '/var/www/travis_artifacts/' . $filename . '.jpg';
+    $dir = '/var/www/travis_artifacts';
+    if (is_writeable($dir)) {
+      $file_and_path = $dir . '/' . $filename . '.jpg';
       file_put_contents($file_and_path, $screenshot);
     }
   }

--- a/tests/behat/features/bootstrap/SocialMinkContext.php
+++ b/tests/behat/features/bootstrap/SocialMinkContext.php
@@ -54,8 +54,10 @@ class SocialMinkContext extends MinkContext{
    */
   public function iMakeAScreenshotWithFileName($filename) {
     $screenshot = $this->getSession()->getDriver()->getScreenshot();
-    $file_and_path = '/var/www/travis_artifacts/' . $filename . '.jpg';
-    file_put_contents($file_and_path, $screenshot);
+    if (is_dir('/var/www/travis_artifacts')) {
+      $file_and_path = '/var/www/travis_artifacts/' . $filename . '.jpg';
+      file_put_contents($file_and_path, $screenshot);
+    }
   }
 
 


### PR DESCRIPTION
## Problem
Getting lot's of errors related to this on Shippable builds. The directory does not exist. So it throws errors like this:
`Warning: file_put_contents(/var/www/travis_artifacts/20180627-05_33_27-enroll-for-an-event-error.jpg): failed to open stream: No such file or directory in /var/www/html/profiles/contrib/social/tests/behat/features/bootstrap/SocialMinkContext.php line 58`

## Solution
Let's make this code a bit more defensive and check for the directory before trying to save the screenshot.

## Issue tracker
- n/a

## HTT
- [x] Check out the code changes
- [x] See if the tests pass (screenshots are not used anyways anymore)

## Documentation
- [ ] This item is added to the release notes
- [ ] This item is documented on LGOS
- [ ] This item has been added to the feature overview
