### PR TITLE
Issue #3047439: Add support for unpublished groups

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,8 @@
                 "Add computed field for Group reference": "https://www.drupal.org/files/issues/add-computed-field-without-FieldItemListComputedInterface-2718195-34.patch",
                 "Add permission to view group overview": "https://www.drupal.org/files/issues/group-2943564-2.patch",
                 "Use VBO together with group permission": "https://www.drupal.org/files/issues/2018-12-18/vbo-and-group-permission-3020883-5.patch",
-                "Ability to use group tokens in node context": "https://www.drupal.org/files/issues/2018-12-19/group-2774827-41-gnode-tokens.patch"
+                "Ability to use group tokens in node context": "https://www.drupal.org/files/issues/2018-12-19/group-2774827-41-gnode-tokens.patch",
+                "Add a status to the group (Publish/Unpublish)": "https://www.drupal.org/files/issues/2019-02-15/group-status-2873212-9.patch"
             },
             "drupal/image_widget_crop": {
                 "Remove theme function override for verticalTabs": "https://www.drupal.org/files/issues/2019-02-13/3032584-verticaltabs-theme-override-removal-2.patch"

--- a/drupal-org.make
+++ b/drupal-org.make
@@ -44,6 +44,7 @@ projects[group][version] = 1.0-rc2
 projects[group][patch][] = "https://www.drupal.org/files/issues/add-computed-field-without-FieldItemListComputedInterface-2718195-34.patch"
 projects[group][patch][] = "https://www.drupal.org/files/issues/group-2943564-2.patch"
 projects[group][patch][] = "https://www.drupal.org/files/issues/2018-12-18/vbo-and-group-permission-3020883-5.patch"
+projects[group][patch][] = "https://www.drupal.org/files/issues/2019-02-15/group-status-2873212-9.patch"
 projects[image_effects][type] = module
 projects[image_effects][version] = 2.3
 projects[image_widget_crop][type] = module


### PR DESCRIPTION
<h2>Problem</h2>

For the course module which uses Groups we have custom logic to be able to unpublish groups. We also have a custom extension to emulate this. 

The group module is working on incorporating this functionality into the Group module itself. Using that code would make our lives a lot easier: [#2873212]

<h2>Solution</h2>
Apply the patch from the group issue to implement the group publishing behaviour so that we can start removing our custom code.

## Issue tracker
https://www.drupal.org/project/social/issues/3047439

## How to test
- [ ] This should do nothing by default. We should add permissions for site managers, content managers to publish/unpublish groups in a follow-up.

## Release notes
The group module now supports the functionality to publish and unpublish groups. This simplifies some of the functionality that we've previously built and allows us to improve on this in the future. This is currently a developer only change.

# Release target
I think we can put this in 5.0 but if the timing of that is too short then feel free to push it to 5.1. The patch can be included in any project that needs it before that.
