### PR TITLE
Issue #3061984 by albertoalaejos: Warning: in_array() expects paramet…

### DIFF
--- a/themes/socialbase/src/Plugin/Preprocess/FormElement.php
+++ b/themes/socialbase/src/Plugin/Preprocess/FormElement.php
@@ -22,7 +22,8 @@ class FormElement extends BaseFormElement {
 
     // Check if form element is part of
     // email_notifications and add class to label.
-    if (in_array('email_notifications', $element['#parents'])) {
+    if (isset($element['#parents'])
+      && in_array('email_notifications', $element['#parents'])) {
       $variables['label']['#attributes']['class'][] = 'control-label--wide';
     }
 


### PR DESCRIPTION
Warning: in_array() expects parameter 2 to be array, null given in Drupal\socialbase\Plugin\Preprocess\FormElement->preprocessElement() (line 25 of profiles/contrib/social/themes/socialbase/src/Plugin/Preprocess/FormElement.php).

## Problem
while logged in as admin using the dummy content

choose a group. then click on the "manage members"

Warning: in_array() expects parameter 2 to be array, null given in Drupal\socialbase\Plugin\Preprocess\FormElement->preprocessElement() (line 25 of profiles/contrib/social/themes/socialbase/src/Plugin/Preprocess/FormElement.php).

## Solution
Defensive line in an if condition

## Issue tracker
https://www.drupal.org/project/social/issues/3061984

## How to test
- [ ] Log in as site admin
- [ ] Enable log warnings in configuration->development
- [ ] Choose a group
- [ ] Click on manage members
