### PR TITLE
Social Path Manager issues

### DIFF
--- a/modules/custom/social_path_manager/social_path_manager.module
+++ b/modules/custom/social_path_manager/social_path_manager.module
@@ -252,8 +252,9 @@ function _social_path_manager_update_alias(EntityInterface $entity, $op, $bulk =
             }
           }
 
-          // Clear cache of the group tag and route_match.
-          \Drupal::service('cache_tags.invalidator')->invalidateTags(['group:' . $entity->id(), 'route_match']);
+          // Clear cache of the group tag and rebuild routes.
+          \Drupal::service('cache_tags.invalidator')->invalidateTags(['group:' . $entity->id()]);
+          \Drupal::service('router.builder')->rebuild();
         }
         break;
 

--- a/modules/custom/social_path_manager/social_path_manager.module
+++ b/modules/custom/social_path_manager/social_path_manager.module
@@ -253,8 +253,7 @@ function _social_path_manager_update_alias(EntityInterface $entity, $op, $bulk =
           }
 
           // Clear cache of the group tag and route_match.
-          \Drupal::service('cache_tags.invalidator')->invalidateTags(['group:' . $entity->id()]);
-          \Drupal::service('cache_tags.invalidator')->invalidateTags(['route_match']);
+          \Drupal::service('cache_tags.invalidator')->invalidateTags(['group:' . $entity->id(), 'route_match']);
         }
         break;
 

--- a/modules/custom/social_path_manager/social_path_manager.module
+++ b/modules/custom/social_path_manager/social_path_manager.module
@@ -211,7 +211,10 @@ function _social_path_manager_update_alias(EntityInterface $entity, $op, $bulk =
 
         // If it's a bulk generate then get the alias by path.
         if ($bulk === TRUE) {
-          $path['alias'] = $pam->getAliasByPath('/group/' . $entity->id() . '/stream');
+          $url = Url::fromRoute('entity.group.canonical', ['group' => $entity->id()]);
+          $url = $url->getInternalPath();
+
+          $path['alias'] = $pam->getAliasByPath('/' . $url);
         }
         else {
           // New alias.

--- a/modules/custom/social_path_manager/social_path_manager.module
+++ b/modules/custom/social_path_manager/social_path_manager.module
@@ -252,8 +252,9 @@ function _social_path_manager_update_alias(EntityInterface $entity, $op, $bulk =
             }
           }
 
-          // Clear cache of the group tag.
+          // Clear cache of the group tag and route_match.
           \Drupal::service('cache_tags.invalidator')->invalidateTags(['group:' . $entity->id()]);
+          \Drupal::service('cache_tags.invalidator')->invalidateTags(['route_match']);
         }
         break;
 


### PR DESCRIPTION
## Problem
1. When the social_group_default_route module is enabled the canonical of groups is changed. The social path module depends on the canonical to be /stream.
2.When a group is saved the tabs are updated, but not showing on the front, only after a cache clear

## Solution
1. Don't rely on the canonical to be /stream, but get the url based on the canonical, so it can be anything.
2. Also clear the cache tag route_match so they are refreshed.

## Issue tracker
https://www.drupal.org/project/social/issues/3060880

## How to test
1.
- [ ] Enable the social_group_default_route
- [ ] Bulk generate url's for group content
- [ ] See the url's for the group tabs are correct with the group name instead of /stream/events etc.

2. 
- [ ] Edit a group and save.
- [ ] Notice that the tabs are now showing the pathauto alias without clearing the cache manually.

## Release notes
1.
We have fixed a bug in the social path manager where it would conflict with the Social Group Default Route module, resulting in group url all having the prefix "steam" after bulk generating the new aliases.

2.
We have fixed a bug in the social path manager where after saving a group, the tabs would still go to the old url's.
