### PR TITLE
Issue #3000026 by mdeny: Add patch for message to fix Notice: 'Undefined index: value in MessageTemplate->getText()'

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -72,6 +72,9 @@
             "drupal/bootstrap": {
                 "Dropdown toggle variable ignored when using links__dropbutton": "https://www.drupal.org/files/issues/2018-12-19/dropdown-without-default-button-3021413-2.patch",
                 "JSDeliver issues unsupported operand types": "https://www.drupal.org/files/issues/2019-01-24/3027569-8.x-3.x-8.patch"
+            },
+            "drupal/message": {
+                "Notice: Undefined index: value in MessageTemplate->getText()": "https://www.drupal.org/files/issues/2018-09-16/undefined-index-value-3000026-2.patch"
             }
         }
     },

--- a/drupal-org.make
+++ b/drupal-org.make
@@ -58,6 +58,7 @@ projects[mailsystem][type] = module
 projects[mailsystem][version] = 4.1
 projects[message][type] = module
 projects[message][version] = 1.0-rc2
+projects[message][patch][] = "https://www.drupal.org/files/issues/2018-09-16/undefined-index-value-3000026-2.patch"
 projects[metatag][type] = module
 projects[metatag][version] = 1.8
 projects[override_node_options][type] = module


### PR DESCRIPTION
## Problem
On Course and Challenge group stream and about pages there we see notices:
`Notice: Undefined index: value in MessageTemplate->getText()`

## Solution
I found the related issue on drupal.org (https://www.drupal.org/project/message/issues/3000026) and applied patch

## Issue tracker
- https://www.drupal.org/project/message/issues/3000026

## How to test
This issue reproduced on enterprise projects (ECI demo).
- [x] Go to the Course and Challenge group stream and about pages you can see notice (Undefined index: value in MessageTemplate->getText())
- [x] Apply patch via composer install
- [x] Go to the Course and Challenge group stream and about pages and be sure that notice (Undefined index: value in MessageTemplate->getText()) is not appear

## Release notes
Fix notice caused by message module (Undefined index: value in MessageTemplate->getText()) on custom group types.