### PR TITLE
DS-6570 - Improvement - Can’t find someone for adding to event

### DIFF
--- a/modules/social_features/social_core/src/Entity/EntityAutocompleteMatcher.php
+++ b/modules/social_features/social_core/src/Entity/EntityAutocompleteMatcher.php
@@ -34,6 +34,13 @@ class EntityAutocompleteMatcher extends EntityAutocompleteMatcherBase {
       // Loop through the entities and convert them into autocomplete output.
       foreach ($entity_labels as $values) {
         foreach ($values as $entity_id => $label) {
+          // Skip certain entity_id's that are already a member or a enrollee.
+          // We can just add this to our render arrays from now on.
+          // '#selection_settings' => [ 'skip_entity' => ['7', '8', '9'] ].
+          if (in_array($entity_id, $selection_settings['skip_entity'], FALSE)) {
+            continue;
+          }
+
           $key = !empty($selection_settings['hide_id']) ? $label : "$label ($entity_id)";
           // Strip things like starting/trailing white spaces, line breaks and
           // tags.

--- a/modules/social_features/social_event/modules/social_event_managers/src/Form/SocialEventManagersAddEnrolleeForm.php
+++ b/modules/social_features/social_event/modules/social_event_managers/src/Form/SocialEventManagersAddEnrolleeForm.php
@@ -119,15 +119,6 @@ class SocialEventManagersAddEnrolleeForm extends FormBase {
   public function buildForm(array $form, FormStateInterface $form_state) {
     $form['#attributes']['class'][] = 'card card__block form--default form-wrapper form-group';
 
-    $form['name'] = [
-      '#type' => 'social_enrollment_entity_autocomplete',
-      '#selection_handler' => 'social',
-      '#target_type' => 'user',
-      '#tags' => TRUE,
-      '#description' => $this->t('To add multiple members, separate each member with a comma ( , ).'),
-      '#title' => $this->t('Select members to add'),
-    ];
-
     if (empty($nid)) {
       $node = \Drupal::routeMatch()->getParameter('node');
       if ($node instanceof NodeInterface) {
@@ -138,6 +129,27 @@ class SocialEventManagersAddEnrolleeForm extends FormBase {
         $nid = $node;
       }
     }
+
+    // Load the current Event enrollments so we can check duplicates.
+    $storage = \Drupal::entityTypeManager()->getStorage('event_enrollment');
+    $enrollments = $storage->loadByProperties(['field_event' => $nid]);
+
+    $enrollmentIds = [];
+    foreach ($enrollments as $enrollment) {
+      $enrollmentIds[] = $enrollment->getAccount();
+    }
+
+    $form['name'] = [
+      '#type' => 'social_enrollment_entity_autocomplete',
+      '#selection_handler' => 'social',
+      '#selection_settings' => [
+        'skip_entity' => $enrollmentIds,
+      ],
+      '#target_type' => 'user',
+      '#tags' => TRUE,
+      '#description' => $this->t('To add multiple members, separate each member with a comma ( , ).'),
+      '#title' => $this->t('Select members to add'),
+    ];
 
     $form['actions']['cancel'] = [
       '#type' => 'link',

--- a/modules/social_features/social_event/modules/social_event_managers/src/Form/SocialEventManagersAddEnrolleeForm.php
+++ b/modules/social_features/social_event/modules/social_event_managers/src/Form/SocialEventManagersAddEnrolleeForm.php
@@ -121,6 +121,7 @@ class SocialEventManagersAddEnrolleeForm extends FormBase {
 
     $form['name'] = [
       '#type' => 'social_enrollment_entity_autocomplete',
+      '#selection_handler' => 'social',
       '#target_type' => 'user',
       '#tags' => TRUE,
       '#description' => $this->t('To add multiple members, separate each member with a comma ( , ).'),


### PR DESCRIPTION
## Problem
We noticed the Add Enrollee autocomplete input field doesn't behave the same as the others for lets say adding members to a group.

## Solution
We forgot to use the custom selection handler which ensures the correct Social EntityAutocompleteMatcher is used.
In this case:
`social_features/social_core/src/Entity/EntityAutocompleteMatcher.php`

## Issue tracker
https://jira.goalgorilla.com/browse/DS-6570

## How to test
- [x] Enable Social Event Organizers
- [x] Go to Event management tab and click Add Enrollee
- [x] Search for Tony Stark (no results found)
- [x] Try the same on Adding members to a group, you will see a result
- [x] Now checkout this branch, do a `drush cr`
- [ ] Search for Tony Stark, it has been found!

## Release notes
The behavior for adding Enrollee's to an event is now similar as the one for adding members to a group.