### PR TITLE
Issue #3044815 by kavbiswa, xinyuma, jaapjan: The unfollow button on …

### DIFF
--- a/modules/social_features/social_follow_content/config/install/views.view.following.yml
+++ b/modules/social_features/social_follow_content/config/install/views.view.following.yml
@@ -257,7 +257,7 @@ display:
           exclude: false
           alter:
             alter_text: true
-            text: '<div class="btn btn-default btn-sm"> {{ link_flag }} </div>'
+            text: '<div class="btn btn-sm"> {{ link_flag }} </div>'
             make_link: false
             path: ''
             absolute: false


### PR DESCRIPTION
## Problem
In the followed content overview, the unfollow button has a strange style. The button has two borders around it.

## Solution
Only keep the inner border.

## Issue tracker
https://www.drupal.org/project/social/issues/3044815

## How to test
- [ ] Check the followed content overview styling
- [ ] Check the code

## Release notes
The unfollow button in the followed content overview is now styled correctly.