### PR TITLE
Issue #2992737: fix translation of the bundle in like modal title

### DIFF
--- a/modules/social_features/social_like/social_like.module
+++ b/modules/social_features/social_like/social_like.module
@@ -70,20 +70,23 @@ function social_like_invalidate_cache(EntityInterface $entity) {
  */
 function social_like_preprocess_like_and_dislike_icons(&$variables) {
   $bundle = $variables['entity_type'];
-  if ($variables['entity_type'] === 'node') {
-    $bundle = \Drupal::entityTypeManager()->getStorage($variables['entity_type'])->load($variables['entity_id'])->bundle();
-  }
+  if ($entity = \Drupal::entityTypeManager()->getStorage($variables['entity_type'])->load($variables['entity_id'])) {
+    $bundle = $entity->bundle();
 
-  if ($variables['entity_type'] === 'comment') {
-    /** @var \Drupal\comment\Entity\Comment $entity */
-    $entity = \Drupal::entityTypeManager()->getStorage($variables['entity_type'])->load($variables['entity_id']);
+    $entity_type = $entity->getEntityType();
+    $entity_type_bundle_info = \Drupal::service('entity_type.bundle.info');
+    $entity_bundles = $entity_type_bundle_info->getBundleInfo($entity_type->id());
 
-    // If the comment is unpublished disable voting.
-    if (!$entity->isPublished()) {
+    if (array_key_exists($bundle, $entity_bundles)) {
+      $bundle = $entity_bundles[$bundle]['label'];
+    }
+
+    // If the entity is unpublished and of type comment disable voting.
+    if (!$entity->isPublished() && $entity->getEntityTypeId() === 'comment') {
       $variables['like_attributes']->addClass('disable-status');
       $variables['dislike_attributes']->addClass('disable-status');
     }
-  }
 
-  $variables['modal_title'] = t('Members who liked this @content', ['@content' => $bundle]);
+  }
+  $variables['modal_title'] = t('Members who liked this @content', ['@content' => strtolower($bundle)]);
 }


### PR DESCRIPTION
## Problem
The bundle in the title in the like modal window is untranslatable.

## Solution
Let's make it translatable. Best is to retrieve the bundle settings and retrieve the label from there. The bundle settings label respect the current active language and the label is always the label from the configuration translation of the current bundle.

## Issue tracker
https://www.drupal.org/project/social/issues/2992737

## How to test
- [x] Enable social_language and dependencies
- [x] Add a language
- [x] Go to `/admin/structure/types/manage/topic/translate` and add translation for the new language there.
- [x] Go to a topic and open the like modal window. Verify the word "topic" is translated correctly.
- [x] Now check comments, posts, other entity types as well. Verify it all still works as expected.
- [x] Check code changes.

## Release notes
The entity type in a like modal window is now showing the translated word in multi-language sites.