### PR TITLE
Issue #3010322 by ZeppinM: "Edit group" button not translatable

### DIFF
--- a/themes/socialbase/templates/group/group--hero.html.twig
+++ b/themes/socialbase/templates/group/group--hero.html.twig
@@ -32,7 +32,7 @@
   <div class="hero__bgimage-overlay"></div>
   {% if group_edit_url %}
     <div class="hero-action-button">
-      <a href="{{ group_edit_url }}"  title="Edit group" class="btn btn-default btn-floating">
+      <a href="{{ group_edit_url }}"  title="{% trans %}Edit group{% endtrans %}" class="btn btn-default btn-floating">
         <svg class="icon-gray icon-medium">
           <use xlink:href="#icon-edit"></use>
         </svg>
@@ -75,7 +75,7 @@
             {% elseif closed_group %}
               <a href="{{ group_operations_url }}" class="btn btn-accent btn-lg btn-raised dropdown-toggle disabled" title="{{ cta }}">{{ cta }}</a>
             {% else %}
-              <a href="{{ group_operations_url }}" class="btn btn-accent btn-lg btn-raised dropdown-toggle" title="Join">{% trans %}Join{% endtrans %}</a>
+              <a href="{{ group_operations_url }}" class="btn btn-accent btn-lg btn-raised dropdown-toggle" title="{% trans %}Join{% endtrans %}">{% trans %}Join{% endtrans %}</a>
             {% endif %}
           </div>
         </div>


### PR DESCRIPTION
## Problem
Some terms (link titles) in the socialbase theme templates are not translatable. For example the title of the "Edit group" button.

## Solution
Let's make them translatable.

## Issue tracker
https://www.drupal.org/project/social/issues/3010322

## How to test
- [ ] Check if the strings are translatable  by checking the source code and translating the string

## Release notes
Some link titles in the group hero area were not translated correctly.
