### PR TITLE
2928228 - Open Social (admin) configuration page category page

### DIFF
--- a/modules/social_features/social_core/social_core.links.menu.yml
+++ b/modules/social_features/social_core/social_core.links.menu.yml
@@ -1,4 +1,4 @@
 social_core.admin.config.social:
-  title: Opensocial settings
+  title: Open Social Settings
   parent: system.admin_config
   route_name: social_core.admin.config.social

--- a/modules/social_features/social_core/social_core.routing.yml
+++ b/modules/social_features/social_core/social_core.routing.yml
@@ -17,6 +17,7 @@ social_core.homepage:
 social_core.admin.config.social:
   path: '/admin/config/opensocial'
   defaults:
-    _title: 'Open Social'
+    _controller: '\Drupal\system\Controller\SystemController::systemAdminMenuBlockPage'
+    _title: 'Open Social Settings'
   requirements:
     _permission: 'access administration pages'


### PR DESCRIPTION
## Problem
The config > open social settings page is empty. This is especially annoying when you've enabled a lot of extra open social modules and the sub-menu list gets too long. 

## Solution
Add the systemcontroller on the route, that is reponsible for building the default main category pages

## Issue tracker
https://www.drupal.org/project/social/issues/2928228

## How to test
- [x] Login as an admin or SM
- [x] Go to configuration and click on "Open Social Settings"
- [x] Notice you land on an overview page with all the subsettings

## Release notes
The main category page of Open Social Settings now renders all the subitems that are part of the Open Social Settings eco-system
