### PR TITLE
Issue #3018215 by robertragas: Add context for comment button to aid …

### DIFF
--- a/modules/social_features/social_comment/social_comment.module
+++ b/modules/social_features/social_comment/social_comment.module
@@ -287,7 +287,7 @@ function social_comment_comment_view(array &$build, EntityInterface $entity, Ent
           ],
         ];
         $commented_entity_url = $commented_entity->toUrl('canonical', $link_options);
-        $build['comment_link'] = Link::fromTextAndUrl(t('Comment'), $commented_entity_url)->toRenderable();
+        $build['comment_link'] = Link::fromTextAndUrl(t('Comment', [], ['context' => 'Comment Button']), $commented_entity_url)->toRenderable();
       }
 
       $comment_count = $commented_entity->{$comment_field_name}->comment_count;


### PR DESCRIPTION
…in translation

## Problem
Open Social has the ability to be multilingual. The "Comment" text though can have different meanings in another language which require a better context.

Example:
- Notifications center: xxx likes your comment.
- Post comment button: comment.
These are perfectly fine but when translated to dutch

- Notifications center: xxx vindt jouw reageer leuk.
- Post comment button: reageer
Here the first line has the incorrect context

## Solution
Add context to the comment button. 

## Issue tracker
https://www.drupal.org/project/social/issues/3018215

## How to test
- [ ] Use a Dutch version of Open Social
- [ ] Create a comment and let someone else like it
- [ ] It will show a notification like above
- [ ] Check out the code and see the translations now has more context and able to translate more accurately.

## Release notes
Added a translation context to the comment button to be able to translate more accurately without conflicting with the comment entity type.
