### PR TITLE
Issue #3022444 by ribel: As a LU I want to see only one date for events

### DIFF
--- a/themes/socialbase/templates/node/event/node--event--full.html.twig
+++ b/themes/socialbase/templates/node/event/node--event--full.html.twig
@@ -1,5 +1,33 @@
 {% extends "node--full.html.twig" %}
 
+{% if display_submitted %}
+  {% block metainfo %}
+    <header class="metainfo">
+
+      <div class="metainfo__avatar">
+        {{ author_picture }}
+      </div>
+
+      <div class="metainfo__content">
+
+        {{ author }}
+
+        <div>
+          {% if event_type %}
+            {{ event_type }}
+          {% endif %}
+          {% if group_link %}
+            {% trans %} in group {% endtrans %}
+            {{ group_link }}
+          {% endif %}
+        </div>
+
+      </div>
+
+    </header>
+  {% endblock %}
+{% endif %}
+
 {# add specific fields to body for events only #}
 {% block nodefull_specialfields %}
 


### PR DESCRIPTION
## Problem
Users are confused about what is the event date.

## Solution
Remove creation date from the Event detail page

## Issue tracker
- https://www.drupal.org/project/social/issues/3022444
- https://jira.goalgorilla.com/browse/PAC-478

## How to test
- [ ] Go to the event detail page, you should see event creation date after the author name
- [ ] Checkout to this branch and clear the cache
- [ ] Go to the event detail page, you should NOT see event creation date after the author name

## Release notes
<describe the release notes>
