### PR TITLE
Issue #2952504: Deprecated function: Non-static method should not be called statically

### DIFF
--- a/modules/social_features/social_group/src/Controller/DeleteGroup.php
+++ b/modules/social_features/social_group/src/Controller/DeleteGroup.php
@@ -38,7 +38,7 @@ class DeleteGroup {
   /**
    * Callback when the batch for group and content deletion is done.
    */
-  public function deleteGroupAndContentFinishedCallback($success, $results, $operations) {
+  public static function deleteGroupAndContentFinishedCallback($success, $results, $operations) {
     // The 'success' parameter means no fatal PHP errors were detected. All
     // other error management should be handled using 'results'.
     if ($success) {


### PR DESCRIPTION
## Problem
Non-static method Drupal\social_group\Controller\DeleteGroup::deleteGroupAndContentFinishedCallback() should not be called statically in _batch_finished()

## Solution
Method is made static.

## Issue tracker
https://www.drupal.org/project/social/issues/2952504

## How to test
- [x] Delete a closed group and see that everything gets deleted correctly.

## Release notes
Non-static method was called statically in DeleteGroup class which is called when deleting a (closed) group. This method is now made static.