### PR TITLE
Issue #2980980: Set correct classes for alert messages

### DIFF
--- a/themes/socialbase/templates/system/status-messages.html.twig
+++ b/themes/socialbase/templates/system/status-messages.html.twig
@@ -64,5 +64,7 @@
   {% else %}
     {{ messages|first }}
   {% endif %}
+  {# Remove type specific classes. #}
+  {% set attributes = attributes.removeClass(classes) %}
 </div>
 {% endfor %}


### PR DESCRIPTION
## Problem
Alert classes leak between messages

## Solution
Set variable classes empty for each cycle

## Issue tracker
- https://jira.goalgorilla.com/browse/DS-5916
- https://www.drupal.org/project/social/issues/2980980

## HTT
- [x] Check out the code changes
- [x] Checkout to this branch
- [x] Check multiple alerts message

Test by applying for example:
```
diff --git a/modules/social_features/social_core/src/Controller/SocialCoreController.php b/modules/social_features/social_core/src/Controller/SocialCoreController.php
index c8592a013..4027d54d8 100644
--- a/modules/social_features/social_core/src/Controller/SocialCoreController.php
+++ b/modules/social_features/social_core/src/Controller/SocialCoreController.php
@@ -27,6 +27,9 @@ class SocialCoreController extends ControllerBase {
    * Empty page for the homepage.
    */
   public function stream() {
+    drupal_set_message(t('An error occurred and processing did not complete.'), 'error');
+    drupal_set_message(t('A warning occurred and processing did not complete.'), 'warning');
+    drupal_set_message(t('A status occurred and processing did not complete.'), 'status');
     $element = [
       '#markup' => '',
     ];
```

## Documentation
- [x] This item is documented on LGOS
- [x] This item has been added to the feature overview

## Release notes
When multiple messages were displayed on one page it would sometimes display the wrong message color. From now on this should always be correct.

<img width="815" alt="status-messages-after" src="https://user-images.githubusercontent.com/2848293/48780396-19856b80-ecda-11e8-80a7-70f601c5e4db.png">
