### PR TITLE
by robertragas: make behat tests more generic

### DIFF
--- a/tests/behat/features/bootstrap/FeatureContext.php
+++ b/tests/behat/features/bootstrap/FeatureContext.php
@@ -287,6 +287,28 @@ class FeatureContext extends RawMinkContext implements Context, SnippetAccepting
   }
 
   /**
+   * @When I click the xth :position element with the css :css in the :region( region)
+   */
+  public function iClickTheRegionElementWithTheCSS($position, $css, $region)
+  {
+    $session = $this->getSession();
+    $regionObj = $session->getPage()->find('region', $region);
+    $elements = $regionObj->findAll('css', $css);
+
+    $count = 0;
+
+    foreach($elements as $element) {
+      if ($count == $position) {
+        // Now click the element.
+        $element->click();
+        return;
+      }
+      $count++;
+    }
+    throw new \InvalidArgumentException(sprintf('Element not found with the css: "%s"', $css));
+  }
+
+  /**
    * Click on the element with the provided CSS Selector
    *
    * @When /^I click the element with css selector "([^"]*)"$/

--- a/tests/behat/features/capabilities/alternative-frontpage/alternative-frontpage.feature
+++ b/tests/behat/features/capabilities/alternative-frontpage/alternative-frontpage.feature
@@ -40,11 +40,7 @@ Feature: Set alternative frontpage
     Then I should see "Frontpage AN"
 
     # Restore the settings
-    Given I am on "user/login"
-    When I fill in the following:
-      | Username or email address | admin |
-      | Password                  | admin |
-    And I press "Log in"
+    Given I am logged in as a user with the "administer alternative frontpage settings" permission
     Given I am on "admin/config/alternative_frontpage"
     # Error validation
     When I fill in the following:

--- a/tests/behat/features/capabilities/event-management/event-management.feature
+++ b/tests/behat/features/capabilities/event-management/event-management.feature
@@ -11,6 +11,9 @@ Feature: Event Management
       | name            | mail             | field_profile_organization | status |
       | event_organiser_1 | eo_1@example.com | GoalGorilla                | 1      |
       | event_organiser_2 | eo_2@example.com | Drupal                     | 1      |
+    And groups:
+      | title           | description      | author         | type        | language |
+      | Springfield local business collaboration | Description text | event_organiser_1 | open_group  | en       |
     And I am logged in as an "authenticated user"
     And I am on "user"
     And I click "Events"

--- a/tests/behat/features/capabilities/group/group-create-public.feature
+++ b/tests/behat/features/capabilities/group/group-create-public.feature
@@ -15,7 +15,7 @@ Feature: Create Public Group
       | Other    |
     And I am logged in as "GivenUserOne"
     And I am on "user"
-    And I click "Groups"
+    And I click "Groups" in the "Tabs"
     And I click "Add a group"
     Then I click radio button "Public group This is a public group. Users may join without approval and all content added in this group will be visible to all community members and anonymous users." with the id "edit-group-type-public-group"
     And I press "Continue"
@@ -48,14 +48,14 @@ Feature: Create Public Group
     And I should see "Lviv" in the "Hero block"
     And I should see "Lviv oblast" in the "Hero block"
 
-    When I click "About"
+    When I click "About" in the "Tabs"
     Then I should see "Description text" in the "Main content"
 
     And I am logged in as "GivenUserTwo"
     And I am on "all-members"
     And I click "GivenUserOne"
     And I should see "Test public group" in the "Sidebar second"
-    And I click "Groups"
+    And I click "Groups" in the "Tabs"
     And I should see "Test public group" in the "Main content"
     And I should not see the link "Add a group" in the "Main content"
     And I click "Test public group"
@@ -69,7 +69,7 @@ Feature: Create Public Group
     And I should see the button "Join group"
     And I press "Join group"
     And I am on "user"
-    And I click "Groups"
+    And I click "Groups" in the "Tabs"
     And I click "Test public group"
     Then I should see the button "Joined"
 

--- a/tests/behat/features/capabilities/post/post-comments.feature
+++ b/tests/behat/features/capabilities/post/post-comments.feature
@@ -29,7 +29,7 @@ Feature: Comment on a Post
    Then I should see the success message "Your comment has been posted."
 
         # Scenario: edit comment
-  When I click the xth "5" element with the css ".dropdown-toggle"
+  When I click the xth "1" element with the css ".dropdown-toggle" in the "Main content"
     And I click "Edit"
     And I fill in "Comment #1 to be deleted" for "Post comment"
     And I press "Submit"
@@ -37,7 +37,7 @@ Feature: Comment on a Post
 
         # Scenario: delete comment
    When I am on the homepage
-    And I click the xth "5" element with the css ".dropdown-toggle"
+    And I click the xth "1" element with the css ".dropdown-toggle" in the "Main content"
     And I click "Delete"
    Then I should see "This action cannot be undone."
         # Confirm delete

--- a/tests/behat/features/capabilities/post/post-create.feature
+++ b/tests/behat/features/capabilities/post/post-create.feature
@@ -30,7 +30,7 @@ Feature: Create Post
     And I should be on "/stream"
 
         # Scenario: edit the post
-   When I click the xth "5" element with the css ".dropdown-toggle"
+   When I click the xth "1" element with the css ".dropdown-toggle" in the "Main content"
     And I click "Edit"
     And I fill in "Say something to the Community" with "This is a community post edited."
     And I press "Post"

--- a/tests/behat/features/capabilities/post/post-photo-create.feature
+++ b/tests/behat/features/capabilities/post/post-photo-create.feature
@@ -24,7 +24,7 @@ Feature: Create Post with Photo
     And I should be on "/stream"
 
         # Scenario: edit the post
-   When I click the xth "5" element with the css ".dropdown-toggle"
+   When I click the xth "1" element with the css ".dropdown-toggle" in the "Main content"
     And I click "Edit"
     And I fill in "Say something to the Community" with "This is a post with a photo edited."
     And I press "Post"


### PR DESCRIPTION
## Problem
Behat tests are not generic enough

## Solution
Use given more so we don't depend on demo content. Also added a new function where you can call the css in a certain region.

## HTT
- [ ] Check out the code changes
- [ ] Run behat tests with fixture db like enterprise client 16.
- [ ] Notice it doesn't work because they have a top-menu with multiple dropdown items crashing the notifications, and also with menulink named the same as in groups, such as "about"
- [ ] Checkout to this branch
- [ ] Now the test will run, and also for the Distro it should still work.

## Release notes
We improved the behat tests by making the steps more specific, making it less dependent on a certain set of demo content.
