### PR TITLE
Issue #3002195 by jaapjan: updating SocialUserLoginBlock to prevent errors

### DIFF
--- a/modules/social_features/social_user/src/Plugin/Block/SocialUserLoginBlock.php
+++ b/modules/social_features/social_user/src/Plugin/Block/SocialUserLoginBlock.php
@@ -30,23 +30,38 @@ class SocialUserLoginBlock extends UserLoginBlock {
     unset($form['pass']['#attributes']['aria-describedby']);
     $form['name_or_mail']['#size'] = 15;
     $form['pass']['#size'] = 15;
-    $form['#action'] = $this->url('<current>', [], ['query' => $this->getDestinationArray(), 'external' => FALSE]);
+
+    // See UserLoginBlock::build() for the logic behind this.
+    $placeholder = 'form_action_p_4r8ITd22yaUvXM6SzwrSe9rnQWe48hz9k1Sxto3pBvE';
+    $form['#attached']['placeholders'][$placeholder] = [
+      '#lazy_builder' => ['\Drupal\user\Plugin\Block\UserLoginBlock::renderPlaceholderFormAction', []],
+    ];
+    $form['#action'] = $placeholder;
+
     // Build action links.
     $items = [];
     if (\Drupal::config('user.settings')->get('register') != USER_REGISTER_ADMINISTRATORS_ONLY) {
-      $items['create_account'] = \Drupal::l($this->t('Create new account'), new Url('user.register', [], [
-        'attributes' => [
-          'title' => $this->t('Create a new user account.'),
-          'class' => ['create-account-link'],
-        ],
-      ]));
+      $items['create_account'] = [
+        '#type' => 'link',
+        '#title' => $this->t('Create new account'),
+        '#url' => Url::fromRoute('user.register', [], [
+          'attributes' => [
+            'title' => $this->t('Create a new user account.'),
+            'class' => ['create-account-link'],
+          ],
+        ]),
+      ];
     }
-    $items['request_password'] = \Drupal::l($this->t('Reset your password'), new Url('user.pass', [], [
-      'attributes' => [
-        'title' => $this->t('Send password reset instructions via email.'),
-        'class' => ['request-password-link'],
-      ],
-    ]));
+    $items['request_password'] = [
+      '#type' => 'link',
+      '#title' => $this->t('Reset your password'),
+      '#url' => Url::fromRoute('user.pass', [], [
+        'attributes' => [
+          'title' => $this->t('Send password reset instructions via email.'),
+          'class' => ['request-password-link'],
+        ],
+      ]),
+    ];
     return [
       'social_user_login_form' => $form,
       'user_links' => [


### PR DESCRIPTION
## Problem
Whenever I try to place the Social user login block in an active region such as content region or footer region, the homepage becomes in accessible. It gives a message "an unexpected error occured...". It happens with and without configuring social login configurations.

The UrlGeneratorTrait is removed which is causing this issue.

The issue seems to be introduced in: https://www.drupal.org/node/2867703. You can see the diff here: https://github.com/drupal/drupal/commit/dcec8637914897589f9e0c736b71d5169e7ccfc7#diff-2bd8cf9c6914a40c4877e15defd96498

## Solution
We could have just added the UrlGeneratorTrait but I think it's better to implement the same logic as in the core <a href="https://api.drupal.org/api/drupal/core%21modules%21user%21src%21Plugin%21Block%21UserLoginBlock.php/8.6.x">UserLoginBlock.php</a>.

## Issue tracker
- https://www.drupal.org/project/social/issues/3002195

## HTT
- [ ] Check the code changes and compare to the UserLoginBlock from core. 
- [ ] Login as administrator and add the block to a region and make sure it's visible by Anonymous currentUser.
- [ ] Logout and go to a page where this block should be visible.
- [ ] Try to login with different credentials and notice the results are as expected.

## Release notes
The Social User Login Block was trying to call an undefined method since the update to Drupal Core 8.4. This has now been solved by implementing the same logic as the core UserLoginBlock.
