### PR TITLE
#3039585 - Composer updates cause twig to fail.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,8 @@
                 "Color module html preview optional": "https://www.drupal.org/files/issues/color-optional-html-preview-2844190-2.patch",
                 "Restrict images to this site blocks image style derivatives": "https://www.drupal.org/files/issues/2018-10-26/2528214-47.patch",
                 "Fix SQL error when importing translations": "https://www.drupal.org/files/issues/2018-10-01/2599228-SQL_error_on_content_creation-78_0.patch",
-                "Optimize getCommentedEntity()": "https://www.drupal.org/files/issues/get-commented-entity-2580551.52.patch"
+                "Optimize getCommentedEntity()": "https://www.drupal.org/files/issues/get-commented-entity-2580551.52.patch",
+                "Updating twig/twig to v1.38.1 causes fatal error": "https://www.drupal.org/project/drupal/issues/3039408"
             },
             "drupal/flag": {
                 "Add relationship to flagged entities when Flagging is base table": "https://www.drupal.org/files/issues/2723703_31.patch"

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
                 "Restrict images to this site blocks image style derivatives": "https://www.drupal.org/files/issues/2018-10-26/2528214-47.patch",
                 "Fix SQL error when importing translations": "https://www.drupal.org/files/issues/2018-10-01/2599228-SQL_error_on_content_creation-78_0.patch",
                 "Optimize getCommentedEntity()": "https://www.drupal.org/files/issues/get-commented-entity-2580551.52.patch",
-                "Updating twig/twig to v1.38.1 causes fatal error": "https://www.drupal.org/files/issues/2019-03-12/3039408-81.patch"
+                "Updating twig/twig to v1.38.1 causes fatal error": "https://www.drupal.org/files/issues/2019-03-13/3039408-99.patch"
             },
             "drupal/flag": {
                 "Add relationship to flagged entities when Flagging is base table": "https://www.drupal.org/files/issues/2723703_31.patch"

--- a/composer.json
+++ b/composer.json
@@ -107,7 +107,7 @@
         "drupal/override_node_options": "2.4",
         "drupal/paragraphs": "1.6",
         "drupal/private_message": "1.2",
-        "drupal/profile": "1.0-rc3",
+        "drupal/profile": "1.0-rc4",
         "drupal/r4032login": "1.1",
         "drupal/search_api": "1.6",
         "drupal/shariff": "1.3",

--- a/composer.json
+++ b/composer.json
@@ -35,8 +35,7 @@
                 "Color module html preview optional": "https://www.drupal.org/files/issues/color-optional-html-preview-2844190-2.patch",
                 "Restrict images to this site blocks image style derivatives": "https://www.drupal.org/files/issues/2018-10-26/2528214-47.patch",
                 "Fix SQL error when importing translations": "https://www.drupal.org/files/issues/2018-10-01/2599228-SQL_error_on_content_creation-78_0.patch",
-                "Optimize getCommentedEntity()": "https://www.drupal.org/files/issues/get-commented-entity-2580551.52.patch",
-                "Updating twig/twig to v1.38.1 causes fatal error": "https://www.drupal.org/files/issues/2019-03-13/3039408-99.patch"
+                "Optimize getCommentedEntity()": "https://www.drupal.org/files/issues/get-commented-entity-2580551.52.patch"
             },
             "drupal/flag": {
                 "Add relationship to flagged entities when Flagging is base table": "https://www.drupal.org/files/issues/2723703_31.patch"
@@ -120,6 +119,7 @@
         "drupal/votingapi": "3.0-beta1",
         "drupal/bootstrap": "3.17",
         "league/csv": "^8.2",
+        "twig/twig": "1.37.1",
         "facebook/graph-sdk": "^5.6",
         "google/apiclient": "^2.1",
         "php-http/curl-client": "^1.7",

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
                 "Restrict images to this site blocks image style derivatives": "https://www.drupal.org/files/issues/2018-10-26/2528214-47.patch",
                 "Fix SQL error when importing translations": "https://www.drupal.org/files/issues/2018-10-01/2599228-SQL_error_on_content_creation-78_0.patch",
                 "Optimize getCommentedEntity()": "https://www.drupal.org/files/issues/get-commented-entity-2580551.52.patch",
-                "Updating twig/twig to v1.38.1 causes fatal error": "https://www.drupal.org/project/drupal/issues/3039408"
+                "Updating twig/twig to v1.38.1 causes fatal error": "https://www.drupal.org/files/issues/2019-03-12/3039408-81.patch"
             },
             "drupal/flag": {
                 "Add relationship to flagged entities when Flagging is base table": "https://www.drupal.org/files/issues/2723703_31.patch"

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
                 "Restrict images to this site blocks image style derivatives": "https://www.drupal.org/files/issues/2018-10-26/2528214-47.patch",
                 "Fix SQL error when importing translations": "https://www.drupal.org/files/issues/2018-10-01/2599228-SQL_error_on_content_creation-78_0.patch",
                 "Optimize getCommentedEntity()": "https://www.drupal.org/files/issues/get-commented-entity-2580551.52.patch",
-                "Updating twig/twig to v1.38.1 causes fatal error": "https://www.drupal.org/files/issues/2019-03-13/3039408-99.patch"
+                "Updating twig/twig to v1.38.1 causes fatal error": "https://www.drupal.org/files/issues/2019-03-12/3039408-81.patch"
             },
             "drupal/flag": {
                 "Add relationship to flagged entities when Flagging is base table": "https://www.drupal.org/files/issues/2723703_31.patch"

--- a/composer.json
+++ b/composer.json
@@ -68,6 +68,9 @@
             },
             "drupal/shariff": {
                 "Allow shariff to use composer": "https://www.drupal.org/files/issues/2018-09-17/shariff-libraries_path_with_composer-2987789-5.patch"
+            },
+            "drupal/bootstrap": {
+                "JSDeliver issues unsupported operand types": "https://www.drupal.org/files/issues/2019-01-24/3027569-8.x-3.x-8.patch"
             }
         }
     },


### PR DESCRIPTION
## Problem
Since we didnt specify which version `twig/twig` we use `composer update` updates to the latest version which causes a fatal error. 

## Solution
Core is trying to patch using: https://www.drupal.org/project/drupal/issues/3039408
this however results in a patch which doesnt work since core needs to patch composer.lock files we don't use. Custom copying that pach results in errors in Open Social with twig caching. 
We will open up a separate issue for that. First lets go for green on the tests again.

## Issue tracker
- None.

## How to test
- [ ] See that travis doesn't fail on composer update step

## Release notes
None