### PR TITLE
Issue #3038770 by truls1502: Update bower-asset/bootstrap from v3.4.0 to v3.4.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -129,7 +129,7 @@
         "bower-asset/tablesaw": "~3.1.0",
         "bower-asset/morris.js": "0.5.1",
         "bower-asset/raphael": "2.2.7",
-        "bower-asset/bootstrap": "3.4.0",
+        "bower-asset/bootstrap": "v3.4.1",
         "bower-asset/select2": "~4.0.5",
         "bower-asset/autosize": "~4.0.2",
         "bower-asset/d3": "v3.5.17",


### PR DESCRIPTION
## Problem & Solution
Update to the latest version

## Issue tracker
https://www.drupal.org/project/social/issues/3038770

## Release notes
Update bower-asset/bootstrap from v3.4.0 to v3.4.1
