### PR TITLE
Issue #2989176 : Can't select myself in user reference fields / mentions

### DIFF
--- a/modules/social_features/social_profile/src/Plugin/EntityReferenceSelection/UserSelection.php
+++ b/modules/social_features/social_profile/src/Plugin/EntityReferenceSelection/UserSelection.php
@@ -72,12 +72,7 @@ class UserSelection extends UserSelectionBase {
     }
 
     $query = parent::buildEntityQuery(NULL, $match_operator);
-
-    $or = $query->orConditionGroup();
-    $or->condition('uid', $ids, 'IN');
-
-    $query->condition($or);
-    $query->condition('uid', $this->currentUser->id(), '!=');
+    $query->condition('uid', $ids, 'IN');
 
     return $query;
   }


### PR DESCRIPTION
## Problem
If you want to select yourself in a Entity reference selecter you get filtered out. Imagine for example wanting to select yourself as an Event organizer. It got filtered out as part of #884 where it never was a requirement as far as I can tell.

## Solution
By removing the filter from the User EntityReferenceSelection the current logged in user is not filtered out anymore. This also makes sure it becomes available for private message & mentions. Added benefits here is that sending yourself a private message works well and has its use cases (sending yourself an reminder). Mentions work as well but the need for this is not that clear for me so we might be able to fix this in a follow up. 

## Issue tracker
- https://www.drupal.org/node/2989176

## HTT
- [x] Check out the code changes
- [ ] Enable the Event Enrollments & Private message modules (or any other modules with User entity reference selections you can think of)
- [ ] Login as user benflorez and send yourself a private message, see you have a new private message
- [ ] Send yourself and another recipient a private message, see that again you have a new message
- [ ] Mention yourself on several places (comment in stream / nodes) see that it works as like you are mentioning someone else
- [ ] Add yourself as an event organiser
- [ ] Add yourself as group manager

## Release notes
It is now possible to find yourself when you are searching for users in an autocomplete field. These autocomplete fields are used for example when you try to mention people or when you search for reciepients for your private messages. 