### PR TITLE
Issue #3005678 by Kingdutch: Loading the CsvEncoder as a service caus…

### DIFF
--- a/modules/social_features/social_user_export/src/ExportUser.php
+++ b/modules/social_features/social_user_export/src/ExportUser.php
@@ -4,6 +4,7 @@ namespace Drupal\social_user_export;
 
 use Drupal\Core\Entity\ContentEntityBase;
 use Drupal\Core\Url;
+use Drupal\csv_serialization\Encoder\CsvEncoder;
 use Drupal\user\UserInterface;
 use League\Csv\Writer;
 use Drupal\Core\Link;
@@ -54,8 +55,7 @@ class ExportUser extends ContentEntityBase {
     }
 
     // Add formatter.
-    $encoder = \Drupal::service('csv_serialization.encoder.csv');
-    $csv->addFormatter([$encoder, 'formatRow']);
+    $csv->addFormatter([new CsvEncoder(), 'formatRow']);
 
     $row = [];
     /** @var \Drupal\social_user_export\Plugin\UserExportPluginBase $instance */


### PR DESCRIPTION
…es the user export to be broken

## Problem
User export is fully broken in 3.1

The following change record details how it's no longer allowed to request a service tagged as "Encoder": [#2936397]. This causes line 57 of the <code>Drupal\social_user_export\ExportUser</code> class to throw an error: <code>$encoder = \Drupal::service('csv_serialization.encoder.csv');</code>

## Solution
To remedy this quickly we should just call the <code>CsvEncoder</code> class directly instead of through a service.

As a follow-up we should work on fixing [#2854087] so that we can properly use Drupal's serializer API for CSV output instead of rebuilding what the serializer does in the <code>ExportUser</code> class. This also makes it easier to use other formats in the future.

## Issue tracker
- https://www.drupal.org/project/social/issues/3005678

## HTT
- [ ] Export a user from the People overview (1 or many)

## Release notes
User export now works with the following change in Drupal 8.6: https://www.drupal.org/node/2936397
