### PR TITLE
Issue #3035614 by agami4: Add the ability to move the text to a new line in the card block

### DIFF
--- a/themes/socialbase/assets/css/cards.css
+++ b/themes/socialbase/assets/css/cards.css
@@ -47,10 +47,6 @@
   padding-top: 0;
 }
 
-.card__block.dropdown-header {
-  white-space: normal;
-}
-
 .card__block--table {
   padding: 1.25rem 0;
 }

--- a/themes/socialbase/assets/css/cards.css
+++ b/themes/socialbase/assets/css/cards.css
@@ -47,6 +47,10 @@
   padding-top: 0;
 }
 
+.card__block.dropdown-header {
+  white-space: normal;
+}
+
 .card__block--table {
   padding: 1.25rem 0;
 }

--- a/themes/socialbase/components/02-atoms/cards/cards.scss
+++ b/themes/socialbase/components/02-atoms/cards/cards.scss
@@ -93,10 +93,6 @@
   & + .card__block {
     padding-top: 0;
   }
-
-  &.dropdown-header {
-    white-space: normal;
-  }
 }
 
 .card__block--table {

--- a/themes/socialbase/components/02-atoms/cards/cards.scss
+++ b/themes/socialbase/components/02-atoms/cards/cards.scss
@@ -94,6 +94,9 @@
     padding-top: 0;
   }
 
+  &.dropdown-header {
+    white-space: normal;
+  }
 }
 
 .card__block--table {

--- a/themes/socialbase/templates/views/views-view.html.twig
+++ b/themes/socialbase/templates/views/views-view.html.twig
@@ -46,7 +46,7 @@
 {%
   set error_classes = [
     display_id == 'page' ? 'alert alert-info',
-    display_id != 'page' ? 'small card__block dropdown-header',
+    display_id != 'page' ? 'small card__block',
   ]
 %}
 


### PR DESCRIPTION
## Problem
When you have no upcoming events and use the site in another language then English that has a longer phrase to describe the absence of events, the texts doesn't wrap as it should. Unsure if it's just this block or more blocks.

## Solution
Add the ability to move the text to a new line in the card block.

## Issue tracker
https://www.drupal.org/project/social/issues/3035614

## How to test
- [x] Should add more texts to 'My upcoming events' block

## Release notes
When you have no upcoming events and use the site in another language than English that has a longer phrase to describe the absence of events, the long texts now move to a new line and displayed correctly.