### PR TITLE
DS-5502 - Group overview available for Content Manager

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,8 @@
                 "Add relationship to flagged entities when Flagging is base table": "https://www.drupal.org/files/issues/2723703_31.patch"
             },
             "drupal/group": {
-                "Add computed field for Group reference": "https://www.drupal.org/files/issues/add-computed-field-without-FieldItemListComputedInterface-2718195-34.patch"
+                "Add computed field for Group reference": "https://www.drupal.org/files/issues/add-computed-field-without-FieldItemListComputedInterface-2718195-34.patch",
+                "Add permission to view group overview": "https://www.drupal.org/files/issues/group-2943564-2.patch"
             },
             "drupal/image_widget_crop": {
                 "Initial crop fix": "https://www.drupal.org/files/issues/2018-07-05/2865396-36-apply-default-crop.diff"

--- a/drupal-org.make
+++ b/drupal-org.make
@@ -37,6 +37,7 @@ projects[flag][patch][] = "https://www.drupal.org/files/issues/2723703_31.patch"
 projects[group][type] = module
 projects[group][version] = 1.0-rc2
 projects[group][patch][] = "https://www.drupal.org/files/issues/add-computed-field-without-FieldItemListComputedInterface-2718195-34.patch"
+projects[group][patch][] = "https://www.drupal.org/files/issues/group-2943564-2.patch"
 projects[image_effects][type] = module
 projects[image_effects][version] = 1.0
 projects[image_widget_crop][type] = module

--- a/modules/social_features/social_group/social_group.install
+++ b/modules/social_features/social_group/social_group.install
@@ -110,6 +110,7 @@ function _social_group_get_permissions($role) {
     'view node.event.field_content_visibility:group content',
     'view node.topic.field_content_visibility:group content',
     'view node.page.field_content_visibility:group content',
+    'access group overview',
   ]);
 
   // Site manager.
@@ -365,4 +366,12 @@ function social_group_update_8011() {
  */
 function social_group_update_8012() {
   module_set_weight('social_group', 2);
+}
+
+/**
+ * Grant permission to access group overview to contentmanager and sitemanager.
+ */
+function social_group_update_8013() {
+  user_role_grant_permissions('contentmanager', ['access group overview']);
+  user_role_grant_permissions('sitemanager', ['access group overview']);
 }

--- a/modules/social_features/social_group/social_group.module
+++ b/modules/social_features/social_group/social_group.module
@@ -790,6 +790,7 @@ function social_group_menu_local_actions_alter(&$local_actions) {
 function social_group_entity_type_alter(array &$entity_types) {
   /* @var $entity_types \Drupal\Core\Entity\EntityTypeInterface[] */
   $entity_types['group_content']->setListBuilderClass('Drupal\social_group\Controller\SocialGroupContentListBuilder');
+  $entity_types['group']->setListBuilderClass('Drupal\social_group\Controller\SocialGroupListBuilder');
 }
 
 /**

--- a/modules/social_features/social_group/src/Controller/SocialGroupListBuilder.php
+++ b/modules/social_features/social_group/src/Controller/SocialGroupListBuilder.php
@@ -40,6 +40,8 @@ class SocialGroupListBuilder extends EntityListBuilder {
    *   The entity storage class.
    * @param \Drupal\Core\Routing\RedirectDestinationInterface $redirect_destination
    *   The redirect destination service.
+   * @param \Drupal\Core\Datetime\DateFormatterInterface $date_time
+   *   The datetime formatter service.
    */
   public function __construct(EntityTypeInterface $entity_type, EntityStorageInterface $storage, RedirectDestinationInterface $redirect_destination, DateFormatterInterface $date_time) {
     parent::__construct($entity_type, $storage);
@@ -96,8 +98,7 @@ class SocialGroupListBuilder extends EntityListBuilder {
   /**
    * {@inheritdoc}
    */
-  public function buildRow(EntityInterface $entity)
-  {
+  public function buildRow(EntityInterface $entity) {
     /** @var \Drupal\group\Entity\GroupInterface $entity */
     // EntityListBuilder sets the table rows using the #rows property, so we
     // need to add the render array using the 'data' key.

--- a/modules/social_features/social_group/src/Controller/SocialGroupListBuilder.php
+++ b/modules/social_features/social_group/src/Controller/SocialGroupListBuilder.php
@@ -1,0 +1,154 @@
+<?php
+
+namespace Drupal\social_group\Controller;
+
+use Drupal\Core\Datetime\DateFormatterInterface;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Entity\EntityListBuilder;
+use Drupal\Core\Entity\EntityStorageInterface;
+use Drupal\Core\Entity\EntityTypeInterface;
+use Drupal\Core\Routing\RedirectDestinationInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Provides a list controller for group from GroupListBuilder.
+ *
+ * @ingroup group
+ */
+class SocialGroupListBuilder extends EntityListBuilder {
+
+  /**
+   * The redirect destination service.
+   *
+   * @var \Drupal\Core\Routing\RedirectDestinationInterface
+   */
+  protected $redirectDestination;
+
+  /**
+   * The DateTime formatter service.
+   *
+   * @var \Drupal\Core\Datetime\DateFormatterInterface
+   */
+  protected $dateTime;
+
+  /**
+   * Constructs a new GroupListBuilder object.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeInterface $entity_type
+   *   The entity type definition.
+   * @param \Drupal\Core\Entity\EntityStorageInterface $storage
+   *   The entity storage class.
+   * @param \Drupal\Core\Routing\RedirectDestinationInterface $redirect_destination
+   *   The redirect destination service.
+   */
+  public function __construct(EntityTypeInterface $entity_type, EntityStorageInterface $storage, RedirectDestinationInterface $redirect_destination, DateFormatterInterface $date_time) {
+    parent::__construct($entity_type, $storage);
+    $this->redirectDestination = $redirect_destination;
+    $this->dateTime = $date_time;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function createInstance(ContainerInterface $container, EntityTypeInterface $entity_type) {
+    return new static(
+      $entity_type,
+      $container->get('entity_type.manager')->getStorage($entity_type->id()),
+      $container->get('redirect.destination'),
+      $container->get('date.formatter')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildHeader() {
+    $header = [
+      'name' => [
+        'data' => $this->t('Name'),
+        'field' => 'label',
+        'specifier' => 'label',
+      ],
+      'type' => [
+        'data' => $this->t('Type'),
+        'field' => 'type',
+        'specifier' => 'type',
+      ],
+      'uid' => [
+        'data' => $this->t('Creator'),
+        'field' => 'uid',
+        'specifier' => 'uid',
+      ],
+      'members' => [
+        'data' => $this->t('Members'),
+      ],
+      'created' => [
+        'data' => $this->t('Created'),
+        'field' => 'created',
+        'specifier' => 'created',
+        'sort' => 'desc',
+      ],
+    ];
+
+    return $header + parent::buildHeader();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildRow(EntityInterface $entity)
+  {
+    /** @var \Drupal\group\Entity\GroupInterface $entity */
+    // EntityListBuilder sets the table rows using the #rows property, so we
+    // need to add the render array using the 'data' key.
+    $row['name']['data'] = $entity->toLink()->toRenderable();
+    $row['type'] = $entity->getGroupType()->label();
+    $row['uid'] = $entity->uid->entity->toLink();
+    $row['members'] = count($entity->getMembers());
+    $row['created'] = $this->dateTime->format($entity->getCreatedTime(), 'short');
+
+    return $row + parent::buildRow($entity);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getEntityIds() {
+    $query = $this->getStorage()->getQuery();
+
+    // Add table sorting functionality.
+    $headers = $this->buildHeader();
+    $query->tableSort($headers);
+
+    // Only add the pager if a limit is specified.
+    if ($this->limit) {
+      $query->pager($this->limit);
+    }
+    return $query->execute();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function render() {
+    $build = parent::render();
+    $build['table']['#empty'] = $this->t('There are no groups yet.');
+    return $build;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getDefaultOperations(EntityInterface $entity) {
+    $operations = parent::getDefaultOperations($entity);
+
+    // Add the current path or destination as a redirect to the operation links.
+    $destination = $this->redirectDestination->getAsArray();
+    foreach ($operations as $key => $operation) {
+      $operations[$key]['query'] = $destination;
+    }
+
+    return $operations;
+  }
+
+}


### PR DESCRIPTION
## Problem
The content manager is able to edit and delete groups. However, due to the Group module not having granular permissions the overview was not reachable for that role.

This made managing groups harder for the content manager.

## Solution
There is a patch from the Group module that introduces a new permission to visit the group overview page. This has been granted to the CM and SM roles.

Next to that I took the opportunity to make the Group overview a bit more useful by removing the Group ID and introducing the numbers of members as well as the creation date.
Also I made these columns sortable!

## Issue tracker
- https://jira.goalgorilla.com/browse/DS-5502

## HTT
- [x] Check out the code changes and run the database update with the permission changes
- [x] Login as a CM
- [x] Notice the menu item for Groups is in your admin menu
- [x] Go to the Groups overview, you should see the name, type, creator, member count and creation date
- [x] Also notice that you have the Edit and Delete operations
- [x] Try sorting the table, but notice the members column is sortable as that is a different entity
- [x] Now change the advanced outsider permissions of for example the closed group.. for example remove the 'administer group' and 'edit group' permissions
- [x] Check the overview, the button for editing the group is no longer visible

## Documentation
- [x] This item is documented on LGOS
- [ ] This item has been added to the feature overview

## Release notes
The group overview page is now accessible for the Content Manager role. The overview is also improved as the number of members and creation date are now in there. You can also sort the columns, it's sorted on latest created group by default.
