### PR TITLE
2962184 - Remove social_font dependencies

### DIFF
--- a/modules/social_features/social_activity/config/install/field.storage.activity.field_activity_entity.yml
+++ b/modules/social_features/social_activity/config/install/field.storage.activity.field_activity_entity.yml
@@ -3,19 +3,7 @@ status: true
 dependencies:
   module:
     - activity_creator
-    - comment
-    - crop
     - dynamic_entity_reference
-    - flag
-    - group
-    - mentions
-    - message
-    - node
-    - search_api
-    - social_event
-    - social_font
-    - social_post
-    - votingapi
 id: activity.field_activity_entity
 field_name: field_activity_entity
 entity_type: activity

--- a/modules/social_features/social_activity/social_activity.info.yml
+++ b/modules/social_features/social_activity/social_activity.info.yml
@@ -24,7 +24,6 @@ dependencies:
   - search_api:search_api
   - social_comment:social_comment
   - social_event:social_event
-  - social_font:social_font
   - social_group:social_group
   - social_post:social_post
   - social_topic:social_topic

--- a/modules/social_features/social_activity/social_activity.install
+++ b/modules/social_features/social_activity/social_activity.install
@@ -188,6 +188,20 @@ function social_activity_update_8003() {
 }
 
 /**
+ * Remove weird dependencies from field_activity_entity.
+ */
+function social_activity_update_8004() {
+  $config = \Drupal::configFactory()->getEditable('field.storage.activity.field_activity_entity');
+
+  $dependencies['module'] = [
+    'activity_creator',
+    'dynamic_entity_reference',
+  ];
+
+  $config->set('dependencies', $dependencies)->save();
+}
+
+/**
  * Get entity view mode settings for Dynamic Entity Reference update.
  *
  * @return array


### PR DESCRIPTION
## Problem
The social activity module has some weird dependencies, that make it difficult to uninstall some modules that should be uninstallable without any problem

## Solution
Make sure there are no strange dependencies and social_font can be uninstalled, without breaking stuff.

## Issue tracker
https://www.drupal.org/project/social/issues/2962184

## How to test
- [ ] <enter multiple how to test steps here>

## Release notes
<describe the release notes>
