### PR TITLE
#3021176 : Featuring a landing page without hero causes the image to show "Array"

### DIFF
--- a/modules/social_features/social_landing_page/social_landing_page.module
+++ b/modules/social_features/social_landing_page/social_landing_page.module
@@ -256,7 +256,7 @@ function _social_landing_page_get_hero_image(Node $node) {
     $paragraph_content = Paragraph::load($section_id);
 
     // Must be of type hero.
-    if ($paragraph_content->getType() === 'hero') {
+    if ($paragraph_content && $paragraph_content->getType() === 'hero') {
       $fid = $paragraph_content->get('field_hero_image')->target_id;
       $file = File::load($fid);
       // Check if it's an existing file.

--- a/modules/social_features/social_landing_page/social_landing_page.module
+++ b/modules/social_features/social_landing_page/social_landing_page.module
@@ -181,11 +181,13 @@ function social_landing_page_preprocess_node(&$variables) {
   if ($node->getType() === 'landing_page') {
     // If featured we need to do some magic.
     if ($variables['view_mode'] === 'featured') {
-      $variables['content']['field_landing_page_image'] = [
-        '#type' => 'markup',
-        '#markup' => _social_landing_page_get_hero_image($node),
-      ];
-
+      $hero_image = _social_landing_page_get_hero_image($node);
+      if (!empty($hero_image)) {
+        $variables['content']['field_landing_page_image'] = [
+          '#type' => 'markup',
+          '#markup' => $hero_image,
+        ];
+      }
     }
     // Get current user.
     $account = \Drupal::currentUser();


### PR DESCRIPTION
## Problem
Featuring a landing page without hero causes the image to show "Array"

## Solution
Let's check first if we actually have an image object before trying to render it. 

## Issue tracker
https://www.drupal.org/project/social/issues/3021176

## How to test
- [ ] Create a landing page (landing page "Y") without any sections
- [ ] Create a landing page (landing page "X") with one or multiple sections, but without a hero image.
- [ ] Create a new landing page with a "Featured" section and feature the landing pages you created in the first two steps.
- [ ] Notice you don't get to see the text "Array" and you will not get any warnings in the logs.
- [ ] When you switch to 8.x-3.x branch you will see the warnings and errors.

## Release notes
When you featured a landing page without a hero section on another landing page you could see the text "Array" on top of the teaser. This is now fixed to prevent this from happening again.