### PR TITLE
#2992332 by ronaldtebrake: Default visibility fix for Open Groups

### DIFF
--- a/modules/social_features/social_group/social_group.install
+++ b/modules/social_features/social_group/social_group.install
@@ -399,10 +399,11 @@ function social_group_update_8014() {
 }
 
 /**
- * DATA ALTERATION:
+ * DATA ALTERATION.
+ *
  * Update all post visibility for public posts placed in a group with group type
  * open_group set public to community.
- * See: https://www.drupal.org/project/social/issues/2992332#comment-12790905
+ * See: https://www.drupal.org/project/social/issues/2992332#comment-12790905.
  */
 function social_group_update_8301(&$sandbox) {
   if (!isset($sandbox['progress'])) {

--- a/modules/social_features/social_group/social_group.install
+++ b/modules/social_features/social_group/social_group.install
@@ -11,6 +11,7 @@ use Drupal\field\Entity\FieldStorageConfig;
 use Drupal\Core\Database\Database;
 use Drupal\user\Entity\Role;
 use Drupal\social_post\Entity\Post;
+use Drupal\node\Entity\Node;
 
 /**
  * Implements hook_update_dependencies().
@@ -399,10 +400,10 @@ function social_group_update_8014() {
 }
 
 /**
- * DATA ALTERATION.
+ * NOTE: Contains possible data alteration!
  *
- * Update all post visibility for public posts placed in a group with group type
- * open_group set public to community.
+ * Change the visibility of all posts placed in an open group, which have
+ * visibility public, to community.
  * See: https://www.drupal.org/project/social/issues/2992332#comment-12790905.
  */
 function social_group_update_8301(&$sandbox) {
@@ -411,7 +412,7 @@ function social_group_update_8301(&$sandbox) {
     $sandbox['items'] = [];
     $sandbox['max'] = 0;
 
-    // First grab all the post id's that are affected.
+    // First grab all the post IDs that need to change.
     $connection = Database::getConnection();
     $sth = $connection->select('post__field_visibility', 'pv');
     $sth->fields('pv', ['entity_id']);
@@ -431,11 +432,56 @@ function social_group_update_8301(&$sandbox) {
 
   if ($sandbox['items']['post_ids']) {
     $pid = array_shift($sandbox['items']['post_ids']);
-    // Load all the entities with entity_load_multiple.
+
+    // Load all the entities and re-save them with the correct visibility.
     $post = Post::load($pid);
     /** @var \Drupal\social_post\Entity\Post $post */
     $post->set('field_visibility', '0');
     $post->save();
+  }
+
+  $sandbox['progress']++;
+  $sandbox['#finished'] = empty($sandbox['max']) ? 1 : ($sandbox['progress'] / $sandbox['max']);
+}
+
+/**
+ * NOTE: Contains possible data alteration!
+ *
+ * Change the visibility of all nodes placed in an open group, which have
+ * visibility public, to community.
+ * See: https://www.drupal.org/project/social/issues/2992332#comment-12790905.
+ */
+function social_group_update_8302(&$sandbox) {
+  if (!isset($sandbox['progress'])) {
+    $sandbox['progress'] = 0;
+    $sandbox['items'] = [];
+    $sandbox['max'] = 0;
+
+    // First grab all the node IDs that need to change.
+    $connection = Database::getConnection();
+    $sth = $connection->select('group_content_field_data', 'gc');
+    $sth->fields('gc', ['entity_id']);
+    $sth->join('node__field_content_visibility', 'nv', 'gc.entity_id = nv.entity_id');
+    $sth->join('node_field_data', 'nd', 'gc.entity_id = nd.nid');
+    $sth->condition('gc.type', 'open_group-group_node-%', 'LIKE');
+    $sth->condition('nv.field_content_visibility_value', 'public', '=');
+    // Timestamp is from the moment the commit landed in 8.x-3.x see:
+    // https://cgit.drupalcode.org/social/commit/?id=3e465bb1ad927712e22469c193b6e9547ba1c081
+    $sth->condition('nd.created', '1534118400', '>');
+    $data = $sth->execute();
+
+    $sandbox['items']['node_ids'] = $data->fetchCol();
+    $sandbox['max'] = count($sandbox['items']['node_ids']);
+  }
+
+  if ($sandbox['items']['node_ids']) {
+    $pid = array_shift($sandbox['items']['node_ids']);
+
+    // Load all the entities and re-save them with the correct visibility.
+    $node = Node::load($pid);
+    /** @var \Drupal\node\Entity\Node $node */
+    $node->set('field_content_visibility', 'community');
+    $node->save();
   }
 
   $sandbox['progress']++;

--- a/modules/social_features/social_group/social_group.install
+++ b/modules/social_features/social_group/social_group.install
@@ -10,6 +10,7 @@ use Drupal\field\Entity\FieldConfig;
 use Drupal\field\Entity\FieldStorageConfig;
 use Drupal\Core\Database\Database;
 use Drupal\user\Entity\Role;
+use Drupal\social_post\Entity\Post;
 
 /**
  * Implements hook_update_dependencies().
@@ -395,4 +396,37 @@ function social_group_update_8013() {
 function social_group_update_8014() {
   user_role_grant_permissions('contentmanager', ['access group overview']);
   user_role_grant_permissions('sitemanager', ['access group overview']);
+}
+
+/**
+ * DATA ALTERATION:
+ * Update all post visibility for public posts placed in a group with group type
+ * open_group set public to community.
+ * See: https://www.drupal.org/project/social/issues/2992332#comment-12790905
+ */
+function social_group_update_8305() {
+  // First grab all the post id's that are affected.
+  $connection = Database::getConnection();
+  $sth = $connection->select('post__field_visibility', 'pv');
+  $sth->fields('pv', array('entity_id'));
+  $sth->join('post_field_data', 'pd', 'pd.id = pv.entity_id');
+  $sth->join('post__field_recipient_group', 'pg', 'pv.entity_id = pg.entity_id');
+  $sth->join('groups', 'g', 'pg.field_recipient_group_target_id = g.id');
+  $sth->condition('pv.field_visibility_value', '1', '=');
+  $sth->condition('g.type', 'open_group', '=');
+  // Timestamp is from the moment the commit landed in 8.x-3.x see:
+  // https://cgit.drupalcode.org/social/commit/?id=3e465bb1ad927712e22469c193b6e9547ba1c081
+  $sth->condition('pd.created', '1534118400', '>');
+  $data = $sth->execute();
+  $results = $data->fetchCol();
+
+  // Load all the entities with entity_load_multiple.
+  $posts = Post::loadMultiple($results);
+  // Update the post entities, set the visibility and save it so also the
+  // correct caches are cleared.
+  /** @var \Drupal\social_post\Entity\Post $post */
+  foreach ($posts as $post) {
+    $post->set('field_visibility', '0');
+    $post->save();
+  }
 }

--- a/modules/social_features/social_group/social_group.install
+++ b/modules/social_features/social_group/social_group.install
@@ -404,29 +404,39 @@ function social_group_update_8014() {
  * open_group set public to community.
  * See: https://www.drupal.org/project/social/issues/2992332#comment-12790905
  */
-function social_group_update_8305() {
-  // First grab all the post id's that are affected.
-  $connection = Database::getConnection();
-  $sth = $connection->select('post__field_visibility', 'pv');
-  $sth->fields('pv', array('entity_id'));
-  $sth->join('post_field_data', 'pd', 'pd.id = pv.entity_id');
-  $sth->join('post__field_recipient_group', 'pg', 'pv.entity_id = pg.entity_id');
-  $sth->join('groups', 'g', 'pg.field_recipient_group_target_id = g.id');
-  $sth->condition('pv.field_visibility_value', '1', '=');
-  $sth->condition('g.type', 'open_group', '=');
-  // Timestamp is from the moment the commit landed in 8.x-3.x see:
-  // https://cgit.drupalcode.org/social/commit/?id=3e465bb1ad927712e22469c193b6e9547ba1c081
-  $sth->condition('pd.created', '1534118400', '>');
-  $data = $sth->execute();
-  $results = $data->fetchCol();
+function social_group_update_8301(&$sandbox) {
+  if (!isset($sandbox['progress'])) {
+    $sandbox['progress'] = 0;
+    $sandbox['items'] = [];
+    $sandbox['max'] = 0;
 
-  // Load all the entities with entity_load_multiple.
-  $posts = Post::loadMultiple($results);
-  // Update the post entities, set the visibility and save it so also the
-  // correct caches are cleared.
-  /** @var \Drupal\social_post\Entity\Post $post */
-  foreach ($posts as $post) {
+    // First grab all the post id's that are affected.
+    $connection = Database::getConnection();
+    $sth = $connection->select('post__field_visibility', 'pv');
+    $sth->fields('pv', ['entity_id']);
+    $sth->join('post_field_data', 'pd', 'pd.id = pv.entity_id');
+    $sth->join('post__field_recipient_group', 'pg', 'pv.entity_id = pg.entity_id');
+    $sth->join('groups', 'g', 'pg.field_recipient_group_target_id = g.id');
+    $sth->condition('pv.field_visibility_value', '1', '=');
+    $sth->condition('g.type', 'open_group', '=');
+    // Timestamp is from the moment the commit landed in 8.x-3.x see:
+    // https://cgit.drupalcode.org/social/commit/?id=3e465bb1ad927712e22469c193b6e9547ba1c081
+    $sth->condition('pd.created', '1534118400', '>');
+    $data = $sth->execute();
+
+    $sandbox['items']['post_ids'] = $data->fetchCol();
+    $sandbox['max'] = count($sandbox['items']['post_ids']);
+  }
+
+  if ($sandbox['items']['post_ids']) {
+    $pid = array_shift($sandbox['items']['post_ids']);
+    // Load all the entities with entity_load_multiple.
+    $post = Post::load($pid);
+    /** @var \Drupal\social_post\Entity\Post $post */
     $post->set('field_visibility', '0');
     $post->save();
   }
+
+  $sandbox['progress']++;
+  $sandbox['#finished'] = empty($sandbox['max']) ? 1 : ($sandbox['progress'] / $sandbox['max']);
 }

--- a/modules/social_features/social_group/social_group.module
+++ b/modules/social_features/social_group/social_group.module
@@ -1214,6 +1214,12 @@ function social_group_get_allowed_visibility_options_per_group_type($group_type_
       $visibility_options['community'] = FALSE;
       break;
 
+    case 'open_group':
+      $visibility_options['public'] = FALSE;
+      $visibility_options['community'] = TRUE;
+      $visibility_options['group'] = FALSE;
+      break;
+
     default:
       $config = \Drupal::config('entity_access_by_field.settings');
       $visibility_options['public'] = TRUE;

--- a/tests/behat/features/capabilities/post/post-group.feature
+++ b/tests/behat/features/capabilities/post/post-group.feature
@@ -30,9 +30,6 @@ Feature: Create Post on Group
     And I should see "1 member"
     And I should see "Joined"
     And I should see "Test open group" in the "Hero block"
-    And I click the post visibility dropdown
-    Then I should not see "Public"
-    And I should not see "Closed"
 
     When I click "Stream"
     And I fill in "Say something to the group" with "This is a community post in a group."
@@ -40,6 +37,9 @@ Feature: Create Post on Group
     Then I should see the success message "Your post has been posted."
     And I should see "This is a community post in a group."
     And I should see "Group User One" in the ".media-heading" element
+    And I click the post visibility dropdown
+    Then I should not see "Public"
+    And I should not see "Closed"
 
           # Scenario: See post on profile stream
     When I am on "/user"

--- a/tests/behat/features/capabilities/post/post-group.feature
+++ b/tests/behat/features/capabilities/post/post-group.feature
@@ -30,6 +30,9 @@ Feature: Create Post on Group
     And I should see "1 member"
     And I should see "Joined"
     And I should see "Test open group" in the "Hero block"
+    And I click the post visibility dropdown
+    Then I should not see "Public"
+    And I should not see "Closed"
 
     When I click "Stream"
     And I fill in "Say something to the group" with "This is a community post in a group."


### PR DESCRIPTION
## Problem
In PR #994 a default statement was added to make sure custom group types have all the visibility settings giving distro users more flexibility. However as you can see in the switch statement open_group wasn't covered in this scenario. This meant that "public" became an option in the visibility selector for Posts in streams for open groups and "public" was the default value. This is something we don't allow. 

## Solution
By adding a switch statement we provide the available options for posts in open groups. Only community is allowed in this case. We also made a data alteration that ensures all the posts created, that have visibility "Public" become "Community". By checking the timestamp of when #994 landed in the Distro we ensure not to many posts are loaded and changed.  

## Issue tracker
- https://www.drupal.org/project/social/issues/2992332

## HTT
- [x] Check out the code changes
- [x] Login as user X and go to / join an open group
- [x] See that on the stream page you can now add a Public post and Public is the default selection
- [x] See that when you save your public post, you go to /explore as AN user you actually see this post popping up in the stream
- [x] Checkout this branch, run the update, see that now your post is put back to community
- [x] Edit your post, see that the disabled visibility selector shows "Community" as well
- [x] See that your post is still shown in the Group stream

## Release notes
t.b.d still working on behat as well but lets see what our tests are doing in the meantime :) 
