### PR TITLE
Issue #3027339: The 'pill badge' style is not working properly in text editors

### DIFF
--- a/modules/social_features/social_editor/config/install/editor.editor.full_html.yml
+++ b/modules/social_features/social_editor/config/install/editor.editor.full_html.yml
@@ -59,7 +59,7 @@ settings:
     language:
       language_list: un
     stylescombo:
-      styles: "a.btn.btn-default|Default link\r\na.btn.btn-primary|Primary link\r\na.btn.btn-accent|Accent link\r\nspan.badge.badge-primary|Primary badge\r\nspan.badge.badge-secondary|Secondary badge\r\nspan.badge.badge-pill|Pill badge"
+      styles: "a.btn.btn-default|Default link\r\na.btn.btn-primary|Primary link\r\na.btn.btn-accent|Accent link\r\nspan.badge.badge-primary|Primary badge\r\nspan.badge.badge-secondary|Secondary badge\r\nspan.badge.badge--pill.badge-default|Pill badge"
 image_upload:
   status: true
   scheme: public


### PR DESCRIPTION
## Problem
After configuring text into 'pill badge' style in text editors, it shows blank white after saving it. So the text is actually not visible anymore.
This is due to the fact the incorrect classes are applied.

## Solution
Use other CSS classes for **Pill badge** CKEditor style for fix showing text with this style as invisible.

## Issue tracker
https://www.drupal.org/project/social/issues/3027339

## How to test
- [ ] Create a topic.
- [ ] Add some text to the "Description" field.
- [ ] Apply the "Pill badge" CKEditor style for some phrase in the description.
- [ ] When you save topic then you should not see the styled phrase in the text of the description.

## Release notes
Make text visible when it used "Pill badge" CKEditor style.
