### PR TITLE
Issue #2992979 : Blocked users should NOT be in the search

### DIFF
--- a/modules/social_features/social_search/social_search.install
+++ b/modules/social_features/social_search/social_search.install
@@ -297,3 +297,21 @@ function social_search_update_8109() {
     }
   }
 }
+
+/**
+ * Trigger a search_api re-index.
+ */
+function social_search_update_8110() {
+  $indexes = [
+    'social_all',
+    'social_users',
+  ];
+
+  foreach ($indexes as $index_id) {
+    $index = Index::load($index_id);
+    if ($index->status()) {
+      $index->clear();
+      $index->reindex();
+    }
+  }
+}

--- a/modules/social_features/social_search/social_search.module
+++ b/modules/social_features/social_search/social_search.module
@@ -5,11 +5,15 @@
  * The Social search module.
  */
 
+use Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException;
+use Drupal\Component\Plugin\Exception\PluginNotFoundException;
 use Drupal\Core\Block\BlockPluginInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\profile\Entity\Profile;
 use Drupal\search_api\Entity\Index;
 use Drupal\search_api\Plugin\search_api\datasource\ContentEntity;
+use Drupal\user\Entity\User;
 
 /**
  * Implements hook_form_FORM_ID_alter().
@@ -73,37 +77,63 @@ function social_block_view_search_hero_block_alter(array &$build, BlockPluginInt
  * Update the profile index when user is updated or delete entry when blocked.
  */
 function social_search_user_update(EntityInterface $entity) {
-  if ($entity->getEntityTypeId() === 'user') {
-    $indexes = [
-      'social_all',
-      'social_users',
-    ];
-    foreach ($indexes as $index_id) {
-      $index = Index::load($index_id);
-      if ($index) {
-        $entity_type_manager = \Drupal::entityTypeManager();
-        /** @var \Drupal\profile\ProfileStorage $storage */
-        $storage = $entity_type_manager->getStorage('profile');
-        /** @var \Drupal\user\Entity\User $entity */
-        if (!empty($storage)) {
-          $profile = $storage->loadByUser($entity, 'profile');
-          $profile_ids = [];
-          $original_entity = $entity->original;
-          foreach ($profile->getTranslationLanguages() as $langcode => $language) {
-            $profile_ids[] = $profile->id() . ':' . $langcode;
-          }
-          $datasource_id = 'entity:profile';
-          if ($entity->isBlocked() && $original_entity->isActive()) {
-            $index->trackItemsDeleted($datasource_id, $profile_ids);
-          }
-          elseif ($entity->isActive() && $original_entity->isBlocked()) {
-            $filtered_item_ids = ContentEntity::filterValidItemIds($index, $datasource_id, $profile_ids);
-            $index->trackItemsInserted($datasource_id, $filtered_item_ids);
-          }
-          else {
-            $index->trackItemsUpdated($datasource_id, $profile_ids);
-          }
-        }
+  /** @var \Drupal\user\Entity\User $entity */
+  _social_search_retrigger_profile($entity);
+}
+
+/**
+ * Retriggers the profile in the search when a user has ben changed.
+ *
+ * @param \Drupal\user\Entity\User $user
+ *   The user whose profile we want to retrigger.
+ */
+function _social_search_retrigger_profile(User $user) {
+  // These indices need to be updated.
+  $indexes = [
+    'social_all',
+    'social_users',
+  ];
+
+  try {
+    /** @var \Drupal\profile\ProfileStorage $profile_storage */
+    $profile_storage = \Drupal::entityTypeManager()->getStorage('profile');
+  }
+  catch (InvalidPluginDefinitionException $e) {
+    return;
+  }
+  catch (PluginNotFoundException $e) {
+    return;
+  }
+
+  /** @var \Drupal\profile\Entity\Profile $profile */
+  $profile = $profile_storage->loadByUser($user, 'profile');
+
+  // Must be a profile, otherwise we can leave.
+  if (!$profile instanceof Profile) {
+    return;
+  }
+
+  // Loop over the indexes that need to be updated.
+  foreach ($indexes as $index_id) {
+    $index = Index::load($index_id);
+    if ($index instanceof  Index) {
+      // Init.
+      $profile_ids = [];
+      /** @var \Drupal\user\Entity\User $original_user */
+      $original_user = $user->original;
+      foreach ($profile->getTranslationLanguages() as $langcode => $language) {
+        $profile_ids[] = $profile->id() . ':' . $langcode;
+      }
+      $datasource_id = 'entity:profile';
+      if ($user->isBlocked() && $original_user->isActive()) {
+        $index->trackItemsDeleted($datasource_id, $profile_ids);
+      }
+      elseif ($user->isActive() && $original_user->isBlocked()) {
+        $filtered_item_ids = ContentEntity::filterValidItemIds($index, $datasource_id, $profile_ids);
+        $index->trackItemsInserted($datasource_id, $filtered_item_ids);
+      }
+      else {
+        $index->trackItemsUpdated($datasource_id, $profile_ids);
       }
     }
   }

--- a/modules/social_features/social_search/social_search.module
+++ b/modules/social_features/social_search/social_search.module
@@ -6,7 +6,10 @@
  */
 
 use Drupal\Core\Block\BlockPluginInterface;
+use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\search_api\Entity\Index;
+use Drupal\search_api\Plugin\search_api\datasource\ContentEntity;
 
 /**
  * Implements hook_form_FORM_ID_alter().
@@ -62,4 +65,46 @@ function social_search_block_view_views_exposed_filter_block_alter(array &$build
  */
 function social_block_view_search_hero_block_alter(array &$build, BlockPluginInterface $block) {
   $build['#configuration']['label'] = t('Search');
+}
+
+/**
+ * Implements hook_entity_update().
+ *
+ * Update the profile index when user is updated or delete entry when blocked.
+ */
+function social_search_entity_update(EntityInterface $entity) {
+  if ($entity->getEntityTypeId() === 'user') {
+    $indexes = [
+      'social_all',
+      'social_users',
+    ];
+    foreach ($indexes as $index_id) {
+      $index = Index::load($index_id);
+      if ($index) {
+        $entity_type_manager = \Drupal::entityTypeManager();
+        /** @var \Drupal\profile\ProfileStorage $storage */
+        $storage = $entity_type_manager->getStorage('profile');
+        /** @var \Drupal\user\Entity\User $entity */
+        if (!empty($storage)) {
+          $profile = $storage->loadByUser($entity, 'profile');
+          $profile_ids = [];
+          $original_entity = $entity->original;
+          foreach ($profile->getTranslationLanguages() as $langcode => $language) {
+            $profile_ids[] = $profile->id() . ':' . $langcode;
+          }
+          $datasource_id = 'entity:profile';
+          if ($entity->isBlocked() && $original_entity->isActive()) {
+            $index->trackItemsDeleted($datasource_id, $profile_ids);
+          }
+          elseif ($entity->isActive() && $original_entity->isBlocked()) {
+            $filtered_item_ids = ContentEntity::filterValidItemIds($index, $datasource_id, $profile_ids);
+            $index->trackItemsInserted($datasource_id, $filtered_item_ids);
+          }
+          else {
+            $index->trackItemsUpdated($datasource_id, $profile_ids);
+          }
+        }
+      }
+    }
+  }
 }

--- a/modules/social_features/social_search/social_search.module
+++ b/modules/social_features/social_search/social_search.module
@@ -68,11 +68,11 @@ function social_block_view_search_hero_block_alter(array &$build, BlockPluginInt
 }
 
 /**
- * Implements hook_entity_update().
+ * Implements hook_ENTITY_TYPE_update().
  *
  * Update the profile index when user is updated or delete entry when blocked.
  */
-function social_search_entity_update(EntityInterface $entity) {
+function social_search_user_update(EntityInterface $entity) {
   if ($entity->getEntityTypeId() === 'user') {
     $indexes = [
       'social_all',


### PR DESCRIPTION
## Problem
Blocked users are still in the search results (on All and on Users tab). This is happening because the change is in the User entity while the Profile entity is being indexed.

## Solution
When the user entity is updated, let's trigger a re-index of the related Profile entity. In some cases we need to add or remove the Profile from the index.

## Issue tracker
- https://www.drupal.org/project/social/issues/2992979
-See old (related) PR: https://github.com/goalgorilla/open_social/pull/854

## HTT
- [x] Check out the code changes
- [x] Login as SM
- [x] Block an active user
- [x] Notice that the user is still in the search results (also after running cron)
- [x] Clear all the indexes and re-index
- [x] Notice the user is not in results anymore
- [x] Go to this branch
- [x] run update script and cron and notice all is good
- [x] Make the user active
- [x] Check the search and notice the user is in the search again.
- [x] Block the user and notice the user is not in the search results anymore.
- [x] Also try the bulk operations on the `/admin/people` overview

## Release notes
Blocked users were still showing up in search results. When a user is blocked they should never be in the search results.