### PR TITLE
Issue #3039063 by Kingdutch: Add styling for node content_lock unlock button

### DIFF
--- a/themes/socialbase/includes/form.inc
+++ b/themes/socialbase/includes/form.inc
@@ -406,6 +406,13 @@ function socialbase_form_node_form_alter(&$form, FormStateInterface $form_state,
     $form['actions']['delete']['#attributes']['class'][] = 'btn btn-flat';
   }
 
+  // Unlock is not an input element, so we must apply extra classes
+  // to anchor directly.
+  if (isset($form['actions']['unlock'])) {
+    $form['actions']['unlock']['#attributes']['class'][] = 'btn';
+    $form['actions']['unlock']['#attributes']['class'][] = 'btn-flat';
+  }
+
   if (isset($form['actions']['preview'])) {
     $form['actions']['preview']['#button_type'] = 'flat';
   }


### PR DESCRIPTION
<h2>Problem</h2>
The content_lock module adds an "unlock" action to nodes. This should be styled like the other secondary actions.

<h2>Solution</h2>
Add the btn, btn-flat classes to the "unlock" link in socialbase if the link exists.

## Issue tracker
https://www.drupal.org/project/social/issues/3039063

## How to test
- [x] Install the content_lock module
- [x] Enable it for a node
- [x] Check the "unlock" link is correctly styled.

## Release notes
The unlock link added by the content_lock module will now be correctly styled when used with a theme inheriting from socialbase.
