### PR TITLE
DS-5892 by serhiy-chornobay: Fix position for comment actions

### DIFF
--- a/themes/socialbase/templates/comment/links--comment.html.twig
+++ b/themes/socialbase/templates/comment/links--comment.html.twig
@@ -43,7 +43,7 @@
   {%- endif -%}
 
   {% if links['comment-edit'] or links['comment-delete'] %}
-    <div class="comment__actions btn-group pull-right">
+    <div class="comment__actions pull-right">
       <button type="button" data-toggle="dropdown" aria-expanded="false" aria-haspopup="true" class="btn btn-icon-toggle dropdown-toggle">
         <svg class="btn-icon icon-gray">
           <use xlink:href="#icon-expand_more"></use>

--- a/themes/socialbase/templates/system/links.html.twig
+++ b/themes/socialbase/templates/system/links.html.twig
@@ -41,7 +41,7 @@
     {%- endif -%}
   {%- endif -%}
   {%- if links.edit -%}
-    <div class="comment__actions btn-group pull-right">
+    <div class="comment__actions pull-right">
       <button type="button" data-toggle="dropdown" aria-expanded="false" aria-haspopup="true" class="btn btn-icon-toggle dropdown-toggle">
         <svg class="btn-icon icon-gray">
           <use xlink:href="#icon-expand_more"></use>


### PR DESCRIPTION
## Problem
The 'v' button for edit and delete my own post is not positioned correctly.( only if Big Pipe module is enabled)

## Solution
Fix templates for comment actions block

## Issue tracker
- https://jira.goalgorilla.com/browse/DS-5892

## HTT
- [ ] Check out the code changes
- [ ] Checkout to this branch
- [ ] Login as user NORMAL USER and check comment actions

## Documentation
- [ ] This item is documented on LGOS
- [ ] This item has been added to the feature overview
