### PR TITLE
Issue #3040981 by Kingdutch: The event_an_enroll_email_notify setting…

### DIFF
--- a/modules/social_features/social_event/modules/social_event_an_enroll/src/Form/EventAnEnrollForm.php
+++ b/modules/social_features/social_event/modules/social_event_an_enroll/src/Form/EventAnEnrollForm.php
@@ -155,8 +155,11 @@ class EventAnEnrollForm extends EnrollActionForm {
         ['query' => ['token' => $values['field_token']]]
       );
 
-      // Send email.
-      social_event_an_enroll_send_mail($values);
+      // Send email if the setting is enabled.
+      $event_an_enroll_config = $this->config('social_event_an_enroll.settings');
+      if ($event_an_enroll_config->get('event_an_enroll_email_notify')) {
+        social_event_an_enroll_send_mail($values);
+      }
     }
   }
 


### PR DESCRIPTION
… doesn't do anything

<h2>Problem</h2>
Messages to new AN enrollments are always sent, even if the setting is disabled.

<h2>Solution</h2>
Implement the check for event_an_enroll_email_notify ...

## Issue tracker
https://www.drupal.org/project/social/issues/3040981

## How to test
- [ ] Create an event with AN enrollment
- [ ] Enable "Notify user by email after anonymous enrollment" on /admin/config/opensocial/event-an-enroll
- [ ] Sign up for the event as AN user and verify you have an e-mail
- [ ] Disable "Notify user by email after anonymous enrollment" on /admin/config/opensocial/event-an-enroll
- [ ] Sign up for the event as a different AN user and verify you do not have an e-mail.

## Release notes
The "Notify user by email after anonymous enrollment" setting had no effect for e-mails after anonymous event enrollments. When the setting is disabled the users will no longer receive an e-mail (this was the intended behaviour).
