### PR TITLE
Issue #2992959 by agami4: Add color inherit for accent button on hover

### DIFF
--- a/themes/socialblue/assets/css/brand.css
+++ b/themes/socialblue/assets/css/brand.css
@@ -127,6 +127,7 @@ fieldset[disabled] .btn-secondary.focus {
   border-color: #ffc142;
   background-image: -webkit-gradient(linear, left top, left bottom, from(rgba(0, 0, 0, 0.2)), to(rgba(0, 0, 0, 0.2)));
   background-image: linear-gradient(to bottom, rgba(0, 0, 0, 0.2) 0%, rgba(0, 0, 0, 0.2) 100%);
+  color: inherit;
 }
 
 .btn-accent.disabled:hover, .btn-accent.disabled:focus, .btn-accent.disabled.focus, .btn-accent[disabled]:hover, .btn-accent[disabled]:focus, .btn-accent[disabled].focus,
@@ -137,6 +138,7 @@ fieldset[disabled] .btn-accent.focus {
   border-color: #ffc142;
   background-image: -webkit-gradient(linear, left top, left bottom, from(rgba(0, 0, 0, 0.2)), to(rgba(0, 0, 0, 0.2)));
   background-image: linear-gradient(to bottom, rgba(0, 0, 0, 0.2) 0%, rgba(0, 0, 0, 0.2) 100%);
+  color: inherit;
 }
 
 .btn-flat,

--- a/themes/socialblue/components/brand.scss
+++ b/themes/socialblue/components/brand.scss
@@ -150,6 +150,7 @@
     background-color: $brand-accent;
     border-color: $brand-accent;
     background-image: linear-gradient(to bottom, rgba(black, 0.2) 0%, rgba(black, 0.2) 100%);
+    color: inherit;
   }
 
   &.disabled,
@@ -161,6 +162,7 @@
       background-color: $brand-accent;
       border-color: $brand-accent;
       background-image: linear-gradient(to bottom, rgba(black, 0.2) 0%, rgba(black, 0.2) 100%);
+      color: inherit;
     }
   }
 


### PR DESCRIPTION
## Problem
if we configure the accent color of the site into a dark color, the button text is still black which makes it not readable.

## Solution
Added color of the text 'inherit' for accent button on hover

## Issue tracker
https://www.drupal.org/project/social/issues/2992959

## How to test
- [ ] Should hover on accent button and you will see a change in the color of the text

## Release notes
Changed text color for accent button from black to white(inherit)
