### PR TITLE
Issue #2949011 by agami4: Add new styles for unread thread card on social base theme

### DIFF
--- a/themes/socialbase/assets/css/message.css
+++ b/themes/socialbase/assets/css/message.css
@@ -157,12 +157,17 @@
   background-size: 22px 22px;
 }
 
+.unread-thread .card {
+  background: rgba(0, 0, 0, 0.02);
+}
+
 .unread-thread .read-indicator {
   display: inline-block;
   width: 10px;
   height: 10px;
   border-radius: 50%;
   margin: 0 5px;
+  background-color: rgba(0, 0, 0, 0.2);
 }
 
 @media (min-width: 600px) {

--- a/themes/socialbase/components/04-organisms/message/message.scss
+++ b/themes/socialbase/components/04-organisms/message/message.scss
@@ -200,11 +200,16 @@
 
 // Unread thread styling
 .unread-thread {
+  .card {
+    background: rgba(0, 0, 0, .02);
+  }
+
   .read-indicator {
     display: inline-block;
     width: 10px;
     height: 10px;
     border-radius: 50%;
     margin: 0 5px;
+    background-color: rgba(0,0,0, .2);
   }
 }


### PR DESCRIPTION
## Problem
Colors are reserved for the socialblue theme which is good. However, the unread-thread class for the private message module contains no color changes at all in the socialbase theme which can lead to UX issues.

## Solution
Let socialbase change:
- The background card color to be slightly off-white (from it's default, white).
- The read-indicator a background-color of something like rgba(0,0,0,0.2)

## Issue tracker
https://www.drupal.org/project/social/issues/2949011

## How to test
- [ ] Should enable Social Base theme
- [ ] Send private message and  check styles for unread thread card and read indicaotr

## Release notes
Added new styles for unread thread:
- The background card color to be slightly off-white 
(from it's default, white) background: rgba(0, 0, 0, .02);.
- The read-indicator a background-color of something like rgba(0,0,0,0.2)
