### PR TITLE
Issue #3061121 by Kalavan, albertoalaejos: Warning: in_array() expect…

### DIFF
--- a/modules/social_features/social_core/src/Entity/EntityAutocompleteMatcher.php
+++ b/modules/social_features/social_core/src/Entity/EntityAutocompleteMatcher.php
@@ -38,7 +38,7 @@ class EntityAutocompleteMatcher extends EntityAutocompleteMatcherBase {
           // We can just add this to our render arrays from now on.
           // '#selection_settings' => [ 'skip_entity' => ['7', '8', '9'] ].
           if (!empty($selection_settings['skip_entity']) && in_array($entity_id, $selection_settings['skip_entity'], FALSE)) {
-              continue;
+            continue;
           }
 
           $key = !empty($selection_settings['hide_id']) ? $label : "$label ($entity_id)";

--- a/modules/social_features/social_core/src/Entity/EntityAutocompleteMatcher.php
+++ b/modules/social_features/social_core/src/Entity/EntityAutocompleteMatcher.php
@@ -37,8 +37,8 @@ class EntityAutocompleteMatcher extends EntityAutocompleteMatcherBase {
           // Skip certain entity_id's that are already a member or a enrollee.
           // We can just add this to our render arrays from now on.
           // '#selection_settings' => [ 'skip_entity' => ['7', '8', '9'] ].
-          if (in_array($entity_id, $selection_settings['skip_entity'], FALSE)) {
-            continue;
+          if (!empty($selection_settings['skip_entity']) && in_array($entity_id, $selection_settings['skip_entity'], FALSE)) {
+              continue;
           }
 
           $key = !empty($selection_settings['hide_id']) ? $label : "$label ($entity_id)";


### PR DESCRIPTION
Warning: in_array() expects parameter 2 to be array, null given in Drupal\social_core\Entity\EntityAutocompleteMatcher->getMatches()

## Problem
When user uses autocomplete this two warning appearing in status report.

1) Warning: in_array() expects parameter 2 to be array, null given in Drupal\social_core\Entity\EntityAutocompleteMatcher->getMatches() (line 40 of /var/www/html/docroot/profiles/contrib/open_social/modules/social_features/social_core/src/Entity/EntityAutocompleteMatcher.php)

2) Notice: Undefined index: skip_entity in Drupal\social_core\Entity\EntityAutocompleteMatcher->getMatches()

## Solution
Defensive code in an if condition

## Issue tracker
https://www.drupal.org/project/social/issues/3061121

## How to test
- [x] Select a group where the user is an admin
- [x] Click on manage members
- [ ] Search so that it triggers autocomplete
- [ ] Check the Recent log messages