### PR TITLE
Issue #2992753 by Kingdutch: landing page block styling

### DIFF
--- a/themes/socialblue/assets/css/button.css
+++ b/themes/socialblue/assets/css/button.css
@@ -106,8 +106,8 @@ fieldset[disabled] .btn-accent.focus {
 
 .btn-flat:focus, .btn-flat.focus, .btn-flat:hover, .btn-flat:active, .btn-flat.active,
 .open > .btn-flat.dropdown-toggle {
-  background-color: rgba(0, 0, 0, 0);
-  border-color: rgba(0, 0, 0, 0);
+  background-color: transparent;
+  border-color: transparent;
   color: #29abe2;
 }
 
@@ -187,8 +187,8 @@ fieldset[disabled]
 
 .btn-link:focus, .btn-link.focus, .btn-link:hover, .btn-link:active, .btn-link.active,
 .open > .btn-link.dropdown-toggle {
-  background-color: rgba(0, 0, 0, 0);
-  border-color: rgba(0, 0, 0, 0);
+  background-color: transparent;
+  border-color: transparent;
   color: #29abe2;
 }
 

--- a/themes/socialblue/assets/css/cards.css
+++ b/themes/socialblue/assets/css/cards.css
@@ -13,7 +13,9 @@
 }
 
 .region--complementary .card__title,
-.region--complementary .card__actionbar {
+.region--complementary .card__actionbar,
+.paragraph--block .secondary-col .card__title,
+.paragraph--block .secondary-col .card__actionbar {
   text-align: center;
 }
 

--- a/themes/socialblue/assets/css/ckeditor.css
+++ b/themes/socialblue/assets/css/ckeditor.css
@@ -106,8 +106,8 @@ fieldset[disabled] .btn-accent.focus {
 
 .btn-flat:focus, .btn-flat.focus, .btn-flat:hover, .btn-flat:active, .btn-flat.active,
 .open > .btn-flat.dropdown-toggle {
-  background-color: rgba(0, 0, 0, 0);
-  border-color: rgba(0, 0, 0, 0);
+  background-color: transparent;
+  border-color: transparent;
   color: #29abe2;
 }
 
@@ -187,8 +187,8 @@ fieldset[disabled]
 
 .btn-link:focus, .btn-link.focus, .btn-link:hover, .btn-link:active, .btn-link.active,
 .open > .btn-link.dropdown-toggle {
-  background-color: rgba(0, 0, 0, 0);
-  border-color: rgba(0, 0, 0, 0);
+  background-color: transparent;
+  border-color: transparent;
   color: #29abe2;
 }
 

--- a/themes/socialblue/assets/css/like.css
+++ b/themes/socialblue/assets/css/like.css
@@ -27,8 +27,8 @@
 
 .view--who-liked .views-field-view-user a:focus, .view--who-liked .views-field-view-user a.focus, .view--who-liked .views-field-view-user a:hover, .view--who-liked .views-field-view-user a:active, .view--who-liked .views-field-view-user a.active,
 .open > .view--who-liked .views-field-view-user a.dropdown-toggle {
-  background-color: rgba(0, 0, 0, 0);
-  border-color: rgba(0, 0, 0, 0);
+  background-color: transparent;
+  border-color: transparent;
   color: #29abe2;
 }
 

--- a/themes/socialblue/assets/css/preview.css
+++ b/themes/socialblue/assets/css/preview.css
@@ -697,8 +697,8 @@ fieldset[disabled] .btn-accent.focus {
 
 .btn-flat:focus, .btn-flat.focus, .btn-flat:hover, .btn-flat:active, .btn-flat.active,
 .open > .btn-flat.dropdown-toggle {
-  background-color: rgba(0, 0, 0, 0);
-  border-color: rgba(0, 0, 0, 0);
+  background-color: transparent;
+  border-color: transparent;
   color: #29abe2;
 }
 
@@ -778,8 +778,8 @@ fieldset[disabled]
 
 .btn-link:focus, .btn-link.focus, .btn-link:hover, .btn-link:active, .btn-link.active,
 .open > .btn-link.dropdown-toggle {
-  background-color: rgba(0, 0, 0, 0);
-  border-color: rgba(0, 0, 0, 0);
+  background-color: transparent;
+  border-color: transparent;
   color: #29abe2;
 }
 

--- a/themes/socialblue/assets/css/preview.css
+++ b/themes/socialblue/assets/css/preview.css
@@ -916,7 +916,9 @@ fieldset[disabled] .btn--twitter.focus {
 }
 
 .region--complementary .card__title,
-.region--complementary .card__actionbar {
+.region--complementary .card__actionbar,
+.paragraph--block .secondary-col .card__title,
+.paragraph--block .secondary-col .card__actionbar {
   text-align: center;
 }
 

--- a/themes/socialblue/components/02-atoms/cards/cards.scss
+++ b/themes/socialblue/components/02-atoms/cards/cards.scss
@@ -14,13 +14,14 @@
   text-transform: uppercase;
 }
 
-.region--complementary {
-
+// Cards in the sidebar should have a centered title.
+.region--complementary,
+// Cards used on landing page streams as a sidebar should look the same.
+.paragraph--block .secondary-col {
   .card__title,
   .card__actionbar {
     text-align: center;
   }
-
 }
 
 .card__block {


### PR DESCRIPTION
## Problem
Socialblue centers the titles on cards that are on the default stream. This style does not apply when those same blocks are placed on a stream that is built in a landing page.

## Solution
Ensure that the styling applies to both equally.

## Issue tracker
- https://www.drupal.org/project/social/issues/2992753

## HTT
- [x] Check out the code changes
- [x] Login as content manager and create a landing page with right side blocks
- [x] See that they now look the way they do on the default /stream

## Release notes
When creating a stream on a landing page the informational blocks such as "New groups" now look the same as they do on the default Open Social streams.
