### PR TITLE
Issue #3010784: Remove unnecessary Node checks from social_core_menu_local_tasks_alter

### DIFF
--- a/modules/social_features/social_core/social_core.module
+++ b/modules/social_features/social_core/social_core.module
@@ -7,7 +7,6 @@
 
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\node\Entity\Node;
-use Drupal\node\Entity\NodeType;
 use Drupal\node\NodeInterface;
 use Drupal\image\Entity\ImageStyle;
 use Drupal\Core\Url;
@@ -338,19 +337,11 @@ function social_core_menu_local_tasks_alter(&$data, $route_name) {
     }
   }
 
-  $node = \Drupal::service('current_route_match')->getParameter('node');
-
-  if (!is_null($node) && !is_object($node)) {
-    $node = Node::load($node);
+  // Remove node Edit tab. Edit will always go through Floating Edit Button.
+  if (isset($data['tabs'][0]['entity.node.edit_form'])) {
+    unset($data['tabs'][0]['entity.node.edit_form']);
   }
 
-  // Check for all active node types.
-  if ($node instanceof Node && array_key_exists($node->getType(), NodeType::loadMultiple())) {
-    // Remove Edit tab. Edit will always go through Floating Edit Button.
-    if (isset($data['tabs'][0]['entity.node.edit_form'])) {
-      unset($data['tabs'][0]['entity.node.edit_form']);
-    }
-  }
   // Change the default 'View' tab title.
   if (isset($data['tabs'][0]['entity.node.canonical']['#link'])) {
     $data['tabs'][0]['entity.node.canonical']['#link']['title'] = t('Details');

--- a/modules/social_features/social_core/social_core.module
+++ b/modules/social_features/social_core/social_core.module
@@ -6,7 +6,6 @@
  */
 
 use Drupal\Core\Form\FormStateInterface;
-use Drupal\node\Entity\Node;
 use Drupal\node\NodeInterface;
 use Drupal\image\Entity\ImageStyle;
 use Drupal\Core\Url;
@@ -72,7 +71,7 @@ function template_preprocess_page_hero_data(array &$variables) {
     }
 
     // Add node edit url for management.
-    if ($node instanceof Node) {
+    if ($node instanceof NodeInterface) {
       // Get the current route name to check if the user is on the
       // edit or delete page.
       $route = \Drupal::routeMatch()->getRouteName();


### PR DESCRIPTION
<h2>Problem</h2>

<code>social_core_menu_local_tasks_alter</code> removes the <code>entity.node.edit_form</code> tab to force editing through the floating edit button. Before doing this it checks whether we're currently viewing a node of any valid node type. This logic isn't needed because if we weren't viewing a node then we wouldn't have the <code>entity.node.edit_form</code> task present.

<h2>Solution</h2>
Just remove the edit form tab if it's set (less computations => more performance!)

## Issue tracker
- https://www.drupal.org/project/social/issues/3010784

## HTT
- [ ] Check out the code changes
