### PR TITLE
Issue #2993854: Group manage members tab not display correctly

### DIFF
--- a/modules/social_features/social_group/social_group.module
+++ b/modules/social_features/social_group/social_group.module
@@ -762,17 +762,19 @@ function social_group_menu_local_tasks_alter(&$data, $route_name) {
     /** @var \Drupal\group\Entity\GroupTypeInterface $group_type */
     $group_type = $group->getGroupType()->id();
     // Check if it's a closed group.
-    if ($group_type == 'closed_group') {
+    if ($group_type === 'closed_group') {
       // And if the user is not user 1.
-      if ($user->id() != 1) {
+      if ($user->id() !== 1) {
         if ($user->hasPermission('manage all groups')) {
           return;
         }
         // If the user is not an member of this group.
-        elseif (!$group->getMember($user)) {
+        if (!$group->getMember($user)) {
           // Disable these local tasks.
           $data['tabs'][0]['group.view'] = [];
-          $data['tabs'][0]['group.content'] = [];
+          if (!$group->hasPermission('administer members', $user)) {
+            $data['tabs'][0]['group.content'] = [];
+          }
           $data['tabs'][0]['social_group.events'] = [];
           $data['tabs'][0]['social_group.topics'] = [];
         }


### PR DESCRIPTION
## Problem
The Manage members tab is not showing up for Advanced outsider permissions roles.

## Solution
We should instead check if user don't have the Administer group members permission and remove the tab.

## Issue tracker
- https://www.drupal.org/project/social/issues/2993854

## HTT
- [ ] Created a role site_admin and assign a user admin that role
- [ ] Created a group friends, make sure admin is not member of that group
- [ ] Went to the Advanced outsider permissions tab and checked the Administer group members box for the site_admin
- [ ] Logged in as "admin", visited the friends; the Manage members is not showing up.
- [ ] Now visited /group/[group id]/membership, and the page is displaying just fine, but the tab is still not showing.

## Release notes
The manage members tab on a group was not showing when an outsider has the "Administer group permissions"  permission. The tab is now only removed when a user does not have this permission. Note: this issue did not happen on default Open Social installations as all the necessary outside roles have the "Administer group" permission already.