### PR TITLE
3039042: Member tab in group shows the same members on the second page

### DIFF
--- a/modules/social_features/social_group/config/install/views.view.group_members.yml
+++ b/modules/social_features/social_group/config/install/views.view.group_members.yml
@@ -48,7 +48,7 @@ display:
           sort_asc_label: Asc
           sort_desc_label: Desc
       pager:
-        type: mini
+        type: full
         options:
           items_per_page: 10
           offset: 0
@@ -57,6 +57,8 @@ display:
           tags:
             previous: ‹‹
             next: ››
+            first: '« First'
+            last: 'Last »'
           expose:
             items_per_page: false
             items_per_page_label: 'Items per page'
@@ -65,6 +67,7 @@ display:
             items_per_page_options_all_label: '- All -'
             offset: false
             offset_label: Offset
+          quantity: 9
       style:
         type: default
       row:
@@ -150,46 +153,6 @@ display:
           entity_field: type
           plugin_id: bundle
           group: 1
-        type_1:
-          id: type_1
-          table: group_content_field_data
-          field: type
-          relationship: none
-          group_type: group
-          admin_label: ''
-          operator: in
-          value:
-            closed_group-group_membership: closed_group-group_membership
-          group: 1
-          exposed: false
-          expose:
-            operator_id: ''
-            label: ''
-            description: ''
-            use_operator: false
-            operator: ''
-            identifier: ''
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-            reduce: false
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
-          entity_type: group_content
-          entity_field: type
-          plugin_id: bundle
       sorts:
         created:
           id: created
@@ -198,6 +161,13 @@ display:
           entity_type: group_content
           entity_field: created
           plugin_id: date
+        label:
+          id: label
+          table: group_content_field_data
+          field: label
+          entity_type: group_content
+          entity_field: label
+          plugin_id: standard
       title: 'Group Members'
       header: {  }
       footer: {  }
@@ -337,6 +307,30 @@ display:
     display_options:
       display_extenders: {  }
       path: group/%group/members
+      sorts:
+        created:
+          id: created
+          table: group_content_field_data
+          field: created
+          entity_type: group_content
+          entity_field: created
+          plugin_id: date
+        label:
+          id: label
+          table: group_content_field_data
+          field: label
+          relationship: none
+          group_type: group
+          admin_label: sort_title
+          order: ASC
+          exposed: false
+          expose:
+            label: ''
+          entity_type: group_content
+          entity_field: label
+          plugin_id: standard
+      defaults:
+        sorts: false
     cache_metadata:
       max-age: -1
       contexts:


### PR DESCRIPTION
## Problem
Whenever a group has more than 10 people, pagination appears. However when you go to the next page, a couple of the same users appears as on the first page. Seems to be a bit random. Maybe something with sorting?

## Solution
I turned out to be related to the create date of the group content (mass added users). Since that creation data of the group content (the membership) was the same for almost all members, views is kind of clueless. I've added an additional sorting on name (label of the group content)

## Issue tracker
- https://www.drupal.org/project/social/issues/3039042
- https://jira.goalgorilla.com/browse/YANG-757

## How to test
- [ ] Add multiple members to a group at the same time (bulk). Add like 15 or something like that
- [ ] Notice that when you go to older items, there's an issue that you see the same people you've already seen on the first page.
- [ ] Checkout this branch
- [ ] Revert features and clear caches
- [ ] Retest and notice all is good now

## Release notes
In some rare cases when a lot of users were added to a group in bulk, the pagination of the members in a group would show the same results on the second page of the group members page. This is now fixed by not just sorting on the date people were added to the group, but next to that also on the name of the person added.
