### PR TITLE
Issue #2946146 by Kingdutch, sukh.singh: Don't run entity queries for…

### DIFF
--- a/modules/custom/activity_creator/activity_creator.module
+++ b/modules/custom/activity_creator/activity_creator.module
@@ -7,6 +7,7 @@
 
 use Drupal\message\Entity\Message;
 use Drupal\Core\Cache\Cache;
+use Drupal\Core\Config\Entity\ConfigEntityInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\Display\EntityViewDisplayInterface;
 use Drupal\activity_creator\Entity\Activity;
@@ -255,6 +256,15 @@ function _activity_creator_activity_for_entity_updater($action, EntityInterface 
   if ($entity !== NULL) {
     $entity_type = $entity->getEntityTypeId();
     $entity_id = $entity->id();
+
+    // We never create activities for configuration entities but accessing
+    // entity queries during configuration changes may cause errors.
+    if ($entity instanceof ConfigEntityInterface) {
+      return;
+    }
+
+    // TODO: The if statement below can be refactored after the code that was
+    // added above but we didn't have time for that yet.
     if ($entity_type !== 'activity') {
 
       $entity_query = \Drupal::entityQuery('activity');


### PR DESCRIPTION
… activities during configuration entity modification.


## Problem
Activities should never be created for config entities (they notify of
content). However, in certain cases (feature reverts, module uninstall,
update hooks) it can cause issues when an entity query is executed for
activities during a configuration change.

This can cause fatal errors during things such as update hooks, feature imports and module uninstalls.

## Solution
The easiest way is to just stop doing things when we're triggered for a configuration entity.

## Issue tracker
https://www.drupal.org/project/social/issues/2946146

## How to test
- [ ] Uninstall the activity_creator module

## Release notes
Configuration changes could sometimes trigger an error in the activity_creator module due to transitive field configuration. This has been resolved by no longer trying to process activities as a result of a configuration change. This solution relies on the fact that activities were only supported for content changes.
