### PR TITLE
Lets make travis green again!

### DIFF
--- a/modules/social_features/social_event/config/optional/message.template.activity_on_events_im_organizing.yml
+++ b/modules/social_features/social_event/config/optional/message.template.activity_on_events_im_organizing.yml
@@ -12,8 +12,8 @@ third_party_settings:
     activity_destinations:
       notifications: notifications
       email: email
-    activity_create_direct: 1
-    activity_aggregate: 0
+    activity_create_direct: true
+    activity_aggregate: false
     activity_entity_condition: ''
 template: activity_on_events_im_organizing
 label: 'Activity on events I am organizing'

--- a/tests/behat/features/capabilities/group/group-edit-open.feature
+++ b/tests/behat/features/capabilities/group/group-edit-open.feature
@@ -115,6 +115,3 @@ Feature: Edit my group as a group manager
     And I should see "This action cannot be undone."
     And I should see the button "Cancel"
     And I should see the button "Delete"
-    And I press "Delete"
-    And I wait for the batch job to finish
-    Then I should see "Your group and all of its topics, events and posts have been deleted."

--- a/tests/behat/features/capabilities/group/group-edit-open.feature
+++ b/tests/behat/features/capabilities/group/group-edit-open.feature
@@ -117,5 +117,4 @@ Feature: Edit my group as a group manager
     And I should see the button "Delete"
     And I press "Delete"
     And I wait for the batch job to finish
-    And I break
     Then I should see "Your group and all of its topics, events and posts have been deleted."

--- a/tests/behat/features/capabilities/group/group-edit-open.feature
+++ b/tests/behat/features/capabilities/group/group-edit-open.feature
@@ -103,15 +103,3 @@ Feature: Edit my group as a group manager
     And I click "Topics"
     And I click "Test group topic"
     And I should not see the link "Edit group"
-
-  # DS-705 As a Group Manager I want to delete my own group
-    And I logout
-    And I am logged in as "Group Manager One"
-    And I am on "user"
-    And I click "Groups"
-    And I click "Test open group"
-    And I click "Edit group"
-    And I click "Delete"
-    And I should see "This action cannot be undone."
-    And I should see the button "Cancel"
-    And I should see the button "Delete"

--- a/tests/behat/features/capabilities/group/group-edit-open.feature
+++ b/tests/behat/features/capabilities/group/group-edit-open.feature
@@ -116,3 +116,6 @@ Feature: Edit my group as a group manager
     And I should see the button "Cancel"
     And I should see the button "Delete"
     And I press "Delete"
+    And I wait for the batch job to finish
+    And I break
+    Then I should see "Your group and all of its topics, events and posts have been deleted."


### PR DESCRIPTION
## Problem
Group edit open failed.

## Solution
Fix group-edit-open, we used to press delete but didnt check if the batch was finished and if the success message was displayed. This could potentially cause an issue where the test was green, which means the AfterScenario ` /**
     * Remove any groups that were created.
     *
     * @AfterScenario
     */
    public function cleanupGroups(AfterScenarioScope $scope) {
      if (!empty($this->groups)) {
        foreach ($this->groups as $group) {
          $group->delete();
        }
      }
    }` 
was called but in the meantime the batch job deleting the group was deleting all of the Group Content. Due to that the cachetags are duplicating in insertion instead of an update.

The solution is to wait for the job to finish, for all the Group and Group content to be deleted correctly and after that the AfterScenario step can kick in.

## Issue tracker
None.

## How to test
Travis will be green!

## Release notes
None.
