### PR TITLE
Issue #3020007 : prevent error on post list when field_post does not exist

### DIFF
--- a/modules/social_features/social_post/src/PostListBuilder.php
+++ b/modules/social_features/social_post/src/PostListBuilder.php
@@ -31,8 +31,11 @@ class PostListBuilder extends EntityListBuilder {
   public function buildRow(EntityInterface $entity) {
     /* @var $entity \Drupal\social_post\Entity\Post */
     $row['id'] = $entity->id();
-    $post_value = $entity->get('field_post')->value;
-    $row['post'] = text_summary($post_value, NULL, 120);
+    $row['post'] = '';
+    if ($entity->hasField('field_post')) {
+      $post_value = $entity->get('field_post')->value;
+      $row['post'] = text_summary($post_value, NULL, 120);
+    }
     $row['author'] = $entity->getOwner()->toLink();
     $row['created'] = \Drupal::service('date.formatter')->format($entity->getCreatedTime(), 'small');
     return $row + parent::buildRow($entity);


### PR DESCRIPTION
## Problem
If the field `field_post` does not exist on a post it throws an error on `admin/content/post`.

## Solution
Let's check if the entity has the field before trying to get the field value from the entity.

## Issue tracker
https://www.drupal.org/project/social/issues/3020007

## How to test
- [ ] Login as user 1, remove the field `field_post` from the post or post_photo entity.
- [ ] Check `admin/content/post` and notice an error.
- [ ] Switch to this branch and notice the error is gone.

## Release notes
The `admin/content/post` overview only worked if all the post entities had the field `field_post. Now it checks if the field exists before trying to display the field value.