### PR TITLE
Issue #3064560 by Makishima: Makes the activity statistics block on the landing page extensible by other modules

### DIFF
--- a/modules/social_features/social_landing_page/social_landing_page.api.php
+++ b/modules/social_features/social_landing_page/social_landing_page.api.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * @file
+ * Hooks provided by the Social Landing Page module.
+ */
+
+/**
+ * @addtogroup hooks
+ */
+
+/**
+ * Provide a method to alter array of activity overview block items.
+ *
+ * @param array $build
+ *   Array with build data.
+ *
+ * @ingroup social_landing_page_api
+ */
+function hook_social_landing_page_activity_overview_alter(array &$build) {
+  unset($build[0]['group_info']);
+}
+
+/**
+ * @} End of "addtogroup hooks".
+ */

--- a/modules/social_features/social_landing_page/src/Plugin/Block/ActivityOverviewBlock.php
+++ b/modules/social_features/social_landing_page/src/Plugin/Block/ActivityOverviewBlock.php
@@ -4,6 +4,7 @@ namespace Drupal\social_landing_page\Plugin\Block;
 
 use Drupal\Core\Block\BlockBase;
 use Drupal\Core\Database\Connection;
+use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -25,16 +26,25 @@ class ActivityOverviewBlock extends BlockBase implements ContainerFactoryPluginI
   protected $connection;
 
   /**
+   * The module handler service.
+   *
+   * @var \Drupal\Core\Extension\ModuleHandlerInterface
+   */
+  protected $moduleHandler;
+
+  /**
    * {@inheritdoc}
    */
   public function __construct(
     array $configuration,
     $plugin_id,
     $plugin_definition,
-    Connection $connection
+    Connection $connection,
+    ModuleHandlerInterface $module_handler
   ) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
     $this->connection = $connection;
+    $this->moduleHandler = $module_handler;
   }
 
   /**
@@ -45,7 +55,8 @@ class ActivityOverviewBlock extends BlockBase implements ContainerFactoryPluginI
       $configuration,
       $plugin_id,
       $plugin_definition,
-      $container->get('database')
+      $container->get('database'),
+      $container->get('module_handler')
     );
   }
 
@@ -53,7 +64,7 @@ class ActivityOverviewBlock extends BlockBase implements ContainerFactoryPluginI
    * {@inheritdoc}
    */
   public function build() {
-    return [
+    $build = [
       [
         '#type' => 'container',
         '#attributes' => [
@@ -274,6 +285,10 @@ class ActivityOverviewBlock extends BlockBase implements ContainerFactoryPluginI
       ],
     ];
 
+    $this->moduleHandler
+      ->alter('social_landing_page_activity_overview', $build);
+
+    return $build;
   }
 
   /**


### PR DESCRIPTION
## Problem
As a LU I want to see relevant statistics for Challenges and Ideas in the Activity overview block on the landing page

## Solution
Add the alter hook in the social_landing_page module to allow other modules to extend Activity overview block items

## Issue tracker
https://www.drupal.org/project/social/issues/3064560
https://jira.goalgorilla.com/browse/FOR-163
