### PR TITLE
DS-6572 in remembrance of Allo Allo - I shall attach the gallery / click handlers only ONCE

### DIFF
--- a/modules/social_features/social_comment_upload/js/comment-upload.js
+++ b/modules/social_features/social_comment_upload/js/comment-upload.js
@@ -6,14 +6,14 @@
     attach: function(context, setting) {
       $('.comment-attachments').once('socialCommentUpload').each(function () {
         var $content = $('> div', this).filter(function () {
-              return !$(this).hasClass('panel-heading');
-            }),
-            $header = $('> summary', this),
-            display = true,
-            handle = function () {
-              display = !display;
-              $content.toggle(display);
-            };
+            return !$(this).hasClass('panel-heading');
+          }),
+          $header = $('> summary', this),
+          display = true,
+          handle = function () {
+            display = !display;
+            $content.toggle(display);
+          };
 
         $header
           .on('click', handle)
@@ -28,7 +28,7 @@
       var $pswp = $('.pswp')[0];
       var image = [];
 
-      $('.photoswipe-gallery-custom').each( function() {
+      $('.photoswipe-gallery-custom').once('AttachGalleryToPhotoswipeElement').each( function() {
         var $pic     = $(this),
           getItems = function() {
             var items = [];
@@ -56,7 +56,7 @@
           image[index].src = value['src'];
         });
 
-        $pic.on('click', 'a.photoswipe-item', function(event) {
+        $pic.once('ClickItemFromGallery').on('click', 'a.photoswipe-item', function(event) {
           event.preventDefault();
 
           // Get the index of our parent which is part of the grid.


### PR DESCRIPTION
## Problem
We encountered issues on SaaS (but could also be on other platforms) where the image gallery in a comment upload would not open anymore after closing.

## Solution
This was caused by the good old JS firing multiple times. Which would always reopen the modal after closing. You wouldnt be able to see this unless directly but when inspecting the code you would see it being fired several times (up to 15x). This caused a transparent overlay to appear which made sure the images weren't clickable anymore.

## Issue tracker
- https://jira.goalgorilla.com/browse/DS-6572

## How to test
- [ ] Will update SaaS with this patch so you can test it there since that is where we encountered the issue, distro should still work fine as well :) 

## Release notes
In 5.0 we added a nice image upload possibility for attachments in comments. Sometimes the image gallery would not be able to open up anymore after closing. This should now work as supposed to. 