### PR TITLE
Issue #3015568 by serhiy-chornobay, ribel: As a LU I want the teasers to look complete even if no image is uploaded

### DIFF
--- a/modules/social_features/social_landing_page/css/social_landing_page.featured.css
+++ b/modules/social_features/social_landing_page/css/social_landing_page.featured.css
@@ -82,6 +82,8 @@
     background-color: rgba(0, 0, 0, 0.5);
     border-radius: 8px 0 8px 0;
     left: 0; }
+  .teaser.teaser--tile.no-image .teaser__teaser-type {
+    background-color: transparent; }
 
 .paragraph--section .paragraph--featured {
   background-color: #f3f3f3;
@@ -126,7 +128,7 @@
 .paragraph--featured .field--name-field-featured-items {
   margin-top: 30px;
   margin-bottom: 0.75rem; }
-.paragraph--featured .card__actionbar {
+.paragraph--featured footer.card__actionbar {
   padding-right: 0; }
 
 /*# sourceMappingURL=social_landing_page.featured.css.map */

--- a/modules/social_features/social_landing_page/css/social_landing_page.featured.scss
+++ b/modules/social_features/social_landing_page/css/social_landing_page.featured.scss
@@ -51,7 +51,7 @@
     margin-top: 30px;
     margin-bottom: 0.75rem;
   }
-  .card__actionbar {
+  footer.card__actionbar {
     padding-right: 0;
   }
 }

--- a/modules/social_features/social_landing_page/css/social_landing_page.section.featured.css
+++ b/modules/social_features/social_landing_page/css/social_landing_page.section.featured.css
@@ -82,5 +82,7 @@
     background-color: rgba(0, 0, 0, 0.5);
     border-radius: 8px 0 8px 0;
     left: 0; }
+  .teaser.teaser--tile.no-image .teaser__teaser-type {
+    background-color: transparent; }
 
 /*# sourceMappingURL=social_landing_page.section.featured.css.map */

--- a/modules/social_features/social_landing_page/css/social_landing_page.section.featured.scss
+++ b/modules/social_features/social_landing_page/css/social_landing_page.section.featured.scss
@@ -130,4 +130,10 @@
     left: 0;
   }
 
+  &.no-image {
+    .teaser__teaser-type {
+      background-color: transparent;
+    }
+  }
+
 }

--- a/modules/social_features/social_landing_page/templates/node--featured.html.twig
+++ b/modules/social_features/social_landing_page/templates/node--featured.html.twig
@@ -66,7 +66,8 @@
 
 {%
   set classes = [
-  'card teaser teaser--tile'
+  'card teaser teaser--tile',
+  no_image ? 'no-image'
 ]
 %}
 

--- a/themes/socialbase/assets/css/teaser.css
+++ b/themes/socialbase/assets/css/teaser.css
@@ -26,10 +26,29 @@
   margin-bottom: -10px;
 }
 
+.no-image .teaser__teaser-type {
+  background: none;
+  width: 100%;
+  height: 100%;
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-align: center;
+      -ms-flex-align: center;
+          align-items: center;
+}
+
 .teaser__teaser-type-icon {
   width: 18px;
   height: 18px;
   display: table;
+}
+
+.no-image .teaser__teaser-type-icon {
+  width: 100px;
+  height: 100px;
+  margin: 0 auto;
+  fill: #4d4d4d;
 }
 
 .teaser__title {

--- a/themes/socialbase/components/03-molecules/teaser/teaser.scss
+++ b/themes/socialbase/components/03-molecules/teaser/teaser.scss
@@ -77,6 +77,13 @@
     height: 44px;
     padding: 12px;
   }
+  .no-image & {
+    background: none;
+    width: 100%;
+    height: 100%;
+    display: flex;
+    align-items: center;
+  }
 
 }
 
@@ -85,6 +92,12 @@
   width: 18px;
   height: 18px;
   display: table;
+  .no-image & {
+    width: 100px;
+    height: 100px;
+    margin: 0 auto;
+    fill: #4d4d4d;
+  }
 }
 
 // Title of the teaser

--- a/themes/socialbase/src/Plugin/Preprocess/Node.php
+++ b/themes/socialbase/src/Plugin/Preprocess/Node.php
@@ -187,6 +187,28 @@ class Node extends PreprocessBase {
       $variables['#attached']['library'][] = 'socialbase/preview';
     }
 
+    // Add no_image flag if there are no image uploaded.
+    $variables['no_image'] = TRUE;
+    $image_field = "field_{$node->getType()}_image";
+
+    if (!empty($node->{$image_field}->entity)) {
+      $variables['no_image'] = FALSE;
+    }
+    else {
+      // If machine name too long or using another image field.
+      $node_fields = $node->getFields();
+      $image_fields = array_filter($node_fields, '_social_core_find_image_field');
+      // Get the first image field of all the fields.
+      $field = reset($image_fields);
+      if ($field !== NULL && $field !== FALSE) {
+        if ($field->getFieldDefinition()->get("field_type") === 'image') {
+          if (!empty(($node->get($field->getName())->entity))) {
+            $variables['no_image'] = FALSE;
+          }
+        }
+      }
+    }
+
   }
 
 }

--- a/themes/socialbase/templates/node/node--teaser.html.twig
+++ b/themes/socialbase/templates/node/node--teaser.html.twig
@@ -78,6 +78,7 @@
     node.isPromoted() ? 'promoted',
     node.isSticky() ? 'sticky',
     not node.isPublished() ? 'teaser--unpublished',
+    no_image ? 'no-image'
   ]
 %}
 
@@ -90,7 +91,7 @@
 
   <div class='teaser__image'>
 
-    {% if view_mode == 'teaser' %}
+    {% if view_mode == 'teaser' or no_image %}
       {% block card_teaser_type %}
 
         <div class="teaser__teaser-type">


### PR DESCRIPTION
## Problem
If no image is uploaded now we see just empty grey area with a small icon in a corner.

## Solution
If no image is uploaded the icon should be shown in the image field of the teaser.
See screenshots on drupal.org

## Issue tracker
- https://www.drupal.org/project/social/issues/3015568
- https://jira.goalgorilla.com/browse/FOR-181

## HTT
- [ ] Check out the code changes
- [ ] Check teasers and featured topics and events with images and no images
- [ ] Teasers without images should look better than before :)

## Release notes
<describe the release notes>
