### PR TITLE
Issue #2992332 by ribel: Fix allowed visibility options for a custom group types

### DIFF
--- a/modules/social_features/social_group/social_group.module
+++ b/modules/social_features/social_group/social_group.module
@@ -1169,7 +1169,7 @@ function social_group_get_allowed_visibility_options_per_group_type($group_type_
       $visibility_options['community'] = FALSE;
       break;
 
-    case NULL:
+    default:
       $config = \Drupal::config('entity_access_by_field.settings');
       $visibility_options['public'] = TRUE;
       if ($config->get('disable_public_visibility') === 1 && !$account->hasPermission('override disabled public visibility')) {


### PR DESCRIPTION
## Problem
When a group of custom group type is selected during creation of Topic or Content, only Community option is allowed in the Visibility field. But custom group type could also provide public visibility.

## Solution
Apply the same rules for custom group types, as if there are no group (change `case NULL:` to `default:` in `switch` of `social_group_get_allowed_visibility_options_per_group_type()` function.

## Issue tracker
- https://www.drupal.org/project/social/issues/2992332
- https://jira.goalgorilla.com/browse/CBI-421

## HTT
- [ ] Check out the code changes
- [ ] Create custom group type
- [ ] Login as user and create new Topic
- [ ] Select custom group from Groups and see that only Community option is available in Visibility
- [ ] Checkout to this branch
- [ ] Select custom group from Groups and see that Public and Community options are available in Visibility

## Documentation
- [ ] This item is documented on LGOS
- [ ] This item has been added to the feature overview

## Release notes
<describe the release notes>
