### PR TITLE
Issue #3010782 Ensure search menu local tasks have proper weights

### DIFF
--- a/modules/social_features/social_search/social_search.links.task.yml
+++ b/modules/social_features/social_search/social_search.links.task.yml
@@ -2,38 +2,46 @@ social_search.all:
   route_name: view.search_all.page
   base_route: view.search_all.page
   title: All
+  weight: 10
 
 social_search.all_no_value:
   route_name: view.search_all.page_no_value
   base_route: view.search_all.page_no_value
   title: All
+  weight: 10
 
 social_search.content:
   route_name: view.search_content.page
   base_route: view.search_all.page
   title: Content
+  weight: 20
 
 social_search.content_no_value:
   route_name: view.search_content.page_no_value
   base_route: view.search_all.page_no_value
   title: Content
+  weight: 20
 
 social_search.users:
   route_name: view.search_users.page
   base_route: view.search_all.page
   title: Users
+  weight: 30
 
 social_search.users_no_value:
   route_name: view.search_users.page_no_value
   base_route: view.search_all.page_no_value
   title: Users
+  weight: 30
 
 social_search.groups:
   route_name: view.search_groups.page
   base_route: view.search_all.page
   title: Groups
+  weight: 40
 
 social_search.groups_no_value:
   route_name: view.search_groups.page_no_value
   base_route: view.search_all.page_no_value
   title: Groups
+  weight: 40


### PR DESCRIPTION
## Problem
The items in this render array should have #weight properties that are properly spaced (e.g. 10, 20, 30, 40) so that their order remains consistent across releases and other modules can easily add their own items in the desired place.

## Solution
Add the correct weight for search related links to the following .yml files:
- social_search.links.task.yml

## Issue tracker
https://www.drupal.org/project/social/issues/3010782

## How to test
- [ ] Do update to this branch.
- [ ] Check if the search tabs are still in the correct order.

## Release notes
(developer) Tabs on the search pages now have a default weight with some spacing in between. This allows other modules to easily add their own these local tasks.