### PR TITLE
Issue #3021889 by truls1502: Update bower-asset/bootstrap from v3.3.7 to v3.4.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -124,7 +124,7 @@
         "bower-asset/tablesaw": "~3.0.9",
         "bower-asset/morris.js": "0.5.1",
         "bower-asset/raphael": "2.2.7",
-        "bower-asset/bootstrap": "3.3.7",
+        "bower-asset/bootstrap": "3.4.0",
         "bower-asset/select2": "~4.0.5",
         "bower-asset/autosize": "~4.0.2",
         "bower-asset/d3": "v3.5.17",


### PR DESCRIPTION
## Problem & Solution
Update to the latest version

## Issue tracker
https://www.drupal.org/project/social/issues/3021889

## Release notes
Updated bower-asset/bootstrap

## Extra info
I assume the bootstrap-module will release a new version to include the Bootstrap framework 3.4.0 very soon.