### PR TITLE
Issue #3035592: make sure event exists before calling toUrl method on it

### DIFF
--- a/modules/social_features/social_event/social_event.tokens.inc
+++ b/modules/social_features/social_event/social_event.tokens.inc
@@ -108,11 +108,15 @@ function get_link_to_event_from_enrollment($object_id, $as_link = FALSE) {
     /** @var \Drupal\node\Entity\Node $event */
     $event = $storage->load($event_id);
 
-    if ($as_link) {
-      return $event->toUrl('canonical')->toString();
+    // Check if the event still exists.
+    if ($event !== NULL) {
+      if ($as_link) {
+        return $event->toUrl('canonical')->toString();
+      }
+
+      return Link::fromTextAndUrl($event->getTitle(), $event->toUrl('canonical'))->toString();
     }
 
-    return Link::fromTextAndUrl($event->getTitle(), $event->toUrl('canonical'))->toString();
   }
 
   return NULL;


### PR DESCRIPTION
## Problem
When you create an event as LU, enrol to the event yourself, let some other people enrol to your event, run the cron and then delete the event you will receive a 500 error when trying to load your notification bar resulting in a non-working website.

## Solution
Let's add an extra check before blindly calling the toUrl() method on an object which might be NULL.

## Issue tracker
https://www.drupal.org/project/social/issues/3035592

## How to test
- [ ] Check code
- [ ] Stay on the 4.x branch
- [ ] Create event
- [ ] Signup to event (yourself and/or maybe others)
- [ ] Run cron few times (at least make sure you have a notification about an event signup to that event in your notification bar - https://github.com/goalgorilla/open_social/pull/1138)
- [ ] Delete the event
- [ ] Notice you receive an unexpected error immediately
- [ ] Switch to this feature branch.
- [ ] Retry above steps and notice it works now (or just refresh the page)

## Release notes
If an event was deleted and an event organizer received a notification for it this could result in an error on the page/your stream not loading correctly. This is now solved.
