### PR TITLE
Issue #3042537: Remove twig/twig on 8.x-3.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,8 @@ services:
   - docker
 
 before_install:
+  # Set php memory limit to -1 so composer update will not fail
+  - export COMPOSER_MEMORY_LIMIT=-1
   # Kill the install_update, drush_make and accessibility jobs if it is not a PR build.
   - if [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TEST_SUITE" = "install_update" ]; then exit 0; fi
   - if [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TEST_SUITE" = "drush_make" ]; then exit 0; fi

--- a/composer.json
+++ b/composer.json
@@ -112,7 +112,6 @@
         "drupal/votingapi": "3.0-beta1",
         "drupal/bootstrap": "3.15",
         "league/csv": "^8",
-        "twig/twig": "1.37.1",
         "facebook/graph-sdk": "^5.4",
         "google/apiclient": "^2.1",
         "php-http/curl-client": "^1.6",


### PR DESCRIPTION
## Problem && Solution
Since Drupal has released [8.6.11](https://www.drupal.org/project/drupal/releases/8.6.11), this composer-file has a conflict with OpenSocial's composer-file. 

## Issue tracker
https://www.drupal.org/project/social/issues/3042537

## Release notes
Removed twig/twig on OpenSocial