### PR TITLE
DS-3488 - Comment overview available for CM and SM

### DIFF
--- a/modules/custom/mentions/mentions.module
+++ b/modules/custom/mentions/mentions.module
@@ -129,9 +129,13 @@ function mentions_crud_update($type, $mentions, $id, $author) {
     ->execute();
   foreach ($mention_ids as $mention) {
     $entity = $mentions_storage->load($mention);
-    $old_user = $entity->get('uid')->getValue()[0]['value'];
-    $old_users[] = $old_user;
-    $old_mids[$old_user] = $mention;
+
+    // Make sure the uid value is available.
+    if (isset($entity->get('uid')->getValue()[0]['value'])) {
+      $old_user = $entity->get('uid')->getValue()[0]['value'];
+      $old_users[] = $old_user;
+      $old_mids[$old_user] = $mention;
+    }
   }
 
   // Build array of new mentions.

--- a/modules/social_features/social_comment/social_comment.install
+++ b/modules/social_features/social_comment/social_comment.install
@@ -59,7 +59,9 @@ function _social_comment_get_permissions($role) {
   ]);
 
   // Content manager.
-  $permissions['contentmanager'] = array_merge($permissions['authenticated'], []);
+  $permissions['contentmanager'] = array_merge($permissions['authenticated'], [
+    'administer comments',
+  ]);
 
   // Site manager.
   $permissions['sitemanager'] = array_merge($permissions['contentmanager'], []);

--- a/modules/social_features/social_comment/src/Form/SocialCommentAdminOverview.php
+++ b/modules/social_features/social_comment/src/Form/SocialCommentAdminOverview.php
@@ -1,0 +1,290 @@
+<?php
+
+namespace Drupal\social_comment\Form;
+
+use Drupal\comment\CommentInterface;
+use Drupal\Core\Datetime\DateFormatterInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Extension\ModuleHandlerInterface;
+use Drupal\Core\Form\FormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Render\Renderer;
+use Drupal\Core\TempStore\PrivateTempStoreFactory;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Provides the comments overview administration form.
+ *
+ * @internal
+ */
+class SocialCommentAdminOverview extends FormBase {
+
+  /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * The comment storage.
+   *
+   * @var \Drupal\comment\CommentStorageInterface
+   */
+  protected $commentStorage;
+
+  /**
+   * The date formatter service.
+   *
+   * @var \Drupal\Core\Datetime\DateFormatterInterface
+   */
+  protected $dateFormatter;
+
+  /**
+   * The module handler.
+   *
+   * @var \Drupal\Core\Extension\ModuleHandlerInterface
+   */
+  protected $moduleHandler;
+
+  /**
+   * The tempstore factory.
+   *
+   * @var \Drupal\Core\TempStore\PrivateTempStoreFactory
+   */
+  protected $tempStoreFactory;
+
+  /**
+   * The renderer.
+   *
+   * @var \Drupal\Core\Render\Renderer
+   */
+  protected $renderer;
+
+  /**
+   * Creates a CommentAdminOverview form.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity manager service.
+   * @param \Drupal\Core\Datetime\DateFormatterInterface $date_formatter
+   *   The date formatter service.
+   * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
+   *   The module handler.
+   * @param \Drupal\Core\TempStore\PrivateTempStoreFactory $temp_store_factory
+   *   The tempstore factory.
+   * @param \Drupal\Core\Render\Renderer $renderer
+   *   The renderer.
+   */
+  public function __construct(EntityTypeManagerInterface $entity_type_manager, DateFormatterInterface $date_formatter, ModuleHandlerInterface $module_handler, PrivateTempStoreFactory $temp_store_factory, Renderer $renderer) {
+    $this->entityTypeManager = $entity_type_manager;
+    $this->commentStorage = $entity_type_manager->getStorage('comment');
+    $this->dateFormatter = $date_formatter;
+    $this->moduleHandler = $module_handler;
+    $this->tempStoreFactory = $temp_store_factory;
+    $this->renderer = $renderer;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('entity_type.manager'),
+      $container->get('date.formatter'),
+      $container->get('module_handler'),
+      $container->get('tempstore.private'),
+      $container->get('renderer')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'comment_admin_overview';
+  }
+
+  /**
+   * Form constructor for the comment overview administration form.
+   *
+   * @param array $form
+   *   An associative array containing the structure of the form.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The current state of the form.
+   * @param string $type
+   *   The type of the overview form ('approval' or 'new').
+   *
+   * @return array
+   *   The form structure.
+   */
+  public function buildForm(array $form, FormStateInterface $form_state, $type = 'new') {
+
+    // Build an 'Update options' form.
+    $form['options'] = [
+      '#type' => 'details',
+      '#title' => $this->t('Update options'),
+      '#open' => TRUE,
+      '#attributes' => ['class' => ['container-inline']],
+    ];
+
+    if ($type == 'approval') {
+      $options['publish'] = $this->t('Publish the selected comments');
+    }
+    else {
+      $options['unpublish'] = $this->t('Unpublish the selected comments');
+    }
+    $options['delete'] = $this->t('Delete the selected comments');
+
+    $form['options']['operation'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Action'),
+      '#title_display' => 'invisible',
+      '#options' => $options,
+      '#default_value' => 'publish',
+    ];
+    $form['options']['submit'] = [
+      '#type' => 'submit',
+      '#value' => $this->t('Update'),
+    ];
+
+    // Load the comments that need to be displayed.
+    $status = ($type == 'approval') ? CommentInterface::NOT_PUBLISHED : CommentInterface::PUBLISHED;
+    $header = [
+      'author' => [
+        'data' => $this->t('Author'),
+        'specifier' => 'name',
+        'class' => [RESPONSIVE_PRIORITY_MEDIUM],
+      ],
+      'comment' => [
+        'data' => $this->t('Comment'),
+        'specifier' => 'comment_body',
+        'class' => [RESPONSIVE_PRIORITY_LOW],
+      ],
+      'changed' => [
+        'data' => $this->t('Updated'),
+        'specifier' => 'changed',
+        'sort' => 'desc',
+        'class' => [RESPONSIVE_PRIORITY_LOW],
+      ],
+      'operations' => $this->t('Operations'),
+    ];
+    $cids = $this->commentStorage->getQuery()
+      ->condition('status', $status)
+      ->tableSort($header)
+      ->pager(50)
+      ->execute();
+
+    /** @var $comments \Drupal\comment\CommentInterface[] */
+    $comments = $this->commentStorage->loadMultiple($cids);
+
+    // Build a table listing the appropriate comments.
+    $options = [];
+    $destination = $this->getDestinationArray();
+
+    foreach ($comments as $comment) {
+      // Get a render array for the comment body field. We'll render it in the
+      // table.
+      $comment_body = $comment->field_comment_body->view('full');
+
+      $options[$comment->id()] = [
+        'title' => ['data' => ['#title' => $comment->getSubject() ?: $comment->id()]],
+        'author' => [
+          'data' => [
+            '#theme' => 'username',
+            '#account' => $comment->getOwner(),
+          ],
+        ],
+        'comment' => [
+          'data' => [
+            '#markup' => $this->renderer->renderRoot($comment_body),
+          ],
+        ],
+        'changed' => $this->dateFormatter->format($comment->getChangedTimeAcrossTranslations(), 'short'),
+      ];
+
+      // Create a list of operations.
+      $comment_uri_options = $comment->toUrl()->getOptions() + ['query' => $destination];
+
+      $links['view'] = [
+        'title' => $this->t('View'),
+        'url' => $comment->toUrl(),
+      ];
+      $links['edit'] = [
+        'title' => $this->t('Edit'),
+        'url' => $comment->toUrl('edit-form', $comment_uri_options),
+      ];
+      $links['delete'] = [
+        'title' => $this->t('Delete'),
+        'url' => $comment->toUrl('delete-form', $comment_uri_options),
+      ];
+      if ($this->moduleHandler->moduleExists('content_translation') && $this->moduleHandler->invoke('content_translation', 'translate_access', [$comment])->isAllowed()) {
+        $links['translate'] = [
+          'title' => $this->t('Translate'),
+          'url' => $comment->toUrl('drupal:content-translation-overview', $comment_uri_options),
+        ];
+      }
+      $options[$comment->id()]['operations']['data'] = [
+        '#type' => 'operations',
+        '#links' => $links,
+      ];
+    }
+
+    $form['comments'] = [
+      '#type' => 'tableselect',
+      '#header' => $header,
+      '#options' => $options,
+      '#empty' => $this->t('No comments available.'),
+    ];
+
+    $form['pager'] = ['#type' => 'pager'];
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function validateForm(array &$form, FormStateInterface $form_state) {
+    $form_state->setValue('comments', array_diff($form_state->getValue('comments'), [0]));
+    // We can't execute any 'Update options' if no comments were selected.
+    if (count($form_state->getValue('comments')) == 0) {
+      $form_state->setErrorByName('', $this->t('Select one or more comments to perform the update on.'));
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    $operation = $form_state->getValue('operation');
+    $cids = $form_state->getValue('comments');
+    /** @var \Drupal\comment\CommentInterface[] $comments */
+    $comments = $this->commentStorage->loadMultiple($cids);
+    if ($operation != 'delete') {
+      foreach ($comments as $comment) {
+        if ($operation == 'unpublish') {
+          $comment->setUnpublished();
+        }
+        elseif ($operation == 'publish') {
+          $comment->setPublished();
+        }
+        $comment->save();
+      }
+      drupal_set_message($this->t('The update has been performed.'));
+      $form_state->setRedirect('comment.admin');
+    }
+    else {
+      $info = [];
+      /** @var \Drupal\comment\CommentInterface $comment */
+      foreach ($comments as $comment) {
+        $langcode = $comment->language()->getId();
+        $info[$comment->id()][$langcode] = $langcode;
+      }
+      $this->tempStoreFactory
+        ->get('comment_multiple_delete_confirm')
+        ->set($this->currentUser()->id(), $info);
+      $form_state->setRedirect('comment.multiple_delete_confirm');
+    }
+  }
+
+}

--- a/modules/social_features/social_comment/src/Form/SocialCommentAdminOverview.php
+++ b/modules/social_features/social_comment/src/Form/SocialCommentAdminOverview.php
@@ -174,7 +174,7 @@ class SocialCommentAdminOverview extends FormBase {
       ->pager(50)
       ->execute();
 
-    /** @var $comments \Drupal\comment\CommentInterface[] */
+    /* @var $comments \Drupal\comment\CommentInterface[] */
     $comments = $this->commentStorage->loadMultiple($cids);
 
     // Build a table listing the appropriate comments.

--- a/modules/social_features/social_comment/src/Routing/RouteSubscriber.php
+++ b/modules/social_features/social_comment/src/Routing/RouteSubscriber.php
@@ -33,6 +33,19 @@ class RouteSubscriber extends RouteSubscriberBase {
       $route->setDefaults($defaults);
     }
 
+    /** @var \Symfony\Component\Routing\Route $route */
+    if ($route = $collection->get('comment.admin')) {
+      $defaults = $route->getDefaults();
+      $defaults['_form'] = '\Drupal\social_comment\Form\SocialCommentAdminOverview';
+      $route->setDefaults($defaults);
+    }
+
+    /** @var \Symfony\Component\Routing\Route $route */
+    if ($route = $collection->get('comment.admin_approval')) {
+      $defaults = $route->getDefaults();
+      $defaults['_form'] = '\Drupal\social_comment\Form\SocialCommentAdminOverview';
+      $route->setDefaults($defaults);
+    }
   }
 
 }


### PR DESCRIPTION
## Problem
Currently both the content manager and site manager do not have access to the comment overview page. However they are able to edit and delete comments.

It would be much more useful if you had access to the comment overview page.

## Solution
Grant access to content manager and site manager to access the comment overview page.

Make the comment overview page a bit more useful by removing the _Subject_ and _Posted on_ columns. Also added more buttons as well as showing the actual comment text in the table for quick access.

## Issue tracker
- https://jira.goalgorilla.com/browse/DS-3488

## HTT
- [x] Check out the code changes
- [x] Login as CM and go to the comment overview
- [x] Notice you have two pages (published comments and unapproved comments)
- [x] Check that all the links work
- [x] When unpublishing comments via the actions make sure no notices or errors are thrown (see 5885f11)
- [x] Check that it works for SM as well

## Documentation
- [x] This item is documented on LGOS
- [x] This item has been added to the feature overview

## Release notes
The comments overview page is now accessible for the Content Manager and Site Manager roler. The overview is also improved as the comment text is now in there. The default columns 'subject' and 'posted on' have been removed.