### PR TITLE
Improve event-max-enroll and topic-download-count test

### DIFF
--- a/tests/behat/features/capabilities/event-an-enroll/event-max-enroll.feature
+++ b/tests/behat/features/capabilities/event-an-enroll/event-max-enroll.feature
@@ -8,11 +8,8 @@ Feature: Limitation event enrollments
   Scenario: Successfully limited event enrollments
     Given I enable the module "social_event_max_enroll"
     When I am logged in as a user with the "sitemanager" role
-    And I am on "admin/config/opensocial"
-    Then I should see the link "Maximum Event EnrollmentSettings for Social Event Max Enroll module."
-    When I click "Maximum Event EnrollmentSettings for Social Event Max Enroll module."
-    Then I should be on "admin/config/opensocial/event-max-enroll"
-    And I should see the text "Maximum Event Enrollment settings"
+    And I am on "admin/config/opensocial/event-max-enroll"
+    Then I should see the text "Maximum Event Enrollment settings"
     And I should see checked the box "Enable maximum number of event enrollments"
     And I should see unchecked the box "Maximum event enrollments field is required"
     And I should see the button "Save configuration"

--- a/tests/behat/features/capabilities/topic/topic-download-count.feature
+++ b/tests/behat/features/capabilities/topic/topic-download-count.feature
@@ -22,9 +22,9 @@ Feature: Download Topic
     And I should see "This is a test topic" in the "Hero block"
     And I should see "Discussion" in the "Main content"
     And I should see "Body description text" in the "Main content"
-    And I click "humans.txt"
+    And I click "Open or download file"
     Given I am logged in as an "authenticated user"
     And I am on the homepage
     And I click "This is a test topic"
-    And I should see "humans.txt"
+    And I should see "humans"
     And I should see "1 download"

--- a/tests/behat/features/capabilities/topic/topic-download-count.feature
+++ b/tests/behat/features/capabilities/topic/topic-download-count.feature
@@ -26,5 +26,5 @@ Feature: Download Topic
     Given I am logged in as an "authenticated user"
     And I am on the homepage
     And I click "This is a test topic"
-    And I should see "humans"
+    And I should see text matching "humans(| \d+).txt"
     And I should see "1 download"


### PR DESCRIPTION
## Problem
1. When Sitemanager does not have permission to go to `admin/config/opensocial` the test is failing.
2. Topic download count test seems to fail if other humans.txt files were already uploaded.

## Solution
1. Let's go to the configuration page directly.
2. Make the check a bit smarter so we don't care if somebody uploads human 0.txt or humans 200.txt or humans.txt.

## Issue tracker
not needed

## How to test
- [x] Just check the code changes
- [x] Check if Travis and test in Moss is passing

## Release notes
not needed...
