### PR TITLE
Issue #3051436 by Kingdutch: Sub-theme hero gradient broken

### DIFF
--- a/modules/custom/improved_theme_settings/improved_theme_settings.module
+++ b/modules/custom/improved_theme_settings/improved_theme_settings.module
@@ -172,13 +172,13 @@ function improved_theme_settings_page_attachments(array &$page) {
       $hero_gradient_opacity_end = 0.7;
 
       // Alwasys cast as an integer.
-      $hero_gradient_opacity = (integer) improved_theme_settings_get_setting('hero_gradient_opacity', $system_theme_settings);
-      if (isset($hero_gradient_opacity)) {
+      $hero_gradient_opacity = improved_theme_settings_get_setting('hero_gradient_opacity', $system_theme_settings);
+      if ($hero_gradient_opacity !== FALSE) {
         // Convert to values that the gradient can work with.
-        $hero_gradient_opacity_end = $hero_gradient_opacity / 100;
+        $hero_gradient_opacity_end = (int) $hero_gradient_opacity / 100;
 
         // If our opacity has been set to 0, also change the start value to 0.
-        if ($hero_gradient_opacity === 0) {
+        if ($hero_gradient_opacity_end === 0) {
           $hero_gradient_opacity_start = 0;
         }
       }


### PR DESCRIPTION
<h2>Problem</h2>
The usage of the gradient parameter in the theme settings does not properly check for a non existent theme setting. This causes output to be generated even when the setting is not set. Because the default output with a non-existent value results in the values used for 0, there is no hero gradient being applied.

An <code>isset</code> check is performed but the variable is set a line earlier so this check will always be true.

This change was introduced in [#3044302]. #1282 

<h2>Solution</h2>
Properly utilise the return value of the get-theme setting to check whether we have a usable value instead of using isset. The cast to integer is also not needed because it will be output as string.

## Issue tracker
https://www.drupal.org/project/social/issues/3051436

## How to test
- [x] Create a sub-theme without the setting enabled
- [x] Expect the default hero but see no hero

## Release notes
The new adjustable hero background gradient could break the existing background for sub-themes of socialblue. This has been fixed to output no overriding gradient if none is configured.
