### PR TITLE
Issue #3054534 by robertragas: add patch to remove group machine name…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,8 @@
                 "Add computed field for Group reference": "https://www.drupal.org/files/issues/add-computed-field-without-FieldItemListComputedInterface-2718195-34.patch",
                 "Add permission to view group overview": "https://www.drupal.org/files/issues/group-2943564-2.patch",
                 "Use VBO together with group permission": "https://www.drupal.org/files/issues/2018-12-18/vbo-and-group-permission-3020883-5.patch",
-                "Ability to use group tokens in node context": "https://www.drupal.org/files/issues/2018-12-19/group-2774827-41-gnode-tokens.patch"
+                "Ability to use group tokens in node context": "https://www.drupal.org/files/issues/2018-12-19/group-2774827-41-gnode-tokens.patch",
+                "group_type and content_plugin of group_content_type are translatable": "https://www.drupal.org/files/issues/2019-05-14/group-content_schema-3054534-2-D8.patch"
             },
             "drupal/image_widget_crop": {
                 "Remove theme function override for verticalTabs": "https://www.drupal.org/files/issues/2019-02-13/3032584-verticaltabs-theme-override-removal-2.patch"


### PR DESCRIPTION
## Problem
When you have multilingual sites you are able to translate machine names of the group types. Translating this will break your website.

## Solution
Change type from text to string so they are not translatable anymore.

## Issue tracker
https://www.drupal.org/project/group/issues/3054534

## How to test
- [ ] Add a different language and go to translations and translate a group machine name such as closed_group
- [ ] Add closed group with content so it's present throughout the website.
- [ ] Check out to this branch and remove the source translation from the database
- [ ] It will not get imported anymore and not break the site.

## Release notes
We have added a fix for the group module removing the possibility to translate the machine names for group types which would break the site if translated.
