### PR TITLE
DS-6236, #3005538, 2965717: Mention improvements

### DIFF
--- a/modules/social_features/social_profile/src/SocialProfileTrait.php
+++ b/modules/social_features/social_profile/src/SocialProfileTrait.php
@@ -46,6 +46,19 @@ trait SocialProfileTrait {
 
       case SOCIAL_PROFILE_SUGGESTIONS_FULL_NAME:
       case SOCIAL_PROFILE_SUGGESTIONS_ALL:
+        $strings = explode(' ', $name);
+        if (count($strings) > 1) {
+          $query->where("CONCAT(fn.field_profile_first_name_value, ' ', ln.field_profile_last_name_value) LIKE :full_name", array(':full_name' => '%' . $name . '%'));
+          $query = $this->sortQuery($query, $name, $suggestion_format);
+          $results = $this->endQuery($query, $count);
+
+          if (count($results) > 0) {
+            return $results;
+          }
+          // Fallback to creating a new query if there is no hit on full name.
+          $query = $this->startQuery();
+        }
+
         $or_query = $query->orConditionGroup();
         $or_query
           ->condition('fn.field_profile_first_name_value', '%' . $name . '%', 'LIKE')

--- a/modules/social_features/social_profile/src/SocialProfileTrait.php
+++ b/modules/social_features/social_profile/src/SocialProfileTrait.php
@@ -48,7 +48,7 @@ trait SocialProfileTrait {
       case SOCIAL_PROFILE_SUGGESTIONS_ALL:
         $strings = explode(' ', $name);
         if (count($strings) > 1) {
-          $query->where("CONCAT(fn.field_profile_first_name_value, ' ', ln.field_profile_last_name_value) LIKE :full_name", array(':full_name' => '%' . $name . '%'));
+          $query->where("CONCAT(fn.field_profile_first_name_value, ' ', ln.field_profile_last_name_value) LIKE :full_name", [':full_name' => '%' . $name . '%']);
           $query = $this->sortQuery($query, $name, $suggestion_format);
           $results = $this->endQuery($query, $count);
 

--- a/modules/social_features/social_profile/src/SocialProfileTrait.php
+++ b/modules/social_features/social_profile/src/SocialProfileTrait.php
@@ -2,12 +2,24 @@
 
 namespace Drupal\social_profile;
 
+use Drupal\Core\Database\Query\SelectInterface;
+
 /**
  * Trait SocialProfileTrait.
  *
  * @package Drupal\social_profile
  */
 trait SocialProfileTrait {
+
+  /**
+   * Add Nickname.
+   *
+   * @return bool
+   *   Whether or not the nickname needs to be added.
+   */
+  private function addNickname() {
+    return \Drupal::moduleHandler()->moduleExists('social_profile_fields');
+  }
 
   /**
    * Get a list of account IDs whose account names begin with the given string.
@@ -24,16 +36,8 @@ trait SocialProfileTrait {
    *   given string.
    */
   public function getUserIdsFromName($name, $count, $suggestion_format = SOCIAL_PROFILE_SUGGESTIONS_ALL) {
-    $connection = \Drupal::database();
-
-    // Nickname.
-    $addNickName = \Drupal::moduleHandler()->moduleExists('social_profile_fields');
-
-    $query = $connection->select('users', 'u')->fields('u', ['uid']);
-    $query->join('users_field_data', 'uf', 'uf.uid = u.uid');
-    $query->condition('uf.status', 1);
-
-    $name = $connection->escapeLike($name);
+    $query = $this->startQuery();
+    $name = $query->escapeLike($name);
 
     switch ($suggestion_format) {
       case SOCIAL_PROFILE_SUGGESTIONS_USERNAME:
@@ -41,49 +45,96 @@ trait SocialProfileTrait {
         break;
 
       case SOCIAL_PROFILE_SUGGESTIONS_FULL_NAME:
-        $query->join('profile', 'p', 'p.uid = u.uid');
-        $query->join('profile__field_profile_first_name', 'fn', 'fn.entity_id = p.profile_id');
-        $query->join('profile__field_profile_last_name', 'ln', 'ln.entity_id = p.profile_id');
-        // Add nickname.
-        if ($addNickName === TRUE) {
-          $query->leftJoin('profile__field_profile_nick_name', 'nn', 'nn.entity_id = p.profile_id');
-        }
-
-        $or = $query->orConditionGroup();
-        $or
-          ->condition('fn.field_profile_first_name_value', '%' . $name . '%', 'LIKE')
-          ->condition('ln.field_profile_last_name_value', '%' . $name . '%', 'LIKE');
-        // Add Nickname.
-        if ($addNickName === TRUE) {
-          $or->condition('nn.field_profile_nick_name_value', '%' . $name . '%', 'LIKE');
-        }
-
-        $query->condition($or);
-        break;
-
       case SOCIAL_PROFILE_SUGGESTIONS_ALL:
-        $query->leftJoin('profile', 'p', 'p.uid = u.uid');
-        $query->leftJoin('profile__field_profile_first_name', 'fn', 'fn.entity_id = p.profile_id');
-        $query->leftJoin('profile__field_profile_last_name', 'ln', 'ln.entity_id = p.profile_id');
-        // Add nickname.
-        if ($addNickName === TRUE) {
-          $query->leftJoin('profile__field_profile_nick_name', 'nn', 'nn.entity_id = p.profile_id');
-        }
-
-        $or = $query->orConditionGroup();
-        $or
-          ->condition('uf.name', '%' . $name . '%', 'LIKE')
+        $or_query = $query->orConditionGroup();
+        $or_query
           ->condition('fn.field_profile_first_name_value', '%' . $name . '%', 'LIKE')
           ->condition('ln.field_profile_last_name_value', '%' . $name . '%', 'LIKE');
-        // Add Nickname.
-        if ($addNickName === TRUE) {
-          $or->condition('nn.field_profile_nick_name_value', '%' . $name . '%', 'LIKE');
+        // Add name only when needed.
+        if ($suggestion_format === SOCIAL_PROFILE_SUGGESTIONS_ALL) {
+          $or_query->condition('uf.name', '%' . $name . '%', 'LIKE');
         }
-
-        $query->condition($or);
+        if ($this->addNickName() === TRUE) {
+          $or_query->condition('nn.field_profile_nick_name_value', '%' . $name . '%', 'LIKE');
+        }
+        $query->condition($or_query);
         break;
     }
 
+    // Now we sort the query.
+    $query = $this->sortQuery($query, $name, $suggestion_format);
+
+    return $this->endQuery($query, $count);
+  }
+
+  /**
+   * Start a Social Profile Mention Query.
+   *
+   * @return \Drupal\Core\Database\Query\SelectInterface
+   *   Returns the query object.
+   */
+  private function startQuery() {
+    $connection = \Drupal::database();
+
+    $query = $connection->select('users', 'u')->fields('u', ['uid']);
+    $query->join('users_field_data', 'uf', 'uf.uid = u.uid');
+    $query->join('profile', 'p', 'p.uid = u.uid');
+    $query->join('profile__field_profile_first_name', 'fn', 'fn.entity_id = p.profile_id');
+    $query->join('profile__field_profile_last_name', 'ln', 'ln.entity_id = p.profile_id');
+    if ($this->addNickName() === TRUE) {
+      $query->leftJoin('profile__field_profile_nick_name', 'nn', 'nn.entity_id = p.profile_id');
+    }
+    return $query;
+  }
+
+  /**
+   * Sorts the query.
+   *
+   * Following the rules:
+   * 1. Users whose have first name starting by the given string;
+   * 2. Users whose have last name starting by the given string;
+   * 3. Users whose have nickname starting by the given string;
+   * 4. Users whose have username  starting by the given string;
+   * 5. Users containing the string.
+   *
+   * @param \Drupal\Core\Database\Query\SelectInterface $query
+   *   The select query.
+   * @param string $name
+   *   The string to search for.
+   * @param string $suggestion_format
+   *   (optional) The suggestion format.
+   *
+   * @return \Drupal\Core\Database\Query\SelectInterface
+   *   The select query.
+   */
+  private function sortQuery(SelectInterface $query, $name, $suggestion_format) {
+    if ($suggestion_format !== SOCIAL_PROFILE_SUGGESTIONS_USERNAME) {
+      $query->addExpression("
+    CASE WHEN fn.field_profile_first_name_value LIKE '" . $query->escapeLike($name) . "%' THEN 0
+      WHEN ln.field_profile_last_name_value LIKE '" . $query->escapeLike($name) . "%' THEN 1
+      ELSE 2
+    END
+  ", 'mention_sort');
+      $query->orderBy('mention_sort', 'ASC');
+      $query->orderBy('fn.field_profile_first_name_value', 'ASC');
+      $query->orderBy('ln.field_profile_last_name_value', 'ASC');
+    }
+    if ($this->addNickName() === TRUE) {
+      $query->orderBy('nn.field_profile_nick_name_value', 'ASC');
+    }
+    $query->orderBy('uf.name', 'ASC');
+
+    return $query;
+  }
+
+  /**
+   * End a Social Profile Mention Query.
+   *
+   * @return int[]
+   *   An array of account IDs for accounts whose account names begin with the
+   *   given string.
+   */
+  private function endQuery(SelectInterface $query, $count) {
     $result = $query
       ->range(0, $count)
       ->execute()

--- a/modules/social_features/social_profile/src/SocialProfileTrait.php
+++ b/modules/social_features/social_profile/src/SocialProfileTrait.php
@@ -97,6 +97,7 @@ trait SocialProfileTrait {
     if ($this->addNickName() === TRUE) {
       $query->leftJoin('profile__field_profile_nick_name', 'nn', 'nn.entity_id = p.profile_id');
     }
+    $query->condition('uf.status', 1);
     return $query;
   }
 

--- a/modules/social_features/social_profile/src/SocialProfileTrait.php
+++ b/modules/social_features/social_profile/src/SocialProfileTrait.php
@@ -37,7 +37,7 @@ trait SocialProfileTrait {
    */
   public function getUserIdsFromName($name, $count, $suggestion_format = SOCIAL_PROFILE_SUGGESTIONS_ALL) {
     $query = $this->startQuery();
-    $name = $query->escapeLike($name);
+    $name = ltrim($query->escapeLike($name));
 
     switch ($suggestion_format) {
       case SOCIAL_PROFILE_SUGGESTIONS_USERNAME:

--- a/modules/social_features/social_profile/src/SocialProfileTrait.php
+++ b/modules/social_features/social_profile/src/SocialProfileTrait.php
@@ -48,7 +48,7 @@ trait SocialProfileTrait {
       case SOCIAL_PROFILE_SUGGESTIONS_ALL:
         $strings = explode(' ', $name);
         if (count($strings) > 1) {
-          $query->where("CONCAT(fn.field_profile_first_name_value, ' ', ln.field_profile_last_name_value) LIKE :full_name", [':full_name' => '%' . $name . '%']);
+          $query->where("CONCAT(TRIM(fn.field_profile_first_name_value), ' ', TRIM(ln.field_profile_last_name_value)) LIKE :full_name", [':full_name' => '%' . $name . '%']);
           $query = $this->sortQuery($query, $name, $suggestion_format);
           $results = $this->endQuery($query, $count);
 
@@ -91,9 +91,9 @@ trait SocialProfileTrait {
 
     $query = $connection->select('users', 'u')->fields('u', ['uid']);
     $query->join('users_field_data', 'uf', 'uf.uid = u.uid');
-    $query->join('profile', 'p', 'p.uid = u.uid');
-    $query->join('profile__field_profile_first_name', 'fn', 'fn.entity_id = p.profile_id');
-    $query->join('profile__field_profile_last_name', 'ln', 'ln.entity_id = p.profile_id');
+    $query->leftJoin('profile', 'p', 'p.uid = u.uid');
+    $query->leftJoin('profile__field_profile_first_name', 'fn', 'fn.entity_id = p.profile_id');
+    $query->leftJoin('profile__field_profile_last_name', 'ln', 'ln.entity_id = p.profile_id');
     if ($this->addNickName() === TRUE) {
       $query->leftJoin('profile__field_profile_nick_name', 'nn', 'nn.entity_id = p.profile_id');
     }

--- a/themes/socialbase/assets/css/autocomplete.css
+++ b/themes/socialbase/assets/css/autocomplete.css
@@ -5,7 +5,7 @@
   padding: 0;
   list-style: none;
   max-height: 305px;
-  overflow-y: scroll;
+  overflow-y: auto;
 }
 
 .ui-autocomplete.ui-widget-content.upward {

--- a/themes/socialbase/components/03-molecules/form-elements/autocomplete/autocomplete.scss
+++ b/themes/socialbase/components/03-molecules/form-elements/autocomplete/autocomplete.scss
@@ -18,7 +18,7 @@
   padding: 0;
   list-style: none;
   max-height: 305px;
-  overflow-y: scroll;
+  overflow-y: auto;
 
 	&.upward {
 		bottom: 38px; // height of textarea


### PR DESCRIPTION
## Problem
On platforms which multiple users it is hard to find the correct user in user reference fields or in the mentions. This is already partly improved in PR #1082 but this is only part of the solution. If your platform has more than 50 John's it is still hard to find `John Doe` as there is no sorting by relevance and it is not possible to search for space-separated strings.

- [#2965717 - When searching for a user to mention the suggestions should sort by relevance](https://www.drupal.org/project/social/issues/2965717)
- [#3005538 - When searching for a user to mention the suggestions should sort by relevance](https://www.drupal.org/project/social/issues/3005538)

## Solution
The solution is two-fold. 

### 1. Better sorting
By providing better sorting it is easier to find a given user. Let's say you have the following users:

- Robert Johnson (username: robertjohnson, uid: 5)
- John Doe (username: harn8, uid: 3)
- John Marksen (username: xiou, uid: 8)
- Noah Farais (username: johnny, uid: 2)

When searching for `John` the results would have been ordered like this:

- Noah Farais
- John Doe
- Robert Johnson
- John Marksen

This was confusing to users as the sorting didn't make sense. By implementing a sort with the following rules the results are much better:

1. Users whose have first name starting by the given string;
2. Users whose have last name starting by the given string;
3. Users whose have nickname starting by the given string;
4. Users whose have username  starting by the given string;
5. Users containing the string.

### 2. Allow searching with a space
By allowing multiple strings and filtering on a concatenated value of first name and last name it allows users to narrow down a search with a combination of first name and last name.

E.g. when you have a list of those 4 users again and you know that the user you want to reference is named `John Doe` you can just search for `John Doe` and it will return the user.

## Issue tracker
- DS-6236
- https://www.drupal.org/project/social/issues/3005538
- https://www.drupal.org/project/social/issues/2965717

## HTT
- [ ] Check out the code changes
- [ ] Import a bunch of demo users (Jaap has demo content folder you can use) or try it out on a big enterprise site or create users with similar names (like the examples above)
- [ ] Try it out on the 8.x-4.x branch and notice that the experience to mention a user is not so nice and might be unusable on bigger sites
- [ ] Checkout to this branch
- [ ] Notice you can find users because the search sorting is a lot better
- [ ] Notice you can find users by specifying a combination of first name and last name
- [ ] Enable the optional social_profile_fields module and test the nickname search as well

## Release notes
On platforms with a lot of users it was sometimes hard to mention a user or add a user to a group. The provided sort was not logical for users. This has now been improved. It is now also possible to narrow down your search by providing a combination of first and last name.