### PR TITLE
Move profile display 'Expertise' field above 'Interests'

### DIFF
--- a/themes/socialbase/templates/profile/profile--profile--default.html.twig
+++ b/themes/socialbase/templates/profile/profile--profile--default.html.twig
@@ -101,16 +101,16 @@
       {{ content.field_profile_self_introduction }}
     {% endif %}
 
-    {% if content.field_profile_interests['#items'] %}
-      <h5>{% trans %}Your interests{% endtrans %}</h5>
-      {% for item in content.field_profile_interests['#items'] %}
+    {% if content.field_profile_expertise['#items'] %}
+      <h5>{% trans %}Your expertise{% endtrans %}</h5>
+      {% for item in content.field_profile_expertise['#items'] %}
         <div class="badge badge--pill badge--large badge-default">{{ item.entity.label }}</div>
       {% endfor %}
     {% endif %}
 
-    {% if content.field_profile_expertise['#items'] %}
-      <h5>{% trans %}Your expertise{% endtrans %}</h5>
-      {% for item in content.field_profile_expertise['#items'] %}
+    {% if content.field_profile_interests['#items'] %}
+      <h5>{% trans %}Your interests{% endtrans %}</h5>
+      {% for item in content.field_profile_interests['#items'] %}
         <div class="badge badge--pill badge--large badge-default">{{ item.entity.label }}</div>
       {% endfor %}
     {% endif %}


### PR DESCRIPTION
Reorder default profile display fields 'Expertise' and 'Interests' so that the order is consistent with the edit profile form, in which 'Expertise' comes first.

## Problem
Expertise and Interests' order in the edit profile form does not match that of the profile display. On the edit form, 'Expertise' appears first, while when displayed, 'Interests' is first.

## Solution
Changed the order in the default profile twig template, so that 'Expertise' is now first, to match the order of the edit profile form.

## Issue tracker
https://www.drupal.org/project/social/issues/2986249

## How to test
- [x] Edit a profile (e.g. /user/12/profile) and add data to both the  Expertise and Interests fields.
- [x] Save the profile and view the profile information page, e.g. /user/12/information
- [x] When viewing the profile information page you should see that the 'Interests' field appears above the 'Expertise' field.
- [x] Checkout to this branch and clear the cache.
- [x] View the profile information page again and you should now see that the 'Expertise' field appears above 'Interests': 
![image](https://user-images.githubusercontent.com/227775/49861797-635b0080-fe05-11e8-9fa4-10545f528962.png)

## Release notes
Moved the display of the 'Expertise' field in the default profile twig template so that it appears above 'Interests', to match the order of the profile edit form. 
