### PR TITLE
Issue #3024352 - do not override existing services as it will break comment upload

### DIFF
--- a/modules/social_features/social_profile/modules/social_profile_organization_tag/social_profile_organization_tag.services.yml
+++ b/modules/social_features/social_profile/modules/social_profile_organization_tag/social_profile_organization_tag.services.yml
@@ -1,5 +1,5 @@
 services:
-  social_comment_upload.override:
+  social_profile_organization_tag.override:
     class: \Drupal\social_profile_organization_tag\SocialProfileOrgTagConfigOverride
     tags:
       - {name: config.factory.override, priority: 5}


### PR DESCRIPTION
## Problem
When social comment upload is enabled I can't see the attachment upload on the comment form. This happens when social_profile_organization_tag is enabled.

## Solution
The social_profile_organization_tag.services.yml contains a service which already exist. I've renamed this to a different override function.

## Issue tracker
https://www.drupal.org/project/social/issues/3024352

## How to test
- [x] Enable social_comment_upload module
- [x] Go to a node and see that you can upload attachments to nodes.
- [x] Enable social_profile_organization_tag and notice you can't anymore.
- [x] Switch to this branch and notice all is fine.
- [x] Check code changes.

## Release notes
The attachment upload are not working correctly when the optional Profile Organization Tag was also enabled. This has been solved now.