### PR TITLE
Issue #3027247: Call to function isAnonymous() on null in template_preprocess_activity()

### DIFF
--- a/modules/custom/activity_creator/activity.page.inc
+++ b/modules/custom/activity_creator/activity.page.inc
@@ -62,7 +62,7 @@ function template_preprocess_activity(array &$variables) {
         $content = \Drupal::entityTypeManager()
           ->getViewBuilder('profile')
           ->view($user_profile, 'compact_notification');
-        if ($full_url == '') {
+        if ($full_url === '') {
           $variables['actor'] = $content;
         }
         else {
@@ -70,24 +70,25 @@ function template_preprocess_activity(array &$variables) {
         }
       }
     }
-  }
 
-  // Our author is Anonymous. If that happens for a notification.
-  // Lets provide the author as a default profile image.
-  if ($variables['elements']['#view_mode'] === 'notification' && $account->isAnonymous()) {
-    $default_image = social_profile_get_default_image();
-    if (!empty($default_image['id'])) {
-      $file = File::load($default_image['id']);
-      $uri = $file->getFileUri();
+    // Our author is Anonymous. If that happens for a notification.
+    // Lets provide the author as a default profile image.
+    if ($variables['elements']['#view_mode'] === 'notification' && $account->isAnonymous()) {
+      $default_image = social_profile_get_default_image();
+      if (!empty($default_image['id'])) {
+        $file = File::load($default_image['id']);
+        $uri = $file->getFileUri();
 
-      $variables['actor'] = [
-        '#theme' => 'image_style',
-        '#width' => $default_image['width'],
-        '#height' => $default_image['height'],
-        '#style_name' => 'social_medium',
-        '#uri' => $uri,
-      ];
+        $variables['actor'] = [
+          '#theme' => 'image_style',
+          '#width' => $default_image['width'],
+          '#height' => $default_image['height'],
+          '#style_name' => 'social_medium',
+          '#uri' => $uri,
+        ];
+      }
     }
+
   }
 
   $variables['full_url'] = $full_url;


### PR DESCRIPTION
## Problem
Call to function isAnonymous() on null in template_preprocess_activity()

## Solution
Only run the code when the `$account` is set.

## Issue tracker
https://www.drupal.org/project/social/issues/3027247

## How to test
- [ ] Check if notifications still work as expected.

## Release notes
Generation/displaying of activity items could in some cases result in an error on page, this is now solved by adding some more defensive coding.
