### PR TITLE
Issue #3005110 by Kingdutch: UserExportPluginBase sometimes returns F…

### DIFF
--- a/modules/social_features/social_user_export/src/Plugin/UserExportPluginBase.php
+++ b/modules/social_features/social_user_export/src/Plugin/UserExportPluginBase.php
@@ -131,6 +131,11 @@ abstract class UserExportPluginBase extends PluginBase implements UserExportPlug
       $storage = $this->entityTypeManager->getStorage('profile');
       if (!empty($storage)) {
         $user_profile = $storage->loadByUser($entity, 'profile', TRUE);
+
+        // TODO: Remove once #3005113 is fixed in the profile module.
+        if ($user_profile === FALSE) {
+          $user_profile = NULL;
+        }
       }
     }
     catch (\Exception $e) {


### PR DESCRIPTION
…ALSE instead of NULL which breaks the export

## Problem

<code>UserExportPluginBase</code> provides two utility methods that can be used to quickly load profile data: <code>profileGetFieldValue</code> and <code>getProfile</code>.

<code>profileGetFieldValue</code> takes a profile as second argument but allows passing NULL for a profile that's not found. This allows usage with <code>getProfile</code> without intermediate return value checking such as demonstrated in <code>UserFirstName::getValue</code>: <code>return $this->profileGetFieldValue('field_profile_first_name', $this->getProfile($entity));</code>.

The trouble is that <code>UserExportPluginBase::getProfile</code> may return <code>FALSE</code> instead of <code>NULL</code>. This results in the following error.

<blockquote>
TypeError: Argument 2 passed to Drupal\social_user_export\Plugin\UserExportPluginBase::profileGetFieldValue() must implement interface Drupal\profile\Entity\ProfileInterface or be null, boolean given, called in /app/html/profiles/contrib/social/modules/social_features/social_user_export/src/Plugin/UserExportPlugin/UserFirstName.php on line 30 in Drupal\social_user_export\Plugin\UserExportPluginBase->profileGetFieldValue() (line 152 of /app/html/profiles/contrib/social/modules/social_features/social_user_export/src/Plugin/UserExportPluginBase.php)

#0 /app/html/profiles/contrib/social/modules/social_features/social_user_export/src/Plugin/UserExportPlugin/UserFirstName.php(30): Drupal\social_user_export\Plugin\UserExportPluginBase->profileGetFieldValue('field_profile_f...', false)

#1 /app/html/profiles/contrib/social/modules/social_features/social_user_export/src/ExportUser.php(64): Drupal\social_user_export\Plugin\UserExportPlugin\UserFirstName->getValue(Object(Drupal\user\Entity\User))

#2 /app/html/profiles/contrib/social/modules/social_features/social_user_export/src/ExportUser.php(111): Drupal\social_user_export\ExportUser::exportUserOperation(Object(Drupal\user\Entity\User), Array)

#3 /app/html/core/includes/batch.inc(294): Drupal\social_user_export\ExportUser::exportUsersAllOperation(Array, Array)

#4 /app/html/core/includes/batch.inc(137): _batch_process()

#5 /app/html/core/includes/batch.inc(93): _batch_do()

#6 /app/html/core/modules/system/src/Controller/BatchController.php(55): _batch_page(Object(Symfony\Component\HttpFoundation\Request))

#7 [internal function]: Drupal\system\Controller\BatchController->batchPage(Object(Symfony\Component\HttpFoundation\Request))

#8 /app/html/core/lib/Drupal/Core/EventSubscriber/EarlyRenderingControllerWrapperSubscriber.php(123): call_user_func_array(Array, Array)

#9 /app/html/core/lib/Drupal/Core/Render/Renderer.php(582): Drupal\Core\EventSubscriber\EarlyRenderingControllerWrapperSubscriber->Drupal\Core\EventSubscriber

{closure}
()
</blockquote>

## Cause
The <code>UserExportPluginBase::getProfile</code> method uses <code>ProfileStorage::loadByUser</code> internally and if profiles are enabled sets the return value directly to the output of that function. <code>ProfileStorage::loadByUser</code> uses the PHP <code>reset</code> function on the output of a call to <code>EntityStorageBase::loadByProperties</code>. 

The <code>EntityStorageBase::loadByProperties</code> function returns an empty array when an entity could not be found. According to <a href="http://php.net/manual/en/function.reset.php">the PHP documentation for reset</a> the function returns <code>FALSE</code> when it is called on an empty array. This in turn causes <code>ProfileStorage::loadByUser</code> to return FALSE instead of NULL when a profile could not be found.

## Solution
In <code>UserExportPluginBase::getProfile</code> add a check for the return value of <code>$storage->loadByUser($entity, 'profile', TRUE);</code> and translate <code>FALSE</code> to <code>NULL</code> to conform to the rest of Drupal and make the checks that rely on this function correctly.

## Issue tracker
- https://www.drupal.org/project/social/issues/3005110

## HTT
- [ ] Create a user without a profile
- [ ] Export the user
- [ ] See that it fails without this PR but works with this PR

## Release notes
The export sometimes broke when it tried to export a user without a profile. This should now be fixed!