### PR TITLE
by robertragas: make the suggestions amount in mentions configurable

### DIFF
--- a/modules/custom/mentions/config/schema/mentions.schema.yml
+++ b/modules/custom/mentions/config/schema/mentions.schema.yml
@@ -8,6 +8,9 @@ mentions.settings:
       sequence:
         type: string
         label: 'The entity type'
+    suggestions_amount:
+      type: number
+      label: 'Number of suggestions'
 
 mentions.mentions_type.*:
   type: config_entity

--- a/modules/custom/mentions/src/Form/MentionsSettingsForm.php
+++ b/modules/custom/mentions/src/Form/MentionsSettingsForm.php
@@ -77,6 +77,13 @@ class MentionsSettingsForm extends ConfigFormBase {
       '#description' => $this->t('Mentions entity will be created only for selected entity types.'),
     ];
 
+    $form['general']['suggestions_amount'] = [
+      '#title' => $this->t('Number of suggestions'),
+      '#type' => 'number',
+      '#default_value' => $config->get('suggestions_amount'),
+      '#description' => $this->t('How many suggestions do you want to show when mentioning.'),
+    ];
+
     return parent::buildForm($form, $form_state);
   }
 
@@ -88,6 +95,8 @@ class MentionsSettingsForm extends ConfigFormBase {
     $config = $this->config('mentions.settings');
 
     $config->set('supported_entity_types', $form_state->getValue('supported_entity_types'));
+
+    $config->set('suggestions_amount', $form_state->getValue('suggestions_amount'));
 
     $config->save();
 

--- a/modules/social_features/social_mentions/social_mentions.install
+++ b/modules/social_features/social_mentions/social_mentions.install
@@ -20,6 +20,17 @@ function social_mentions_install() {
 }
 
 /**
+ * Re-set permissions for viewing the like widget.
+ */
+function social_mentions_update_8001() {
+  $config = \Drupal::configFactory()->getEditable('mentions.settings');
+
+  $config->set('suggestions_amount', 8);
+
+  $config->save();
+}
+
+/**
  * Function to set permissions.
  */
 function _social_mentions_set_permissions() {
@@ -70,6 +81,8 @@ function _social_mentions_set_default_config() {
   $config->set('supported_entity_types', $allowed_entity_types);
 
   $config->set('suggestions_format', SOCIAL_PROFILE_SUGGESTIONS_ALL);
+
+  $config->set('suggestions_amount', 8);
 
   $config->save();
 }

--- a/modules/social_features/social_mentions/src/Controller/AutocompleteController.php
+++ b/modules/social_features/social_mentions/src/Controller/AutocompleteController.php
@@ -84,7 +84,8 @@ class AutocompleteController extends ControllerBase {
     $name = $request->get('term');
     $config = $this->configFactory->get('mentions.settings');
     $suggestion_format = $config->get('suggestions_format');
-    $result = $this->getUserIdsFromName($name, 8, $suggestion_format);
+    $suggestion_amount = $config->get('suggestions_amount');
+    $result = $this->getUserIdsFromName($name, $suggestion_amount, $suggestion_format);
     $response = [];
     $accounts = User::loadMultiple($result);
     $storage = $this->entityTypeManager->getStorage('profile');


### PR DESCRIPTION
Set default to 8.

## Problem
When creating mentions the full name is not respected and checking on either first or last name resulting in some people not being found. Since this is a complex problem a solution for now would be to be able to increase the suggestion amount.

## Solution
Create a new form field where people are able to alter the suggestion amount from 8 to another value.

## Issue tracker
- none

## HTT
- [ ] Check out the code changes
- [ ] Make sure you have enough users
- [ ] Go to admin/config/people/mentions and change the default setting from 8 to another number
- [ ] Mention someone and see the amount of results is increased


## Release notes
We made it possible to alter the number of suggestions you get when mentioning a person so the chance the person you are searching for is within this list. 

You can alter this setting under the people mentions setting at  admin/config/people/mentions
