### PR TITLE
Update patch after core update - lets see what it does

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
             "drupal/core": {
                 "Color module html preview optional": "https://www.drupal.org/files/issues/color-optional-html-preview-2844190-2.patch",
                 "Restrict images to this site blocks image style derivatives": "https://www.drupal.org/files/issues/2018-06-14/2528214-36.patch",
-                "Fix SQL error when importing translations": "https://www.drupal.org/files/issues/2599228-31.patch",
+                "Fix SQL error when importing translations": "https://www.drupal.org/files/issues/2018-10-01/2599228-SQL_error_on_content_creation-78_0.patch",
                 "Optimize getCommentedEntity()": "https://www.drupal.org/files/issues/get-commented-entity-2580551.52.patch"
             },
             "drupal/flag": {


### PR DESCRIPTION
## Problem
Since we allow core to be updated with a composer update and not locking the version, one of the patches that we apply don't work. Yesterday a new core version was released which broke the patch compatibility and it's unfortunately not in core yet. 

## Solution
Updated the patch to the latests version in the comments. See what it does :). 

## Issue tracker
- 

## HTT
- [ ] Patch is related to SQL Errors on importing translations. See if that still works.

## Release notes
Since we allow core to be updated with a composer update and not locking the version, one of the patches that we apply don't work. A new core version was released which broke the patch when using composer update and it's unfortunately not in core yet. 