### PR TITLE
Feature/3050093 create events after update

### DIFF
--- a/modules/social_features/social_event/social_event.module
+++ b/modules/social_features/social_event/social_event.module
@@ -460,7 +460,8 @@ function social_event_form_alter(&$form, FormStateInterface $form_state, $form_i
   switch ($form_id) {
     case 'node_event_edit_form':
       // Set allow event enrollment checked by default for existing events.
-      if ($form_state->getFormObject()->getEntity()->field_event_enroll->isEmpty()) {
+      $entity = $form_state->getFormObject()->getEntity();
+      if ($entity->hasField('field_event_enroll') && $entity->field_event_enroll->isEmpty()) {
         $form['field_event_enroll']['widget']['value']['#default_value'] = TRUE;
       }
 

--- a/modules/social_features/social_event/src/Service/SocialEventEnrollService.php
+++ b/modules/social_features/social_event/src/Service/SocialEventEnrollService.php
@@ -15,7 +15,7 @@ class SocialEventEnrollService implements SocialEventEnrollServiceInterface {
    * {@inheritdoc}
    */
   public function isEnabled(NodeInterface $node) {
-    if ($node->bundle() === 'event') {
+    if ($node->bundle() === 'event' && $node->hasField('field_event_enroll')) {
       $was_not_changed = $node->field_event_enroll->isEmpty();
       $is_enabled = $node->field_event_enroll->value;
 


### PR DESCRIPTION
## Problem
https://www.drupal.org/project/social/issues/3050093

After update from previous versions of 5.x some events are already created and may not contain the field field_event_enroll.

## Solution
Validate properly the field field_event_enroll

## Issue tracker
https://www.drupal.org/project/social/issues/3050093https://www.drupal.org/project/social/issues/3050093

## How to test
After an update from previous version of 5.x, got to see an exist event.

## Release notes
Some people reported issues after update from previous versions to 5.x with creating events. This is caused by the fact that features are not reverted and the field_event_enroll field does not exist on an event. We've made the code a bit more defensive to prevent critical errors in your site. This does not change the fact that you are still required to run a feature revert to make full use of Open Social. Always follow the <a href="https://www.drupal.org/docs/8/distributions/open-social/installing-and-updating">update instructions</a> provided by the software.

## Change Record
If this Pull Request changes the way that developers should do things or introduces a new API for developers then a change record to document this is needed. Please provide a draft for a change record or a link to an unpublished change record below. [Existing change records](https://www.drupal.org/list-changes/social) can be consulted as example.