### PR TITLE
Issue #3056837 - Improve profile rendering

### DIFF
--- a/modules/custom/activity_creator/activity.page.inc
+++ b/modules/custom/activity_creator/activity.page.inc
@@ -72,20 +72,14 @@ function template_preprocess_activity(array &$variables) {
   // 'compact_notification' view mode might not be configured, so remember to
   // always check the theme setting first.
   if ($account) {
-    $storage = \Drupal::entityTypeManager()->getStorage('profile');
-    if (!empty($storage)) {
-      $user_profile = $storage->loadByUser($account, 'profile');
-      if ($user_profile) {
-        $content = \Drupal::entityTypeManager()
-          ->getViewBuilder('profile')
-          ->view($user_profile, 'compact_notification');
-        if ($full_url === '') {
-          $variables['actor'] = $content;
-        }
-        else {
-          $variables['actor'] = Link::fromTextAndUrl($content, $account->toUrl());
-        }
-      }
+    $content = \Drupal::service('social_profile.render_service')
+      ->renderUserProfile($account, 'compact_notification');
+
+    if ($full_url === '') {
+      $variables['actor'] = $content;
+    }
+    else {
+      $variables['actor'] = Link::fromTextAndUrl($content, $account->toUrl());
     }
 
     // Our author is Anonymous. If that happens for a notification.

--- a/modules/social_features/social_comment/social_comment.module
+++ b/modules/social_features/social_comment/social_comment.module
@@ -212,16 +212,8 @@ function social_comment_preprocess_comment(&$variables) {
 
   $account = $comment->getOwner();
   if ($account) {
-    $storage = \Drupal::entityTypeManager()->getStorage('profile');
-    if (!empty($storage)) {
-      $user_profile = $storage->loadByUser($account, 'profile');
-      if ($user_profile) {
-        $content = \Drupal::entityTypeManager()
-          ->getViewBuilder('profile')
-          ->view($user_profile, 'compact');
-        $variables['author_picture'] = $content;
-      }
-    }
+    $variables['author_picture'] = \Drupal::service('social_profile.render_service')
+      ->renderUserProfile($account, 'compact');
   }
 
   // Add node ID attribute for comment "new" indicator.

--- a/modules/social_features/social_group/social_group.module
+++ b/modules/social_features/social_group/social_group.module
@@ -843,9 +843,8 @@ function social_group_views_post_render(ViewExecutable $view, &$output, CachePlu
           // Use teaser for page and small_teaser for block.
           $view_mode = ($view->current_display === 'block_newest_members') ? 'small_teaser' : 'teaser';
           // Replace output with profile teaser.
-          $output['#rows'][0]['#rows'][$key] = \Drupal::entityTypeManager()
-            ->getViewBuilder('profile')
-            ->view($user_profile, $view_mode);
+          $output['#rows'][0]['#rows'][$key] = \Drupal::service('social_profile.render_service')
+            ->renderUserProfile($user_profile, $view_mode);
         }
         else {
           // Remove output if user don't have profile (admin).

--- a/modules/social_features/social_post/post.page.inc
+++ b/modules/social_features/social_post/post.page.inc
@@ -40,16 +40,8 @@ function template_preprocess_post(array &$variables) {
   // not be configured, so remember to always check the theme setting first.
   $account = $post->getOwner();
   if ($account) {
-    $storage = \Drupal::entityTypeManager()->getStorage('profile');
-    if (!empty($storage)) {
-      $user_profile = $storage->loadByUser($account, 'profile');
-      if ($user_profile) {
-        $content = \Drupal::entityTypeManager()
-          ->getViewBuilder('profile')
-          ->view($user_profile, 'compact');
-        $variables['author_picture'] = $content;
-      }
-    }
+    $variables['author_picture'] = \Drupal::service('social_profile.render_service')
+      ->renderUserProfile($account, 'compact');
   }
 
   // Show a post has been edited.

--- a/modules/social_features/social_post/social_post.module
+++ b/modules/social_features/social_post/social_post.module
@@ -22,7 +22,7 @@ function social_post_form_post_form_alter(&$form, FormStateInterface $form_state
 
   if ($form_state->getFormObject()->getEntity()->isNew()) {
     // Load current user.
-    $account = User::load(Drupal::currentUser()->id());
+    $account = Drupal::currentUser();
     // Load compact notification view mode of the attached profile.
     if ($account) {
       // Add to a new field, so twig can render it.

--- a/modules/social_features/social_post/social_post.module
+++ b/modules/social_features/social_post/social_post.module
@@ -25,17 +25,9 @@ function social_post_form_post_form_alter(&$form, FormStateInterface $form_state
     $account = User::load(Drupal::currentUser()->id());
     // Load compact notification view mode of the attached profile.
     if ($account) {
-      $storage = \Drupal::entityTypeManager()->getStorage('profile');
-      if (!empty($storage)) {
-        $user_profile = $storage->loadByUser($account, 'profile');
-        if ($user_profile) {
-          $content = \Drupal::entityTypeManager()
-            ->getViewBuilder('profile')
-            ->view($user_profile, 'compact_notification');
-          // Add to a new field, so twig can render it.
-          $form['current_user_image'] = $content;
-        }
-      }
+      // Add to a new field, so twig can render it.
+      $form['current_user_image'] = \Drupal::service('social_profile.render_service')
+        ->renderUserProfile($account, 'compact_notification');
     }
   }
 

--- a/modules/social_features/social_private_message/social_private_message.module
+++ b/modules/social_features/social_private_message/social_private_message.module
@@ -301,17 +301,8 @@ function social_private_message_entity_view_alter(array &$build, EntityInterface
 
         // Load compact notification view mode of the attached profile.
         if ($recipient instanceof User) {
-          $storage = \Drupal::entityTypeManager()->getStorage('profile');
-          if (!empty($storage)) {
-            $user_profile = $storage->loadByUser($recipient, 'profile');
-            if ($user_profile) {
-              $content = \Drupal::entityTypeManager()
-                ->getViewBuilder('profile')
-                ->view($user_profile, 'compact_notification');
-              // Add to a new field, so twig can render it.
-              $profile_picture = $content;
-            }
-          }
+          $profile_picture = \Drupal::service('social_profile.render_service')
+            ->renderUserProfile($recipient, 'compact_notification');
         }
       }
 

--- a/modules/social_features/social_private_message/social_private_message.module
+++ b/modules/social_features/social_private_message/social_private_message.module
@@ -269,9 +269,8 @@ function social_private_message_entity_view_alter(array &$build, EntityInterface
           }
           else {
             $user_profile = \Drupal::entityTypeManager()->getStorage('profile')->loadByUser($member, 'profile');
-            $content = \Drupal::entityTypeManager()
-              ->getViewBuilder('profile')
-              ->view($user_profile, 'name_raw');
+            $content = \Drupal::service('social_profile.render_service')
+              ->renderUserProfile($user_profile, 'name_raw');
             $members_string[] = $content;
           }
         }
@@ -289,7 +288,8 @@ function social_private_message_entity_view_alter(array &$build, EntityInterface
 
         if ($recipient instanceof UserInterface) {
           $user_profile = \Drupal::entityTypeManager()->getStorage('profile')->loadByUser($recipient, 'profile');
-          $display_name = \Drupal::entityTypeManager()->getViewBuilder('profile')->view($user_profile, 'name_raw');
+          $display_name = \Drupal::service('social_profile.render_service')
+            ->renderUserProfile($user_profile, 'name_raw');
         }
         else {
           // Make this an array, since we no longer render in here.

--- a/modules/social_features/social_profile/social_profile.module
+++ b/modules/social_features/social_profile/social_profile.module
@@ -696,17 +696,8 @@ function social_profile_social_user_account_header_items_alter(array &$menu_item
     return;
   }
 
-  $storage = \Drupal::entityTypeManager()->getStorage('profile');
-  $profile = $storage->loadByUser($context['user'], 'profile');
-
-  // If the user does not have a profile then there's no profile image.
-  if (empty($profile)) {
-    return;
-  }
-
   // Provide a render array as image which will overrule the user icon.
-  $menu_items['account_box']['#image'] = \Drupal::entityTypeManager()
-    ->getViewBuilder('profile')
-    ->view($profile, 'small');;
+  $menu_items['account_box']['#image'] = \Drupal::service('social_profile.render_service')
+    ->renderUserProfile($context['user'], 'small');
 
 }

--- a/modules/social_features/social_profile/social_profile.services.yml
+++ b/modules/social_features/social_profile/social_profile.services.yml
@@ -3,3 +3,8 @@ services:
     class: Drupal\social_profile\EventSubscriber\ProfileLabelSubscriber
     tags:
       - { name: event_subscriber }
+
+  social_profile.render_service:
+    class: Drupal\social_profile\SocialProfileRenderService
+    arguments:
+      - '@entity_type.manager'

--- a/modules/social_features/social_profile/src/SocialProfileRenderService.php
+++ b/modules/social_features/social_profile/src/SocialProfileRenderService.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Drupal\social_profile;
+
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\profile\Entity\ProfileInterface;
+use Drupal\user\UserInterface;
+
+/**
+ * Class SocialProfileRenderService.
+ *
+ * @package Drupal\social_profile
+ */
+class SocialProfileRenderService {
+
+  /**
+   * The Profile Entity Storage.
+   *
+   * @var \Drupal\Core\Entity\EntityStorageInterface
+   */
+  protected $profileStorage;
+
+  /**
+   * The Profile View Builder.
+   *
+   * @var \Drupal\Core\Entity\EntityViewBuilderInterface
+   */
+  protected $profileViewBuilder;
+
+  /**
+   * SocialProfileRenderService Constructor.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The Entity Type Manager.
+   *
+   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
+   * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
+   */
+  public function __construct(EntityTypeManagerInterface $entity_type_manager) {
+    $this->profileStorage = $entity_type_manager->getStorage('profile');
+    $this->profileViewBuilder = $entity_type_manager->getViewBuilder('profile');
+  }
+
+  /**
+   * Renders the profile of a user
+   *
+   * @param UserInterface $account
+   *   The user account for which we render the profile.
+   * @param $view_mode
+   *   The view mode in which the profile gets rendered.
+   *
+   * @return array
+   *   A render array for the profile.
+   */
+  public function renderUserProfile(UserInterface $account, $view_mode) {
+    $profiles = &drupal_static(__FUNCTION__);
+
+    // Check if we already have rendered something previously.
+    if (!empty($profile[$account->id()]['view_mode'])) {
+      return $profile[$account->id()]['view_mode'];
+    }
+
+    // Try to load a cached users profile.
+    if ($profile[$account->id()]['profile'] instanceof ProfileInterface) {
+      $profile = $profile[$account->id()]['profile'];
+    }
+    else {
+      // Load the profile, we don't have anything cached at this moment..
+      $profile = $this->profileStorage->loadByUser($account, 'profile');
+
+      // Check if we have a valid profile.
+      if ($profile instanceof ProfileInterface) {
+        // Cache the loaded profile in the static variable.
+        $profile[$account->id()]['profile'] = $profile;
+      }
+      else {
+        // Return early, we have no valid profile to work with.
+        return [];
+      }
+    }
+
+    // Render the profile in the required view mode.
+    $profile_render = $this->profileViewBuilder->view($profile, $view_mode);
+
+    // Cache this in the static variable.
+    $profiles[$account->id()]['view_mode'] = $profile_render;
+
+    // Return the render array.
+    return $profile_render;
+  }
+
+}

--- a/themes/socialbase/includes/form.inc
+++ b/themes/socialbase/includes/form.inc
@@ -39,6 +39,7 @@ function socialbase_preprocess_form(&$variables) {
 
   if ($element['#form_id'] === 'comment_comment_form' || $element['#form_id'] === 'comment_post_comment_form' || $element['#form_id'] === 'private_message_add_form') {
     $current_user = \Drupal::currentUser();
+    // @TODO: Needs to be UserInterface before we drag it through the service.
     if ($current_user) {
       $variables['current_user_picture'] = \Drupal::service('social_profile.render_service')
         ->renderUserProfile($current_user, 'compact');

--- a/themes/socialbase/includes/form.inc
+++ b/themes/socialbase/includes/form.inc
@@ -7,6 +7,7 @@
 
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Link;
+use Drupal\user\UserInterface;
 use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
 
 /**
@@ -39,16 +40,8 @@ function socialbase_preprocess_form(&$variables) {
   if ($element['#form_id'] === 'comment_comment_form' || $element['#form_id'] === 'comment_post_comment_form' || $element['#form_id'] === 'private_message_add_form') {
     $current_user = \Drupal::currentUser();
     if ($current_user) {
-      $storage = \Drupal::entityTypeManager()->getStorage('profile');
-      if (!empty($storage)) {
-        $user_profile = $storage->loadByUser($current_user, 'profile');
-        if ($user_profile) {
-          $content = \Drupal::entityTypeManager()
-            ->getViewBuilder('profile')
-            ->view($user_profile, 'compact');
-          $variables['current_user_picture'] = $content;
-        }
-      }
+      $variables['current_user_picture'] = \Drupal::service('social_profile.render_service')
+        ->renderUserProfile($current_user, 'compact');
     }
 
     // Comment edit form.
@@ -66,18 +59,9 @@ function socialbase_preprocess_form(&$variables) {
 
         // Display author information.
         $account = $comment->getOwner();
-        if ($account) {
-          // Author profile picture.
-          $storage = \Drupal::entityTypeManager()->getStorage('profile');
-          if (!empty($storage)) {
-            $user_profile = $storage->loadByUser($account, 'profile');
-            if ($user_profile) {
-              $content = \Drupal::entityTypeManager()
-                ->getViewBuilder('profile')
-                ->view($user_profile, 'compact');
-              $variables['author_picture'] = $content;
-            }
-          }
+        if ($account instanceof UserInterface) {
+          $variables['author_picture'] = \Drupal::service('social_profile.render_service')
+            ->renderUserProfile($account, 'compact');
 
           // Author name.
           $username = [
@@ -110,20 +94,12 @@ function socialbase_preprocess_form(&$variables) {
       // view mode on the User entity. Note that the 'compact' view mode might
       // not be configured, so remember to always check the theme setting first.
       $account = $post->getOwner();
-      if ($account) {
+      if ($account instanceof UserInterface) {
         $author_name = $account->getDisplayName();
         $variables['author_name']['#markup'] = $author_name;
 
-        $storage = \Drupal::entityTypeManager()->getStorage('profile');
-        if (!empty($storage)) {
-          $user_profile = $storage->loadByUser($account, 'profile');
-          if ($user_profile) {
-            $content = \Drupal::entityTypeManager()
-              ->getViewBuilder('profile')
-              ->view($user_profile, 'compact');
-            $variables['author_picture'] = $content;
-          }
-        }
+        $variables['author_picture'] = \Drupal::service('social_profile.render_service')
+          ->renderUserProfile($account, 'compact');
       }
     }
   }

--- a/themes/socialbase/src/Plugin/Preprocess/Node.php
+++ b/themes/socialbase/src/Plugin/Preprocess/Node.php
@@ -36,16 +36,8 @@ class Node extends PreprocessBase {
     // Display author information.
     if ($account) {
       // Author profile picture.
-      $storage = \Drupal::entityTypeManager()->getStorage('profile');
-      if (!empty($storage)) {
-        $user_profile = $storage->loadByUser($account, 'profile');
-        if ($user_profile) {
-          $content = \Drupal::entityTypeManager()
-            ->getViewBuilder('profile')
-            ->view($user_profile, 'compact');
-          $variables['author_picture'] = $content;
-        }
-      }
+      $variables['author_picture'] = \Drupal::service('social_profile.render_service')
+        ->renderUserProfile($account, 'compact');
 
       // Author name.
       $username = [


### PR DESCRIPTION
## Problem
Profiles are often rendered on the same page in the same way. However every time we load the profile entity again and render the same exact content as well.

## Solution
A new service is created that statically caches the loaded profile and the view mode render output.

## Issue tracker
https://www.drupal.org/project/social/issues/3056837

## How to test
- [ ] Browse through the site, the profiles should be rendered in the same way as before

## Release notes
<describe the release notes>