### PR TITLE
Fix Social module names for better consistency

### DIFF
--- a/modules/custom/alternative_frontpage/alternative_frontpage.info.yml
+++ b/modules/custom/alternative_frontpage/alternative_frontpage.info.yml
@@ -1,4 +1,4 @@
-name: 'Alternative frontpage'
+name: 'Alternative Frontpage'
 description: 'Provides an alternative frontpage option for authenticated users via redirect.'
 type: module
 core: 8.x

--- a/modules/social_features/social_event/modules/social_event_an_enroll/social_event_an_enroll.info.yml
+++ b/modules/social_features/social_event/modules/social_event_an_enroll/social_event_an_enroll.info.yml
@@ -1,4 +1,4 @@
-name: 'Social Event Anonymous Enrollments'
+name: 'Social Event Anonymous Enrolments'
 description: 'Provides ability to enroll to an event without having to create an account.'
 type: module
 core: 8.x

--- a/modules/social_features/social_event/modules/social_event_an_enroll/social_event_an_enroll.info.yml
+++ b/modules/social_features/social_event/modules/social_event_an_enroll/social_event_an_enroll.info.yml
@@ -1,4 +1,4 @@
-name: 'Social Event AN Enroll'
+name: 'Social Event Anonymous Enrollments'
 description: 'Provides ability to enroll to an event without having to create an account.'
 type: module
 core: 8.x

--- a/modules/social_features/social_event/modules/social_event_an_enroll_enrolments_export/social_event_an_enroll_enrolments_export.info.yml
+++ b/modules/social_features/social_event/modules/social_event_an_enroll_enrolments_export/social_event_an_enroll_enrolments_export.info.yml
@@ -1,4 +1,4 @@
-name: 'Social Event An Enroll Enrolments Export'
+name: 'Social Event Anonymous Enrolments Export'
 description: 'Adds ability to export event enrolments (include guests) to a CSV.'
 type: module
 core: 8.x

--- a/modules/social_features/social_event/modules/social_event_max_enroll/social_event_max_enroll.info.yml
+++ b/modules/social_features/social_event/modules/social_event_max_enroll/social_event_max_enroll.info.yml
@@ -1,4 +1,4 @@
-name: 'Event Max Enroll'
+name: 'Social Event Max Enroll'
 description: 'Allow setting the maximum participant number for events.'
 type: module
 core: 8.x


### PR DESCRIPTION
## Problem
I noticed that Social prefix is missing for **Max Event Enroll** module and second word for **Alternative frontpage** is in lowercase.

## Solution
Add Social prefix and use Uppercase to be consistent.

## Issue tracker
- None

## How to test
- [ ] Login as admin, go to the module list and see that it looks nice :)

## Release notes
I think it's not needed.
