### PR TITLE
Revert "Merge pull request #952"

### DIFF
--- a/modules/custom/activity_basics/activity_basics.module
+++ b/modules/custom/activity_basics/activity_basics.module
@@ -7,7 +7,6 @@
 
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\node\NodeInterface;
-use Drupal\group\Entity\GroupContent;
 
 /**
  * Implements hook_entity_insert().
@@ -21,18 +20,7 @@ function activity_basics_entity_insert(EntityInterface $entity) {
  */
 function activity_basics_social_group_move(NodeInterface $node) {
   $node->setCreatedTime($node->getChangedTime());
-
-  // If the node is placed within a new group, we add the move_entity_action
-  // activity.
-  $group_contents = GroupContent::loadByEntity($node);
-  if (!empty($group_contents)) {
-    _activity_basics_entity_action($node, 'move_entity_action');
-  }
-  // If the node is placed from a group in to the community, we add the
-  // create_node-bundle_community activity.
-  if (empty($group_contents)) {
-    _activity_basics_entity_action($node, 'create_entitiy_action');
-  }
+  _activity_basics_entity_action($node, 'move_entity_action');
 }
 
 /**

--- a/modules/social_features/social_group/social_group.module
+++ b/modules/social_features/social_group/social_group.module
@@ -1095,15 +1095,6 @@ function social_group_form_node_form_alter(&$form, FormStateInterface $form_stat
           unset($form['actions']['submit']['#submit'][$submit_key]);
         }
       }
-
-      /* @var \Drupal\node\Entity\Node $node */
-      $node = $form_state->getFormObject()->getEntity();
-      // Store if the node is new or not.
-      $form['is_new'] = [
-        '#type' => 'value',
-        '#value' => $node->isNew(),
-      ];
-
       $form['actions']['submit']['#submit'][] = 'social_group_save_group_from_node';
     }
   }
@@ -1120,10 +1111,6 @@ function social_group_form_node_form_alter(&$form, FormStateInterface $form_stat
 function social_group_save_group_from_node(array $form, FormStateInterface $form_state) {
   /* @var \Drupal\node\Entity\Node $node */
   $node = $form_state->getFormObject()->getEntity();
-
-  // Check if the created node is new or updated.
-  $is_new = NULL !== $form_state->getValue('is_new') ? $form_state->getValue('is_new') : FALSE;
-
   $original_groups = [];
   $groups_to_add = [];
   $groups_to_remove = [];
@@ -1145,7 +1132,7 @@ function social_group_save_group_from_node(array $form, FormStateInterface $form
 
   // Now make sure the relevant GroupContent is removed or added.
   $setGroupsForNodeService = \Drupal::service('social_group.set_groups_for_node_service');
-  $setGroupsForNodeService->setGroupsForNode($node, $groups_to_remove, $groups_to_add, $original_groups, $is_new);
+  $setGroupsForNodeService->setGroupsForNode($node, $groups_to_remove, $groups_to_add, $original_groups);
 }
 
 /**

--- a/modules/social_features/social_group/social_group.services.yml
+++ b/modules/social_features/social_group/social_group.services.yml
@@ -8,7 +8,7 @@ services:
     arguments: []
   social_group.set_groups_for_node_service:
     class: Drupal\social_group\SetGroupsForNodeService
-    arguments: ['@entity_type.manager', '@module_handler']
+    arguments: []
   social_group.address_format_subscriber:
     class: Drupal\social_group\EventSubscriber\AddressFormatSubscriber
     tags:

--- a/modules/social_features/social_group/src/SetGroupsForNodeService.php
+++ b/modules/social_features/social_group/src/SetGroupsForNodeService.php
@@ -5,8 +5,6 @@ namespace Drupal\social_group;
 use Drupal\group\Entity\Group;
 use Drupal\group\Entity\GroupContent;
 use Drupal\node\NodeInterface;
-use Drupal\Core\Entity\EntityTypeManagerInterface;
-use Drupal\Core\Extension\ModuleHandlerInterface;
 
 /**
  * Class SetGroupsForNodeService.
@@ -16,111 +14,53 @@ use Drupal\Core\Extension\ModuleHandlerInterface;
 class SetGroupsForNodeService {
 
   /**
-   * The entity type manager.
-   *
-   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
-   */
-  protected $entityTypeManager;
-
-  /**
-   * The Module handler.
-   *
-   * @var \Drupal\Core\Extension\ModuleHandlerInterface
-   */
-  protected $moduleHandler;
-
-  /**
    * Constructor.
-   *
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
-   *   The entity manager.
-   * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
-   *   The module handler.
    */
-  public function __construct(EntityTypeManagerInterface $entity_type_manager, ModuleHandlerInterface $module_handler) {
-    $this->entityTypeManager = $entity_type_manager;
-    $this->moduleHandler = $module_handler;
+  public function __construct() {
+
   }
 
   /**
    * Save groups for a given node.
-   *
-   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
-   * @throws \Drupal\Core\Entity\EntityStorageException
    */
-  public function setGroupsForNode(NodeInterface $node, array $groups_to_remove, array $groups_to_add, array $original_groups = [], $is_new = FALSE) {
+  public static function setGroupsForNode(NodeInterface $node, array $groups_to_remove, array $groups_to_add, array $original_groups = []) {
     $moved = FALSE;
 
     // Remove the notifications related to the node if a group is added or
     // moved.
-    if ((empty($original_groups) || $original_groups != $groups_to_add)) {
-      $entity_query = $this->entityTypeManager->getStorage('activity')->getQuery();
+    if ((empty($original_groups) || $original_groups != $groups_to_add) && !empty($groups_to_add)) {
+      $entity_query = \Drupal::entityQuery('activity');
       $entity_query->condition('field_activity_entity.target_id', $node->id(), '=');
       $entity_query->condition('field_activity_entity.target_type', 'node', '=');
 
-      // 1. From Group -> Community OR Group.
-      // If there are original groups, it means content is removed from
-      // inside a group. So we can remove the create_node-bundle_group
-      // message from the streams.
       if (!empty($original_groups)) {
         $template = 'create_' . $node->bundle() . '_group';
-        $messages = $this->entityTypeManager->getStorage('message')
+        $messages = \Drupal::entityTypeManager()->getStorage('message')
           ->loadByProperties(['template' => $template]);
-
-        // Make sure we have a message template to work with.
-        if ($messages) {
-          $entity_query->condition('field_activity_message.target_id', array_keys($messages), 'IN');
-        }
-
-        $moved = TRUE;
-      }
-      // 1. From Community -> GROUP
-      // If there are no original groups, and there are groups we should add the
-      // piece of content to it means content is placed from the community
-      // in to a group and we remove the "create_node-bundle_community
-      // message from the streams.
-      elseif (empty($original_groups) && !empty($groups_to_add)) {
-        $template = 'create_' . $node->bundle() . '_community';
-        $messages = $this->entityTypeManager->getStorage('message')
-          ->loadByProperties(['template' => $template]);
-
-        // Make sure we have a message template to work with.
-        if ($messages) {
-          $entity_query->condition('field_activity_message.target_id', array_keys($messages), 'IN');
-        }
+        $entity_query->condition('field_activity_message.target_id', array_keys($messages), 'IN');
 
         $moved = TRUE;
       }
 
-      // Delete all activity items connected to our query.
       if (!empty($ids = $entity_query->execute())) {
-        $controller = $this->entityTypeManager->getStorage('activity');
+        $controller = \Drupal::entityTypeManager()->getStorage('activity');
         $controller->delete($controller->loadMultiple($ids));
       }
     }
 
-    // Remove all the group content references from the Group as well if we
-    // moved it out of the group.
-    if (!empty($groups_to_remove)) {
-      foreach ($groups_to_remove as $group_id) {
-        $group = Group::load($group_id);
-        self::removeGroupContent($node, $group);
-      }
+    foreach ($groups_to_remove as $group_id) {
+      $group = Group::load($group_id);
+      self::removeGroupContent($node, $group);
+    }
+    foreach ($groups_to_add as $group_id) {
+      $group = Group::load($group_id);
+      self::addGroupContent($node, $group);
     }
 
-    // Add the content to the Group if we placed it in a group.
-    if (!empty($groups_to_add)) {
-      foreach ($groups_to_add as $group_id) {
-        $group = Group::load($group_id);
-        self::addGroupContent($node, $group);
-      }
-    }
-
-    // Invoke hook_social_group_move if the content is not new.
-    if ($moved && !$is_new) {
+    if ($moved) {
       $hook = 'social_group_move';
 
-      foreach ($this->moduleHandler->getImplementations($hook) as $module) {
+      foreach (\Drupal::moduleHandler()->getImplementations($hook) as $module) {
         $function = $module . '_' . $hook;
         $function($node);
       }

--- a/tests/behat/features/bootstrap/FeatureContext.php
+++ b/tests/behat/features/bootstrap/FeatureContext.php
@@ -235,18 +235,11 @@ class FeatureContext extends RawMinkContext implements Context, SnippetAccepting
      */
     public function iSelectGroup($group) {
 
-      if ($group === "- None -") {
-        $option = '_none';
-      }
-
-      if ($group !== "- None -") {
-        $option = $this->getGroupIdFromTitle($group);
-      }
+      $option = $this->getGroupIdFromTitle($group);
 
       if (!$option) {
         throw new \InvalidArgumentException(sprintf('Could not find group for "%s"', $group));
       }
-
       $this->getSession()->getPage()->selectFieldOption('edit-groups', $option);
 
     }

--- a/tests/behat/features/bootstrap/SocialDrupalContext.php
+++ b/tests/behat/features/bootstrap/SocialDrupalContext.php
@@ -129,26 +129,10 @@ class SocialDrupalContext extends DrupalContext {
   }
 
   /**
-   * @When I empty the queue
-   */
-  public function iEmptyTheQueue() {
-    $this->processQueue(TRUE);
-  }
-
-  /**
    * @When I wait for the queue to be empty
    */
-  public function iWaitForTheQueueToBeEmpty() {
-    $this->processQueue();
-  }
-
-  /**
-   * Process queue items.
-   *
-   * @param bool $just_delete
-   *   If set to TRUE, it doesn't process the items, but simply deletes them.
-   */
-  protected function processQueue($just_delete = FALSE) {
+  public function iWaitForTheQueueToBeEmpty()
+  {
     $workerManager = \Drupal::service('plugin.manager.queue_worker');
     /** @var Drupal\Core\Queue\QueueFactory; $queue */
     $queue = \Drupal::service('queue');
@@ -163,10 +147,7 @@ class SocialDrupalContext extends DrupalContext {
 
         if ($worker->numberOfItems() > 0) {
           while ($item = $worker->claimItem()) {
-            // If we don't just delete them, process the item first.
-            if ($just_delete === FALSE) {
-              $queue_worker->processItem($item->data);
-            }
+            $queue_worker->processItem($item->data);
             $worker->deleteItem($item);
           }
         }

--- a/tests/behat/features/capabilities/group/group-edit-content-in-group.feature
+++ b/tests/behat/features/capabilities/group/group-edit-content-in-group.feature
@@ -7,10 +7,9 @@ Feature: Move content after creation
   Scenario: Successfully add new content with the group selector
 
     Given users:
-      | name  | pass | mail              | status | roles         |
-      | harry | 1234 | harry@example.com | 1      |               |
-      | sally | 1234 | sally@example.com | 1      |               |
-      | smith | 1234 | sm@example.com    | 1      |  sitemanager  |
+      | name  | pass | mail              | status |
+      | harry | 1234 | harry@example.com | 1      |
+      | sally | 1234 | sally@example.com | 1      |
     Given groups:
       | title      | description    | author | type       | language |
       | Motorboats | Vroem vroem..  | sally  | open_group | en       |
@@ -35,46 +34,3 @@ Feature: Move content after creation
     # Edit topic
     When I click "Edit content"
     Then I should see "Moving content after creation function has been disabled. In order to move this content, please contact a site manager."
-
-    # Edit topic as SM to move in a new group.
-    When I am logged in as "smith"
-    And I am on "/all-topics"
-    And I should see "I love this sport"
-    And I click "I love this sport"
-    Then I should see "Kayaking"
-    And I click "Edit content"
-    And I select group "Motorboats"
-    And I wait for AJAX to finish
-    And I press "Save"
-    Then I should see "Motorboats"
-
-    When I am logged in as "harry"
-    And I am on the stream of group "Motorboats"
-    Then I should see "harry created a topic in Motorboats"
-    And I should see "I love this sport"
-    And I am on the stream of group "Kayaking"
-    And I should not see "I love this sport"
-
-    # Edit topic as SM to move outside of a group in community.
-    When I am logged in as "smith"
-    And I am on "/all-topics"
-    And I should see "I love this sport"
-    And I click "I love this sport"
-    And I empty the queue
-    And I click "Edit content"
-    And I select group "- None -"
-    And I press "Save"
-    And I run cron
-    Then I should not see "Motorboats" in the "Main content"
-    And I should not see "Kayaking" in the "Main content"
-
-    When I am logged in as "harry"
-    And I am on the stream of group "Motorboats"
-    Then I should not see "harry created a topic in Motorboats"
-    And I should not see "I love this sport"
-    And I am on the stream of group "Kayaking"
-    And I should not see "I love this sport"
-    And I click "Home"
-    Then I should see "harry created a topic"
-    And I should see "I love this sport"
-


### PR DESCRIPTION
This reverts commit fa00cf68af5331723ae66c437f5ce03999900a50, reversing
changes made to bd3c7c876f2389ef009e279cda2134285f8c2c59.

Unfortunately this had to be done because we found some cases where this functionality
would introduce multiple messages.

See a solution at https://github.com/goalgorilla/open_social/pull/984. However this is
not yet complete and needs a bit more work still.

## Problem
At #815 we introduced a functionality to move content between groups, we extended it at #952.

In cases where a node was created and it was edited and moved into or out of a group before the cron ran, it would create multiple activity messages.

## Solution
As duplicate messages are very annoying and can clutter up the database we decided to revert pull request #952.

We're working on a solution at #984 but it is not yet ready to be released as it doesn't fix all the cases.

## Release notes
A few releases ago we introduced a functionality to move content between groups. In 2.2 we extended it with moving content into and outside of groups. This however introduces an issues where multiple activity messages can be created.

In order to not make the functionality worse we're taking this functionality out of the release until it is fixed and no such cases will appear.