### PR TITLE
Issue #3059892: Added the static keyword to the statically called function

### DIFF
--- a/modules/social_features/social_profile/modules/social_profile_fields/src/SocialProfileFieldsBatch.php
+++ b/modules/social_features/social_profile/modules/social_profile_fields/src/SocialProfileFieldsBatch.php
@@ -59,7 +59,7 @@ class SocialProfileFieldsBatch {
    * @param string $operations
    *   The operation performed.
    */
-  public function performFlushFinishedCallback($success, array $results, $operations) {
+  public static function performFlushFinishedCallback($success, array $results, $operations) {
     // The 'success' parameter means no fatal PHP errors were detected. All
     // other error management should be handled using 'results'.
     if ($success) {


### PR DESCRIPTION
## Problem
Deprecated function: Non-static method Drupal\social_profile_fields\SocialProfileFieldsBatch::performFlushFinishedCallback() should not be called statically in _batch_finished() (line 454 of core/includes/batch.inc)

## Solution
I added the static keyword to the callback function, because this function is always called statically.

## Issue tracker
https://www.drupal.org/project/social/issues/3059892

## How to test
- Go to `/admin/config/opensocial/profile-fields`;
- Deselect fields and save them;
- Flush the profiles. See that the deprecation warning is not shown in the logs.

## Release notes
Updated the static function call.

## Change Record

