### PR TITLE
3021721 by jaapjan: Create routes only after the vbo module is installed

### DIFF
--- a/modules/social_features/social_event/modules/social_event_managers/social_event_managers.routing.yml
+++ b/modules/social_features/social_event/modules/social_event_managers/social_event_managers.routing.yml
@@ -6,16 +6,6 @@ social_event_managers.settings:
   requirements:
     _permission: 'set social event managers settings'
 
-social_event_managers.vbo.execute_configurable:
-  path: '/node/{node}/manage-all-enrollments/configure-action'
-  defaults:
-    _form: '\Drupal\social_event_managers\Form\SocialEventManagementViewsBulkOperationsConfigureAction'
-    _title: 'Configure action'
-    view_id: 'event_manage_enrollments'
-    display_id: 'page_manage_enrollments'
-  requirements:
-    _views_bulk_operation_access: 'TRUE'
-
 social_event_managers.add_enrollees:
   path: '/node/{node}/manage-all-enrollments/add-enrollees'
   defaults:
@@ -24,12 +14,5 @@ social_event_managers.add_enrollees:
   requirements:
     _permission: 'manage everything enrollments'
 
-social_event_managers.vbo.confirm:
-  path: '/node/{node}/manage-all-enrollments/confirm-action'
-  defaults:
-    _form: '\Drupal\social_event_managers\Form\SocialEventManagersViewsBulkOperationsConfirmAction'
-    _title: 'Confirm action'
-    view_id: 'event_manage_enrollments'
-    display_id: 'page_manage_enrollments'
-  requirements:
-    _views_bulk_operation_access: 'TRUE'
+route_callbacks:
+  - 'social_event_managers.route_subscriber:routes'

--- a/modules/social_features/social_event/modules/social_event_managers/social_event_managers.services.yml
+++ b/modules/social_features/social_event/modules/social_event_managers/social_event_managers.services.yml
@@ -4,8 +4,8 @@ services:
     tags:
       - {name: config.factory.override, priority: 5}
 
-social_event_managers.route_subscriber:
-  class: Drupal\social_event_managers\EventSubscriber\RouteSubscriber
-  arguments: ['@module_handler']
-  tags:
-    - { name: 'event_subscriber' }
+  social_event_managers.route_subscriber:
+    class: Drupal\social_event_managers\EventSubscriber\RouteSubscriber
+    arguments: ['@module_handler']
+    tags:
+      - { name: 'event_subscriber' }

--- a/modules/social_features/social_event/modules/social_event_managers/social_event_managers.services.yml
+++ b/modules/social_features/social_event/modules/social_event_managers/social_event_managers.services.yml
@@ -3,3 +3,9 @@ services:
     class: \Drupal\social_event_managers\SocialEventManagersConfigOverride
     tags:
       - {name: config.factory.override, priority: 5}
+
+social_event_managers.route_subscriber:
+  class: Drupal\social_event_managers\EventSubscriber\RouteSubscriber
+  arguments: ['@module_handler']
+  tags:
+    - { name: 'event_subscriber' }

--- a/modules/social_features/social_event/modules/social_event_managers/src/EventSubscriber/RouteSubscriber.php
+++ b/modules/social_features/social_event/modules/social_event_managers/src/EventSubscriber/RouteSubscriber.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Drupal\social_event_managers\EventSubscriber;
+
+use Drupal\Core\Extension\ModuleHandler;
+use Drupal\Core\Routing\RouteSubscriberBase;
+use Symfony\Component\Routing\Route;
+use Symfony\Component\Routing\RouteCollection;
+
+/**
+ * Builds up the routes of event management forms.
+ */
+class RouteSubscriber extends RouteSubscriberBase {
+
+  /**
+   * The config factory.
+   *
+   * @var \Drupal\Core\Extension\ModuleHandler
+   */
+  protected $moduleHandler;
+
+  /**
+   * Constructs the service with DI.
+   *
+   * @param \Drupal\Core\Extension\ModuleHandler $module_handler
+   *   The module handler.
+   */
+  public function __construct(ModuleHandler $module_handler) {
+    $this->moduleHandler = $module_handler;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function alterRoutes(RouteCollection $collection) :void {
+  }
+
+  /**
+   * Returns a set of route objects.
+   *
+   * @return \Symfony\Component\Routing\RouteCollection
+   *   A route collection.
+   */
+  public function routes() :RouteCollection {
+    $collection = new RouteCollection();
+
+    if ($this->moduleHandler->moduleExists('views_bulk_operations')) {
+      $route = new Route(
+        '/node/{node}/manage-all-enrollments/configure-action',
+        [
+          '_form' => '\Drupal\social_event_managers\Form\SocialEventManagementViewsBulkOperationsConfigureAction',
+          '_title' => 'Configure action',
+          'view_id' => 'event_manage_enrollments',
+          'display_id' => 'page_manage_enrollments',
+        ],
+        [
+          '_views_bulk_operation_access' => 'TRUE',
+        ]
+      );
+      $collection->add('social_event_managers.vbo.execute_configurable', $route);
+
+      $route = new Route(
+        '/node/{node}/manage-all-enrollments/add-enrollees',
+        [
+          '_form' => '\Drupal\social_event_managers\Form\SocialEventManagersViewsBulkOperationsConfirmAction',
+          '_title' => 'Confirm action',
+          'view_id' => 'event_manage_enrollments',
+          'display_id' => 'page_manage_enrollments',
+        ],
+        [
+          '_views_bulk_operation_access' => 'TRUE',
+        ]
+      );
+      $collection->add('social_event_managers.vbo.confirm', $route);
+    }
+
+    return $collection;
+  }
+
+}

--- a/modules/social_features/social_group/social_group.install
+++ b/modules/social_features/social_group/social_group.install
@@ -26,6 +26,10 @@ function social_group_update_dependencies() {
   $dependencies['social_group'][8011] = [
     'gnode' => 8005,
   ];
+  // Prevent errors when missing VBO module.
+  $dependencies['profile'][8002] = [
+    'social_group' => 8501,
+  ];
   return $dependencies;
 }
 

--- a/modules/social_features/social_user/social_user.install
+++ b/modules/social_features/social_user/social_user.install
@@ -111,7 +111,8 @@ function social_user_update_8007() {
     'views_bulk_operations',
   ];
   \Drupal::service('module_installer')->install($modules);
-
+  // Rebuild the router for social_event_managers.route_subscriber.
+  \Drupal::service('router.builder')->rebuild();
 }
 
 /**


### PR DESCRIPTION
## Problem
Problem with the current implementation is the forms that are written for the social_event_managers module. Those extend some forms from views_bulk_operations. When you don't have the social_event_managers enabled there's no problem, since it now has a dependency towards views_bulk_operations. However if you had already enabled social_event_managers and you take this code, you get an error, because the autoloader is not yet aware of the extended 'Drupal\views_bulk_operations\Form\ConfigureAction', causing a fatal error.


## Solution
Turns out a solution was already made in #1250 

## Issue tracker
http://www.drupal.org/node/3021721

## How to test
- [x] Install this branch on an existing platform that has the `social_event_managers` module enabled and notice the installation / update goes according to plan

## Release notes
...
