### PR TITLE
2985023: Fix sorting of topics in groups

### DIFF
--- a/modules/social_features/social_group/config/install/views.view.group_topics.yml
+++ b/modules/social_features/social_group/config/install/views.view.group_topics.yml
@@ -312,7 +312,22 @@ display:
             default_group_multiple: {  }
             group_items: {  }
           plugin_id: node_access
-      sorts: {  }
+      sorts:
+        created:
+          id: created
+          table: node_field_data
+          field: created
+          relationship: gc__node
+          group_type: group
+          admin_label: sort_created
+          order: DESC
+          exposed: false
+          expose:
+            label: ''
+          granularity: second
+          entity_type: node
+          entity_field: created
+          plugin_id: date
       title: 'Group Topics'
       header: {  }
       footer: {  }


### PR DESCRIPTION
## Problem
The topics overview in groups did not sort on created date of the topic (desc)

## Solution
Added a sorting to the view

## Issue tracker
- https://www.drupal.org/project/social/issues/2985023

## HTT
- [ ] Check out the code changes
- [ ] Use a group with a couple of topics. Change some of the create dates to see the sorting is off
- [ ] Checkout to this branch
- [ ] Revert social_groups and notice the sorting is now correct

## Documentation
- [ ] This item is documented on LGOS
- [ ] This item has been added to the feature overview

## Release notes
The sorting of topics in groups did not have any sorting. As all other topic overview this overview now sorts descending on create date.
