### PR TITLE
#3056651 - Performance optimisation for counting group members

### DIFF
--- a/modules/social_features/social_group/social_group.module
+++ b/modules/social_features/social_group/social_group.module
@@ -33,7 +33,6 @@ use Drupal\image\Entity\ImageStyle;
 use Drupal\Core\Block\BlockPluginInterface;
 use Drupal\user\Entity\Role;
 use Drupal\user\Entity\User;
-use Drupal\profile\Entity\Profile;
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\social_group\GroupContentVisibilityUpdate;

--- a/modules/social_features/social_group/social_group.module
+++ b/modules/social_features/social_group/social_group.module
@@ -218,18 +218,16 @@ function social_group_preprocess_group(array &$variables) {
   if ($group->getMember($account)) {
     $variables['joined'] = TRUE;
     if ($group->hasPermission('leave group', $account)) {
-      // @todo switch this to get URL from routes correctly.
-      $variables['group_operations_url'] = Url::fromUserInput('/group/' . $group->id() . '/leave');
+      $variables['group_operations_url'] = Url::fromRoute('entity.group.leave', ['group' => $group->id()]);
     }
   }
   elseif ($group->hasPermission('join group', $account)) {
-    // @todo switch this to get URL from routes correctly.
-    $variables['group_operations_url'] = Url::fromUserInput('/group/' . $group->id() . '/join');
+    $variables['group_operations_url'] = Url::fromRoute('entity.group.join', ['group' => $group->id()]);
   }
   // If the group type is a closed_group.
   elseif ($group_type_id == 'closed_group' && !$group->hasPermission('manage all groups', $account)) {
     // Users can only be invited.
-    $variables['group_operations_url'] = Url::fromUserInput('/group/' . $group->id() . '/join');
+    $variables['group_operations_url'] = Url::fromRoute('entity.group.join', ['group' => $group->id()]);
     $variables['closed_group'] = TRUE;
     $variables['cta'] = t('Invitation only');
   }
@@ -269,24 +267,9 @@ function social_group_preprocess_group(array &$variables) {
       }
     }
   }
+
   // Count number of group members.
-  $members = $group->getMembers();
-  $profile_storage = \Drupal::entityTypeManager()->getStorage('profile');
-
-  $members_count = 0;
-  if ($members && $profile_storage) {
-    foreach ($members as $member) {
-      $member_account = $member->getUser();
-      if ($member_account instanceof User) {
-        $member_profile = $profile_storage->loadByUser($member_account, 'profile');
-        if ($member_profile instanceof Profile) {
-          $members_count++;
-        }
-      }
-    }
-  }
-  $variables['group_members'] = $members_count;
-
+  $variables['group_members'] = count($group->getMembers());
 }
 
 /**


### PR DESCRIPTION
## Problem
Counting group members originally had to load the user profiles of members to make sure the calculation matched the actual members within the group.

## Solution
Removed custom group membership calculation which isn't necessary any more as it has been fixed within groups. Also generated group operation urls based on routes instead of custom paths.

## Issue tracker
https://www.drupal.org/project/social/issues/3056651

## How to test
- [ ] As a logged in user go to the 'all groups' page and see that the membership count in the teasers for each group resembles the actual group count.
- [ ] Now go to the 'my group overview' page and see that the membership count in the teasers for each group resembles the actual group count.
- [ ] Go to a group from the list and see that the membership count in the hero region/header resembles the  actual group count.

## Release notes
<describe the release notes>

