### PR TITLE
Issue #3018268 by jaapjan: don't send notification for liking own content

### DIFF
--- a/modules/social_features/social_like/src/Plugin/ActivityContext/VoteActivityContext.php
+++ b/modules/social_features/social_like/src/Plugin/ActivityContext/VoteActivityContext.php
@@ -32,11 +32,15 @@ class VoteActivityContext extends ActivityContextBase {
           $entity_storage = \Drupal::entityTypeManager()->getStorage($vote->getVotedEntityType());
           /** @var \Drupal\Core\Entity\Entity $entity */
           $entity = $entity_storage->load($vote->getVotedEntityId());
+          $uid = $entity->getOwnerId();
 
-          $recipients[] = [
-            'target_type' => 'user',
-            'target_id' => $entity->getOwnerId(),
-          ];
+          // Don't send notifications to myself.
+          if ($uid !== $data['actor']) {
+            $recipients[] = [
+              'target_type' => 'user',
+              'target_id' => $uid,
+            ];
+          }
         }
       }
     }


### PR DESCRIPTION
## Problem
You get a notification when liking your own entity.

## Solution
Let's implement the same solution as we did in #464 this will prevent an actor from being marked as recipient.

## Issue tracker
https://www.drupal.org/project/social/issues/3018268

## How to test
- [ ] Like your own post, comment and topic
- [ ] Notice you don't receive a notification = great success.
- [ ] You can debug with Xdebug as well if needed.

## Release notes
From now on you will not receive notifications when you like your own comment or post. 
