### PR TITLE
Issue #3020084 by ribel: Replace hardcoded 'Data policy' title with value from variable

### DIFF
--- a/themes/socialbase/templates/block/block--data-policy-page-title-block.html.twig
+++ b/themes/socialbase/templates/block/block--data-policy-page-title-block.html.twig
@@ -34,7 +34,7 @@
 
   <div class="cover-wrap container">
     <div class="cover-small">
-      <h1 class="page-title">{{ 'Data Policy'|t }}</h1>
+      <h1 class="page-title">{{ content['#title'] }}</h1>
     </div>
   </div> {# cover-wrap #}
 </div> {# cover #}


### PR DESCRIPTION

## Problem
Data policy has no editable title and is fixed to "Data policy"

## Solution
Replace the hardcoded string with an already existing variable, so it can be changed by SM

## Issue tracker
- https://www.drupal.org/project/social/issues/3020084
- https://www.drupal.org/project/data_policy/issues/3020081
- https://jira.goalgorilla.com/browse/HGT-40


## How to test
- [ ] Go to /data-policy page and see 'Data policy' title in a hero
- [ ] Checkout to this branch and clear cache
- [ ] Go to /data-policy page and see 'Data policy' title in a hero
- [ ] Apply changes from data policy issue 3020081 and then you will be able to edit this title
- [ ] Go to /data-policy page and see the edited title in a hero

## Release notes
<describe the release notes>
