### PR TITLE
Issue #2969028: Failed to load resource: jquery.mentions.js.map

### DIFF
--- a/modules/social_features/social_mentions/js/jquery.mentions.ckeditor.js
+++ b/modules/social_features/social_mentions/js/jquery.mentions.ckeditor.js
@@ -525,4 +525,3 @@
 
 }).call(this);
 
-//# sourceMappingURL=jquery.mentions.js.map


### PR DESCRIPTION
## Problem
Failed to load resource: the server responded with a status of 404 (Not Found) https://mysite.com/user/11/jquery.mentions.js.map

I get the above error on Safari.

profiles/contrib/social/modules/social_features/social_mentions/js/jquery.mentions.ckeditor.js:528://# sourceMappingURL=jquery.mentions.js.map

## Solution
Remove this line

## Issue tracker
https://www.drupal.org/project/social/issues/2969028

## How to test
- [ ] Check the code changes
- [ ] Verify site still works as expected
- [ ] Check if the error is on gone in Safari
- [ ] See also this PR in which this file was introduced: https://github.com/goalgorilla/open_social/pull/801

## Release notes
Prevent Safari from trying to load jquery.mentions.js.map.