### PR TITLE
#3020575: Fix configuration schema for modules/social_features/social_page/config/install/core.entity_form_display.node.page.default.yml

### DIFF
--- a/modules/social_features/social_page/config/install/core.entity_form_display.node.page.default.yml
+++ b/modules/social_features/social_page/config/install/core.entity_form_display.node.page.default.yml
@@ -129,7 +129,7 @@ content:
   status:
     region: content
     settings:
-      display_label: 1
+      display_label: true
     type: boolean_checkbox
     weight: 120
     third_party_settings: {  }


### PR DESCRIPTION
PR for https://www.drupal.org/project/social/issues/3020575

## Release notes
The configuration value core.entity_form_display.node.page.default.content.status.settings.display_label was installed as an integer but it is now converted to a boolean.