### PR TITLE
#3034356 - Event Organiser receives notification when (s)he enrolls in his/her own event

### DIFF
--- a/modules/custom/activity_basics/activity_basics.api.php
+++ b/modules/custom/activity_basics/activity_basics.api.php
@@ -17,11 +17,17 @@
  *   The recipients receiving a notification.
  * @param \Drupal\node\Entity\Node $event
  *   The Event that was joined.
+ * @param array $data
+ *   The data concerning the activity needed for context.
  *
  * @ingroup activity_basics_api
  */
-function hook_activity_recipient_organizer_alter(array &$recipients, \Drupal\node\Entity\Node $event) {
+function hook_activity_recipient_organizer_alter(array &$recipients, \Drupal\node\Entity\Node $event, array $data) {
   $organizers = $event->getOwnerId();
+
+  if ($data['target_type'] !== 'event_enrollment') {
+    return;
+  }
 
   // Add the creator of the Event as a recipient.
   $recipients[] = [

--- a/modules/custom/activity_basics/src/Plugin/ActivityContext/OrganizerActivityContext.php
+++ b/modules/custom/activity_basics/src/Plugin/ActivityContext/OrganizerActivityContext.php
@@ -67,7 +67,7 @@ class OrganizerActivityContext extends ActivityContextBase {
     // If there are any others we should add. Make them also part of the
     // recipients array.
     \Drupal::moduleHandler()
-      ->alter('activity_recipient_organizer', $recipients, $event);
+      ->alter('activity_recipient_organizer', $recipients, $event, $original_related_object);
 
     return $recipients;
   }

--- a/modules/custom/activity_basics/src/Plugin/ActivityContext/OrganizerActivityContext.php
+++ b/modules/custom/activity_basics/src/Plugin/ActivityContext/OrganizerActivityContext.php
@@ -32,7 +32,9 @@ class OrganizerActivityContext extends ActivityContextBase {
     // Remove the actor (user performing action) from recipients list.
     if (!empty($data['actor'])) {
       $key = array_search($data['actor'], array_column($recipients, 'target_id'), FALSE);
-      unset($recipients[$key]);
+      if ($key !== FALSE) {
+        unset($recipients[$key]);
+      }
     }
 
     return $recipients;

--- a/modules/custom/activity_basics/src/Plugin/ActivityContext/OrganizerActivityContext.php
+++ b/modules/custom/activity_basics/src/Plugin/ActivityContext/OrganizerActivityContext.php
@@ -29,6 +29,12 @@ class OrganizerActivityContext extends ActivityContextBase {
       }
     }
 
+    // Remove the actor (user performing action) from recipients list.
+    if (!empty($data['actor'])) {
+      $key = array_search($data['actor'], array_column($recipients, 'target_id'), FALSE);
+      unset($recipients[$key]);
+    }
+
     return $recipients;
   }
 
@@ -38,7 +44,7 @@ class OrganizerActivityContext extends ActivityContextBase {
   public function getRecipientOrganizerFromEntity(array $related_entity, array $data) {
     $recipients = [];
 
-    // Don't return recipients if user comments on own content.
+    // Don't return recipients if user enrolls to own Event.
     $original_related_object = $data['related_object'][0];
     if (isset($original_related_object['target_type'])
       && $original_related_object['target_type'] === 'event_enrollment'

--- a/modules/custom/activity_basics/src/Plugin/ActivityContext/OwnerActivityContext.php
+++ b/modules/custom/activity_basics/src/Plugin/ActivityContext/OwnerActivityContext.php
@@ -30,6 +30,12 @@ class OwnerActivityContext extends ActivityContextBase {
       }
     }
 
+    // Remove the actor (user performing action) from recipients list.
+    if (!empty($data['actor'])) {
+      $key = array_search($data['actor'], array_column($recipients, 'target_id'), FALSE);
+      unset($recipients[$key]);
+    }
+
     return $recipients;
   }
 

--- a/modules/custom/activity_basics/src/Plugin/ActivityContext/OwnerActivityContext.php
+++ b/modules/custom/activity_basics/src/Plugin/ActivityContext/OwnerActivityContext.php
@@ -33,7 +33,9 @@ class OwnerActivityContext extends ActivityContextBase {
     // Remove the actor (user performing action) from recipients list.
     if (!empty($data['actor'])) {
       $key = array_search($data['actor'], array_column($recipients, 'target_id'), FALSE);
-      unset($recipients[$key]);
+      if ($key !== FALSE) {
+        unset($recipients[$key]);
+      }
     }
 
     return $recipients;

--- a/modules/social_features/social_event/modules/social_event_managers/social_event_managers.module
+++ b/modules/social_features/social_event/modules/social_event_managers/social_event_managers.module
@@ -370,7 +370,7 @@ function social_event_managers_activity_recipient_organizer_alter(array &$recipi
   // so we add them to the array of recipients.
   if (!empty($organizers)) {
     foreach ($organizers as $organizer) {
-      // We don't want the Organizer to receive activity_on_events_im_organizing.
+      // We don't want Organizers to receive activity_on_events_im_organizing.
       // He will already receive it as part of a different context.
       if (!empty($receiver) && $organizer['target_id'] === $receiver) {
         continue;

--- a/modules/social_features/social_event/modules/social_event_managers/social_event_managers.module
+++ b/modules/social_features/social_event/modules/social_event_managers/social_event_managers.module
@@ -20,6 +20,7 @@ use Drupal\social_event\EventEnrollmentInterface;
 use Drupal\social_event_managers\SocialEventManagersAccessHelper;
 use Drupal\user\Entity\User;
 use Drupal\views\ViewExecutable;
+use Drupal\social_event\Entity\EventEnrollment;
 
 /**
  * Implements hook_preprocess_block().
@@ -356,13 +357,25 @@ function social_event_managers_form_node_event_form_alter(&$form, FormStateInter
 /**
  * Implements hook_activity_recipient_organizer_alter().
  */
-function social_event_managers_activity_recipient_organizer_alter(array &$recipients, Node $event) {
+function social_event_managers_activity_recipient_organizer_alter(array &$recipients, Node $event, $data) {
+  $receiver = '';
   $organizers = $event->get('field_event_managers')->getValue();
+
+  if ($data['target_type'] === 'event_enrollment' && !empty($data['target_id'])) {
+    $enrollment = EventEnrollment::load($data['target_id']);
+    $receiver = $enrollment->getAccount();
+  }
 
   // If there are more organizers we want them to receive a notification too
   // so we add them to the array of recipients.
   if (!empty($organizers)) {
     foreach ($organizers as $organizer) {
+      // We don't want the Organizer to receive activity_on_events_im_organizing.
+      // He will already receive it as part of a different context.
+      if (!empty($receiver) && $organizer['target_id'] === $receiver) {
+        continue;
+      }
+
       // Make sure we don't add the people twice.
       if (!in_array($organizer['target_id'], array_column($recipients, 'target_id'))) {
         $recipients[] = [


### PR DESCRIPTION
## Problem
When an Event organiser Enrolls to his / her own event they get a notification. Whether that is through the Enroll button or through the "Add Enrollees" management function doesn't matter.

## Solution
We filter out the actor, we don't want them to receive notifications from actions they did themselves. 

## Issue tracker
- https://www.drupal.org/project/social/issues/3034356
- https://jira.goalgorilla.com/browse/DS-6568


## How to test
- [x] Login as Admin (make sure event management is enabled)
- [x] Add Chris Hall as Event Organiser
- [x] Login with Chris Hall incognito
- [x] Press the Enroll button and see you don't receive a notification
- [x] As admin add yourself and Chris Hall to the event through the Add Enrollee function
- [x] See that you as Admin don't receive anything

## Release notes
As an Event Creator or Organiser you accidentally received notifications when you would add or enroll yourself to an event yourself.