### PR TITLE
Issue #3028153: Profile Tag List not displaying correctly in filter on user search page

### DIFF
--- a/modules/social_features/social_profile/social_profile.module
+++ b/modules/social_features/social_profile/social_profile.module
@@ -90,19 +90,14 @@ function social_profile_form_profile_profile_add_form_alter(array &$form, FormSt
  * Implements hook_form_FORM_ID_alter().
  */
 function social_profile_form_profile_profile_edit_form_alter(array &$form, FormStateInterface $form_state, $form_id) {
-  $user = \Drupal::currentUser();
-  $account = \Drupal::routeMatch()->getParameter('user');
+  $viewing_user = \Drupal::currentUser();
 
   /** @var \Drupal\profile\Entity\Profile $profile */
   $profile = $form_state->getFormObject()->getEntity();
 
-  if (!$account instanceof User && $profile instanceof Profile) {
-    $account = $profile->getOwner();
-  }
-
   // Check for permission on custom edit profile tags, it's only for CM+ who can
   // actually edit a users profile and add profile tags there.
-  if (!$user->hasPermission('edit profile tags')) {
+  if (!$viewing_user->hasPermission('edit profile tags')) {
     $form['field_profile_profile_tag']['#access'] = FALSE;
   }
   // We hide the label and form field when there are no options. This is the
@@ -143,13 +138,30 @@ function social_profile_form_profile_profile_edit_form_alter(array &$form, FormS
         $form['empty_profile'] = [
           '#type' => 'fieldset',
         ];
-        $form['empty_profile']['notice'] = [
-          '#type' => 'html_tag',
-          '#tag' => 'p',
-          '#value' => t('There is no profile information you can change here. Change your @settings.', [
-            '@settings' => Link::createFromRoute(t('account settings here'), 'entity.user.edit_form', ['user' => $account->id()])->toString(),
-          ]),
-        ];
+        // If a user is viewing their own profile, suggest they change settings.
+        if ($viewing_user->id() === $profile->getOwnerId()) {
+          $settings_link = Link::createFromRoute(
+            t('account settings here'),
+            'entity.user.edit_form',
+            ['user' => $profile->getOwnerId()]
+          )->toString();
+          $form['empty_profile']['notice'] = [
+            '#type' => 'html_tag',
+            '#tag' => 'p',
+            '#value' => t(
+              'There is no profile information you can change here. Change your @settings.',
+              ['@settings' => $settings_link]
+            ),
+          ];
+        }
+        // For other users there's nothing left to do.
+        else {
+          $form['empty_profile']['notice'] = [
+            '#type' => 'html_tag',
+            '#tag' => 'p',
+            '#value' => t('There is no profile information you can change here.'),
+          ];
+        }
 
         $form['actions']['submit']['#disabled'] = TRUE;
       }
@@ -164,7 +176,7 @@ function social_profile_form_profile_profile_edit_form_alter(array &$form, FormS
   $form['actions']['cancel'] = [
     '#type' => 'link',
     '#title' => t('Cancel'),
-    '#url' => Url::fromRoute('view.user_information.user_information', ['user' => $account->id()]),
+    '#url' => Url::fromRoute('view.user_information.user_information', ['user' => $profile->getOwnerId()]),
   ];
 }
 

--- a/modules/social_features/social_profile/social_profile.module
+++ b/modules/social_features/social_profile/social_profile.module
@@ -102,7 +102,10 @@ function social_profile_form_profile_profile_edit_form_alter(array &$form, FormS
   }
   // We hide the label and form field when there are no options. This is the
   // case by default. Since we provide an empty vocabulary.
-  if (empty($form['field_profile_profile_tag']['widget']['#options'])) {
+  // We also check for a fieldset, used by our special widget which doesn't use
+  // #options.
+  if (empty($form['field_profile_profile_tag']['widget']['#options'])
+    && $form['field_profile_profile_tag']['widget']['#type'] !== 'container') {
     unset($form['field_profile_profile_tag']);
   }
 

--- a/modules/social_features/social_profile/social_profile.module
+++ b/modules/social_features/social_profile/social_profile.module
@@ -230,10 +230,61 @@ function social_profile_form_views_exposed_form_alter(&$form, FormStateInterface
   if ($form['#id'] == 'views-exposed-form-search-users-page') {
     if (!empty($form['profile_tag'])) {
       $form['profile_tag']['#type'] = 'checkboxes';
+      // If the view is configured to preserve hierarchy we need to do a bit
+      // more to make checkboxes work.
+      if (is_object($form['profile_tag']['#options'][0])) {
+        $options = [];
+        // The #options array is an array of stdClass objects with an array in
+        // the option key that has the tid as key and label as value.
+        foreach ($form['profile_tag']['#options'] as $option) {
+          $options[key($option->option)] = reset($option->option);
+        }
+        // Set the options array to the format expected for checkboxes.
+        $form['profile_tag']['#options'] = $options;
+      }
     }
     if (empty($form['profile_tag']['#options'])) {
       unset($form['profile_tag']);
     }
+  }
+}
+
+/**
+ * Implements hook_preprocess_fieldset().
+ */
+function social_profile_preprocess_fieldset(&$variables) {
+  // Style our checkboxes as nested checkboxes.
+  if ($variables['element']['#name'] === 'profile_tag') {
+    $variables['attributes']['class'][] = 'checkboxes--nested';
+  }
+}
+
+/**
+ * Implements hook_preprocess_input().
+ */
+function social_profile_preprocess_input(&$variables) {
+  // Edit the profile tag displays to show the hierarchy to users.
+  // Only do this if it starts with a - to indicate it's a child.
+  if (
+    !empty($variables['element']['#parents'])
+    && $variables['element']['#parents'][0] === 'profile_tag'
+    && substr($variables['element']['#title'], 0, 1) === '-'
+  ) {
+    $variables['element']['#attributes']['class'][] = 'checkboxes--nested__child';
+  }
+}
+
+/**
+ * Implements hook_preprocess_form_element_label().
+ */
+function social_profile_preprocess_form_element_label(&$variables) {
+  // Edit the profile tag displays to show the hierarchy to users.
+  // Only do this if it starts with a - to indicate it's a child.
+  if (
+    substr($variables['element']['#id'], 0, 17) === 'edit-profile-tag-'
+    && substr($variables['element']['#title'], 0, 1) === '-'
+  ) {
+    $variables['title']['#markup'] = substr($variables['title']['#markup'], 1);
   }
 }
 

--- a/modules/social_features/social_profile/src/Plugin/Field/FieldWidget/CategorizedOptionsbuttonsWidget.php
+++ b/modules/social_features/social_profile/src/Plugin/Field/FieldWidget/CategorizedOptionsbuttonsWidget.php
@@ -1,0 +1,207 @@
+<?php
+
+namespace Drupal\social_profile\Plugin\Field\FieldWidget;
+
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Field\Plugin\Field\FieldWidget\OptionsButtonsWidget;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Plugin implementation of the 'categorized_options_buttons' widget.
+ *
+ * TODO: Handle submit to add categories also as tags on user profile.
+ *
+ * @FieldWidget(
+ *   id = "categorized_options_buttons",
+ *   label = @Translation("Categorized check boxes/radio buttons"),
+ *   field_types = {
+ *     "boolean",
+ *     "entity_reference",
+ *     "list_integer",
+ *     "list_float",
+ *     "list_string",
+ *   },
+ *   multiple_values = TRUE
+ * )
+ */
+class CategorizedOptionsbuttonsWidget extends OptionsButtonsWidget {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function formElement(FieldItemListInterface $items, $delta, array $element, array &$form, FormStateInterface $form_state) {
+    $element = parent::formElement($items, $delta, $element, $form, $form_state);
+
+    // We can only overwrite the default behaviour if the user is allowed to
+    // select multiple elements and we have something to choose from.
+    // Otherwise we just default back to default behaviour.
+    if ($this->multiple && !empty($element['#options'])) {
+      $grouped_options = $this->getGroupedOptions($element['#options'], $element['#default_value']);
+
+      // Change the parent type.
+      $element['#type'] = 'container';
+      $element['#attributes']['class'][] = 'checkboxes--nested';
+      unset($element['#options']);
+      unset($element['#default_value']);
+
+      // Used to ensure that we don't need to alter the submit handler too much.
+      $element['#checkbox_categories'] = [];
+      $field_name = $this->fieldDefinition->getName();
+
+      foreach ($grouped_options as $tid => $option) {
+        // If this is a top level element without children then we just treat it
+        // normally.
+        if (empty($option['children'])) {
+          $element += [
+            'label' => [
+              '#type' => 'label',
+              '#title' => $element['#title'],
+            ],
+            'checkboxes' => [
+              '#type' => 'checkboxes',
+              '#default_value' => [],
+              '#options' => [],
+            ],
+          ];
+          $element['checkboxes']['#options'][$tid] = $option['label'];
+          if ($option['selected']) {
+            $element['checkboxes']['#default_value'][] = $tid;
+          }
+        }
+        // Otherwise we just display all children. We don't support more than
+        // a single level of nesting at the moment.
+        else {
+          $children = $this->getTaxonomyChildren($option);
+          $element['#checkbox_categories'][] = $tid;
+          $element[$tid] = [
+            '#type' => 'container',
+            'label' => [
+              '#type' => 'label',
+              '#title' => $option['label'],
+              '#attributes' => [
+                'class' => ['checkboxes__label'],
+              ],
+            ],
+            'checkboxes' => [
+              '#type' => 'checkboxes',
+              '#default_value' => $children['selected'],
+              '#options' => $children['children'],
+            ],
+          ];
+        }
+      }
+    }
+
+    return $element;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function validateElement(array $element, FormStateInterface $form_state) {
+    // Only pre-process the validation if this is a categorized checkbox
+    // element.
+    if (isset($element['#checkbox_categories'])) {
+      // This turns the tree back into a single checkbox element that our parent
+      // widget can handle. We didn't disable value tree submission because it
+      // gives us issues in FormValidator::performRequiredValidation.
+      $element['#value'] = [];
+      $element['#options'] = [];
+      if (isset($element['checkboxes'])) {
+        $element['#value'] += $element['checkboxes']['#value'];
+        $element['#options'] += $element['checkboxes']['#options'];
+      }
+      foreach ($element['#checkbox_categories'] as $tid) {
+        // If a value in a category was checked then those selections are added
+        // but we also select the category itself.
+        if (!empty($element[$tid]['checkboxes']['#value'])) {
+          $element['#value'] += [$tid => $tid];
+          $element['#options'] += [$tid => $tid];
+          $element['#value'] += $element[$tid]['checkboxes']['#value'];
+          $element['#options'] += $element[$tid]['checkboxes']['#options'];
+        }
+      }
+    }
+
+    parent::validateElement($element, $form_state);
+  }
+
+  /**
+   * Group the options with their parent taxonomy terms.
+   *
+   * This makes it easier to arrange them for display later. Relies on a proper
+   * ordering of parent > child from the taxonomy validation.
+   *
+   * @param array $options
+   *   The options to group.
+   * @param array $selected
+   *   The currently selected options.
+   *
+   * @return array
+   *   A tree structure with labels and selection status as leaf values.
+   */
+  protected function getGroupedOptions(array $options, array $selected) {
+    $grouped_options = [];
+
+    foreach ($options as $tid => $label) {
+      // Start at the top for the current element.
+      $group = &$grouped_options;
+
+      // Find the position for this element based on its parent group. If it
+      // contains a dash (-) then it's a child and we find its parent.
+      while (strpos($label, '-') === 0) {
+        // Remove the dash denoting this is a child.
+        $label = substr($label, 1);
+        // Move into the last parent added.
+        end($group);
+        $group = &$group[key($group)]['children'];
+      }
+
+      // This is now a new child to the currently selected parent.
+      $group[$tid] = [
+        'label' => $label,
+        'selected' => in_array($tid, $selected),
+      ];
+    }
+
+    return $grouped_options;
+  }
+
+  /**
+   * Reaches into all children and flattens the taxonomy.
+   *
+   * This method is private for a reason. We don't handle extra nesting yet but
+   * could want to do this in the future. Do not rely on this method existing
+   * in the future.
+   *
+   * @param array $parent
+   *   The parent whose children to recurse through.
+   * @param int $hyphens
+   *   The number of hyphens to use as a label prefix.
+   *
+   * @return array[]
+   *   A flattened array of children.
+   */
+  private function getTaxonomyChildren(array $parent, $hyphens = 0) {
+    $children = [];
+    $selected = [];
+
+    foreach ($parent['children'] as $tid => $child) {
+      $children[$tid] = str_repeat('-', $hyphens) . $child['label'];
+      if ($child['selected']) {
+        $selected[] = $tid;
+      }
+      if (!empty($child['children'])) {
+        $result = $this->getTaxonomyChildren($child, $hyphens + 1);
+        $children += $result['children'];
+        $selected += $result['selected'];
+      }
+    }
+
+    return [
+      'children' => $children,
+      'selected' => $selected,
+    ];
+  }
+
+}

--- a/modules/social_features/social_search/config/install/views.view.search_users.yml
+++ b/modules/social_features/social_search/config/install/views.view.search_users.yml
@@ -267,7 +267,7 @@ display:
           type: select
           limit: true
           vid: profile_tag
-          hierarchy: false
+          hierarchy: true
           error_message: false
           plugin_id: search_api_term
       sorts:
@@ -295,7 +295,7 @@ display:
           empty: true
           tokenize: true
           content:
-            value: '<h4>Member results</h4>'
+            value: '<h4 class="section-title">Member results</h4>'
             format: full_html
           plugin_id: text
       footer: {  }
@@ -406,7 +406,7 @@ display:
           empty: true
           tokenize: true
           content:
-            value: '<h4>Member results</h4>'
+            value: '<h4 class="section-title">Member results</h4>'
             format: basic_html
           plugin_id: text
       defaults:

--- a/modules/social_features/social_search/social_search.module
+++ b/modules/social_features/social_search/social_search.module
@@ -40,15 +40,6 @@ function social_search_form_views_exposed_form_alter(&$form, FormStateInterface 
           $element['#selection_settings']['hide_id'] = TRUE;
         }
       }
-
-      $form['profile_tag']['#options'] = [];
-
-      $terms = \Drupal::entityTypeManager()->getStorage('taxonomy_term')
-        ->loadTree('profile_tag');
-
-      foreach ($terms as $term) {
-        $form['profile_tag']['#options'][$term->tid] = $term->name;
-      }
     }
     if ($form['#id'] == 'views-exposed-form-search-groups-page') {
       $options = [

--- a/modules/social_features/social_search/social_search.module
+++ b/modules/social_features/social_search/social_search.module
@@ -40,6 +40,15 @@ function social_search_form_views_exposed_form_alter(&$form, FormStateInterface 
           $element['#selection_settings']['hide_id'] = TRUE;
         }
       }
+
+      $form['profile_tag']['#options'] = [];
+
+      $terms = \Drupal::entityTypeManager()->getStorage('taxonomy_term')
+        ->loadTree('profile_tag');
+
+      foreach ($terms as $term) {
+        $form['profile_tag']['#options'][$term->tid] = $term->name;
+      }
     }
     if ($form['#id'] == 'views-exposed-form-search-groups-page') {
       $options = [

--- a/themes/socialbase/assets/css/base.css
+++ b/themes/socialbase/assets/css/base.css
@@ -131,7 +131,7 @@ optgroup {
 
 html {
   font-size: 16px;
-  -webkit-tap-highlight-color: transparent;
+  -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
   font-family: sans-serif;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;

--- a/themes/socialbase/assets/css/ckeditor.css
+++ b/themes/socialbase/assets/css/ckeditor.css
@@ -44,7 +44,7 @@ pre code {
 
 html {
   font-size: 16px;
-  -webkit-tap-highlight-color: transparent;
+  -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
   font-family: sans-serif;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;

--- a/themes/socialbase/assets/css/dropdown.css
+++ b/themes/socialbase/assets/css/dropdown.css
@@ -5,7 +5,7 @@
   margin-left: 2px;
   vertical-align: middle;
   border-top: 4px dashed;
-  border-top: 4px solid \9 ;
+  border-top: 4px solid \9 ;
   border-right: 4px solid transparent;
   border-left: 4px solid transparent;
 }
@@ -131,7 +131,7 @@
 .navbar-fixed-bottom .dropdown .caret {
   border-top: 0;
   border-bottom: 4px dashed;
-  border-bottom: 4px solid \9 ;
+  border-bottom: 4px solid \9 ;
   content: "";
 }
 

--- a/themes/socialbase/assets/css/form-elements.css
+++ b/themes/socialbase/assets/css/form-elements.css
@@ -83,6 +83,20 @@ label {
   display: none;
 }
 
+.form-group.checkboxes--nested {
+  outline: red;
+}
+
+.form-group.checkboxes--nested > .form-checkboxes,
+.form-group.checkboxes--nested > .form-group {
+  margin-left: 25px;
+  margin-bottom: .5em;
+}
+
+.form-group.checkboxes--nested .checkboxes__label {
+  margin-bottom: 0;
+}
+
 span.form-required {
   margin: 0 3px;
 }

--- a/themes/socialbase/assets/css/form-elements.css
+++ b/themes/socialbase/assets/css/form-elements.css
@@ -97,6 +97,10 @@ label {
   margin-bottom: 0;
 }
 
+.checkboxes--nested .checkboxes--nested__child + label {
+  margin-left: 25px;
+}
+
 span.form-required {
   margin: 0 3px;
 }

--- a/themes/socialbase/assets/css/nav-tabs.css
+++ b/themes/socialbase/assets/css/nav-tabs.css
@@ -16,7 +16,7 @@
       -ms-user-select: none;
           user-select: none;
   -webkit-touch-callout: none;
-  -webkit-tap-highlight-color: transparent;
+  -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
 }
 
 .nav-tabs > li > a:hover, .nav-tabs > li > a:focus {

--- a/themes/socialbase/assets/css/teaser.css
+++ b/themes/socialbase/assets/css/teaser.css
@@ -182,8 +182,8 @@
     display: block;
     position: absolute;
     content: '';
-    background-image: -webkit-gradient(linear, left top, left bottom, color-stop(40%, transparent), color-stop(70%, rgba(0, 0, 0, 0.1)), to(rgba(34, 34, 34, 0.5)));
-    background-image: linear-gradient(transparent 40%, rgba(0, 0, 0, 0.1) 70%, rgba(34, 34, 34, 0.5) 100%);
+    background-image: -webkit-gradient(linear, left top, left bottom, color-stop(40%, rgba(0, 0, 0, 0)), color-stop(70%, rgba(0, 0, 0, 0.1)), to(rgba(34, 34, 34, 0.5)));
+    background-image: linear-gradient(rgba(0, 0, 0, 0) 40%, rgba(0, 0, 0, 0.1) 70%, rgba(34, 34, 34, 0.5) 100%);
     height: 100%;
     width: 100%;
     left: 0;

--- a/themes/socialbase/components/03-molecules/form-elements/form-elements.scss
+++ b/themes/socialbase/components/03-molecules/form-elements/form-elements.scss
@@ -134,6 +134,21 @@ label {
   display: none;
 }
 
+// Nested checkboxes are indented to show that they belong together.
+.form-group.checkboxes--nested {
+  outline: red;
+
+  & > .form-checkboxes,
+  & > .form-group {
+    margin-left: 25px;
+    margin-bottom: .5em;
+  }
+
+  .checkboxes__label {
+    margin-bottom: 0;
+  }
+}
+
 // Indication on labels for required fields
 span.form-required {
   margin: 0 3px;

--- a/themes/socialbase/components/03-molecules/form-elements/form-elements.scss
+++ b/themes/socialbase/components/03-molecules/form-elements/form-elements.scss
@@ -149,6 +149,11 @@ label {
   }
 }
 
+// In the search filter they do not appear in a form-group.
+.checkboxes--nested .checkboxes--nested__child + label {
+  margin-left: 25px;
+}
+
 // Indication on labels for required fields
 span.form-required {
   margin: 0 3px;


### PR DESCRIPTION
## Problem
Taxonomy terms sorting by IDs.

## Solution
Sort taxonomy terms by weight and name.

## Issue tracker
https://www.drupal.org/project/social/issues/3028153

## Release notes
It's now possible to create multiple levels of Profile Tags. Similarly to content tagging the top level taxonomy term can now be used as a category by giving it children. When only a single level of profile tags exist the current behaviour will be preserved. When a user receives a taxonomy term in a category then they will also receive the tag of the category itself to facilitate searching.