### PR TITLE
Issue #3034318 by jaapjan: prevent Notifications 500 errors after upd…

### DIFF
--- a/modules/custom/activity_creator/activity.page.inc
+++ b/modules/custom/activity_creator/activity.page.inc
@@ -7,6 +7,7 @@
  * Page callback for Activity entities.
  */
 
+use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Render\Element;
 use Drupal\file\Entity\File;
 use Drupal\Core\Link;
@@ -54,9 +55,9 @@ function template_preprocess_activity(array &$variables) {
     /** @var \Drupal\Core\Entity\EntityInterface $entity */
     $entity = reset($entities);
 
-    if ($entity && $entity->getEntityTypeId() === 'group_content') {
+    if ($entity instanceof EntityInterface && $entity->getEntityTypeId() === 'group_content') {
       /** @var \Drupal\group\Entity\GroupContentInterface $entity */
-      if ($entity->getGroupContentType()->getContentPluginId() === 'group_membership' && $entity->getEntity()->id() != $activity->getOwnerId()) {
+      if ($entity->getGroupContentType()->getContentPluginId() === 'group_membership' && $entity->getEntity()->id() !== $activity->getOwnerId()) {
         $account = $entity->getEntity();
       }
     }

--- a/modules/custom/activity_creator/activity.page.inc
+++ b/modules/custom/activity_creator/activity.page.inc
@@ -49,19 +49,16 @@ function template_preprocess_activity(array &$variables) {
   }
   $variables['#cache']['max-age'] = $created_time_ago->getMaxAge();
 
-  // To change user picture settings (e.g. image style), edit the
-  // 'compact_notification' view mode on the User entity. Note that the
-  // 'compact_notification' view mode might not be configured, so remember to
-  // always check the theme setting first.
   $entities = $activity->field_activity_entity->referencedEntities();
+  if (!empty($entities)) {
+    /** @var \Drupal\Core\Entity\EntityInterface $entity */
+    $entity = reset($entities);
 
-  /** @var \Drupal\Core\Entity\EntityInterface $entity */
-  $entity = reset($entities);
-
-  if ($entity->getEntityTypeId() === 'group_content') {
-    /** @var \Drupal\group\Entity\GroupContentInterface $entity */
-    if ($entity->getGroupContentType()->getContentPluginId() === 'group_membership' && $entity->getEntity()->id() != $activity->getOwnerId()) {
-      $account = $entity->getEntity();
+    if ($entity && $entity->getEntityTypeId() === 'group_content') {
+      /** @var \Drupal\group\Entity\GroupContentInterface $entity */
+      if ($entity->getGroupContentType()->getContentPluginId() === 'group_membership' && $entity->getEntity()->id() != $activity->getOwnerId()) {
+        $account = $entity->getEntity();
+      }
     }
   }
 
@@ -69,6 +66,10 @@ function template_preprocess_activity(array &$variables) {
     $account = $activity->getOwner();
   }
 
+  // To change user picture settings (e.g. image style), edit the
+  // 'compact_notification' view mode on the User entity. Note that the
+  // 'compact_notification' view mode might not be configured, so remember to
+  // always check the theme setting first.
   if ($account) {
     $storage = \Drupal::entityTypeManager()->getStorage('profile');
     if (!empty($storage)) {


### PR DESCRIPTION
## Problem
500 errors on certain platforms after the 4.4 update because referenced entities can't be found.

## Solution
More defensive coding by first checking if the entity exist before calling method on it.

## Issue tracker
https://drupal.org/node/3034318

## How to test
- [ ] Open old platform as group manager.
- [ ] Notice site works as expected

## Release notes

