### PR TITLE
DS-5960 - Missing permission(s) for API

### DIFF
--- a/modules/social_features/social_event/social_event.install
+++ b/modules/social_features/social_event/social_event.install
@@ -85,6 +85,7 @@ function _social_event_get_permissions($role) {
   $permissions['sitemanager'] = array_merge($permissions['contentmanager'], [
     'administer visibility settings',
     'administer social_event settings',
+    'view published event enrollment entities',
   ]);
 
   if (isset($permissions[$role])) {


### PR DESCRIPTION
## Problem
The JSON API user will be using the SM perm. We also want the api to retrieve all the event enrolments. The permission to view the event enrolments was not yet assigned to sitemanagers.

## Solution
I propose to enable this for NEW installations. For existing installations we can enable the permission in the install hook of the social json api.

## Issue tracker
- DS-5960

## HTT
- [x] Check out the code changes
- [ ] Open page `{{host}}/jsonapi/event_enrollment/event_enrollment` with a SM access token

## Release notes
n/a
