### PR TITLE
Issue #2968506 by uros.ceh, jaapjan, truls1502: When group is deleted the posts in this group should be deleted as well

### DIFF
--- a/modules/social_features/social_group/social_group.module
+++ b/modules/social_features/social_group/social_group.module
@@ -526,7 +526,7 @@ function social_group_form_alter(&$form, FormStateInterface $form_state, $form_i
     if (in_array($form_id, $group_forms['delete'])) {
       // Add custom submit handler to delete all content of the group.
       $group = _social_group_get_current_group();
-      $form['description']['#markup'] = t('Are you sure you want to delete your group "@group" along with all of the posts, events and topics inside this group?', ['@group' => $group->label()]);
+      $form['description']['#markup'] = t('Are you sure you want to delete your group "@group" along with all of the posts, events and topics inside this group? This action cannot be undone.', ['@group' => $group->label()]);
       $form['actions']['cancel'] = [
         '#type' => 'submit',
         '#value' => t('Cancel'),
@@ -545,7 +545,7 @@ function social_group_form_alter(&$form, FormStateInterface $form_state, $form_i
  *   An ajax command containing the informative text.
  */
 function _social_group_inform_group_type_selection() {
-  $text = t('Please note that changing the group type will also change the 
+  $text = t('Please note that changing the group type will also change the
   visibility of the group content and the way users can join the group.');
   drupal_set_message($text, 'info');
   $alert = ['#type' => 'status_messages'];

--- a/modules/social_features/social_group/social_group.module
+++ b/modules/social_features/social_group/social_group.module
@@ -94,22 +94,6 @@ function social_group_group_type_permission_check() {
 }
 
 /**
- * Implements hook_form_FORM_ID_alter().
- */
-function social_group_form_group_closed_group_delete_form_alter(&$form, FormStateInterface $form_state, $form_id) {
-  // Add custom submit handler to delete all content of the group.
-  $group = _social_group_get_current_group();
-  $form['description']['#markup'] = t('Are you sure you want to delete your group "@group" along with all of the posts, events and topics inside this group?', ['@group' => $group->label()]);
-  $form['actions']['cancel'] = [
-    '#type' => 'submit',
-    '#value' => t('Cancel'),
-    '#submit' => ['_social_group_cancel_join_leave_form'],
-    '#limit_validation_errors' => [],
-  ];
-  array_unshift($form['actions']['submit']['#submit'], '_social_group_delete_closed_group');
-}
-
-/**
  * Get group overview route.
  *
  * @return array
@@ -537,6 +521,19 @@ function social_group_form_alter(&$form, FormStateInterface $form_state, $form_i
       }
 
       $form['actions']['submit']['#submit'][] = '_social_group_type_edit_submit';
+    }
+
+    if (in_array($form_id, $group_forms['delete'])) {
+      // Add custom submit handler to delete all content of the group.
+      $group = _social_group_get_current_group();
+      $form['description']['#markup'] = t('Are you sure you want to delete your group "@group" along with all of the posts, events and topics inside this group?', ['@group' => $group->label()]);
+      $form['actions']['cancel'] = [
+        '#type' => 'submit',
+        '#value' => t('Cancel'),
+        '#submit' => ['_social_group_cancel_join_leave_form'],
+        '#limit_validation_errors' => [],
+      ];
+      array_unshift($form['actions']['submit']['#submit'], '_social_group_delete_group');
     }
   }
 }
@@ -1144,11 +1141,9 @@ function social_group_block_access(Block $block, $operation, AccountInterface $a
 /**
  * Delete the group and all of its content.
  */
-function _social_group_delete_closed_group() {
+function _social_group_delete_group() {
   // Get the group.
-  $group = _social_group_get_current_group();
-  // Make sure its a group of type closed_group.
-  if ($group && $group->getGroupType()->id() == 'closed_group') {
+  if ($group = _social_group_get_current_group()) {
     $group_content_types = GroupContentType::loadByEntityTypeId('node');
     $group_content_types = array_keys($group_content_types);
 

--- a/tests/behat/features/capabilities/group/group-edit-open.feature
+++ b/tests/behat/features/capabilities/group/group-edit-open.feature
@@ -113,6 +113,6 @@ Feature: Edit my group as a group manager
     And I click "Edit group"
     And I click "Delete"
     And I should see "This action cannot be undone."
-    And I should see the link "Cancel"
+    And I should see the button "Cancel"
     And I should see the button "Delete"
     And I press "Delete"


### PR DESCRIPTION
## Issue tracker
https://www.drupal.org/project/social/issues/2968506

## Release notes
When a group of any type (closed, open, public) is deleted the posts and content in this group are also deleted. 