### PR TITLE
3050192: Check if Url is instanceof Url and check if the Url is routed

### DIFF
--- a/modules/social_features/social_event/modules/social_event_managers/social_event_managers.module
+++ b/modules/social_features/social_event/modules/social_event_managers/social_event_managers.module
@@ -96,7 +96,7 @@ function social_event_managers_link_alter(&$variables) {
   $url = $variables['url'];
 
   // Let's make sure we reroute the view more link.
-  if (!$url->isExternal() && $url->getRouteName() === 'view.event_enrollments.view_enrollments'
+  if ($url instanceof Url && !$url->isExternal() && $url->isRouted() && $url->getRouteName() === 'view.event_enrollments.view_enrollments'
     && stripos(strtolower($variables['text']), 'all enrollments') !== FALSE) {
     $params = $url->getRouteParameters();
     $variables['url'] = Url::fromRoute('view.event_manage_enrollments.page_manage_enrollments', $params);


### PR DESCRIPTION
## Problem
Sometimes non-external Urls are still not routed. This can lead to a hard crash of the platform.

## Solution
Check if an Url is routed before fetching the routename and parameters.

## Issue tracker
https://www.drupal.org/project/social/issues/3050192

## How to test
- [ ] <enter multiple how to test steps here>

## Release notes
Sometimes non-external Urls are still not routed. This can lead to a hard crash of the platform. This is fixed now

