### PR TITLE
Issue #3005537 by Kingdutch: Remove hero from "leave group" page

### DIFF
--- a/modules/social_features/social_group/config/optional/block.block.socialblue_groupheroblock.yml
+++ b/modules/social_features/social_group/config/optional/block.block.socialblue_groupheroblock.yml
@@ -20,6 +20,6 @@ settings:
 visibility:
   request_path:
     id: request_path
-    pages: "/group/*/stream\r\n/group/*/about\r\n/group/*/events\r\n/group/*/topics\r\n/group/*/members\r\n/group/*/membership\r\n/group/*/leave\r\n/group/*/content/*"
+    pages: "/group/*/stream\r\n/group/*/about\r\n/group/*/events\r\n/group/*/topics\r\n/group/*/members\r\n/group/*/membership\r\n/group/*/content/*"
     negate: false
     context_mapping: {  }

--- a/tests/behat/features/capabilities/group/group-create-closed.feature
+++ b/tests/behat/features/capabilities/group/group-create-closed.feature
@@ -190,7 +190,6 @@ Feature: Create Closed Group
     And I click the element with css selector "#hero .dropdown-toggle"
     And I should see the link "Leave group"
     And I click "Leave group"
-    And I should see "Test closed group 2" in the "Hero block"
     And I should see "This action cannot be undone."
     And I should see the button "Cancel"
     And I should see the button "Leave group"

--- a/tests/behat/features/capabilities/group/group-create-open.feature
+++ b/tests/behat/features/capabilities/group/group-create-open.feature
@@ -151,7 +151,6 @@ Feature: Create Open Group
     And I click the element with css selector "#hero .dropdown-toggle"
     And I should see the link "Leave group"
     And I click "Leave group"
-    And I should see "Test open group" in the "Hero block"
     And I should see "This action cannot be undone."
     And I should see the button "Cancel"
     And I should see the button "Leave group"

--- a/tests/behat/features/capabilities/group/group-create-public.feature
+++ b/tests/behat/features/capabilities/group/group-create-public.feature
@@ -119,7 +119,6 @@ Feature: Create Public Group
     And I click the element with css selector "#hero .dropdown-toggle"
     And I should see the link "Leave group"
     And I click "Leave group"
-    And I should see "Test public group" in the "Hero block"
     And I should see "This action cannot be undone."
     And I should see the button "Cancel"
     And I should see the button "Leave group"


### PR DESCRIPTION
This is my first issue I'm taking on with this project so please let me know if I've missed anything in terms of the workflow, and pull request information below. I also don't know if you require an install hook or some other automated way to import the updated feature configuration, other than manually importing the feature with drush, as indicated below.
## Problem
The hero can push simple action forms (such as join group/leave group) below the fold on smaller screens. This makes it more difficult for users to perform the action. Because of this we've decided to remove the hero on the join group screen. However, this causes the experience between leaving a group and joining a group to be inconsistent, as the hero still appears on the leave group screen.

## Solution
The "Leave group" page path has been removed from the group hero block page visibility paths. This was done in the social_group feature.
## Issue tracker
- https://www.drupal.org/project/social/issues/3005537

## HTT
- [x] Check out the code changes
- [x] Login as a user who has permission to join groups, join a group, and then leave a group. On the "Leave group" confirmation page, the Hero block and image will appear. 
- [x] Checkout to this branch
- [x] Import the updated social group feature configuration, e.g. `drush fim social_group -y`
- [x] Clear the cache `drush cr`
- [x] Login as a user who has permission to join groups, join a group, and then leave a group. On the "Leave group" confirmation page, the Hero block and image will no longer appear.

## Release notes

