### PR TITLE
 Issue #2991128 by Kingdutch: Check that the group_profile_names_image field_group exists before overriding.

### DIFF
--- a/modules/social_features/social_profile/modules/social_profile_fields/src/SocialProfileFieldsOverride.php
+++ b/modules/social_features/social_profile/modules/social_profile_fields/src/SocialProfileFieldsOverride.php
@@ -27,21 +27,22 @@ class SocialProfileFieldsOverride implements ConfigFactoryOverrideInterface {
     if (in_array($config_name, $names)) {
       $config = $config_factory->getEditable($config_name);
 
+      // Add the nick name field to the profile.
+      $overrides[$config_name]['content']['field_profile_nick_name'] = [
+        'weight' => 0,
+        'settings' => [
+          'size' => '60',
+          'placeholder' => '',
+        ],
+        'third_party_settings' => [],
+        'type' => 'string_textfield',
+        'region' => 'content',
+      ];
+
+      // If there is a profile names and image field_group we move the field.
       $third_party = $config->get('third_party_settings');
       if (isset($third_party['field_group']['group_profile_names_image'])) {
         $third_party['field_group']['group_profile_names_image']['children'][] = 'field_profile_nick_name';
-
-        // Add the nick name field to the profile.
-        $overrides[$config_name]['content']['field_profile_nick_name'] = [
-          'weight' => 0,
-          'settings' => [
-            'size' => '60',
-            'placeholder' => '',
-          ],
-          'third_party_settings' => [],
-          'type' => 'string_textfield',
-          'region' => 'content',
-        ];
 
         // We use the entire children array because a deep merge on a numerical
         // key array doesn't work.

--- a/modules/social_features/social_profile/modules/social_profile_fields/src/SocialProfileFieldsOverride.php
+++ b/modules/social_features/social_profile/modules/social_profile_fields/src/SocialProfileFieldsOverride.php
@@ -28,22 +28,24 @@ class SocialProfileFieldsOverride implements ConfigFactoryOverrideInterface {
       $config = $config_factory->getEditable($config_name);
 
       $third_party = $config->get('third_party_settings');
-      $third_party['field_group']['group_profile_names_image']['children'][] = 'field_profile_nick_name';
+      if (isset($third_party['field_group']['group_profile_names_image'])) {
+        $third_party['field_group']['group_profile_names_image']['children'][] = 'field_profile_nick_name';
 
-      $content = $config->get('content');
-      $content['field_profile_nick_name'] = [
-        'weight' => 0,
-        'settings' => [
-          'size' => '60',
-          'placeholder' => '',
-        ],
-        'third_party_settings' => [],
-        'type' => 'string_textfield',
-        'region' => 'content',
-      ];
+        $content = $config->get('content');
+        $content['field_profile_nick_name'] = [
+          'weight' => 0,
+          'settings' => [
+            'size' => '60',
+            'placeholder' => '',
+          ],
+          'third_party_settings' => [],
+          'type' => 'string_textfield',
+          'region' => 'content',
+        ];
 
-      $overrides[$config_name]['third_party_settings'] = $third_party;
-      $overrides[$config_name]['content'] = $content;
+        $overrides[$config_name]['third_party_settings'] = $third_party;
+        $overrides[$config_name]['content'] = $content;
+      }
     }
 
     // Add field_group and field_comment_files.

--- a/modules/social_features/social_profile/modules/social_profile_fields/src/SocialProfileFieldsOverride.php
+++ b/modules/social_features/social_profile/modules/social_profile_fields/src/SocialProfileFieldsOverride.php
@@ -31,8 +31,8 @@ class SocialProfileFieldsOverride implements ConfigFactoryOverrideInterface {
       if (isset($third_party['field_group']['group_profile_names_image'])) {
         $third_party['field_group']['group_profile_names_image']['children'][] = 'field_profile_nick_name';
 
-        $content = $config->get('content');
-        $content['field_profile_nick_name'] = [
+        // Add the nick name field to the profile.
+        $overrides[$config_name]['content']['field_profile_nick_name'] = [
           'weight' => 0,
           'settings' => [
             'size' => '60',
@@ -43,8 +43,11 @@ class SocialProfileFieldsOverride implements ConfigFactoryOverrideInterface {
           'region' => 'content',
         ];
 
-        $overrides[$config_name]['third_party_settings'] = $third_party;
-        $overrides[$config_name]['content'] = $content;
+        // We use the entire children array because a deep merge on a numerical
+        // key array doesn't work.
+        $children = $third_party['field_group']['group_profile_names_image']['children'];
+        $children[] = 'field_profile_nick_name';
+        $overrides[$config_name]['third_party_settings']['field_group']['group_profile_names_image']['children'] = $children;
       }
     }
 


### PR DESCRIPTION
## Problem
The SocialProfileFieldsOverride class adds the field_profile_nick_name to the group_profile_names_image group. However, if that group is not present then the override will cause a group with malformed properties to be created which crashes the field_group module.

This makes it impossible for a user to edit their profile.

## Solution
Only override the configuration if the field is actually present.

## Issue tracker
- https://www.drupal.org/project/social/issues/2991128

## HTT
- [x] Check out the code changes
- [x] Remove the group_profile_names_image field group in the profile
- [x] Check that the profile edit form no longer shows an error message.

## Release notes
Removing the Names and Profile Image (group_profile_names_image) field group with the social_profile_fields module enabled would make the user profile uneditable. This has been fixed by checking for the group's existence before overriding the configuration.
