### PR TITLE
#2983658: Make sure apostrophes in users name is not escaped

### DIFF
--- a/modules/social_features/social_user/social_user.module
+++ b/modules/social_features/social_user/social_user.module
@@ -285,6 +285,23 @@ function _social_user_search_content_pre_render(array $build) {
 }
 
 /**
+ * Implements hook_user_format_name_alter().
+ */
+function social_user_user_format_name_alter(&$name, $account) {
+  /** @var \Drupal\Core\Session\AccountInterface $account */
+  $accountname = '';
+  $storage = \Drupal::entityTypeManager()->getStorage('profile');
+  if (!empty($storage)) {
+    // Returns false.
+    if ($user_profile = $storage->loadByUser($account, 'profile', TRUE)) {
+      $accountname = $user_profile->get('field_profile_first_name')->value . " " . $user_profile->get('field_profile_last_name')->value;
+      $accountname = trim($accountname);
+    }
+  }
+  $name = ($accountname !== '') ? $accountname : $name;
+}
+
+/**
  * Implements hook_menu_local_tasks_alter().
  */
 function social_user_menu_local_tasks_alter(&$data, $route_name) {


### PR DESCRIPTION
## Problem
Apostrophe in users name is escaped. This was introduced merge conflict. It's not an issue in the `1.x` branch.

![bug](https://user-images.githubusercontent.com/7124754/42285479-0bc14574-7fb0-11e8-81d2-e2a3f512a2a7.png)

## Solution
Put back code that was removed in merge conflict at https://github.com/goalgorilla/open_social/commit/7c6dbca4482c2d2421607af3e05679eef1f9e6cd#diff-532d07b1089c812bbec838eb49043722.

Original code changes: https://github.com/goalgorilla/open_social/pull/855/files#diff-532d07b1089c812bbec838eb49043722

![expected](https://user-images.githubusercontent.com/7124754/42285493-186c8ed2-7fb0-11e8-9d0a-8380bec85e50.png)

## Issue tracker
- https://www.drupal.org/project/social/issues/2983658

## HTT
- [ ] Check out the code changes
- [ ] Login as user X and change your name to something like `Александр 'o Donnel`
- [ ] Notice on the profile page it escapes the apostrophe
- [ ] Checkout to this branch
- [ ] Clear the cache and see that it no longer escapes the apostrophe
- [ ] Test that it also works for mentioning users and entity autocomplete reference fields

## Documentation
- [ ] This item is added to the release notes