### PR TITLE
Issue #3042119 by Kingdutch: The socialbase like_and_dislike_service …

### DIFF
--- a/themes/socialbase/components/03-molecules/like/like_and_dislike_service.js
+++ b/themes/socialbase/components/03-molecules/like/like_and_dislike_service.js
@@ -20,12 +20,8 @@
           $('#dislike-container-' + entity_type + '-' + entity_id + ' a').get(0).className = response.operation.dislike;
 
           // Updates the likes and dislikes count.
-          if (response.likes == '1') {
-            var countText = Drupal.t(' like');
-          } else {
-            var countText = Drupal.t(' likes');
-          }
-          $('#like-container-' + entity_type + '-' + entity_id).nextAll('.vote__count').find('a').html(response.likes + countText).attr('data-dialog-options', '{"title":"' + response.likes + countText + '", "width":"auto"}');
+          var likeText = Drupal.formatPlural(response.likes, "@count like", "@count likes");
+          $('#like-container-' + entity_type + '-' + entity_id).nextAll('.vote__count').find('a').html(likeText).attr('data-dialog-options', '{"title":"' + likeText + '", "width":"auto"}');
         }
       });
     };


### PR DESCRIPTION
…should use formatPlural

<h2>Problem</h2>
Socialbase contains an overwrite for the like_and_dislike_service to change how we display likes and dislikes. It contains an if statement that call <code>Drupal.t</code> which makes translation more difficult and increases the number of occurrences of "like" in translation files.

<h2>Solution</h2>
Use <code>Drupal.formatPlural</code> so that we can re-use the translation of <code>@count like</code> and <code>@count likes</code>

## Issue tracker
https://www.drupal.org/project/social/issues/3042119

## How to test
- [ ] Check that liking a post still shows the correct string and is translatable

## Release notes
The like_and_dislike_service in SocialBase now translates the like count correctly.
