### PR TITLE
Issue #3053668: Load all activity entities at once instead of one by one

### DIFF
--- a/modules/custom/activity_creator/src/ActivityNotifications.php
+++ b/modules/custom/activity_creator/src/ActivityNotifications.php
@@ -62,13 +62,12 @@ class ActivityNotifications extends ControllerBase {
     // Retrieve all the activities referring this entity for this account.
     $ids = $this->getNotificationIds($account, [ACTIVITY_STATUS_RECEIVED]);
 
-    foreach ($ids as $activity_id) {
-      $activity = Activity::load($activity_id);
+    $activities = Activity::loadMultiple($ids);
+    foreach ($activities as $activity) {
       $this->changeStatusOfActivity($activity, ACTIVITY_STATUS_SEEN);
     }
 
-    $remaining_notifications = 0;
-    return $remaining_notifications;
+    return 0;
   }
 
   /**
@@ -84,8 +83,8 @@ class ActivityNotifications extends ControllerBase {
     // Retrieve all the activities referring this entity for this account.
     $ids = $this->getNotificationIds($account, [ACTIVITY_STATUS_RECEIVED, ACTIVITY_STATUS_SEEN], $entity);
 
-    foreach ($ids as $activity_id) {
-      $activity = Activity::load($activity_id);
+    $activities = Activity::loadMultiple($ids);
+    foreach ($activities as $activity) {
       $this->changeStatusOfActivity($activity, ACTIVITY_STATUS_READ);
     }
 
@@ -104,8 +103,8 @@ class ActivityNotifications extends ControllerBase {
     // Retrieve all the activities referring this entity for this account.
     $ids = $this->getNotificationIds($account, [ACTIVITY_STATUS_RECEIVED, ACTIVITY_STATUS_SEEN], $entity);
 
-    foreach ($ids as $activity_id) {
-      $activity = Activity::load($activity_id);
+    $activities = Activity::loadMultiple($ids);
+    foreach ($activities as $activity) {
       $this->changeStatusOfActivity($activity, ACTIVITY_STATUS_READ);
     }
 


### PR DESCRIPTION
## Problem
When a user marks notifications as read (automatically) this will load activity entities one by one.

## Solution
Load all activity entities at once.

## Issue tracker
https://www.drupal.org/project/social/issues/3053668

## How to test
- [x] Generate some notifications for a user
- [x] Log in as that user, hover over the notification centre
- [x] After a few seconds the notifications should be marked as read
- [x] Reload the page, check that they are no longer marked as read

## Release notes
By refactoring old code we improved the performance of the "mark as read" functionality of the notification centre.