### PR TITLE
Issue #3050760: Ensure event max enroll limit takes anonymous enrollments into account

### DIFF
--- a/modules/social_features/social_event/modules/social_event_an_enroll/social_event_an_enroll.module
+++ b/modules/social_features/social_event/modules/social_event_an_enroll/social_event_an_enroll.module
@@ -130,7 +130,7 @@ function social_event_an_enroll_views_post_render(ViewExecutable $view, &$output
       if (!empty($view->args[0])) {
         $nid = $view->args[0];
         $node = Node::load($nid);
-        $an_count = social_event_an_enroll_count($nid);
+        $an_count = \Drupal::service('social_event_an_enroll.service')->enrollmentCount($nid);
         if (social_event_an_enroll_is_enabled($node) && $an_count && $an_count > 0) {
           // Fix counter in block title.
           $view->total_rows += $an_count;
@@ -159,40 +159,6 @@ function social_event_an_enroll_views_post_render(ViewExecutable $view, &$output
       }
     }
   }
-}
-
-/**
- * Returns number of anonymous enrollments.
- */
-function social_event_an_enroll_count($nid) {
-  $query = \Drupal::database()
-    ->select('event_enrollment__field_account', 'eefa');
-  $query->join('event_enrollment__field_event', 'eefe', 'eefa.entity_id = eefe.entity_id');
-  $query->condition('eefa.field_account_target_id', 0);
-  $query->condition('eefe.field_event_target_id', $nid);
-
-  return (int) $query
-    ->countQuery()
-    ->execute()
-    ->fetchField();
-}
-
-/**
- * Returns number of anonymous enrollments.
- */
-function social_event_an_enroll_token_exists($token, $nid) {
-  $query = \Drupal::database()
-    ->select('event_enrollment__field_token', 'eeft');
-  $query->join('event_enrollment__field_event', 'eefe', 'eeft.entity_id = eefe.entity_id');
-  $query->condition('eeft.field_token_value', $token);
-  $query->condition('eefe.field_event_target_id', $nid);
-
-  $results = $query
-    ->countQuery()
-    ->execute()
-    ->fetchField();
-
-  return !empty($results);
 }
 
 /**

--- a/modules/social_features/social_event/modules/social_event_an_enroll/social_event_an_enroll.services.yml
+++ b/modules/social_features/social_event/modules/social_event_an_enroll/social_event_an_enroll.services.yml
@@ -5,3 +5,9 @@ services:
     class: \Drupal\social_event_an_enroll\EventAnEnrollOverride
     tags:
       - {name: config.factory.override, priority: 5}
+  social_event_an_enroll.service:
+    class: Drupal\social_event_an_enroll\EventAnEnrollService
+    arguments:
+      - '@current_user'
+      - '@current_route_match'
+      - '@database'

--- a/modules/social_features/social_event/modules/social_event_an_enroll/src/EventAnEnrollService.php
+++ b/modules/social_features/social_event/modules/social_event_an_enroll/src/EventAnEnrollService.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace Drupal\social_event_an_enroll;
+
+use Drupal\Core\Database\Connection;
+use Drupal\Core\Routing\CurrentRouteMatch;
+use Drupal\Core\Session\AccountProxyInterface;
+
+/**
+ * Class EventAnEnrollService.
+ */
+class EventAnEnrollService {
+
+  /**
+   * The current user.
+   *
+   * @var \Drupal\Core\Session\AccountProxyInterface
+   */
+  protected $currentUser;
+
+  /**
+   * The current route.
+   *
+   * @var \Drupal\Core\Routing\CurrentRouteMatch
+   */
+  protected $currentRouteMatch;
+
+  /**
+   * Database connection.
+   *
+   * @var \Drupal\Core\Database\Connection
+   */
+  protected $database;
+
+  /**
+   * EventAnEnrollService constructor.
+   *
+   * @param \Drupal\Core\Session\AccountProxyInterface $account_proxy
+   *   Account proxy.
+   * @param \Drupal\Core\Routing\CurrentRouteMatch $current_route_match
+   *   Current route match.
+   * @param \Drupal\Core\Database\Connection $connection
+   *   Database connection.
+   */
+  public function __construct(AccountProxyInterface $account_proxy, CurrentRouteMatch $current_route_match, Connection $connection) {
+    $this->currentUser = $account_proxy;
+    $this->currentRouteMatch = $current_route_match;
+    $this->database = $connection;
+  }
+
+  /**
+   * Returns number of anonymous enrollments.
+   *
+   * @param int $nid
+   *   The node ID.
+   *
+   * @return int
+   *   The number of anonymous event enrollments.
+   */
+  public function enrollmentCount($nid) {
+    $query = $this->database
+      ->select('event_enrollment__field_account', 'eefa');
+    $query->join('event_enrollment__field_event', 'eefe', 'eefa.entity_id = eefe.entity_id');
+    $query->condition('eefa.field_account_target_id', 0);
+    $query->condition('eefe.field_event_target_id', $nid);
+
+    return (int) $query
+      ->countQuery()
+      ->execute()
+      ->fetchField();
+  }
+
+  /**
+   * Returns number of anonymous enrollments.
+   *
+   * @param string $token
+   *   Token to validate.
+   * @param int $nid
+   *   The node ID.
+   *
+   * @return bool
+   *   TRUE if token exists, FALSE otherwise.
+   */
+  public function tokenExists($token, $nid) {
+    $query = $this->database
+      ->select('event_enrollment__field_token', 'eeft');
+    $query->join('event_enrollment__field_event', 'eefe', 'eeft.entity_id = eefe.entity_id');
+    $query->condition('eeft.field_token_value', $token);
+    $query->condition('eefe.field_event_target_id', $nid);
+
+    $results = $query
+      ->countQuery()
+      ->execute()
+      ->fetchField();
+
+    return !empty($results);
+  }
+
+  /**
+   * Checks if a visitor is enrolled.
+   *
+   * @return bool
+   *   Returns TRUE if the visitor is enrolled to this event, otherwise FALSE.
+   */
+  public function isEnrolled() {
+    // Make sure the current user is anonymous.
+    if (!$this->currentUser->isAnonymous()) {
+      return FALSE;
+    }
+
+    // Get the token and Node ID from the route.
+    $token = $this->currentRouteMatch->getParameter('token');
+    /** @var \Drupal\node\NodeInterface $node */
+    $node = $this->currentRouteMatch->getParameter('node');
+
+    // If some data is missing we can already return FALSE.
+    if (!empty($token) || !empty($node)) {
+      return FALSE;
+    }
+
+    // Check if the token is valid.
+    return $this->tokenExists($token, $node->id());
+  }
+
+}

--- a/modules/social_features/social_event/modules/social_event_an_enroll/src/Form/EventAnEnrollActionForm.php
+++ b/modules/social_features/social_event/modules/social_event_an_enroll/src/Form/EventAnEnrollActionForm.php
@@ -29,7 +29,7 @@ class EventAnEnrollActionForm extends EnrollActionForm {
     $nid = $node->id();
     $token = $this->getRequest()->query->get('token');
 
-    if (!empty($token) && social_event_an_enroll_token_exists($token, $nid)) {
+    if (!empty($token) && \Drupal::service('social_event_an_enroll.service')->tokenExists($token, $nid)) {
       $form['event'] = [
         '#type' => 'hidden',
         '#value' => $nid,

--- a/modules/social_features/social_event/modules/social_event_max_enroll/social_event_max_enroll.module
+++ b/modules/social_features/social_event/modules/social_event_max_enroll/social_event_max_enroll.module
@@ -88,13 +88,26 @@ function social_event_max_enroll_form_alter(&$form, FormStateInterface $form_sta
         $left = $event_max_enroll_service->getEnrollmentsLeft($node);
 
         if ($left < 1) {
-          $enrollments = \Drupal::entityTypeManager()->getStorage('event_enrollment')
-            ->loadByProperties([
-              'field_event' => $node->id(),
-              'user_id' => \Drupal::currentUser()->id(),
-            ]);
+          $enrollments = FALSE;
+          // Only load enrollments for authenticated users.
+          if (\Drupal::currentUser()->isAuthenticated()) {
+            $enrollments = \Drupal::entityTypeManager()->getStorage('event_enrollment')
+              ->loadByProperties([
+                'field_event' => $node->id(),
+                'user_id' => \Drupal::currentUser()->id(),
+              ]);
+          }
 
-          if (!$enrollments) {
+          $an_enrollments = FALSE;
+          // If Social Event AN Enroll module is enabled, check if the current
+          // visitor is enrolled to the event.
+          if (\Drupal::service('module_handler')->moduleExists('social_event_an_enroll') && \Drupal::service('social_event_an_enroll.service')->isEnrolled()) {
+            $an_enrollments = TRUE;
+          }
+
+          // If this user or visitor is not enrolled to the event, show that
+          // there are no more spots left.
+          if (!$enrollments && !$an_enrollments) {
             if ($form_id === 'enroll_action_form') {
               $form['enroll_for_this_event']['#value'] = t('No spots left');
               $form['enroll_for_this_event']['#disabled'] = TRUE;


### PR DESCRIPTION
## Problem
The enroll button for anonymous users is never showing the 'no spots left' disabled button when there was at least one anonymous enrollment.

There was only a check if the current user had an event enrollment. But when there was already one anonymous enrollment, this would always be positive for anonymous visitors as the user ID would be 0.

## Solution
Refactored the check for authenticated enrollments and added a new one for anonymous enrollments if the module was enabled.

Also moved AN enroll functions to a service, where I also added a function to see if there was a "logged-in" visitor looking at the event.

## Issue tracker
https://www.drupal.org/project/social/issues/3050760

## How to test
- [x] Set max enroll limit for an event at 2
- [x] Enroll as authenticated user, you should see the "Enrolled" state button
- [x] Enroll as anonymous visitor, you should see the "Enrolled" state button
- [x] As another anonymous visitor try to enroll, you should see "No spots left" instead of the "Enroll" button
- [x] As another authenticated user try to enroll, you should see "No spots left" instead of the "Enroll" button 

## Release notes
The event enroll button is now respecting the maximum enrollment limit of events for anonymous visitors.