### PR TITLE
#3063713 - bulk actions on all pages fails for event enrollments

### DIFF
--- a/modules/social_features/social_event/modules/social_event_managers/social_event_managers.module
+++ b/modules/social_features/social_event/modules/social_event_managers/social_event_managers.module
@@ -410,41 +410,11 @@ function social_event_managers_batch_alter(&$batch) {
   if ($url->getRouteName() === 'social_event_managers.vbo.confirm' ||
     $url->getRouteName() === 'views_bulk_operations.confirm' ||
     $url->getRouteName() === 'views_bulk_operations.execute_batch') {
-    // @todo: Put the code from 414 to 443 in a separate function where it finds
-    // the Action ID.
-    /** @var \Drupal\Core\Form\FormStateInterface $form_state */
-    $form_state = &$batch['form_state'];
-
-    $action_id = '';
-    if ($form_state instanceof FormStateInterface) {
-      $data = $form_state->get('views_bulk_operations');
-      $action_id = $data['action_id'];
-    }
-    else {
-      foreach ($batch['sets'][0]['operations'] as $operations) {
-        if (empty($operations) || !is_array($operations)) {
-          break;
-        }
-        foreach ($operations as $operation) {
-          if (empty($operation) || !is_array($operation)) {
-            break;
-          }
-          foreach ($operation as $items) {
-            if (empty($items) || !is_array($items)) {
-              break;
-            }
-
-            if (!empty($items['action_id'])) {
-              $action_id = $items['action_id'];
-              break;
-            }
-          }
-        }
-      }
-    }
+    // Get the action ID.
+    $action_id = _social_event_managers_get_action_id($batch);
 
     $batch['sets'][0]['results']['action'] = $action_id;
-    if (in_array($action_id, $actions)) {
+    if (in_array($action_id, $actions, TRUE)) {
       $batch['sets'][0]['finished'] = '_social_event_managers_action_batch_finish';
     }
   }
@@ -498,6 +468,49 @@ function _social_event_managers_action_batch_finish($success, array $results, ar
       }
     }
   }
+}
+
+/**
+ * Function to get the action id of a batch.
+ *
+ * @param array $batch
+ *   The batch array.
+ *
+ * @return string
+ *   Returns the batch action id.
+ */
+function _social_event_managers_get_action_id(array &$batch) {
+  /** @var \Drupal\Core\Form\FormStateInterface $form_state */
+  $form_state = &$batch['form_state'];
+
+  $action_id = '';
+  if ($form_state instanceof FormStateInterface) {
+    $data = $form_state->get('views_bulk_operations');
+    $action_id = $data['action_id'];
+  }
+  else {
+    foreach ($batch['sets'][0]['operations'] as $operations) {
+      if (empty($operations) || !is_array($operations)) {
+        break;
+      }
+      foreach ($operations as $operation) {
+        if (empty($operation) || !is_array($operation)) {
+          break;
+        }
+        foreach ($operation as $items) {
+          if (empty($items) || !is_array($items)) {
+            break;
+          }
+
+          if (!empty($items['action_id'])) {
+            $action_id = $items['action_id'];
+            break;
+          }
+        }
+      }
+    }
+  }
+  return $action_id;
 }
 
 /**

--- a/modules/social_features/social_event/modules/social_event_managers/social_event_managers.module
+++ b/modules/social_features/social_event/modules/social_event_managers/social_event_managers.module
@@ -408,13 +408,43 @@ function social_event_managers_batch_alter(&$batch) {
   $url = &$batch['source_url'];
 
   if ($url->getRouteName() === 'social_event_managers.vbo.confirm' ||
-    $url->getRouteName() === 'views_bulk_operations.confirm') {
+    $url->getRouteName() === 'views_bulk_operations.confirm' ||
+    $url->getRouteName() === 'views_bulk_operations.execute_batch') {
+    // @todo: Put the code from 414 to 443 in a separate function where it finds
+    // the Action ID.
     /** @var \Drupal\Core\Form\FormStateInterface $form_state */
     $form_state = &$batch['form_state'];
 
-    $data = $form_state->get('views_bulk_operations');
-    $batch['sets'][0]['results']['action'] = $data['action_id'];
-    if (in_array($data['action_id'], $actions)) {
+    $action_id = '';
+    if ($form_state instanceof FormStateInterface) {
+      $data = $form_state->get('views_bulk_operations');
+      $action_id = $data['action_id'];
+    }
+    else {
+      foreach ($batch['sets'][0]['operations'] as $operations) {
+        if (empty($operations) || !is_array($operations)) {
+          break;
+        }
+        foreach ($operations as $operation) {
+          if (empty($operation) || !is_array($operation)) {
+            break;
+          }
+          foreach ($operation as $items) {
+            if (empty($items) || !is_array($items)) {
+              break;
+            }
+
+            if (!empty($items['action_id'])) {
+              $action_id = $items['action_id'];
+              break;
+            }
+          }
+        }
+      }
+    }
+
+    $batch['sets'][0]['results']['action'] = $action_id;
+    if (in_array($action_id, $actions)) {
       $batch['sets'][0]['finished'] = '_social_event_managers_action_batch_finish';
     }
   }
@@ -436,10 +466,8 @@ function _social_event_managers_action_batch_finish($success, array $results, ar
   // the actual action is performed on the entities.
   if (!empty($results['view_id']) && !empty($results['display_id'])) {
     ViewsBulkOperationsBatch::saveList(TRUE, $results, $operations);
+    return;
   }
-
-  // @todo: make sure the code below also works for when you select all across
-  // all pages. It already works for when you select anything other than that.
 
   $operations = array_count_values($results['operations']);
   $results_count = 0;

--- a/modules/social_features/social_event/modules/social_event_managers/social_event_managers.module
+++ b/modules/social_features/social_event/modules/social_event_managers/social_event_managers.module
@@ -21,6 +21,7 @@ use Drupal\social_event_managers\SocialEventManagersAccessHelper;
 use Drupal\user\Entity\User;
 use Drupal\views\ViewExecutable;
 use Drupal\social_event\Entity\EventEnrollment;
+use Drupal\views_bulk_operations\ViewsBulkOperationsBatch;
 
 /**
  * Implements hook_preprocess_block().
@@ -430,6 +431,16 @@ function social_event_managers_batch_alter(&$batch) {
  *   Performed operations array.
  */
 function _social_event_managers_action_batch_finish($success, array $results, array $operations) {
+  // When we do a bulk action on all the items in a view, across multiple pages,
+  // the saveList function needs to be called. So after pre-populating the list
+  // the actual action is performed on the entities.
+  if (!empty($results['view_id']) && !empty($results['display_id'])) {
+    ViewsBulkOperationsBatch::saveList(TRUE, $results, $operations);
+  }
+
+  // @todo: make sure the code below also works for when you select all across
+  // all pages. It already works for when you select anything other than that.
+
   $operations = array_count_values($results['operations']);
   $results_count = 0;
 


### PR DESCRIPTION
## Problem
When selecting all entities of a view (event enrollments or group memberships) and performing a bulk action on them you end up on a 404 or 403 page.

## Solution
By adding an extra check in the custom batch callback function for views that are executed, rather than just checking for the final batch, we can make it work. We have to also add the custom batch callback function for this second batch job after the first pre-populating one is finished.

## Issue tracker
https://www.drupal.org/project/social/issues/3063713

## How to test
- [x] Create an event and enroll enough people so you have multiple pages, either by enrolling a lot or changing view pager to 1 item per page
- [x] Select all the members across all pages by using the VBO
- [x] Notice it ends up in a 404/403 page, but after this fix not anymore

## Release notes
We have created a fix for the views bulk operations module which is used to execute actions on multiple people throughout multiple pages such as exporting event enrollees. Normally when selecting all members across al pages you would end up on a 404/403 page when trying to export, but this has been solved.
