### PR TITLE
2965655 by jochemvn: Make the group widget check for installed plugins.

### DIFF
--- a/modules/social_features/social_group/social_group.module
+++ b/modules/social_features/social_group/social_group.module
@@ -1053,7 +1053,7 @@ function social_group_field_info_alter(&$info) {
  * Implements hook_entity_base_field_info_alter().
  */
 function social_group_entity_base_field_info_alter(&$fields, EntityTypeInterface $entity_type) {
-  $entity_types = ['node', 'user'];
+  $entity_types = ['node'];
   if (in_array($entity_type->id(), $entity_types)) {
     if (isset($fields['groups'])) {
       /* @var \Drupal\Core\Field\BaseFieldDefinition $fields['groups'] */

--- a/modules/social_features/social_group/src/Plugin/Field/FieldWidget/SocialGroupSelectorWidget.php
+++ b/modules/social_features/social_group/src/Plugin/Field/FieldWidget/SocialGroupSelectorWidget.php
@@ -84,11 +84,15 @@ class SocialGroupSelectorWidget extends OptionsSelectWidget implements Container
   protected function getOptions(FieldableEntityInterface $entity) {
     if (!isset($this->options)) {
 
-      // Get the bundle fron the node.
-      $entity_type = '';
-      if ($entity->getEntityTypeId() == 'node') {
-        $entity_type = $entity->bundle();
+      // Must be a node.
+      if ($entity->getEntityTypeId() !== 'node') {
+        // We only handle nodes. When using this widget on other content types,
+        // we simply return the normal options.
+        return parent::getOptions($entity);
       }
+
+      // Get the bundle fron the node.
+      $entity_type = $entity->bundle();
 
       $account = $entity->getOwner();
       // Limit the settable options for the current user account.

--- a/modules/social_features/social_group/src/Plugin/Field/FieldWidget/SocialGroupSelectorWidget.php
+++ b/modules/social_features/social_group/src/Plugin/Field/FieldWidget/SocialGroupSelectorWidget.php
@@ -16,6 +16,7 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Session\AccountProxyInterface;
 use Drupal\group\Entity\Group;
+use Drupal\group\Plugin\GroupContentEnablerManager;
 use Drupal\user\Entity\User;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -39,17 +40,19 @@ class SocialGroupSelectorWidget extends OptionsSelectWidget implements Container
   protected $configFactory;
   protected $moduleHander;
   protected $currentUser;
+  protected $pluginManager;
 
   /**
    * Creates a SocialGroupSelectorWidget instance.
    *
    * {@inheritdoc}
    */
-  public function __construct($plugin_id, $plugin_definition, FieldDefinitionInterface $field_definition, array $settings, array $third_party_settings, ConfigFactory $configFactory, AccountProxyInterface $currentUser, ModuleHandler $moduleHandler) {
+  public function __construct($plugin_id, $plugin_definition, FieldDefinitionInterface $field_definition, array $settings, array $third_party_settings, ConfigFactory $configFactory, AccountProxyInterface $currentUser, ModuleHandler $moduleHandler, GroupContentEnablerManager $pluginManager) {
     parent::__construct($plugin_id, $plugin_definition, $field_definition, $settings, $third_party_settings);
     $this->configFactory = $configFactory;
     $this->moduleHander = $moduleHandler;
     $this->currentUser = $currentUser;
+    $this->pluginManager = $pluginManager;
   }
 
   /**
@@ -64,7 +67,8 @@ class SocialGroupSelectorWidget extends OptionsSelectWidget implements Container
       $configuration['third_party_settings'],
       $container->get('config.factory'),
       $container->get('current_user'),
-      $container->get('module_handler')
+      $container->get('module_handler'),
+      $container->get('plugin.manager.group_content_enabler')
     );
   }
 
@@ -79,12 +83,42 @@ class SocialGroupSelectorWidget extends OptionsSelectWidget implements Container
    */
   protected function getOptions(FieldableEntityInterface $entity) {
     if (!isset($this->options)) {
+
+      // Get the bundle fron the node.
+      $entity_type = '';
+      if ($entity->getEntityTypeId() == 'node') {
+        $entity_type = $entity->bundle();
+      }
+
       $account = $entity->getOwner();
       // Limit the settable options for the current user account.
       $options = $this->fieldDefinition
         ->getFieldStorageDefinition()
         ->getOptionsProvider($this->column, $entity)
         ->getSettableOptions($account);
+
+      // Check for each group type if the content type is installed.
+      foreach ($options as $key => $optgroup) {
+        // Groups are in the array below.
+        if (is_array($optgroup)) {
+          // Loop through the groups.
+          foreach ($optgroup as $gid => $title) {
+            // If the group exists.
+            if ($group = Group::load($gid)) {
+              // Load all installed plugins for this group type.
+              $plugin_ids = $this->pluginManager->getInstalledIds($group->getGroupType());
+              // If the bundle is not installed,
+              // then unset the entire optiongroup (=group type).
+              if (!in_array('group_node:' . $entity_type, $plugin_ids)) {
+                unset($options[$key]);
+              }
+            }
+            // We need to check only one of each group type,
+            // so break out the second each.
+            break;
+          }
+        }
+      }
 
       // Remove groups the user does not have create access to.
       if (!$account->hasPermission('manage all groups')) {


### PR DESCRIPTION
## Problem
Content types with the group field (mostly accidental, or upgrades), didn't check if the content type was installed in the group. When trying to add such a content type in a group you'd get a WSOD 

## Solution
Make sure the group widget only shows group types that are have the current content type installed

## Issue tracker
- https://www.drupal.org/project/social/issues/2965655

## HTT
- [x] Check out the code changes
- [x] Login as an admin and add the group field to the page content type (through the field_ui)
- [x] Create a new page and notice you can place it in a couple of groups
- [x] Select a group and submit
- [x] WSOD (Pluginnotfoundexception)
- [x] Try it on this branch.
- [x] Notice that the group selector is empty
- [x] Submit the page
- [x] Notice you now have a page
- [x] Try to create a page and node
- [x] Notice that you can still place both in all group types

## Documentation
- [x] This item is added to the release notes
- [ ] This item is documented on LGOS
- [ ] This item has been added to the feature overview

## Release notes
The group field would in some cases appear on node add/edit screens of content types that are not installed in the group type. Would you then select a group and submit, it would crash because of a `Pluginnotfoundexception`. 
This fix makes sure the widget checks if the current content type is installed in any of the group types. If not, the group type and all of its groups are removed from the widget.
