### PR TITLE
Added translation for topic_type display

### DIFF
--- a/modules/social_features/social_topic/social_topic.module
+++ b/modules/social_features/social_topic/social_topic.module
@@ -5,12 +5,18 @@
  * The Social topic module.
  */
 
+use Drupal\block\Entity\Block;
+use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Access\AccessResultNeutral;
 use Drupal\Core\Block\BlockPluginInterface;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\Url;
 use Drupal\Core\Link;
+use Drupal\social_topic\Controller\SocialTopicController;
 use Drupal\views\Plugin\views\query\QueryPluginBase;
 use Drupal\views\ViewExecutable;
+use Drupal\Core\Language\LanguageInterface;
 
 /**
  * Prepares variables for node templates.
@@ -34,11 +40,12 @@ function social_topic_preprocess_node(array &$variables) {
     $topic_type = $node->get('field_topic_type');
     $topic_type_entities = $topic_type->referencedEntities();
     if (count($topic_type_entities) === 1) {
+      $curr_langcode = \Drupal::languageManager()->getCurrentLanguage(LanguageInterface::TYPE_CONTENT)->getId();
       foreach ($topic_type_entities as $topic) {
         $variables['metadata'] = t('in @topic', ['@topic' => $topic->link()]);
         // Set topic type link.
         $topic_type_url = Url::fromRoute('view.latest_topics.page_latest_topics', ['field_topic_type_target_id' => $topic->id()]);
-        $topic_type_link = Link::fromTextAndUrl($topic->label(), $topic_type_url)
+        $topic_type_link = Link::fromTextAndUrl($topic->getTranslation($curr_langcode)->label(), $topic_type_url)
           ->toString();
         $variables['topic_type'] = $topic_type_link;
       }
@@ -162,4 +169,29 @@ function social_topic_views_query_alter(ViewExecutable $view, QueryPluginBase $q
       ];
     }
   }
+}
+
+/**
+ * Custom permission check, to see if people have access to users' topics.
+ *
+ * Implements hook_block_access().
+ */
+function social_topic_block_access(Block $block, $operation, AccountInterface $account) {
+
+  if ($operation === 'view' && ($block->getPluginId() === 'views_exposed_filter_block:topics-page_profile' || $block->getPluginId() === 'views_block:topics-block_user_topics')) {
+    // Here we're going to assume by default access is not granted.
+    $topicController = SocialTopicController::create(\Drupal::getContainer());
+    $access = $topicController->myTopicAccess($account);
+    // If the 'myTopicAccess' returns 'AccessResultNeutral', we have to assume
+    // that access must be denied.
+    if ($access instanceof AccessResultNeutral) {
+      // Return forbidden, since access was not explicitly granted.
+      return AccessResult::forbidden();
+    }
+
+    return $access;
+  }
+
+  // No opinion.
+  return AccessResult::neutral();
 }


### PR DESCRIPTION
## Problem
Using more than one language, the topic_type is always displayed in default language, even, when translation to the current language exists.

## Solution
load correct translation for the topic_type to display

## Issue tracker
- https://www.drupal.org/project/social/issues/3011297

## HTT
- [x] Check out the code changes
- [x] Login as administrator and setup a site with more than one language.
Translate topic_type taxononmy to all languages
Create some topics in all languages

- [x] Look at e.g at /all-topics page in different languages and you will see that the topic-type is always displayed in default language
- [x] Checkout to this branch
- [x] Look at e.g at /all-topics page in different languages and you will see that the topic-type is now displayed in the current language

## Release notes
<describe the release notes>
