### PR TITLE
Fix race condition in group edit content test

### DIFF
--- a/tests/behat/features/capabilities/group/group-edit-content-in-group.feature
+++ b/tests/behat/features/capabilities/group/group-edit-content-in-group.feature
@@ -21,12 +21,12 @@ Feature: Move content after creation
     And I click "Join"
     And I press "Join group"
     And I am on "node/add/topic"
+    And I click radio button "Discussion"
+    And I fill in "Title" with "I love this sport"
+    And I fill in the "edit-body-0-value" WYSIWYG editor with "Do you to?"
     And I select group "Kayaking"
     And I wait for AJAX to finish
     Then I should see "Changing the group may have impact on the visibility settings."
-    And I fill in "Title" with "I love this sport"
-    And I fill in the "edit-body-0-value" WYSIWYG editor with "Do you to?"
-    And I click radio button "Discussion"
     And I press "Save"
     And I should see "Kayaking" in the "Main content"
     And I wait for "2" seconds


### PR DESCRIPTION
## Problem
There is currently a race condition in the group-edit-content-in-group.feature between selecting the discussion and the AJAX request for changing a group which could undo that selection.

## Solution
To fix it the order is changed so the topic type is selected first and is included in the pre-AJAX state so the race condition is avoided.

## Issue tracker
- https://www.drupal.org/project/social/issues/2994271

## HTT
- [x] Check out the code changes
- [x] No test behaviour should have changed.
