### PR TITLE
Issue #3053609 by Kingdutch: Default metatag configuration for topics…

### DIFF
--- a/modules/custom/social_metatag/config/install/metatag.metatag_defaults.node__topic.yml
+++ b/modules/custom/social_metatag/config/install/metatag.metatag_defaults.node__topic.yml
@@ -1,8 +1,8 @@
 langcode: en
 status: true
 dependencies: {  }
-id: node__event
-label: 'Content: Event'
+id: node__topic
+label: 'Content: Topic'
 tags:
   title: '[current-page:title]'
   og_description: '[node:body]'

--- a/modules/custom/social_metatag/social_metatag.post_update.php
+++ b/modules/custom/social_metatag/social_metatag.post_update.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * @file
+ * Contains post-update hooks for the Social Metatag module.
+ */
+
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * Correctly import the default topic metatag configuration.
+ */
+function social_metatag_post_update_0001_fix_node_topic_defaults() {
+  $config_yaml = <<<YAML
+langcode: en
+status: true
+dependencies: {  }
+id: node__topic
+label: 'Content: Topic'
+tags:
+  title: '[current-page:title]'
+  og_description: '[node:body]'
+  og_image: '[node:field_topic_image:entity:url]'
+  og_site_name: '[site:name]'
+  og_title: '[current-page:title]'
+YAML;
+
+  $default_config = Yaml::parse($config_yaml);
+  $topic_config = \Drupal::configFactory()->getEditable('metatag.metatag_defaults.node__topic');
+
+  $topic_config->setData($default_config)->save(TRUE);
+}


### PR DESCRIPTION
… has incorrect id

<h2>Problem</h2>

The id and label in the configuration file are incorrect. This causes the configuration not to be loaded.

<h2>Solution</h2>
Fix this and create an update hook.

## Issue tracker
https://www.drupal.org/project/social/issues/3053609

## How to test
- [ ] Update and check Metatag configuration

## Release notes
Due to an error in the metatag configuration for topics the defaults were not properly installed. This has been corrected.
