### PR TITLE
#2996728 by ronaldtebrake: Cannot use isset() on the result of a func…

### DIFF
--- a/modules/custom/mentions/mentions.module
+++ b/modules/custom/mentions/mentions.module
@@ -129,10 +129,11 @@ function mentions_crud_update($type, $mentions, $id, $author) {
     ->execute();
   foreach ($mention_ids as $mention) {
     $entity = $mentions_storage->load($mention);
+    $uid = $entity->get('uid')->getValue();
 
     // Make sure the uid value is available.
-    if (isset($entity->get('uid')->getValue()[0]['value'])) {
-      $old_user = $entity->get('uid')->getValue()[0]['value'];
+    if (isset($uid[0]['value'])) {
+      $old_user = $uid[0]['value'];
       $old_users[] = $old_user;
       $old_mids[$old_user] = $mention;
     }


### PR DESCRIPTION
## Problem
For some hosting providers (?) People get a Fatal error:  `Cannot use isset() on the result of a function call (you can use "null !== func()" instead)` in `/home/public/profiles/contrib/social/modules/custom/mentions/mentions.module on line 134`

## Solution
According to [http://php.net/manual/en/function.isset.php](http://php.net/manual/en/function.isset.php)
`isset()` only works with variables as passing anything else will result in a parse error. For checking if constants are set use the defined() function.. So we make sure we only check variables.

## Issue tracker
- [https://www.drupal.org/project/social/issues/2996728](https://www.drupal.org/project/social/issues/2996728)

## HTT to be updated.
- [ ] Check out the code changes
- [ ] Login as user X and do this and this and that
- [ ] Notice it doesn't work
- [ ] Checkout to this branch
- [ ] Try this and this and that and see that it works now

## Release notes
TBD
