### PR TITLE
Issue #2936146: Cannot save 'social_content' search_api index fields

### DIFF
--- a/modules/social_features/social_search/config/install/search_api.index.social_content.yml
+++ b/modules/social_features/social_search/config/install/search_api.index.social_content.yml
@@ -50,7 +50,7 @@ field_settings:
     type: integer
     indexed_locked: true
     type_locked: true
-  search_api_node_grants:
+  node_grants:
     label: 'Node access information'
     property_path: search_api_node_grants
     type: string


### PR DESCRIPTION
## Problem
When going to the fields section of then 'social_content' search api index, you can add fields. However when saving this you get a 'search_api_node_grants is a reserved value and cannot be used as the machine name of a normal field. validation message. 

## Solution
- Change search_api_node_grants to node_grants in the configuration file
- Importing of the configuration (`drush fra`) automatically triggers a reindex, so update hook isn't necessary.

## Issue tracker
https://www.drupal.org/project/social/issues/2936146

## How to test
- [x] Go to `/admin/config/search/search-api/index/social_content/fields` and click on "Save changes" without making a change. See that you get an error.
- [x] Switch to this branch and repeat the step. Notice you don't get an error.

## Release notes
Administrators were unable to save the Fields configuration for the Search API index social_content because of a malformed configuration. This should be solved now!
