### PR TITLE
Remove geolocation code for search block

### DIFF
--- a/themes/socialbase/src/Plugin/Preprocess/Block.php
+++ b/themes/socialbase/src/Plugin/Preprocess/Block.php
@@ -130,9 +130,7 @@ class Block extends PreprocessBase {
 
     // Add search_block to main menu.
     if (\Drupal::moduleHandler()->moduleExists('social_search') && ($variables['elements']['#id'] == 'mainnavigation' || $variables['elements']['#id'] == $prefix . '_mainnavigation')) {
-      $block_id = \Drupal::moduleHandler()
-        ->moduleExists('social_geolocation') ? 'geolocation_search_content_block_header' : 'search_content_block_header';
-      $block = BlockEntity::load($block_id);
+      $block = BlockEntity::load('search_content_block_header');
 
       if (!empty($block)) {
         $block_output = \Drupal::entityManager()


### PR DESCRIPTION
<h2>Problem</h2>

For the social geolocation module some code was added to load a replacement search block if the module was enabled. This search block has been removed long ago but the code was never removed. This now causes the search to be come unavailable in the menu bar when the social_geolocation module is enabled.

<h2>Solution</h2>
Remove the logic for replacing the search block and always load the theme's search block.

This code was added long ago in 09319ab but the module has since been
removed from Open Social and used in another project. In this other
project the block that was referenced to has been removed because it was
no longer needed. Finally the module was re-introduced as a stand-alone
extension when it was extracted from the project. This has surfaced the
bug that this code now causes.

## Issue tracker
https://www.drupal.org/project/social/issues/3038249

## How to test
- [x] Install the social_geolocation module and verify that search still works from the navbar
- [x] Verify that search works from the navbar without geolocation module

## Release notes
Using the social_geolocation module with an Open Social installation could cause the search to go missing from the navbar. We've located the search and taught it not to be afraid of the geolocation module.
