### PR TITLE
Issue #3042115: lowercase bundle can be incorrect in some languages

### DIFF
--- a/modules/social_features/social_like/social_like.module
+++ b/modules/social_features/social_like/social_like.module
@@ -88,5 +88,5 @@ function social_like_preprocess_like_and_dislike_icons(&$variables) {
     }
 
   }
-  $variables['modal_title'] = t('Members who liked this @content', ['@content' => strtolower($bundle)]);
+  $variables['modal_title'] = t('Members who liked this @content', ['@content' => $bundle]);
 }


### PR DESCRIPTION
## Problem
In #2992737: The bundle inside the like modal title is not translatable the bundle name was retrieved and lowercased to be able to translate the bundle name in the like message. However, in some languages such as German the bundle name is a noun that should start with an uppercase letter.

## Solution
Remove the strtolower that was added in the PR for #2992737: The bundle inside the like modal title is not translatable: https://github.com/goalgorilla/open_social/pull/1234/files#diff-7a427f5a...

## Issue tracker
https://github.com/goalgorilla/open_social/pull/new/feature/3042115

## How to test
- [ ] <enter multiple how to test steps here>

## Release notes
The bundle name in the Like modal window title was retrieved and lowercased to be able to translate the bundle name in the like message. However, in some languages such as German the bundle name is a noun that should start with an uppercase letter. We will stick to Drupal Core behaviour for now and just show the bundle label as is.