### PR TITLE
Event improvements after Event Manager & Max attendees are merged.

### DIFF
--- a/modules/social_features/social_event/modules/social_event_managers/social_event_managers.module
+++ b/modules/social_features/social_event/modules/social_event_managers/social_event_managers.module
@@ -95,7 +95,7 @@ function social_event_managers_link_alter(&$variables) {
   // Let's make sure we reroute the view more link.
   if (strpos($variables['text'], 'all enrollments') !== false && $variables['url']->getRouteName() === 'view.event_enrollments.view_enrollments') {
     $params = $variables['url']->getRouteParameters();
-    $variables['url'] = Url::fromRoute('view.event_manage_enrollments.page_manage_enrollments', $params);;
+    $variables['url'] = Url::fromRoute('view.event_manage_enrollments.page_manage_enrollments', $params);
   }
 }
 

--- a/modules/social_features/social_event/modules/social_event_managers/social_event_managers.module
+++ b/modules/social_features/social_event/modules/social_event_managers/social_event_managers.module
@@ -89,6 +89,17 @@ function social_event_managers_block_access(Block $block, $operation, AccountInt
 }
 
 /**
+ * Implements hook_link_alter().
+ */
+function social_event_managers_link_alter(&$variables) {
+  // Let's make sure we reroute the view more link.
+  if (strpos($variables['text'], 'all enrollments') !== false && $variables['url']->getRouteName() === 'view.event_enrollments.view_enrollments') {
+    $params = $variables['url']->getRouteParameters();
+    $variables['url'] = Url::fromRoute('view.event_manage_enrollments.page_manage_enrollments', $params);;
+  }
+}
+
+/**
  * Implements hook_entity_access().
  */
 function social_event_managers_entity_access(EntityInterface $entity, $operation, AccountInterface $account) {

--- a/modules/social_features/social_event/modules/social_event_managers/social_event_managers.module
+++ b/modules/social_features/social_event/modules/social_event_managers/social_event_managers.module
@@ -92,9 +92,13 @@ function social_event_managers_block_access(Block $block, $operation, AccountInt
  * Implements hook_link_alter().
  */
 function social_event_managers_link_alter(&$variables) {
+  /** @var \Drupal\Core\Url $url */
+  $url = $variables['url'];
+
   // Let's make sure we reroute the view more link.
-  if (strpos($variables['text'], 'all enrollments') !== false && $variables['url']->getRouteName() === 'view.event_enrollments.view_enrollments') {
-    $params = $variables['url']->getRouteParameters();
+  if (!$url->isExternal() && $url->getRouteName() === 'view.event_enrollments.view_enrollments'
+    && stripos(strtolower($variables['text']), 'all enrollments') !== FALSE) {
+    $params = $url->getRouteParameters();
     $variables['url'] = Url::fromRoute('view.event_manage_enrollments.page_manage_enrollments', $params);
   }
 }

--- a/tests/behat/features/capabilities/event/eventenrollment.feature
+++ b/tests/behat/features/capabilities/event/eventenrollment.feature
@@ -25,9 +25,6 @@ Feature: Enroll for an event
 
     When I click "All enrollments"
     Then I should see the button "Enrolled"
-    And I should see the link "Enrollments"
-    And I should see "View profile"
-    And I should see "View activities"
 
   @AN
   Scenario: Successfully redirect an AN from an event enrollment action


### PR DESCRIPTION
## Problem
- Make sure the all enrollments link now goes to the new enrollments

## Solution
Made sure we alter the views link.

## Issue tracker
Nope

## How to test
- [x] Enable social_event_managers and see the link in the event enrollments block on the full event node now links to the event managers tab. 

## Release notes
- all 5.0 releases so nothing here :) 