### PR TITLE
Issue #3053953 by robertragas: fix enrollments export for event managers

### DIFF
--- a/modules/social_features/social_user_export/social_user_export.module
+++ b/modules/social_features/social_user_export/social_user_export.module
@@ -5,6 +5,8 @@
  * The Social User Export module.
  */
 
+use Drupal\file\Entity\File;
+
 /**
  * Implements hook_file_download().
  */
@@ -18,7 +20,7 @@ function social_user_export_file_download($uri) {
   $fid = $query->execute();
 
   /* @var \Drupal\file\FileInterface $file */
-  $file = \Drupal\file\Entity\File::load(reset($fid));
+  $file = File::load(reset($fid));
 
   $access = FALSE;
 

--- a/modules/social_features/social_user_export/social_user_export.module
+++ b/modules/social_features/social_user_export/social_user_export.module
@@ -11,9 +11,23 @@
 function social_user_export_file_download($uri) {
   $scheme = \Drupal::service('file_system')->uriScheme($uri);
   $target = file_uri_target($uri);
-  $access = \Drupal::currentUser()->hasPermission('administer users');
 
-  if ($scheme === 'private' && preg_match('/^csv\/export-users-([a-f0-9]{12})\.csv$/i', $target) && $access) {
+  // Get the file to see who the owner is.
+  $query = \Drupal::entityQuery('file');
+  $query->condition('uri', $uri);
+  $fid = $query->execute();
+
+  /* @var \Drupal\file\FileInterface $file */
+  $file = \Drupal\file\Entity\File::load(reset($fid));
+
+  $access = FALSE;
+
+  // Allow access to users with correct permission or file owner.
+  if (\Drupal::currentUser()->hasPermission('administer users') || \Drupal::currentUser()->id() === $file->get('uid')->getString()) {
+    $access = TRUE;
+  }
+
+  if ($scheme === 'private' && $access && preg_match('/^csv\/export-(users|enrollments)-([a-f0-9]{12})\.csv$/i', $target)) {
     return [
       'Content-disposition' => 'attachment; filename="' . basename($target) . '"',
     ];


### PR DESCRIPTION
## Problem
When the event export is enabled it gives the event manager the possibility to download the event enrollees, but this fails giving the user an access denied page.

## Solution
Fix the social_export file download hook to give permission to the author of the file to download it.

## Issue tracker
https://www.drupal.org/project/social/issues/3053953

## How to test
- [ ] As an authenticated user create an event and set yourself as event manager.
- [ ] Enroll with some users and now try to export the enrollees as the event manager
- [ ] Click on the download link and see the access denied
- [ ] Check out to this branch and repeat, now it will work. 

## Release notes
We have fixed an issue where the event managers were not able to export the enrollees of their events because of a permissions issue. 

