### PR TITLE
Issue #2993086: Message related object entity type is empty

### DIFF
--- a/modules/custom/activity_creator/activity_creator.tokens.inc
+++ b/modules/custom/activity_creator/activity_creator.tokens.inc
@@ -47,7 +47,7 @@ function activity_creator_tokens($type, $tokens, array $data, array $options, Bu
 
           // Get the targeted user, and his display name.
           if ($name === 'field_activity_recipient_user_display_name') {
-            if (isset($message->field_message_related_object)) {
+            if (isset($message->field_message_related_object) && !empty($message->field_message_related_object->target_type)) {
               $target_type = $message->field_message_related_object->target_type;
               $target_id = $message->field_message_related_object->target_id;
               $entity = \Drupal::entityTypeManager()

--- a/modules/custom/activity_logger/activity_logger.tokens.inc
+++ b/modules/custom/activity_logger/activity_logger.tokens.inc
@@ -72,7 +72,7 @@ function activity_logger_tokens($type, $tokens, array $data, array $options, Bub
         case 'recipient-user-url':
         case 'pmt-url':
 
-          if (isset($message->field_message_related_object)) {
+          if (isset($message->field_message_related_object) && !empty($message->field_message_related_object->target_type)) {
             $target_type = $message->field_message_related_object->target_type;
             $target_id = $message->field_message_related_object->target_id;
             $entity = \Drupal::entityTypeManager()


### PR DESCRIPTION
## Problem
In some cases, the entity type of the activity message is empty, therefore, the site encounters an error.

## Solution
We can make the code more defensive to prevent this type of error.

## Issue tracker
https://www.drupal.org/project/social/issues/2993086

## How to test
- [x] Check the code changes
- [ ] Verify message system still works as expected.

## Release notes
In some cases, the entity type of the activity message is empty for customised sites, therefore, the site encounters an error. We've rewritten the code a bit to make this more defensive.