### PR TITLE
Issue #3005063 by Kingdutch: E-mail notification wording for liked co…

### DIFF
--- a/modules/social_features/social_like/social_like.tokens.inc
+++ b/modules/social_features/social_like/social_like.tokens.inc
@@ -109,7 +109,7 @@ function social_like_tokens($type, $tokens, array $data, array $options, Bubblea
                     else {
                       $commented_content_type = $commented_entity->bundle();
                     }
-                    $liked_entity_link_html .= ' ' . t('on') . ' ' . $commented_content_type . ' <a href="' . $ref_link . '">' . $ref_link_label . '</a>';
+                    $liked_entity_link_html .= ' ' . t('on the') . ' ' . $commented_content_type . ' <a href="' . $ref_link . '">' . $ref_link_label . '</a>';
                   }
                   else {
                     $commented_content_type = Unicode::strtolower($commented_entity->getEntityType()->getLabel());


### PR DESCRIPTION
…mments

## Problem
From a client:

I like the improved specificity of the notification emails. I think a small wording change would help for the notifications when someone likes a comment: add "the" before topic or event. Instead of

"[user name] likes your comment on [content type] [content title]"

## Solution
"[user name] likes your comment on the [content type] [content title]"

Natasha approved of this request

## Issue tracker
- https://www.drupal.org/project/social/issues/3005063

## HTT
- [x] As user 1 place a comment on a topic or event and logout
- [x] As user 2 like that comment
- [x] See the text change

## Release notes
The notification for likes on comments placed on content was missing an article. We've found the article and put it back in its place.
