### PR TITLE
Issue #3045773 by agami4: Add name and title attributes for dropdown button and link wrapped the teaser icon

### DIFF
--- a/themes/socialbase/templates/comment/links--comment.html.twig
+++ b/themes/socialbase/templates/comment/links--comment.html.twig
@@ -44,7 +44,7 @@
 
   {% if links['comment-edit'] or links['comment-delete'] %}
     <div class="comment__actions pull-right">
-      <button type="button" data-toggle="dropdown" aria-expanded="false" aria-haspopup="true" class="btn btn-icon-toggle dropdown-toggle">
+      <button type="button" data-toggle="dropdown" aria-expanded="false" aria-haspopup="true" class="btn btn-icon-toggle dropdown-toggle" name="{{ 'More options'|t }}">
         <svg class="btn-icon icon-gray">
           <use xlink:href="#icon-expand_more"></use>
         </svg>

--- a/themes/socialbase/templates/node/node--teaser.html.twig
+++ b/themes/socialbase/templates/node/node--teaser.html.twig
@@ -93,7 +93,7 @@
 
     {% if view_mode == 'teaser' or no_image %}
       {% block card_teaser_type %}
-        <a href="{{ url }}">
+        <a href="{{ url }}" title="{{- label|render|striptags|trim -}}">
           <div class="teaser__teaser-type">
             <svg class="teaser__teaser-type-icon">
               <use xlink:href="#icon-{{- node.bundle|clean_class -}}"></use>

--- a/themes/socialbase/templates/system/links.html.twig
+++ b/themes/socialbase/templates/system/links.html.twig
@@ -42,7 +42,7 @@
   {%- endif -%}
   {%- if links.edit -%}
     <div class="comment__actions pull-right">
-      <button type="button" data-toggle="dropdown" aria-expanded="false" aria-haspopup="true" class="btn btn-icon-toggle dropdown-toggle">
+      <button type="button" data-toggle="dropdown" aria-expanded="false" aria-haspopup="true" class="btn btn-icon-toggle dropdown-toggle" name="{{ 'More options'|t }}">
         <svg class="btn-icon icon-gray">
           <use xlink:href="#icon-expand_more"></use>
         </svg>


### PR DESCRIPTION
## Problem
The dropdown button in the activity stream, and other places, does not have a discernable name.
Lighthouse accessibility audits also report that the links wrapped around the default content type icons in the activity stream do not have a discernable name either.

## Solution
Add name attribute to button dropdown with text "More options".
Add title attribute to link wrapped the default content type icons.

## Issue tracker
https://www.drupal.org/project/social/issues/3045773

## How to test
- [ ] You can hover to link wrapped the default content type icons and you can see title current teaser
- [ ] Should open inspect element for button dropdown and you can see name attribute with text "More options"

## Release notes
Added 'title' for link wrapped tease icons and 'name' for button dropdown attributes for improve accessibility
