### PR TITLE
SHN-226: Quickjoin groups

### DIFF
--- a/modules/social_features/social_event/src/Form/EnrollActionForm.php
+++ b/modules/social_features/social_event/src/Form/EnrollActionForm.php
@@ -152,9 +152,10 @@ class EnrollActionForm extends FormBase implements ContainerInjectionInterface {
         foreach ($groups as $group) {
           $group_type_id = $group->bundle();
 
-          // The join group permission has never really been used since this commit.
-          // This now means that events in a closed group cannot be joined by outsiders,
-          // which makes sense, since they also couldn't see these events in the first place.
+          // The join group permission has never really been used since
+          // this commit. This now means that events in a closed group cannot
+          // be joined by outsiders, which makes sense, since they also
+          // couldn't see these events in the first place.
           if (in_array($group_type_id, $group_type_ids) && $group->hasPermission('join group', $current_user)) {
             break;
           }

--- a/modules/social_features/social_event/src/Form/EnrollActionForm.php
+++ b/modules/social_features/social_event/src/Form/EnrollActionForm.php
@@ -152,6 +152,9 @@ class EnrollActionForm extends FormBase implements ContainerInjectionInterface {
         foreach ($groups as $group) {
           $group_type_id = $group->bundle();
 
+          // The join group permission has never really been used since this commit.
+          // This now means that events in a closed group cannot be joined by outsiders,
+          // which makes sense, since they also couldn't see these events in the first place.
           if (in_array($group_type_id, $group_type_ids) && $group->hasPermission('join group', $current_user)) {
             break;
           }

--- a/modules/social_features/social_group/config/install/group.role.closed_group-outsider.yml
+++ b/modules/social_features/social_group/config/install/group.role.closed_group-outsider.yml
@@ -11,7 +11,6 @@ audience: outsider
 group_type: closed_group
 permissions_ui: true
 permissions:
-  - 'join group'
   - 'view group'
   - 'update own group_node:topic entity'
   - 'update own group_node:event entity'

--- a/modules/social_features/social_group/modules/social_group_quickjoin/social_group_quickjoin.features.yml
+++ b/modules/social_features/social_group/modules/social_group_quickjoin/social_group_quickjoin.features.yml
@@ -1,0 +1,2 @@
+bundle: social
+required: true

--- a/modules/social_features/social_group/modules/social_group_quickjoin/social_group_quickjoin.info.yml
+++ b/modules/social_features/social_group/modules/social_group_quickjoin/social_group_quickjoin.info.yml
@@ -1,0 +1,7 @@
+name: 'Social Group Quickjoin'
+description: 'Allows users to skip confirmation when joining a group.'
+type: module
+core: 8.x
+dependencies:
+- social_group:social_group
+package: Social

--- a/modules/social_features/social_group/modules/social_group_quickjoin/social_group_quickjoin.install
+++ b/modules/social_features/social_group/modules/social_group_quickjoin/social_group_quickjoin.install
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * @file
+ * Install, update and uninstall functions for the social_group_quickjoin module.
+ */
+
+use Drupal\Core\Entity\EntityStorageException;
+use Drupal\user\Entity\Role;
+
+/**
+ * Implements hook_install().
+ *
+ * Perform actions related to the installation of social_group_quickjoin.
+ */
+function social_event_type_install() {
+  // Fetch sitemananger role.
+  $role = Role::load('sitemanager');
+  // Set permission for site manager.
+  if ($role instanceof Role) {
+    // Set permission.
+    $role->grantPermission('set group quickjoin settings');
+    try {
+      $role->trustData()->save();
+    }
+    catch (EntityStorageException $e) {
+      \Drupal::logger('social_group_quickjoin')->critical($e->getMessage());
+    }
+
+  }
+}
+
+/**
+ * Implements hook_uninstall().
+ *
+ * Perform actions related to the de-installation of social_group_quickjoin.
+ */
+function social_event_type_uninstall() {
+  // Fetch sitemananger role.
+  $role = Role::load('sitemanager');
+  // Set permission for site manager.
+  if ($role instanceof Role) {
+    // Set permission.
+    $role->revokePermission('set group quickjoin settings');
+    try {
+      $role->trustData()->save();
+    }
+    catch (EntityStorageException $e) {
+      \Drupal::logger('social_group_quickjoin')->critical($e->getMessage());
+    }
+  }
+
+  // Also remove the fields and the vocabulary.
+  \Drupal::configFactory()->getEditable('field.field.node.event.field_event_type')->delete();
+}

--- a/modules/social_features/social_group/modules/social_group_quickjoin/social_group_quickjoin.install
+++ b/modules/social_features/social_group/modules/social_group_quickjoin/social_group_quickjoin.install
@@ -2,7 +2,7 @@
 
 /**
  * @file
- * Install, update and uninstall functions for the social_group_quickjoin module.
+ * Install, update and uninstall functions for social_group_quickjoin module.
  */
 
 use Drupal\Core\Entity\EntityStorageException;

--- a/modules/social_features/social_group/modules/social_group_quickjoin/social_group_quickjoin.install
+++ b/modules/social_features/social_group/modules/social_group_quickjoin/social_group_quickjoin.install
@@ -13,7 +13,7 @@ use Drupal\user\Entity\Role;
  *
  * Perform actions related to the installation of social_group_quickjoin.
  */
-function social_event_type_install() {
+function social_group_quickjoin_install() {
   // Fetch sitemananger role.
   $role = Role::load('sitemanager');
   // Set permission for site manager.
@@ -35,7 +35,7 @@ function social_event_type_install() {
  *
  * Perform actions related to the de-installation of social_group_quickjoin.
  */
-function social_event_type_uninstall() {
+function social_group_quickjoin_uninstall() {
   // Fetch sitemananger role.
   $role = Role::load('sitemanager');
   // Set permission for site manager.

--- a/modules/social_features/social_group/modules/social_group_quickjoin/social_group_quickjoin.links.menu.yml
+++ b/modules/social_features/social_group/modules/social_group_quickjoin/social_group_quickjoin.links.menu.yml
@@ -1,0 +1,6 @@
+social_group_quickjoin.settings:
+  title: 'Group Quickjoin settings'
+  description: 'Settings for group quckjoin.'
+  route_name: social_group_quickjoin.settings
+  parent: social_core.admin.config.social
+  weight: 60

--- a/modules/social_features/social_group/modules/social_group_quickjoin/social_group_quickjoin.permissions.yml
+++ b/modules/social_features/social_group/modules/social_group_quickjoin/social_group_quickjoin.permissions.yml
@@ -1,0 +1,4 @@
+set group quickjoin settings:
+  title: 'Social Group Quickjoin settings'
+  description: 'Allow to set for which group types quickjoin is enabled.'
+  restrict access: true

--- a/modules/social_features/social_group/modules/social_group_quickjoin/social_group_quickjoin.routing.yml
+++ b/modules/social_features/social_group/modules/social_group_quickjoin/social_group_quickjoin.routing.yml
@@ -1,0 +1,13 @@
+social_group_quickjoin.settings:
+  path: '/admin/config/opensocial/group-quickjoin'
+  defaults:
+    _form: 'Drupal\social_group_quickjoin\Form\SocialGroupQuickjoinSettings'
+    _title: 'Group Quickjoin settings'
+  requirements:
+    _permission: 'set group quickjoin settings'
+social_group_quickjoin.quickjoin_group:
+  path: '/group/{group}/quickjoin'
+  defaults:
+    _controller: '\Drupal\social_group_quickjoin\Controller\SocialQuickJoinController::quickJoin'
+  requirements:
+    _user_is_logged_in: 'TRUE'

--- a/modules/social_features/social_group/modules/social_group_quickjoin/social_group_quickjoin.services.yml
+++ b/modules/social_features/social_group/modules/social_group_quickjoin/social_group_quickjoin.services.yml
@@ -1,0 +1,6 @@
+services:
+  social_group_quickjoin.redirect_subscriber:
+    class: Drupal\social_group_quickjoin\EventSubscriber\RedirectSubscriber
+    arguments: ['@current_route_match', '@current_user', '@config.factory']
+    tags:
+      - { name: event_subscriber }

--- a/modules/social_features/social_group/modules/social_group_quickjoin/src/Controller/SocialQuickJoinController.php
+++ b/modules/social_features/social_group/modules/social_group_quickjoin/src/Controller/SocialQuickJoinController.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace Drupal\social_group_quickjoin\Controller;
+
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\Messenger\MessengerTrait;
+use Drupal\Core\Routing\CurrentRouteMatch;
+use Drupal\Core\Url;
+use Drupal\group\Entity\GroupInterface;
+use Drupal\user\Entity\User;
+use Drupal\user\UserInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+
+/**
+ * Class SocialQuickJoinController.
+ *
+ * @package Drupal\social_group_quickjoin\Controller
+ */
+class SocialQuickJoinController extends ControllerBase {
+
+  use MessengerTrait;
+
+  /**
+   * The request.
+   *
+   * @var \Drupal\Core\Routing\CurrentRouteMatch
+   */
+  protected $currentRoute;
+
+  /**
+   * The config factory.
+   *
+   * @var \Drupal\Core\Config\ConfigFactoryInterface
+   */
+  protected $configFactory;
+
+  /**
+   * SocialEventController constructor.
+   *
+   * @param \Drupal\Core\Routing\CurrentRouteMatch $currentRoute
+   *   The request stack.
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $configFactory
+   *   The config factory.
+   */
+  public function __construct(CurrentRouteMatch $currentRoute, ConfigFactoryInterface $configFactory) {
+    $this->currentRoute = $currentRoute;
+    $this->configFactory = $configFactory;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('current_route_match'),
+      $container->get('config.factory')
+    );
+  }
+
+  /**
+   * Function that add the current user to a group without confirmation step.
+   *
+   * @param \Drupal\group\Entity\GroupInterface $group
+   *   The group you want to join.
+   *
+   * @return \Symfony\Component\HttpFoundation\RedirectResponse
+   *   Where to redirect to.
+   *
+   * @throws \Drupal\Core\Entity\EntityMalformedException
+   */
+  public function quickJoin(GroupInterface $group) {
+
+    // No group, so go home.
+    if (!$group instanceof GroupInterface) {
+      return new RedirectResponse(Url::fromRoute('<front>')->toString());
+    }
+
+    // It's a group, so determine the path for redirection.
+    $groupRedirect = $group->toUrl()->toString();
+
+    // Check if the settings are active.
+    $active = $this->configFactory->get('social_group_quickjoin.settings')->get('social_group_quickjoin_enabled');
+
+    // Not active, so back to group canonical.
+    if (!$active) {
+      // Redirect to the group.
+      return new RedirectResponse($groupRedirect);
+    }
+
+    // Already a member.
+    if ($group->getMember($this->currentUser())) {
+      // Set a message.
+      $this->messenger()->addMessage($this->t("You're already a member of this group."));
+      // Redirect to the group.
+      return new RedirectResponse($groupRedirect);
+    }
+
+    // Fetch the user from the accountproxy.
+    $account = User::load($this->currentUser()->id());
+    if ($account instanceof UserInterface) {
+      // Extra exceptions based on groupmembership rules.
+      if ($group->hasPermission('join group', $account) === FALSE) {
+        $this->messenger()->addMessage($this->t("You don't have access to join this group."));
+        return new RedirectResponse($groupRedirect);
+      }
+
+      // Add this person to the group.
+      $group->addMember($account);
+      // Invalidate cache of the group, so we see newest member block updated.
+      $this->cache()->invalidate('group:' . $group->id());
+      // Set message and redirect.
+      $this->messenger()->addMessage($this->t("You've been added to this group."));
+      return new RedirectResponse($groupRedirect);
+    }
+
+    // Weird behaviour if here, so just go to group home.
+    return new RedirectResponse($groupRedirect);
+  }
+
+}

--- a/modules/social_features/social_group/modules/social_group_quickjoin/src/EventSubscriber/RedirectSubscriber.php
+++ b/modules/social_features/social_group/modules/social_group_quickjoin/src/EventSubscriber/RedirectSubscriber.php
@@ -107,7 +107,7 @@ class RedirectSubscriber implements EventSubscriberInterface {
       'group' => $group->id(),
     ])->toString();
 
-    // Redirect ot quickjoin.
+    // Redirect to quickjoin.
     $event->setResponse(new RedirectResponse($url));
   }
 

--- a/modules/social_features/social_group/modules/social_group_quickjoin/src/EventSubscriber/RedirectSubscriber.php
+++ b/modules/social_features/social_group/modules/social_group_quickjoin/src/EventSubscriber/RedirectSubscriber.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Drupal\social_group_quickjoin_quickjoin\EventSubscriber;
+
+use Drupal\Core\Routing\CurrentRouteMatch;
+use Drupal\Core\Session\AccountProxy;
+use Drupal\group\Entity\Group;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * Class RedirectSubscriber.
+ *
+ * @package Drupal\social_group_quickjoin\EventSubscriber
+ */
+class RedirectSubscriber implements EventSubscriberInterface {
+
+  /**
+   * The current route.
+   *
+   * @var \Drupal\Core\Routing\CurrentRouteMatch
+   */
+  protected $currentRoute;
+
+  /**
+   * The current user.
+   *
+   * @var \Drupal\Core\Session\AccountProxy
+   */
+  protected $currentUser;
+
+  /**
+   * Redirectsubscriber construct.
+   *
+   * @param \Drupal\Core\Routing\CurrentRouteMatch $route_match
+   *   The current route.
+   * @param \Drupal\Core\Session\AccountProxy $current_user
+   *   The current user.
+   */
+  public function __construct(CurrentRouteMatch $route_match, AccountProxy $current_user) {
+    $this->currentRoute = $route_match;
+    $this->currentUser = $current_user;
+  }
+
+  /**
+   * Get the request events.
+   *
+   * @return mixed
+   *   Returns request events.
+   */
+  public static function getSubscribedEvents() {
+    $events[KernelEvents::REQUEST][] = ['groupQuickJoin'];
+    return $events;
+  }
+
+  /**
+   * This method is called when the KernelEvents::REQUEST event is dispatched.
+   *
+   * @param \Symfony\Component\HttpKernel\Event\GetResponseEvent $event
+   *   The event.
+   */
+  public function groupQuickJoin(GetResponseEvent $event) {
+
+    // First check if the current route is the group canonical.
+    $routeMatch = $this->currentRoute->getRouteName();
+    // Not group canonical, then we leave.
+    if ($routeMatch != 'entity.group.canonical') {
+      return;
+    }
+
+    // Fetch the group parameter and check if's an actual group.
+    $group = $this->currentRoute->getParameter('group');
+    // Not group, then we leave.
+    if (!$group instanceof Group) {
+      return;
+    }
+
+    return;
+
+//    $event->setResponse(new RedirectResponse(Url::fromRoute($route, ['group' => $group->id()])->toString()));
+  }
+
+}

--- a/modules/social_features/social_group/modules/social_group_quickjoin/src/Form/SocialGroupQuickjoinSettings.php
+++ b/modules/social_features/social_group/modules/social_group_quickjoin/src/Form/SocialGroupQuickjoinSettings.php
@@ -37,7 +37,7 @@ class SocialGroupQuickjoinSettings extends ConfigFormBase {
 
     $form['help'] = [
       '#type' => 'item',
-      '#markup' => $this->t("Enabling this feature gives site builders the possibility to create group 'quickjoin' links. Furthermore it's possible to skip the confirmation step on a group type basis."),
+      '#markup' => $this->t("Enabling this feature gives site builders the possibility to create group quickjoin links (EG: /group/1/quickjoin). Furthermore it's possible to skip the confirmation step on a group type basis."),
     ];
 
     $form['social_group_quickjoin_enabled'] = [

--- a/modules/social_features/social_group/modules/social_group_quickjoin/src/Form/SocialGroupQuickjoinSettings.php
+++ b/modules/social_features/social_group/modules/social_group_quickjoin/src/Form/SocialGroupQuickjoinSettings.php
@@ -47,11 +47,11 @@ class SocialGroupQuickjoinSettings extends ConfigFormBase {
       '#default_value' => $config->get('social_group_quickjoin_enabled'),
     ];
 
-    $form['grouptypes'] = array(
+    $form['grouptypes'] = [
       '#type' => 'details',
       '#title' => $this->t('Group types'),
       '#open' => TRUE,
-    );
+    ];
 
     /** @var \Drupal\group\Entity\GroupType $group_type */
     foreach ($this->getGroups() as $group_type) {
@@ -67,11 +67,11 @@ class SocialGroupQuickjoinSettings extends ConfigFormBase {
           '@grouptype' => $group_type->label(),
         ]),
         '#default_value' => $config->get($setting_name),
-        '#states' => array(
-          'visible' => array(
-            ':input[name="social_group_quickjoin_enabled"]' => array('checked' => TRUE),
-          ),
-        ),
+        '#states' => [
+          'visible' => [
+            ':input[name="social_group_quickjoin_enabled"]' => ['checked' => TRUE],
+          ],
+        ],
       ];
 
     }
@@ -113,7 +113,8 @@ class SocialGroupQuickjoinSettings extends ConfigFormBase {
     $types = [];
     /** @var \Drupal\group\Entity\GroupType $group_type */
     foreach (GroupType::loadMultiple() as $group_type) {
-      // We can only select group types that have the 'join group' permission enabled.
+      // We can only select group types that have the 'join group'
+      // permission enabled.
       if (in_array('join group', $group_type->getOutsiderRole()->getPermissions())) {
         $types[] = $group_type;
       }

--- a/modules/social_features/social_group/modules/social_group_quickjoin/src/Form/SocialGroupQuickjoinSettings.php
+++ b/modules/social_features/social_group/modules/social_group_quickjoin/src/Form/SocialGroupQuickjoinSettings.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace Drupal\social_group_quickjoin\Form;
+
+use Drupal\Core\Form\ConfigFormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\group\Entity\GroupType;
+
+/**
+ * Class SocialEventTypeSettings.
+ *
+ * @package Drupal\social_group_quickjoin\Form
+ */
+class SocialGroupQuickjoinSettings extends ConfigFormBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getEditableConfigNames() {
+    return [
+      'social_group_quickjoin.settings',
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'social_group_quickjoin_form';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    $config = $this->config('social_group_quickjoin.settings');
+
+    $form['social_group_quickjoin_enabled'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Enable quickjoin'),
+      '#description' => $this->t('Set wether quickjoin is enabled.'),
+      '#default_value' => $config->get('social_group_quickjoin_enabled'),
+    ];
+
+    /** @var \Drupal\group\Entity\GroupType $group_type */
+    foreach ($this->getGroups() as $group_type) {
+      // The setting name.
+      $setting_name = 'social_group_quickjoin_' . $group_type->id();
+
+      $form[$setting_name] = [
+        '#type' => 'checkbox',
+        '#title' => $this->t('Quickjoin enabled for @grouptype', [
+          '@grouptype' => $group_type->label(),
+        ]),
+        '#description' => $this->t('Set wether quickjoin is enabled for this group type or not.'),
+        '#default_value' => $config->get($setting_name),
+        '#states' => array(
+          'visible' => array(
+            ':input[name="social_group_quickjoin_enabled"]' => array('checked' => TRUE),
+          ),
+        ),
+      ];
+
+    }
+
+    return parent::buildForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    parent::submitForm($form, $form_state);
+
+    // Set the value for the general setting.
+    $this->config('social_group_quickjoin.settings')
+      ->set('social_group_quickjoin_enabled', $form_state->getValue('social_group_quickjoin_enabled'));
+
+    /** @var \Drupal\group\Entity\GroupType $group_type */
+    foreach ($this->getGroups() as $group_type) {
+      // The setting name.
+      $setting_name = 'social_group_quickjoin_' . $group_type->id();
+      $setting_value = $form_state->getValue('social_group_quickjoin_enabled') ? $form_state->getValue($setting_name) : FALSE;
+      // Set the value in the config.
+      $this->config('social_group_quickjoin.settings')
+        ->set($setting_name, $setting_value);
+    }
+    // Save the config.
+    $this->config('social_group_quickjoin.settings')->save();
+  }
+
+  /**
+   * Function that returns all groups that outsider can become a member of.
+   *
+   * @return array
+   *   Joinable groups.
+   */
+  protected function getGroups() {
+    $types = [];
+    /** @var \Drupal\group\Entity\GroupType $group_type */
+    foreach (GroupType::loadMultiple() as $group_type) {
+      if (in_array('join group', $group_type->getOutsiderRole()->getPermissions())) {
+        $types[] = $group_type;
+      }
+    }
+    return $types;
+
+  }
+
+}

--- a/modules/social_features/social_group/modules/social_group_quickjoin/src/Form/SocialGroupQuickjoinSettings.php
+++ b/modules/social_features/social_group/modules/social_group_quickjoin/src/Form/SocialGroupQuickjoinSettings.php
@@ -35,24 +35,37 @@ class SocialGroupQuickjoinSettings extends ConfigFormBase {
   public function buildForm(array $form, FormStateInterface $form_state) {
     $config = $this->config('social_group_quickjoin.settings');
 
+    $form['help'] = [
+      '#type' => 'item',
+      '#markup' => $this->t("Enabling this feature gives site builders the possibility to create group 'quickjoin' links. Furthermore it's possible to skip the confirmation step on a group type basis."),
+    ];
+
     $form['social_group_quickjoin_enabled'] = [
       '#type' => 'checkbox',
-      '#title' => $this->t('Enable quickjoin'),
-      '#description' => $this->t('Set wether quickjoin is enabled.'),
+      '#title' => $this->t("Enable quickjoin"),
+      '#description' => $this->t("Allow users to join groups with a singe click."),
       '#default_value' => $config->get('social_group_quickjoin_enabled'),
     ];
+
+    $form['grouptypes'] = array(
+      '#type' => 'details',
+      '#title' => $this->t('Group types'),
+      '#open' => TRUE,
+    );
 
     /** @var \Drupal\group\Entity\GroupType $group_type */
     foreach ($this->getGroups() as $group_type) {
       // The setting name.
       $setting_name = 'social_group_quickjoin_' . $group_type->id();
 
-      $form[$setting_name] = [
+      $form['grouptypes'][$setting_name] = [
         '#type' => 'checkbox',
-        '#title' => $this->t('Quickjoin enabled for @grouptype', [
+        '#title' => $this->t('Skip confirmation for type @grouptype', [
           '@grouptype' => $group_type->label(),
         ]),
-        '#description' => $this->t('Set wether quickjoin is enabled for this group type or not.'),
+        '#description' => $this->t('Allow users to skip the confirmation step when joining a group of type @grouptype', [
+          '@grouptype' => $group_type->label(),
+        ]),
         '#default_value' => $config->get($setting_name),
         '#states' => array(
           'visible' => array(

--- a/modules/social_features/social_group/modules/social_group_quickjoin/src/Form/SocialGroupQuickjoinSettings.php
+++ b/modules/social_features/social_group/modules/social_group_quickjoin/src/Form/SocialGroupQuickjoinSettings.php
@@ -43,7 +43,7 @@ class SocialGroupQuickjoinSettings extends ConfigFormBase {
     $form['social_group_quickjoin_enabled'] = [
       '#type' => 'checkbox',
       '#title' => $this->t("Enable quickjoin"),
-      '#description' => $this->t("Allow users to join groups with a singe click."),
+      '#description' => $this->t("Allow users to join groups with a single click."),
       '#default_value' => $config->get('social_group_quickjoin_enabled'),
     ];
 

--- a/modules/social_features/social_group/modules/social_group_quickjoin/src/Form/SocialGroupQuickjoinSettings.php
+++ b/modules/social_features/social_group/modules/social_group_quickjoin/src/Form/SocialGroupQuickjoinSettings.php
@@ -74,7 +74,8 @@ class SocialGroupQuickjoinSettings extends ConfigFormBase {
 
     // Set the value for the general setting.
     $this->config('social_group_quickjoin.settings')
-      ->set('social_group_quickjoin_enabled', $form_state->getValue('social_group_quickjoin_enabled'));
+      ->set('social_group_quickjoin_enabled', $form_state->getValue('social_group_quickjoin_enabled'))
+      ->save();
 
     /** @var \Drupal\group\Entity\GroupType $group_type */
     foreach ($this->getGroups() as $group_type) {
@@ -99,12 +100,12 @@ class SocialGroupQuickjoinSettings extends ConfigFormBase {
     $types = [];
     /** @var \Drupal\group\Entity\GroupType $group_type */
     foreach (GroupType::loadMultiple() as $group_type) {
+      // We can only select group types that have the 'join group' permission enabled.
       if (in_array('join group', $group_type->getOutsiderRole()->getPermissions())) {
         $types[] = $group_type;
       }
     }
     return $types;
-
   }
 
 }

--- a/modules/social_features/social_group/modules/social_group_quickjoin/src/Form/SocialGroupQuickjoinSettings.php
+++ b/modules/social_features/social_group/modules/social_group_quickjoin/src/Form/SocialGroupQuickjoinSettings.php
@@ -37,7 +37,7 @@ class SocialGroupQuickjoinSettings extends ConfigFormBase {
 
     $form['help'] = [
       '#type' => 'item',
-      '#markup' => $this->t("Enabling this feature gives site builders the possibility to create group quickjoin links (EG: /group/1/quickjoin). Furthermore it's possible to skip the confirmation step on a group type basis."),
+      '#markup' => $this->t("Enabling this feature gives site builders the possibility to create group 'quick join' links (ex., /group/1/quickjoin). Furthermore, it's possible to skip the confirmation step on a group type basis."),
     ];
 
     $form['social_group_quickjoin_enabled'] = [
@@ -68,7 +68,7 @@ class SocialGroupQuickjoinSettings extends ConfigFormBase {
         '#title' => $this->t('Skip confirmation for type @grouptype', [
           '@grouptype' => $group_type->label(),
         ]),
-        '#description' => $this->t('Allow users to skip the confirmation step when joining a group of type @grouptype', [
+        '#description' => $this->t('Allow users to skip the confirmation step when joining any @grouptype.', [
           '@grouptype' => $group_type->label(),
         ]),
         '#default_value' => $config->get($setting_name),

--- a/modules/social_features/social_group/modules/social_group_quickjoin/src/Form/SocialGroupQuickjoinSettings.php
+++ b/modules/social_features/social_group/modules/social_group_quickjoin/src/Form/SocialGroupQuickjoinSettings.php
@@ -51,6 +51,11 @@ class SocialGroupQuickjoinSettings extends ConfigFormBase {
       '#type' => 'details',
       '#title' => $this->t('Group types'),
       '#open' => TRUE,
+      '#states' => [
+        'visible' => [
+          ':input[name="social_group_quickjoin_enabled"]' => ['checked' => TRUE],
+        ],
+      ],
     ];
 
     /** @var \Drupal\group\Entity\GroupType $group_type */
@@ -67,11 +72,6 @@ class SocialGroupQuickjoinSettings extends ConfigFormBase {
           '@grouptype' => $group_type->label(),
         ]),
         '#default_value' => $config->get($setting_name),
-        '#states' => [
-          'visible' => [
-            ':input[name="social_group_quickjoin_enabled"]' => ['checked' => TRUE],
-          ],
-        ],
       ];
 
     }

--- a/modules/social_features/social_group/social_group.module
+++ b/modules/social_features/social_group/social_group.module
@@ -192,12 +192,13 @@ function social_group_preprocess_group(array &$variables) {
   elseif ($group->hasPermission('join group', $account)) {
     // @todo switch this to get URL from routes correctly.
     $variables['group_operations_url'] = Url::fromUserInput('/group/' . $group->id() . '/join');
-    // If the group type is a closed_group.
-    if ($group_type_id == 'closed_group' && !$group->hasPermission('manage all groups', $account)) {
-      // Users can only be invited.
-      $variables['closed_group'] = TRUE;
-      $variables['cta'] = t('Invitation only');
-    }
+  }
+  // If the group type is a closed_group.
+  elseif ($group_type_id == 'closed_group' && !$group->hasPermission('manage all groups', $account)) {
+    // Users can only be invited.
+    $variables['group_operations_url'] = Url::fromUserInput('/group/' . $group->id() . '/join');
+    $variables['closed_group'] = TRUE;
+    $variables['cta'] = t('Invitation only');
   }
 
   // Add the hero styled image.


### PR DESCRIPTION
## Problem
When joining a group there's an unnecessary threshold of a 2 step verification. This is not always needed. Also CTA links to joining a group create a threshold with the confirmation step

## Solution
On a group type basis it's now possible to override the 'Join' link to join a group instantly. Also sitebuilder can now make CTA links (EG: in landing pages) like: `/group/1/quickjoin` in order to allow users to join a group with a single click.

## Extra description
In order to make this feature work I made a change to the permissions of an outsider of closed groups. The issue was that the `join group` permission was enabled on those groups and that the code made sure we weren't able to join closed groups anyway. This has changed a but. In practice this doesn't make any difference, apart from the fact that the permissions are now in fact correct and usable.  There should not be any differences in the way closed group act.

## Issue tracker
- https://jira.goalgorilla.com/browse/SHN-226

## HTT
- [ ] Check out the code changes
- [ ] Revert features
- [ ] Enabled the module
- [ ] Login as a SM and go to the settings page `configuration` > `open social settings` > `group quickjoin settings`
- [ ] Enable the feature
- [ ] Notice the (joinable) groups appear
- [ ] Save without selecting any groups
- [ ] As a LU try to join a group and notice there's still a 2 step wizard
- [ ] Try the manual link `/group/3/quickjoin` on the group you just joined
- [ ] You get a message you're already a member
- [ ] Try it for a group you're not yet a member of and notice you are immediately a member and you get feedback about this
- [ ] Try it on a closed group and notice that it doesn't work
- [ ] As SM Enable it for open and public group
- [ ] As LU join a public/open group from the join button
- [ ] Notice you're immediately added to the group

## Release notes
By enabling the social_group_quickjoin module, a site manager get the possibility to create CTA link for landing pages to allow users to join (non-closed) groups with a single click. Also a site manager has the possibility to override the 'Join' button on those groups and make sure people can join with a single click.

## Release notes extra
During the development of this feature I notice that the permission 'join group' for closed group was turned on for outsiders. This is incorrect, since outsiders cannot join closed groups. This was taken care of in code, so no real issue. The permission has now been set correct. This is mainly a developers change. It means that as a developer you can actually use that permission now to check group join permissions. 