### PR TITLE
 Issue #2976046: add pager to community activities block in landing page

### DIFF
--- a/modules/social_features/social_landing_page/config/install/views.view.community_activities.yml
+++ b/modules/social_features/social_landing_page/config/install/views.view.community_activities.yml
@@ -2,11 +2,11 @@ langcode: en
 status: true
 dependencies:
   config:
-    - block.block.postblock
+  - block.block.postblock
   module:
-    - activity_creator
-    - activity_viewer
-    - options
+  - activity_creator
+  - activity_viewer
+  - options
 id: community_activities
 label: 'Community activities'
 module: views
@@ -47,10 +47,23 @@ display:
           sort_asc_label: Asc
           sort_desc_label: Desc
       pager:
-        type: some
+        type: mini
         options:
           items_per_page: 5
           offset: 0
+          id: 0
+          total_pages: null
+          tags:
+            previous: ‹‹
+            next: ››
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
       style:
         type: default
       row:
@@ -234,11 +247,12 @@ display:
     cache_metadata:
       max-age: -1
       contexts:
-        - 'languages:language_interface'
+      - 'languages:language_interface'
+      - url.query_args
       tags:
-        - 'config:core.entity_view_display.activity.activity.default'
-        - 'config:core.entity_view_display.activity.activity.notification'
-        - 'config:core.entity_view_display.activity.activity.notification_archive'
+      - 'config:core.entity_view_display.activity.activity.default'
+      - 'config:core.entity_view_display.activity.activity.notification'
+      - 'config:core.entity_view_display.activity.activity.notification_archive'
   block_stream_landing:
     display_plugin: block
     id: block_stream_landing
@@ -250,8 +264,9 @@ display:
     cache_metadata:
       max-age: -1
       contexts:
-        - 'languages:language_interface'
+      - 'languages:language_interface'
+      - url.query_args
       tags:
-        - 'config:core.entity_view_display.activity.activity.default'
-        - 'config:core.entity_view_display.activity.activity.notification'
-        - 'config:core.entity_view_display.activity.activity.notification_archive'
+      - 'config:core.entity_view_display.activity.activity.default'
+      - 'config:core.entity_view_display.activity.activity.notification'
+      - 'config:core.entity_view_display.activity.activity.notification_archive'


### PR DESCRIPTION
## Problem
Block community activities doesn't have a pager.

## Solution
Add a mini pager just like the (personalised) activity stream block.

## Issue tracker
https://www.drupal.org/project/social/issues/2976046

## How to test
- [ ] Create landing page with community activities block.
- [ ] Verify the pager works as expected.

## Release notes
The community activities block on a landing page now has a pager when there are more than the set amount of activities available in the stream.
