### PR TITLE
DS-6569 Minor textual change on Adding event enrollee submit message.

### DIFF
--- a/modules/social_features/social_event/modules/social_event_managers/src/Form/SocialEventManagersAddEnrolleeForm.php
+++ b/modules/social_features/social_event/modules/social_event_managers/src/Form/SocialEventManagersAddEnrolleeForm.php
@@ -89,8 +89,13 @@ class SocialEventManagersAddEnrolleeForm extends FormBase {
 
       // Add nice messages.
       if (!empty($count)) {
-        $singular = '@count new member is enrolled to your event.';
-        $plural = '@count new members are enrolled to your event.';
+        $singular = '@count new member is enrolled to this event.';
+        $plural = '@count new members are enrolled to this event.';
+
+        if (social_event_manager_or_organizer(NULL, TRUE)) {
+          $singular = '@count new member is enrolled to your event.';
+          $plural = '@count new members are enrolled to your event.';
+        }
 
         $message = $this->formatPlural($count, $singular, $plural);
         \Drupal::messenger()->addMessage($message, 'status');

--- a/modules/social_features/social_event/social_event.module
+++ b/modules/social_features/social_event/social_event.module
@@ -71,15 +71,19 @@ function social_event_form_views_exposed_form_alter(&$form, FormStateInterface $
  *
  * @param \Drupal\node\Entity\Node|null $node
  *   The node the current user could be organizer of.
+ * @param boolean $skipTrustedRoles
+ *   Should we skip CM/SM with the manage everything enrollments
  *
  * @return bool
  *   If the user is actually a manager or organizer.
  */
-function social_event_manager_or_organizer(Node $node = NULL) {
+function social_event_manager_or_organizer(Node $node = NULL, $skipTrustedRoles = FALSE) {
   $account = \Drupal::currentUser();
 
   // Allow if user has the manage everything permission.
-  if ($account->hasPermission('manage everything enrollments')) {
+  // We can skip this to make sure we truly only check organizer & managers, used
+  // for context in notifications.
+  if ($skipTrustedRoles === FALSE && $account->hasPermission('manage everything enrollments')) {
     return TRUE;
   }
 

--- a/modules/social_features/social_event/social_event.module
+++ b/modules/social_features/social_event/social_event.module
@@ -71,8 +71,8 @@ function social_event_form_views_exposed_form_alter(&$form, FormStateInterface $
  *
  * @param \Drupal\node\Entity\Node|null $node
  *   The node the current user could be organizer of.
- * @param boolean $skipTrustedRoles
- *   Should we skip CM/SM with the manage everything enrollments
+ * @param bool $skipTrustedRoles
+ *   Should we skip CM/SM with the manage everything enrollments.
  *
  * @return bool
  *   If the user is actually a manager or organizer.
@@ -81,8 +81,8 @@ function social_event_manager_or_organizer(Node $node = NULL, $skipTrustedRoles 
   $account = \Drupal::currentUser();
 
   // Allow if user has the manage everything permission.
-  // We can skip this to make sure we truly only check organizer & managers, used
-  // for context in notifications.
+  // We can skip this to make sure we truly only check organizer & managers
+  // used for context in notifications.
   if ($skipTrustedRoles === FALSE && $account->hasPermission('manage everything enrollments')) {
     return TRUE;
   }


### PR DESCRIPTION
## Problem
For non event organizers (CM/SM) we show "your event" as part of the submit message, which is a little confusing.

## Solution
We now check if it's actually an organizer or manager. If that is the case we show this message. Of it's someone else we make it this event as a better descriptive message.

## Issue tracker
https://jira.goalgorilla.com/browse/DS-6569

## How to test
- [x] Login as CM
- [x] Add someone to an event
- [x] See that the text refers to the correct plural version of 

```
$singular = '@count new member is enrolled to this event.';
$plural = '@count new members are enrolled to this event.';
```
- [x] Enable Social Event Organizers
- [x] Edit an event and add a Event organisers user
- [x] Login with that user, go to that event you just edited and add an enrollee and see the text refers to the correct plural version of 

```
$singular = '@count new member is enrolled to your event.';
$plural = '@count new members are enrolled to your event.';
```

## Release notes
Only Event Organisers see the your event context, since it's theirs.