### PR TITLE
Bug 3055336 likes translation

### DIFF
--- a/themes/socialbase/templates/node/node--full.html.twig
+++ b/themes/socialbase/templates/node/node--full.html.twig
@@ -172,7 +172,7 @@
                   {{ likes_count }}
                 </span>
                 <span class="badge__label badge__label--description">
-                  likes
+                  {% trans %}likes{% endtrans %}
                 </span>
               </span>
             </div>

--- a/themes/socialbase/templates/node/node--full.html.twig
+++ b/themes/socialbase/templates/node/node--full.html.twig
@@ -152,11 +152,11 @@
                   {{ comment_count }}
                 </span>
                 <span class="badge__label badge__label--description">
-                  {% if comment_count == 1 %}
-                    {% trans %}comment{% endtrans %}
-                  {% else %}
-                    {% trans %}comments{% endtrans %}
-                  {% endif %}
+                  {% trans %}
+                      comment
+                  {% plural comment_count %}
+                      comments
+                  {% endtrans %}
                 </span>
               </span>
             </a>
@@ -172,7 +172,11 @@
                   {{ likes_count }}
                 </span>
                 <span class="badge__label badge__label--description">
-                  {% trans %}likes{% endtrans %}
+                  {% trans %}
+                      like
+                  {% plural likes_count %}
+                      likes
+                  {% endtrans %}
                 </span>
               </span>
             </div>


### PR DESCRIPTION
## Problem
likes is missing translation in node--full.html.twig from socialbase theme

## Solution
changed to {% trans %}likes{% endtrans %}

## Issue tracker
https://www.drupal.org/project/social/issues/3055336

## How to test
- [ ] open full display of a node fe. topic in an other language than english
- [ ] "likes" is not translated
- [ ] install the patch
- [ ] "likes" is translated

## Release notes
The text indicating the number of likes or comments on content is now translatable even when no Javascript is used.

~Translation for "likes" in node--full.html.twig from socialbase theme was added.~
