### PR TITLE
issue #2998508 by albertoalaejos: Comment unpublished status translat…

### DIFF
--- a/themes/socialbase/templates/comment/comment.html.twig
+++ b/themes/socialbase/templates/comment/comment.html.twig
@@ -84,7 +84,7 @@
       <span class="comment__metadata">&bullet; {{ submitted }} </span>
       <mark class="badge badge-default badge--pill hidden" data-comment-timestamp="{{ new_indicator_timestamp }}"></mark>
       {% if (status == 'unpublished') %}
-        <span class="badge badge-default badge--pill">{{ status }}</span>
+        <span class="badge badge-default badge--pill">{{ status|trans }}</span>
       {% endif %}
     </div>
     {% endblock %}


### PR DESCRIPTION
Comment unpublished status translatable

## Problem
Comment unpublished status is not translatable

## Solution
Make status translatable in the twig file

## Issue tracker
https://www.drupal.org/project/social/issues/2998508

## How to test
- [ ] Enable Interface Translation
- [ ] Change the language in configuration
- [ ] Comment on a post
- [ ] Unpublish the comment
- [ ] See if the unpublished label shows in the the selected language