### PR TITLE
Issue #2994207: Checkboxes are not shown in the Social Blue theme because checkboxes need titles

### DIFF
--- a/themes/socialbase/templates/form/form-element-label.html.twig
+++ b/themes/socialbase/templates/form/form-element-label.html.twig
@@ -18,22 +18,25 @@
 #}
 
 {%-
-  set classes = [
+    set classes = [
     'control-label',
     title_display == 'after' ? 'option',
     title_display == 'invisible' ? 'sr-only',
     title_display == 'above' ? 'control-label--above',
     required ? 'js-form-required',
     required ? 'form-required',
-  ]
+]
 -%}
 
 {{ element }}
-<label{{ attributes.addClass(classes) }}>{{ title }}
-  {%- if description -%}
-    <p class="help-block">{{ description }}</p>
-  {%- endif -%}
-</label>
+{%- if title is not empty -%}
+  <label{{ attributes.addClass(classes) }}>
+      {{ title }}
+      {%- if description -%}
+        <p class="help-block">{{ description }}</p>
+      {%- endif -%}
+  </label>
+{%- endif -%}
 {%- if required and title_display != 'invisible' -%}
   <span class="form-required">*</span>
 {%- endif -%}

--- a/themes/socialbase/templates/form/form-element-label.html.twig
+++ b/themes/socialbase/templates/form/form-element-label.html.twig
@@ -28,14 +28,12 @@
   ]
 -%}
 
-{%- if title is not empty -%}
-  {{ element }}
-  <label{{ attributes.addClass(classes) }}>{{ title }}
-    {%- if description -%}
-      <p class="help-block">{{ description }}</p>
-    {%- endif -%}
-  </label>
-  {%- if required and title_display != 'invisible' -%}
-    <span class="form-required">*</span>
+{{ element }}
+<label{{ attributes.addClass(classes) }}>{{ title }}
+  {%- if description -%}
+    <p class="help-block">{{ description }}</p>
   {%- endif -%}
+</label>
+{%- if required and title_display != 'invisible' -%}
+  <span class="form-required">*</span>
 {%- endif -%}


### PR DESCRIPTION
## Problem
Checkboxes are not shown in the Social Blue theme because checkboxes need titles.

## Solution
Let's not test for the title. The title can be empty so the label can still be printed with a description.

## Issue tracker
https://www.drupal.org/project/social/issues/2994207

## How to test
- [ ] Test all the checkboxes and form elements.
- [ ] Install the filebrowser (see issue) and test it.

## Release notes
In some cases (contributed modules) checkboxes in forms were not shown when there was no title filled in. Now the label element is always printed.
