### PR TITLE
Issue #3013128 by Kingdutch: Wrong button class causes incorrect sizing for landing pages

### DIFF
--- a/modules/social_features/social_landing_page/social_landing_page.module
+++ b/modules/social_features/social_landing_page/social_landing_page.module
@@ -217,7 +217,7 @@ function social_landing_page_preprocess_field(&$variables) {
     foreach ($variables['items'] as $key => $value) {
       if (isset($variables['items'][$key]['content'])) {
         $variables['items'][$key]['content']['#options']['attributes'] = [
-          'class' => 'btn btn-large ' . $button_style,
+          'class' => 'btn btn-lg ' . $button_style,
         ];
       }
     }


### PR DESCRIPTION
<h3>Problem</h3>

Issue [#3002541] moved the classes from a template's wrapping div onto the link using a preprocess hook. While doing this the button class was changed from <code>btn-lg</code> to <code>btn-large</code>. The former is the correct class for a large button (the large one worked in Bootstrap 2.x but does not work in Bootstrap 3.x and is not used in Open Social).

<h3>Solution</h3>
Change the class back to <code>btn-lg</code> what it should be.

This is a potential breaking change if users have come to rely on the <code>btn-large</code> class for styling this specific element but the button is currently incorrectly styled because it does not have the <code>btn-lg</code> class.

## Issue tracker
- https://www.drupal.org/project/social/issues/3013128

## HTT
- [x] Check out the code changes
- [x] Create a landing page before the code changes
- [x] Compare this to a landing page after the code changes
- [x] See that after the changes the button has the correct size (the same as other buttons in hero's)

## Release notes
Due to an incorrect classname the size for buttons in landing page hero's was wrong. The correct classname is now applied. If you were using a custom theme that targetted the `btn-large` class  you should adjust this to target the correct `btn-lg` class that is used by Bootstrap 3 instead.