### PR TITLE
#3022657 / SHN-267: Add some predefined styles to the CKEditor (full_html)

### DIFF
--- a/modules/social_features/social_editor/config/install/editor.editor.full_html.yml
+++ b/modules/social_features/social_editor/config/install/editor.editor.full_html.yml
@@ -49,16 +49,21 @@ settings:
           name: 'Block Formatting'
           items:
             - Format
+            - Styles
         -
           name: Tools
           items:
             - ShowBlocks
             - Source
+        -
+          name: Embed
+          items:
+            - social_embed
   plugins:
     language:
       language_list: un
     stylescombo:
-      styles: ''
+      styles: "a.btn.btn-default|Default link\r\na.btn.btn-primary|Primary link\r\na.btn.btn-accent|Accent link\r\nspan.badge.badge-primary|Primary badge\r\nspan.badge.badge-secondary|Secondary badge\r\nspan.badge.badge-pill|Pill badge"
 image_upload:
   status: true
   scheme: public

--- a/modules/social_features/social_editor/config/install/editor.editor.full_html.yml
+++ b/modules/social_features/social_editor/config/install/editor.editor.full_html.yml
@@ -55,10 +55,6 @@ settings:
           items:
             - ShowBlocks
             - Source
-        -
-          name: Embed
-          items:
-            - social_embed
   plugins:
     language:
       language_list: un


### PR DESCRIPTION
## Problem
Users sometimes find it difficult to create nice content from the CKeditor.

## Solution
Added some predefined styles such as the buttons, so user can create a link and simple set the styl with the dropdown.

## Issue tracker
- https://jira.goalgorilla.com/browse/SHN-267

## How to test
- [x] Checkout this branch and revert features
- [x] Edit a piece of content with the full_html text format. Notice you now have styles. 
- [x] Apply some styles. 
- [x] Save and see the (pretty) result
- [x] Merge!

## Release notes
When editing text as a CM+ there's now an extra dropdown in the editor, that allows you to create nicer links and add some other special Open Social styling to your text.
