### PR TITLE
#3020038 - Group content manage members tab order weight

### DIFF
--- a/modules/social_features/social_group/social_group.module
+++ b/modules/social_features/social_group/social_group.module
@@ -742,6 +742,7 @@ function social_group_menu_local_tasks_alter(&$data, $route_name) {
   // Rename Group "Related Entities" tab.
   if (isset($data['tabs'][0]['group.content']['#link'])) {
     $data['tabs'][0]['group.content']['#link']['title'] = t('Manage members');
+    $data['tabs'][0]['group.content']['#weight'] = 70;
   }
 
   // Remove the default View tab.


### PR DESCRIPTION
## Problem
Manage members is now the first tab in the group local tabs. Due to #3010778.

## Solution
Made sure that we set the weight only when the tab is available.

## Issue tracker
https://www.drupal.org/project/social/issues/3020038

## How to test
- [x] See that manage members is now the last tab. (Is only there for people with permissions)

## Release notes
The order of the Group tabs is now fixed so Manage Members is right after Members.
