### PR TITLE
Issue #3029643: teasers for topics and event body text.

### DIFF
--- a/themes/socialbase/templates/node/event/node--event--teaser.html.twig
+++ b/themes/socialbase/templates/node/event/node--event--teaser.html.twig
@@ -26,4 +26,10 @@
     {% endembed %}
   {% endif %}
 
+  {% if content.body %}
+    {% embed "node--teaser__body.html.twig" %}
+      {% block field_body %} {{ content.body }} {% endblock %}
+    {% endembed %}
+  {% endif %}
+
 {% endblock %}

--- a/themes/socialbase/templates/node/topic/node--topic--teaser.html.twig
+++ b/themes/socialbase/templates/node/topic/node--topic--teaser.html.twig
@@ -26,4 +26,10 @@
     {% endembed %}
   {% endif %}
 
+  {% if content.body %}
+    {% embed "node--teaser__body.html.twig" %}
+      {% block field_body %} {{ content.body }} {% endblock %}
+    {% endembed %}
+  {% endif %}
+
 {% endblock %}


### PR DESCRIPTION
## Problem
When a body text is enabled in the teaser display of an event or topic it is not displayed in the actual teaser. The field is missing in the twig template.

## Solution
Add the field in the twig file.

## Issue tracker
https://www.drupal.org/project/social/issues/3029643

## How to test
- [x] Enable description field display for topic and event on the Node display settings. Play around with trimmed/summary settings as well.
- [x] Go to /all-topics or the upcoming events and check the teaser displays.
- [x] Remove the field from the display again, notice that it is not displayed accordingly.

## Release notes
When a body text is enabled in the teaser display of an event or topic it is now displayed in the actual teaser as it is added in the teaser template.