### PR TITLE
Add a section for a Change Records

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,3 +12,6 @@
 
 ## Release notes
 <describe the release notes>
+
+## Change Record
+If this Pull Request changes the way that developers should do things or introduces a new API for developers then a change record to document this is needed. Please provide a draft for a change record or a link to an unpublished change record below. [Existing change records](https://www.drupal.org/list-changes/social) can be consulted as example.


### PR DESCRIPTION
## Problem
The PR template should encourage developers to document the API changes and additions that we make for other developers. 

## Solution
To facilitate this a section has been added about change records.

## Issue tracker
Not applicable for workflow only change.

## Release notes
Not needed

## Change Record
Not needed