### PR TITLE
Issue #3053671 by robertragas: Check if the message thread exists bef…

### DIFF
--- a/modules/social_features/social_private_message/src/Plugin/ActivityContext/PrivateMessageActivityContext.php
+++ b/modules/social_features/social_private_message/src/Plugin/ActivityContext/PrivateMessageActivityContext.php
@@ -4,6 +4,7 @@ namespace Drupal\social_private_message\Plugin\ActivityContext;
 
 use Drupal\activity_creator\Plugin\ActivityContextBase;
 use Drupal\private_message\Entity\PrivateMessage;
+use Drupal\private_message\Entity\PrivateMessageThreadInterface;
 use Drupal\user\Entity\User;
 
 /**
@@ -36,21 +37,24 @@ class PrivateMessageActivityContext extends ActivityContextBase {
             $pmService = \Drupal::service('private_message.service');
             // Get the thread of this message.
             $thread = $pmService->getThreadFromMessage($private_message);
-            // Get all members of this thread.
-            /** @var \Drupal\private_message\Entity\PrivateMessageThreadInterface $members */
-            $members = $thread->getMembers();
-            // Loop over all PMT participants.
-            foreach ($members as $member) {
-              if ($member instanceof User) {
-                // Filter out the author of this message.
-                if ($member->id() == $data['actor']) {
-                  continue;
+
+            if ($thread instanceof PrivateMessageThreadInterface) {
+              // Get all members of this thread.
+              /** @var \Drupal\private_message\Entity\PrivateMessageThreadInterface $members */
+              $members = $thread->getMembers();
+              // Loop over all PMT participants.
+              foreach ($members as $member) {
+                if ($member instanceof User) {
+                  // Filter out the author of this message.
+                  if ($member->id() == $data['actor']) {
+                    continue;
+                  }
+                  // Create the recipients array.
+                  $recipients[] = [
+                    'target_type' => 'user',
+                    'target_id' => $member->id(),
+                  ];
                 }
-                // Create the recipients array.
-                $recipients[] = [
-                  'target_type' => 'user',
-                  'target_id' => $member->id(),
-                ];
               }
             }
           }


### PR DESCRIPTION
## Problem
In the private message activity context it gets all the members from a certain thread so it can create the activity for all the correct people. This function is not checking correctly if a thread still exists, and when this threat does not exist it will return false, which crashes.

## Solution
Check if the thread is instanceof PrivateMessageThreadInterface

## Issue tracker
https://www.drupal.org/project/social/issues/3053671

## How to test
- [x] Send a private message and delete the thread before the activity is created.
- [x] Notice it will error because we are trying to use method from boolean
- [x] Checkout to this branch and try again

## Release notes
We have added better defensive checking to prevent errors if a private message thread is deleted.