### PR TITLE
Issue #3057217 by Salif, albertoalaejos: Notice: Undefined index: #id…

### DIFF
--- a/modules/social_features/social_profile/social_profile.module
+++ b/modules/social_features/social_profile/social_profile.module
@@ -282,7 +282,8 @@ function social_profile_preprocess_form_element_label(&$variables) {
   // Edit the profile tag displays to show the hierarchy to users.
   // Only do this if it starts with a - to indicate it's a child.
   if (
-    substr($variables['element']['#id'], 0, 17) === 'edit-profile-tag-'
+    isset($variables['element']['#id'])
+    && substr($variables['element']['#id'], 0, 17) === 'edit-profile-tag-'
     && substr($variables['element']['#title'], 0, 1) === '-'
   ) {
     $variables['title']['#markup'] = substr($variables['title']['#markup'], 1);


### PR DESCRIPTION
Notice: Undefined index: #id in social_profile_preprocess_form_element_label()

## Problem
Happens after Upgrading Open Social from 8.4.13 to 8.5.4
There are some issues related to group and addtoany.
After following some instructions from Open Social issue https://www.drupal.org/project/social/issues/3048980, there is an error message when visiting admin/structure/views page:
Notice: Undefined index: #id in social_profile_preprocess_form_element_label() (line 286 of profiles/contrib/social/modules/social_features/social_profile/social_profile.module)...

## Solution
Defensive line in an if condition

## Issue tracker
https://www.drupal.org/project/social/issues/3057217

## How to test

- [ ] Upgrade opensocial from 4.13 to 5.4

- [ ] Run composer require drupal/addtoany to reinstall and then enable it

- [ ] Export the "Group Manage Members (group_manage_members)" View from a clean vanilla OpenSocial 5.4 install. "/admin/config/development/configuration/single/export"

- [ ] Import the missing configuration "Group Manage Members (group_manage_members)" View to my upgraded site configuration. "/admin/config/development/configuration/single/import"

- [ ] drush cr && entup && updb

- [ ] Visit admin/structure/views page
