### PR TITLE
Issue #2948979 - Improve search relevancy (node type, creation date and title boost)

### DIFF
--- a/modules/social_features/social_search/config/install/search_api.index.social_all.yml
+++ b/modules/social_features/social_search/config/install/search_api.index.social_all.yml
@@ -2,8 +2,8 @@ langcode: en
 status: true
 dependencies:
   module:
-    - node
     - group
+    - node
     - profile
     - user
     - search_api
@@ -12,10 +12,10 @@ dependencies:
     - field.storage.group.field_group_description
     - field.storage.group.field_group_location
     - field.storage.profile.field_profile_expertise
-    - field.storage.profile.field_profile_interests
-    - field.storage.profile.field_profile_profile_tag
     - field.storage.profile.field_profile_first_name
+    - field.storage.profile.field_profile_interests
     - field.storage.profile.field_profile_last_name
+    - field.storage.profile.field_profile_profile_tag
     - search_api.server.social_database
     - core.entity_view_mode.group.teaser
     - core.entity_view_mode.node.search_index
@@ -65,6 +65,15 @@ field_settings:
     dependencies:
       config:
         - field.storage.profile.field_profile_expertise
+  field_profile_first_name:
+    label: 'First name'
+    datasource_id: 'entity:profile'
+    property_path: field_profile_first_name
+    type: text
+    boost: !!float 2
+    dependencies:
+      config:
+        - field.storage.profile.field_profile_first_name
   field_profile_interests:
     label: Interests
     datasource_id: 'entity:profile'
@@ -73,6 +82,15 @@ field_settings:
     dependencies:
       config:
         - field.storage.profile.field_profile_interests
+  field_profile_last_name:
+    label: 'Last name'
+    datasource_id: 'entity:profile'
+    property_path: field_profile_last_name
+    type: text
+    boost: !!float 2
+    dependencies:
+      config:
+        - field.storage.profile.field_profile_last_name
   field_profile_profile_tag:
     label: 'Profile tag'
     datasource_id: 'entity:profile'
@@ -86,7 +104,7 @@ field_settings:
     datasource_id: 'entity:group'
     property_path: label
     type: text
-    boost: !!float 8
+    boost: !!float 21
     dependencies:
       module:
         - group
@@ -99,6 +117,7 @@ field_settings:
     dependencies:
       module:
         - profile
+        - user
         - user
   node_grants:
     label: 'Node access information'
@@ -140,7 +159,7 @@ field_settings:
     datasource_id: 'entity:node'
     property_path: title
     type: text
-    boost: !!float 8
+    boost: !!float 21
     dependencies:
       module:
         - node
@@ -149,6 +168,15 @@ field_settings:
     datasource_id: 'entity:node'
     property_path: type
     type: string
+    dependencies:
+      module:
+        - node
+  type_1:
+    label: 'Content type'
+    datasource_id: 'entity:node'
+    property_path: type
+    type: text
+    boost: !!float 13
     dependencies:
       module:
         - node
@@ -187,22 +215,7 @@ field_settings:
       module:
         - profile
         - user
-  field_profile_first_name:
-    label: 'First name'
-    datasource_id: 'entity:profile'
-    property_path: field_profile_first_name
-    type: text
-    dependencies:
-      config:
-        - field.storage.profile.field_profile_first_name
-  field_profile_last_name:
-    label: 'Last name'
-    datasource_id: 'entity:profile'
-    property_path: field_profile_last_name
-    type: text
-    dependencies:
-      config:
-        - field.storage.profile.field_profile_last_name
+        - user
 datasource_settings:
   'entity:group':
     bundles:

--- a/modules/social_features/social_search/config/install/search_api.index.social_all.yml
+++ b/modules/social_features/social_search/config/install/search_api.index.social_all.yml
@@ -2,8 +2,8 @@ langcode: en
 status: true
 dependencies:
   module:
-    - group
     - node
+    - group
     - profile
     - user
     - search_api

--- a/modules/social_features/social_search/config/install/search_api.index.social_content.yml
+++ b/modules/social_features/social_search/config/install/search_api.index.social_content.yml
@@ -1,23 +1,32 @@
 langcode: en
 status: true
 dependencies:
+  module:
+    - node
+    - search_api
   config:
     - search_api.server.social_database
     - core.entity_view_mode.node.search_index
-  module:
-    - search_api
-    - node
 id: social_content
 name: 'Social Content'
 description: 'Default content index created for the Social distribution.'
 read_only: false
 field_settings:
-  title:
-    label: Title
+  created:
+    label: 'Authored on'
     datasource_id: 'entity:node'
-    property_path: title
-    type: text
-    boost: !!float 8
+    property_path: created
+    type: date
+    dependencies:
+      module:
+        - node
+  node_grants:
+    label: 'Node access information'
+    property_path: search_api_node_grants
+    type: string
+    indexed_locked: true
+    type_locked: true
+    hidden: true
   rendered_item:
     label: 'Rendered HTML output'
     property_path: rendered_item
@@ -31,11 +40,6 @@ field_settings:
           event: search_index
           page: search_index
           topic: search_index
-  type:
-    label: Type
-    datasource_id: 'entity:node'
-    property_path: type
-    type: string
   status:
     label: 'Publishing status'
     datasource_id: 'entity:node'
@@ -43,6 +47,27 @@ field_settings:
     type: boolean
     indexed_locked: true
     type_locked: true
+    dependencies:
+      module:
+        - node
+  title:
+    label: Title
+    datasource_id: 'entity:node'
+    property_path: title
+    type: text
+    boost: !!float 21
+    dependencies:
+      module:
+        - node
+  type:
+    label: Type
+    datasource_id: 'entity:node'
+    property_path: type
+    type: text
+    boost: !!float 13
+    dependencies:
+      module:
+        - node
   uid:
     label: 'Authored by'
     datasource_id: 'entity:node'
@@ -50,18 +75,9 @@ field_settings:
     type: integer
     indexed_locked: true
     type_locked: true
-  node_grants:
-    label: 'Node access information'
-    property_path: search_api_node_grants
-    type: string
-    indexed_locked: true
-    type_locked: true
-    hidden: true
-  created:
-    label: 'Authored on'
-    datasource_id: 'entity:node'
-    property_path: created
-    type: date
+    dependencies:
+      module:
+        - node
 datasource_settings:
   'entity:node':
     plugin_id: 'entity:node'
@@ -93,12 +109,12 @@ processor_settings:
     title: true
     alt: true
     tags:
+      b: 2
+      em: 1
       h1: 5
       h2: 3
       h3: 2
       strong: 2
-      b: 2
-      em: 1
       u: 1
     weights:
       preprocess_index: -10
@@ -107,8 +123,8 @@ processor_settings:
     plugin_id: ignorecase
     all_fields: false
     fields:
-      - title
       - rendered_item
+      - title
     weights:
       preprocess_index: -10
       preprocess_query: -10
@@ -121,8 +137,8 @@ processor_settings:
     plugin_id: stopwords
     all_fields: false
     fields:
-      - title
       - rendered_item
+      - title
     stopwords:
       - a
       - an
@@ -166,8 +182,8 @@ processor_settings:
     plugin_id: tokenizer
     all_fields: false
     fields:
-      - title
       - rendered_item
+      - title
     spaces: ''
     overlap_cjk: 1
     minimum_word_size: '3'
@@ -178,8 +194,8 @@ processor_settings:
     plugin_id: transliteration
     all_fields: false
     fields:
-      - title
       - rendered_item
+      - title
     weights:
       preprocess_index: -10
       preprocess_query: -10

--- a/modules/social_features/social_search/config/install/search_api.index.social_groups.yml
+++ b/modules/social_features/social_search/config/install/search_api.index.social_groups.yml
@@ -2,9 +2,9 @@ langcode: en
 status: true
 dependencies:
   module:
+    - group
     - user
     - search_api
-    - group
   config:
     - field.storage.group.field_group_description
     - search_api.server.social_database
@@ -14,6 +14,41 @@ name: 'Social Groups'
 description: 'Default group index created for the Social distribution.'
 read_only: false
 field_settings:
+  created:
+    label: 'Created on'
+    datasource_id: 'entity:group'
+    property_path: created
+    type: date
+    dependencies:
+      module:
+        - group
+  field_group_description:
+    label: Description
+    datasource_id: 'entity:group'
+    property_path: field_group_description
+    type: text
+    dependencies:
+      config:
+        - field.storage.group.field_group_description
+  label:
+    label: Title
+    datasource_id: 'entity:group'
+    property_path: label
+    type: text
+    boost: !!float 21
+    dependencies:
+      module:
+        - group
+  name:
+    label: 'Group creator » User » Name'
+    datasource_id: 'entity:group'
+    property_path: 'uid:entity:name'
+    type: string
+    dependencies:
+      module:
+        - group
+        - user
+        - user
   rendered_item:
     label: 'Rendered HTML output'
     property_path: rendered_item
@@ -30,28 +65,9 @@ field_settings:
     datasource_id: 'entity:group'
     property_path: type
     type: string
-  label:
-    label: Title
-    datasource_id: 'entity:group'
-    property_path: label
-    type: text
-    boost: !!float 8
-  name:
-    label: 'Group creator » User » Name'
-    datasource_id: 'entity:group'
-    property_path: 'uid:entity:name'
-    type: string
     dependencies:
       module:
-        - user
-  field_group_description:
-    label: Description
-    datasource_id: 'entity:group'
-    property_path: field_group_description
-    type: text
-    dependencies:
-      config:
-        - field.storage.group.field_group_description
+        - group
 datasource_settings:
   'entity:group':
     plugin_id: 'entity:group'
@@ -79,25 +95,13 @@ processor_settings:
     title: true
     alt: true
     tags:
+      b: 2
+      em: 1
       h1: 5
       h2: 3
       h3: 2
       strong: 2
-      b: 2
-      em: 1
       u: 1
-    weights:
-      preprocess_index: -10
-      preprocess_query: -10
-  ignorecase:
-    plugin_id: ignorecase
-    all_fields: false
-    fields:
-      - type
-      - label
-      - name
-      - field_group_description
-      - rendered_item
     weights:
       preprocess_index: -10
       preprocess_query: -10
@@ -105,10 +109,10 @@ processor_settings:
     plugin_id: ignore_character
     all_fields: false
     fields:
-      - type
+      - field_group_description
       - label
       - name
-      - field_group_description
+      - type
     ignorable: '[''¿¡!?,.:;]'
     strip:
       character_sets:
@@ -119,6 +123,26 @@ processor_settings:
         Pi: Pi
         Po: Po
         Ps: Ps
+    weights:
+      preprocess_index: -10
+      preprocess_query: -10
+    ignorable_classes:
+      - Pc
+      - Pd
+      - Pe
+      - Pf
+      - Pi
+      - Po
+      - Ps
+  ignorecase:
+    plugin_id: ignorecase
+    all_fields: false
+    fields:
+      - field_group_description
+      - label
+      - name
+      - rendered_item
+      - type
     weights:
       preprocess_index: -10
       preprocess_query: -10
@@ -188,8 +212,8 @@ processor_settings:
     plugin_id: transliteration
     all_fields: false
     fields:
-      - label
       - field_group_description
+      - label
       - rendered_item
     weights:
       preprocess_index: -10

--- a/modules/social_features/social_search/config/install/search_api.index.social_users.yml
+++ b/modules/social_features/social_search/config/install/search_api.index.social_users.yml
@@ -1,24 +1,85 @@
 langcode: en
 status: true
 dependencies:
-  config:
-    - field.storage.profile.field_profile_expertise
-    - field.storage.profile.field_profile_interests
-    - field.storage.profile.field_profile_profile_tag
-    - field.storage.profile.field_profile_first_name
-    - field.storage.profile.field_profile_last_name
-    - search_api.server.social_database
-    - core.entity_view_mode.profile.search_index
   module:
+    - profile
     - user
     - search_api
     - social_search
-    - profile
+  config:
+    - field.storage.profile.field_profile_expertise
+    - field.storage.profile.field_profile_first_name
+    - field.storage.profile.field_profile_interests
+    - field.storage.profile.field_profile_last_name
+    - field.storage.profile.field_profile_profile_tag
+    - search_api.server.social_database
+    - core.entity_view_mode.profile.search_index
 id: social_users
 name: 'Social Users'
 description: 'Default users index created for the Social distribution.'
 read_only: false
 field_settings:
+  created:
+    label: Created
+    datasource_id: 'entity:profile'
+    property_path: created
+    type: date
+    dependencies:
+      module:
+        - profile
+  field_profile_expertise:
+    label: Expertise
+    datasource_id: 'entity:profile'
+    property_path: field_profile_expertise
+    type: integer
+    dependencies:
+      config:
+        - field.storage.profile.field_profile_expertise
+  field_profile_first_name:
+    label: 'First name'
+    datasource_id: 'entity:profile'
+    property_path: field_profile_first_name
+    type: text
+    boost: !!float 2
+    dependencies:
+      config:
+        - field.storage.profile.field_profile_first_name
+  field_profile_interests:
+    label: Interests
+    datasource_id: 'entity:profile'
+    property_path: field_profile_interests
+    type: integer
+    dependencies:
+      config:
+        - field.storage.profile.field_profile_interests
+  field_profile_last_name:
+    label: 'Last name'
+    datasource_id: 'entity:profile'
+    property_path: field_profile_last_name
+    type: text
+    boost: !!float 2
+    dependencies:
+      config:
+        - field.storage.profile.field_profile_last_name
+  field_profile_profile_tag:
+    label: 'Profile tag'
+    datasource_id: 'entity:profile'
+    property_path: field_profile_profile_tag
+    type: integer
+    dependencies:
+      config:
+        - field.storage.profile.field_profile_profile_tag
+  name:
+    label: 'Owner » User » Name'
+    datasource_id: 'entity:profile'
+    property_path: 'uid:entity:name'
+    type: text
+    boost: !!float 2
+    dependencies:
+      module:
+        - profile
+        - user
+        - user
   rendered_item:
     label: 'Rendered HTML output'
     property_path: rendered_item
@@ -28,45 +89,16 @@ field_settings:
         authenticated: authenticated
       view_mode:
         'entity:profile':
-          profile: search_index
           main: ''
-  field_profile_expertise:
-    label: Expertise
-    datasource_id: 'entity:profile'
-    property_path: field_profile_expertise
-    type: integer
-    dependencies:
-      config:
-        - field.storage.profile.field_profile_expertise
-  field_profile_interests:
-    label: Interests
-    datasource_id: 'entity:profile'
-    property_path: field_profile_interests
-    type: integer
-    dependencies:
-      config:
-        - field.storage.profile.field_profile_interests
-  field_profile_profile_tag:
-    label: 'Profile tag'
-    datasource_id: 'entity:profile'
-    property_path: field_profile_profile_tag
-    type: integer
-    dependencies:
-      config:
-        - field.storage.profile.field_profile_profile_tag
+          profile: search_index
   uid:
     label: Owner
     datasource_id: 'entity:profile'
     property_path: uid
     type: integer
-  name:
-    label: 'Owner » User » Name'
-    datasource_id: 'entity:profile'
-    property_path: 'uid:entity:name'
-    type: text
     dependencies:
       module:
-        - user
+        - profile
   user_status:
     label: 'Owner » User » User status'
     datasource_id: 'entity:profile'
@@ -74,23 +106,9 @@ field_settings:
     type: boolean
     dependencies:
       module:
+        - profile
         - user
-  field_profile_first_name:
-    label: 'First name'
-    datasource_id: 'entity:profile'
-    property_path: field_profile_first_name
-    type: text
-    dependencies:
-      config:
-        - field.storage.profile.field_profile_first_name
-  field_profile_last_name:
-    label: 'Last name'
-    datasource_id: 'entity:profile'
-    property_path: field_profile_last_name
-    type: text
-    dependencies:
-      config:
-        - field.storage.profile.field_profile_last_name
+        - user
 datasource_settings:
   'entity:profile':
     plugin_id: 'entity:profile'
@@ -106,21 +124,24 @@ processor_settings:
     plugin_id: aggregated_field
     weights:
       add_properties: 20
+  blocked_users:
+    weights:
+      preprocess_query: -30
   html_filter:
     plugin_id: html_filter
     all_fields: false
     fields:
-      - rendered_item
       - name
+      - rendered_item
     title: true
     alt: true
     tags:
+      b: 2
+      em: 1
       h1: 5
       h2: 3
       h3: 2
       strong: 2
-      b: 2
-      em: 1
       u: 1
     weights:
       preprocess_index: -10
@@ -129,10 +150,10 @@ processor_settings:
     plugin_id: ignorecase
     all_fields: false
     fields:
-      - rendered_item
-      - name
       - field_profile_first_name
       - field_profile_last_name
+      - name
+      - rendered_item
     weights:
       preprocess_index: -10
       preprocess_query: -10
@@ -145,8 +166,8 @@ processor_settings:
     plugin_id: stopwords
     all_fields: false
     fields:
-      - rendered_item
       - name
+      - rendered_item
     stopwords:
       - a
       - an
@@ -186,14 +207,17 @@ processor_settings:
     weights:
       preprocess_index: -5
       preprocess_query: -2
+  super_user:
+    weights:
+      preprocess_query: 30
   tokenizer:
     plugin_id: tokenizer
     all_fields: false
     fields:
-      - rendered_item
-      - name
       - field_profile_first_name
       - field_profile_last_name
+      - name
+      - rendered_item
     spaces: ''
     overlap_cjk: 1
     minimum_word_size: '3'
@@ -204,19 +228,13 @@ processor_settings:
     plugin_id: transliteration
     all_fields: false
     fields:
-      - rendered_item
-      - name
       - field_profile_first_name
       - field_profile_last_name
+      - name
+      - rendered_item
     weights:
       preprocess_index: -10
       preprocess_query: -10
-  super_user:
-    weights:
-      preprocess_query: 30
-  blocked_users:
-    weights:
-      preprocess_query: -30
 tracker_settings:
   default:
     indexing_order: fifo

--- a/modules/social_features/social_search/config/install/views.view.search_all.yml
+++ b/modules/social_features/social_search/config/install/views.view.search_all.yml
@@ -68,15 +68,15 @@ display:
         type: search_api
         options:
           view_modes:
-            'entity:node':
-              event: teaser
-              page: teaser
-              topic: teaser
-              book: teaser
             'entity:group':
               closed_group: teaser
               open_group: teaser
               public_group: teaser
+            'entity:node':
+              book: teaser
+              event: teaser
+              page: teaser
+              topic: teaser
             'entity:profile':
               profile: teaser
       fields:
@@ -159,6 +159,18 @@ display:
           id: search_api_relevance
           table: search_api_index_social_all
           field: search_api_relevance
+          relationship: none
+          group_type: group
+          admin_label: ''
+          order: DESC
+          exposed: false
+          expose:
+            label: ''
+          plugin_id: search_api
+        created:
+          id: created
+          table: search_api_index_social_all
+          field: created
           relationship: none
           group_type: group
           admin_label: ''

--- a/modules/social_features/social_search/config/install/views.view.search_content.yml
+++ b/modules/social_features/social_search/config/install/views.view.search_content.yml
@@ -185,6 +185,18 @@ display:
           expose:
             label: ''
           plugin_id: search_api
+        created:
+          id: created
+          table: search_api_index_social_content
+          field: created
+          relationship: none
+          group_type: group
+          admin_label: ''
+          order: DESC
+          exposed: false
+          expose:
+            label: ''
+          plugin_id: search_api
       title: 'Search content'
       header:
         area:
@@ -247,6 +259,7 @@ display:
           validate_options: {  }
           break_phrase: false
           not: false
+          parse_mode: terms
           fields: {  }
           conjunction: AND
           plugin_id: search_api_fulltext

--- a/modules/social_features/social_search/config/install/views.view.search_groups.yml
+++ b/modules/social_features/social_search/config/install/views.view.search_groups.yml
@@ -2,10 +2,10 @@ langcode: en
 status: true
 dependencies:
   config:
-  - search_api.index.social_groups
+    - search_api.index.social_groups
   module:
-  - search_api
-  - user
+    - search_api
+    - user
 id: search_groups
 label: 'Search Groups'
 module: views
@@ -190,6 +190,18 @@ display:
           expose:
             label: ''
           plugin_id: search_api
+        created:
+          id: created
+          table: search_api_index_social_groups
+          field: created
+          relationship: none
+          group_type: group
+          admin_label: ''
+          order: DESC
+          exposed: false
+          expose:
+            label: ''
+          plugin_id: search_api
       title: 'Search Groups'
       header:
         area:
@@ -259,10 +271,10 @@ display:
     cache_metadata:
       max-age: -1
       contexts:
-      - 'languages:language_interface'
-      - url
-      - url.query_args
-      - user.permissions
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - user.permissions
       tags: {  }
   page:
     display_plugin: page
@@ -276,10 +288,10 @@ display:
     cache_metadata:
       max-age: -1
       contexts:
-      - 'languages:language_interface'
-      - url
-      - url.query_args
-      - user.permissions
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - user.permissions
       tags: {  }
   page_no_value:
     display_plugin: page
@@ -319,8 +331,8 @@ display:
     cache_metadata:
       max-age: -1
       contexts:
-      - 'languages:language_interface'
-      - url
-      - url.query_args
-      - user.permissions
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - user.permissions
       tags: {  }

--- a/modules/social_features/social_search/config/install/views.view.search_users.yml
+++ b/modules/social_features/social_search/config/install/views.view.search_users.yml
@@ -283,6 +283,18 @@ display:
           expose:
             label: ''
           plugin_id: search_api
+        created:
+          id: created
+          table: search_api_index_social_users
+          field: created
+          relationship: none
+          group_type: group
+          admin_label: ''
+          order: DESC
+          exposed: false
+          expose:
+            label: ''
+          plugin_id: search_api
       title: 'Search users'
       header:
         area:

--- a/modules/social_features/social_search/modules/social_search_autocomplete/config/install/views.view.search_all_autocomplete.yml
+++ b/modules/social_features/social_search/modules/social_search_autocomplete/config/install/views.view.search_all_autocomplete.yml
@@ -3,14 +3,14 @@ status: true
 dependencies:
   config:
     - search_api.index.social_all
+  enforced:
+    module:
+      - social_search_autocomplete
   module:
     - rest
     - search_api
     - serialization
     - user
-  enforced:
-    module:
-      - social_search_autocomplete
 id: search_all_autocomplete
 label: 'Search All autocomplete'
 module: views
@@ -915,6 +915,18 @@ display:
           id: search_api_relevance
           table: search_api_index_social_all
           field: search_api_relevance
+          relationship: none
+          group_type: group
+          admin_label: ''
+          order: DESC
+          exposed: false
+          expose:
+            label: ''
+          plugin_id: search_api
+        created:
+          id: created
+          table: search_api_index_social_all
+          field: created
           relationship: none
           group_type: group
           admin_label: ''


### PR DESCRIPTION
## Problem
Search relevancy sorting should be improved.

## Solution
Let's work within the limitation of database search and add the following:
* Fallback for creation date (descending = newest on top) after relevancy sort.
* Boost the title 21 times
* Add content type to the index to enable searching for `Pizza event` when searching for events about Pizza.

We also wanted to include Prioritising intact phrases over separate words (e.g. when searching for "Intro call" any exact matches with "Intro call" should prioritise over "Let's plan a call for an introduction.") However that is not possible it seems. We should start with this and in case we want to add this prioritisation later we should consider using Apache SOLR.

## Issue tracker
https://www.drupal.org/project/social/issues/2948979

## How to test
- [ ] Create multiple nodes and test the search.
- [ ] Make sure to test for `Introduction call` and `Intro call` and `Monthly welcome` (e.g. all the monthly welcome nodes in one node with title `welcome 2019` should now be lower than nodes with 
title `monthly welcome march 2019`) and `Pizza event`, etc.
- [ ] See if tests pass

## Release notes
Will follow

## Change Record
Maybe needed.
