### PR TITLE
Added translation for gtitle

### DIFF
--- a/modules/custom/activity_logger/activity_logger.tokens.inc
+++ b/modules/custom/activity_logger/activity_logger.tokens.inc
@@ -112,7 +112,8 @@ function activity_logger_tokens($type, $tokens, array $data, array $options, Bub
               // If it's a group.. add it in the arguments.
               if (isset($group) && $group instanceof Group) {
                 if ($name === 'gtitle') {
-                  $replacements[$original] = $group->label();
+                  $curr_langcode = \Drupal::languageManager()->getCurrentLanguage(\Drupal\Core\Language\LanguageInterface::TYPE_CONTENT)->getId();
+                  $replacements[$original] = $group->getTranslation($curr_langcode)->label();
                 }
                 if ($name === 'gurl') {
                   $gurl = Url::fromRoute('entity.group.canonical',

--- a/modules/custom/activity_logger/activity_logger.tokens.inc
+++ b/modules/custom/activity_logger/activity_logger.tokens.inc
@@ -9,6 +9,7 @@ use Drupal\Core\Render\BubbleableMetadata;
 use Drupal\Core\Url;
 use Drupal\group\Entity\Group;
 use Drupal\group\Entity\GroupContent;
+use Drupal\Core\Language\LanguageInterface;
 
 /**
  * Implements hook_token_info().
@@ -112,7 +113,7 @@ function activity_logger_tokens($type, $tokens, array $data, array $options, Bub
               // If it's a group.. add it in the arguments.
               if (isset($group) && $group instanceof Group) {
                 if ($name === 'gtitle') {
-                  $curr_langcode = \Drupal::languageManager()->getCurrentLanguage(\Drupal\Core\Language\LanguageInterface::TYPE_CONTENT)->getId();
+                  $curr_langcode = \Drupal::languageManager()->getCurrentLanguage(LanguageInterface::TYPE_CONTENT)->getId();
                   $replacements[$original] = $group->getTranslation($curr_langcode)->label();
                 }
                 if ($name === 'gurl') {


### PR DESCRIPTION
## Problem
Using more than one language and have translated all content, the gtitle token in the Activity Logger always shows the group->label in default language, even if a translation exists.
Solution

## Solution
load correct translation for the group label

## Issue tracker
- https://www.drupal.org/project/social/issues/3011070

## HTT
- [x] Check out the code changes
- [x] Login as administrator and setup a site with more than one language.
Create some groups and translate the group to other language(s)
Create a topic, or post in the group and translate it.
Swich the language and the acitivity stream will show the group title in default language (see screenshot at https://www.drupal.org/project/social/issues/3011070)

- [x] Notice it doesn't work
- [x] Checkout to this branch
- [x] Group title will be displayed in correct language in activity stream

## Release notes
<describe the release notes>
