### PR TITLE
Issue #2989731 : Added related "Create" permissions for block display

### DIFF
--- a/modules/social_features/social_event/src/Plugin/Block/EventAddBlock.php
+++ b/modules/social_features/social_event/src/Plugin/Block/EventAddBlock.php
@@ -64,7 +64,7 @@ class EventAddBlock extends BlockBase implements ContainerFactoryPluginInterface
    */
   protected function blockAccess(AccountInterface $account) {
     $route_user_id = $this->routeMatch->getParameter('user');
-    if ($account->id() == $route_user_id) {
+    if ($account->id() == $route_user_id && $account->hasPermission("create event content")) {
       return AccessResult::allowed();
     }
     // By default, the block is not visible.

--- a/modules/social_features/social_group/src/Plugin/Block/GroupAddBlock.php
+++ b/modules/social_features/social_group/src/Plugin/Block/GroupAddBlock.php
@@ -7,6 +7,7 @@ use Drupal\Core\Url;
 use Drupal\Core\Link;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\Access\AccessResult;
+use Drupal\group\Entity\GroupType;
 
 /**
  * Provides a 'GroupAddBlock' block.
@@ -28,7 +29,15 @@ class GroupAddBlock extends BlockBase {
     $route_user_id = \Drupal::routeMatch()->getParameter('user');
 
     // Show this block only on current user Groups page.
-    if ($current_user->id() == $route_user_id && ($account->hasPermission("create open_group group") || $account->hasPermission("creat closed group") || $account->hasPermission("create public_group group"))) {
+    $can_create_groups = False;
+    foreach (GroupType::loadMultiple() as $group_type) {
+      $permissions = 'create ' . $group_type->id() . ' group';
+      if ($account->hasPermission($permissions)) {
+        $can_create_groups = True;
+        break;
+      }
+    }
+    if ($current_user->id() == $route_user_id && $can_create_groups) {
       return AccessResult::allowed();
     }
 

--- a/modules/social_features/social_group/src/Plugin/Block/GroupAddBlock.php
+++ b/modules/social_features/social_group/src/Plugin/Block/GroupAddBlock.php
@@ -29,11 +29,11 @@ class GroupAddBlock extends BlockBase {
     $route_user_id = \Drupal::routeMatch()->getParameter('user');
 
     // Show this block only on current user Groups page.
-    $can_create_groups = False;
+    $can_create_groups = FALSE;
     foreach (GroupType::loadMultiple() as $group_type) {
       $permissions = 'create ' . $group_type->id() . ' group';
       if ($account->hasPermission($permissions)) {
-        $can_create_groups = True;
+        $can_create_groups = TRUE;
         break;
       }
     }

--- a/modules/social_features/social_group/src/Plugin/Block/GroupAddBlock.php
+++ b/modules/social_features/social_group/src/Plugin/Block/GroupAddBlock.php
@@ -28,7 +28,7 @@ class GroupAddBlock extends BlockBase {
     $route_user_id = \Drupal::routeMatch()->getParameter('user');
 
     // Show this block only on current user Groups page.
-    if ($current_user->id() == $route_user_id) {
+    if ($current_user->id() == $route_user_id && ($account->hasPermission("create open_group group") || $account->hasPermission("creat closed group") || $account->hasPermission("create public_group group"))) {
       return AccessResult::allowed();
     }
 

--- a/modules/social_features/social_group/src/Plugin/Block/GroupAddEventBlock.php
+++ b/modules/social_features/social_group/src/Plugin/Block/GroupAddEventBlock.php
@@ -27,7 +27,7 @@ class GroupAddEventBlock extends BlockBase {
     $group = _social_group_get_current_group();
 
     if (is_object($group)) {
-      if ($group->hasPermission('create group_node:event entity', $account)) {
+      if ($group->hasPermission('create group_node:event entity', $account)&& $account->hasPermission("create event content")) {
         if ($group->getGroupType()->id() === 'public_group') {
           $config = \Drupal::config('entity_access_by_field.settings');
           if ($config->get('disable_public_visibility') === 1 && !$account->hasPermission('override disabled public visibility')) {

--- a/modules/social_features/social_group/src/Plugin/Block/GroupAddTopicBlock.php
+++ b/modules/social_features/social_group/src/Plugin/Block/GroupAddTopicBlock.php
@@ -27,7 +27,7 @@ class GroupAddTopicBlock extends BlockBase {
     $group = _social_group_get_current_group();
 
     if (is_object($group)) {
-      if ($group->hasPermission('create group_node:topic entity', $account)) {
+      if ($group->hasPermission('create group_node:topic entity', $account)&& $account->hasPermission("create topic content")) {
         if ($group->getGroupType()->id() === 'public_group') {
           $config = \Drupal::config('entity_access_by_field.settings');
           if ($config->get('disable_public_visibility') === 1 && !$account->hasPermission('override disabled public visibility')) {

--- a/modules/social_features/social_post/src/Plugin/Block/PostGroupBlock.php
+++ b/modules/social_features/social_post/src/Plugin/Block/PostGroupBlock.php
@@ -33,7 +33,7 @@ class PostGroupBlock extends PostBlock {
     $group = _social_group_get_current_group();
 
     if (is_object($group)) {
-      if ($group->hasPermission('add post entities in group', $account)) {
+      if ($group->hasPermission('add post entities in group', $account) && $account->hasPermission("add post entities")) {
         $membership = $group->getMember($account);
         $context = [];
         if (!empty($membership)) {

--- a/modules/social_features/social_topic/src/Plugin/Block/TopicAddBlock.php
+++ b/modules/social_features/social_topic/src/Plugin/Block/TopicAddBlock.php
@@ -64,7 +64,7 @@ class TopicAddBlock extends BlockBase implements ContainerFactoryPluginInterface
    */
   protected function blockAccess(AccountInterface $account) {
     $route_user_id = $this->routeMatch->getParameter('user');
-    if ($account->id() == $route_user_id) {
+    if ($account->id() == $route_user_id && $account->hasPermission("create topic content")) {
       return AccessResult::allowed();
     }
     // By default, the block is not visible.


### PR DESCRIPTION
## Problem
The "Add a group", "Add topic" and "Add event" Button show allways up on the related page of the user profile, even if the user has no permission to create the related group/content.

## Solution
Added related permission to check if block is displayed or not

## Issue tracker
- https://www.drupal.org/project/social/issues/2989731

## HTT
- [x] Check out the code changes
- [x] Remove permission to create topic, event or all kind of groups from user role
- [x] Login as user with the role from above and go to the user profile
- [x] Verify that the "Add" buttons do not appear
- [x] Add permission to create topic, event or all kind of groups from user role
- [x] Verify that the "Add" buttons do not appear

## Documentation
- [ ] This item is documented on LGOS
- [ ] This item has been added to the feature overview

## Release notes
<describe the release notes>
