### PR TITLE
Issue #3052391 by jaapjan: make privacy setting description clearer

### DIFF
--- a/modules/social_features/social_profile/modules/social_profile_privacy/social_profile_privacy.module
+++ b/modules/social_features/social_profile/modules/social_profile_privacy/social_profile_privacy.module
@@ -30,7 +30,7 @@ function social_profile_privacy_form_social_profile_admin_settings_form_alter(&$
   $form['privacy']['limit_search_and_mention'] = [
     '#type' => 'checkbox',
     '#title' => t('Limit search and mention'),
-    '#description' => t("Enabling this setting causes users' full name to be hidden on the platform. Users with the '%display_name' permission will still see the full name whenever available. Only users with the '%search_name' permission will find users using their full name through search or mentions.", [
+    '#description' => t("Enabling this setting causes users' full name to be hidden on the platform when the user has filled in their nickname. This setting won't hide the full name of users who didn't fill in a nickname. Users with the '%display_name' permission will still see the full name whenever available. Only users with the '%search_name' permission will find users using their full name through search or mentions.", [
       '%display_name' => t('View full name when restricted'),
       '%search_name' => t('View full name when restricted'),
     ]),


### PR DESCRIPTION
## Problem
On the profile privacy settings page (/admin/config/people/social-profile) it is not clear that the setting to "Limit search and mention" only has effect on people who actually filled in their nickname.

This is the current description for this setting.

```Enabling this setting causes users' full name to be hidden on the platform. Users with the '%display_name' permission will still see the full name whenever available. Only users with the '%search_name' permission will find users using their full name through search or mentions.```

## Solution
Let's change the description text to make this clearer:

```Enabling this setting causes users' full name to be hidden on the platform when the user has filled in their nickname. This setting won't hide the full name of users who didn't fill in a nickname. Users with the '%display_name' permission will still see the full name whenever available. Only users with the '%search_name' permission will find users using their full name through search or mentions.```

## Issue tracker
https://www.drupal.org/project/social/issues/3052391

## How to test
- [ ] Just open the settings page and see it still works as expected.
- [ ] Check code changes.

## Release notes
In the last release we introduced a setting to prevent finding people by their first or last name when their nickname is filled in. It wasn't clear to site managers that this only has effect on people if they actually filled in their nickname.
