### PR TITLE
Issue #2990176 by bramtenhove: Add self introduction as field to the export

### DIFF
--- a/modules/social_features/social_private_message/src/Plugin/UserExportPlugin/UserAnalyticsPrivateMessage.php
+++ b/modules/social_features/social_private_message/src/Plugin/UserExportPlugin/UserAnalyticsPrivateMessage.php
@@ -11,7 +11,7 @@ use Drupal\user\UserInterface;
  * @UserExportPlugin(
  *  id = "user_private_message",
  *  label = @Translation("Number of Private messages"),
- *  weight = -190,
+ *  weight = -180,
  * )
  */
 class UserAnalyticsPrivateMessage extends UserExportPluginBase {

--- a/modules/social_features/social_user_export/src/Plugin/UserExportPlugin/UserAnalyticsCommentsCreated.php
+++ b/modules/social_features/social_user_export/src/Plugin/UserExportPlugin/UserAnalyticsCommentsCreated.php
@@ -11,7 +11,7 @@ use Drupal\user\UserInterface;
  * @UserExportPlugin(
  *  id = "user_comments_created",
  *  label = @Translation("Comments created"),
- *  weight = -250,
+ *  weight = -240,
  * )
  */
 class UserAnalyticsCommentsCreated extends UserExportPluginBase {

--- a/modules/social_features/social_user_export/src/Plugin/UserExportPlugin/UserAnalyticsEventEnrollments.php
+++ b/modules/social_features/social_user_export/src/Plugin/UserExportPlugin/UserAnalyticsEventEnrollments.php
@@ -11,7 +11,7 @@ use Drupal\user\UserInterface;
  * @UserExportPlugin(
  *  id = "user_event_enrollments",
  *  label = @Translation("Event enrollments"),
- *  weight = -230,
+ *  weight = -210,
  * )
  */
 class UserAnalyticsEventEnrollments extends UserExportPluginBase {

--- a/modules/social_features/social_user_export/src/Plugin/UserExportPlugin/UserAnalyticsGroupsCreated.php
+++ b/modules/social_features/social_user_export/src/Plugin/UserExportPlugin/UserAnalyticsGroupsCreated.php
@@ -11,7 +11,7 @@ use Drupal\user\UserInterface;
  * @UserExportPlugin(
  *  id = "user_groups_created",
  *  label = @Translation("Groups created"),
- *  weight = -210,
+ *  weight = -200,
  * )
  */
 class UserAnalyticsGroupsCreated extends UserExportPluginBase {

--- a/modules/social_features/social_user_export/src/Plugin/UserExportPlugin/UserAnalyticsLikes.php
+++ b/modules/social_features/social_user_export/src/Plugin/UserExportPlugin/UserAnalyticsLikes.php
@@ -11,7 +11,7 @@ use Drupal\user\UserInterface;
  * @UserExportPlugin(
  *  id = "user_likes",
  *  label = @Translation("Number of Likes"),
- *  weight = -200,
+ *  weight = -190,
  * )
  */
 class UserAnalyticsLikes extends UserExportPluginBase {

--- a/modules/social_features/social_user_export/src/Plugin/UserExportPlugin/UserAnalyticsPostsCreated.php
+++ b/modules/social_features/social_user_export/src/Plugin/UserExportPlugin/UserAnalyticsPostsCreated.php
@@ -11,7 +11,7 @@ use Drupal\user\UserInterface;
  * @UserExportPlugin(
  *  id = "user_posts_created",
  *  label = @Translation("Posts created"),
- *  weight = -260,
+ *  weight = -250,
  * )
  */
 class UserAnalyticsPostsCreated extends UserExportPluginBase {

--- a/modules/social_features/social_user_export/src/Plugin/UserExportPlugin/UserAnalyticsTopicsCreated.php
+++ b/modules/social_features/social_user_export/src/Plugin/UserExportPlugin/UserAnalyticsTopicsCreated.php
@@ -11,7 +11,7 @@ use Drupal\user\UserInterface;
  * @UserExportPlugin(
  *  id = "user_topics_created",
  *  label = @Translation("Topics created"),
- *  weight = -240,
+ *  weight = -230,
  * )
  */
 class UserAnalyticsTopicsCreated extends UserExportPluginBase {

--- a/modules/social_features/social_user_export/src/Plugin/UserExportPlugin/UserProfileTag.php
+++ b/modules/social_features/social_user_export/src/Plugin/UserExportPlugin/UserProfileTag.php
@@ -11,7 +11,7 @@ use Drupal\user\UserInterface;
  * @UserExportPlugin(
  *  id = "user_profile_tag",
  *  label = @Translation("Profile tag"),
- *  weight = -280,
+ *  weight = -270,
  * )
  */
 class UserProfileTag extends UserExportPluginBase {

--- a/modules/social_features/social_user_export/src/Plugin/UserExportPlugin/UserRoles.php
+++ b/modules/social_features/social_user_export/src/Plugin/UserExportPlugin/UserRoles.php
@@ -11,7 +11,7 @@ use Drupal\user\UserInterface;
  * @UserExportPlugin(
  *  id = "user_roles",
  *  label = @Translation("Roles"),
- *  weight = -270,
+ *  weight = -260,
  * )
  */
 class UserRoles extends UserExportPluginBase {

--- a/modules/social_features/social_user_export/src/Plugin/UserExportPlugin/UserSelfIntroduction.php
+++ b/modules/social_features/social_user_export/src/Plugin/UserExportPlugin/UserSelfIntroduction.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Drupal\social_user_export\Plugin\UserExportPlugin;
+
+use Drupal\social_user_export\Plugin\UserExportPluginBase;
+use Drupal\user\UserInterface;
+
+/**
+ * Provides a 'UserSelfIntroduction' user export row.
+ *
+ * @UserExportPlugin(
+ *  id = "user_self_introduction",
+ *  label = @Translation("Self Introduction"),
+ *  weight = -280,
+ * )
+ */
+class UserSelfIntroduction extends UserExportPluginBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getHeader() {
+    return $this->t('Self introduction');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getValue(UserInterface $entity) {
+    return $this->profileGetFieldValue('field_profile_self_introduction', $this->getProfile($entity));
+  }
+
+}


### PR DESCRIPTION
## Problem
The self introduction field can be useful for measuring community activity. We did not include it in the [other PR](https://github.com/goalgorilla/open_social/pull/987) that introduces a lot of new fields to the export.

## Solution
Added the _Self introduction_ to the export and changed the weights of the plugins so it fits nicely somewhere at the end.

The output of the _Self introduction_ field is automatically escaped, just like the rest of the fields. This means that links and images are stripped. I don't think this is an issue.

## Issue tracker
- https://www.drupal.org/project/social/issues/2990176

## HTT
- [ ] Check out the code changes
- [ ] Login as a SM and export users
- [ ] Observe that the between _Interests_ and _Profile tag_ the _Self introduction_ of the user is filled in

## Documentation
- [ ] This item is documented on LGOS
- [ ] This item has been added to the feature overview

## Release notes
n/a