### PR TITLE
Issue #2936477 : dependency declaration in social.info.yml

### DIFF
--- a/social.info.yml
+++ b/social.info.yml
@@ -6,11 +6,11 @@ version: '8.x-4.3'
 project: social
 
 dependencies:
-  - config
-  - system
-  - user
-  - breakpoint
-  - features
+  - drupal:config
+  - drupal:system
+  - drupal:user
+  - drupal:breakpoint
+  - features:features
 themes:
   - seven
   - socialbase


### PR DESCRIPTION
All dependencies must be prefixed with the project name, for example "drupal:"

## Issue tracker
https://www.drupal.org/project/social/issues/2936477

## How to test
- Verify installation works still as expected, wait for Travis to be completed.

## Release notes
(developer) All dependencies in social.info.yml are now with the project name, for example "drupal:".

