### PR TITLE
Issue #2988332 by robertragas, jaapjan: bump up restrict images patch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "patches": {
             "drupal/core": {
                 "Color module html preview optional": "https://www.drupal.org/files/issues/color-optional-html-preview-2844190-2.patch",
-                "Restrict images to this site blocks image style derivatives": "https://www.drupal.org/files/issues/2018-06-14/2528214-36.patch",
+                "Restrict images to this site blocks image style derivatives": "https://www.drupal.org/files/issues/2018-10-26/2528214-47.patch",
                 "Fix SQL error when importing translations": "https://www.drupal.org/files/issues/2018-10-01/2599228-SQL_error_on_content_creation-78_0.patch",
                 "Optimize getCommentedEntity()": "https://www.drupal.org/files/issues/get-commented-entity-2580551.52.patch"
             },

--- a/drupal-org-core.make
+++ b/drupal-org-core.make
@@ -3,6 +3,6 @@ core = 8.x
 projects[drupal][type] = core
 projects[drupal][version] = 8.6.2
 projects[drupal][patch][] = "https://www.drupal.org/files/issues/color-optional-html-preview-2844190-2.patch"
-projects[drupal][patch][] = "https://www.drupal.org/files/issues/2018-06-14/2528214-36.patch"
+projects[drupal][patch][] = "https://www.drupal.org/files/issues/2018-10-26/2528214-47.patch"
 projects[drupal][patch][] = "https://www.drupal.org/files/issues/2599228-31.patch"
 projects[drupal][patch][] = "https://www.drupal.org/files/issues/get-commented-entity-2580551.52.patch"


### PR DESCRIPTION
Original PR: #976 

Support special characters in image names.

## Problem
When restrict images text format filter is on and there are images with special characters in them, it fails the search indexing which also will crash the cronjob.

## Solution
Bump up the patch number to 47 which includes support for special characters

## Issue tracker
https://www.drupal.org/project/social/issues/2988332#comment-12706997

## HTT
- [x] Check out the code changes
- [x] Login, and add some images with special characters in it.
- [x] clear the search index from "all" and reindex
- [ ] Notice that the indexing will crash with the message about insecure images
- [ ] Checkout to this branch
- [ ] Retry and it works.

## Documentation
- [ ] This item is documented on LGOS
- [ ] This item has been added to the feature overview

## Release notes
Updated the restrict images patch that will prevent crashes during reindexing of search results when images had special characters in them. 