### PR TITLE
2992994: URL alias add on too long and making vertical tabs autogrow on input

### DIFF
--- a/modules/social_features/social_core/social_core.module
+++ b/modules/social_features/social_core/social_core.module
@@ -479,7 +479,28 @@ function social_core_field_widget_form_alter(&$element, FormStateInterface $form
     $url = Url::fromRoute('<front>', [], [
       'absolute' => TRUE,
     ]);
-    $element['alias']['#field_prefix'] = '<div class="input-group input-group-expanded"><span class="input-group-addon">' . $url->toString() . '</span>';
+
+    // Protocols we can strip.
+    $protocols = [
+      'https://www.',
+      'http://www.',
+      'https://',
+      'http://',
+      'www.',
+    ];
+
+    // The URL.
+    $truncate_url = $url->toString();
+    // Loop over the protocols and try to replace them in the string.
+    foreach ($protocols as $protocol) {
+      $truncate_url = str_replace($protocol, '', $truncate_url);
+    }
+    // If the URL is still longer than 40 characters, we trim.
+    if (strlen($truncate_url) > 40) {
+      $truncate_url = substr($truncate_url, 0, 37) . '.../';
+    }
+    // Put the protocoless, truncated URL in the addon.
+    $element['alias']['#field_prefix'] = '<div class="input-group input-group-expanded"><span class="input-group-addon">' . $truncate_url . '</span>';
     $element['alias']['#field_suffix'] = '</div>';
     $element['alias']['#description'] = t('The URL alias allows you to customise the link to this page.');
 

--- a/themes/socialblue/assets/css/nav-tabs.css
+++ b/themes/socialblue/assets/css/nav-tabs.css
@@ -33,6 +33,7 @@
 
 .tabs-left > .nav-tabs {
   border-radius: 10px 0 0 10px;
+  max-width: 35%;
 }
 
 .tabs-right > .nav-tabs {


### PR DESCRIPTION
## Problem
Whenever the URL of a website is really long, there's not a lot of space for input in the URL alias field, due to the input add-on. Also when filling out the URL Alias field, the vertical tabs on the left keep growing, making the mentioned problem above even bigger.

## Solution
Make sure the vertical tabs section doesn't grow ever. Secondly, strip protocols from the URL and trim if still longer than 40 chars.

## Issue tracker
- https://www.drupal.org/project/social/issues/2992994
- https://jira.goalgorilla.com/browse/SHN-163

## HTT
- [ ] Check out the code changes
- [ ] Login as a SM and add a node or topic
- [ ] Go to the vertical tabs at the bottom
- [ ] Notice that when you enter a long alias, the pane left keeps on growing
- [ ] Also notice that if the URL if the site is very long, that there's not a lot of room for input (EG: https://demo.getopensocial.com)
- [ ] Checkout to this branch and clear the cache
- [ ] Notice both problems are fixed

## Release notes
As a SM when editing the URL Alias field, the input section is now bigger and the URL part shorter. Also when entering a long URL Alias, the pane on the left stays the same size and does not grow.
