### PR TITLE
Issue #3027295: remove Translate tab from Tab management landing tab on Group

### DIFF
--- a/modules/custom/social_language/social_language.module
+++ b/modules/custom/social_language/social_language.module
@@ -26,3 +26,12 @@ function social_language_form_user_form_alter(&$form, FormStateInterface $form_s
     $form['language']['#access'] = FALSE;
   }
 }
+
+/**
+ * Implements hook_default_route_group_tabs_alter().
+ */
+function social_language_social_group_default_route_tabs_alter(&$tabs) {
+  // Unset some tabs created by group.
+  unset($tabs['content_translation.local_tasks:entity.group.content_translation_overview']);
+}
+

--- a/modules/custom/social_language/social_language.module
+++ b/modules/custom/social_language/social_language.module
@@ -34,4 +34,3 @@ function social_language_social_group_default_route_tabs_alter(&$tabs) {
   // Unset some tabs created by group.
   unset($tabs['content_translation.local_tasks:entity.group.content_translation_overview']);
 }
-


### PR DESCRIPTION
## Problem
When social_language is enabled you could select the Translate tab as landing tab of a group.

## Solution
Let's remove that tab and use the alter function provided.

## Issue tracker
N/A (but check the testing 5.0 doc)

## How to test
- [x] Enable social_language and social_group_default_route and notice that you have a "Translate" tab in the options. 
- [x] Switch to this branch and notice the tab is gone in the select box.
- [x] Check code.

## Release notes
Not necessary, because it is just introduced in this release.
