### PR TITLE
Issue #3056298: Removed group content causes error in GroupContentInM…

### DIFF
--- a/modules/custom/activity_basics/src/Plugin/ActivityContext/GroupContentInMyGroupActivityContext.php
+++ b/modules/custom/activity_basics/src/Plugin/ActivityContext/GroupContentInMyGroupActivityContext.php
@@ -82,6 +82,13 @@ class GroupContentInMyGroupActivityContext extends ActivityContextBase {
       $group_content = $this->entityTypeManager->getStorage('group_content')
         ->load($referenced_entity['target_id']);
 
+      // It could happen that a notification has been queued but the content
+      // has since been deleted. In that case we can find no additional
+      // recipients.
+      if (!$group_content) {
+        return $recipients;
+      }
+
       /** @var \Drupal\group\Entity\GroupInterface $group */
       $group = $group_content->getGroup();
 


### PR DESCRIPTION
…yGroupActivityContext

<h2>Problem</h2>

The recipient generator for the activity doesn't properly check whether content still exists which can cause fatal errors for cron.

<h2>Solution</h2>

If content has been removed simply return no recipients.

## Issue tracker
https://www.drupal.org/project/social/issues/3056298

## How to test
- [ ] Create a content in a group
- [ ] Check that another user in the group gets a notification (the creator is excluded)
- [ ] Create content in the group
- [ ] Quickly delete the content
- [ ] Observe that without this PR there is an error during the next cron run and that error is no longer present with the changes in this PR.

## Release notes
Cron no longer breaks when content for a group content notification is deleted before the notification is processed.
