### PR TITLE
DS-3621 by jaapjan: implement new label 'You are enrolled' for LU

### DIFF
--- a/modules/social_features/social_event/social_event.module
+++ b/modules/social_features/social_event/social_event.module
@@ -153,7 +153,7 @@ function social_event_node_view_alter(array &$build, EntityInterface $entity, En
       if ($current_enrollment_status === '1') {
         $build['enrolled'] = [
           '#type' => '#text_field',
-          '#markup' => t('Enrolled'),
+          '#markup' => t('You are enrolled'),
         ];
       }
     }

--- a/tests/behat/features/capabilities/event/eventenrollment.feature
+++ b/tests/behat/features/capabilities/event/eventenrollment.feature
@@ -105,14 +105,14 @@ Feature: Enroll for an event
       | status           | 1                     |
     And I click "eventenrollment" in the "Main content"
     And I click "Events"
-    Then I should not see "Enrolled"
+    Then I should not see "You are enrolled"
 
     When I click "Enrollment test event"
     And I press the "Enroll" button
     Then I should see the button "Enrolled"
     And I click "eventenrollment" in the "Main content"
     And I click "Events"
-    Then I should see "Enrolled"
+    Then I should see "You are enrolled"
 
   @closed_enrollments
   Scenario: Can no longer enroll to an event when it has finished.

--- a/tests/behat/features/capabilities/event/lu-homepage-my-events.feature
+++ b/tests/behat/features/capabilities/event/lu-homepage-my-events.feature
@@ -28,15 +28,15 @@ Feature: See my upcoming events
     When I go to the homepage
     Then I should not see "My Behat Event created" in the ".view-display-id-block_my_upcoming_events" element
     And I should see "My Behat Event enrolled" in the ".view-display-id-block_my_upcoming_events" element
-    And I should see "Enrolled" in the ".view-display-id-block_my_upcoming_events" element
+    And I should see "You are enrolled" in the ".view-display-id-block_my_upcoming_events" element
 
     When I am at "user"
     And I click "Events"
     Then I should see "Events for this user"
     And I should see "My Behat Event created"
     And I should see "My Behat Event enrolled"
+    And I should see "You are enrolled"
 
     When I am at "user"
     Then I should see "My Behat Event created"
     And I should see "My Behat Event enrolled"
-    And I should see "enrolled"

--- a/themes/socialbase/components/02-atoms/badge/badge.twig
+++ b/themes/socialbase/components/02-atoms/badge/badge.twig
@@ -1,2 +1,2 @@
 <h2>Example heading <span class="badge badge-default">New</span></h2>
-<h4>Example heading <span class="badge badge-secondary">Enrolled</span></h4>
+<h4>Example heading <span class="badge badge-secondary">You are enrolled</span></h4>

--- a/themes/socialbase/templates/node/event/node--event--teaser.html.twig
+++ b/themes/socialbase/templates/node/event/node--event--teaser.html.twig
@@ -26,4 +26,10 @@
     {% endembed %}
   {% endif %}
 
+  {% if content.enrolled %}
+    <span class="badge badge-secondary teaser__badge">
+      {%- trans -%} You are enrolled {%- endtrans -%}
+    </span>
+  {% endif %}
+
 {% endblock %}

--- a/themes/socialbase/templates/node/node--teaser.html.twig
+++ b/themes/socialbase/templates/node/node--teaser.html.twig
@@ -171,12 +171,6 @@
           </div>
         {% endif %}
 
-        {% if content.enrolled %}
-          <span class="badge badge-secondary teaser__badge">
-            {%- trans -%} Enrolled {%- endtrans -%}
-          </span>
-        {% endif %}
-
       {{ content.links }}
     </div>
 

--- a/themes/socialblue/components/02-atoms/badge/badge-variation.twig
+++ b/themes/socialblue/components/02-atoms/badge/badge-variation.twig
@@ -1,1 +1,1 @@
-<span class="badge {{ modifier_class }}">Enrolled</span>
+<span class="badge {{ modifier_class }}">You are enrolled</span>


### PR DESCRIPTION
New PR based on changes made in #951 

NOTE: I did not (yet) check for compatibility with the AN event enrolment feature released in 3.x via PR #792

## Problem
In user testing, users are not clear what the label means. And on the event overview page of anther user, users thought that is about the user they are looking at. We should make this label clear that it is about the user him/herself. 

## Solution
Change the label from "Enrolled" to "You are enrolled". ## Issue tracker
- DS-3621

## HTT
- [x] Check out the code changes
- [x] Login as user X and enroll to an event
- [x] Check the event label on the button
- [x] Go to your profile and see the block on the right with upcoming events (same as homepage)
- [x] Go to event overview on your profile and verify your label
- [x] Go to event overview and verify label
- [x] Check changes in Behat

## Documentation
- [ ] This item is documented on LGOS
- [ ] This item has been added to the feature overview

## Release notes
In user testing, users are not clear what the label means. And on the event overview page of anther user, users thought that is about the user they are looking at. We have changed the label "Enrolled" to "You are enrolled" to solve that problem.
