### PR TITLE
Issue #3045199 by bramtenhove: Fix possible fatal error can occur while generating activities

### DIFF
--- a/modules/custom/activity_logger/src/Service/ActivityLoggerFactory.php
+++ b/modules/custom/activity_logger/src/Service/ActivityLoggerFactory.php
@@ -40,7 +40,14 @@ class ActivityLoggerFactory {
       // Set the values.
       $new_message['template'] = $message_type;
       $new_message['created'] = $entity->getCreatedTime();
-      $new_message['uid'] = $entity->getOwner()->id();
+
+      // Get the owner or default to anonymous.
+      if (method_exists($entity, 'getOwner') && $entity->getOwner() !== NULL) {
+        $new_message['uid'] = $entity->getOwner()->id();
+      }
+      else {
+        $new_message['uid'] = 0;
+      }
 
       $additional_fields = [
         ['name' => 'field_message_context', 'type' => 'list_string'],


### PR DESCRIPTION
In some cases it is possible that, when preparing to generate activities a fatal error can occur. This is usually not noticeable for the user as it is most likely something that is happening when processing a queue item.

## Problem
In the `ActivityLoggerFactory.php` the code assumes the owner of the entity is available, this is however not always the case. Next to that `getOwner()` method does not always exist for an entity.

## Solution
Add a check to make sure `getOwner()` method exists and the value is not `null`.

## Issue tracker
https://www.drupal.org/project/social/issues/3045199

## How to test
- [ ] Check the code

## Release notes
In some cases it was possible that, when the system is preparing to generate activities an error could occur. By adding an extra check we prevent the error from occurring.