### PR TITLE
Issue #2978324 by robertragas: fix issue where unread private message…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,8 @@
                 "Fix preview on node": "https://www.drupal.org/files/issues/2848080-2-preview-fails-on-node.patch"
             },
             "drupal/private_message": {
-                "Entity field weights": "https://www.drupal.org/files/issues/2018-05-15/set-entity-field-weights-2972948-2.patch"
+                "Entity field weights": "https://www.drupal.org/files/issues/2018-05-15/set-entity-field-weights-2972948-2.patch",
+                "Private message unread messages fix": "https://www.drupal.org/files/issues/2018-06-08/2978324-getthreads-sort-order-2.patch"
             },
             "drupal/swiftmailer": {
                 "Fix missing filter_format after update to beta2": "https://www.drupal.org/files/issues/2018-03-26/2948607-fix-filter-format-1.patch"

--- a/modules/social_features/social_private_message/src/Service/SocialPrivateMessageService.php
+++ b/modules/social_features/social_private_message/src/Service/SocialPrivateMessageService.php
@@ -108,7 +108,7 @@ class SocialPrivateMessageService extends PrivateMessageService {
       'WHERE owner_delete_time.delete_time <= messages.created ';
     $vars = [':uid' => $uid];
 
-    $query .= 'GROUP BY thread.id ORDER BY MAX(thread.updated) ASC, thread.id';
+    $query .= 'GROUP BY thread.id ORDER BY MAX(thread.updated) DESC, thread.id';
 
     $thread_ids = $this->database->query(
       $query,


### PR DESCRIPTION
… are not shown after max-count

## Problem
Users have a inbox for private messages. There is a count of 30 messages being displayed based on the thread updated time. This has the wrong sort order and causes that when you have over 30 message that latest unread message will not be shown.

## Solution
Reverse the order in the query of the private messages

## Issue tracker
- https://www.drupal.org/project/private_message/issues/2978324

## HTT
- [ ] Check out the code changes
- [ ] Login as a user that has over 30 private messages and send one from another account so you will have 1 unread message
- [ ] Notice that the notification centre says you have 1 unread message but you don't see it in your inbox
- [ ] Checkout to this branch
- [ ] Retry and see it now shows

## Documentation
- [ ] This item is added to the release notes
- [ ] This item is documented on LGOS
- [ ] This item has been added to the feature overview
