### PR TITLE
Issue #3019760: consistency featured profile links on landing pages

### DIFF
--- a/modules/social_features/social_landing_page/templates/profile--featured.html.twig
+++ b/modules/social_features/social_landing_page/templates/profile--featured.html.twig
@@ -26,3 +26,11 @@
 {% endblock %}
 
 {% block card_body %}{% endblock %}
+
+{% block card_link %}
+  <div class="card__link">
+    <a href="{{ profile_stream_url }}" rel="bookmark">{{ 'Read more'|t }}
+      <span class="visually-hidden">{{ 'about'|t }}{{ label }}</span>
+    </a>
+  </div>
+{% endblock %}


### PR DESCRIPTION
## Problem
In #1161 we re-introduced this problem: https://www.drupal.org/project/social/issues/3019760 

## Solution
Let's add the code back which changes the read more link in the profile--featured template. It is not necessary to do this for 3.x branch.

## Issue tracker
https://www.drupal.org/project/social/issues/3019760

## How to test
- [ ] Feature a few profiles
- [ ] Notice the links of title (name), image and read more link are consistent.

## Release notes
`Not necessary because this is actually introduced and solved in the dev branch.`.
