### PR TITLE
Issue #2984864 by bramtenhove: Fix untranslatable string at comment form

### DIFF
--- a/modules/social_features/social_comment/social_comment.module
+++ b/modules/social_features/social_comment/social_comment.module
@@ -55,6 +55,7 @@ function social_comment_form_comment_form_alter(&$form, FormStateInterface $form
       // See social_post_form_comment_post_comment_form_alter for posts.
       if ($form_id !== 'comment_post_comment_form') {
         $form['#action'] = \Drupal::request()->getRequestUri();
+        $form['field_comment_body']['widget'][0]['#placeholder'] = t('Add a comment');
       }
       break;
   }


### PR DESCRIPTION
## Problem
String "Add a comment" can be translated but the translation is not shown.

![screen shot 2018-07-10 at 15 56 19](https://user-images.githubusercontent.com/7124754/42514673-45c16d72-845a-11e8-977d-cd06a9a7ecc4.png)

## Solution
Add the placeholder text with t() around it as is done at other places in the same function.

![screen shot 2018-07-10 at 15 50 18](https://user-images.githubusercontent.com/7124754/42514708-5b332c90-845a-11e8-97eb-724fc3ee45e6.png)

## Issue tracker
- https://www.drupal.org/project/social/issues/2984864

## HTT
- [x] Check out the code changes
- [x] Login as user X and go to an event or topic
- [x] Notice it shows "Add a comment"
- [x] Now set Dutch as a default language and make sure the English string is translated
- [x] Check the comment form again and notice it is now translated
- [x] Check the comment form for posts and replying to comments, they are also translated (possibly they have custom translations)

## Release notes
The translation for the  placeholder text at the comment form for nodes was not shown. We made sure the placeholder text passes the translation function.