### PR TITLE
Issue #3012005 by Kingdutch: Creating an all day event on GMT - X tim…

### DIFF
--- a/tests/behat/features/capabilities/event/all-day-timezone.feature
+++ b/tests/behat/features/capabilities/event/all-day-timezone.feature
@@ -1,0 +1,33 @@
+@api @event @stability @javascript @stability-1 @event-all-day-timezone
+Feature: All day event for different timezones
+  Benefit: Correct handling of non GMT timezones
+  Role: As a LU
+  Goal/desire: I want to create all day events
+
+  @LU @perfect @critical
+  Scenario: Successfully create an all day event in GMT - 8
+    Given I set the configuration item "system.date" with key "date_default_timezone" to "America/Los_Angeles"
+    And I am logged in as an "authenticated user"
+    And I am on "/node/add/event"
+    When I fill in the custom fields for this "event"
+    And I fill in the following:
+      | Title | This is a timezone test for all day events |
+      | edit-field-event-date-0-value-date | 2025-01-01 |
+      | edit-field-event-date-end-0-value-date | 2025-01-01 |
+      | Time | 11:00:00 |
+      | Location name | Technopark |
+    And I fill in the "edit-body-0-value" WYSIWYG editor with "Body description text."
+    And I select "UA" from "Country"
+    And I wait for AJAX to finish
+    Then I should see "City"
+    And I fill in the following:
+      | City | Lviv |
+      | Street address | Fedkovycha 60a |
+      | Postal code | 79000 |
+      | Oblast | Lviv oblast |
+    And I show hidden checkboxes
+    And I check the box "edit-event-all-day"
+    And I press "Save"
+    Then I should see "This is a test event has been created."
+    And I should see "1 Jan '25"
+    And I should not see "31 Dec '24"


### PR DESCRIPTION
…ezones causes the wrong date

Adds a test to display the broken behaviour.

## Problem
The all day event sets the time to 0:01 and also does some trickery with timezones. When you save an event on a website with a timezone below GMT (e.g. America/Los_Angeles for GMT - 8) then this trickery causes the 0:01 to change to the previous day which causes an event created for 10 November 2018 to be displayed as taking place on 9 November 2018.

## Solution
Drupal's time functions should take care of all the timezone things for us relative to the site and user's timezone configuration and there should be no need to touch this manually. Furthermore it might be a good idea to convert the "All day" field to a Flag module field that denotes the event as being an all day event. This would allow us to fill in any time for the hour/minutes and just ignore it on when printing. Any if statement that now checks for 0:01 would then check for the flag instead.

## Issue tracker
- https://www.drupal.org/project/social/issues/3012005

## HTT
- [ ] See the failing test as a sign of success
