### PR TITLE
DS-5716 by bramtenhove: Update Drupal core to 8.5.5 [1.x]

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -72,7 +72,7 @@
         "composer/installers": "^1.0",
         "oomphinc/composer-installers-extender": "^1.1",
         "drupal-composer/drupal-scaffold": "^2.0.0",
-        "drupal/core": "~8.5.3",
+        "drupal/core": "~8.5.5",
         "drupal/address": "1.4",
         "drupal/addtoany": "1.9",
         "drupal/admin_toolbar": "1.24",

--- a/drupal-org-core.make
+++ b/drupal-org-core.make
@@ -1,7 +1,7 @@
 api = 2
 core = 8.x
 projects[drupal][type] = core
-projects[drupal][version] = 8.5.3
+projects[drupal][version] = 8.5.5
 projects[drupal][patch][] = "https://www.drupal.org/files/issues/color-optional-html-preview-2844190-2.patch"
 projects[drupal][patch][] = "https://www.drupal.org/files/issues/image_restrict_image_styles-2528214-19.patch"
 projects[drupal][patch][] = "https://www.drupal.org/files/issues/2599228-31.patch"


### PR DESCRIPTION
## Problem
Drupal Core 8.5.5 is just out!

## Solution
Updated to 8.5.5. Composer goes automatically, but it is important for the .make files.

See https://github.com/goalgorilla/open_social/pull/942 for 2.x branch.

## HTT
- [x] Check out the code changes
- [x] Check the release notes at https://www.drupal.org/project/drupal/releases/8.5.5
- [x] Make sure to verify https://www.drupal.org/project/drupal/issues/2959370 is not an issue

## Documentation
- [ ] This item is added to the release notes 