### PR TITLE
Issue #3024448: html in pop-up for anonymous event enrolment

### DIFF
--- a/modules/social_features/social_event/modules/social_event_an_enroll/src/Form/EventAnEnrollActionForm.php
+++ b/modules/social_features/social_event/modules/social_event_an_enroll/src/Form/EventAnEnrollActionForm.php
@@ -92,7 +92,7 @@ class EventAnEnrollActionForm extends EnrollActionForm {
           ],
           'data-dialog-type' => 'modal',
           'data-dialog-options' => json_encode([
-            'title' => t('Enroll in @event Event', ['@event' => $node->getTitle()]),
+            'title' => t('Enroll in') . ' ' . strip_tags($node->getTitle()),
             'width' => 'auto',
           ]),
         ];


### PR DESCRIPTION
## Problem
HTML in pop-up for anonymous event enrolment. 

## Solution
I followed this solution in Core
https://www.drupal.org/project/drupal/issues/2568149#comment-10327469

## Issue tracker
https://www.drupal.org/project/social/issues/3024448

## How to test
- [ ] Enable social_event_an_enroll
- [ ] Create public event with title `New year's party` or similar and enable anonymous event enrolment as well for that event.
- [ ] Open the event as anonymous user.
- [ ] Click on enrol button and notice the nice title as expected.

## Release notes
If an event title included any special characters (for example an apostrophe `) it would not display correctly in the pop-up window which anonymous users see after clicking on the "Enrol" button. This is now solved.