### PR TITLE
DS - 5479 - As GM+ being able to add multiple people to a group at once

### DIFF
--- a/modules/social_features/social_group/social_group.module
+++ b/modules/social_features/social_group/social_group.module
@@ -487,7 +487,16 @@ function _social_group_action_form_submit($form, FormStateInterface $form_state)
 
     // Get form that was submitted.
     $complete_form = $form_state->getCompleteForm();
-
+    // For multiple Group Members that are valid we add multiple entities.
+    if ($complete_form['#form_id'] == 'group_content_' . $group->bundle() . '-group_membership_add_form') {
+      // We passed the validation.
+      // Let's create the Group Content for all our members just like
+      // Group does it for creating a Group and adding its creator as member.
+      $values = ['group_roles' => $form_state->getValue('group_roles')];
+      foreach ($form_state->getValue('entity_id_new') as $key => $uid) {
+        $group->addMember(User::load($uid['target_id']), $values);
+      }
+    }
     if (in_array($complete_form['#form_id'], ['group_content_' . $group->bundle() . '-group_membership_group-join_form', 'group_content_' . $group->bundle() . '-group_membership_add_form'])) {
       // Set redirect to group home page.
       $form_state->setRedirect(

--- a/modules/social_features/social_group/src/Element/SocialGroupEntityAutocomplete.php
+++ b/modules/social_features/social_group/src/Element/SocialGroupEntityAutocomplete.php
@@ -5,6 +5,7 @@ namespace Drupal\social_group\Element;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\social_core\Entity\Element\EntityAutocomplete;
 use Drupal\Component\Utility\Tags;
+use Drupal\user\Entity\User;
 
 /**
  * Provides an Group member autocomplete form element.
@@ -20,15 +21,26 @@ class SocialGroupEntityAutocomplete extends EntityAutocomplete {
    * Form element validation handler for entity_autocomplete elements.
    */
   public static function validateEntityAutocomplete(array &$element, FormStateInterface $form_state, array &$complete_form) {
-    // For other types not using members, we have entity_id as multiple
-    // options. For example adding multiple members to a group.
-    $input_values = Tags::explode($element['#value']);
+    $duplicated_values = [];
 
+    // Load the current Group so we can see if there are existing members.
+    $group = _social_group_get_current_group();
+
+    // Grab all the input values so we can get the ID's out of them.
+    $input_values = Tags::explode($element['#value']);
     foreach ($input_values as $input) {
       $match = static::extractEntityIdFromAutocompleteInput($input);
       if ($match === NULL) {
+        $options = $element['#selection_settings'] + [
+          'target_type' => $element['#target_type'],
+          'handler' => $element['#selection_handler'],
+        ];
+
+        /* @var /Drupal\Core\Entity\EntityReferenceSelection\SelectionInterface $handler */
+        $handler = \Drupal::service('plugin.manager.entity_reference_selection')->getInstance($options);
         // Try to get a match from the input string when the user didn't use
         // the autocomplete but filled in a value manually.
+        // Got this from the parent::validateEntityAutocomplete.
         $match = static::matchEntityByTitle($handler, $input, $element, $form_state, !$autocreate);
       }
 
@@ -37,22 +49,42 @@ class SocialGroupEntityAutocomplete extends EntityAutocomplete {
           'target_id' => $match,
         ];
 
+        $account = User::load($match);
+        // User is already a member, add it to an array for the Form element
+        // to render an error after all checks are gone.
+        if ($group->getMember($account)) {
+          $duplicated_values[] = $input;
+        }
+
         // Validate input for every single user. This way we make sure that
-        // The element validates one, two or more users added in the autocomplete.
-        // This is because Group doesnt allow adding multiple users at once,
+        // The element validates one, or more users added in the autocomplete.
+        // This is because Group doesn't allow adding multiple users at once,
         // so we need to validate single users, if they all pass we can add
         // them all in the _social_group_action_form_submit.
-
-        $form_state->setValue('entity_id', $value[$match]['target_id']);
         parent::validateEntityAutocomplete($element, $form_state, $complete_form);
       }
     }
 
-    if ($value !== null) {
-      $form_state->setValue('entity_id_new', $value);
+    // If we have duplicates, provide an error message.
+    if (!empty($duplicated_values)) {
+      $usernames = "";
+      foreach ($duplicated_values as $values) {
+        $usernames .= $values . " ";
+      }
+
+      $message = t('Users: @usernames are already members of the group, 
+      you can\'t add them again', ['@usernames' => $usernames]);
+
+      // We have to kick in a form set error here, or else the
+      // GroupContentCardinalityValidator will kick in and show a faulty
+      // error message. Alter this later when Group supports multiple members.
+      $form_state->setError($element, $message);
+      return;
     }
 
-//    parent::validateEntityAutocomplete($element, $form_state, $complete_form);
+    if ($value !== NULL) {
+      $form_state->setValue('entity_id_new', $value);
+    }
   }
 
 }

--- a/modules/social_features/social_group/src/Element/SocialGroupEntityAutocomplete.php
+++ b/modules/social_features/social_group/src/Element/SocialGroupEntityAutocomplete.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Drupal\social_group\Element;
+
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\social_core\Entity\Element\EntityAutocomplete;
+use Drupal\Component\Utility\Tags;
+
+/**
+ * Provides an Group member autocomplete form element.
+ *
+ * The #default_value accepted by this element is either an entity object or an
+ * array of entity objects.
+ *
+ * @FormElement("social_group_entity_autocomplete")
+ */
+class SocialGroupEntityAutocomplete extends EntityAutocomplete {
+
+  /**
+   * Form element validation handler for entity_autocomplete elements.
+   */
+  public static function validateEntityAutocomplete(array &$element, FormStateInterface $form_state, array &$complete_form) {
+    // For other types not using members, we have entity_id as multiple
+    // options. For example adding multiple members to a group.
+    $input_values = Tags::explode($element['#value']);
+
+    foreach ($input_values as $input) {
+      $match = static::extractEntityIdFromAutocompleteInput($input);
+      if ($match === NULL) {
+        // Try to get a match from the input string when the user didn't use
+        // the autocomplete but filled in a value manually.
+        $match = static::matchEntityByTitle($handler, $input, $element, $form_state, !$autocreate);
+      }
+
+      if ($match !== NULL) {
+        $value[] = [
+          'target_id' => $match,
+        ];
+      }
+    }
+
+    if ($value !== null) {
+      $form_state->setValue('entity_id_new', $value['target_id']);
+    }
+
+//    parent::validateEntityAutocomplete($element, $form_state, $complete_form);
+  }
+
+}

--- a/modules/social_features/social_group/src/Element/SocialGroupEntityAutocomplete.php
+++ b/modules/social_features/social_group/src/Element/SocialGroupEntityAutocomplete.php
@@ -33,14 +33,23 @@ class SocialGroupEntityAutocomplete extends EntityAutocomplete {
       }
 
       if ($match !== NULL) {
-        $value[] = [
+        $value[$match] = [
           'target_id' => $match,
         ];
+
+        // Validate input for every single user. This way we make sure that
+        // The element validates one, two or more users added in the autocomplete.
+        // This is because Group doesnt allow adding multiple users at once,
+        // so we need to validate single users, if they all pass we can add
+        // them all in the _social_group_action_form_submit.
+
+        $form_state->setValue('entity_id', $value[$match]['target_id']);
+        parent::validateEntityAutocomplete($element, $form_state, $complete_form);
       }
     }
 
     if ($value !== null) {
-      $form_state->setValue('entity_id_new', $value['target_id']);
+      $form_state->setValue('entity_id_new', $value);
     }
 
 //    parent::validateEntityAutocomplete($element, $form_state, $complete_form);

--- a/modules/social_features/social_profile/social_profile.module
+++ b/modules/social_features/social_profile/social_profile.module
@@ -45,6 +45,11 @@ function social_profile_field_widget_form_alter(&$element, FormStateInterface $f
   if ($field_definition->getType() === 'entity_reference') {
     if (isset($element['target_id']['#target_type']) && $element['target_id']['#target_type'] === 'user') {
       $element['target_id']['#selection_handler'] = 'social';
+      $element['target_id']['#type'] = 'social_private_message_entity_autocomplete';
+      $build_info = $form_state->getBuildInfo();
+      if ($build_info['base_form_id'] === 'group_content_form') {
+        $element['target_id']['#type'] = 'social_group_entity_autocomplete';
+      }
     }
   }
 }

--- a/modules/social_features/social_profile/social_profile.module
+++ b/modules/social_features/social_profile/social_profile.module
@@ -47,6 +47,7 @@ function social_profile_field_widget_form_alter(&$element, FormStateInterface $f
       $element['target_id']['#selection_handler'] = 'social';
       $element['target_id']['#type'] = 'social_private_message_entity_autocomplete';
       $build_info = $form_state->getBuildInfo();
+      // For Adding Multiple Group members we have our own autocomplete.
       if ($build_info['base_form_id'] === 'group_content_form') {
         $element['target_id']['#type'] = 'social_group_entity_autocomplete';
       }


### PR DESCRIPTION
## Problem
On the "add member" page of the Manage members tab of a group you can not add multiple users to a group making it a dreadfull job adding users to a group. 

## Solution
We have implemented the same widget as for the private message. Unfortunately Group didnt support multiple entity cardinality for members yet. This means I had to go for a Distro custom solution and add my own validation and submit handler. 

## Issue tracker
- https://jira.goalgorilla.com/browse/DS-5497

## HTT
- [ ] Check out the code changes
- [ ] Login as user with GM permissions (or a SM)
- [ ] Go to your Group and go to the Manage Members tab and click Add members
- [ ] Try adding one user to the group, see that it works as before
- [ ] Try adding two users to the group, see that this also works
- [ ] Try adding two users where one or more are already members of the group, validation should fail and none of the users should be added to the groupl
- [ ] Try pasting a string with multiple users all at once like: _EAA_official (9), Alison Hendrix (13)_ and see the widget also allows this
- [ ] Try adding multiple users with a role, see that all of them have the role added as well.

## Documentation
- [ ] This item is **NOT** documented on LGOS yet
- [ ] This item has **NOT** been added to the feature overview yet

## Release notes
Want to add multiple users to a group? We’ve just made it easier for you! Group Managers are now able to add multiple users to a group by referencing them just as you are able to do in the private message functions. 