### PR TITLE
Issue #2976023 by agami4: Add the ability to show default profile banner image

### DIFF
--- a/modules/social_features/social_profile/social_profile.module
+++ b/modules/social_features/social_profile/social_profile.module
@@ -369,6 +369,14 @@ function social_profile_preprocess_profile(array &$variables) {
     $variables['profile_hero_styled_image_url'] = ImageStyle::load('social_xx_large')
       ->buildUrl($profile->field_profile_banner_image->entity->getFileUri());
   }
+  else {
+    if ($file_uuid = $profile->field_profile_banner_image->getSetting('default_image')['uuid']) {
+      $banner_image = \Drupal::service('entity.repository')->loadEntityByUuid('file', $file_uuid)->getFileUri();
+      if ($banner_image) {
+        $variables['profile_hero_styled_image_url'] = ImageStyle::load('social_xx_large')->buildUrl($banner_image);
+      }
+    }
+  }
 
   // Add the profile image.
   if (!empty($profile->field_profile_image->entity)) {


### PR DESCRIPTION
## Problem
Default profile banner image is not shown

## Solution
Added the ability to show default profile banner image

## Issue tracker
https://www.drupal.org/project/social/issues/2976023

## How to test
- [ ] Should load default profile banner image (/admin/config/people/profiles/manage/profile/fields/profile.profile.field_profile_banner_image)
- [ ] Go to the profile page (if this profile has a default image -> please remove) and check it.

## Release notes
When you upload a default image banner to an image, you can see this image on the profile page if this page does not have its own default image.
