### PR TITLE
Issue #2984283 by agami4: Add loader indicator when loading image

### DIFF
--- a/themes/socialbase/assets/css/ajax.css
+++ b/themes/socialbase/assets/css/ajax.css
@@ -59,18 +59,21 @@ html.js .ajax-new-content:empty {
 
 .form-managed-file {
   position: relative;
-  display: inline-block;
+}
+
+.form-managed-file .form-submit[data-drupal-selector*='upload-button'] {
+  font-size: 0;
+  color: transparent;
 }
 
 .form-managed-file .js-hide.form-submit[disabled] {
-  position: absolute;
-  display: block !important;
+  position: relative;
+  display: inline-block !important;
   width: 40px;
   height: 40px;
-  top: -1px;
+  top: 0;
   right: 0;
   padding: 0;
-  font-size: 0;
 }
 
 .form-managed-file .js-hide.form-submit[disabled] .ajax-throbber {

--- a/themes/socialbase/assets/css/ajax.css
+++ b/themes/socialbase/assets/css/ajax.css
@@ -52,3 +52,33 @@ html.js .input-group-addon .glyphicon.glyphicon-spin {
 html.js .ajax-new-content:empty {
   display: none !important;
 }
+
+.form-type-managed-file label {
+  display: block;
+}
+
+.form-managed-file {
+  position: relative;
+  display: inline-block;
+}
+
+.form-managed-file .js-hide.form-submit[disabled] {
+  position: absolute;
+  display: block !important;
+  width: 40px;
+  height: 40px;
+  top: -1px;
+  right: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.form-managed-file .js-hide.form-submit[disabled] .ajax-throbber {
+  position: absolute;
+  top: 10px;
+  left: 10px;
+}
+
+.form-managed-file .js-hide.form-submit[disabled] .ajax-throbber:before {
+  top: 0;
+}

--- a/themes/socialbase/assets/css/comment.css
+++ b/themes/socialbase/assets/css/comment.css
@@ -108,6 +108,10 @@ a[id^="comment-"] {
   display: none;
 }
 
+.comment-form .form-managed-file {
+  padding-right: 40px;
+}
+
 .comment-form textarea.form-control {
   height: 38px;
 }

--- a/themes/socialbase/assets/css/form-controls.css
+++ b/themes/socialbase/assets/css/form-controls.css
@@ -54,7 +54,7 @@ input[type="checkbox"] {
 }
 
 input[type="file"] {
-  display: block;
+  display: inline-block;
 }
 
 select[multiple],

--- a/themes/socialbase/assets/css/form-post-create.css
+++ b/themes/socialbase/assets/css/form-post-create.css
@@ -53,6 +53,21 @@
   margin-bottom: 1rem;
 }
 
+.form--post-create .field--name-field-post-image .image-widget.hidden {
+  display: block !important;
+  height: 0;
+  margin-bottom: 0 !important;
+}
+
+.form--post-create .field--name-field-post-image .image-widget.hidden .form-file {
+  display: none;
+}
+
+.form--post-create .field--name-field-post-image .image-widget.hidden .form-submit {
+  position: absolute;
+  z-index: 10;
+}
+
 .form--post-create .field--name-field-post-visibility {
   -webkit-box-flex: 1;
       -ms-flex: 1 1 auto;
@@ -71,6 +86,12 @@
 }
 
 @media (min-width: 600px) {
+  .form--post-create .field--name-field-post-image .image-widget.hidden .form-submit {
+    position: relative;
+    top: -2px;
+    left: 150px;
+    right: auto;
+  }
   .form--post-create .field--name-field-post-image {
     -ms-flex-preferred-size: auto;
         flex-basis: auto;
@@ -89,5 +110,18 @@
     -webkit-box-flex: 0;
         -ms-flex-positive: 0;
             flex-grow: 0;
+  }
+}
+
+@media (max-width: 599px) {
+  .form--post-create .field--name-field-post-image .image-widget.hidden .form-submit {
+    width: 29px;
+    height: 29px;
+    top: 3px;
+    right: 3px;
+  }
+  .form--post-create .field--name-field-post-image .image-widget.hidden .form-submit .ajax-throbber {
+    top: 4px;
+    left: 4px;
   }
 }

--- a/themes/socialbase/components/02-atoms/form-controls/_input.scss
+++ b/themes/socialbase/components/02-atoms/form-controls/_input.scss
@@ -43,7 +43,7 @@ input[type="checkbox"] {
 }
 
 input[type="file"] {
-  display: block;
+  display: inline-block;
 }
 
 // Make multiple select elements height not fixed

--- a/themes/socialbase/components/03-molecules/form-elements/autocomplete/ajax.scss
+++ b/themes/socialbase/components/03-molecules/form-elements/autocomplete/ajax.scss
@@ -57,17 +57,20 @@ html.js {
 
 .form-managed-file {
   position: relative;
-  display: inline-block;
+
+  .form-submit[data-drupal-selector*='upload-button'] {
+    font-size: 0;
+    color: transparent;
+  }
 
   .js-hide.form-submit[disabled] {
-    position: absolute;
-    display: block !important;
+    position: relative;
+    display: inline-block !important;
     width: 40px;
     height: 40px;
-    top: -1px;
+    top: 0;
     right: 0;
     padding: 0;
-    font-size: 0;
 
     .ajax-throbber {
       position: absolute;

--- a/themes/socialbase/components/03-molecules/form-elements/autocomplete/ajax.scss
+++ b/themes/socialbase/components/03-molecules/form-elements/autocomplete/ajax.scss
@@ -45,3 +45,42 @@ html.js {
     display: none !important;
   }
 }
+
+// For position progress bar.
+.form-type-managed-file {
+
+  label {
+    display: block;
+  }
+
+}
+
+.form-managed-file {
+  position: relative;
+  display: inline-block;
+
+  .js-hide.form-submit[disabled] {
+    position: absolute;
+    display: block !important;
+    width: 40px;
+    height: 40px;
+    top: -1px;
+    right: 0;
+    padding: 0;
+    font-size: 0;
+
+    .ajax-throbber {
+      position: absolute;
+      top: 10px;
+      left: 10px;
+
+
+      &:before {
+        top: 0;
+      }
+
+    }
+
+  }
+
+}

--- a/themes/socialbase/components/04-organisms/comment/comment.scss
+++ b/themes/socialbase/components/04-organisms/comment/comment.scss
@@ -131,6 +131,10 @@ a[id^="comment-"] {
 
 .comment-form {
 
+  .form-managed-file {
+    padding-right: 40px;
+  }
+
   @include for-phone-only {
 
     .btn--comment-submit {

--- a/themes/socialbase/components/04-organisms/forms/form-post-create.scss
+++ b/themes/socialbase/components/04-organisms/forms/form-post-create.scss
@@ -37,6 +37,41 @@
       justify-content: flex-end;
       position: relative;
       margin-bottom: 1rem;
+
+      &.hidden {
+        display: block !important;
+        height: 0;
+        margin-bottom: 0 !important;
+
+        .form-file {
+          display: none;
+        }
+
+        .form-submit {
+          position: absolute;
+          z-index: 10;
+
+          @include for-phone-only {
+            width: 29px;
+            height: 29px;
+            top: 3px;
+            right: 3px;
+
+            .ajax-throbber {
+              top: 4px;
+              left: 4px;
+            }
+          }
+
+          @include for-tablet-portrait-up {
+            position: relative;
+            top: -2px;
+            left: 150px;
+            right: auto;
+          }
+        }
+
+      }
     }
 
     @include for-tablet-portrait-up {


### PR DESCRIPTION
## Problem
When loading image from any input form (stream, topic etc.) there's no loader indicating to wait.

## Solution
Show loading indicator when loading image

## Issue tracker
https://www.drupal.org/project/social/issues/2984283

## How to test
- [x] Should create new topic or other Content Type and it should be clear there is a loader indicating to wait.
- [x] Should create new comment with attachment and it should be clear there is a loader indicating to wait.
- [x] Should create new post with image and it should be clear there is a loader indicating to wait.

## Release notes
When uploading an image in any file attachment form (post, comment and topic for example) there is now a loader which indicate that the user should wait for the image to upload.
