### PR TITLE
FOR-101 by serhiy-chornobay: Fix brand color for Social Vote widget

### DIFF
--- a/themes/socialblue/assets/css/brand.css
+++ b/themes/socialblue/assets/css/brand.css
@@ -261,6 +261,10 @@ blockquote {
   color: #33b5e5;
 }
 
+.vote-widget--social-vote .vote-vote {
+  background-color: #ffc142;
+}
+
 @media (min-width: 900px) {
   .search-take-over .form-text {
     color: #ffffff;

--- a/themes/socialblue/assets/css/preview.css
+++ b/themes/socialblue/assets/css/preview.css
@@ -1676,6 +1676,10 @@ blockquote {
   color: #33b5e5;
 }
 
+.vote-widget--social-vote .vote-vote {
+  background-color: #ffc142;
+}
+
 @media (min-width: 600px) {
   .teaser__image {
     border-top-left-radius: inherit;

--- a/themes/socialblue/components/brand.scss
+++ b/themes/socialblue/components/brand.scss
@@ -349,3 +349,7 @@ blockquote {
     }
   }
 }
+.vote-widget--social-vote .vote-vote {
+  background-color: $brand-accent;
+}
+


### PR DESCRIPTION
## Problem
External Social Vote module can't use theme settings colours.

## Solution
Add styles for Social Vote module in socialblue brand styles.

See: https://prnt.sc/kl3oym

## Issue tracker
- https://jira.goalgorilla.com/browse/FOR-101

## HTT
- [x] Check out the code changes
- [x] Checkout to this branch
- [x] Try change theme color scheme and check if background color for vote are correct
