### PR TITLE
Fix for #3050192 - Cannot get routename of unrouted URLs

### DIFF
--- a/modules/social_features/social_event/modules/social_event_managers/social_event_managers.module
+++ b/modules/social_features/social_event/modules/social_event_managers/social_event_managers.module
@@ -96,7 +96,11 @@ function social_event_managers_link_alter(&$variables) {
   $url = $variables['url'];
 
   // Let's make sure we reroute the view more link.
-  if (!$url->isExternal() && $url->getRouteName() === 'view.event_enrollments.view_enrollments'
+  if (!$url->isExternal()) {
+    return;
+  }
+
+  if ($url->isRouted() && $url->getRouteName() === 'view.event_enrollments.view_enrollments'
     && stripos(strtolower($variables['text']), 'all enrollments') !== FALSE) {
     $params = $url->getRouteParameters();
     $variables['url'] = Url::fromRoute('view.event_manage_enrollments.page_manage_enrollments', $params);


### PR DESCRIPTION
## Problem
The social_event_managers module implement the link alter hook, which checks of an URL is not external and then tries to fetch the routename... however it's not checked that the URL is routed....

## Solution
1. Check if the URL is external
2. Check if it is routed, and then check route characteristics

## Issue tracker
https://www.drupal.org/project/social/issues/3050192

## Release notes
N/A

## Change Record
Not needed