### PR TITLE
Fix broken default profile image

### DIFF
--- a/modules/social_features/social_profile/social_profile.module
+++ b/modules/social_features/social_profile/social_profile.module
@@ -489,7 +489,6 @@ function social_profile_profile_view_alter(array &$build, EntityInterface $entit
         if (!$file->access('view', $current_user)) {
           // Load default data.
           $replacement_data = social_profile_get_default_image();
-          $default_profile = FALSE;
           // Check if we have default profile image
           if (!empty($replacement_data['id'])) {
             $default = \Drupal\file\Entity\File::load($replacement_data['id']);

--- a/modules/social_features/social_profile/social_profile.module
+++ b/modules/social_features/social_profile/social_profile.module
@@ -489,14 +489,23 @@ function social_profile_profile_view_alter(array &$build, EntityInterface $entit
         if (!$file->access('view', $current_user)) {
           // Load default data.
           $replacement_data = social_profile_get_default_image();
-          /** @var \Drupal\image\Plugin\Field\FieldType\ImageItem $imgitem */
-          $imgitem = $build['field_profile_image'][0]['#item'];
-          // Time to override the data that going to be rendered.
-          $imgitem->set('target_id', $replacement_data['id']);
-          $imgitem->set('width', $replacement_data['width']);
-          $imgitem->set('height', $replacement_data['height']);
-          // Put replacement data back in the object that's about to be built.
-          $build['field_profile_image'][0]['#item'] = $imgitem;
+          $default_profile = FALSE;
+          // Check if we have default profile image
+          if (!empty($replacement_data['id'])) {
+            $default = \Drupal\file\Entity\File::load($replacement_data['id']);
+            // Potentially the default profile image is in the private file system.
+            // Show default profile image if current user have access to it
+            if ($default->access('view', $current_user)) {
+              /** @var \Drupal\image\Plugin\Field\FieldType\ImageItem $imgitem */
+              $imgitem = $build['field_profile_image'][0]['#item'];
+              // Time to override the data that going to be rendered.
+              $imgitem->set('target_id', $replacement_data['id']);
+              $imgitem->set('width', $replacement_data['width']);
+              $imgitem->set('height', $replacement_data['height']);
+              // Put replacement data back in the object that's about to be built.
+              $build['field_profile_image'][0]['#item'] = $imgitem;              
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
## Problem
Custom default profile image is not shown when we set profile image on private files

## Solution
Add conditional check to see if current user has permission to default profile image

## Issue tracker
https://www.drupal.org/project/social/issues/2978581

## HTT
- [ ] Check out the code changes
- [ ] Set a path for private files in settings.php
- [ ] Add a new default profile image
- [ ] Check some public post as anonymous user


## Release notes
Fix broken custom default image on private file and wsod for anonymous user.
