### PR TITLE
#3047076: Featuring landing pages on a landing page, shows svg icon over the image

### DIFF
--- a/modules/social_features/social_landing_page/social_landing_page.module
+++ b/modules/social_features/social_landing_page/social_landing_page.module
@@ -241,7 +241,7 @@ function social_landing_page_preprocess_field(&$variables) {
  */
 function _social_landing_page_get_hero_image(Node $node) {
   // Must be a valid node.
-  if (!$node instanceof Node) {
+  if (!$node instanceof Node || $node->getType() !== 'landing_page') {
     return [];
   }
 

--- a/themes/socialbase/src/Plugin/Preprocess/Node.php
+++ b/themes/socialbase/src/Plugin/Preprocess/Node.php
@@ -211,7 +211,7 @@ class Node extends PreprocessBase {
     }
 
     // A landing page has a different way of determining this.
-    if ($node->getType() !== 'landing_page') {
+    if ($node->getType() === 'landing_page') {
       $variables['no_image'] = FALSE;
       $image = _social_landing_page_get_hero_image($node);
       if (empty($image)) {

--- a/themes/socialbase/src/Plugin/Preprocess/Node.php
+++ b/themes/socialbase/src/Plugin/Preprocess/Node.php
@@ -21,6 +21,7 @@ class Node extends PreprocessBase {
    * {@inheritdoc}
    */
   protected function preprocessElement(Element $element, Variables $variables) {
+    /** @var \Drupal\node\Entity\Node $node */
     $node = $variables['node'];
     $account = $node->getOwner();
     $variables['content_type'] = $node->bundle();
@@ -206,6 +207,15 @@ class Node extends PreprocessBase {
             $variables['no_image'] = FALSE;
           }
         }
+      }
+    }
+
+    // A landing page has a different way of determining this.
+    if ($node->getType() !== 'landing_page') {
+      $variables['no_image'] = FALSE;
+      $image = _social_landing_page_get_hero_image($node);
+      if (empty($image)) {
+        $variables['no_image'] = TRUE;
       }
     }
 


### PR DESCRIPTION
## Problem
When you add a featured content section to a landing page and in that section, you link to another landing page, you see a big SVG icon over the image.

## Solution
Only show if the landing page has no image.

## Issue tracker
https://www.drupal.org/project/social/issues/3047076

## How to test
- [ ] Create 2 landing pages (without a hero section)
- [ ] In 1 of them create a featured section with a link to the other landing page
- [ ] Notice the featured LP has an icon
- [ ] Add a hero image to that LP
- [ ] Notice the featured LP has a SMALL icon now. No longer the big one.

## Release notes
When featuring a landing page on another landing page, a big SVG Icon would display over the landing page image. This is now fixed.
