### PR TITLE
#2982250: Fix styles for modal buttons

### DIFF
--- a/themes/socialbase/assets/css/dropdown.css
+++ b/themes/socialbase/assets/css/dropdown.css
@@ -5,7 +5,7 @@
   margin-left: 2px;
   vertical-align: middle;
   border-top: 4px dashed;
-  border-top: 4px solid \9 ;
+  border-top: 4px solid \9 ;
   border-right: 4px solid transparent;
   border-left: 4px solid transparent;
 }
@@ -131,7 +131,7 @@
 .navbar-fixed-bottom .dropdown .caret {
   border-top: 0;
   border-bottom: 4px dashed;
-  border-bottom: 4px solid \9 ;
+  border-bottom: 4px solid \9 ;
   content: "";
 }
 

--- a/themes/socialbase/assets/css/modal.css
+++ b/themes/socialbase/assets/css/modal.css
@@ -261,8 +261,9 @@
 }
 
 .social-dialog .btn {
-  padding: 0.5rem 2rem;
-  width: 100%;
+  padding: 0.5rem 2rem !important;
+  width: 100% !important;
+  height: auto !important;
 }
 
 .social-dialog .btn + .btn {
@@ -277,6 +278,10 @@
   margin-right: 1rem;
 }
 
+.ui-dialog--narrow .ui-dialog-buttonpane {
+  padding: 0 1rem 1rem;
+}
+
 @media (min-width: 900px) {
   .ui-dialog-title {
     font-size: 1.25rem;
@@ -285,7 +290,7 @@
     max-width: 400px;
   }
   .social-dialog .ui-dialog-content {
-    padding: 2rem 2.5rem  2.5rem;
+    padding: 2rem 2.5rem 2.5rem;
   }
 }
 

--- a/themes/socialbase/components/04-organisms/modal/modal.scss
+++ b/themes/socialbase/components/04-organisms/modal/modal.scss
@@ -14,15 +14,24 @@
 // http://api.jqueryui.com/dialog/#theming
 //
 
-
 @keyframes fadein {
-  from { opacity: 0; }
-  to   { opacity: $modal-backdrop-opacity; }
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: $modal-backdrop-opacity;
+  }
 }
 
 @keyframes fadein_scale {
-  from { opacity: 0; transform: translateY(-30px); }
-  to   { opacity: 1; transform: translateY(0); }
+  from {
+    opacity: 0;
+    transform: translateY(-30px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
 .ui-front {
@@ -53,7 +62,6 @@
   width: 1px;
 }
 
-
 .ui-dialog {
   overflow-x: hidden;
   overflow-y: auto;
@@ -67,7 +75,7 @@
   z-index: $zindex-modal;
   background-color: $modal-content-bg;
   border: 1px solid $modal-content-border-color;
-  box-shadow: 0 3px 9px rgba(0,0,0,.5);
+  box-shadow: 0 3px 9px rgba(0, 0, 0, .5);
   background-clip: padding-box;
   backface-visibility: hidden;
   animation: fadein_scale 0.5s ease-out;
@@ -141,7 +149,6 @@
   }
 }
 
-
 // Kill the scroll on the body
 .modal-open {
   overflow: hidden;
@@ -168,8 +175,11 @@
     transform: translate(0, -25%);
     transition: transform 0.3s ease-out;
   }
-  &.in .modal-dialog { transform: translate(0, 0); }
+  &.in .modal-dialog {
+    transform: translate(0, 0);
+  }
 }
+
 .modal-open .modal {
   overflow-x: hidden;
   overflow-y: auto;
@@ -189,7 +199,7 @@
   border: 1px solid $modal-content-fallback-border-color; //old browsers fallback (ie8 etc)
   border: 1px solid $modal-content-border-color;
   border-radius: 12px;
-  box-shadow: 0 3px 9px rgba(0,0,0,.5);
+  box-shadow: 0 3px 9px rgba(0, 0, 0, .5);
   background-clip: padding-box;
   // Remove focus outline from opened modal
   outline: 0;
@@ -209,7 +219,7 @@
     padding: 2rem 1rem;
 
     @media(min-width: 900px) {
-      padding: 2rem 2.5rem  2.5rem;
+      padding: 2rem 2.5rem 2.5rem;
     }
 
   }
@@ -238,15 +248,16 @@
   }
 
   .form-actions {
-    display:flex;
+    display: flex;
     justify-content: space-between;
     flex: 0 0 50%;
     margin-bottom: 0;
   }
 
   .btn {
-    padding: 0.5rem 2rem;
-    width: 100%;
+    padding: 0.5rem 2rem !important;
+    width: 100% !important;
+    height: auto !important;
   }
 
   .btn + .btn {
@@ -258,4 +269,10 @@
     margin-right: 1rem;
   }
 
+}
+
+.ui-dialog-buttonpane {
+  .ui-dialog--narrow & {
+    padding: 0 1rem 1rem;
+  }
 }


### PR DESCRIPTION
## Problem
The Bootstrap update to 3.11 breaks the Data Policy revert button in the modal

## Solution
Fix styles for modal buttons

## Issue tracker
- https://www.drupal.org/node/2982250

## HTT
- [x] Check out the code changes
- [x] Checkout to this branch
- [x] Enable in distro social_gdpr; Go to /data-policy/revisions; Add a new revision; Add another revision
- [x] Revert the first revision (button to revert revision should be there)

## Release notes
The data policy revert button was not visible anymore due to a update in the Bootstrap theme. We updated the styles and the revert button functions again as it is supposed to.

