### PR TITLE
Issue #3056603: Increased performance for marking notifications as read

### DIFF
--- a/modules/custom/activity_creator/js/notifications.js
+++ b/modules/custom/activity_creator/js/notifications.js
@@ -3,38 +3,40 @@
  * Update the notification bell badge.
  */
 
-(function ($) {
+(function ($, Drupal) {
   /**
    * Notification centre bell update behavior.
    */
   Drupal.behaviors.notificationUpdate = {
-    attach: function (context, settings) {
+    attach: function (context) {
+      $('.notification-bell', context)
+        .once('notificationUpdate')
+        .click(this._updateNotificationCount);
+    },
 
+    _updateNotificationCount: function () {
+      var $notificationCount = $('.notification-bell .badge');
+
+      // We won't proceed if the notification count is 0 or the dropdown is
+      // open.
       // @todo: Refactor to use data-* attributes and `jQuery.data()` to store
       //   the unread notification count.
-      $('.notification-bell', context).once('notificationUpdate').click(function (e) {
-        var $notificationCount = $('.notification-bell .badge');
+      if (!$notificationCount.html() || $notificationCount.html() === '0' || $(this).hasClass('open')) {
+        return;
+      }
 
-        // We won't proceed if the notification count is 0 or the dropdown is
-        // open.
-        if (!$notificationCount.html() || $notificationCount.html() === '0' || $(this).hasClass('open')) {
-          return;
+      // Post to the notification endpoint.
+      $.ajax({
+        method: 'POST',
+        url: '/ajax/notifications-mark-as-read',
+        data: { },
+        success: function (result) {
+          // Update the notification bell.
+          var $remainingNotifications = result['remaining_notifications'];
+
+          $notificationCount.html($remainingNotifications);
         }
-
-        // Post to the notification endpoint.
-        $.ajax({
-          method: 'POST',
-          url: '/ajax/notifications-mark-as-read',
-          data: { },
-          success: function (result) {
-            // Update the notification bell.
-            var $remainingNotifications = result['remaining_notifications'];
-
-            $notificationCount.html($remainingNotifications);
-          }
-        });
       });
-
     }
   };
-})(jQuery);
+})(jQuery, Drupal);

--- a/modules/custom/activity_creator/js/notifications.js
+++ b/modules/custom/activity_creator/js/notifications.js
@@ -4,30 +4,36 @@
  */
 
 (function ($) {
-    /**
-     * Behaviors.
-     */
-    Drupal.behaviors.notificationUpdate = {
-        attach: function (context, settings) {
-            // TODO Implement this with a no-js fallback.
-            var notification_count = $('.notification-bell .badge');
+  /**
+   * Notification centre bell update behavior.
+   */
+  Drupal.behaviors.notificationUpdate = {
+    attach: function (context, settings) {
 
-          if (notification_count.val() != "0") {
-              $('.notification-bell').click(function(e) {
-                  $.ajax({
-                      method: 'POST',
-                      url: '/ajax/notifications-mark-as-read',
-                      data: { },
-                      success: function(result) {
-                          // Update the notification bell.
-                          var remaining_notifications = result['remaining_notifications'];
+      $('.notification-bell', context).once('notificationUpdate').click(function(e) {
+        var notification_count = $('.notification-bell .badge');
 
-                          notification_count.html(remaining_notifications);
-                        $('.notification-bell.mobile .badge').html(remaining_notifications);
-                      }
-                    });
-              });
-          }
+        // We won't proceed if the notification count is 0 or the dropdown is
+        // open.
+        if (!notification_count.html() || notification_count.html() === "0" || $(this).hasClass('open')) {
+          return;
         }
+
+        // Post to the notification endpoint.
+        $.ajax({
+          method: 'POST',
+          url: '/ajax/notifications-mark-as-read',
+          data: { },
+          success: function(result) {
+            // Update the notification bell.
+            var remaining_notifications = result['remaining_notifications'];
+
+            notification_count.html(remaining_notifications);
+            $('.notification-bell.mobile .badge').html(remaining_notifications);
+          }
+        });
+      });
+
+    }
   };
 })(jQuery);

--- a/modules/custom/activity_creator/js/notifications.js
+++ b/modules/custom/activity_creator/js/notifications.js
@@ -11,11 +11,11 @@
     attach: function (context, settings) {
 
       $('.notification-bell', context).once('notificationUpdate').click(function(e) {
-        var notification_count = $('.notification-bell .badge');
+        var $notificationCount = $('.notification-bell .badge');
 
         // We won't proceed if the notification count is 0 or the dropdown is
         // open.
-        if (!notification_count.html() || notification_count.html() === "0" || $(this).hasClass('open')) {
+        if (!$notificationCount.html() || $notificationCount.html() === "0" || $(this).hasClass('open')) {
           return;
         }
 
@@ -28,7 +28,7 @@
             // Update the notification bell.
             var remaining_notifications = result['remaining_notifications'];
 
-            notification_count.html(remaining_notifications);
+            $notificationCount.html(remaining_notifications);
             $('.notification-bell.mobile .badge').html(remaining_notifications);
           }
         });
@@ -37,3 +37,4 @@
     }
   };
 })(jQuery);
+https://github.com/goalgorilla/open_social/pull/1405#discussion_r287411473

--- a/modules/custom/activity_creator/js/notifications.js
+++ b/modules/custom/activity_creator/js/notifications.js
@@ -18,11 +18,11 @@
       var $notificationCount = $('.notification-bell .badge');
 
       // We won't proceed if the notification count is 0 or the dropdown is
-      // open.
+      // already open.
       // @todo: Refactor to use data-* attributes and `jQuery.data()` to store
       //   the unread notification count. This should be less expensive than
       //   reading the DOM
-      if (!$notificationCount.text() || $notificationCount.text() === '0' || $(this).hasClass('open')) {
+      if (!$notificationCount.first().text() || $notificationCount.first().text() === '0' || $(this).hasClass('open')) {
         return;
       }
 

--- a/modules/custom/activity_creator/js/notifications.js
+++ b/modules/custom/activity_creator/js/notifications.js
@@ -10,6 +10,8 @@
   Drupal.behaviors.notificationUpdate = {
     attach: function (context, settings) {
 
+      // @todo: Refactor to use data-* attributes and `jQuery.data()` to store
+      //   the unread notification count.
       $('.notification-bell', context).once('notificationUpdate').click(function (e) {
         var $notificationCount = $('.notification-bell .badge');
 
@@ -29,7 +31,6 @@
             var $remainingNotifications = result['remaining_notifications'];
 
             $notificationCount.html($remainingNotifications);
-            $('.notification-bell.mobile .badge').html($remainingNotifications);
           }
         });
       });

--- a/modules/custom/activity_creator/js/notifications.js
+++ b/modules/custom/activity_creator/js/notifications.js
@@ -10,12 +10,12 @@
   Drupal.behaviors.notificationUpdate = {
     attach: function (context, settings) {
 
-      $('.notification-bell', context).once('notificationUpdate').click(function(e) {
+      $('.notification-bell', context).once('notificationUpdate').click(function (e) {
         var $notificationCount = $('.notification-bell .badge');
 
         // We won't proceed if the notification count is 0 or the dropdown is
         // open.
-        if (!$notificationCount.html() || $notificationCount.html() === "0" || $(this).hasClass('open')) {
+        if (!$notificationCount.html() || $notificationCount.html() === '0' || $(this).hasClass('open')) {
           return;
         }
 
@@ -24,12 +24,12 @@
           method: 'POST',
           url: '/ajax/notifications-mark-as-read',
           data: { },
-          success: function(result) {
+          success: function (result) {
             // Update the notification bell.
-            var remaining_notifications = result['remaining_notifications'];
+            var $remainingNotifications = result['remaining_notifications'];
 
-            $notificationCount.html(remaining_notifications);
-            $('.notification-bell.mobile .badge').html(remaining_notifications);
+            $notificationCount.html($remainingNotifications);
+            $('.notification-bell.mobile .badge').html($remainingNotifications);
           }
         });
       });
@@ -37,4 +37,3 @@
     }
   };
 })(jQuery);
-https://github.com/goalgorilla/open_social/pull/1405#discussion_r287411473

--- a/modules/custom/activity_creator/js/notifications.js
+++ b/modules/custom/activity_creator/js/notifications.js
@@ -20,8 +20,9 @@
       // We won't proceed if the notification count is 0 or the dropdown is
       // open.
       // @todo: Refactor to use data-* attributes and `jQuery.data()` to store
-      //   the unread notification count.
-      if (!$notificationCount.html() || $notificationCount.html() === '0' || $(this).hasClass('open')) {
+      //   the unread notification count. This should be less expensive than
+      //   reading the DOM
+      if (!$notificationCount.text() || $notificationCount.text() === '0' || $(this).hasClass('open')) {
         return;
       }
 
@@ -32,9 +33,7 @@
         data: { },
         success: function (result) {
           // Update the notification bell.
-          var $remainingNotifications = result['remaining_notifications'];
-
-          $notificationCount.html($remainingNotifications);
+          $notificationCount.text(result['remaining_notifications']);
         }
       });
     }


### PR DESCRIPTION
## Problem
The notification centre in Open Social has a bell with the unread notifications. There is some Javascript code that, when clicked on the notification centre icon, sends a request to the back-end. In the back-end all unread notifications are then marked as read.

First of all there is no check that determines if the notification centre was closed and opened again. In that case no request has to be send as we can assume the notifications are already marked as unread anyway.

Next to that there is no limit on the amount of click handlers attached to the notification centre icon. When using BigPipe there are easily 30 click handlers assigned which all do requests to the back-end to mark notifications as read.

Demonstration of the problem: https://www.loom.com/share/c37b9a43fd3e42d0a3944e0e012030e0

## Solution
Implemented `.once()` on the click handler and added a few checks to ensure nothing is done when the notifications have been marked as unread already.

Demonstration of the solution: https://www.loom.com/share/c00a28ec0c7444e7b1de5e0a3e313ff2

## Issue tracker
https://www.drupal.org/project/social/issues/3056603

## How to test
- [ ] Enable BigPipe
- [ ] As user X write a post in which you mention user Y
- [ ] Login as user Y and open up the browser's network tab
- [ ] Click on the notification centre icon (where you have at least one new notification), you should see only one request being send to the back-end
- [ ] Close the notification centre, no requests should be send
- [ ] Open it again, no requests should be send
- [ ] Refresh the page, you should have no new notifications
- [ ] Click on the notification centre icon, you should see no requests being send

## Release notes
When you click on the notification centre icon a request is send to the back-end to mark all notifications as read. With BigPipe enabled this could result in up to 50 requests at the same time doing the exact same thing, slowing everything down. By adding a few extra checks just one request is send.