### PR TITLE
Issue #2999361 by frankgraave: improve group-edit-content-in-group.feature

### DIFF
--- a/tests/behat/features/capabilities/group/group-edit-content-in-group.feature
+++ b/tests/behat/features/capabilities/group/group-edit-content-in-group.feature
@@ -63,6 +63,7 @@ Feature: Move content after creation
     And I empty the queue
     And I click "Edit content"
     And I select group "- None -"
+    And I wait for AJAX to finish
     And I press "Save"
     And I run cron
     Then I should not see "Motorboats" in the "Main content"


### PR DESCRIPTION
## Problem
The **group-edit-content-in-group.feature** has a part where there's a topic being moved from a group to " - None - " and then saves the node. But this can cause false positives.

## Solution
Add a **_And I wait for AJAX to finish_** step just before it tries to save the node.

## Issue tracker
- https://www.drupal.org/project/social/issues/2999361

## HTT
- [ ] Check out the code changes
- [ ] Make sure the tests are green
- [ ] Run the test on your local machine and see it turning green

