### PR TITLE
Issue #2994272 by Kingdutch: Increase waiting time for AJAX requests …

### DIFF
--- a/tests/behat/features/bootstrap/SocialMinkContext.php
+++ b/tests/behat/features/bootstrap/SocialMinkContext.php
@@ -152,5 +152,42 @@ class SocialMinkContext extends MinkContext {
       }
     }
   }
+  
+  
+  /**
+   * Wait for AJAX to finish.
+   *
+   * Overwrites the default iWaitForAjaxToFinish step to increase the time-out to 
+   * allow tests to pass with longer running ajax requests.
+   *
+   * @see \Drupal\FunctionalJavascriptTests\JSWebAssert::assertWaitOnAjaxRequest()
+   * @see \Drupal\DrupalExtension\Context\MinkContext::iWaitForAjaxToFinish()
+   *
+   * @Given I wait for AJAX to finish
+   */
+  public function iWaitForAjaxToFinish() {
+    $condition = <<<JS
+    (function() {
+      function isAjaxing(instance) {
+        return instance && instance.ajaxing === true;
+      }
+      var d7_not_ajaxing = true;
+      if (typeof Drupal !== 'undefined' && typeof Drupal.ajax !== 'undefined' && typeof Drupal.ajax.instances === 'undefined') {
+        for(var i in Drupal.ajax) { if (isAjaxing(Drupal.ajax[i])) { d7_not_ajaxing = false; } }
+      }
+      var d8_not_ajaxing = (typeof Drupal === 'undefined' || typeof Drupal.ajax === 'undefined' || typeof Drupal.ajax.instances === 'undefined' || !Drupal.ajax.instances.some(isAjaxing))
+      return (
+        // Assert no AJAX request is running (via jQuery or Drupal) and no
+        // animation is running.
+        (typeof jQuery === 'undefined' || (jQuery.active === 0 && jQuery(':animated').length === 0)) &&
+        d7_not_ajaxing && d8_not_ajaxing
+      );
+    }());
+JS;
+    $result = $this->getSession()->wait(20000, $condition);
+    if (!$result) {
+      throw new \RuntimeException('Unable to complete AJAX request.');
+    }
+  }
 
 }


### PR DESCRIPTION
…in Behat tests

## Problem
Paragraphs can be quite slow to load by AJAX. Especially with a lot of elements such as what happens in some landing page tests. This can cause the 5 second timeout for the iWaitForAJAX step to be insufficient.

## Solution
To solve this we extend the time to 20 seconds which should be enough to let the AJAX requests pass even in slower conditions. Subjective tests show it takes about 10-15 seconds so this should provide a safe margin.

## Issue tracker
- https://www.drupal.org/project/social/issues/2994272

## HTT
- [ ] Check out the code changes
- [ ] No test behaviour should change in this commit. However, some tests (e.g. landing pages) should be more reliable.