### PR TITLE
Add update hook to enable views_bulk_operations module.

### DIFF
--- a/modules/social_features/social_group/social_group.install
+++ b/modules/social_features/social_group/social_group.install
@@ -518,3 +518,14 @@ function social_group_update_8502() {
   $config->set('default_hero', 'hero');
   $config->save();
 }
+
+/**
+ * Install views_bulk_operation module.
+ */
+function social_group_update_8503() {
+  $modules = [
+    'views_bulk_operations',
+  ];
+
+  \Drupal::service('module_installer')->install($modules);
+}

--- a/modules/social_features/social_group/social_group.install
+++ b/modules/social_features/social_group/social_group.install
@@ -526,6 +526,10 @@ function social_group_update_8503() {
   $modules = [
     'views_bulk_operations',
   ];
-
   \Drupal::service('module_installer')->install($modules);
+
+  // Install default configuration from social_group module so we can reimport
+  // views from the configuration set.
+  \Drupal::service('config.installer')->installDefaultConfig('module', 'social_group');
+
 }


### PR DESCRIPTION
On 8.4.x to 8.5.x update views_bulk_operations module is disabled. So it doesn't allow to import view 'group_manage_members' and group/{group}/stream pages are broken.
Enabling module before config import will fix the issue.

## Problem
group pages wrong after upgrade to 8.5
https://www.drupal.org/project/social/issues/3048980

## Solution
Adding an update hook to enable the module will do the job and by doing config import after enabling module, will allow to import the view.

## Issue tracker
https://www.drupal.org/project/social/issues/3048980

## How to reproduce
- [ ] Switch to 8.x-4.x branch and install the site
- [ ] Notice vbo module is disabled.
- [ ] Switch code base to 8.x-5.x site
- [ ] Do partial config import
- [ ] `group_manage_members` will not be imported due to dependency of `view_bulk_operations`.

## How to test
- [ ] Switch to 8.x-4.x branch and install the site
- [ ] Switch code base to 8.x-5.x site
- [ ] Apply patch and run `drush updb`
~~- [ ] Do partial config import~~ Done automatically by update hook.
- [ ] `group_manage_members` will imported now.

## Release notes

## Change Record

