### PR TITLE
Bug 3045903 private messages permission

### DIFF
--- a/modules/social_features/social_private_message/social_private_message.module
+++ b/modules/social_features/social_private_message/social_private_message.module
@@ -455,7 +455,7 @@ function social_private_message_social_user_account_header_items(array $context)
   }
 
   // We require a logged in user for this button.
-  if (empty($context['user']) || !$context['user']->isAuthenticated()) {
+  if (empty($context['user']) || !$context['user']->isAuthenticated() || !$context['user']->hasPermission('use private messaging system') ) {
     return [];
   }
 

--- a/modules/social_features/social_private_message/src/Plugin/Block/PmAddBlock.php
+++ b/modules/social_features/social_private_message/src/Plugin/Block/PmAddBlock.php
@@ -24,7 +24,10 @@ class PmAddBlock extends BlockBase {
    * Custom access logic to display the block.
    */
   public function blockAccess(AccountInterface $account) {
-    return AccessResult::allowed();
+    if ($account->hasPermission('use private messaging system')) {
+      return AccessResult::allowed();
+    }
+    return AccessResult::forbidden();
   }
 
   /**

--- a/modules/social_features/social_profile/social_profile.module
+++ b/modules/social_features/social_profile/social_profile.module
@@ -336,7 +336,7 @@ function social_profile_preprocess_profile(array &$variables) {
   // The actual label text should be changeable in the template.
   // Disable for the LU's own profile.
   $variables['profile_contact_label'] = 'profile_info';
-  if (\Drupal::moduleHandler()->moduleExists('social_private_message') && $current_user->id() != $profile->getOwnerId()) {
+  if (\Drupal::moduleHandler()->moduleExists('social_private_message') && $current_user->id() != $profile->getOwnerId() && $current_user->hasPermission('use private messaging system') && User::load($profile->getOwnerId())->hasPermission('use private messaging system')) {
     $variables['profile_contact_label'] = 'private_message';
     $variables['#cache']['contexts'][] = 'user';
   }


### PR DESCRIPTION
## Problem
You can or will have users with differet roles / permissions in the community. If users based on their roles are not allowed to use private messaging, all private messaging stuff should be hidden for them. And for users who are allowed to use Private messages, they should not be able to send a message to a user who cant read it.

## Solution
Better check for user permissions implemented

## Issue tracker
https://www.drupal.org/project/social/issues/3045903

## How to test
- [ ] Have users with the permission to use private messages and users without the permission
- [ ] Login as user without the permission to use Private messages
- [ ] You will see the envelope icon in menu
- [ ] go to /user/inbox -> you will get a "permission denied" notice for the page, but the button will still show up
- [ ] go to /all-members -> you will see "Private message" link for all users listed

- [ ]  install the patch

- [ ] Login as user without the permission to use Private messages
- [ ] You will see NO envelope icon in menu
- [ ] go to /user/inbox -> you will get a "permission denied" notice for the page, NO button will show up
- [ ] go to /all-members -> you will see NO "Private message" link for all users listed

- [ ] Login as user WITH the permission to use Private messages
- [ ] You will see the envelope icon in menu
- [ ] go to /user/inbox -> you will see the page and the button will show up
- [ ] go to /all-members -> you will see NO "Private message" link for all users who are not allowed to use Private messages, you will see the "Private message" link for users who are allowed to use private messages


## Release notes
<describe the release notes>
