### PR TITLE
Issue #2975701 by agami4: Add content variable without default fields

### DIFF
--- a/themes/socialbase/templates/profile/profile--profile--default.html.twig
+++ b/themes/socialbase/templates/profile/profile--profile--default.html.twig
@@ -122,6 +122,10 @@
       {% endfor %}
     {% endif %}
 
+    {{  content|without('field_profile_phone_number', 'user_mail', 'field_profile_address',
+      'field_profile_self_introduction', 'field_profile_interests', 'field_profile_expertise',
+      'field_profile_profile_tag') }}
+
     {% if (content|render is empty and user_mail is empty)%}
         {% trans %}{{ profile_name }} {{ profile_name_extra }} has not shared profile information.{% endtrans %}
     {% endif %}


### PR DESCRIPTION
## Problem
Currently when you change display settings of the profile to display more fields these are not displayed without making any required changes to the template.

## Solution
Add content variable without default fields

## Issue tracker
https://www.drupal.org/project/social/issues/2975701

## How to test
- [x] Should add new filed to profile page
- [x] Edit some profile page
- [x] Add some content for new field
- [x] Check input the new field on page

## Release notes
When you change display settings of the profile to display more fields these are not displayed without making changes to the profile template. The content variable is now also rendered without default fields so that when you add new fields they will display
