### PR TITLE
Issue #3019316 : Update documentation links from github.com to drupal.org

### DIFF
--- a/modules/custom/social_demo/content/entity/page.yml
+++ b/modules/custom/social_demo/content/entity/page.yml
@@ -22,7 +22,7 @@ c0ca3235-fb0f-497c-a594-67753bdebce0:
         <li>You give back to the open-source community.</li>
         <li>As a Drupal freelancer or professional you improve your Drupal.org standing</li>
     </ol>
-    <p>We welcome code contributions, issue reports and translations. Learn how you can<a href="https://github.com/goalgorilla/drupal_social/wiki/Contributing-to-Open-Social">&nbsp;contribute in our Wiki</a>.</p>
+    <p>We welcome code contributions, issue reports and translations. Learn how you can <a href="https://www.drupal.org/docs/8/distributions/open-social/contribute-to-open-social">&nbsp;contribute in our Wiki</a>.</p>
   field_content_visibility: public
   image: aa51f774-dee0-11e5-b86d-9a79f06e9478
   image_alt: About and contact details

--- a/modules/custom/social_file_private/social_file_private.info.yml
+++ b/modules/custom/social_file_private/social_file_private.info.yml
@@ -1,5 +1,5 @@
 name: 'Social File Private'
-description: 'Enforces the use of Private Files for content, posts and file uploads (highly recommended!). More info: https://github.com/goalgorilla/drupal_social/wiki/Private-files'
+description: 'Enforces the use of Private Files for content, posts and file uploads (highly recommended!). More info: https://www.drupal.org/docs/8/distributions/open-social/private-files'
 type: module
 core: 8.x
 dependencies:

--- a/modules/custom/social_file_private/social_file_private.install
+++ b/modules/custom/social_file_private/social_file_private.install
@@ -22,7 +22,7 @@ function social_file_private_requirements($phase) {
         'title' => 'Social Private Files',
         'value' => t('Private file system path not set'),
         'severity' => REQUIREMENT_ERROR,
-        'description' => t('Your uploaded files on the Open Social entities are not fully protected because you did not set a Private File Directory. You need to set an existing local file system path for storing private files. It should be writable by Drupal and not accessible over the web. This must be changed in settings.php. More info: https://github.com/goalgorilla/drupal_social/wiki/Private-files'),
+        'description' => t('Your uploaded files on the Open Social entities are not fully protected because you did not set a Private File Directory. You need to set an existing local file system path for storing private files. It should be writable by Drupal and not accessible over the web. This must be changed in settings.php. More info: https://www.drupal.org/docs/8/distributions/open-social/private-files'),
       ];
     }
     else {
@@ -30,7 +30,7 @@ function social_file_private_requirements($phase) {
         'title' => 'Social Private Files',
         'value' => t('Private file system path is set'),
         'severity' => REQUIREMENT_OK,
-        'description' => t('Assuming your private file system path configuration is functional and no other warnings are shown: your uploaded files on the Open Social entities are fully protected. More info: https://github.com/goalgorilla/drupal_social/wiki/Private-files'),
+        'description' => t('Assuming your private file system path configuration is functional and no other warnings are shown: your uploaded files on the Open Social entities are fully protected. More info: https://www.drupal.org/docs/8/distributions/open-social/private-files'),
       ];
     }
 
@@ -60,7 +60,7 @@ function social_file_private_requirements($phase) {
         'title' => 'Social Private Files Unprotected',
         'value' => t('Private file system path not set for some fields'),
         'severity' => REQUIREMENT_ERROR,
-        'description' => t('Some files uploaded on fields are not protected against access by unauthorized users. These fields were found: :fields More info: https://github.com/goalgorilla/drupal_social/wiki/Private-files', [':fields' => implode(',', $unprotected_fields)]),
+        'description' => t('Some files uploaded on fields are not protected against access by unauthorized users. These fields were found: :fields More info: https://www.drupal.org/docs/8/distributions/open-social/private-files', [':fields' => implode(',', $unprotected_fields)]),
       ];
     }
   }

--- a/modules/social_features/social_core/social_core.install
+++ b/modules/social_features/social_core/social_core.install
@@ -33,7 +33,7 @@ function social_core_requirements($phase) {
         'title' => 'Social Private Files',
         'value' => t('All your uploaded files on the Open Social entities are potentially reachable by unauthorized users'),
         'severity' => REQUIREMENT_WARNING,
-        'description' => t('It is strongly recommended to enable social_file_private module to make sure your file and image uploads on Open Social entities can not be accessed by unauthorized users. More info: https://github.com/goalgorilla/drupal_social/wiki/Private-files'),
+        'description' => t('It is strongly recommended to enable social_file_private module to make sure your file and image uploads on Open Social entities can not be accessed by unauthorized users. More info: https://www.drupal.org/docs/8/distributions/open-social/private-files'),
       ];
     }
   }
@@ -604,10 +604,10 @@ function social_core_update_8019() {
       'social_file_private',
     ];
     \Drupal::service('module_installer')->install($modules);
-    drupal_set_message(t('Installed the social_file_private module. Make sure to read: https://github.com/goalgorilla/drupal_social/wiki/Private-files'));
+    drupal_set_message(t('Installed the social_file_private module. Make sure to read: https://www.drupal.org/docs/8/distributions/open-social/private-files'));
   }
   else {
-    drupal_set_message(t('Skipped installing the social_file_private module because your Private file system is not set. This could have some security implications. More info: https://github.com/goalgorilla/drupal_social/wiki/Private-files'), 'warning');
+    drupal_set_message(t('Skipped installing the social_file_private module because your Private file system is not set. This could have some security implications. More info: https://www.drupal.org/docs/8/distributions/open-social/private-files'), 'warning');
   }
 }
 

--- a/social.profile
+++ b/social.profile
@@ -75,7 +75,7 @@ function social_verify_custom_requirements(array &$install_state) {
     $requirements['addressing_library'] = [
       'title' => t('Address module requirements)'),
       'value' => t('Not installed'),
-      'description' => t('The Address module requires the commerceguys/addressing library. <a href=":link" target="_blank">For more information check our readme</a>', [':link' => 'https://github.com/goalgorilla/drupal_social/blob/master/readme.md#install-from-project-page-on-drupalorg']),
+      'description' => t('The Address module requires the commerceguys/addressing library. <a href=":link" target="_blank">For more information check our readme</a>', [':link' => 'https://www.drupal.org/docs/8/distributions/open-social/installing-and-updating']),
       'severity' => REQUIREMENT_ERROR,
     ];
   }


### PR DESCRIPTION
## Problem
There are still some links to github.com wiki in the repo. They should be changed to drupal.org docs.

## Solution
I'v grepped for all the changes and changed them accordingly.

## Issue tracker
https://www.drupal.org/project/social/issues/3019316

## How to test
- [ ] Dry code check
- [ ] Grep in code base to see if I missed any references
- [ ] Check if the links work (dry code check should be fine)

## Release notes
n/a.
