### PR TITLE
Issue #3053044: Open Social 5.0 introduces incorrect dependencies in …

### DIFF
--- a/modules/social_features/social_event/modules/social_event_an_enroll/social_event_an_enroll.info.yml
+++ b/modules/social_features/social_event/modules/social_event_an_enroll/social_event_an_enroll.info.yml
@@ -4,4 +4,4 @@ type: module
 core: 8.x
 package: Social
 dependencies:
-  - social_event:social_event_managers
+  - social:social_event_managers

--- a/modules/social_features/social_event/modules/social_event_an_enroll_enrolments_export/social_event_an_enroll_enrolments_export.info.yml
+++ b/modules/social_features/social_event/modules/social_event_an_enroll_enrolments_export/social_event_an_enroll_enrolments_export.info.yml
@@ -4,6 +4,6 @@ type: module
 core: 8.x
 package: Social
 dependencies:
-  - social_event:social_event_an_enroll
-  - social_event:social_event_enrolments_export
-  - social_event:social_event_managers
+  - social:social_event_an_enroll
+  - social:social_event_enrolments_export
+  - social:social_event_managers

--- a/modules/social_features/social_event/modules/social_event_enrolments_export/social_event_enrolments_export.info.yml
+++ b/modules/social_features/social_event/modules/social_event_enrolments_export/social_event_enrolments_export.info.yml
@@ -4,5 +4,5 @@ type: module
 core: 8.x
 package: Social
 dependencies:
-  - social_event:social_event
-  - social_user_export:social_user_export
+  - social:social_event
+  - social:social_user_export

--- a/modules/social_features/social_event/modules/social_event_managers/social_event_managers.info.yml
+++ b/modules/social_features/social_event/modules/social_event_managers/social_event_managers.info.yml
@@ -11,9 +11,6 @@ dependencies:
   - drupal:profile
   - social:social_event
   - social:social_profile
-  - drupal:user
+  - social:social_user
   - drupal:views
-  - social_event:social_event
-  - social_profile:social_profile
-  - social_user:social_user
   - views_bulk_operations:views_bulk_operations

--- a/modules/social_features/social_event/social_event.info.yml
+++ b/modules/social_features/social_event/social_event.info.yml
@@ -30,7 +30,4 @@ dependencies:
   - group_core_comments:group_core_comments
   - image_widget_crop:image_widget_crop
   - profile:profile
-  - social_comment:social_comment
-  - social_core:social_core
-  - social_profile:social_profile
 package: Social


### PR DESCRIPTION
…some modules

<h2>Problem</h2>
The definition <code>project:module</code> is about the Drupal.org project before the colon (:) and the module name after. In Open Social 5.0 some dependencies were introduced where a module name was used before the colon instead of the <code>social</code> project. This can be easily found by:

<code>grep -r --include="*.info.yml" social_.*: modules</code>

Which returned:
<code>
modules/social_features/social_content_report/social_content_report.info.yml:  - social_post:social_post
modules/social_features/social_event/modules/social_event_an_enroll_enrolments_export/social_event_an_enroll_enrolments_export.info.yml:  - social_event:social_event_an_enroll
modules/social_features/social_event/modules/social_event_an_enroll_enrolments_export/social_event_an_enroll_enrolments_export.info.yml:  - social_event:social_event_enrolments_export
modules/social_features/social_event/modules/social_event_an_enroll_enrolments_export/social_event_an_enroll_enrolments_export.info.yml:  - social_event:social_event_managers
modules/social_features/social_event/modules/social_event_enrolments_export/social_event_enrolments_export.info.yml:  - social_event:social_event
modules/social_features/social_event/modules/social_event_enrolments_export/social_event_enrolments_export.info.yml:  - social_user_export:social_user_export
modules/social_features/social_event/modules/social_event_an_enroll/social_event_an_enroll.info.yml:  - social_event:social_event_managers
modules/social_features/social_event/modules/social_event_managers/social_event_managers.info.yml:  - social_event:social_event
modules/social_features/social_event/modules/social_event_managers/social_event_managers.info.yml:  - social_profile:social_profile
modules/social_features/social_event/modules/social_event_managers/social_event_managers.info.yml:  - social_user:social_user
modules/social_features/social_event/social_event.info.yml:  - social_comment:social_comment
modules/social_features/social_event/social_event.info.yml:  - social_core:social_core
modules/social_features/social_event/social_event.info.yml:  - social_profile:social_profile
</code>

<h2>Solution</h2>
Replace the project by <code>social</code>. When this causes duplicate dependencies, remove them.

## Issue tracker
https://www.drupal.org/project/social/issues/3053044

## How to test
- [x] Check that the modules correctly show and enable their dependencies
- [x] Tests still pass

## Release notes
[Internal cleanup can be omitted]