### PR TITLE
IE explorer svg issue

### DIFF
--- a/themes/socialbase/assets/css/base.css
+++ b/themes/socialbase/assets/css/base.css
@@ -334,8 +334,7 @@ img {
   vertical-align: middle;
 }
 
-img,
-svg {
+img {
   max-width: 100%;
   height: auto;
 }

--- a/themes/socialbase/assets/css/ckeditor.css
+++ b/themes/socialbase/assets/css/ckeditor.css
@@ -153,8 +153,7 @@ img {
   vertical-align: middle;
 }
 
-img,
-svg {
+img {
   max-width: 100%;
   height: auto;
 }

--- a/themes/socialbase/assets/css/dropdown.css
+++ b/themes/socialbase/assets/css/dropdown.css
@@ -5,7 +5,7 @@
   margin-left: 2px;
   vertical-align: middle;
   border-top: 4px dashed;
-  border-top: 4px solid \9 ;
+  border-top: 4px solid \9 ;
   border-right: 4px solid transparent;
   border-left: 4px solid transparent;
 }
@@ -131,7 +131,7 @@
 .navbar-fixed-bottom .dropdown .caret {
   border-top: 0;
   border-bottom: 4px dashed;
-  border-bottom: 4px solid \9 ;
+  border-bottom: 4px solid \9 ;
   content: "";
 }
 

--- a/themes/socialbase/components/01-base/embedded/_embedded.scss
+++ b/themes/socialbase/components/01-base/embedded/_embedded.scss
@@ -38,8 +38,7 @@ img {
   vertical-align: middle;
 }
 
-img,
-svg {
+img {
   // Suppress the space beneath the baseline
   // vertical-align: bottom;
 


### PR DESCRIPTION
## Problem
auto: height for SVG brocked styles.

## Solution
Remove height: auto for SVG 

## Issue tracker
- https://jira.goalgorilla.com/browse/ECI-832

## HTT
- [ ] Check out the code changes
- [ ] Checkout to this branch
- [ ] Login as normal user and try to add a reply in IE11 browser
- [ ] Check if height for SVG works okay

