### PR TITLE
Issue #3010525 by ribel: Fix double accept of data policy when using Social GDPR together with Social SSO

### DIFF
--- a/modules/custom/social_auth_extra/social_auth_extra.module
+++ b/modules/custom/social_auth_extra/social_auth_extra.module
@@ -245,6 +245,15 @@ function social_auth_extra_form_user_register_form_submit($form, FormStateInterf
       }
 
       \Drupal::service('plugin.manager.mail')->mail('social_auth_extra', 'email_social_login', $account->getEmail(), $langcode, $params, $site_mail);
+      // Save user consent.
+      if (\Drupal::hasService('data_policy.manager')) {
+        /** @var \Drupal\data_policy\DataPolicyManagerInterface $data_policy_manager */
+        $data_policy_manager = \Drupal::service('data_policy.manager');
+
+        if ($data_policy_manager->isDataPolicy() && !empty($form_state->getValue('data_policy'))) {
+          $data_policy_manager->saveConsent($account->id(), TRUE);
+        }
+      }
     }
     catch (EntityStorageException $e) {
       drupal_set_message($this->t('Creation of user account failed. Please contact site administrator.'), 'error');


### PR DESCRIPTION
## Problem
When Data Policy consent is checked on signup form after signup with one of the social networks, you need to agree with consent again.

## Solution
Save consent when it was checked on the signup form.

## Issue tracker
- https://www.drupal.org/project/social/issues/3010525
- https://jira.goalgorilla.com/browse/HGT-25

## HTT
- [ ] Check out the code changes
- [ ] Enable and setup Social GDPR and Social SSO modules
- [ ] Try to signup using social network
- [ ] Notice you need to accept data policy even it was checked on signup form
- [ ] Checkout to this branch
- [ ] Try to signup again and notice that you don't need to do additional data policy consent

## Release notes
<describe the release notes>
