### PR TITLE
Issue #2992737: bundle inside the like modal title is not translatable

### DIFF
--- a/modules/social_features/social_like/social_like.module
+++ b/modules/social_features/social_like/social_like.module
@@ -84,6 +84,6 @@ function social_like_preprocess_like_and_dislike_icons(&$variables) {
       $variables['dislike_attributes']->addClass('disable-status');
     }
   }
-
+  $bundle = t($bundle);
   $variables['modal_title'] = t('Members who liked this @content', ['@content' => $bundle]);
 }


### PR DESCRIPTION
## Problem
Bundle is not translatable inside like modal window

## Solution
Add a t() function around it.

## Issue tracker
https://www.drupal.org/project/social/issues/2992737

## How to test
- [ ] <enter multiple how to test steps here>

## Release notes
Bundle is not translatable inside like modal window, this should be translatable again now.
