### PR TITLE
DS-5933 by jaapjan: add more context to e-mails

### DIFF
--- a/modules/custom/activity_logger/activity_logger.tokens.inc
+++ b/modules/custom/activity_logger/activity_logger.tokens.inc
@@ -9,6 +9,7 @@ use Drupal\Core\Render\BubbleableMetadata;
 use Drupal\Core\Url;
 use Drupal\group\Entity\Group;
 use Drupal\group\Entity\GroupContent;
+use Drupal\node\Entity\Node;
 
 /**
  * Implements hook_token_info().
@@ -64,6 +65,7 @@ function activity_logger_tokens($type, $tokens, array $data, array $options, Bub
     foreach ($tokens as $name => $original) {
       switch ($name) {
 
+        case 'node-title':
         case 'gtitle':
         case 'gurl':
         case 'recipient-user-url':
@@ -80,6 +82,10 @@ function activity_logger_tokens($type, $tokens, array $data, array $options, Bub
               // If comment get the entity to which the comment is attached.
               if ($entity->getEntityTypeId() === 'comment') {
                 $entity = $entity->getCommentedEntity();
+              }
+              // When it is a node.
+              if ($entity->getEntityTypeId() === 'node') {
+                $node = $entity;
               }
 
               // Try to get the group.
@@ -103,6 +109,7 @@ function activity_logger_tokens($type, $tokens, array $data, array $options, Bub
               // Handling for group content entities.
               if ($entity->getEntityTypeId() === 'group_content') {
                 $group = $entity->getGroup();
+                $node = $entity->getEntity();
               }
               // Handling for group entities.
               if ($entity->getEntityTypeId() === 'group') {
@@ -149,6 +156,12 @@ function activity_logger_tokens($type, $tokens, array $data, array $options, Bub
                   ['absolute' => TRUE]
                 );
                 $replacements[$original] = $thread_url->toString();
+              }
+
+              if ($name === 'node-title') {
+                if (isset($node) && $node instanceof Node) {
+                  $replacements[$original] = $node->label();
+                }
               }
 
             }

--- a/modules/social_features/social_activity/config/install/message.template.create_comment_author_node_post.yml
+++ b/modules/social_features/social_activity/config/install/message.template.create_comment_author_node_post.yml
@@ -21,13 +21,13 @@ label: 'Create comment on authors node or post'
 description: 'A person commented on content created or organised by me'
 text:
   -
-    value: '<p><a href="[message:author:url:absolute]">[message:author:display-name]</a> commented on your <a href="[message:field_message_related_object:entity:url:absolute]">[social_comment:commented_content_type]</a></p>'
+    value: '<p><a href="[message:author:url:absolute]">[message:author:display-name]</a> commented on your [social_comment:commented_entity_link_html]</p>'
     format: full_html
   -
-    value: '<p><a href="[message:author:url:absolute]">[message:author:display-name]</a> commented on your <a href="[message:field_message_related_object:entity:url:absolute]">[social_comment:commented_content_type]</a></p>'
+    value: '<p><a href="[message:author:url:absolute]">[message:author:display-name]</a> commented on your [social_comment:commented_entity_link_html]</p>'
     format: full_html
   -
-    value: '<p><a href="[message:author:url:absolute]">[message:author:display-name]</a> commented on your <a href="[message:field_message_related_object:entity:url:absolute]">[social_comment:commented_content_type]</a></p>'
+    value: '<p><a href="[message:author:url:absolute]">[message:author:display-name]</a> commented on your [social_comment:commented_entity_link_html]</p>'
     format: full_html
 settings:
   'token options':

--- a/modules/social_features/social_activity/config/install/message.template.create_comment_reply.yml
+++ b/modules/social_features/social_activity/config/install/message.template.create_comment_reply.yml
@@ -21,13 +21,13 @@ description: 'A person replied on my comments'
 text:
   -
     format: full_html
-    value: "<p><a href=\"[message:author:url:absolute]\">[message:author:display-name]</a> replied on your <a href=\"[message:field_message_related_object:entity:url:absolute]\">comment</a></p>\r\n"
+    value: "<p><a href=\"[message:author:url:absolute]\">[message:author:display-name]</a> replied on your <a href=\"[message:field_message_related_object:entity:url:absolute]\">comment</a> in [social_comment:commented_entity_link_html]</p>\r\n"
   -
     format: full_html
-    value: "<p><a href=\"[message:author:url:absolute]\">[message:author:display-name]</a> replied on your <a href=\"[message:field_message_related_object:entity:url:absolute]\">comment</a></p>\r\n"
+    value: "<p><a href=\"[message:author:url:absolute]\">[message:author:display-name]</a> replied on your <a href=\"[message:field_message_related_object:entity:url:absolute]\">comment</a> in [social_comment:commented_entity_link_html]</p>\r\n"
   -
     format: full_html
-    value: '<p><a href="[message:author:url:absolute]">[message:author:display-name]</a> replied on your <a href="[message:field_message_related_object:entity:url:absolute]">comment</a></p>'
+    value: '<p><a href="[message:author:url:absolute]">[message:author:display-name]</a> replied on your <a href="[message:field_message_related_object:entity:url:absolute]">comment</a> in [social_comment:commented_entity_link_html]</p>'
 settings:
   'token options':
     clear: false

--- a/modules/social_features/social_activity/config/install/message.template.create_content_in_joined_group.yml
+++ b/modules/social_features/social_activity/config/install/message.template.create_content_in_joined_group.yml
@@ -25,13 +25,13 @@ label: 'Create a post, topic or event in a joined group'
 description: 'A person created a post, event or topic in a group I joined'
 text:
   -
-    value: '<p><a href="[message:author:url:absolute]">[message:author:display-name]</a> created a <a href="[social_group:content_url]">[social_group:content_type]</a> in the <a href="[message:gurl]">[message:gtitle]</a> group.</p>'
+    value: '<p><a href="[message:author:url:absolute]">[message:author:display-name]</a> created [social_group:created_entity_link_html] in the <a href="[message:gurl]">[message:gtitle]</a> group</p>'
     format: full_html
   -
-    value: '<p><a href="[message:author:url:absolute]">[message:author:display-name]</a> created a <a href="[social_group:content_url]">[social_group:content_type]</a> in the <a href="[message:gurl]">[message:gtitle]</a> group.</p>'
+    value: '<p><a href="[message:author:url:absolute]">[message:author:display-name]</a> created [social_group:created_entity_link_html] in the <a href="[message:gurl]">[message:gtitle]</a> group</p>'
     format: full_html
   -
-    value: '<p><a href="[message:author:url:absolute]">[message:author:display-name]</a> created a <a href="[social_group:content_url]">[social_group:content_type]</a> in the <a href="[message:gurl]">[message:gtitle]</a> group.</p>'
+    value: '<p><a href="[message:author:url:absolute]">[message:author:display-name]</a> created [social_group:created_entity_link_html] in the <a href="[message:gurl]">[message:gtitle]</a> group</p>'
     format: full_html
 settings:
   'token options':

--- a/modules/social_features/social_comment/social_comment.tokens.inc
+++ b/modules/social_features/social_comment/social_comment.tokens.inc
@@ -30,6 +30,11 @@ function social_comment_token_info() {
     'description' => t('The type of the content that was commented on.'),
   ];
 
+  $social_mentions['commented_entity_link_html'] = [
+    'name' => t('The (html) link to the commented entity.'),
+    'description' => t('The link to the commented entity, can be post or node, will include raw HTML.'),
+  ];
+
   return [
     'types' => ['social_comment' => $type],
     'tokens' => [
@@ -79,6 +84,7 @@ function social_comment_tokens($type, $tokens, array $data, array $options, Bubb
           break;
 
         case 'commented_content_type':
+        case 'commented_entity_link_html':
 
           if (isset($message->field_message_related_object)) {
             $target_type = $message->field_message_related_object->target_type;
@@ -93,28 +99,45 @@ function social_comment_tokens($type, $tokens, array $data, array $options, Bubb
               $entity = $comment->getCommentedEntity();
               if (!empty($entity)) {
                 if ($entity instanceof PostInterface) {
-                  $display_name = Unicode::strtolower($entity->getEntityType()->getLabel());
+                  $commented_content_type = Unicode::strtolower($entity->getEntityType()->getLabel());
                 }
                 elseif (is_callable([$entity, 'getDisplayName'])) {
-                  $display_name = $entity->getDisplayName();
+                  $commented_content_type = $entity->getDisplayName();
                 }
                 else {
                   if ($entity instanceof NodeInterface) {
-                    $display_name = strtolower($entity->type->entity->label());
+                    $commented_content_type = strtolower($entity->type->entity->label());
                   }
                   else {
-                    $display_name = $entity->bundle();
+                    $commented_content_type = $entity->bundle();
                   }
                 }
 
-                if (!empty($display_name)) {
-                  $replacements[$original] = $display_name;
+                if ($name === 'commented_content_type') {
+                  if (!empty($commented_content_type)) {
+                    $replacements[$original] = $commented_content_type;
+                  }
+                }
+                else {
+                  $url_options = ['absolute' => TRUE];
+                  $link = $entity->toUrl('canonical', $url_options)->toString();
+
+                  // We should only use the label of entities who have a label.
+                  if ($link_label = $entity->label()) {
+                    $entity_link_html = $commented_content_type . ' <a href="' . $link . '">' . $link_label . '</a>';
+                  }
+                  else {
+                    $entity_link_html = '<a href="' . $link . '">' . $commented_content_type . '</a>';
+                  }
+
+                  $replacements[$original] = \Drupal\Core\Render\Markup::create($entity_link_html);
                 }
               }
             }
           }
 
           break;
+
       }
     }
   }

--- a/modules/social_features/social_comment/social_comment.tokens.inc
+++ b/modules/social_features/social_comment/social_comment.tokens.inc
@@ -9,6 +9,7 @@ use Drupal\Component\Utility\Unicode;
 use Drupal\Core\Render\BubbleableMetadata;
 use Drupal\node\NodeInterface;
 use Drupal\social_post\Entity\PostInterface;
+use Drupal\Core\Render\Markup;
 
 /**
  * Implements hook_token_info().
@@ -130,7 +131,7 @@ function social_comment_tokens($type, $tokens, array $data, array $options, Bubb
                     $entity_link_html = '<a href="' . $link . '">' . $commented_content_type . '</a>';
                   }
 
-                  $replacements[$original] = \Drupal\Core\Render\Markup::create($entity_link_html);
+                  $replacements[$original] = Markup::create($entity_link_html);
                 }
               }
             }

--- a/modules/social_features/social_follow_content/config/install/message.template.create_comment_following_node.yml
+++ b/modules/social_features/social_follow_content/config/install/message.template.create_comment_following_node.yml
@@ -20,13 +20,13 @@ label: 'Create comment on following node'
 description: 'A person commented on content I am following'
 text:
   -
-    value: "<p><a href=\"[message:author:url:absolute]\">[message:author:display-name]</a> commented on [social_comment:parent_entity_author]'s <a href=\"[message:field_message_related_object:entity:url:absolute]\">[social_comment:commented_content_type]</a> you are following</p>\r\n"
+    value: "<p><a href=\"[message:author:url:absolute]\">[message:author:display-name]</a> commented on [social_comment:parent_entity_author]'s [social_comment:commented_content_type] <a href=\"[message:field_message_related_object:entity:url:absolute]\">[message:node-title]</a> you are following</p>\r\n"
     format: full_html
   -
-    value: "<p><a href=\"[message:author:url:absolute]\">[message:author:display-name]</a> commented on [social_comment:parent_entity_author]'s <a href=\"[message:field_message_related_object:entity:url:absolute]\">[social_comment:commented_content_type]</a> you are following</p>\r\n"
+    value: "<p><a href=\"[message:author:url:absolute]\">[message:author:display-name]</a> commented on [social_comment:parent_entity_author]'s [social_comment:commented_content_type] <a href=\"[message:field_message_related_object:entity:url:absolute]\">[message:node-title]</a> you are following</p>\r\n"
     format: full_html
   -
-    value: "<p><a href=\"[message:author:url:absolute]\">[message:author:display-name]</a> commented on [social_comment:parent_entity_author]'s <a href=\"[message:field_message_related_object:entity:url:absolute]\">[social_comment:commented_content_type]</a> you are following</p>\r\n"
+    value: "<p><a href=\"[message:author:url:absolute]\">[message:author:display-name]</a> commented on [social_comment:parent_entity_author]'s [social_comment:commented_content_type] <a href=\"[message:field_message_related_object:entity:url:absolute]\">[message:node-title]</a> you are following</p>\r\n"
     format: full_html
 settings:
   'token options':

--- a/modules/social_features/social_group/social_group.tokens.inc
+++ b/modules/social_features/social_group/social_group.tokens.inc
@@ -29,6 +29,11 @@ function social_group_token_info() {
     'description' => t('The url to the content that is created in the group.'),
   ];
 
+  $social_group['created_entity_link_html'] = [
+    'name' => t('The (html) link to the created entity.'),
+    'description' => t('The link to the created entity, can be post or node, will include raw HTML.'),
+  ];
+
   return [
     'types' => ['social_group' => $type],
     'tokens' => [
@@ -51,6 +56,8 @@ function social_group_tokens($type, $tokens, array $data, array $options, Bubble
       switch ($name) {
 
         case 'content_type':
+        case 'content_url':
+        case 'created_entity_link_html':
 
           // Get the related entity.
           if (isset($message->field_message_related_object)) {
@@ -68,73 +75,68 @@ function social_group_tokens($type, $tokens, array $data, array $options, Bubble
                   /** @var \Drupal\group\Entity\GroupContent $entity */
                   $group_content_type = $entity->getGroupContentType();
                   if (!empty($group_content_type)) {
-                    $replacements[$original] = $group_content_type->label();
+                    $display_name = $group_content_type->label();
+                    $content_url = Url::fromRoute('entity.node.canonical',
+                      ['node' => $entity->getEntity()->id()],
+                      ['absolute' => TRUE]
+                    );
                   }
                   break;
 
                 // If it's node.
                 case 'node':
-                  $content_type = $entity->bundle();
-
-                  // When a name of content name starts from a vowel letter then
-                  // will be added "an" before this name. For example "an
-                  // event".
-                  if (preg_match('/^[aeiou]/', $content_type)) {
-                    $replacements[$original] = 'an ' . $content_type;
-                  }
-
-                  // When a name of content name starts from a consonant letter
-                  // then will be added "a" before this name. For example
-                  // "a topic".
-                  else {
-                    $replacements[$original] = 'a ' . $content_type;
-                  }
+                  $display_name = $entity->bundle();
                   break;
 
                 // When it's a post or photo post.
                 case 'photo':
                 case 'post':
                   $display_name = Unicode::strtolower($entity->getEntityType()->getLabel());
-                  if (!empty($display_name)) {
-                    $replacements[$original] = $display_name;
-                  }
+                  $content_url = Url::fromRoute('entity.post.canonical',
+                    ['post' => $entity->id()],
+                    ['absolute' => TRUE]
+                  );
                   break;
 
               }
+
+              // When a name of content name starts from a vowel letter then
+              // will be added "an" before this name. For example "an
+              // event".
+              if (isset($display_name)) {
+                if (preg_match('/^[aeiou]/', $display_name)) {
+                  $display_name = t('an @content_type', ['@content_type' => $display_name]);
+                }
+                else {
+                  $display_name = t('a @content_type', ['@content_type' => $display_name]);
+                }
+              }
+
+              if ($name === 'content_url') {
+                if (isset($content_url)) {
+                  $replacements[$original] = $content_url->toString();
+                }
+              }
+              elseif ($name === 'content_type') {
+                if (isset($display_name)) {
+                  $replacements[$original] = $display_name;
+                }
+              }
+              elseif ($name === 'created_entity_link_html') {
+                // We should only use the label of entities who have a label.
+                if ($link_label = $entity->label()) {
+                  $entity_link_html = $display_name . ' <a href="' . $content_url->toString() . '">' . $link_label . '</a>';
+                }
+                else {
+                  $entity_link_html = '<a href="' . $content_url->toString() . '">' . $display_name . '</a>';
+                }
+
+                $replacements[$original] = \Drupal\Core\Render\Markup::create($entity_link_html);
+              }
+
             }
           }
 
-          break;
-
-        case 'content_url':
-
-          // Get the related entity.
-          if (isset($message->field_message_related_object)) {
-            $target_type = $message->field_message_related_object->target_type;
-            $target_id = $message->field_message_related_object->target_id;
-            $entity = \Drupal::entityTypeManager()
-              ->getStorage($target_type)
-              ->load($target_id);
-
-            if (is_object($entity)) {
-              // If it's group content.
-              if ($entity->getEntityTypeId() === 'group_content') {
-                $content_url = Url::fromRoute('entity.node.canonical',
-                  ['node' => $entity->getEntity()->id()],
-                  ['absolute' => TRUE]
-                );
-                $replacements[$original] = $content_url->toString();
-              }
-              // For posts, it works slightly different.
-              elseif ($entity->getEntityTypeId() === 'post') {
-                $content_url = Url::fromRoute('entity.post.canonical',
-                  ['post' => $entity->id()],
-                  ['absolute' => TRUE]
-                );
-                $replacements[$original] = $content_url->toString();
-              }
-            }
-          }
           break;
       }
     }

--- a/modules/social_features/social_group/social_group.tokens.inc
+++ b/modules/social_features/social_group/social_group.tokens.inc
@@ -8,6 +8,7 @@
 use Drupal\Core\Render\BubbleableMetadata;
 use Drupal\Core\Url;
 use Drupal\Component\Utility\Unicode;
+use Drupal\Core\Render\Markup;
 
 /**
  * Implements hook_token_info().
@@ -131,7 +132,7 @@ function social_group_tokens($type, $tokens, array $data, array $options, Bubble
                   $entity_link_html = '<a href="' . $content_url->toString() . '">' . $display_name . '</a>';
                 }
 
-                $replacements[$original] = \Drupal\Core\Render\Markup::create($entity_link_html);
+                $replacements[$original] = Markup::create($entity_link_html);
               }
 
             }

--- a/modules/social_features/social_like/config/install/message.template.create_like_node_or_post.yml
+++ b/modules/social_features/social_like/config/install/message.template.create_like_node_or_post.yml
@@ -17,16 +17,16 @@ third_party_settings:
     activity_entity_condition: ''
 template: create_like_node_or_post
 label: 'Create like on node or post'
-description: 'A person likes a post, topic or event created by me'
+description: 'A person likes a post, topic, comment or event created by me'
 text:
   -
-    value: '<p><a href="[message:author:url:absolute]">[message:author:display-name]</a> likes your <a href="[social_like:liked_entity]">[social_like:liked_content_type]</a></p>'
+    value: '<p><a href="[message:author:url:absolute]">[message:author:display-name]</a> likes your [social_like:liked_entity_link_html]</p>'
     format: full_html
   -
-    value: '<p><a href="[message:author:url:absolute]">[message:author:display-name]</a> likes your <a href="[social_like:liked_entity]">[social_like:liked_content_type]</a></p>'
+    value: '<p><a href="[message:author:url:absolute]">[message:author:display-name]</a> likes your [social_like:liked_entity_link_html]</p>'
     format: full_html
   -
-    value: '<p><a href="[message:author:url:absolute]">[message:author:display-name]</a> likes your <a href="[social_like:liked_entity]">[social_like:liked_content_type]</a></p>'
+    value: '<p><a href="[message:author:url:absolute]">[message:author:display-name]</a> likes your [social_like:liked_entity_link_html]</p>'
     format: full_html
 settings:
   'token options':

--- a/modules/social_features/social_like/social_like.tokens.inc
+++ b/modules/social_features/social_like/social_like.tokens.inc
@@ -87,7 +87,7 @@ function social_like_tokens($type, $tokens, array $data, array $options, Bubblea
 
             if ($name === 'liked_entity_link_html') {
               // We should only use the label of entities who have a label.
-              if ($link_label = $entity->label()) {
+              if ($content_type !== 'comment' && $link_label = $entity->label()) {
                 $liked_entity_link_html = $content_type_label . ' <a href="' . $link . '">' . $link_label . '</a>';
               }
               else {

--- a/modules/social_features/social_like/social_like.tokens.inc
+++ b/modules/social_features/social_like/social_like.tokens.inc
@@ -8,6 +8,8 @@
 use Drupal\Component\Utility\Unicode;
 use Drupal\Core\Render\BubbleableMetadata;
 use Drupal\votingapi\Entity\Vote;
+use Drupal\Core\Render\Markup;
+use Drupal\node\Entity\Node;
 
 /**
  * Implements hook_token_info().
@@ -95,12 +97,13 @@ function social_like_tokens($type, $tokens, array $data, array $options, Bubblea
                 if ($content_type === 'comment') {
                   $commented_entity = $entity->getCommentedEntity();
 
+                  $url_options = ['absolute' => TRUE];
+                  /** @var \Drupal\Core\Entity\Entity $commented_entity */
+                  $ref_link = $commented_entity->toUrl('canonical', $url_options)->toString();
+
                   // We should only use the label of entities who have a label.
                   if ($ref_link_label = $commented_entity->label()) {
-                    $url_options = ['absolute' => TRUE];
-                    /** @var \Drupal\Core\Entity\Entity $commented_entity */
-                    $ref_link = $commented_entity->toUrl('canonical', $url_options)->toString();
-                    if ($commented_entity instanceof \Drupal\node\Entity\Node) {
+                    if ($commented_entity instanceof Node) {
                       $commented_content_type = strtolower($commented_entity->type->entity->label());
                     }
                     else {
@@ -115,7 +118,7 @@ function social_like_tokens($type, $tokens, array $data, array $options, Bubblea
                 }
               }
 
-              $replacements[$original] = \Drupal\Core\Render\Markup::create($liked_entity_link_html);
+              $replacements[$original] = Markup::create($liked_entity_link_html);
             }
             break;
 

--- a/modules/social_features/social_like/social_like.tokens.inc
+++ b/modules/social_features/social_like/social_like.tokens.inc
@@ -29,6 +29,11 @@ function social_like_token_info() {
     'description' => t('The type of the content that was liked'),
   ];
 
+  $social_like['liked_entity_link_html'] = [
+    'name' => t('The (html) link to the liked entity.'),
+    'description' => t('The link to the entity, can be post or node, will include raw HTML.'),
+  ];
+
   return [
     'types' => ['social_like' => $type],
     'tokens' => [
@@ -51,29 +56,67 @@ function social_like_tokens($type, $tokens, array $data, array $options, Bubblea
         switch ($name) {
 
           case 'liked_entity':
+          case 'liked_content_type':
+          case 'liked_entity_link_html':
+
             $storage = \Drupal::entityTypeManager()->getStorage($vote->getVotedEntityType());
             $entity = $storage->load($vote->getVotedEntityId());
             $url_options = ['absolute' => TRUE];
-            $replacements[$original] = $entity->toUrl('canonical', $url_options)->toString();
-            break;
+            $link = $entity->toUrl('canonical', $url_options)->toString();
+            if ($name === 'liked_entity') {
+              $replacements[$original] = $link;
+            }
 
-          case 'liked_content_type':
-            $storage = \Drupal::entityTypeManager()->getStorage($vote->getVotedEntityType());
-            $entity = $storage->load($vote->getVotedEntityId());
             $content_type = $entity->getEntityTypeId();
             // Check if the content type is node.
             if ($content_type === 'node') {
               // Then get the bundle name.
-              $content_type = Unicode::strtolower(\Drupal::entityTypeManager()
+              $content_type_label = Unicode::strtolower(\Drupal::entityTypeManager()
                 ->getStorage('node_type')
                 ->load($entity->bundle())
                 ->label());
             }
             if ($content_type === 'post' || $content_type === 'photo' || $content_type === 'comment') {
-              $content_type = Unicode::strtolower($entity->getEntityType()->getLabel());
+              $content_type_label = Unicode::strtolower($entity->getEntityType()->getLabel());
+            }
+            if ($name === 'liked_content_type') {
+              $replacements[$original] = $content_type_label;
             }
 
-            $replacements[$original] = $content_type;
+            if ($name === 'liked_entity_link_html') {
+              // We should only use the label of entities who have a label.
+              if ($link_label = $entity->label()) {
+                $liked_entity_link_html = $content_type_label . ' <a href="' . $link . '">' . $link_label . '</a>';
+              }
+              else {
+                $liked_entity_link_html = '<a href="' . $link . '">' . $content_type_label . '</a>';
+
+                // Let's make an exception for comments.
+                if ($content_type === 'comment') {
+                  $commented_entity = $entity->getCommentedEntity();
+
+                  // We should only use the label of entities who have a label.
+                  if ($ref_link_label = $commented_entity->label()) {
+                    $url_options = ['absolute' => TRUE];
+                    /** @var \Drupal\Core\Entity\Entity $commented_entity */
+                    $ref_link = $commented_entity->toUrl('canonical', $url_options)->toString();
+                    if ($commented_entity instanceof \Drupal\node\Entity\Node) {
+                      $commented_content_type = strtolower($commented_entity->type->entity->label());
+                    }
+                    else {
+                      $commented_content_type = $commented_entity->bundle();
+                    }
+                    $liked_entity_link_html .= ' ' . t('in') . ' ' . $commented_content_type . ' <a href="' . $ref_link . '">' . $ref_link_label . '</a>';
+                  }
+                  else {
+                    $commented_content_type = Unicode::strtolower($commented_entity->getEntityType()->getLabel());
+                    $liked_entity_link_html .= ' ' . t('in a') . ' <a href="' . $ref_link . '">' . $commented_content_type . '</a>';
+                  }
+                }
+              }
+
+              $replacements[$original] = \Drupal\Core\Render\Markup::create($liked_entity_link_html);
+            }
             break;
 
         }

--- a/modules/social_features/social_mentions/config/install/message.template.create_mention_comment.yml
+++ b/modules/social_features/social_mentions/config/install/message.template.create_mention_comment.yml
@@ -20,13 +20,13 @@ label: 'Create mention in a comment'
 description: 'A person mentioned me in a comment'
 text:
   -
-    value: '<p><a href="[message:author:url:absolute]">[message:author:display-name]</a> mentioned you in a comment</p>'
+    value: '<p><a href="[message:author:url:absolute]">[message:author:display-name]</a> mentioned you in a <a href="[message:field_message_related_object:entity:url:absolute]">comment</a> in [social_mentions:commented_entity_link_html]</p>'
     format: full_html
   -
-    value: '<p><a href="[message:author:url:absolute]">[message:author:display-name]</a> mentioned you in a comment</p>'
+    value: '<p><a href="[message:author:url:absolute]">[message:author:display-name]</a> mentioned you in a <a href="[message:field_message_related_object:entity:url:absolute]">comment</a> in [social_mentions:commented_entity_link_html]</p>'
     format: full_html
   -
-    value: '<p><a href="[message:author:url:absolute]">[message:author:display-name]</a> mentioned you in a <a href="[message:field_message_related_object:entity:url:absolute]">comment</a></p>'
+    value: '<p><a href="[message:author:url:absolute]">[message:author:display-name]</a> mentioned you in a <a href="[message:field_message_related_object:entity:url:absolute]">comment</a> in [social_mentions:commented_entity_link_html]</p>'
     format: full_html
 settings:
   'token options':

--- a/modules/social_features/social_mentions/social_mentions.tokens.inc
+++ b/modules/social_features/social_mentions/social_mentions.tokens.inc
@@ -5,6 +5,7 @@
  * Builds placeholder replacement tokens for Social Mentions module.
  */
 
+use Drupal\Component\Utility\Unicode;
 use Drupal\Core\Render\BubbleableMetadata;
 use Drupal\user\Entity\User;
 
@@ -26,6 +27,11 @@ function social_mentions_token_info() {
   $social_mentions['user_name'] = [
     'name' => t('User name'),
     'description' => t('First and last name or username, depends on settings.'),
+  ];
+
+  $social_mentions['commented_entity_link_html'] = [
+    'name' => t('The (html) link to the commented entity.'),
+    'description' => t('The link to the commented entity, can be post or node, will include raw HTML.'),
   ];
 
   return [
@@ -91,6 +97,60 @@ function social_mentions_tokens($type, $tokens, array $data, array $options, Bub
                 $replacements[$original] = $user;
               }
             }
+          }
+
+          break;
+
+        case 'commented_entity_link_html':
+
+          if (isset($message->field_message_related_object)) {
+            $target_type = $message->field_message_related_object->target_type;
+            $target_id = $message->field_message_related_object->target_id;
+            /** @var \Drupal\mentions\Entity\Mentions $mention */
+            $mention = \Drupal::entityTypeManager()
+              ->getStorage($target_type)
+              ->load($target_id);
+
+            if ($mentioned_entity = $mention->getMentionedEntity()) {
+              if ($mentioned_entity->getEntityTypeId() === 'comment') {
+                $entity = $mentioned_entity->getCommentedEntity();
+              }
+              else {
+                $entity = $mentioned_entity;
+              }
+            }
+          }
+
+          if (isset($entity)) {
+            switch ($entity->getEntityTypeId()) {
+              case 'node':
+                // Then get the bundle name.
+                $content_type_label = Unicode::strtolower(\Drupal::entityTypeManager()
+                  ->getStorage('node_type')
+                  ->load($entity->bundle())
+                  ->label());
+                break;
+
+              case 'post':
+              case 'photo':
+              case 'comment':
+                $content_type_label = Unicode::strtolower($entity->getEntityType()->getLabel());
+                break;
+
+            }
+
+            $url_options = ['absolute' => TRUE];
+            $link = $entity->toUrl('canonical', $url_options)->toString();
+
+            // We should only use the label of entities who have a label.
+            if ($link_label = $entity->label()) {
+              $entity_link_html = $content_type_label . ' <a href="' . $link . '">' . $link_label . '</a>';
+            }
+            else {
+              $entity_link_html = '<a href="' . $link . '">' . $content_type_label . '</a>';
+            }
+
+            $replacements[$original] = \Drupal\Core\Render\Markup::create($entity_link_html);
           }
 
           break;

--- a/modules/social_features/social_mentions/social_mentions.tokens.inc
+++ b/modules/social_features/social_mentions/social_mentions.tokens.inc
@@ -8,6 +8,7 @@
 use Drupal\Component\Utility\Unicode;
 use Drupal\Core\Render\BubbleableMetadata;
 use Drupal\user\Entity\User;
+use Drupal\Core\Render\Markup;
 
 /**
  * Implements hook_token_info().
@@ -150,7 +151,7 @@ function social_mentions_tokens($type, $tokens, array $data, array $options, Bub
               $entity_link_html = '<a href="' . $link . '">' . $content_type_label . '</a>';
             }
 
-            $replacements[$original] = \Drupal\Core\Render\Markup::create($entity_link_html);
+            $replacements[$original] = Markup::create($entity_link_html);
           }
 
           break;


### PR DESCRIPTION
See full overview here:
https://docs.google.com/spreadsheets/d/16NdIBG8GZXaXQV5YpCfp17yKm7RshArRs_goKZNlU5E/edit?usp=sharing

## Problem
Not clear about which topics/events/groups etc the notification is about.

## Solution
If we know the title of the node, let's show it in the (e-mail) notification.

## Issue tracker
- DS-5933

## HTT
- [x] Test all notifications from this overview: https://docs.google.com/spreadsheets/d/16NdIBG8GZXaXQV5YpCfp17yKm7RshArRs_goKZNlU5E/edit?usp=sharing (make sure to test the notification (in-site), push notification and the e-mail notification for each.
- [x] See if any of the greyed-out or yellow notfications from the overview should have been worked on.

## Documentation
- [ ] This item is documented on LGOS
- [ ] This item has been added to the feature overview

## Release notes
Will follow.