### PR TITLE
Issue #3021140 by robertragas: relocate empty space to place where we…

### DIFF
--- a/modules/social_features/social_profile/modules/social_profile_organization_tag/social_profile_organization_tag.module
+++ b/modules/social_features/social_profile/modules/social_profile_organization_tag/social_profile_organization_tag.module
@@ -97,7 +97,7 @@ function social_profile_organization_tag_fetch(Profile $profile, $return_html = 
         foreach ($organization_tag_entities as $organization) {
           $value = t('from @org');
           if ($return_html === TRUE) {
-            $value = ' <span class="profile-organization-tag">&nbsp;<span class="text">@org</span></span>';
+            $value = '<span class="profile-organization-tag">&nbsp;<span class="text">@org</span></span>';
           }
           $arguments = [
             '@org' => $organization->label(),

--- a/modules/social_features/social_profile/modules/social_profile_organization_tag/social_profile_organization_tag.module
+++ b/modules/social_features/social_profile/modules/social_profile_organization_tag/social_profile_organization_tag.module
@@ -71,7 +71,7 @@ function social_profile_organization_tag_tokens_alter(array &$replacements, arra
       $storage = \Drupal::entityTypeManager()->getStorage('profile');
       if (!empty($storage)) {
         if ($user_profile = $storage->loadByUser($account, 'profile', TRUE)) {
-          $replacements['[message:author:display-name]'] .= social_profile_organization_tag_fetch($user_profile, FALSE);
+          $replacements['[message:author:display-name]'] .= rtrim(" " . social_profile_organization_tag_fetch($user_profile, FALSE));
         }
       }
     }

--- a/modules/social_features/social_profile/modules/social_profile_organization_tag/social_profile_organization_tag.module
+++ b/modules/social_features/social_profile/modules/social_profile_organization_tag/social_profile_organization_tag.module
@@ -71,7 +71,7 @@ function social_profile_organization_tag_tokens_alter(array &$replacements, arra
       $storage = \Drupal::entityTypeManager()->getStorage('profile');
       if (!empty($storage)) {
         if ($user_profile = $storage->loadByUser($account, 'profile', TRUE)) {
-          $replacements['[message:author:display-name]'] .= " " . social_profile_organization_tag_fetch($user_profile, FALSE);
+          $replacements['[message:author:display-name]'] .= social_profile_organization_tag_fetch($user_profile, FALSE);
         }
       }
     }
@@ -97,7 +97,7 @@ function social_profile_organization_tag_fetch(Profile $profile, $return_html = 
         foreach ($organization_tag_entities as $organization) {
           $value = t('from @org');
           if ($return_html === TRUE) {
-            $value = '<span class="profile-organization-tag">&nbsp;<span class="text">@org</span></span>';
+            $value = ' <span class="profile-organization-tag">&nbsp;<span class="text">@org</span></span>';
           }
           $arguments = [
             '@org' => $organization->label(),


### PR DESCRIPTION
## Problem
When the organizational module alters tokens to set the tag it will add an empty space unregarding if this is filled for the person. This will create an empty space failing the email notification tests.

## Solution
Relocate the empty space to the tag itself where we know it's set.

## Issue tracker
https://www.drupal.org/project/social/issues/3021140

## How to test
- [x] Enable the organizational tag module
- [x] Mention someone in a post
- [x] See that the output will be something like "xxx  mentioned you in a post" with an extra space.
- [x] Optional you can also run the behat tests on tag @notification-emails which will fail.
- [x] Try again with the new code and it just works.

## Release notes
The organizational tag module added an empty space in notification emails when no tag was set. This has now been fixed.
