### PR TITLE
Issue by Makishima: Embed button is not displayed in the CKEditor for basic_html format

### DIFF
--- a/modules/social_features/social_embed/src/SocialEmbedConfigOverride.php
+++ b/modules/social_features/social_embed/src/SocialEmbedConfigOverride.php
@@ -132,7 +132,6 @@ class SocialEmbedConfigOverride implements ConfigFactoryOverrideInterface {
       return;
     }
 
-    $overrides = [];
     $button_exists = FALSE;
 
     foreach ($settings['toolbar']['rows'] as $row) {


### PR DESCRIPTION
## Problem
The  Embed button  is not displayed in the CKEditor for Basic HTML format if Comment text format also available in the form.
This is because when several text formats are available in the form, the global variable $overrides is cleared and the override applies only to the last text format in the list.

## Solution
Remove the line: `$overrides = [];` from social_embed/src/SocialEmbedConfigOverride.php


