### PR TITLE
Issue #3047142: Prefer instanceof over method_exists in ActivityLoggerFactory::createMessages

### DIFF
--- a/modules/custom/activity_logger/src/Service/ActivityLoggerFactory.php
+++ b/modules/custom/activity_logger/src/Service/ActivityLoggerFactory.php
@@ -4,6 +4,7 @@ namespace Drupal\activity_logger\Service;
 
 use Drupal\Core\Entity\Entity;
 use Drupal\message\Entity\Message;
+use Drupal\user\EntityOwnerInterface;
 
 /**
  * Class ActivityLoggerFactory.
@@ -49,7 +50,7 @@ class ActivityLoggerFactory {
       }
 
       // Get the owner or default to anonymous.
-      if (method_exists($entity, 'getOwner') && $entity->getOwner() !== NULL) {
+      if ($entity instanceof EntityOwnerInterface && $entity->getOwner() !== NULL) {
         $new_message['uid'] = $entity->getOwner()->id();
       }
       else {

--- a/modules/custom/mentions/src/Entity/Mentions.php
+++ b/modules/custom/mentions/src/Entity/Mentions.php
@@ -6,6 +6,7 @@ use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Entity\ContentEntityBase;
 use Drupal\Core\Field\BaseFieldDefinition;
 use Drupal\mentions\MentionsInterface;
+use Drupal\user\UserInterface;
 
 /**
  * Mentions Class.
@@ -103,6 +104,22 @@ class Mentions extends ContentEntityBase implements MentionsInterface {
    */
   public function getOwnerId() {
     return $this->get('auid')->target_id;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setOwnerId($uid) {
+    $this->set('auid', $uid);
+    return $this;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setOwner(UserInterface $account) {
+    $this->set('auid', $account->id());
+    return $this;
   }
 
   /**

--- a/modules/custom/mentions/src/MentionsInterface.php
+++ b/modules/custom/mentions/src/MentionsInterface.php
@@ -3,11 +3,12 @@
 namespace Drupal\mentions;
 
 use Drupal\Core\Entity\ContentEntityInterface;
+use Drupal\user\EntityOwnerInterface;
 
 /**
  * Provides an interface defining a Mention entity.
  */
-interface MentionsInterface extends ContentEntityInterface {
+interface MentionsInterface extends ContentEntityInterface, EntityOwnerInterface {
 
   /**
    * Gets the Mentions creation timestamp.


### PR DESCRIPTION
## Problem/Solution
We should encourage the use of Interfaces (this is exactly what they're for) instead of checking whether the method exists.

Performance wise the difference is negligible (<a href="https://stackoverflow.com/a/29496479/576060">instanceof is even slightly faster</a>). However, <code>instanceof</code> more clearly communicates intent because we're looking to use the <code>getOwner</code> function in the way that it's defined in that interface. When using <code>method_exists</code>, if someone were to implement <code>getOwner</code> but not return an instance of <code>UserInterface</code> then our code would still fall apart.

## Issue tracker
https://www.drupal.org/project/social/issues/3047142

## How to test
- [x] Check tests

## Release notes (5.x)
The check in `ActivityLoggerFactory` to detect whether an entity has an owner now uses the `instanceof` method to check against Drupal's `EntityOwnerInterface`. As a result, the `MentionsInterface` now also extends this interface and the `Mentions` entity implements the setter methods for the interface that it was missing.

## Change Record
https://www.drupal.org/node/3046773

## Orginal 4.x PR
#1299