### PR TITLE
 #3018168 - Hotfix 4.1 - Fix read count placement and updateReadCount on click.

### DIFF
--- a/modules/social_features/social_activity/social_activity.module
+++ b/modules/social_features/social_activity/social_activity.module
@@ -23,6 +23,12 @@ function social_activity_social_user_account_header_items(array $context) {
   $account = $context['user'];
 
   $notifications_view = views_embed_view('activity_stream_notifications', 'block_1');
+  // Mark all notifications as seen.
+  $notifications_view['#attached'] = [
+    'library' => [
+      'activity_creator/activity_creator.notifications',
+    ],
+  ];
 
   $account_notifications = \Drupal::service('activity_creator.activity_notifications');
   $num_notifications = count($account_notifications->getNotifications($account, [ACTIVITY_STATUS_RECEIVED]));

--- a/modules/social_features/social_activity/social_activity.module
+++ b/modules/social_features/social_activity/social_activity.module
@@ -30,6 +30,15 @@ function social_activity_social_user_account_header_items(array $context) {
     ],
   ];
 
+  // Make sure we check if attached is part of the render array.
+  if (!isset($notifications_view['#attached'])) {
+    $notifications_view['#attached'] = [];
+  }
+  if (!isset($notifications_view['#attached']['library'])) {
+    $notifications_view['#attached']['library'] = [];
+  }
+  $notifications_view['#attached']['library'][] = 'activity_creator/activity_creator.notifications';
+
   $account_notifications = \Drupal::service('activity_creator.activity_notifications');
   $num_notifications = count($account_notifications->getNotifications($account, [ACTIVITY_STATUS_RECEIVED]));
 

--- a/modules/social_features/social_user/src/Element/AccountHeaderElement.php
+++ b/modules/social_features/social_user/src/Element/AccountHeaderElement.php
@@ -99,18 +99,6 @@ class AccountHeaderElement extends RenderElement {
       ];
     }
 
-    // We always render the label but hide it for non-screenreader users in case
-    // an image or icon is used.
-    $label_class = !empty($item['#image']) || !empty($item['#icon']) ? 'sr-only' : NULL;
-    $link_text[] = [
-      "#type" => "inline_template",
-      "#template" => "<span{{ attributes }}>{{ label }}</span>",
-      '#context' => [
-        'attributes' => new Attribute(['class' => [$label_class]]),
-        'label' => $item['#label'],
-      ],
-    ];
-
     // Allow this menu item to include a notification count.
     if ($item['#notification_count'] !== NULL) {
       $count_classes =
@@ -126,6 +114,18 @@ class AccountHeaderElement extends RenderElement {
         ],
       ];
     }
+
+    // We always render the label but hide it for non-screenreader users in case
+    // an image or icon is used.
+    $label_class = !empty($item['#image']) || !empty($item['#icon']) ? 'sr-only' : NULL;
+    $link_text[] = [
+      "#type" => "inline_template",
+      "#template" => "<span{{ attributes }}>{{ label }}</span>",
+      '#context' => [
+        'attributes' => new Attribute(['class' => [$label_class]]),
+        'label' => $item['#label'],
+      ],
+    ];
 
     $element = [
       "#type" => "unwrapped_container",

--- a/themes/socialbase/templates/views/views-view--activity-stream-notifications--page.html.twig
+++ b/themes/socialbase/templates/views/views-view--activity-stream-notifications--page.html.twig
@@ -36,7 +36,7 @@
 {%
   set error_classes = [
     display_id == 'page' ? 'alert alert-info',
-    display_id != 'page' ? 'small card__block',
+    display_id != 'page' ? 'small card__block dropdown-header',
   ]
 %}
 

--- a/themes/socialbase/templates/views/views-view.html.twig
+++ b/themes/socialbase/templates/views/views-view.html.twig
@@ -46,7 +46,7 @@
 {%
   set error_classes = [
     display_id == 'page' ? 'alert alert-info',
-    display_id != 'page' ? 'small card__block',
+    display_id != 'page' ? 'small card__block dropdown-header',
   ]
 %}
 


### PR DESCRIPTION
## Problem
In 4.0 the AccountHeaderBlock got a massive overhaul. This resulted in the count indicator moving from the Top of the icon to the bottom.
Also the notification reading results in an JS error resulting in messages not being marked as "read" therefore the counter remains the same even after reading the notifications.

## Solution
1. We will update the count to make sure accessibility stays in place and the count shows on top again.
2. We will fix the JS issue that marks messages as read.

## Issue tracker
- https://www.drupal.org/node/3018168

## How to test
- [ ] Login as LU
- [ ] See that he indicator for Notifications is shown on the bottom of the Icon
- [ ] See that when you click the icon you get a JS error and the count doesn't update

- [ ] Checkout this branch, repeat the steps above and see that it now worsk.

## Release notes
In 4.0 the AccountHeaderBlock got an overhaul. This overhaul resulted in two bugs which we managed to fix and release in this hotfix. The count indicator should now be updated again once you click on the Notification Centre icon. And the indicator is shown on the top part of the icon again.  
