### PR TITLE
Issue #2947898: Missing schema for entity_access_by_field.settings

### DIFF
--- a/modules/custom/entity_access_by_field/config/schema/entity_access_by_field.schema.yml
+++ b/modules/custom/entity_access_by_field/config/schema/entity_access_by_field.schema.yml
@@ -1,5 +1,15 @@
 # Schema for the configuration files of the Entity Access By Field.
 
+entity_access_by_field.settings:
+  type: config_object
+  label: 'Entity Access by Field Settings'
+  mapping:
+    disable_public_visibility:
+      type: boolean
+      label: 'Disable public visibility'
+    default_visibility:
+      type: string
+      label: 'The default visibility for fields'
 field.storage_settings.entity_access_field:
   type: mapping
   label: 'Entity access field settings'


### PR DESCRIPTION
## Problem
The entity_access_by_field config schema declaration has no entry for the entity_access_by_field.settings config object.

## Solution
Add this to configuration part to the top of entity_access_by_field.schema.yml.

## Issue tracker
https://www.drupal.org/project/social/issues/2947898

## How to test
- [x] Install the site and see everything is imported and installed correctly
- [ ] Set the configuration for entity access by field and notice everything still works as expected.

## Release notes
The entity_access_by_field config schema declaration now has an entry for the entity_access_by_field.settings config object.