### PR TITLE
DS-6635 - As a AN/LU I want to see the visibility type of content in overviews

### DIFF
--- a/modules/social_features/social_landing_page/templates/node--featured.html.twig
+++ b/modules/social_features/social_landing_page/templates/node--featured.html.twig
@@ -135,6 +135,17 @@
     </div>
   </div>
   <div class="card__actionbar">
+    {% if visibility_icon and visibility_label %}
+      <div class="badge teaser__badge no-padding" title="{% trans %}The visibility of this content is set to {% endtrans %} {{ visibility_label }}">
+        <span class="badge__container">
+          <svg class="badge__icon">
+            <use xlink:href="#icon-{{ visibility_icon }}"></use>
+          </svg>
+          <span class="badge__label text-gray">{{ visibility_label|capitalize }}</span>
+        </span>
+      </div>
+    {% endif %}
+
     {% block card_link %}
     <div class="card__link">
       <a href="{{ url }}" rel="bookmark">{{ 'Read more'|t }}

--- a/themes/socialbase/templates/node/node--teaser.html.twig
+++ b/themes/socialbase/templates/node/node--teaser.html.twig
@@ -154,21 +154,24 @@
     <div class="card__actionbar">
 
         {% if comment_count > 0 %}
-          <a href="{{ url }}#section-comments" class="badge badge--pill badge-default teaser__badge">
+          <a href="{{ url }}#section-comments" class="badge badge--pill teaser__badge">
             <span class="badge__container">
               <svg class="badge__icon">
                 <use xlink:href="#icon-comment"></use>
               </svg>
-              <span class="badge__label">{{ comment_count }}</span>
+              <span class="badge__label text-gray">{{ comment_count }}</span>
             </span>
           </a>
         {% endif %}
 
         {% if visibility_icon and visibility_label %}
           <div class="badge teaser__badge" title="{% trans %}The visibility of this content is set to {% endtrans %} {{ visibility_label }}">
-              <svg class="badge__icon">
-                <use xlink:href="#icon-{{ visibility_icon }}"></use>
-              </svg>
+              <span class="badge__container">
+                  <svg class="badge__icon">
+                    <use xlink:href="#icon-{{ visibility_icon }}"></use>
+                  </svg>
+                  <span class="badge__label text-gray">{{ visibility_label|capitalize }}</span>
+              </span>
           </div>
         {% endif %}
 


### PR DESCRIPTION
## Problem
With the growing flexibility in Content visibility, due to the flexible group types, it's more and more important to show what visibility your content has. Posts already show it, now it will also be available in teasers.

## Solution
Updated the teaser & featured section to show the content visibility label.

## Issue tracker
- https://www.drupal.org/project/social/issues/3062164
- https://jira.goalgorilla.com/browse/DS-6635

## How to test
- [x] Reinstall OS and enable `drush en social_landing_page`
- [x] See that on the overviews, in the stream and for featured items in landing page the content visibility is shown as per screenshots below.

## Release notes
We now clearly indicate the selected visibility for content in overviews and on the stream, this to indicate which users might be able to see the content.

Previews of my local installation:

![Screen Shot 2019-06-17 at 09 45 20](https://user-images.githubusercontent.com/16667281/59587450-97311e80-90e5-11e9-923a-b17e73af4d03.png)
![Screen Shot 2019-06-17 at 09 45 50](https://user-images.githubusercontent.com/16667281/59587451-97311e80-90e5-11e9-9b5f-120a90c666f7.png)
![Screen Shot 2019-06-17 at 09 45 57](https://user-images.githubusercontent.com/16667281/59587453-97c9b500-90e5-11e9-806a-c22d7a0d5990.png)
![Screen Shot 2019-06-17 at 09 46 16](https://user-images.githubusercontent.com/16667281/59587455-97c9b500-90e5-11e9-8961-5a557e27b86c.png)
