### PR TITLE
git commit -m 'Issue #3059829: Add patch: r4032login should perform a…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -62,6 +62,9 @@
                 "Private message unread messages fix": "https://www.drupal.org/files/issues/2018-06-08/2978324-getthreads-sort-order-2.patch",
                 "Own send messages are shown as new messages": "https://www.drupal.org/files/issues/2019-02-05/private_message-message_count-2977310-8_0.patch"
             },
+            "drupal/r4032login": {
+              "r4032login should perform access check for /user/login as anonymous user": "https://www.drupal.org/files/issues/2018-11-01/3010747-3-perform-access-check-as-an-user.patch"
+            },
             "drupal/swiftmailer": {
                 "Fix missing filter_format after update to beta2": "https://www.drupal.org/files/issues/2018-03-26/2948607-fix-filter-format-1.patch"
             },

--- a/drupal-org.make
+++ b/drupal-org.make
@@ -80,6 +80,7 @@ projects[profile][type] = module
 projects[profile][version] = 1.0-rc4
 projects[r4032login][type] = module
 projects[r4032login][version] = 1.1
+projects[r4032login][patch][] = "https://www.drupal.org/files/issues/2018-11-01/3010747-3-perform-access-check-as-an-user.patch"
 projects[redirect][type] = module
 projects[redirect][version] = 1.3
 projects[search_api][type] = module


### PR DESCRIPTION
…ccess check for /user/login as anonymous user'

<h3>Problem</h3>
The access check for the /user/login path is performed as the user that's changing the settings. This is problematic because a logged-in user may not have access to the login screen but may be allowed to change basic site settings. This could also cause the login path to be set to something that the logged in user has access to but an anonymous user does not.

This can be reproduced by installing the latest version of r4032login in a clean Drupal 8 install and creating a new role that has the "Administer basic site settings" permission. Assign this role to a non-admin user and attempt to change the basic site settings with the login path set to /user/login. You'll receive a form error that you're not allowed to access /user/login.

<h3>Solution</h3>
Perform the access check for the chosen login screen path as the anonymous user.

## Issue tracker
https://www.drupal.org/project/social/issues/3059829

Patch from https://www.drupal.org/project/r4032login/issues/3010747

## How to test
- [ ] Try to change the sitename on site settings as sitemanager

## Release notes
Editing basic site settings was sometimes not allowed due to an incorrect access check on the login page path that was configured for redirecting anonymous users on privileged pages.
