### PR TITLE
Issue #3043105: Core Page Title Block returns empty HTML when title is missing

### DIFF
--- a/modules/social_features/social_core/src/Plugin/Block/SocialPageTitleBlock.php
+++ b/modules/social_features/social_core/src/Plugin/Block/SocialPageTitleBlock.php
@@ -149,21 +149,23 @@ class SocialPageTitleBlock extends PageTitleBlock implements ContainerFactoryPlu
           '#node' => $node,
           '#section_class' => 'page-title',
         ];
-      } else {
+      }
+      else {
         $title = $this->title;
 
-        if(!is_null($title) && $title != '') {
+        if (!is_null($title) && $title != '') {
           return [
             '#type' => 'page_title',
             '#title' => $this->title,
           ];
         }
       }
-    } else {
+    }
+    else {
       if ($route = $request->attributes->get(RouteObjectInterface::ROUTE_OBJECT)) {
         $title = $this->titleResolver->getTitle($request, $route);
 
-        if(!is_null($title) && $title != '') {
+        if (!is_null($title) && $title != '') {
           return [
             '#type' => 'page_title',
             '#title' => $title,
@@ -171,5 +173,7 @@ class SocialPageTitleBlock extends PageTitleBlock implements ContainerFactoryPlu
         }
       }
     }
+
   }
+
 }

--- a/modules/social_features/social_core/src/Plugin/Block/SocialPageTitleBlock.php
+++ b/modules/social_features/social_core/src/Plugin/Block/SocialPageTitleBlock.php
@@ -141,7 +141,6 @@ class SocialPageTitleBlock extends PageTitleBlock implements ContainerFactoryPlu
       $in_path = str_replace($paths_to_exclude, '', $current_path) != $current_path;
 
       if (!$in_path) {
-
         $title = $node->getTitle();
 
         return [
@@ -150,35 +149,27 @@ class SocialPageTitleBlock extends PageTitleBlock implements ContainerFactoryPlu
           '#node' => $node,
           '#section_class' => 'page-title',
         ];
+      } else {
+        $title = $this->title;
 
+        if(!is_null($title) && $title != '') {
+          return [
+            '#type' => 'page_title',
+            '#title' => $this->title,
+          ];
+        }
       }
-      else {
-
-        return [
-          '#type' => 'page_title',
-          '#title' => $this->title,
-        ];
-
-      }
-
-    }
-    else {
-
+    } else {
       if ($route = $request->attributes->get(RouteObjectInterface::ROUTE_OBJECT)) {
         $title = $this->titleResolver->getTitle($request, $route);
-        return [
-          '#type' => 'page_title',
-          '#title' => $title,
-        ];
-      }
-      else {
-        return [
-          '#type' => 'page_title',
-          '#title' => '',
-        ];
-      }
 
+        if(!is_null($title) && $title != '') {
+          return [
+            '#type' => 'page_title',
+            '#title' => $title,
+          ];
+        }
+      }
     }
   }
-
 }

--- a/modules/social_features/social_core/src/Plugin/Block/SocialPageTitleBlock.php
+++ b/modules/social_features/social_core/src/Plugin/Block/SocialPageTitleBlock.php
@@ -174,4 +174,5 @@ class SocialPageTitleBlock extends PageTitleBlock implements ContainerFactoryPlu
       }
     }
   }
+
 }

--- a/modules/social_features/social_core/src/Plugin/Block/SocialPageTitleBlock.php
+++ b/modules/social_features/social_core/src/Plugin/Block/SocialPageTitleBlock.php
@@ -153,7 +153,7 @@ class SocialPageTitleBlock extends PageTitleBlock implements ContainerFactoryPlu
       else {
         $title = $this->title;
 
-        if (!is_null($title) && $title != '') {
+        if (!empty($title)) {
           return [
             '#type' => 'page_title',
             '#title' => $this->title,
@@ -165,7 +165,7 @@ class SocialPageTitleBlock extends PageTitleBlock implements ContainerFactoryPlu
       if ($route = $request->attributes->get(RouteObjectInterface::ROUTE_OBJECT)) {
         $title = $this->titleResolver->getTitle($request, $route);
 
-        if (!is_null($title) && $title != '') {
+        if (!empty($title)) {
           return [
             '#type' => 'page_title',
             '#title' => $title,
@@ -173,7 +173,5 @@ class SocialPageTitleBlock extends PageTitleBlock implements ContainerFactoryPlu
         }
       }
     }
-
   }
-
 }


### PR DESCRIPTION
## Problem
Page Title Block returns empty HTML when title is missing

## Solution
Check if title is empty or null before returning the array.

## Issue tracker
https://www.drupal.org/project/social/issues/3043105

## How to test
- [x] Verify the titles still work
- [x] Verify tests are passing.
- [x] Check the code.

## Release notes
The Page Title block outputs empty markup when there is no title set. Since it renders empty markup the block which renders it, gets rendered as HTML and css (which comes with it) creating unnecessary spacings and margins.