### PR TITLE
Issue #3008497 by Kingdutch, bramtenhove: Landing page performance research

### DIFF
--- a/modules/custom/activity_basics/src/Plugin/ActivityContext/GroupActivityContext.php
+++ b/modules/custom/activity_basics/src/Plugin/ActivityContext/GroupActivityContext.php
@@ -4,7 +4,6 @@ namespace Drupal\activity_basics\Plugin\ActivityContext;
 
 use Drupal\activity_creator\Plugin\ActivityContextBase;
 use Drupal\group\Entity\GroupContent;
-use Drupal\social_group\SocialGroupHelperService;
 
 /**
  * Provides a 'GroupActivityContext' activity context.
@@ -28,7 +27,8 @@ class GroupActivityContext extends ActivityContextBase {
 
       $referenced_entity = $data['related_object']['0'];
 
-      if ($gid = SocialGroupHelperService::getGroupFromEntity($referenced_entity)) {
+      // TODO: Replace this with dependency injection.
+      if ($gid = \Drupal::service('social_group.helper_service')->getGroupFromEntity($referenced_entity)) {
         $recipients[] = [
           'target_type' => 'group',
           'target_id' => $gid,

--- a/modules/custom/activity_basics/src/Plugin/ActivityContext/GroupActivityContext.php
+++ b/modules/custom/activity_basics/src/Plugin/ActivityContext/GroupActivityContext.php
@@ -28,7 +28,9 @@ class GroupActivityContext extends ActivityContextBase {
       $referenced_entity = $data['related_object']['0'];
 
       // TODO: Replace this with dependency injection.
-      if ($gid = \Drupal::service('social_group.helper_service')->getGroupFromEntity($referenced_entity)) {
+      /** @var \Drupal\social_group\SocialGroupHelperService $group_helper */
+      $group_helper = \Drupal::service('social_group.helper_service');
+      if ($gid = $group_helper->getGroupFromEntity($referenced_entity, FALSE)) {
         $recipients[] = [
           'target_type' => 'group',
           'target_id' => $gid,

--- a/modules/social_features/social_group/social_group.module
+++ b/modules/social_features/social_group/social_group.module
@@ -18,6 +18,7 @@ use Drupal\group\Entity\GroupContentType;
 use Drupal\group\Entity\GroupInterface;
 use Drupal\group\Entity\GroupContent;
 use Drupal\group\Entity\GroupType;
+use Drupal\node\NodeInterface;
 use Drupal\social_group\Controller\SocialGroupController;
 use Drupal\social_group\Form\SocialGroupAddForm;
 use Drupal\social_group\SocialGroupHelperService;
@@ -843,6 +844,24 @@ function _social_group_get_member_profile(GroupContent $group_content) {
  *   Returns the group object.
  */
 function _social_group_get_current_group($node = NULL) {
+  $cache = &drupal_static(__FUNCTION__, []);
+
+  // For the same $node input, within the same request the return is always
+  // the same.
+  $nid = NULL;
+  if (is_null($node)) {
+    $nid = -1;
+  }
+  elseif ($node instanceof NodeInterface) {
+    $nid = $node->id();
+  }
+
+  // If we have a cache key and it has a value, we're done early.
+  if (!is_null($nid) && isset($cache[$nid])) {
+    // Translate FALSE (so isset works) back to NULL.
+    return $cache[$nid] ?: NULL;
+  }
+
   $group = \Drupal::routeMatch()->getParameter('group');
 
   if (!is_object($group) && !is_null($group)) {
@@ -864,6 +883,12 @@ function _social_group_get_current_group($node = NULL) {
           ->load($gid_from_entity);
       }
     }
+  }
+
+  // If we have a cache key we store the value.
+  if (!is_null($nid)) {
+    // Translate NULL to FALSE so that isset works.
+    $cache[$nid] = isset($group) ? $group : FALSE;
   }
 
   return $group;

--- a/modules/social_features/social_group/social_group.module
+++ b/modules/social_features/social_group/social_group.module
@@ -967,6 +967,20 @@ function social_group_preprocess_profile(&$variables) {
  * If the user is not a member, the user has no access to view this block.
  */
 function social_group_block_access(Block $block, $operation, AccountInterface $account) {
+  $block_id = $block->getPluginId();
+
+  // This is a list of the blocks that this function cares about, if we're being
+  // called for a different block we exit early.
+  $managed_blocks = [
+    'views_exposed_filter_block:newest_groups-page_all_groups',
+    'views_block:groups-block_user_groups',
+    'views_block:upcoming_events-upcoming_events_group',
+    'views_block:latest_topics-group_topics_block',
+  ];
+  if (!in_array($block_id, $managed_blocks)) {
+    return AccessResult::neutral();
+  }
+
   if ($block->getPluginId() == 'views_exposed_filter_block:newest_groups-page_all_groups' && $operation == 'view' && $account->isAnonymous()) {
     $group_types = 0;
 

--- a/modules/social_features/social_group/social_group.module
+++ b/modules/social_features/social_group/social_group.module
@@ -21,7 +21,6 @@ use Drupal\group\Entity\GroupType;
 use Drupal\node\NodeInterface;
 use Drupal\social_group\Controller\SocialGroupController;
 use Drupal\social_group\Form\SocialGroupAddForm;
-use Drupal\social_group\SocialGroupHelperService;
 use Drupal\views\ViewExecutable;
 use Drupal\views\Plugin\views\cache\CachePluginBase;
 use Drupal\views\Plugin\views\query\QueryPluginBase;
@@ -876,7 +875,7 @@ function _social_group_get_current_group($node = NULL) {
         'target_type' => 'node',
         'target_id' => $node->id(),
       ];
-      $gid_from_entity = SocialGroupHelperService::getGroupFromEntity($node_entity);
+      $gid_from_entity = \Drupal::service('social_group.helper_service')->getGroupFromEntity($node_entity);
       if ($gid_from_entity !== NULL) {
         $group = \Drupal::entityTypeManager()
           ->getStorage('group')

--- a/modules/social_features/social_group/social_group.module
+++ b/modules/social_features/social_group/social_group.module
@@ -986,11 +986,7 @@ function social_group_block_access(Block $block, $operation, AccountInterface $a
 
     /** @var \Drupal\group\Entity\GroupTypeInterface $group_type */
     foreach (GroupType::loadMultiple() as $group_type) {
-      $permissions = $group_type->getAnonymousRole()->getPermissions();
-
-      if (in_array('view group', $permissions)) {
-        $group_types++;
-      }
+      $group_types += (int) $group_type->getAnonymousRole()->hasPermission('view group');
     }
 
     if ($group_types < 2) {

--- a/modules/social_features/social_group/src/SocialGroupHelperService.php
+++ b/modules/social_features/social_group/src/SocialGroupHelperService.php
@@ -22,8 +22,20 @@ class SocialGroupHelperService {
 
   /**
    * Returns a group id from a entity (post, node).
+   *
+   * @param array $entity
+   *   The entity in the form of an entity reference array to get the group for.
+   * @param bool $read_cache
+   *   Whether the per request cache should be used. This should only be
+   *   disabled if you know that the group for the entity has changed because
+   *   disabling this can have serious performance implications. Setting this to
+   *   FALSE will update the cache for subsequent calls.
+   *
+   * @return \Drupal\group\Entity\GroupInterface|null
+   *   The group that this entity belongs to or NULL if the entity doesn't
+   *   belong to any group.
    */
-  public function getGroupFromEntity($entity) {
+  public function getGroupFromEntity(array $entity, $read_cache = TRUE) {
     $gid = NULL;
 
     // Comments can have groups based on what the comment is posted on so the
@@ -31,7 +43,7 @@ class SocialGroupHelperService {
     $cache_type = $entity['target_type'];
     $cache_id = $entity['target_id'];
 
-    if (is_array($this->cache[$cache_type]) && isset($this->cache[$cache_type][$cache_id])) {
+    if ($read_cache && is_array($this->cache[$cache_type]) && isset($this->cache[$cache_type][$cache_id])) {
       return $this->cache[$cache_type][$cache_id];
     }
 

--- a/modules/social_features/social_group/src/SocialGroupHelperService.php
+++ b/modules/social_features/social_group/src/SocialGroupHelperService.php
@@ -23,7 +23,7 @@ class SocialGroupHelperService {
   /**
    * Returns a group id from a entity (post, node).
    */
-  public static function getGroupFromEntity($entity) {
+  public function getGroupFromEntity($entity) {
     $gid = NULL;
 
     // Special cases for comments.

--- a/modules/social_features/social_group/src/SocialGroupHelperService.php
+++ b/modules/social_features/social_group/src/SocialGroupHelperService.php
@@ -14,17 +14,26 @@ use Drupal\social_post\Entity\Post;
 class SocialGroupHelperService {
 
   /**
-   * Constructor.
+   * A cache of groups that have been matched to entities.
+   *
+   * @var array
    */
-  public function __construct() {
-
-  }
+  protected $cache;
 
   /**
    * Returns a group id from a entity (post, node).
    */
   public function getGroupFromEntity($entity) {
     $gid = NULL;
+
+    // Comments can have groups based on what the comment is posted on so the
+    // cache type differs from what we later use to fetch the group.
+    $cache_type = $entity['target_type'];
+    $cache_id = $entity['target_id'];
+
+    if (is_array($this->cache[$cache_type]) && isset($this->cache[$cache_type][$cache_id])) {
+      return $this->cache[$cache_type][$cache_id];
+    }
 
     // Special cases for comments.
     // Returns the entity to which the comment is attached.
@@ -57,6 +66,10 @@ class SocialGroupHelperService {
         }
       }
     }
+
+    // Cache the group id for this entity to optimise future calls.
+    $this->cache[$cache_type][$cache_id] = $gid;
+
     return $gid;
   }
 

--- a/themes/socialbase/socialbase.theme
+++ b/themes/socialbase/socialbase.theme
@@ -8,20 +8,12 @@
 use Drupal\comment\Entity\Comment;
 use Drupal\Component\Utility\Html as HtmlUtility;
 use Drupal\Core\Session\AnonymousUserSession;
-use Drupal\bootstrap\Bootstrap;
 use Drupal\node\Entity\Node;
 
 // Include all files from the includes directory.
 $includes_path = dirname(__FILE__) . '/includes/*.inc';
 foreach (glob($includes_path) as $filename) {
   require_once dirname(__FILE__) . '/includes/' . basename($filename);
-}
-
-/**
- * Implements hook_theme_suggestions_alter().
- */
-function socialbase_theme_suggestions_alter(&$data, &$context1 = NULL, &$context2 = NULL) {
-  Bootstrap::alter(__FUNCTION__, $data, $context1, $context2);
 }
 
 /**


### PR DESCRIPTION
## Problem
As part of customer support we've been doing some profiling of a well filled Open Social site and have discovered a few critical paths that lend themselves to optimisations. 

## Solution
Please see the issue for a full description of the changes that were made.

With all the changes we measured a performance improvement of 15-20%

## Issue tracker
- https://www.drupal.org/project/social/issues/3008497

## HTT
- [x] Check out the code changes
- [x] Ensure no tests are now failing

## Release notes
In an ongoing effort to make Open Social sites zoom across the internet we've retrained some of our functions and have measured a collective improvement of roughly 20%.

As part of this clean-up the `SocialGroupHelperService::getGroupFromEntity` method is no longer static as it's an anti-pattern to have static methods on services. If you previously called this method statically you should replace your code with `\Drupal::service('social_group.helper_service')->getGroupFromEntity()` or use dependency injection of the `social_group.helper_service` where applicable.
