### PR TITLE
Issue #3020522: Read more link is shown twice in featured

### DIFF
--- a/modules/social_features/social_landing_page/templates/node--event--featured.html.twig
+++ b/modules/social_features/social_landing_page/templates/node--event--featured.html.twig
@@ -26,13 +26,4 @@
         </span>
       {% endif %}
     </small>
-
-
-  {% endblock %}
-  {% block card_link %}
-    <div class="card__link">
-      <a href="{{ url }}" rel="bookmark">{{ 'Read more'|t }}
-        <span class="visually-hidden">{{ 'about'|t }}{{ label }}</span>
-      </a>
-    </div>
   {% endblock %}

--- a/modules/social_features/social_landing_page/templates/node--landing-page--featured.html.twig
+++ b/modules/social_features/social_landing_page/templates/node--landing-page--featured.html.twig
@@ -13,10 +13,4 @@
 
 {% block card_body %}
 
-  <div class="card__link">
-    <a href="{{ url }}" rel="bookmark">{{ 'Read more'|t }}
-      <span class="visually-hidden">{{ 'about'|t }}{{ label }}</span>
-    </a>
-  </div>
-
 {% endblock %}

--- a/modules/social_features/social_landing_page/templates/node--page--featured.html.twig
+++ b/modules/social_features/social_landing_page/templates/node--page--featured.html.twig
@@ -13,10 +13,4 @@
 
 {% block card_body %}
 
-  <div class="card__link">
-    <a href="{{ url }}" rel="bookmark">{{ 'Read more'|t }}
-      <span class="visually-hidden">{{ 'about'|t }}{{ label }}</span>
-    </a>
-  </div>
-
 {% endblock %}

--- a/modules/social_features/social_landing_page/templates/node--topic--featured.html.twig
+++ b/modules/social_features/social_landing_page/templates/node--topic--featured.html.twig
@@ -31,10 +31,4 @@
       {% endif %}
     </small>
 
-    <div class="card__link">
-      <a href="{{ url }}" rel="bookmark">{{ 'Read more'|t }}
-        <span class="visually-hidden">{{ 'about'|t }}{{ label }}</span>
-      </a>
-    </div>
-
   {% endblock %}

--- a/modules/social_features/social_landing_page/templates/profile--featured.html.twig
+++ b/modules/social_features/social_landing_page/templates/profile--featured.html.twig
@@ -25,14 +25,4 @@
   {{ profile_name_extra }}
 {% endblock %}
 
-{% block card_body %}
-
-
-{% endblock %}
-{% block card_link %}
-  <div class="card__link">
-    <a href="{{ profile_stream_url }}" rel="bookmark">{{ 'Read more'|t }}
-      <span class="visually-hidden">{{ 'about'|t }}{{ profile_name }}</span>
-    </a>
-  </div>
-{% endblock %}
+{% block card_body %}{% endblock %}


### PR DESCRIPTION
## Problem
The "Read More" link is shown twice in Featured blocks on the Social Landing Page. This is happening because certain template files in the social_landing_page module are extended from node--featured.html.twig where the this one already has the card__actionbar with the card__link. These elements were also in the extended template file, which caused it to show twice.

## Solution
Remove the card__link element from node--topic--featured.html.twig and node-landing-page--featured.html.twig since only these two had the duplicate elements.

## Issue tracker
https://www.drupal.org/project/social/issues/3020522

## How to test
- [x] Check out the changes
- [x] Create a landing page with featured items, test any or all kinds.
- [x] Verify that you only have one Read More link in the featured card (on all content types).

## Release notes
Fixed an issue where featured blocks in landing pages showed the Read More link twice.
