### PR TITLE
#3053234: Replaced incorrect route for default profile landing page at user settings

### DIFF
--- a/modules/social_features/social_user/src/Form/SocialUserSettingsForm.php
+++ b/modules/social_features/social_user/src/Form/SocialUserSettingsForm.php
@@ -39,7 +39,7 @@ class SocialUserSettingsForm extends ConfigFormBase {
       '#title' => t('Choose a default landing page'),
       '#description' => t('When visiting a profile the user will end up at this page first'),
       '#options' => [
-        'entity.user.canonical' => t('Stream'),
+        'social_user.stream' => t('Stream'),
         'view.user_information.user_information' => t('Information'),
       ],
       '#default_value' => $config->get('social_user_profile_landingpage'),


### PR DESCRIPTION
## Problem
The default settings works fine, switching from the default (stream) to the information page also works. However when switching back to the default the profile page redirect breaks and you end up on an empty profile page.

<img width="1166" alt="Screenshot 2019-05-07 at 20 22 15" src="https://user-images.githubusercontent.com/7124754/57324308-d001cf00-7107-11e9-966d-db973dee5031.png">

This feature and the issue was introduced in #1284.

## Solution
Changed the default route in the settings form from the entity canonical url to `social_user.stream`.

## Issue tracker
https://www.drupal.org/project/social/issues/3053234

## How to test
- [x] Go to a users profile, you should see the stream
- [x] Switch the default profile landing page to "Information"
- [x] Go to a users profile, you should see the information page
- [x] Switch the default profile landing page to the initial setting "Stream"
- [x] Go to a users profile, you should see the stream (where before it would show an empty page.

## Release notes
Switching back to the default profile landing page setting now delivers the expected page result to users.