### PR TITLE
Use private file system for images in landing page

### DIFF
--- a/modules/custom/social_file_private/src/SocialFilePrivateFieldsConfigOverride.php
+++ b/modules/custom/social_file_private/src/SocialFilePrivateFieldsConfigOverride.php
@@ -42,6 +42,7 @@ class SocialFilePrivateFieldsConfigOverride implements ConfigFactoryOverrideInte
       'field.storage.profile.field_profile_image',
       'field.storage.profile.field_profile_banner_image',
       'field.storage.paragraph.field_hero_image',
+      'field.storage.paragraph.field_hero_small_image',
     ];
     return $config_names;
   }


### PR DESCRIPTION
## Problem
Private file system should be used for any image provided by us.

## Solution
I've added it to the social private files configuration.

## Issue tracker
n/a because 5.0 isn't released yet.

## How to test
- [ ] Check if small hero image upload still works.

## Release notes
n/a because 5.0 isn't released yet.