### PR TITLE
#3017264 by bramtenhove: Reduce the amount of activity stream items

### DIFF
--- a/modules/social_features/social_activity/config/install/views.view.activity_stream.yml
+++ b/modules/social_features/social_activity/config/install/views.view.activity_stream.yml
@@ -50,7 +50,7 @@ display:
       pager:
         type: mini
         options:
-          items_per_page: 30
+          items_per_page: 20
           offset: 0
           id: 0
           total_pages: null

--- a/modules/social_features/social_activity/config/install/views.view.activity_stream_notifications.yml
+++ b/modules/social_features/social_activity/config/install/views.view.activity_stream_notifications.yml
@@ -362,7 +362,7 @@ display:
       pager:
         type: mini
         options:
-          items_per_page: 30
+          items_per_page: 20
           offset: 0
           id: 0
           total_pages: null


### PR DESCRIPTION
I've been profiling the activity stream and noticed a significant performance gain when decreasing the amount of activities shown.

Tests were run on an Open Social installation with a normal amount of activities (15k). But can also be reproduced with less activities or much more.

## Problem
Activity streams are slow.

## Solution
Showing less items in the stream results in significant performance gains:
30 items = 7.23 seconds - default
20 items = 5.01 seconds - approx. 30% of default
10 items = 3.56 seconds - approx. 50% of default

I suggest to decrease the amount of activities shown to 20. This still gives a feeling of a full stream, but reduces page load by 30%.

Also reduced the amount of notifications shown on the notifications overview page from 30 to 20.

## Issue tracker
- https://www.drupal.org/project/social/issues/3017264

## How to test
- [ ] Check the code
- [ ] Open the stream page on a different branch, check page load time
- [ ] Open the stream page on this branch, check page load time. Should be a nice decrease!

## Release notes
By reducing the amount of items shown in the community activity stream from 30 (default) to 20 results in a performance gain of up to 30%.
