### PR TITLE
Issue #2976018 by jaapjan: reset page number when searching

### DIFF
--- a/modules/social_features/social_search/src/Form/SearchContentForm.php
+++ b/modules/social_features/social_search/src/Form/SearchContentForm.php
@@ -86,7 +86,7 @@ class SearchContentForm extends FormBase implements ContainerInjectionInterface 
     }
     $redirect_path = $search_content_page->toString();
 
-    $query = UrlHelper::filterQueryParameters($this->requestStack->getCurrentRequest()->query->all());
+    $query = UrlHelper::filterQueryParameters($this->requestStack->getCurrentRequest()->query->all(), ['page']);
 
     $redirect = Url::fromUserInput($redirect_path, ['query' => $query]);
 

--- a/modules/social_features/social_search/src/Form/SearchHeroForm.php
+++ b/modules/social_features/social_search/src/Form/SearchHeroForm.php
@@ -106,7 +106,7 @@ class SearchHeroForm extends FormBase implements ContainerInjectionInterface {
     }
     $redirect_path = $search_group_page->toString();
 
-    $query = UrlHelper::filterQueryParameters($this->requestStack->getCurrentRequest()->query->all());
+    $query = UrlHelper::filterQueryParameters($this->requestStack->getCurrentRequest()->query->all(), ['page']);
 
     $redirect = Url::fromUserInput($redirect_path, ['query' => $query]);
 


### PR DESCRIPTION
## Problem
On the search page the `page=x` parameter is preserved causing a user to end up on page X after entering a new search term. It makes more sense to serve the user the first page of the results.

## Solution
Rewrote the query parameters to exclude the `page` parameter in SearchContentForm.php and SearchHeroForm.php.

## Issue tracker
https://www.drupal.org/project/social/issues/2976018

## How to test
- [x] Login and go to `/search/all/a?page=1`
- [x] Enter a new search term, e.g. `t` in the hero block.
- [x] Notice the page parameter is not preserved.
- [x] Go to page 2 of the search results.
- [x] Enter a new search term, e.g. `a` in the search block in the menu.
- [x] Notice the page parameter is not preserved.

## Release notes
Whenever a user enters a new search term in the search form the user is now always directed to the first page of the search results.