### PR TITLE
Buttons in hero section on landing pages

### DIFF
--- a/modules/social_features/social_landing_page/social_landing_page.module
+++ b/modules/social_features/social_landing_page/social_landing_page.module
@@ -211,15 +211,15 @@ function social_landing_page_preprocess_node(&$variables) {
  * Implements hook_preprocess_HOOK().
  */
 function social_landing_page_preprocess_field(&$variables) {
-    if ($variables['field_name'] == 'field_button_link_an' || $variables['field_name'] == 'field_button_link_lu') {
-        $entity = $variables['element']['#object'];
-        $button_style = $entity->field_button_style->value;
-        foreach ($variables['items'] as $key => $value){
-            if (isset ($variables['items'][$key]['content'])) {
-                $variables['items'][$key]['content']['#options']['attributes']['class'] .= 'btn btn-large ' . $button_style;
-            }
-        }
+  if ($variables['field_name'] == 'field_button_link_an' || $variables['field_name'] == 'field_button_link_lu') {
+    $entity = $variables['element']['#object'];
+    $button_style = $entity->field_button_style->value;
+    foreach ($variables['items'] as $key => $value){
+      if (isset ($variables['items'][$key]['content'])) {
+        $variables['items'][$key]['content']['#options']['attributes']['class'] .= 'btn btn-large ' . $button_style;
+      }
     }
+  }
 }
 
 /**

--- a/modules/social_features/social_landing_page/social_landing_page.module
+++ b/modules/social_features/social_landing_page/social_landing_page.module
@@ -214,8 +214,8 @@ function social_landing_page_preprocess_field(&$variables) {
   if ($variables['field_name'] == 'field_button_link_an' || $variables['field_name'] == 'field_button_link_lu') {
     $entity = $variables['element']['#object'];
     $button_style = $entity->field_button_style->value;
-    foreach ($variables['items'] as $key => $value){
-      if (isset ($variables['items'][$key]['content'])) {
+    foreach ($variables['items'] as $key => $value) {
+      if (isset($variables['items'][$key]['content'])) {
         $variables['items'][$key]['content']['#options']['attributes']['class'] .= 'btn btn-large ' . $button_style;
       }
     }

--- a/modules/social_features/social_landing_page/social_landing_page.module
+++ b/modules/social_features/social_landing_page/social_landing_page.module
@@ -215,8 +215,8 @@ function social_landing_page_preprocess_field(&$variables) {
         $entity = $variables['element']['#object'];
         $button_style = $entity->field_button_style->value;
         foreach ($variables['items'] as $key => $value){
-            if (isset ($variables['items'][0]['content'])) {
-                $variables['items'][0]['content']['#options']['attributes']['class'] .= 'btn btn-large ' . $button_style;
+            if (isset ($variables['items'][$key]['content'])) {
+                $variables['items'][$key]['content']['#options']['attributes']['class'] .= 'btn btn-large ' . $button_style;
             }
         }
     }

--- a/modules/social_features/social_landing_page/social_landing_page.module
+++ b/modules/social_features/social_landing_page/social_landing_page.module
@@ -208,6 +208,21 @@ function social_landing_page_preprocess_node(&$variables) {
 }
 
 /**
+ * Implements hook_preprocess_HOOK().
+ */
+function social_landing_page_preprocess_field(&$variables) {
+    if ($variables['field_name'] == 'field_button_link_an' || $variables['field_name'] == 'field_button_link_lu') {
+        $entity = $variables['element']['#object'];
+        $button_style = $entity->field_button_style->value;
+        foreach ($variables['items'] as $key => $value){
+            if (isset ($variables['items'][0]['content'])) {
+                $variables['items'][0]['content']['#options']['attributes']['class'] .= 'btn btn-large ' . $button_style;
+            }
+        }
+    }
+}
+
+/**
  * Fetches the first available hero section image from a landing page.
  *
  * @param \Drupal\node\Entity\Node $node

--- a/modules/social_features/social_landing_page/templates/paragraph--button--default.html.twig
+++ b/modules/social_features/social_landing_page/templates/paragraph--button--default.html.twig
@@ -49,7 +49,7 @@
     <div {{ attributes.addClass(classes) }}>
     {% block content %}
       <div class="card__actionbar">
-        <div class="btn btn-lg {{ content.field_button_style|render|striptags|trim }}">
+        <div>
           {% if logged_in %}
             {{ content.field_button_link_lu }}
           {% else %}


### PR DESCRIPTION
## Problem
Buttons in hero section on landing pages do only work if you click on the text. If you click the button outside, nothing happens. The classes "btn btn-lg" are added to a surrounding DIV not the anchor tag.

## Solution
Added a hook_preprocess_field to social_langing_page module to add the classes for buttons to the anchor tag. Thats a lean solution compared to adding additional modules as described in the issue queue.

## Issue tracker
- https://www.drupal.org/project/social/issues/3002541

## HTT
- [ ] Check out the code changes
- [ ] Login as user who can create landing pages. Create a landing page with a hero section and buttons on it.
- [ ] Notice it doesn't work, if you click on the button outside the text
- [ ] Checkout to this branch
- [ ] Refresh Cache. Now you can click on the button wherever you like to

## Release notes
<describe the release notes>
