### PR TITLE
Issue #3026830: language switcher not switching

### DIFF
--- a/modules/custom/social_language/src/SocialLanguageMetadataBubblingUrlGenerator.php
+++ b/modules/custom/social_language/src/SocialLanguageMetadataBubblingUrlGenerator.php
@@ -46,7 +46,7 @@ class SocialLanguageMetadataBubblingUrlGenerator extends MetadataBubblingUrlGene
       $language = $this->languageManager->getCurrentLanguage();
 
       if ($options['language']->getId() != $language->getId()) {
-        $reset_language = TRUE;
+        $reset_language = FALSE;
         $unmodified_pages = [
           'content_translation_overview',
         ];
@@ -56,7 +56,7 @@ class SocialLanguageMetadataBubblingUrlGenerator extends MetadataBubblingUrlGene
         $route_parts = explode('.', $current_route);
         foreach ($unmodified_pages as $page) {
           if (in_array($page, $route_parts)) {
-            $reset_language = FALSE;
+            $reset_language = TRUE;
             break;
           }
         }


### PR DESCRIPTION
Note: only needed for 4.x and 5.x.

## Problem
The language switcher doesn't switch the language anymore in the latest release.

## Solution
It seems like the logic is flawed in the SocialLanguageMetadataBubblingUrlGenerator class with the reset language functionality. Currently, it resets to the current language on every page except for content_translation_overview pages, but it should be reversed instead. The patch above should fix the problem.

## Issue tracker
https://www.drupal.org/project/social/issues/3026830

## How to test
- [ ] Enable social_language
- [ ] Enable a new language
- [ ] Place the social language switcher block in the Header
- [ ] Try to switch the language and notice it doesn't work
- [ ] Switch to this branch and clear cache
- [ ] Notice switching the language now works.

## Release notes
The language switcher didn't work as expected. It should switch the languages now.