### PR TITLE
Issue #2983330 by kavbiswa, Eitisha: Rename "Swiftmailer settings" to…

### DIFF
--- a/modules/social_features/social_swiftmail/social_swiftmail.links.menu.yml
+++ b/modules/social_features/social_swiftmail/social_swiftmail.links.menu.yml
@@ -1,5 +1,5 @@
 social_swiftmail.settings:
-  title: 'Swiftmail settings'
+  title: 'E-mail settings'
   description: 'Settings for Social Swiftmail.'
   route_name: social_swiftmail.settings
   parent: social_core.admin.config.social


### PR DESCRIPTION
… "E-mail settings"

<h3>Problem</h3>
Users don’t care what Swiftmail is or that we use it. If we ever decide that we no longer use the swiftmailer module because something else is now better, the name is no longer applicable.

<h3>Solution</h3>
Rename "Swiftmail Settings" to "E-mail settings".

Ideally we'd rename the module as well to decouple it from our usage of the swiftmailer module but that might break things (we could do it in a major release with a Change Record).

## Issue tracker
https://www.drupal.org/project/social/issues/2983330

## How to test
- [ ] Check the menu item in the admin menu

## Release notes
The name of the menu item for site builders that allows you to remove Open Social branding from notification e-mails is now called "E-mail settings". This was previously named after the module used to send the e-mails which may be inaccurate if that module is not used.

