### PR TITLE
OSSUPPORT-1473 - Adjust newest-topics.feature test to be used more generally

### DIFF
--- a/tests/behat/features/capabilities/topic/newest-topics.feature
+++ b/tests/behat/features/capabilities/topic/newest-topics.feature
@@ -7,16 +7,22 @@ Feature: See newest topics in the community
   Scenario: Successfully show my upcoming events as a LU
 #    TODO: Test visibility settings (Public, Community)
 
-    Given I am on the homepage
+    Given "topic_types" terms:
+      | name          |
+      | Blog          |
+      | News          |
+      | Discussion    |
+
+    Given I am on "/stream"
     Then I should not see "Behat Topic 1"
     And I should not see "Behat Topic 2"
 
-    Given topic content:
+    Given "topic" content:
       | title         | field_topic_type | status | field_content_visibility |
       | Behat Topic 1 | Blog             | 1      | public                   |
       | Behat Topic 2 | News             | 1      | public                   |
 
-    Given I am on the homepage
+    Given I am on "/stream"
 
     Then I should see "All topics"
     And I should see "Behat Topic 1"
@@ -28,6 +34,7 @@ Feature: See newest topics in the community
     And I should see "All topics"
 
     Given I am logged in as an "authenticated user"
+    And I am on "/stream"
     Then I should see "Behat Topic 1"
     And I should see "Behat Topic 2"
 


### PR DESCRIPTION
## Problem
So basically this test would create two topics with a mandatory topic_type and then check on these in the homepage a.k.a. /stream. In _social_topic_install_ there are three _topic_types_ already predefined and shipped with OS. However, if you would run this test on a platform where the initial _topic_types_ are different or gone, this test fails. The test should be flexible enough to create these taxonomy terms inside the test, and then test on them.

## Solution
The provided solution makes use of the standard DrupalContext step **createTerms** where we would create these initial values inside the test. This way the functionality as intended in OS can be tested on platforms where the _topic_types_ differ from the terms that are pre-defined in _social_topic_install_ but may have been altered on a custom platform.

Additionally, the test should check on the default "/stream" instead of homepage since the homepage might also be changed.

## Issue tracker
- https://jira.goalgorilla.com/browse/OSSUPPORT-1473 as part of https://jira.goalgorilla.com/browse/OSSUPPORT-1468
## HTT
- [ ] Check out the code changes in the test
- [ ] Make sure the tests run green, especially the one in question

## Release notes
- Improved the newest-topics.feature test so it's flexible enough to test this functionality on custom platforms.
