### PR TITLE
Issue #3045770 by agami4: Add label to search forms

### DIFF
--- a/modules/social_features/social_search/src/Form/SearchContentForm.php
+++ b/modules/social_features/social_search/src/Form/SearchContentForm.php
@@ -57,6 +57,8 @@ class SearchContentForm extends FormBase implements ContainerInjectionInterface 
   public function buildForm(array $form, FormStateInterface $form_state) {
 
     $form['search_input_content'] = [
+      '#title' => $this->t('Search Content'),
+      '#title_display' => 'invisible',
       '#type' => 'textfield',
     ];
 

--- a/modules/social_features/social_search/src/Form/SearchHeroForm.php
+++ b/modules/social_features/social_search/src/Form/SearchHeroForm.php
@@ -69,6 +69,8 @@ class SearchHeroForm extends FormBase implements ContainerInjectionInterface {
   public function buildForm(array $form, FormStateInterface $form_state) {
 
     $form['search_input'] = [
+      '#title' => $this->t('Search'),
+      '#title_display' => 'invisible',
       '#type' => 'textfield',
     ];
 

--- a/themes/socialbase/templates/form/form-element--search-input-content.html.twig
+++ b/themes/socialbase/templates/form/form-element--search-input-content.html.twig
@@ -46,4 +46,8 @@
  */
 #}
 
+{% if label_display in ['before', 'invisible'] %}
+  {{ label }}
+{% endif %}
+
 {{ children }}


### PR DESCRIPTION
## Problem
Text filed of search form do not have a label describing what kind of textarea it is.

## Solution
Added label for text field on search forms.

## Issue tracker
https://www.drupal.org/project/social/issues/3045770

## How to test
- [ ] You can inspected search form

## Release notes
Added label to search form to improve accessibility
