### PR TITLE
Issue #3017245: set correct user status for new users when signing up via social login

### DIFF
--- a/modules/custom/social_auth_extra/social_auth_extra.module
+++ b/modules/custom/social_auth_extra/social_auth_extra.module
@@ -154,6 +154,8 @@ function social_auth_extra_form_user_register_form_submit($form, FormStateInterf
       'name' => $form_state->getValue('name'),
       'mail' => $form_state->getValue('mail'),
       'init' => $form_state->getValue('mail'),
+      'status' => $form_state->getValue('status'),
+      'preferred_langcode' => $form_state->getValue('preferred_langcode'),
     ]);
 
     try {
@@ -226,25 +228,32 @@ function social_auth_extra_form_user_register_form_submit($form, FormStateInterf
         $form_state->getFormObject()->setEntity($account);
       }
 
-      user_login_finalize($account);
-      drupal_set_message(t('Your account is created. We have sent an email with your account details. You can now start exploring @community_name.', [
-        '@community_name' => \Drupal::config('system.site')->get('name'),
-      ]));
+      if ($account->get('status')->value === 0) {
+        _user_mail_notify('register_pending_approval', $account);
+        drupal_set_message(t('Thank you for applying for an account. Your account is currently pending approval by the site administrator.<br />In the meantime, a welcome message with further instructions has been sent to your email address.'));
+        $form_state->setRedirect('<front>');
+      }
+      else {
+        user_login_finalize($account);
+        drupal_set_message(t('Your account is created. We have sent an email with your account details. You can now start exploring @community_name.', [
+          '@community_name' => \Drupal::config('system.site')->get('name'),
+        ]));
 
-      // Send email notification.
-      $params['account'] = $account;
-      $langcode = $account->getPreferredLangcode();
-      $site_mail = \Drupal::config('system.site')->get('mail_notification');
+        // Send email notification.
+        $params['account'] = $account;
+        $langcode = $account->getPreferredLangcode();
+        $site_mail = \Drupal::config('system.site')->get('mail_notification');
+        if (empty($site_mail)) {
+          $site_mail = \Drupal::config('system.site')->get('mail');
+        }
 
-      if (empty($site_mail)) {
-        $site_mail = \Drupal::config('system.site')->get('mail');
+        if (empty($site_mail)) {
+          $site_mail = ini_get('sendmail_from');
+        }
+
+        \Drupal::service('plugin.manager.mail')->mail('social_auth_extra', 'email_social_login', $account->getEmail(), $langcode, $params, $site_mail);
       }
 
-      if (empty($site_mail)) {
-        $site_mail = ini_get('sendmail_from');
-      }
-
-      \Drupal::service('plugin.manager.mail')->mail('social_auth_extra', 'email_social_login', $account->getEmail(), $langcode, $params, $site_mail);
       // Save user consent.
       if (\Drupal::hasService('data_policy.manager')) {
         /** @var \Drupal\data_policy\DataPolicyManagerInterface $data_policy_manager */
@@ -256,7 +265,7 @@ function social_auth_extra_form_user_register_form_submit($form, FormStateInterf
       }
     }
     catch (EntityStorageException $e) {
-      drupal_set_message($this->t('Creation of user account failed. Please contact site administrator.'), 'error');
+      drupal_set_message(t('Creation of user account failed. Please contact site administrator.'), 'error');
       $logger_factory = \Drupal::service('logger.fatory');
       $logger_factory
         ->get($id)

--- a/modules/social_features/social_profile/modules/social_profile_organization_tag/social_profile_organization_tag.module
+++ b/modules/social_features/social_profile/modules/social_profile_organization_tag/social_profile_organization_tag.module
@@ -69,7 +69,7 @@ function social_profile_organization_tag_tokens_alter(array &$replacements, arra
     $account = $context['data']['user'];
     if ($account instanceof User) {
       $storage = \Drupal::entityTypeManager()->getStorage('profile');
-      if (!empty($storage)) {
+      if ($storage !== NULL && isset($replacements['[message:author:display-name]'])) {
         if ($user_profile = $storage->loadByUser($account, 'profile', TRUE)) {
           $replacements['[message:author:display-name]'] .= rtrim(" " . social_profile_organization_tag_fetch($user_profile, FALSE));
         }


### PR DESCRIPTION
## Problem
When administrator approval is needed (setting in Account settings) and a user signs up via a Social account (e.g. Google) it would get the approved status immediately, thus skipping administrator approval.

## Solution
Ensuring that users get the correct status depending on the registration setting, also when signing up via one of the social accounts.

## Issue tracker
https://www.drupal.org/project/social/issues/3017245

## How to test
- [ ] Switch to 8.x-4.x branch
- [ ] Set-up social signup https://lets.getopensocial.com/manual-social-signup-login
- [ ] Set the registration setting to "Visitor, but administrator approval needed".
- [ ] Signup for a new account with a Social account. 
- [ ] Notice your account is created directly and you are logged in.
- [ ] Notice the emails
- [ ] Delete the user in the database again and switch to this branch.
- [ ] Retry and notice that the user is redirected to the frontpage and sees a message indicating the user needs to wait for approval.
- [ ] Notice the emails
- [ ] Login as sitemanager and unblock the user.
- [ ] Notice the user receives a e-mail with correct login link and information.
- [ ] Retry, but now without the need of administrator approval. See that we didn't create a regression.

## Release notes
When administrator approval is needed (setting in Account settings) and a user signs up via a Social account (e.g. Google) it would get the approved status immediately, thus skipping administrator approval. This issue is solved by ensuring that users get the correct status depending on the registration setting, also when signing up via one of the social accounts.