### PR TITLE
#3015692 -  #3009970 Performance PM and database prefix fix

### DIFF
--- a/modules/social_features/social_private_message/src/Service/SocialPrivateMessageService.php
+++ b/modules/social_features/social_private_message/src/Service/SocialPrivateMessageService.php
@@ -9,7 +9,6 @@ use Drupal\Core\Database\Connection;
 use Drupal\Core\Entity\Entity;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Session\AccountProxyInterface;
-use Drupal\private_message\Entity\PrivateMessageThread;
 use Drupal\private_message\Mapper\PrivateMessageMapperInterface;
 use Drupal\private_message\Service\PrivateMessageService;
 use Drupal\user\UserDataInterface;
@@ -64,23 +63,33 @@ class SocialPrivateMessageService extends PrivateMessageService {
    *   The number of unread threads.
    */
   public function updateUnreadCount() {
+    $unread = 0;
+
     // Get the user.
     $uid = $this->currentUser->id();
     // Get all the thread id's for this user.
-    $thread_info = $this->getAllThreadIdsForUser($uid);
-    // Load these threads.
-    $threads = PrivateMessageThread::loadMultiple($thread_info);
+    $threads = $this->getAllThreadIdsForUser($uid);
 
-    $unread = 0;
-    /* @var PrivateMessageThread $thread */
-    foreach ($threads as $thread) {
-      // Check if the user has a timestamp on the thread and.
-      $thread_last_check_user = $this->userData->get('private_message', $uid, 'private_message_thread:' . $thread->id());
-      // Check the last time someone other than the current user added
-      // something to this thread.
-      $thread_last_message = $this->getLastMessageFromOtherUser($uid, $thread->id());
-      // Compare  those two.
-      if ($thread_last_message > $thread_last_check_user) {
+    if (empty($threads)) {
+      return $unread;
+    }
+
+    // Check the last time someone other than the current user added
+    // something to the threads.
+    $thread_last_messages = $this->getLastMessagesFromOtherUsers($uid, $threads);
+    if (empty($thread_last_messages)) {
+      return $unread;
+    }
+
+    foreach ($thread_last_messages as $thread_id => $last_message) {
+      // Check if the user has a timestamp on the thread.
+      $thread_last_check = $this->userData->get('private_message', $uid, 'private_message_thread:' . $thread_id);
+      if ($thread_last_check === NULL) {
+        $thread_last_check = 0;
+      }
+
+      // Check if someone send a message after your last check.
+      if ($last_message > $thread_last_check) {
         $unread++;
       }
     }
@@ -116,6 +125,31 @@ class SocialPrivateMessageService extends PrivateMessageService {
     )->fetchCol();
 
     return is_array($thread_ids) ? $thread_ids : [];
+  }
+
+  /**
+   * Retrieves times of last message in all threads send by other users.
+   *
+   * @param int $uid
+   *   The user uid to check for.
+   * @param array $threads
+   *   List of thread IDs to che check for.
+   *
+   * @return array
+   *   A list of timestamps linked to the thread IDs.
+   */
+  public function getLastMessagesFromOtherUsers($uid, array $threads) {
+    return $this->database->query(
+      'SELECT MAX(pm.created), pmt.entity_id ' .
+      'FROM {private_message_thread__private_messages} pmt ' .
+      'LEFT JOIN {private_messages} pm ON pmt.private_messages_target_id = pm.id ' .
+      'WHERE pmt.entity_id IN (:threads[]) AND pm.owner <> :uid ' .
+      'GROUP BY pmt.entity_id',
+      [
+        ':threads[]' => $threads,
+        ':uid' => $uid,
+      ]
+    )->fetchAllKeyed(1, 0);
   }
 
   /**

--- a/modules/social_features/social_private_message/src/Service/SocialPrivateMessageService.php
+++ b/modules/social_features/social_private_message/src/Service/SocialPrivateMessageService.php
@@ -157,27 +157,27 @@ class SocialPrivateMessageService extends PrivateMessageService {
    *
    * @param int $uid
    *   The user id.
-   * @param int $theadid
+   * @param int $thread_id
    *   The thread id.
    *
    * @return int
-   *   The timestamp.
+   *   The timestamp or 0 if nothing was found.
    */
-  public function getLastMessageFromOtherUser($uid, $theadid) {
-    $query = "SELECT MAX(`pm`.`created`) FROM `private_message_thread__private_messages` `pmt`  JOIN `private_messages` `pm` ON `pm`.`id` = `pmt`.`private_messages_target_id` WHERE `pmt`.`entity_id` = :pmt AND `pm`.`owner` <> :uid";
-    $vars = [
-      ':uid' => $uid,
-      ':pmt' => $theadid,
-    ];
-
+  public function getLastMessageFromOtherUser($uid, $thread_id) {
     $timestamp = $this->database->query(
-      $query,
-      $vars
+      'SELECT MAX(pm.created) ' .
+      'FROM {private_message_thread__private_messages} pmt ' .
+      'JOIN {private_messages} pm ON pmt.private_messages_target_id = pm.id ' .
+      'WHERE pmt.entity_id = :thread AND pm.owner <> :uid',
+      [
+        ':thread' => $thread_id,
+        ':uid' => $uid,
+      ]
     )->fetchCol();
 
     // Chop of the head.
     if (is_array($timestamp)) {
-      $timestamp = $timestamp[0];
+      $timestamp = ($timestamp[0] !== NULL) ? $timestamp[0] : 0;
     }
 
     return $timestamp;


### PR DESCRIPTION
## Problem
**Performance issue**
On every page load the private message unread count indicator in the header is checking for well, unread private messages.

Considering you have 86 private message threads, it will execute 86 queries to determine how many unread private messages you have. This is not ok and should be limited to one query for all threads.

**Query error**
Also fixed an issue where a query was not using table placeholders and thus breaking sites with a database with a prefix.

## Solution
**Performance issue**
Rewrote the logic to determine the count of unread private messages. It now uses a single query.

Tested with a user that has approximately 90 PM threads, for users with less threads impact will be lower.
![screen shot 2018-11-23 at 12 28 14](https://user-images.githubusercontent.com/7124754/48941299-470d2780-ef1b-11e8-8428-fd377c6ccf89.png)

**Query error**
Rewrote the query to use table placeholders.

## Issue tracker
- https://www.drupal.org/project/social/issues/3015692
- https://www.drupal.org/project/social/issues/3009970

## HTT
- [x] Check out the code changes
- [x] Login as user X and create a new private message, send it to user Y
- [x] Create a new private message and send it to user Y and Z
- [x] Observe that the unread count in the header is still 0
- [x] Login as user Y, notice the PM unread count is 2
- [x] Send some messages to each other and notice the unread count is as it is supposed to be

## Release notes
The unread private message indicator in the header would check every thread one-by-one (using SQL queries) to determine if you have seen the latest messages. This was inefficient, specially with a large number of threads. We rewrote the logic so it runs a single query for all the threads saving a lot of possible overhead.