### PR TITLE
2990496 by jochemvn: Better passthrough of variable in the form (static)

### DIFF
--- a/modules/social_features/social_group/src/Plugin/Field/FieldWidget/SocialGroupSelectorWidget.php
+++ b/modules/social_features/social_group/src/Plugin/Field/FieldWidget/SocialGroupSelectorWidget.php
@@ -165,7 +165,11 @@ class SocialGroupSelectorWidget extends OptionsSelectWidget implements Container
     // So I have to add this setting to the form in order to use it later on.
     $default_visibility = $this->configFactory->get('entity_access_by_field.settings')
       ->get('default_visibility');
-    $form['field_content_visibility']['standard_default'] = $default_visibility;
+
+    $form['default_visibility'] = [
+      '#type' => 'value',
+      '#value' => $default_visibility,
+    ];
 
     $change_group_node = $this->configFactory->get('social_group.settings')
       ->get('allow_group_selection_in_node');
@@ -220,7 +224,7 @@ class SocialGroupSelectorWidget extends OptionsSelectWidget implements Container
       }
     }
     else {
-      $default_visibility = $form['field_content_visibility']['standard_default'];
+      $default_visibility = $form_state->getValue('default_visibility');
       $entity = $form_state->getFormObject()->getEntity();
 
       $allowed_visibility_options = social_group_get_allowed_visibility_options_per_group_type(NULL, NULL, $entity);


### PR DESCRIPTION
## Problem
When creating content that uses the group selector widget (EG: topic/event) an error occurs. A value is being passed through in the form. This should be done slightly different, to make sure the form doesn't think it's a key it should render.

## Solution
Create a 'value' #type, which the form renderer does not try to render. 

## Issue tracker
- https://www.drupal.org/project/social/issues/2990496

## HTT
The HTT of #969 still applies here:
- [ ] Check out the code changes
- [ ] Go to /admin/config/opensocial/visibility and set the default visibility to 'public' 
- [ ] Login as user X and create a topic outside of any groups
- [ ] See the default visibility is still set to 'community' (was hardcoded)
- [ ] Notice it doesn't work
- [ ] Checkout to this branch
- [ ] Login as user X and create a topic outside of any groups
- [ ] See the default visibility is now set to 'public'
- [ ] See when you switch groups the default value changes accordingly (community for open groups, Group members for closed groups) 
- [ ] Switch back to - None - groups again and see it goes back to the default selected visibility.
- [ ] Try it with 'community' as default visibility as well.

## Documentation
- [ ] This item is documented on LGOS
- [ ] This item has been added to the feature overview

## Release notes
Fixed error "standard_default" is an invalid render array
