### PR TITLE
check comment display status for mentions

### DIFF
--- a/modules/social_features/social_mentions/social_mentions.module
+++ b/modules/social_features/social_mentions/social_mentions.module
@@ -11,6 +11,8 @@ use Drupal\Core\Url;
 use Drupal\Component\Serialization\Json;
 use Drupal\mentions\Entity\MentionsType;
 use Drupal\Core\Asset\AttachedAssetsInterface;
+use Drupal\comment\Plugin\Field\FieldType\CommentItemInterface;
+use Drupal\node\Entity\Node;
 
 /**
  * Implements hook_form_alter().
@@ -98,7 +100,9 @@ function social_mentions_preprocess_mentions(&$variables) {
  * Implements hook_comment_links_alter().
  */
 function social_mentions_comment_links_alter(array &$links, CommentInterface $entity, array &$context) {
-  if ($entity->hasParentComment()) {
+  $field_name = $entity->getFieldName();
+  $node = $entity->getCommentedEntity();
+  if ($entity->hasParentComment() && $node->get($field_name)->status == CommentItemInterface::OPEN) {
     /* @var \Drupal\Core\Session\AccountInterface $account */
     $account = $entity->getOwner();
     $storage = \Drupal::entityTypeManager()->getStorage('profile');


### PR DESCRIPTION
## Problem
When commenting of a node with comments and replies is closed
($node->get([comment field])->status =CommentItemInterface::CLOSED),
social mentions module still shows "Reply" links

## Solution
Solution checks node comment display status before creating "Reply" links.

## Issue tracker
- https://www.drupal.org/project/social/issues/2991451

## HTT
- [x] Check out the code changes
- [x] Login as user root and close commenting for a node
- [x] Notice it doesn't work by seeing "Reply" links on the comments
- [x] Checkout to this branch
- [x] Reload the node and check that all "Reply" links are gone

## Documentation
- [ ] This item is documented on LGOS
- [ ] This item has been added to the feature overview

## Release notes
<describe the release notes>
