### PR TITLE
Issue #3063996: add WYSIWYG to comments.

### DIFF
--- a/modules/social_features/social_comment/config/install/editor.editor.comment_text.yml
+++ b/modules/social_features/social_comment/config/install/editor.editor.comment_text.yml
@@ -1,0 +1,34 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - filter.format.comment_text
+  module:
+    - ckeditor
+format: comment_text
+editor: ckeditor
+settings:
+  toolbar:
+    rows:
+      -
+        -
+          name: Formatting
+          items:
+            - Bold
+            - Italic
+            - Underline
+        -
+          name: Links
+          items:
+            - DrupalLink
+            - DrupalUnlink
+        -
+          name: Lists
+          items:
+            - BulletedList
+            - NumberedList
+  plugins:
+    stylescombo:
+      styles: ''
+    language:
+      language_list: un

--- a/modules/social_features/social_comment/config/install/filter.format.comment_text.yml
+++ b/modules/social_features/social_comment/config/install/filter.format.comment_text.yml
@@ -1,0 +1,34 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - mentions
+name: 'Comment text'
+format: comment_text
+weight: 20
+filters:
+  filter_html:
+    id: filter_html
+    provider: filter
+    status: true
+    weight: -10
+    settings:
+      allowed_html: '<a href hreflang> <em> <strong> <blockquote cite> <ul type> <ol start type> <li> <dl> <dt> <dd> <u> <i> <p> <br> <img src alt data-entity-type data-entity-uuid>'
+      filter_html_help: true
+      filter_html_nofollow: false
+  filter_url:
+    id: filter_url
+    provider: filter
+    status: true
+    weight: 0
+    settings:
+      filter_url_length: 72
+  filter_mentions:
+    id: filter_mentions
+    provider: mentions
+    status: true
+    weight: -10
+    settings:
+      mentions_filter:
+        ProfileMention: ProfileMention
+        UserMention: UserMention

--- a/modules/social_features/social_comment/config/install/social_comment.comment_settings.yml
+++ b/modules/social_features/social_comment/config/install/social_comment.comment_settings.yml
@@ -1,2 +1,0 @@
-redirect_comment_to_entity: true
-remove_author_field: true

--- a/modules/social_features/social_comment/config/schema/social_comment.schema.yml
+++ b/modules/social_features/social_comment/config/schema/social_comment.schema.yml
@@ -5,3 +5,9 @@ social_comment.comment_settings:
     redirect_comment_to_entity:
       type: boolean
       label: 'Redirect a comment view to its parent entity'
+    remove_author_field:
+      type: boolean
+      label: 'Remove author field from comment form'
+    wysiwyg:
+      type: boolean
+      label: 'Authenticated users are allowed to use WYSIWYG editor in comment form'

--- a/modules/social_features/social_comment/social_comment.info.yml
+++ b/modules/social_features/social_comment/social_comment.info.yml
@@ -3,8 +3,16 @@ description: 'Provides deafult comment type and related configuration'
 type: module
 core: 8.x
 dependencies:
-  - drupal:comment
-  - drupal:field
-  - drupal:system
-  - drupal:text
+  - ckeditor
+  - comment
+  - 'drupal:comment'
+  - 'drupal:field'
+  - 'drupal:system'
+  - 'drupal:text'
+  - editor
+  - field
+  - filter
+  - mentions
+  - system
+  - text
 package: Social

--- a/modules/social_features/social_comment/social_comment.install
+++ b/modules/social_features/social_comment/social_comment.install
@@ -16,6 +16,13 @@ function social_comment_install() {
 
   // Set some default permissions.
   _social_comment_set_permissions();
+
+  // Set default settings.
+  \Drupal::configFactory()->getEditable('social_comment.comment_settings')
+    ->set('redirect_comment_to_entity', TRUE)
+    ->set('remove_author_field', TRUE)
+    ->set('wysiwyg', TRUE)
+    ->save();
 }
 
 /**
@@ -56,6 +63,7 @@ function _social_comment_get_permissions($role) {
     'edit own comments',
     'delete own comments',
     'administer own comments',
+    'use text format comment_html',
   ]);
 
   // Content manager.
@@ -64,7 +72,9 @@ function _social_comment_get_permissions($role) {
   ]);
 
   // Site manager.
-  $permissions['sitemanager'] = array_merge($permissions['contentmanager'], []);
+  $permissions['sitemanager'] = array_merge($permissions['contentmanager'], [
+    'administer social_comment settings',
+  ]);
 
   if (isset($permissions[$role])) {
     return $permissions[$role];
@@ -98,4 +108,13 @@ function social_comment_update_8002() {
   // hook was not added at that point so this must be rectified now.
   user_role_grant_permissions('contentmanager', ['administer comments']);
   user_role_grant_permissions('sitemanager', ['administer comments']);
+}
+
+/**
+ * Enable 'administer social_comment settings' permission for sitemanagers.
+ */
+function social_comment_update_8601() {
+  // These permissions were added to default installs in PR 959 but an update
+  // hook was not added at that point so this must be rectified now.
+  user_role_grant_permissions('sitemanager', ['administer social_comment settings']);
 }

--- a/modules/social_features/social_comment/social_comment.links.menu.yml
+++ b/modules/social_features/social_comment/social_comment.links.menu.yml
@@ -1,0 +1,5 @@
+social_comment.admin.config.social.comment:
+  title: 'Comment settings'
+  route_name: social_comment.settings
+  description: 'Comment settings'
+  parent: social_core.admin.config.social

--- a/modules/social_features/social_comment/social_comment.module
+++ b/modules/social_features/social_comment/social_comment.module
@@ -379,7 +379,7 @@ function social_comment_filter_process_format(array &$element, FormStateInterfac
   if (in_array($complete_form['#form_id'], $enabled_form_ids, TRUE)) {
 
     // Check if we need to enable WYSIWYG on comment forms.
-    $wysiwyg = \Drupal::config('social_comment.comment_settings')->get('remove_author_field');
+    $wysiwyg = \Drupal::config('social_comment.comment_settings')->get('wysiwyg');
     if ($wysiwyg) {
 
       $comment = $form_state->getFormObject()->getEntity();

--- a/modules/social_features/social_comment/social_comment.module
+++ b/modules/social_features/social_comment/social_comment.module
@@ -335,3 +335,66 @@ function social_comment_field_info_alter(&$info) {
     $info['comment']['list_class'] = '\Drupal\social_comment\SocialCommentFieldItemList';
   }
 }
+
+/**
+ * Implements hook_element_info_alter().
+ */
+function social_comment_element_info_alter(array &$info) {
+  if (isset($info['text_format']) && isset($info['text_format']['#process'])) {
+    $info['text_format']['#process'][] = 'social_comment_filter_process_format';
+  }
+}
+
+/**
+ * Process callback for form elements that have a text format selector attached.
+ *
+ * This callback runs after filter_process_format() and performs additional
+ * modifications to the form element.
+ *
+ * @see \Drupal\filter\Element\TextFormat::processFormat()
+ */
+function social_comment_filter_process_format(array &$element, FormStateInterface $form_state, array $complete_form) {
+  $comment_text_format = 'comment_text';
+
+  $enabled_form_ids = [
+    'comment_post_comment_form',
+    'comment_comment_form',
+  ];
+
+  // Change text format for comment form.
+  if (in_array($complete_form['#form_id'], $enabled_form_ids, TRUE)) {
+
+    // Check if we need to enable WYSIWYG on comment forms.
+    $wysiwyg = \Drupal::config('social_comment.comment_settings')->get('remove_author_field');
+    if ($wysiwyg) {
+
+      $comment = $form_state->getFormObject()->getEntity();
+      $comment_type = $comment->getEntityTypeId();
+      $permission = 'use text format ' . $comment_text_format;
+      $account = \Drupal::currentUser();
+      if ($comment_type === 'comment' && $account->hasPermission($permission)) {
+        // Remove simple text format from comments.
+        if (isset($element['format']['format']['#options']['simple_text'])) {
+          unset($element['format']['format']['#options']['simple_text']);
+        }
+        // Add comment text format to comments.
+        $element['#format'] = $comment_text_format;
+        $element['format']['format']['#value'] = $comment_text_format;
+        $element['format']['format']['#default_value'] = $comment_text_format;
+        $element['format']['format']['#options'][$comment_text_format] = $comment_text_format;
+      }
+    }
+  }
+  // If the form is not comment form, remove the text format comment_text.
+  elseif (isset($element['format']['format']['#options'][$comment_text_format])) {
+    unset($element['format']['format']['#options'][$comment_text_format]);
+  }
+  return $element;
+}
+
+/**
+ * Implements hook_social_embed_formats_alter().
+ */
+function social_comment_social_embed_formats_alter(array &$formats) {
+  $formats['comment_text'] = TRUE;
+}

--- a/modules/social_features/social_comment/social_comment.module
+++ b/modules/social_features/social_comment/social_comment.module
@@ -337,6 +337,20 @@ function social_comment_field_info_alter(&$info) {
 }
 
 /**
+ * Change the CKEditor settings.
+ *
+ * Implements hook_editor_js_settings_alter().
+ */
+function social_comment_editor_js_settings_alter(array &$settings) {
+  foreach (array_keys($settings['editor']['formats']) as $text_format_id) {
+    if ($settings['editor']['formats'][$text_format_id]['editor'] === 'ckeditor' && $text_format_id === 'comment_text') {
+      $settings['editor']['formats'][$text_format_id]['editorSettings']['autoGrow_minHeight'] = '30';
+      $settings['editor']['formats'][$text_format_id]['editorSettings']['removePlugins'] = 'elementspath';
+    }
+  }
+}
+
+/**
  * Implements hook_element_info_alter().
  */
 function social_comment_element_info_alter(array &$info) {

--- a/modules/social_features/social_comment/social_comment.permissions.yml
+++ b/modules/social_features/social_comment/social_comment.permissions.yml
@@ -2,3 +2,5 @@ delete own comments:
   title: 'Delete own comments'
 administer own comments:
   title: 'Administer own comment settings'
+administer social_comment settings:
+  title: 'Administer comment settings'

--- a/modules/social_features/social_comment/social_comment.routing.yml
+++ b/modules/social_features/social_comment/social_comment.routing.yml
@@ -1,0 +1,9 @@
+social_comment.settings:
+  path: '/admin/config/opensocial/comment'
+  defaults:
+    _form: '\Drupal\social_comment\Form\CommentSettingsForm'
+    _title: 'Comment settings'
+  requirements:
+    _permission: 'administer social_comment settings'
+  options:
+    _admin_route: TRUE

--- a/modules/social_features/social_comment/src/Form/CommentSettingsForm.php
+++ b/modules/social_features/social_comment/src/Form/CommentSettingsForm.php
@@ -52,7 +52,6 @@ class CommentSettingsForm extends ConfigFormBase {
       '#default_value' => $config->get('wysiwyg'),
     ];
 
-
     return parent::buildForm($form, $form_state);
   }
 

--- a/modules/social_features/social_comment/src/Form/CommentSettingsForm.php
+++ b/modules/social_features/social_comment/src/Form/CommentSettingsForm.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Drupal\social_comment\Form;
+
+use Drupal\Core\Form\ConfigFormBase;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Class CommentSettingsForm.
+ *
+ * @package Drupal\social_comment\Form
+ */
+class CommentSettingsForm extends ConfigFormBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getEditableConfigNames() {
+    return [
+      'social_comment.comment_settings',
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'social_comment_settings_form';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    $config = $this->config('social_comment.comment_settings');
+
+    $form['redirect_comment_to_entity'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Redirect comment to entity'),
+      '#default_value' => $config->get('redirect_comment_to_entity'),
+    ];
+
+    $form['remove_author_field'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Remove author field from the comment forms'),
+      '#default_value' => $config->get('remove_author_field'),
+    ];
+
+    $form['wysiwyg'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Authenticated users are allowed to use WYSIWYG editor in comment form'),
+      '#default_value' => $config->get('wysiwyg'),
+    ];
+
+
+    return parent::buildForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    parent::submitForm($form, $form_state);
+
+    $this->config('social_comment.comment_settings')
+      ->set('redirect_comment_to_entity', $form_state->getValue('redirect_comment_to_entity'))
+      ->set('remove_author_field', $form_state->getValue('remove_author_field'))
+      ->set('wysiwyg', $form_state->getValue('wysiwyg'))
+      ->save();
+
+    if ($form_state->getValue('wysiwyg') == TRUE) {
+      user_role_grant_permissions('authenticated', ['use text format comment_text']);
+    }
+  }
+
+}


### PR DESCRIPTION
## Problem
Some people want to add WYSIWYG to comments to add links or add some markup to their comment. This is not possible currently.

## Solution
Let's add a simple WYSIWYG to make it configurable.

This change includes:

- New format (comment_text)
- New editor (comment_text)
- Settings for Comments (including previous enabled settings and the option to enable WYSIWYG)
- Code which loads the correct editor when the WYSIWYG config is enabled and the user has the correct permission.
- Removing the social_comment.comment_settings.yml from `config/install` directory to prevent accidental feature overrides during feature revert.

## Issue tracker
https://www.drupal.org/project/social/issues/3063996

## How to test
- [ ] Check code changes.
- [ ] Test re-install and update from previous version.
- [ ] Disable and enable the WYSIWYG in the comment settings.

## Release notes
It is now possible for community members to use a WYSIWYG editor when authoring comments. A site managers can configure this setting on the Comment settings section in Open Social Settings.

## Change Record
might follow