### PR TITLE
#2995247 by robertragas, bramtenhove: change GDPR site manager permission so they can edit the data block inform texts

### DIFF
--- a/modules/custom/social_gdpr/social_gdpr.install
+++ b/modules/custom/social_gdpr/social_gdpr.install
@@ -61,6 +61,10 @@ function _social_gdpr_get_permissions($role) {
     'access data policy revisions',
     'revert all data policy revisions',
     'overview user consents',
+    'edit inform and consent setting',
+    'overview inform and consent settings',
+    'administer inform and consent settings',
+    'change inform and consent setting status',
   ]);
 
   // An authenticated user should give consent when it necessary.


### PR DESCRIPTION
Opened in favor of #1014.

## Problem
When enabling the GDPR you can also set data usage blocks to inform the user about GDPR. Sitemanagers cannot edit these texts.

## Solution
Give sitemanagers more permissions for GDPR.

## Issue tracker
https://www.drupal.org/project/social/issues/2995247

## HTT
- [ ] Check out the code changes
- [ ] Login as a sitemanager and try to create a data usage block on admin/config/system/inform-consent
- [ ] Notice the access is denied
- [ ] Checkout to this branch
- [ ] Try again and see it works

## Release notes
The GDPR permissions have been updated to allow sitemanager to add descriptive text  about the data usage in a block.
