### PR TITLE
Issue #2948330: Distinguish between "Date Joined" and "Has joined"

### DIFF
--- a/themes/socialbase/templates/group/group--hero.html.twig
+++ b/themes/socialbase/templates/group/group--hero.html.twig
@@ -68,7 +68,7 @@
         <div class="hero-footer__cta">
           <div class="btn-group">
             {% if joined %}
-              <button type="button" autocomplete="off" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" class="btn btn-accent btn-lg btn-raised dropdown-toggle">{% trans %}Joined{% endtrans %}<span class="caret"></span></button>
+              <button type="button" autocomplete="off" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" class="btn btn-accent btn-lg btn-raised dropdown-toggle">{% trans with {'context': 'Is a member'} %}Joined{% endtrans %}<span class="caret"></span></button>
               <ul class="dropdown-menu dropdown-menu-right">
                 <li><a href="{{ group_operations_url }}">{% trans %}Leave group{% endtrans %}</a></li>
               </ul>

--- a/themes/socialbase/templates/group/group--teaser.html.twig
+++ b/themes/socialbase/templates/group/group--teaser.html.twig
@@ -88,7 +88,7 @@
     <div class="card__actionbar">
       {% if joined %}
         <span class="badge teaser__badge badge-secondary">
-          {% trans %}Joined{% endtrans %}
+          {% trans with {'context': 'Is a member'} %}Joined{% endtrans %}
         </span>
       {% endif %}
 


### PR DESCRIPTION
The string Joined in the codebase needs a context such as "Became member" to avoid a translation collision with "(date) joined" which is a header used elsewhere in Drupal.

## Issue tracker
https://www.drupal.org/project/social/issues/2948330

## How to test
- [ ] Test if the string is still translatable

## Release notes
(developer) The string Joined in the codebase now has a translation context such as "Became member" to avoid a translation collision with "(date) joined" which is a header used elsewhere in Drupal.