### PR TITLE
Issue #3043426 by slowflyer: page-node-edit css class is missing for node edit

### DIFF
--- a/themes/socialbase/src/Plugin/Preprocess/Html.php
+++ b/themes/socialbase/src/Plugin/Preprocess/Html.php
@@ -23,7 +23,7 @@ class Html extends PreprocessBase {
     if ($variables['root_path'] == 'node') {
       $current_path = \Drupal::service('path.current')->getPath();
       $path_pieces = explode("/", $current_path);
-      $path_target = ['add'];
+      $path_target = ['add','edit'];
       if (count(array_intersect($path_pieces, $path_target)) > 0) {
         $variables['node_edit'] = TRUE;
       }

--- a/themes/socialbase/src/Plugin/Preprocess/Html.php
+++ b/themes/socialbase/src/Plugin/Preprocess/Html.php
@@ -23,7 +23,7 @@ class Html extends PreprocessBase {
     if ($variables['root_path'] == 'node') {
       $current_path = \Drupal::service('path.current')->getPath();
       $path_pieces = explode("/", $current_path);
-      $path_target = ['add','edit'];
+      $path_target = ['add', 'edit'];
       if (count(array_intersect($path_pieces, $path_target)) > 0) {
         $variables['node_edit'] = TRUE;
       }


### PR DESCRIPTION
## Problem
Based on socialbase\src\Plugin\Preprocess\Html.php the .page-node-edit class is only added to the body tag on node add not on node edit.
If you need a css class indicating node editing it should be consistent

## Solution
Add a check for a "edit" as well

## Issue tracker
https://www.drupal.org/project/social/issues/3043426

## How to test
- edit any node content and check that the body tag contains css class "page-node-edit"

## Release notes
The `page-node-edit` class is now also added to the node edit form. Previously it was only added on the node add form. Now the name matches the behaviour.
