### PR TITLE
Issue #3043086 by bramtenhove: Add extra check to prevent notice thrown in social_profile module

### DIFF
--- a/modules/social_features/social_profile/social_profile.module
+++ b/modules/social_features/social_profile/social_profile.module
@@ -104,8 +104,9 @@ function social_profile_form_profile_profile_edit_form_alter(array &$form, FormS
   // case by default. Since we provide an empty vocabulary.
   // We also check for a fieldset, used by our special widget which doesn't use
   // #options.
-  if (empty($form['field_profile_profile_tag']['widget']['#options'])
-    && $form['field_profile_profile_tag']['widget']['#type'] !== 'container') {
+  if (!empty($form['field_profile_profile_tag']['widget']) &&
+    (empty($form['field_profile_profile_tag']['widget']['#options'])
+      && $form['field_profile_profile_tag']['widget']['#type'] !== 'container')) {
     unset($form['field_profile_profile_tag']);
   }
 


### PR DESCRIPTION
## Problem
In some cases a notice is thrown in the social_profile module.

`Notice: Undefined index: field_profile_profile_tag in social_profile_form_profile_profile_edit_form_alter() (line 108 of profiles/contrib/social/modules/social_features/social_profile/social_profile.module).`

## Solution
Add an extra check to prevent a notice being thrown.

## Issue tracker
https://www.drupal.org/project/social/issues/3043086

## How to test
- [x] Take a look at the code

## Release notes
A notice could be thrown in the `social_profile` module when trying to unset the profile tag field when it was already not available. With an extra check this will no longer happen.