### PR TITLE
DS-5827 by jaapjan: update r4032login settings for destination parameter

### DIFF
--- a/modules/social_features/social_core/social_core.install
+++ b/modules/social_features/social_core/social_core.install
@@ -835,3 +835,19 @@ function social_core_update_8026() {
     }
   }
 }
+
+/**
+ * Re-save settings for r4032login to enable redirect to destination.
+ */
+function social_core_update_8027() {
+  if (\Drupal::moduleHandler()->moduleExists('r4032login')) {
+    $config = \Drupal::configFactory()->getEditable('r4032login.settings');
+    if (!$config->get('redirect_to_destination')) {
+      $config->set('redirect_to_destination', TRUE);
+    }
+    if (!$config->get('destination_parameter_override')) {
+      $config->set('destination_parameter_override', '');
+    }
+    $config->save();
+  }
+}


### PR DESCRIPTION

## Problem
In this [PR](https://github.com/goalgorilla/open_social/pull/916) we updated to the latest version of r4032login. Settings file was changed in this module, but there was no update hook. I've compared an Open Social install which had r4032login installed before this update and looked at the settings in the module. There are two settings missing:

* redirect_to_destination
* destination_parameter_override

## Solution
I've created an update hook which adds the default value of these settings IF they are missing.

## Issue tracker
- DS-5827

## HTT
- [ ] Install an older version of Open Social and make sure you have an older version of r4032login as well.
- [ ] Do a `drush cget r4032login.settings`.
- [ ] Verify that a redirect with a destination parameter does not work.
- [ ] Go to this branch and check the code changes
- [ ] Run the update hook.
- [ ] Do a `drush cget r4032login.settings` and compare with the previous output.
- [ ] Verify that the redirects with a destination parameter works again.

## Release notes
In Open Social installations with the r4032login module enabled which were installed before the beta version of this module did not have the correct settings. The r4032login module did not supply an update hook for this. This caused some redirects after user login to not work anymore. E.g. /user/login?destination=/all-notifications wouldn't work anymore. This is now solved by delivering an update hook in the Open Social distro. When the module is not enabled it will not change anything.