### PR TITLE
3020943: Fix image styles that use the wrong effect

### DIFF
--- a/modules/social_features/social_core/config/install/image.style.social_an_hero.yml
+++ b/modules/social_features/social_core/config/install/image.style.social_an_hero.yml
@@ -17,9 +17,10 @@ effects:
       crop_type: hero_an
   c4885faf-b34c-446f-b95b-e0a43dd71080:
     uuid: c4885faf-b34c-446f-b95b-e0a43dd71080
-    id: image_resize
+    id: image_scale_and_crop
     weight: 2
     data:
+      anchor: center-center
       width: 1200
       height: 490
   fa621cfb-8201-4ac7-8dd1-a9a1f6031115:

--- a/modules/social_features/social_core/config/install/image.style.social_x_large.yml
+++ b/modules/social_features/social_core/config/install/image.style.social_x_large.yml
@@ -17,9 +17,10 @@ effects:
       crop_type: teaser
   b4346485-59a7-4ed0-b3d9-57982b3ece26:
     uuid: b4346485-59a7-4ed0-b3d9-57982b3ece26
-    id: image_resize
+    id: image_scale_and_crop
     weight: 2
     data:
+      anchor: center-center
       width: 220
       height: 220
   06429c13-485a-4b8e-80a8-91ca034b566f:

--- a/modules/social_features/social_core/config/install/image.style.social_xx_large.yml
+++ b/modules/social_features/social_core/config/install/image.style.social_xx_large.yml
@@ -17,9 +17,10 @@ effects:
       crop_type: hero
   c4885faf-b34c-446f-b95b-e0a43dd71080:
     uuid: c4885faf-b34c-446f-b95b-e0a43dd71080
-    id: image_resize
+    id: image_scale_and_crop
     weight: 2
     data:
+      anchor: center-center
       width: 1200
       height: 423
   fa621cfb-8201-4ac7-8dd1-a9a1f6031115:


### PR DESCRIPTION
## Problem
Fix image styles that use the wrong effect. Preview images look skewed. Also when mass importing images, the images itself get skewed. 
The interface was working fine btw.

## Solution
Make sure the image styles use the `image_scale_and_crop` effect rather than then `image_resize` effect.

## Issue tracker
- https://www.drupal.org/project/social/issues/3020943

## How to test
- [ ] Look at the code changes
- [ ] Create an image in code (profile load > file create > profile set new image > profile save)
- [ ] In the old way, you can see on `/all-members` that images are skewed
- [ ] Go to the profile and notice the images are good
- [ ] Checkout to this branch
- [ ] Do the same
- [ ] See all is good

## Release notes
Some images used to be resized using the image_resize, rather than the scale and crop typ. This could cause images to look skewed. This has now been fixed. 
