### PR TITLE
SHN-310 by robertragas: add range slider to social blue to control th…

### DIFF
--- a/modules/custom/improved_theme_settings/improved_theme_settings.module
+++ b/modules/custom/improved_theme_settings/improved_theme_settings.module
@@ -167,6 +167,28 @@ function improved_theme_settings_page_attachments(array &$page) {
         ';
       }
 
+      // Default values.
+      $hero_gradient_opacity_start = 0.1;
+      $hero_gradient_opacity_end = 0.7;
+
+      $hero_gradient_opacity = improved_theme_settings_get_setting('hero_gradient_opacity', $system_theme_settings);
+      if (isset($hero_gradient_opacity)) {
+        // Convert to values that the gradient can work with.
+        $hero_gradient_opacity_end = $hero_gradient_opacity / 100;
+
+        // If our opacity has been set to 0, also change the start value to 0.
+        if ($hero_gradient_opacity == 0) {
+          $hero_gradient_opacity_start = 0;
+        }
+      }
+
+      $style_to_add .= '
+        .hero__bgimage-overlay {
+          background: -webkit-gradient(linear, left top, left bottom, from(rgba(0, 0, 0,' . $hero_gradient_opacity_start . ')), to(rgba(34, 34, 34,' . $hero_gradient_opacity_end . '))) !important;
+          background: linear-gradient(rgba(0, 0, 0, ' . $hero_gradient_opacity_start . ') 0%, rgba(34, 34, 34, ' . $hero_gradient_opacity_end . ') 100%) !important;
+        }
+      ';
+
       if (!empty($style_to_add)) {
         $page['#attached']['html_head'][] = [
           [

--- a/modules/custom/improved_theme_settings/improved_theme_settings.module
+++ b/modules/custom/improved_theme_settings/improved_theme_settings.module
@@ -171,7 +171,8 @@ function improved_theme_settings_page_attachments(array &$page) {
       $hero_gradient_opacity_start = 0.1;
       $hero_gradient_opacity_end = 0.7;
 
-      $hero_gradient_opacity = improved_theme_settings_get_setting('hero_gradient_opacity', $system_theme_settings);
+      // Alwasys cast as an integer.
+      $hero_gradient_opacity = (integer) improved_theme_settings_get_setting('hero_gradient_opacity', $system_theme_settings);
       if (isset($hero_gradient_opacity)) {
         // Convert to values that the gradient can work with.
         $hero_gradient_opacity_end = $hero_gradient_opacity / 100;

--- a/modules/custom/improved_theme_settings/improved_theme_settings.module
+++ b/modules/custom/improved_theme_settings/improved_theme_settings.module
@@ -209,10 +209,13 @@ function improved_theme_settings_page_attachments(array &$page) {
 /**
  * Function that returns a valid integer or FALSE.
  *
- * @param $setting
- * @param $themename
+ * @param string $setting
+ *   The setting to retrieve.
+ * @param string $themename
+ *   The theme to retrieve the setting from.
  *
  * @return bool|string
+ *   The value of the settings.
  */
 function improved_theme_settings_get_setting($setting, $themename) {
   // Fetch setting from the theme.

--- a/modules/custom/improved_theme_settings/improved_theme_settings.module
+++ b/modules/custom/improved_theme_settings/improved_theme_settings.module
@@ -177,7 +177,7 @@ function improved_theme_settings_page_attachments(array &$page) {
         $hero_gradient_opacity_end = $hero_gradient_opacity / 100;
 
         // If our opacity has been set to 0, also change the start value to 0.
-        if ($hero_gradient_opacity == 0) {
+        if ($hero_gradient_opacity === 0) {
           $hero_gradient_opacity_start = 0;
         }
       }
@@ -208,12 +208,17 @@ function improved_theme_settings_page_attachments(array &$page) {
 
 /**
  * Function that returns a valid integer or FALSE.
+ *
+ * @param $setting
+ * @param $themename
+ *
+ * @return bool|string
  */
 function improved_theme_settings_get_setting($setting, $themename) {
   // Fetch setting from the theme.
   $themevar = Xss::filter(theme_get_setting($setting, $themename));
   // In this case '' is something different than 0.
-  if ($themevar !== trim(intval($themevar))) {
+  if ($themevar !== trim((int) $themevar)) {
     return FALSE;
   }
   return $themevar;

--- a/modules/custom/social_demo/eaa/content/entity/system.yml
+++ b/modules/custom/social_demo/eaa/content/entity/system.yml
@@ -12,6 +12,7 @@ theme:
   navbar-sec-bg: '#c63f17'
   navbar-sec-text: '#e3f2fd'
   card_radius: 5
+  hero_gradient_opacity: 70
   form_control_radius: 2
   button_radius: 5
   favicon:

--- a/themes/socialblue/config/install/socialblue.settings.yml
+++ b/themes/socialblue/config/install/socialblue.settings.yml
@@ -1,5 +1,6 @@
 font_primary: 'Montserrat'
 card_radius: '10'
+hero_gradient_opacity: '70'
 form_control_radius: '5'
 button_radius: '10'
 color_primary: '#29abe2'

--- a/themes/socialblue/config/install/socialblue.settings.yml
+++ b/themes/socialblue/config/install/socialblue.settings.yml
@@ -1,6 +1,6 @@
 font_primary: 'Montserrat'
 card_radius: '10'
-hero_gradient_opacity: '70'
+hero_gradient_opacity: 70
 form_control_radius: '5'
 button_radius: '10'
 color_primary: '#29abe2'

--- a/themes/socialblue/theme-settings.php
+++ b/themes/socialblue/theme-settings.php
@@ -102,6 +102,22 @@ function socialblue_form_system_theme_settings_alter(&$form, FormStateInterface 
       // Ensure we save the file permanently.
       $form['#submit'][] = 'socialblue_save_email_logo';
 
+      $form['os_hero_settings'] = [
+        '#type' => 'details',
+        '#group' => 'open_social_settings',
+        '#title' => t('Hero'),
+        '#weight' => 30,
+        '#collapsible' => TRUE,
+        '#collapsed' => TRUE,
+      ];
+
+      $form['os_hero_settings']['hero_gradient_opacity'] = [
+        '#type' => 'range',
+        '#title' => t('Hero gradient'),
+        '#default_value' => $config->get('hero_gradient_opacity'),
+        '#description' => t('Define the percentage of darkness of the hero gradient from 0 to 100.'),
+      ];
+
       // Font tab.
       $fonts = [];
       if (\Drupal::service('module_handler')->moduleExists('social_font')) {

--- a/themes/socialblue/theme-settings.php
+++ b/themes/socialblue/theme-settings.php
@@ -116,6 +116,8 @@ function socialblue_form_system_theme_settings_alter(&$form, FormStateInterface 
         '#title' => t('Hero gradient'),
         '#default_value' => $config->get('hero_gradient_opacity'),
         '#description' => t('Define the percentage of darkness of the hero gradient from 0 to 100.'),
+        '#min' => 0,
+        '#max' => 100,
       ];
 
       // Font tab.


### PR DESCRIPTION
## Problem
Some clients find the gradient of the hero a bit too dark and would like to have the possibility to change this.

## Solution
Create a setting in the socialblue theme where SM can set the opacity of the hero gradient with a slider.

## Issue tracker
https://www.drupal.org/project/social/issues/3044302

## How to test
- [x] Go to the social blue theme settings
- [x] Notice there is a category called "hero". In this category you will find a slider to change the opacity. By default it's set to 70 which related to the 0.7 opacity in the css. Try changing this.
- [x] See that the hero gradient changes.

## Release notes
Sitemanagers now have the possibility to control the gradient of the hero. This way you can adjust the opacity to a value that best fits your theme.
