### PR TITLE
Use hirak/prestissimo for faster composer installs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,6 +49,8 @@ before_install:
   - export BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_BRANCH; else echo $TRAVIS_PULL_REQUEST_BRANCH; fi)
   - export COMMIT=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_COMMIT; else echo $TRAVIS_PULL_REQUEST_SHA; fi)
   - export COMPOSER_EXIT_ON_PATCH_FAILURE=1
+  # Installing hirak/prestissimo allows composer to parallelise downloads which speeds up the composer install.
+  - composer global require hirak/prestissimo
   - echo "TRAVIS_BRANCH=$TRAVIS_BRANCH, PR=$PR, BRANCH=$BRANCH, COMMIT=$COMMIT"
   - if [ "$TEST_SUITE" = "install_update" ]; then composer require goalgorilla/open_social:2.0.0 --prefer-dist; fi
   - if [ "$TRAVIS_PULL_REQUEST" != "false" ] && [ "$TRAVIS_PULL_REQUEST_SLUG" != "goalgorilla/open_social" ]; then composer config repositories.social git https://github.com/$TRAVIS_PULL_REQUEST_SLUG.git; fi


### PR DESCRIPTION
## Problem
Installing all composer dependencies can take 3-5 minutes per Travis run. 

## Solution
Use hirak/prestissimo. The package parallelises downloads ahead of time instead of downloading
packages one by one. This can speed up package installs by about 60-80%.

## Issue tracker
No issue for this single line CI change.

## HTT
- [ ] All tests should remain green and the `composer install` run should be faster.

## Release notes
N.A.
