### PR TITLE
Fix circular reference dependency injection

### DIFF
--- a/modules/social_features/social_tagging/social_tagging.services.yml
+++ b/modules/social_features/social_tagging/social_tagging.services.yml
@@ -3,7 +3,6 @@ services:
     class: Drupal\social_tagging\SocialTaggingService
     arguments: ['@entity_type.manager', '@config.factory']
   social_tagging.overrider:
-    class: \Drupal\social_tagging\SocialTaggingOverrides
-    arguments: ['@social_tagging.tag_service', '@config.factory']
+    class: Drupal\social_tagging\SocialTaggingOverrides
     tags:
       - {name: config.factory.override, priority: 5}


### PR DESCRIPTION
## Problem
Problem occured on platforms that have the social tagging enabled (and potentially language is also involved). A circular reference occurs because:
1. The SocialTagService requires config
2. Config checks for overrides....
3. SocialTagsConfigOverride requires SocialTagService.
This results in a chicken and egg scenario. 

## Solution
Remove the injection of the tagservice (and config) in the configoverride.

## How to test
- [ ] Check this solution on SaaS

## Release notes
Not needed. ISsue found during 5.0 testing day.
