### PR TITLE
#3019370: Use hook system for group management overview

### DIFF
--- a/modules/social_features/social_group/social_group.services.yml
+++ b/modules/social_features/social_group/social_group.services.yml
@@ -26,6 +26,7 @@ services:
       - {name: config.factory.override, priority: 10}
   social_group.admin_people_override:
     class: \Drupal\social_group\SocialGroupAdminPeopleConfigOverride
+    arguments: ['@module_handler']
     tags:
     - {name: config.factory.override, priority: 10}
   social_group.hero_image:

--- a/modules/social_features/social_group/src/SocialGroupAdminPeopleConfigOverride.php
+++ b/modules/social_features/social_group/src/SocialGroupAdminPeopleConfigOverride.php
@@ -3,7 +3,6 @@
 namespace Drupal\social_group;
 
 use Drupal\Core\Cache\CacheableMetadata;
-use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Config\ConfigFactoryOverrideInterface;
 use Drupal\Core\Config\StorageInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;

--- a/modules/social_features/social_group/src/SocialGroupAdminPeopleConfigOverride.php
+++ b/modules/social_features/social_group/src/SocialGroupAdminPeopleConfigOverride.php
@@ -3,8 +3,10 @@
 namespace Drupal\social_group;
 
 use Drupal\Core\Cache\CacheableMetadata;
+use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Config\ConfigFactoryOverrideInterface;
 use Drupal\Core\Config\StorageInterface;
+use Drupal\Core\Extension\ModuleHandlerInterface;
 
 /**
  * Class SocialGroupAdminPeopleConfigOverride.
@@ -12,6 +14,23 @@ use Drupal\Core\Config\StorageInterface;
  * @package Drupal\social_group
  */
 class SocialGroupAdminPeopleConfigOverride implements ConfigFactoryOverrideInterface {
+
+  /**
+   * The module handler.
+   *
+   * @var \Drupal\Core\Extension\ModuleHandlerInterface
+   */
+  protected $moduleHandler;
+
+  /**
+   * Constructs the configuration override.
+   *
+   * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
+   *   The module handler.
+   */
+  public function __construct(ModuleHandlerInterface $module_handler) {
+    $this->moduleHandler = $module_handler;
+  }
 
   /**
    * Load overrides.
@@ -22,7 +41,7 @@ class SocialGroupAdminPeopleConfigOverride implements ConfigFactoryOverrideInter
     $config_name = 'views.view.user_admin_people';
 
     // Add AddMembersToGroup to VBO Admin people.
-    if (in_array($config_name, $names)) {
+    if (in_array($config_name, $names, TRUE)) {
       $overrides[$config_name] = [
         'display' => [
           'default' => [
@@ -38,6 +57,24 @@ class SocialGroupAdminPeopleConfigOverride implements ConfigFactoryOverrideInter
           ],
         ],
       ];
+    }
+
+    $config_name = 'views.view.group_manage_members';
+    // Add all available group types on the platform here, so they can all
+    // make use of the new manage members overview.
+    if (in_array($config_name, $names, TRUE)) {
+      $social_group_types = [
+        'open_group',
+        'closed_group',
+        'public_group',
+      ];
+      $this->moduleHandler->alter('social_group_types', $social_group_types);
+      // Loop over all group types.
+      foreach ($social_group_types as $group_type) {
+        $membership = $group_type . '-group_membership';
+        // Add each group type to the filters of this overview.
+        $overrides[$config_name]['display']['default']['display_options']['filters']['type']['value'][$membership] = $membership;
+      }
     }
 
     return $overrides;


### PR DESCRIPTION
## Problem
The new and improved group management overview doesn't work for group types other than those that come with Open Social. 

## Solution
We've implemented the `social_group_types_alter` hook in such a way that custom group builder can now use that hook to enable the group management overview.

## Issue tracker
http://www.drupal.org/node/3019370

## How to test
- [ ] Install 5.0 on a platform that has custom group types or install a module with custom group types.
- [ ] Make sure this uses the social_group_types_alter hook or implement it
- [ ] Create such a group and go to the manage members section
- [ ] Notice you have the members shown and you can perform actions on them

## Release notes
Part of the other story: #1153 
