### PR TITLE
Issue #2985350: Don't use Config getEditable for social_event_type_widget_alter

### DIFF
--- a/modules/social_features/social_event/modules/social_event_type/social_event_type.module
+++ b/modules/social_features/social_event/modules/social_event_type/social_event_type.module
@@ -30,8 +30,8 @@ function social_event_type_form_node_event_edit_form_alter(&$form, FormStateInte
  *   Form array.
  */
 function social_event_type_widget_alter(array &$form) {
-  /** @var \Drupal\Core\Config\ConfigFactory $config */
-  $config = \Drupal::service('config.factory')->getEditable('social_event_type.settings');
+  /** @var \Drupal\Core\Config\ImmutableConfig $config */
+  $config = \Drupal::config('social_event_type.settings');
 
   // Check if the field is set to mandatory.
   if ($config->get('social_event_type_required') == TRUE) {


### PR DESCRIPTION
## Problem
We should only use getEditable when we plan to edit the config settings. In social_event_type_widget_alter.

## Solution
Get the normal read-only config object using \Drupal::config()

## Issue tracker
https://www.drupal.org/project/social/issues/2985350

## How to test
- [x] Check if the social event type widget still works as expected.

## Release notes
Code refactoring to Config read instead of getting the editable config in the social event type widget.
