### PR TITLE
DS-5768 - Fix false negative Behat test: Landing-page-create

### DIFF
--- a/tests/behat/features/capabilities/landing-page/landing-page-create.feature
+++ b/tests/behat/features/capabilities/landing-page/landing-page-create.feature
@@ -1,4 +1,4 @@
-@api @landing-page @stability @perfect @critical @DS-4130 @stability-4 @landing-page-create
+@api @landing-page @stability @javascript @perfect @critical @DS-4130 @stability-4 @landing-page-create
 Feature: Create Landing Page
   Benefit: In order to share useful information with users
   Role: AN
@@ -43,11 +43,9 @@ Feature: Create Landing Page
     And I select "btn-primary" from "field_landing_page_section[0][subform][field_section_paragraph][0][subform][field_hero_buttons][1][subform][field_button_style]"
     And I press "Add Section"
     And I wait for AJAX to finish
-    And I wait for "3" seconds
     # Create Introduction
     And I press "Add Introduction"
     And I wait for AJAX to finish
-    And I wait for "3" seconds
     And I fill in the following:
       | field_landing_page_section[1][subform][field_section_paragraph][0][subform][field_introduction_title][0][value]   | Introduction title             |
       | field_landing_page_section[1][subform][field_section_paragraph][0][subform][field_introduction_link_an][0][uri]   | /log-in                        |
@@ -56,11 +54,9 @@ Feature: Create Landing Page
       | field_landing_page_section[1][subform][field_section_paragraph][0][subform][field_introduction_link_lu][0][title] | Introduction Link LU           |
     And I press "Add Section"
     And I wait for AJAX to finish
-    And I wait for "5" seconds
     # Create Featured
     And I press "Add Featured"
     And I wait for AJAX to finish
-    And I wait for "3" seconds
     And I fill in the following:
       | field_landing_page_section[2][subform][field_section_paragraph][0][subform][field_featured_title][0][value] | Featured title  |
       | field_landing_page_section[2][subform][field_section_paragraph][0][subform][field_featured_link][0][uri]    | /search/content |
@@ -70,11 +66,9 @@ Feature: Create Landing Page
     And I fill in "field_landing_page_section[2][subform][field_section_paragraph][0][subform][field_featured_items][2][target_id]" with "Featured Topic 2"
     And I press "Add Section"
     And I wait for AJAX to finish
-    And I wait for "3" seconds
     # Create Block
     And I press "Add Block"
     And I wait for AJAX to finish
-    And I wait for "3" seconds
     And I select "views_block:community_activities-block_stream_landing" from "field_landing_page_section[3][subform][field_section_paragraph][0][subform][field_block_reference][0][plugin_id]"
     And I select "activity_overview_block" from "field_landing_page_section[3][subform][field_section_paragraph][0][subform][field_block_reference_secondary][0][plugin_id]"
     And I fill in the following:
@@ -84,7 +78,6 @@ Feature: Create Landing Page
     And I click "URL path settings"
     And I fill in "URL alias" with "landingpage"
     And I press "Save"
-    And I wait for "3" seconds
     # Ses as LU
     Then I should see "Landing page This is a dynamic page has been created."
     And I should see "Hero title"
@@ -119,7 +112,6 @@ Feature: Create Landing Page
     And I fill in the following:
       | field_landing_page_section[0][subform][field_section_paragraph][0][subform][field_hero_title][0][value] | Hero title edited |
     And I press "Save"
-    And I wait for "3" seconds
     Then I should see "Landing page This is a dynamic page has been updated."
     # See as AN
     Given I logout


### PR DESCRIPTION
## Problem
The following tests are failing sometimes, ordered by # of occurrences:

- landing-page-create 
- create-private-message
- topic-download-test

## Solution

### Landing-page-create
Added `@javascript` tag to make sure there is full javascript support for the test.

### Create-private-message
Will follow

### Topic-download-test
Will follow

## Issue tracker
- DS-5768

## HTT
- [ ] Check out the code changes
- [ ] Verify test works instantly

## Documentation
- [ ] This item is documented on LGOS
- [ ] This item has been added to the feature overview

## Release notes

