### PR TITLE
Issue #3045772: Alter anonymous enrollment button texts

### DIFF
--- a/modules/social_features/social_event/modules/social_event_an_enroll/templates/event-an-enroll-dialog.html.twig
+++ b/modules/social_features/social_event/modules/social_event_an_enroll/templates/event-an-enroll-dialog.html.twig
@@ -3,11 +3,11 @@
 <div{{ attributes.addClass('event_an_enroll','row') }}>
   <div class="col-md">
     <h5>{% trans %}Enroll with account{% endtrans %}</h5>
-    <p><a class="btn-lg btn btn-primary" href="{{ links.register.uri }}" title="{% trans %}Sign up{% endtrans %}">{% trans %}Sign up{% endtrans %}</a>
+    <p><a class="btn-lg btn btn-primary" href="{{ links.register.uri }}" title="{% trans %}Create an account{% endtrans %}">{% trans %}Create an account{% endtrans %}</a>
     <a class="btn-lg btn btn-default" href="{{ links.login.uri }}" title="{% trans %}Login{% endtrans %}">{% trans %}Log in{% endtrans %}</a></p>
   </div>
   <div class="col-md">
     <h5>{% trans %}Enroll without account{% endtrans %}</h5>
-    <p><a class="btn-lg btn btn-accent" href="{{ links.guest.uri }}" title="{% trans %}Sign up as guest{% endtrans %}">{% trans %}Sign up as guest{% endtrans %}</a></p>
+    <p><a class="btn-lg btn btn-accent" href="{{ links.guest.uri }}" title="{% trans %}Enroll as guest{% endtrans %}">{% trans %}Enroll as guest{% endtrans %}</a></p>
   </div>
 </div>

--- a/tests/behat/features/capabilities/event-an-enroll/event-an-enroll.feature
+++ b/tests/behat/features/capabilities/event-an-enroll/event-an-enroll.feature
@@ -16,9 +16,9 @@ Feature: Enroll for an event without an account
     When I click "Enroll"
     And I wait for AJAX to finish
     And I should see the link "Log in"
-    And I should see the link "Sign up"
-    And I should see the link "Sign up as guest"
-    When I click "Sign up as guest"
+    And I should see the link "Create an account"
+    And I should see the link "Enroll as guest"
+    When I click "Enroll as guest"
     Then I should see "AN Event 1" in the "Hero block"
     And I should not see the link "Enroll" in the "Hero block"
     And I fill in the following:
@@ -38,7 +38,7 @@ Feature: Enroll for an event without an account
     # Duplicate Enrollment.
     When I click "Enroll"
     And I wait for AJAX to finish
-    When I click "Sign up as guest"
+    When I click "Enroll as guest"
     And I fill in the following:
       | First name    | John  |
       | Last name     | Doe   |
@@ -48,7 +48,7 @@ Feature: Enroll for an event without an account
     Given I open the "event" node with title "AN Event 1"
     When I click "Enroll"
     And I wait for AJAX to finish
-    When I click "Sign up as guest"
+    When I click "Enroll as guest"
     And I fill in the following:
       | First name    | John  |
       | Last name     | Doe   |
@@ -76,7 +76,7 @@ Feature: Enroll for an event without an account
       | field_event_date_end     | +4 days                 |
       | field_content_visibility | public                  |
     When I press "Enroll"
-    Then I should not see "Sign up as guest"
+    Then I should not see "Enroll as guest"
 
     ##
     ## In this test the vent must be created using the form because we are
@@ -100,4 +100,4 @@ Feature: Enroll for an event without an account
     And I open the "event" node with title "Anonymous event enrollment"
     When I click "Enroll"
     Then I should see "Enroll in Anonymous event Enrollment"
-    And I should see "Sign up as guest"
+    And I should see "Enroll as guest"


### PR DESCRIPTION
<h2>Problem</h2>
From a customer
<blockquote>I have discovered that the wording on the buttons when an AN tries to enroll in an event can be confusing. Some people interpret "Sign up" to mean sign up for the event rather than sign up for Open Social, and members who have accounts have encountered difficulty by clicking that option.

What do you think about changing the design to have buttons that say something like "Create an Account" "Log In" "Enroll as a Guest" and removing the "Enroll with account" and "Enroll without account" headings?</blockquote>

<h2>Solution</h2>
Change "Sign up" in the modal to "Create an account" and change "Sign up as guest" to "Enroll as guest".

As discussed with Xinyu and Natasha:
<blockquote>I think the problem is the sign up button. I agree that we should change the 'sign up' button into 'Create an account'. 

I don't think we should remove the headings though, they are used to categorise these 2 options conceptually. </blockquote>
<blockquote>

<ul><li>    Create an account</li>
<li>    Log in</li>
<li>    Enroll as guest</li>
</blockquote>

## Issue tracker
https://www.drupal.org/project/social/issues/3045772

## How to test
- [ ] Anonymously try to enrol in an event

## Release notes
The texts that are shown in the modal for anonymous enrolment have been slightly tweaked to clarify the difference between the options for creating an account and enrolling without an account.
