### PR TITLE
Fix styling for social sharing buttons

### DIFF
--- a/modules/custom/improved_theme_settings/improved_theme_settings.module
+++ b/modules/custom/improved_theme_settings/improved_theme_settings.module
@@ -161,6 +161,9 @@ function improved_theme_settings_page_attachments(array &$page) {
             border-radius: 50% !important;
           }
 
+          .shariff-button {
+            border-radius: ' . $button_radius . 'px !important;
+          }
         ';
       }
 

--- a/themes/socialbase/assets/css/button.css
+++ b/themes/socialbase/assets/css/button.css
@@ -414,6 +414,10 @@ input[type="button"].btn-block {
   display: inline-block;
 }
 
+.shariff-button {
+  text-align: center;
+}
+
 @media (min-width: 900px) {
   .block-group-add-event-block,
   .block-group-add-topic-block,

--- a/themes/socialbase/assets/css/ckeditor.css
+++ b/themes/socialbase/assets/css/ckeditor.css
@@ -1321,6 +1321,10 @@ input[type="button"].btn-block {
   display: inline-block;
 }
 
+.shariff-button {
+  text-align: center;
+}
+
 .textarea--cke .cke {
   position: relative;
 }

--- a/themes/socialbase/components/02-atoms/button/button.scss
+++ b/themes/socialbase/components/02-atoms/button/button.scss
@@ -575,3 +575,11 @@ input[type="button"] {
   }
 
 }
+
+//
+// Social sharing buttons
+// --------------------------------------------------
+.shariff-button {
+  // Ensure the icon is always in the middle.
+  text-align: center;
+}

--- a/themes/socialblue/assets/css/button.css
+++ b/themes/socialblue/assets/css/button.css
@@ -309,3 +309,7 @@ fieldset[disabled] .btn--twitter.focus {
 .btn-xs {
   border-radius: 5px;
 }
+
+.shariff-button {
+  border-radius: 10px;
+}

--- a/themes/socialblue/assets/css/ckeditor.css
+++ b/themes/socialblue/assets/css/ckeditor.css
@@ -310,6 +310,10 @@ fieldset[disabled] .btn--twitter.focus {
   border-radius: 5px;
 }
 
+.shariff-button {
+  border-radius: 10px;
+}
+
 body {
   font-family: "montserrat", sans-serif;
   font-weight: 300;

--- a/themes/socialblue/assets/css/preview.css
+++ b/themes/socialblue/assets/css/preview.css
@@ -901,6 +901,10 @@ fieldset[disabled] .btn--twitter.focus {
   border-radius: 5px;
 }
 
+.shariff-button {
+  border-radius: 10px;
+}
+
 .card {
   border-top-left-radius: 10px;
   border-bottom-left-radius: 10px;

--- a/themes/socialblue/components/02-atoms/button/button.scss
+++ b/themes/socialblue/components/02-atoms/button/button.scss
@@ -171,3 +171,10 @@
 .btn-xs {
   border-radius: $border-radius-extrasmall;
 }
+
+//
+// Social sharing buttons
+// --------------------------------------------------
+.shariff-button {
+  border-radius: $btn-border-radius-base;
+}


### PR DESCRIPTION
<h2>Problem</h2>
Switching from AddToAny to Shariff caused a visual regression because the styling that was present in the AddToAny button was not replicated for Shariff.

Related PR: #1100 
See: https://www.drupal.org/files/issues/2019-01-14/Screenshot%202019-01-14%20at%2012.44.10.png

The Shariff buttons don't have rounded corners or centered icons by
default which causes a regression compared to the previously present
addtoany buttons.


<h2>Solution</h2>

Add the centering of icons to Socialbase and the default border-radius to Socialblue. Also ensure that this changes with the button rounding setting in the theme settings.

Result: https://www.drupal.org/files/issues/2019-01-14/Screenshot%202019-01-14%20at%2012.44.30.png

This commit adds a default border-radius for the socialblue theme and
uses the socialbase theme to center the icons. It also ensures that when
a theme sets a custom border-radius for buttons that it's honored on the
sharing buttons.

## Issue tracker
https://www.drupal.org/project/social/issues/3025741

## How to test
- [x] Using the socialblue theme
- [x] Ensure the social_sharing module is enabled
- [x] Visually inspect the "Share this page" block on a public topic
- [x] Change the border-radius under theme settings for socialblue
- [x] Check that the border-radius changes.

## Release notes
The move to Shariff for our social sharing buttons caused a visual regression. Styling has been added to the themes and theme customisation module to ensure that these buttons are properly displayed again.
