### PR TITLE
Issue #3008921 by Kingdutch: Anonymous (AN) Event enrollment settings should use "Administer Event Settings" permissions

### DIFF
--- a/modules/social_features/social_event/modules/social_event_an_enroll/social_event_an_enroll.routing.yml
+++ b/modules/social_features/social_event/modules/social_event_an_enroll/social_event_an_enroll.routing.yml
@@ -4,7 +4,7 @@ social_event_an_enroll.settings:
     _title: 'Anonymous event enrollment settings'
     _form: '\Drupal\social_event_an_enroll\Form\EventAnEnrollSettingsForm'
   requirements:
-    _permission: 'access administration pages'
+    _permission: 'administer social_event settings'
 
 social_event_an_enroll.enroll_dialog:
   path: '/node/{node}/enroll-dialog'


### PR DESCRIPTION
## Problem
The AN Event Enrollment settings currently use the broad "access administration pages" permission, a permission that the Content Manager role has. But, content managers should not actually have the permission to change these settings.

To prevent Content Managers from accessing the AN Event Enrollment configuration settings, the permission should be changed from 'access administration pages' to 'administer social_event settings'. (AN event enrollment is part of configuring how events work so it makes sense to reuse the "Administer Event Settings" permission).

 If a user needs to change these settings, then they should probably be a site manager (or a separate role can be created).

## Solution

The access permission to route social_event_an_enroll.settings with path /admin/config/opensocial/event-an-enroll should been changed from 'access administration pages' to 'administer social_event settings'.

## Issue tracker
- https://www.drupal.org/project/social/issues/3008921

## HTT
- [ ] Check out the code changes
- [ ] Enable the "Social Event AN Enroll" module and dependencies: `drush en social_event_an_enroll -y`
- [ ] Before implementing this fix, login as a content manager, and you should be able to access the /admin/config/opensocial/event-an-enroll settings page.
- [ ] Checkout to this branch
- [ ] Clear the cache so that the changed permission takes effect
- [ ] Login as a Content Manager
- [ ] If you try to access /admin/config/opensocial/event-an-enroll you will get the "Access denied" screen.

## Release notes
The permission granting access to the "Anonymous event enrollment settings" page (admin/config/opensocial/event-an-enroll) has changed from  "Use the administration pages and help" ( permission id 'access administration pages') to "Administer Event Settings" (permission ID 'administer social_event settings'). Users with the Content Manager role will no longer have access to this page. If a user needs to change these settings, then they should probably be a Site Manager, or a separate role should be created.

