### PR TITLE
2988074 by jochemvn: Add fallback way to get the account

### DIFF
--- a/modules/social_features/social_profile/social_profile.module
+++ b/modules/social_features/social_profile/social_profile.module
@@ -91,6 +91,13 @@ function social_profile_form_profile_profile_edit_form_alter(array &$form, FormS
   $user = \Drupal::currentUser();
   $account = \Drupal::routeMatch()->getParameter('user');
 
+  /** @var \Drupal\profile\Entity\Profile $profile */
+  $profile = $form_state->getFormObject()->getEntity();
+
+  if (!$account instanceof User && $profile instanceof Profile) {
+    $account = $profile->getOwner();
+  }
+
   // Check for permission on custom edit profile tags, it's only for CM+ who can
   // actually edit a users profile and add profile tags there.
   if (!$user->hasPermission('edit profile tags')) {


### PR DESCRIPTION
## Problem
Editing profile from profile admin page results in WSOD

## Solution
If the account cannot be retrieved from the URL, we assume the owner of the profile.

## Issue tracker
- https://www.drupal.org/project/social/issues/2885189
- http://drupal.org/node/2988074

## HTT
- [x] Check out the code changes
- [x] Login as admin and go to the profile overview
- [x] Try to edit another users' profile
- [x] WSOD
- [x] Switch to this branch
- [x] Try again
- [x] No WSOD and the cancel buttons leads to the user profile of the profile you're editing
- [x] Try /user/x/profile too
- [x] Cancel buttons works the same here

## Documentation
- [x] This item is documented on LGOS
- [x] This item has been added to the feature overview

## Release notes
Editing a profile from the profile admin overview resulted in a WSOD. This fix makes sure you can now also edit someone's profile from that admin page.
