### PR TITLE
DS-6367 - Adding members to groups in bulk #52395

### DIFF
--- a/modules/social_features/social_group/social_group.module
+++ b/modules/social_features/social_group/social_group.module
@@ -1221,6 +1221,16 @@ function social_group_get_all_open_groups() {
 }
 
 /**
+ * Get all open groups.
+ */
+function social_group_get_all_groups() {
+  $query = Drupal::service('entity.query')
+    ->get('group')
+    ->sort('type');
+  return $query->execute();
+}
+
+/**
  * Get all group memberships for a certain user.
  *
  * @param int $uid

--- a/modules/social_features/social_group/social_group.services.yml
+++ b/modules/social_features/social_group/social_group.services.yml
@@ -24,3 +24,7 @@ services:
     class: \Drupal\social_group\SocialGroupSelectorWidgetConfigOverride
     tags:
       - {name: config.factory.override, priority: 10}
+  social_group.admin_people_override:
+    class: \Drupal\social_group\SocialGroupAdminPeopleConfigOverride
+    tags:
+    - {name: config.factory.override, priority: 10}

--- a/modules/social_features/social_group/src/Plugin/Action/AddMembersToGroup.php
+++ b/modules/social_features/social_group/src/Plugin/Action/AddMembersToGroup.php
@@ -82,11 +82,11 @@ class AddMembersToGroup extends ViewsBulkOperationsActionBase implements Contain
       if (!$is_member) {
         $group->addMember($entity);
 
-        return $this->t('Amount of users added to Group');
+        return $this->t('Amount of users added to group');
       }
 
       // Return this when user is already a member.
-      return $this->t('Amount of users added already a member');
+      return $this->t('Amount of existing members');
     }
 
     // Fail safe if something went wrong.

--- a/modules/social_features/social_group/src/Plugin/Action/AddMembersToGroup.php
+++ b/modules/social_features/social_group/src/Plugin/Action/AddMembersToGroup.php
@@ -137,7 +137,6 @@ class AddMembersToGroup extends ViewsBulkOperationsActionBase implements Contain
       '#markup' => $markup,
     ];
 
-
     // Empty the options so we don't have a massive list of users.
     unset($form['list']);
 

--- a/modules/social_features/social_group/src/Plugin/Action/AddMembersToGroup.php
+++ b/modules/social_features/social_group/src/Plugin/Action/AddMembersToGroup.php
@@ -71,45 +71,48 @@ class AddMembersToGroup extends ViewsBulkOperationsActionBase implements Contain
    * {@inheritdoc}
    */
   public function execute($entity = NULL) {
-    $role = $this->configuration['role'];
-    $is_member = $this->configuration['is_member'];
-    $update = TRUE;
-    $value = [];
 
-    /** @var \Drupal\group\Entity\GroupTypeInterface $group_type */
-    $group_type = $this->storage->load($id)->getGroupType();
+  $x = 1;
 
-    $roles = $group_type->getRoles(FALSE);
-    $id = $group_type->getMemberRoleId();
-    $roles[$id] = $group_type->getMemberRole();
+//    $role = $this->configuration['role'];
+//    $is_member = $this->configuration['is_member'];
+//    $update = TRUE;
+//    $value = [];
+//
+//    /** @var \Drupal\group\Entity\GroupTypeInterface $group_type */
+//    $group_type = $this->storage->load($id)->getGroupType();
+//
+//    $roles = $group_type->getRoles(FALSE);
+//    $id = $group_type->getMemberRoleId();
+//    $roles[$id] = $group_type->getMemberRole();
+//
+//    /** @var \Drupal\group\Entity\GroupContentInterface $entity */
+//    /** @var \Drupal\Core\Field\EntityReferenceFieldItemListInterface $roles */
+//    $roles = &$entity->get('group_roles');
+//
+//    if ($roles->isEmpty() && $is_member) {
+//      $update = FALSE;
+//    }
+//    elseif (!$roles->isEmpty() && !$is_member) {
+//      $value = $roles->getValue();
+//
+//      foreach ($value as $item) {
+//        if ($item['target_id'] === $role) {
+//          $update = FALSE;
+//          break;
+//        }
+//      }
+//    }
+//
+//    if ($update) {
+//      if (!$is_member) {
+//        $value[] = ['target_id' => $role];
+//      }
+//
+//      $entity->set('group_roles', $value)->save();
+//    }
 
-    /** @var \Drupal\group\Entity\GroupContentInterface $entity */
-    /** @var \Drupal\Core\Field\EntityReferenceFieldItemListInterface $roles */
-    $roles = &$entity->get('group_roles');
-
-    if ($roles->isEmpty() && $is_member) {
-      $update = FALSE;
-    }
-    elseif (!$roles->isEmpty() && !$is_member) {
-      $value = $roles->getValue();
-
-      foreach ($value as $item) {
-        if ($item['target_id'] === $role) {
-          $update = FALSE;
-          break;
-        }
-      }
-    }
-
-    if ($update) {
-      if (!$is_member) {
-        $value[] = ['target_id' => $role];
-      }
-
-      $entity->set('group_roles', $value)->save();
-    }
-
-    return $this->t('Change roles');
+    return $this->t('Add to Group');
   }
 
   /**
@@ -142,9 +145,22 @@ class AddMembersToGroup extends ViewsBulkOperationsActionBase implements Contain
       $options[$group_type->label()][$group->id()] = $group->label();
     }
 
+    $markup = $this->formatPlural($this->context['selected_count'],
+      'Please select the group you want to add the member you have selected to',
+      'Please select the group you want to add the @count members you have selected to'
+    );
+
+    $form['description'] = [
+      '#markup' => $markup,
+    ];
+
+
+    // Empty the options so we don't have a massive list of users.
+    unset($form['list']);
+
     $form['groups'] = [
       '#type' => 'select',
-      '#title' => $this->t('Groups'),
+      '#title' => $this->t('Group'),
       '#options' => $options,
     ];
 

--- a/modules/social_features/social_group/src/Plugin/Action/AddMembersToGroup.php
+++ b/modules/social_features/social_group/src/Plugin/Action/AddMembersToGroup.php
@@ -1,0 +1,159 @@
+<?php
+
+namespace Drupal\social_group\Plugin\Action;
+
+use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\Plugin\PluginFormInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\group\Entity\Group;
+use Drupal\group\Entity\GroupContentInterface;
+use Drupal\views_bulk_operations\Action\ViewsBulkOperationsActionBase;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Change group membership role.
+ *
+ * @Action(
+ *   id = "social_group_add_members_to_group_action",
+ *   label = @Translation("Add members to group"),
+ *   type = "user",
+ *   confirm = TRUE,
+ * )
+ */
+class AddMembersToGroup extends ViewsBulkOperationsActionBase implements ContainerFactoryPluginInterface, PluginFormInterface {
+
+  /**
+   * The group storage.
+   *
+   * @var \Drupal\Core\Entity\EntityStorageInterface
+   */
+  protected $storage;
+
+  /**
+   * Constructs a ViewsBulkOperationSendEmail object.
+   *
+   * @param array $configuration
+   *   A configuration array containing information about the plugin instance.
+   * @param string $plugin_id
+   *   The plugin ID for the plugin instance.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager.
+   */
+  public function __construct(
+    array $configuration,
+    $plugin_id,
+    $plugin_definition,
+    EntityTypeManagerInterface $entity_type_manager
+  ) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+
+    $this->storage = $entity_type_manager->getStorage('group');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('entity_type.manager')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function execute($entity = NULL) {
+    $role = $this->configuration['role'];
+    $is_member = $this->configuration['is_member'];
+    $update = TRUE;
+    $value = [];
+
+    /** @var \Drupal\group\Entity\GroupTypeInterface $group_type */
+    $group_type = $this->storage->load($id)->getGroupType();
+
+    $roles = $group_type->getRoles(FALSE);
+    $id = $group_type->getMemberRoleId();
+    $roles[$id] = $group_type->getMemberRole();
+
+    /** @var \Drupal\group\Entity\GroupContentInterface $entity */
+    /** @var \Drupal\Core\Field\EntityReferenceFieldItemListInterface $roles */
+    $roles = &$entity->get('group_roles');
+
+    if ($roles->isEmpty() && $is_member) {
+      $update = FALSE;
+    }
+    elseif (!$roles->isEmpty() && !$is_member) {
+      $value = $roles->getValue();
+
+      foreach ($value as $item) {
+        if ($item['target_id'] === $role) {
+          $update = FALSE;
+          break;
+        }
+      }
+    }
+
+    if ($update) {
+      if (!$is_member) {
+        $value[] = ['target_id' => $role];
+      }
+
+      $entity->set('group_roles', $value)->save();
+    }
+
+    return $this->t('Change roles');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function access($object, AccountInterface $account = NULL, $return_as_object = FALSE) {
+    if ($object instanceof GroupContentInterface && $object->getContentPlugin()->getPluginId() === 'group_membership') {
+      $access = $object->access('update', $account, TRUE);
+    }
+    else {
+      $access = AccessResult::forbidden();
+    }
+
+    return $return_as_object ? $access : $access->isAllowed();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildConfigurationForm(array $form, FormStateInterface $form_state) {
+    $form['#title'] = $this->formatPlural($this->context['selected_count'], 'Add selected member to a group', 'Add @count selected members to a group');
+
+    $groups = Group::loadMultiple(social_group_get_all_groups());
+
+    $options = [];
+    // Grab all the groups, sorted by group type for the select list.
+    foreach ($groups as $group) {
+      /** @var \Drupal\group\Entity\GroupTypeInterface $group_type */
+      $group_type = $group->getGroupType();
+      $options[$group_type->label()][$group->id()] = $group->label();
+    }
+
+    $form['groups'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Groups'),
+      '#options' => $options,
+    ];
+
+    $form['actions']['submit']['#value'] = $this->t('Add to Group');
+
+    $form['actions']['submit']['#attributes']['class'] = ['button button--primary js-form-submit form-submit btn js-form-submit btn-raised btn-primary waves-effect waves-btn waves-light'];
+    $form['actions']['cancel']['#attributes']['class'] = ['button button--danger btn btn-flat waves-effect waves-btn'];
+
+    return $form;
+  }
+
+}

--- a/modules/social_features/social_group/src/SocialGroupAdminPeopleConfigOverride.php
+++ b/modules/social_features/social_group/src/SocialGroupAdminPeopleConfigOverride.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Drupal\social_group;
+
+use Drupal\Core\Cache\CacheableMetadata;
+use Drupal\Core\Config\ConfigFactoryOverrideInterface;
+use Drupal\Core\Config\StorageInterface;
+
+/**
+ * Class SocialGroupAdminPeopleConfigOverride.
+ *
+ * @package Drupal\social_group
+ */
+class SocialGroupAdminPeopleConfigOverride implements ConfigFactoryOverrideInterface {
+
+  /**
+   * Load overrides.
+   */
+  public function loadOverrides($names) {
+    $overrides = [];
+
+    $config_name = 'views.view.user_admin_people';
+
+    // Add AddMembersToGroup to VBO Admin people.
+    if (in_array($config_name, $names)) {
+      $overrides[$config_name] = [
+        'display' => [
+          'default' => [
+            'display_options' => [
+              'fields' => [
+                'views_bulk_operations_bulk_form' => [
+                  'selected_actions' => [
+                    'social_group_add_members_to_group_action' => 'social_group_add_members_to_group_action',
+                  ],
+                ],
+              ],
+            ],
+          ],
+        ],
+      ];
+    }
+
+    return $overrides;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCacheSuffix() {
+    return 'SocialGroupAdminPeopleConfigOverride';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCacheableMetadata($name) {
+    return new CacheableMetadata();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function createConfigObject($name, $collection = StorageInterface::DEFAULT_COLLECTION) {
+    return NULL;
+  }
+
+}


### PR DESCRIPTION
## Problem
There is no easy way for a SiteManager to quickly add multiple people to a group. 

## Solution
Add a new VBO plugin for the `admin/people` overview which enables adding one or more users to a group.

## Issue tracker
https://jira.goalgorilla.com/browse/DS-6367

## How to test
- [x] Login as SM
- [x] Go to `admin/people`
- [x] See that there is now a new _Add members to group_ action
- [x] See that when you select one or more members the users get added to a Group you selected. Scope for now is to not make roles possible, so users you select will become a member. Also only 1 Group is possible for now. 
- [x] See that the user(s) get added to the group
- [x] Go to the `admin/people` overview again, select all users and add them to a group
- [x] See that you get a message that at least one or more users are already part of the group and the rest is added.

## Release notes
As a Site Manager you are now able to add users to a group directly from the People overview.