### PR TITLE
Issue #3010526 by ribel: Prefill Nickname together with First and Last name during social signup

### DIFF
--- a/modules/social_features/social_sso/social_sso.module
+++ b/modules/social_features/social_sso/social_sso.module
@@ -14,8 +14,15 @@ use Drupal\social_auth_extra\UserManagerInterface;
  * Implements hook_social_auth_extra_profile_presave().
  */
 function social_sso_social_auth_extra_profile_presave(UserInterface $account, ProfileInterface $profile, AuthManagerInterface $auth_manager, UserManagerInterface $user_manager) {
-  $profile->get('field_profile_first_name')->setValue($auth_manager->getFirstName());
-  $profile->get('field_profile_last_name')->setValue($auth_manager->getLastName());
+  // If nickname is used prefill it, instead of First and Last name.
+  if (\Drupal::moduleHandler()->moduleExists('social_profile_fields') && _social_profile_fields_get_setting('profile_profile_field_profile_nick_name')) {
+    $nick_name = $auth_manager->getFirstName() . ' ' . $auth_manager->getLastName();
+    $profile->get('field_profile_nick_name')->setValue($nick_name);
+  }
+  else {
+    $profile->get('field_profile_first_name')->setValue($auth_manager->getFirstName());
+    $profile->get('field_profile_last_name')->setValue($auth_manager->getLastName());
+  }
 
   $entity_field_manager = \Drupal::service('entity_field.manager');
   $field_definitions = $entity_field_manager->getFieldDefinitions('profile', 'profile');

--- a/modules/social_features/social_sso/social_sso.module
+++ b/modules/social_features/social_sso/social_sso.module
@@ -14,12 +14,22 @@ use Drupal\social_auth_extra\UserManagerInterface;
  * Implements hook_social_auth_extra_profile_presave().
  */
 function social_sso_social_auth_extra_profile_presave(UserInterface $account, ProfileInterface $profile, AuthManagerInterface $auth_manager, UserManagerInterface $user_manager) {
-  // If nickname is used prefill it, instead of First and Last name.
-  if (\Drupal::moduleHandler()->moduleExists('social_profile_fields') && _social_profile_fields_get_setting('profile_profile_field_profile_nick_name')) {
-    $nick_name = $auth_manager->getFirstName() . ' ' . $auth_manager->getLastName();
-    $profile->get('field_profile_nick_name')->setValue($nick_name);
+  // By default we always use First and Last name fields.
+  $use_first_name = TRUE;
+  $use_last_name = TRUE;
+
+  if (\Drupal::moduleHandler()->moduleExists('social_profile_fields')) {
+    // If nickname is used populate it, instead of First and Last name.
+    if (_social_profile_fields_get_setting('profile_profile_field_profile_nick_name')) {
+      $nick_name = $auth_manager->getFirstName() . ' ' . $auth_manager->getLastName();
+      $profile->get('field_profile_nick_name')->setValue($nick_name);
+    }
+    // Check if First and Last names were not disabled.
+    $use_first_name = _social_profile_fields_get_setting('profile_profile_field_profile_first_name');
+    $use_last_name = _social_profile_fields_get_setting('profile_profile_field_profile_last_name');
   }
-  else {
+
+  if ($use_first_name && $use_last_name) {
     $profile->get('field_profile_first_name')->setValue($auth_manager->getFirstName());
     $profile->get('field_profile_last_name')->setValue($auth_manager->getLastName());
   }


### PR DESCRIPTION
## Problem
In most cases, if you use the Nickname (provided by Social Profile Fields module) you usually want to populate it as well after signup with social networks.

## Solution
If Nickname is used prefill it, together with First and Last name.

## Issue tracker
- https://www.drupal.org/project/social/issues/3010526
- https://jira.goalgorilla.com/browse/HGT-26

## HTT
- [ ] Check out the code changes
- [ ] Enable Social SSO and Social Profile Fields modules and 
- [ ] Enable Nickname field
- [ ] Try to signup using a social network (LinkedIn or Facebook)
- [ ] Notice First and Last Name was prefilled, and Nickname not
- [ ] Checkout to this branch
- [ ] Try to register again and notice that Nickname was prefilled together with First and Last name 

## Release notes
When the Nickname field is available and people sign up via Social Login, we now populate that field with the First and Last Name received from the social networks.
