### PR TITLE
Issue #3024525 by Kingdutch, bramtenhove: Fix project names in fully qualified dependencies

### DIFF
--- a/modules/custom/activity_basics/activity_basics.info.yml
+++ b/modules/custom/activity_basics/activity_basics.info.yml
@@ -4,9 +4,9 @@ description: Basic implementation of activites in Open Social
 core: 8.x
 package: Custom
 dependencies:
-  - activity_creator:activity_creator
-  - activity_logger:activity_logger
-  - activity_viewer:activity_viewer
+  - social:activity_creator
+  - social:activity_logger
+  - social:activity_viewer
   - drupal:block_content
   - drupal:comment
   - dynamic_entity_reference:dynamic_entity_reference
@@ -18,9 +18,9 @@ dependencies:
   - drupal:node
   - drupal:options
   - profile:profile
-  - social_event:social_event
-  - social_group:social_group
-  - social_post:social_post
+  - social:social_event
+  - social:social_group
+  - social:social_post
   - drupal:taxonomy
   - token:token
   - drupal:text

--- a/modules/custom/activity_creator/activity_creator.info.yml
+++ b/modules/custom/activity_creator/activity_creator.info.yml
@@ -15,9 +15,9 @@ dependencies:
   - drupal:node
   - drupal:options
   - profile:profile
-  - social_event:social_event
-  - social_group:social_group
-  - social_post:social_post
+  - social:social_event
+  - social:social_group
+  - social:social_post
   - drupal:taxonomy
   - drupal:text
   - drupal:user

--- a/modules/custom/activity_logger/activity_logger.info.yml
+++ b/modules/custom/activity_logger/activity_logger.info.yml
@@ -4,7 +4,7 @@ description: Used to log activities based on the message module
 core: 8.x
 package: Social
 dependencies:
-  - activity_creator:activity_creator
+  - social:activity_creator
   - drupal:block_content
   - drupal:comment
   - dynamic_entity_reference:dynamic_entity_reference
@@ -15,6 +15,6 @@ dependencies:
   - drupal:node
   - drupal:options
   - profile:profile
-  - social_post:social_post
+  - social:social_post
   - drupal:taxonomy
   - drupal:user

--- a/modules/custom/activity_send/activity_send.info.yml
+++ b/modules/custom/activity_send/activity_send.info.yml
@@ -5,4 +5,4 @@ core: 8.x
 package: Social
 configure: activity_send.settings
 dependencies:
-  - activity_basics:activity_basics
+  - social:activity_basics

--- a/modules/custom/activity_send/modules/activity_send_email/activity_send_email.info.yml
+++ b/modules/custom/activity_send/modules/activity_send_email/activity_send_email.info.yml
@@ -4,4 +4,4 @@ description: Used to send activity notifications by Email
 core: 8.x
 package: Social
 dependencies:
-  - activity_send:activity_send
+  - social:activity_send

--- a/modules/custom/activity_viewer/activity_viewer.info.yml
+++ b/modules/custom/activity_viewer/activity_viewer.info.yml
@@ -4,8 +4,8 @@ description: Used to display activities with support for views
 core: 8.x
 package: Social
 dependencies:
-  - activity_creator:activity_creator
-  - activity_logger:activity_logger
+  - social:activity_creator
+  - social:activity_logger
   - drupal:block_content
   - drupal:comment
   - dynamic_entity_reference:dynamic_entity_reference
@@ -16,6 +16,6 @@ dependencies:
   - drupal:node
   - drupal:options
   - profile:profile
-  - social_post:social_post
+  - social:social_post
   - drupal:taxonomy
   - drupal:user

--- a/modules/custom/social_auth_extra/social_auth_extra.info.yml
+++ b/modules/custom/social_auth_extra/social_auth_extra.info.yml
@@ -4,5 +4,5 @@ description: Open Social coupling for the Social API Auth module.
 core: 8.x
 package: Social
 dependencies:
-  - social_auth:social_auth
+  - social:social_auth
   - profile:profile

--- a/modules/custom/social_auth_facebook/social_auth_facebook.info.yml
+++ b/modules/custom/social_auth_facebook/social_auth_facebook.info.yml
@@ -4,4 +4,4 @@ core: 8.x
 type: module
 package: Social
 dependencies:
-  - social_auth_extra:social_auth_extra
+  - social:social_auth_extra

--- a/modules/custom/social_auth_google/social_auth_google.info.yml
+++ b/modules/custom/social_auth_google/social_auth_google.info.yml
@@ -4,4 +4,4 @@ core: 8.x
 type: module
 package: Social
 dependencies:
-  - social_auth_extra:social_auth_extra
+  - social:social_auth_extra

--- a/modules/custom/social_auth_linkedin/social_auth_linkedin.info.yml
+++ b/modules/custom/social_auth_linkedin/social_auth_linkedin.info.yml
@@ -4,4 +4,4 @@ core: 8.x
 type: module
 package: Social
 dependencies:
-  - social_auth_extra:social_auth_extra
+  - social:social_auth_extra

--- a/modules/custom/social_auth_twitter/social_auth_twitter.info.yml
+++ b/modules/custom/social_auth_twitter/social_auth_twitter.info.yml
@@ -4,4 +4,4 @@ core: 8.x
 type: module
 package: Social
 dependencies:
-  - social_auth_extra:social_auth_extra
+  - social:social_auth_extra

--- a/modules/social_features/social_activity/social_activity.info.yml
+++ b/modules/social_features/social_activity/social_activity.info.yml
@@ -3,9 +3,9 @@ description: 'Provides activity stream for Open Social.'
 type: module
 core: 8.x
 dependencies:
-  - activity_creator:activity_creator
-  - activity_logger:activity_logger
-  - activity_viewer:activity_viewer
+  - social:activity_creator
+  - social:activity_logger
+  - social:activity_viewer
   - drupal:block
   - drupal:block_content
   - drupal:comment
@@ -15,19 +15,19 @@ dependencies:
   - drupal:file
   - flag:flag
   - group:group
-  - mentions:mentions
+  - social:mentions
   - drupal:menu_link_content
   - message:message
   - drupal:node
   - drupal:options
   - profile:profile
   - search_api:search_api
-  - social_comment:social_comment
-  - social_event:social_event
-  - social_font:social_font
-  - social_group:social_group
-  - social_post:social_post
-  - social_topic:social_topic
+  - social:social_comment
+  - social:social_event
+  - social:social_font
+  - social:social_group
+  - social:social_post
+  - social:social_topic
   - drupal:system
   - drupal:taxonomy
   - drupal:text

--- a/modules/social_features/social_book/social_book.info.yml
+++ b/modules/social_features/social_book/social_book.info.yml
@@ -6,17 +6,17 @@ dependencies:
   - drupal:block
   - drupal:book
   - drupal:comment
-  - entity_access_by_field:entity_access_by_field
+  - social:entity_access_by_field
   - drupal:field
   - field_group:field_group
   - drupal:file
-  - group_core_comments:group_core_comments
+  - social:group_core_comments
   - drupal:image
   - drupal:node
   - drupal:options
   - drupal:path
-  - social_core:social_core
-  - social_event:social_event
+  - social:social_core
+  - social:social_event
   - drupal:text
   - drupal:user
 package: Social

--- a/modules/social_features/social_comment_upload/social_comment_upload.info.yml
+++ b/modules/social_features/social_comment_upload/social_comment_upload.info.yml
@@ -8,5 +8,5 @@ dependencies:
   - drupal:field
   - field_group:field_group
   - drupal:file
-  - social_comment:social_comment
+  - social:social_comment
   - drupal:text

--- a/modules/social_features/social_core/social_core.info.yml
+++ b/modules/social_features/social_core/social_core.info.yml
@@ -19,7 +19,7 @@ dependencies:
   - override_node_options:override_node_options
   - r4032login:r4032login
   - drupal:system
-  - template_suggestions_extra:template_suggestions_extra
+  - social:template_suggestions_extra
   - drupal:text
   - drupal:user
   - drupal:views

--- a/modules/social_features/social_download_count/social_download_count.info.yml
+++ b/modules/social_features/social_download_count/social_download_count.info.yml
@@ -3,5 +3,5 @@ description: 'Tracks file downloads for Drupal private core file fields for Open
 type: module
 core: 8.x
 dependencies:
-  - download_count:download_count
+  - social:download_count
 package: Social

--- a/modules/social_features/social_event/modules/social_event_managers/social_event_managers.info.yml
+++ b/modules/social_features/social_event/modules/social_event_managers/social_event_managers.info.yml
@@ -8,7 +8,7 @@ dependencies:
   - drupal:field
   - drupal:node
   - drupal:profile
-  - social_event:social_event
-  - social_profile:social_profile
+  - social:social_event
+  - social:social_profile
   - drupal:user
   - drupal:views

--- a/modules/social_features/social_event/modules/social_event_type/social_event_type.info.yml
+++ b/modules/social_features/social_event/modules/social_event_type/social_event_type.info.yml
@@ -3,5 +3,5 @@ description: 'Provides and event types taxonomy for the event content type.'
 type: module
 core: 8.x
 dependencies:
-  - social_event:social_event
+  - social:social_event
 package: Social

--- a/modules/social_features/social_event/social_event.info.yml
+++ b/modules/social_features/social_event/social_event.info.yml
@@ -8,11 +8,11 @@ dependencies:
   - drupal:block
   - drupal:comment
   - drupal:datetime
-  - entity_access_by_field:entity_access_by_field
+  - social:entity_access_by_field
   - drupal:field
   - drupal:file
   - group:group
-  - group_core_comments:group_core_comments
+  - social:group_core_comments
   - drupal:image
   - image_widget_crop:image_widget_crop
   - drupal:menu_ui
@@ -20,9 +20,9 @@ dependencies:
   - drupal:options
   - drupal:path
   - profile:profile
-  - social_comment:social_comment
-  - social_core:social_core
-  - social_profile:social_profile
+  - social:social_comment
+  - social:social_core
+  - social:social_profile
   - drupal:system
   - drupal:text
   - drupal:user

--- a/modules/social_features/social_follow_content/social_follow_content.info.yml
+++ b/modules/social_features/social_follow_content/social_follow_content.info.yml
@@ -3,7 +3,7 @@ description: 'Provides "Follow Content" flag type and related functionality.'
 type: module
 core: 8.x
 dependencies:
-  - activity_logger:activity_logger
+  - social:activity_logger
   - drupal:block
   - drupal:field
   - drupal:node
@@ -15,7 +15,7 @@ dependencies:
   - flag:flag
   - message:message
   - profile:profile
-  - social_event:social_event
-  - social_page:social_page
-  - social_topic:social_topic
+  - social:social_event
+  - social:social_page
+  - social:social_topic
 package: Social

--- a/modules/social_features/social_group/modules/social_group_gvbo/social_group_gvbo.info.yml
+++ b/modules/social_features/social_group/modules/social_group_gvbo/social_group_gvbo.info.yml
@@ -4,5 +4,5 @@ type: module
 core: 8.x
 package: Social
 dependencies:
-  - social_group:social_group
+  - social:social_group
   - group:gvbo

--- a/modules/social_features/social_group/modules/social_group_members_export/social_group_members_export.info.yml
+++ b/modules/social_features/social_group/modules/social_group_members_export/social_group_members_export.info.yml
@@ -5,5 +5,5 @@ core: 8.x
 package: Social
 dependencies:
   - social:social_group
-  - social:gvbo
+  - social:social_group_gvbo
   - social:social_user_export

--- a/modules/social_features/social_group/modules/social_group_members_export/social_group_members_export.info.yml
+++ b/modules/social_features/social_group/modules/social_group_members_export/social_group_members_export.info.yml
@@ -4,6 +4,6 @@ type: module
 core: 8.x
 package: Social
 dependencies:
-  - social_group:social_group
-  - social_group:gvbo
-  - social_user_export:social_user_export
+  - social:social_group
+  - social:gvbo
+  - social:social_user_export

--- a/modules/social_features/social_group/modules/social_group_quickjoin/social_group_quickjoin.info.yml
+++ b/modules/social_features/social_group/modules/social_group_quickjoin/social_group_quickjoin.info.yml
@@ -3,5 +3,5 @@ description: 'Allows users to skip confirmation when joining a group.'
 type: module
 core: 8.x
 dependencies:
-- social_group:social_group
+- social:social_group
 package: Social

--- a/modules/social_features/social_group/social_group.info.yml
+++ b/modules/social_features/social_group/social_group.info.yml
@@ -17,11 +17,11 @@ dependencies:
   - drupal:node
   - drupal:path
   - profile:profile
-  - social_core:social_core
-  - social_event:social_event
-  - social_profile:social_profile
-  - social_topic:social_topic
-  - social_group:social_group_gvbo
+  - social:social_core
+  - social:social_event
+  - social:social_profile
+  - social:social_topic
+  - social:social_group_gvbo
   - drupal:system
   - drupal:taxonomy
   - drupal:text

--- a/modules/social_features/social_like/social_like.info.yml
+++ b/modules/social_features/social_like/social_like.info.yml
@@ -3,21 +3,21 @@ description: 'Provides Like voting functionality for Open Social.'
 type: module
 core: 8.x
 dependencies:
-  - activity_logger:activity_logger
+  - social:activity_logger
   - drupal:block
   - dynamic_entity_reference:dynamic_entity_reference
   - drupal:field
   - drupal:file
-  - group_core_comments:group_core_comments
+  - social:group_core_comments
   - like_and_dislike:like_and_dislike
   - message:message
   - drupal:node
   - drupal:options
   - profile:profile
-  - social_comment:social_comment
-  - social_post:social_post
-  - social_profile:social_profile
-  - social_topic:social_topic
+  - social:social_comment
+  - social:social_post
+  - social:social_profile
+  - social:social_topic
   - drupal:system
   - drupal:text
   - drupal:user

--- a/modules/social_features/social_mentions/social_mentions.info.yml
+++ b/modules/social_features/social_mentions/social_mentions.info.yml
@@ -3,14 +3,14 @@ description: 'Provide mentions feature for Open Social.'
 type: module
 core: 8.x
 dependencies:
-  - activity_logger:activity_logger
+  - social:activity_logger
   - dynamic_entity_reference:dynamic_entity_reference
   - drupal:field
   - drupal:image
-  - mentions:mentions
+  - social:mentions
   - message:message
   - drupal:options
   - profile:profile
-  - social_core:social_core
-  - social_profile:social_profile
+  - social:social_core
+  - social:social_profile
 package: Social

--- a/modules/social_features/social_page/social_page.info.yml
+++ b/modules/social_features/social_page/social_page.info.yml
@@ -4,7 +4,7 @@ type: module
 core: 8.x
 dependencies:
   - drupal:comment
-  - entity_access_by_field:entity_access_by_field
+  - social:entity_access_by_field
   - drupal:field
   - field_group:field_group
   - drupal:file
@@ -14,9 +14,9 @@ dependencies:
   - drupal:node
   - drupal:options
   - drupal:path
-  - social_comment:social_comment
-  - social_core:social_core
-  - social_event:social_event
+  - social:social_comment
+  - social:social_core
+  - social:social_event
   - drupal:text
   - drupal:user
 package: Social

--- a/modules/social_features/social_post/modules/social_post_photo/social_post_photo.info.yml
+++ b/modules/social_features/social_post/modules/social_post_photo/social_post_photo.info.yml
@@ -4,12 +4,12 @@ type: module
 core: 8.x
 dependencies:
   - drupal:comment
-  - dropdown:dropdown
+  - social:dropdown
   - drupal:field
   - drupal:file
   - drupal:image
   - image_effects:image_effects
-  - social_post:social_post
+  - social:social_post
   - drupal:text
   - drupal:user
 package: Social

--- a/modules/social_features/social_post/social_post.info.yml
+++ b/modules/social_features/social_post/social_post.info.yml
@@ -5,11 +5,11 @@ core: 8.x
 dependencies:
   - drupal:block
   - drupal:comment
-  - dropdown:dropdown
+  - social:dropdown
   - drupal:field
   - group:group
   - drupal:options
-  - social_comment:social_comment
+  - social:social_comment
   - drupal:system
   - drupal:text
   - drupal:user

--- a/modules/social_features/social_private_message/social_private_message.info.yml
+++ b/modules/social_features/social_private_message/social_private_message.info.yml
@@ -5,4 +5,4 @@ core: 8.x
 package: Social (experimental)
 dependencies:
   - private_message:private_message
-  - social_profile:social_profile
+  - social:social_profile

--- a/modules/social_features/social_profile/modules/social_profile_fields/social_profile_fields.info.yml
+++ b/modules/social_features/social_profile/modules/social_profile_fields/social_profile_fields.info.yml
@@ -6,4 +6,4 @@ package: Social (experimental)
 configure: social_profile_fields.settings
 dependencies:
   - drupal:user
-  - social_profile:social_profile
+  - social:social_profile

--- a/modules/social_features/social_profile/modules/social_profile_organization_tag/social_profile_organization_tag.info.yml
+++ b/modules/social_features/social_profile/modules/social_profile_organization_tag/social_profile_organization_tag.info.yml
@@ -4,5 +4,5 @@ type: module
 core: 8.x
 package: Social (experimental)
 dependencies:
-  - social_profile:social_profile
+  - social:social_profile
   - drupal:taxonomy

--- a/modules/social_features/social_profile/modules/social_profile_privacy/social_profile_privacy.info.yml
+++ b/modules/social_features/social_profile/modules/social_profile_privacy/social_profile_privacy.info.yml
@@ -5,5 +5,5 @@ core: 8.x
 package: Social (experimental)
 configure: social_profile.settings
 dependencies:
-  - social_profile:social_profile
+  - social:social_profile
   - drupal:user

--- a/modules/social_features/social_profile/social_profile.info.yml
+++ b/modules/social_features/social_profile/social_profile.info.yml
@@ -12,7 +12,7 @@ dependencies:
   - drupal:image
   - image_widget_crop:image_widget_crop
   - profile:profile
-  - social_core:social_core
+  - social:social_core
   - drupal:system
   - drupal:taxonomy
   - drupal:telephone

--- a/modules/social_features/social_search/social_search.info.yml
+++ b/modules/social_features/social_search/social_search.info.yml
@@ -9,8 +9,8 @@ dependencies:
   - profile:profile
   - search_api:search_api
   - search_api_db:search_api_db
-  - social_group:social_group
-  - social_profile:social_profile
+  - social:social_group
+  - social:social_profile
   - drupal:system
   - drupal:user
   - drupal:views

--- a/modules/social_features/social_sso/social_sso.info.yml
+++ b/modules/social_features/social_sso/social_sso.info.yml
@@ -4,4 +4,4 @@ description: Provides autorizathion with social networks for Open Social
 core: 8.x
 package: Social
 dependencies:
-  - social_auth_extra:social_auth_extra
+  - social:social_auth_extra

--- a/modules/social_features/social_topic/social_topic.info.yml
+++ b/modules/social_features/social_topic/social_topic.info.yml
@@ -5,21 +5,21 @@ core: 8.x
 dependencies:
   - drupal:block
   - drupal:comment
-  - entity_access_by_field:entity_access_by_field
+  - social:entity_access_by_field
   - drupal:field
   - field_group:field_group
   - drupal:file
   - group:group
-  - group_core_comments:group_core_comments
+  - social:group_core_comments
   - drupal:image
   - image_widget_crop:image_widget_crop
   - drupal:menu_ui
   - drupal:node
   - drupal:options
   - drupal:path
-  - social_comment:social_comment
-  - social_core:social_core
-  - social_event:social_event
+  - social:social_comment
+  - social:social_core
+  - social:social_event
   - drupal:system
   - drupal:taxonomy
   - drupal:text

--- a/modules/social_features/social_user_export/social_user_export.info.yml
+++ b/modules/social_features/social_user_export/social_user_export.info.yml
@@ -6,6 +6,6 @@ package: Social
 dependencies:
   - drupal:user
   - csv_serialization:csv_serialization
-  - social_profile:social_profile
+  - social:social_profile
   - profile:profile
   - views_bulk_operations


### PR DESCRIPTION
## Problem
When using the project:module_name syntax for dependency declaration the
`project` part should reflect the name under which the project can be
found on drupal.org. For all modules contained in Open Social this is
thus the `social` project.

## Solution
This change allows automated systems (e.g. automatic updates or
translation servers) to find the correct module even if a module is
contained in multiple projects.

## Issue tracker
https://www.drupal.org/project/social/issues/3024525

## How to test
- [ ] Check that all dependencies are still recognized

## Release notes
Code format change only, release notes not needed.
