### PR TITLE
Issue #2980079: StringTranslationTrait define the same [error] property

### DIFF
--- a/modules/custom/mentions/src/Form/MentionsSettingsForm.php
+++ b/modules/custom/mentions/src/Form/MentionsSettingsForm.php
@@ -7,7 +7,6 @@ use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\ConfigFormBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Entity\ContentEntityTypeInterface;
-use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -15,7 +14,6 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  */
 class MentionsSettingsForm extends ConfigFormBase {
 
-  use StringTranslationTrait;
 
   /**
    * The entity type manager service.


### PR DESCRIPTION
## Problem
Strict warnings during cache rebuild.

## Solution
Remove the StringTranslationTrait.

## Issue tracker
https://www.drupal.org/project/social/issues/2980079 (also related issues)

## How to test
- [x] Check if mentions still work as expected.

## Release notes
StringTranslationTrait define the same [error] property.
