### PR TITLE
#3010275 by Kingdutch, bramtenhove: Added check to prevent undefined index

### DIFF
--- a/modules/social_features/social_event/modules/social_event_managers/src/SocialEventManagersAccessHelper.php
+++ b/modules/social_features/social_event/modules/social_event_managers/src/SocialEventManagersAccessHelper.php
@@ -24,7 +24,7 @@ class SocialEventManagersAccessHelper {
           $event_managers = $node->get('field_event_managers')->getValue();
 
           foreach ($event_managers as $event_manager) {
-            if ($account->id() == $event_manager['target_id']) {
+            if (isset($event_manager['target_id']) && $account->id() == $event_manager['target_id']) {
               return 2;
             }
           }
@@ -41,7 +41,7 @@ class SocialEventManagersAccessHelper {
    * Gets the Entity access for the given node.
    */
   public static function getEntityAccessResult(NodeInterface $node, $op, AccountInterface $account) {
-    $access = SocialEventManagersAccessHelper::nodeAccessCheck($node, $op, $account);
+    $access = self::nodeAccessCheck($node, $op, $account);
 
     switch ($access) {
       case 2:


### PR DESCRIPTION
## Problem
When using the social_event_managers module and creating an event as a LU (non-SM/CM) with the option to automatically add the user as an event manager disabled then the edit event screen throws an error because an empty value is stored in the `field_event_managers`.

## Solution
Add a check to see if we can possibly match a value. Also cleaned up a call to a function in the class.

## Issue tracker
- https://www.drupal.org/node/3010275

## How to test
- [x] Check out the code
- [x] Enable `social_event_managers` module
- [x] Login as LU
- [x] Create an event with the option to automatically add the user as an event manager disabled
- [x] Go to the edit screen, it should not longer throw an error in the logs because an empty value is stored in the field_event_managers

## Release notes
An error is no longer thrown on the edit event screen for the Social Event Managers module when the option to automatically add the user as an event manager was disabled and no other event managers were set.
