### PR TITLE
Issue #3061282 by albertoalaejos: fix group redirecting issue

### DIFF
--- a/modules/social_features/social_group/social_group.routing.yml
+++ b/modules/social_features/social_group/social_group.routing.yml
@@ -1,3 +1,11 @@
+social_group.page_redirect:
+  path: '/group/{group}'
+  defaults:
+    _controller: '\Drupal\social_group\Controller\SocialGroupController::otherGroupPage'
+    _title: 'Account'
+  requirements:
+    _user_is_logged_in: 'TRUE'
+
 social_group.settings:
   path: '/admin/config/opensocial/social-group'
   defaults:

--- a/modules/social_features/social_group/src/Controller/SocialGroupController.php
+++ b/modules/social_features/social_group/src/Controller/SocialGroupController.php
@@ -138,4 +138,14 @@ class SocialGroupController extends ControllerBase {
     return AccessResult::allowedIfHasPermission($account, 'view groups on other profiles');
   }
 
+  /**
+   * OtherGroupPage.
+   *
+   * @return RedirectResponse
+   *   Return Redirect to the group account.
+   */
+  public function otherGroupPage($group) {
+    return $this->redirect('entity.group.canonical', ['group' => $group]);
+  }
+
 }


### PR DESCRIPTION
## Problem
When you select a group in autocomplete it shows page not found

## Solution
The group is now redirected to the stream

## Issue tracker
https://www.drupal.org/project/social/issues/3061282

## How to test
- [ ] Click on the search button
- [ ] Search for a group
- [ ] Click on it