### PR TITLE
Issue #3020084 by ribel: Replace hardcoded 'Data policy' page title with value from variable

### DIFF
--- a/tests/behat/features/capabilities/gdpr/create-data-policy.feature
+++ b/tests/behat/features/capabilities/gdpr/create-data-policy.feature
@@ -19,7 +19,7 @@ Feature: Create data policy and view new policy
     Given I am logged in as "behatsitemanager"
     And I am on "admin/config/people/data-policy"
     Then I should be on "data-policy/revisions"
-    And I should see the heading "Data Policy" in the "Hero block" region
+    And I should see the heading "Revisions" in the "Hero block" region
     And I should see the link "Details" in the "Tabs" region
     And I should see the link "Revisions" in the "Tabs" region
     And I should see the text "Revision"

--- a/themes/socialbase/templates/block/block--data-policy-page-title-block.html.twig
+++ b/themes/socialbase/templates/block/block--data-policy-page-title-block.html.twig
@@ -34,7 +34,13 @@
 
   <div class="cover-wrap container">
     <div class="cover-small">
-      <h1 class="page-title">{{ 'Data Policy'|t }}</h1>
+      <h1 class="page-title">
+        {% if content['#title'] is not empty %}
+          {{ content['#title'] }}
+        {% else %}
+          {{ 'Data Policy'|t }}
+        {% endif %}
+      </h1>
     </div>
   </div> {# cover-wrap #}
 </div> {# cover #}


### PR DESCRIPTION
## Problem
Data policy has no editable title and is fixed to "Data policy"

## Solution
Replace the hardcoded string with an already existing variable, so it can be changed by SM

## Issue tracker
- https://www.drupal.org/project/social/issues/3020084
- https://www.drupal.org/project/data_policy/issues/3020081
- https://jira.goalgorilla.com/browse/HGT-40


## How to test
- [x] Go to /data-policy page and see 'Data policy' title in a hero
- [x] Checkout to this branch and clear cache
- [x] Go to /data-policy page and see 'Data policy' title in a hero
- [x] Apply changes from data policy issue 3020081 and then you will be able to edit this title
- [x] Go to /data-policy page and see the edited title in a hero

## Release notes
<describe the release notes>
