### PR TITLE
Issue #2961232 change private message contact url when thread is deleted

### DIFF
--- a/modules/social_features/social_private_message/social_private_message.module
+++ b/modules/social_features/social_private_message/social_private_message.module
@@ -150,6 +150,31 @@ function social_private_message_thread_delete_redirect(array $form, FormStateInt
   // Force redirect to the inbox.
   $url = Url::fromRoute('social_private_message.inbox');
   $form_state->setRedirectUrl($url);
+
+  // Unset cache tags for user profiles.
+  $build_info = $form_state->getBuildInfo();
+  if (isset($build_info['callback_object'])) {
+    /** @var \Drupal\private_message\Form\PrivateMessageThreadDeleteForm $pm_thread_form */
+    $pm_thread_form = $build_info['callback_object'];
+    $pm_thread = $pm_thread_form->getEntity();
+
+    /** @var \Drupal\private_message\Entity\PrivateMessageThread $pm_thread */
+    if ($pm_thread) {
+      $members = $pm_thread->getMembers();
+
+      $cache_tags = [];
+      foreach ($members as $member) {
+        /** @var \Drupal\user\Entity\User $member */
+        if ($member) {
+          foreach ($member->getCacheTagsToInvalidate() as $cache_tag) {
+            $cache_tags[] = $cache_tag;
+          }
+        }
+      }
+      \Drupal::service('cache_tags.invalidator')->invalidateTags($cache_tags);
+    }
+  }
+
 }
 
 /**

--- a/modules/social_features/social_profile/social_profile.module
+++ b/modules/social_features/social_profile/social_profile.module
@@ -392,11 +392,12 @@ function _social_profile_get_contact_url(User $account) {
       $members = [$current_user, $account];
       $thread_id = \Drupal::service('private_message.mapper')->getThreadIdForMembers($members);
       if ($thread_id) {
-        return Url::fromRoute('entity.private_message_thread.canonical', ['private_message_thread' => $thread_id], ['attributes' => ['class' => ['private_message_link']]]);
+        $url = Url::fromRoute('entity.private_message_thread.canonical', ['private_message_thread' => $thread_id], ['attributes' => ['class' => ['private_message_link']]]);
+        if ($url->access($current_user)) {
+          return $url;
+        }
       }
-      else {
-        return Url::fromRoute('private_message.private_message_create', [], ['query' => ['recipient' => $account->id()]]);
-      }
+      return Url::fromRoute('private_message.private_message_create', [], ['query' => ['recipient' => $account->id()]]);
     }
   }
   return Url::fromUserInput('/user/' . $account->id() . '/information');


### PR DESCRIPTION
## Problem
When a user deletes a private message thread the contact url on the profile of participants in the thread doesn't work anymore (access denied).

## Solution
We check for access before returning the URL. In addition the cache tag is invalidated for every participant to always ensure the latest url.

## Issue tracker
https://www.drupal.org/project/social/issues/2961232

## How to test
- [x] Test first on 4.x
- [x] User 1 messages User 2
- [x] User 1 deletes the thread, but User 2 does not.
- [x] User 1 clicks on the Private Message URL in the all-members view or on the user's page and is given message: "You are not authorised to access this page."
- [x] Now try again on this branch and notice it works as expected.
- [x] Check the cache invalidation code with Xdebug.

## Release notes
When a user deletes a private message thread the contact url on the profile of participants in the thread didn't work in some cases. This issue is now solved.