### PR TITLE
Issue #3054601: VBO Javascript for Manage Members and Enrollees is attached too often

### DIFF
--- a/modules/social_features/social_event/modules/social_event_managers/js/frontUi.js
+++ b/modules/social_features/social_event/modules/social_event_managers/js/frontUi.js
@@ -9,20 +9,20 @@
 
   Drupal.behaviors.viewsBulkOperationsFrontUi = {
     attach: function (context, settings) {
-      var $primarySelectAll = $('.select-all', '.vbo-view-form');
+      var $primarySelectAll = $('.vbo-view-form .select-all', context);
       $primarySelectAll.addClass('form-no-label checkbox form-checkbox');
 
       // Click handler on clicking select all across pages.
-      $('.views-table-row-vbo-select-all .form-submit').on('click', function () {
+      $('.views-table-row-vbo-select-all .form-submit', context).on('click', function () {
         // Put in a message for all selected users.
         if ($('.vbo-select-all').prop('checked') === true) {
           if ($('.temporary-placeholder.panel-heading').length < 1) {
             var message = Drupal.t('<b>All members across all pages</b> are selected.');
-            $('#vbo-action-form-wrapper').append('<div class="temporary-placeholder card__block">' + message +  '</span>');
+            $('#edit-multipage', context).after('<div class="temporary-placeholder card__block">' + message +  '</span>');
           }
         }
         else {
-          $('.temporary-placeholder').remove();
+          $('.temporary-placeholder', context).remove();
         }
       });
     }

--- a/modules/social_features/social_group/js/frontUi.js
+++ b/modules/social_features/social_group/js/frontUi.js
@@ -9,20 +9,20 @@
 
   Drupal.behaviors.viewsBulkOperationsFrontUi = {
     attach: function (context, settings) {
-      var $primarySelectAll = $('.select-all', '.vbo-view-form');
+      var $primarySelectAll = $('.vbo-view-form .select-all', context);
       $primarySelectAll.addClass('form-no-label checkbox form-checkbox');
 
       // Click handler on clicking select all across pages.
-      $('.views-table-row-vbo-select-all .form-submit').on('click', function () {
+      $('.views-table-row-vbo-select-all .form-submit', context).on('click', function () {
         // Put in a message for all selected users.
         if ($('.vbo-select-all').prop('checked') === true) {
           if ($('.temporary-placeholder.panel-heading').length < 1) {
             var message = Drupal.t('<b>All members across all pages</b> are selected.');
-            $('#vbo-action-form-wrapper').append('<div class="temporary-placeholder card__block">' + message +  '</span>');
+            $('#edit-multipage', context).after('<div class="temporary-placeholder card__block">' + message +  '</span>');
           }
         }
         else {
-          $('.temporary-placeholder').remove();
+          $('.temporary-placeholder', context).remove();
         }
       });
     }


### PR DESCRIPTION
<h2>Problem</h2>
VBO Javascript for Manage Members and Enrollees is attached too often

<h2>Solution</h2>
Take context into account

The click handlers were added many times because the context of the
attach method was not taken into account.

Additionally the action button was before the temporary placeholder in
the DOM order which caused it to be unclickable.

## Issue tracker
https://www.drupal.org/project/social/issues/3054601

## How to test
- [x] Visit a group with 50 members
- [x] Select all members

<h2>Release notes</h2>
An over eager attaching of click handlers in the group member and event enrollee management interfaces caused some duplicate messages when all items were selected. We've had a chat with the click handler and it's no longer overly attached.

