### PR TITLE
Issue #2989988 by KingDutch: socialbase grouphero block is outdated

### DIFF
--- a/modules/social_features/social_group/config/optional/block.block.groupheroblock.yml
+++ b/modules/social_features/social_group/config/optional/block.block.groupheroblock.yml
@@ -20,6 +20,6 @@ settings:
 visibility:
   request_path:
     id: request_path
-    pages: '/group/*'
+    pages: "/group/*/stream\r\n/group/*/about\r\n/group/*/events\r\n/group/*/topics\r\n/group/*/members\r\n/group/*/membership\r\n/group/*/content/*"
     negate: false
     context_mapping: {  }


### PR DESCRIPTION
## Problem
The socialblue_groupheroblock has the following pages listed: 

`/group/*/stream\r\n/group/*/about\r\n/group/*/events\r\n/group/*/topics\r\n/group/*/members\r\n/group/*/membership\r\n/group/*/leave\r\n/group/*/content/*`

Meanwhile groupheroblock has only `/group/*`

## Solution
Copy the pages of socialblue_groupheroblock to groupheroblock in the social_group module.

## Issue tracker
- https://www.drupal.org/project/social/issues/2989988

## HTT
- [x] Check out the code changes
- [x] Login as an admin user
- [x] Checkout to this branch
- [x] Browse to admin/structure/block/manage/groupheroblock?destination=/admin/structure/block/list/socialbase and click on the "Pages" visibility tab. You will only see `group/*` in the textarea.
- [x] Revert the social_group feature `drush fr social_group`
- [x] Browse to admin/structure/block/manage/groupheroblock?destination=/admin/structure/block/list/socialbase and click on the "Pages" visibility tab. You will now see 

`/group/*/stream
/group/*/about
/group/*/events
/group/*/topics
/group/*/members
/group/*/membership
/group/*/content/*` 

in the textarea.

This should match what's in the socialblue_groupheroblock (/admin/structure/block/manage/socialblue_groupheroblock?destination=/admin/structure/block).

## Release notes
Group Hero block (groupheroblock) will no longer display on all group/* pages, only those whitelisted.