### PR TITLE
Issue #3019458 by royharink: Issue with Custom email header footer settings page

### DIFF
--- a/modules/custom/activity_send/modules/activity_send_email/activity_send_email.module
+++ b/modules/custom/activity_send/modules/activity_send_email/activity_send_email.module
@@ -88,7 +88,6 @@ function activity_send_email_theme() {
       'variables' => [
         'notification_count' => NULL,
         'notifications' => NULL,
-        'notification_footer' => NULL,
         'notification_settings' => NULL,
       ],
     ],
@@ -96,7 +95,6 @@ function activity_send_email_theme() {
       'template' => 'directmail',
       'variables' => [
         'notification' => NULL,
-        'notification_footer' => NULL,
         'notification_settings' => NULL,
       ],
     ],

--- a/modules/custom/activity_send/modules/activity_send_email/src/Plugin/EmailFrequency/Immediately.php
+++ b/modules/custom/activity_send/modules/activity_send_email/src/Plugin/EmailFrequency/Immediately.php
@@ -67,15 +67,6 @@ class Immediately extends EmailFrequencyBase {
       ],
       ['langcode' => $langcode]),
     ];
-
-    // Get Footer settings.
-    $social_swiftmail_config = \Drupal::config('social_swiftmail.settings');
-    if ($social_swiftmail_config && $social_swiftmail_config->get('template_footer')) {
-      $footer_text = $social_swiftmail_config->get('template_footer');
-      // Construct the render array.
-      $notification['#notification_footer'] = $footer_text;
-    }
-
     $params['body'] = \Drupal::service('renderer')->renderRoot($notification);
 
     // Send the email.

--- a/modules/custom/activity_send/modules/activity_send_email/src/Plugin/QueueWorker/ActivityDigestWorker.php
+++ b/modules/custom/activity_send/modules/activity_send_email/src/Plugin/QueueWorker/ActivityDigestWorker.php
@@ -76,14 +76,6 @@ class ActivityDigestWorker extends ActivitySendWorkerBase {
           ],
           ['langcode' => $langcode]);
 
-          // Get Footer settings.
-          $social_swiftmail_config = \Drupal::config('social_swiftmail.settings');
-          if ($social_swiftmail_config && $social_swiftmail_config->get('template_footer')) {
-            $footer_text = $social_swiftmail_config->get('template_footer');
-            // Construct the render array.
-            $digest_notifications['#notification_footer'] = $footer_text;
-          }
-
           // Render the notifications using the digestmail.html.twig template.
           $params['body'] = \Drupal::service('renderer')->renderRoot($digest_notifications);
 

--- a/modules/custom/activity_send/modules/activity_send_email/templates/digestmail.html.twig
+++ b/modules/custom/activity_send/modules/activity_send_email/templates/digestmail.html.twig
@@ -6,8 +6,6 @@
     {% endfor %}
 </ul>
 
-{{ notification_footer }}
-
 <p>&nbsp;</p>
 
 <p><small>{{ notification_settings|striptags('<a><strong>')|raw }}</small></p>

--- a/modules/custom/activity_send/modules/activity_send_email/templates/directmail.html.twig
+++ b/modules/custom/activity_send/modules/activity_send_email/templates/directmail.html.twig
@@ -1,7 +1,5 @@
 {{ notification|striptags('<p><a>')|raw }}
 
-{{ notification_footer|raw }}
-
 <p>&nbsp;</p>
 
 <p><small>{{ notification_settings|striptags('<a><strong>')|raw }}</small></p>

--- a/modules/social_features/social_swiftmail/config/schema/social_swiftmail.schema.yml
+++ b/modules/social_features/social_swiftmail/config/schema/social_swiftmail.schema.yml
@@ -8,6 +8,12 @@ social_swiftmail.settings:
     template_header:
       type: string
       label: 'Notification email header'
+    template_header_format:
+      type: string
+      label: 'Text format for the notification email header'
     template_footer:
       type: string
       label: 'Notification email footer'
+    template_footer_format:
+      type: string
+      label: 'Text format for the notification email footer'

--- a/modules/social_features/social_swiftmail/config/schema/social_swiftmail.schema.yml
+++ b/modules/social_features/social_swiftmail/config/schema/social_swiftmail.schema.yml
@@ -6,14 +6,22 @@ social_swiftmail.settings:
       type: boolean
       label: 'Open Social Branding will be replaced by site name (and slogan if available).'
     template_header:
-      type: string
-      label: 'Notification email header'
-    template_header_format:
-      type: string
-      label: 'Text format for the notification email header'
+      type: mapping
+      label: 'Template header'
+      mapping:
+        value:
+          type: text
+          label: 'Header markup'
+        format:
+          type: string
+          label: 'Text format'
     template_footer:
-      type: string
-      label: 'Notification email footer'
-    template_footer_format:
-      type: string
-      label: 'Text format for the notification email footer'
+      type: mapping
+      label: 'Template footer'
+      mapping:
+        value:
+          type: text
+          label: 'Footer markup'
+        format:
+          type: string
+          label: 'Text format'

--- a/modules/social_features/social_swiftmail/social_swiftmail.install
+++ b/modules/social_features/social_swiftmail/social_swiftmail.install
@@ -23,6 +23,13 @@ function social_swiftmail_install() {
   $mailsystem_settings->set('defaults.formatter', 'social_swiftmailer')->save();
   $mailsystem_settings->set('modules.swiftmailer.none.sender', 'social_swiftmailer')->save();
   $mailsystem_settings->set('modules.swiftmailer.none.formatter', 'social_swiftmailer')->save();
+
+
+  // Give SM the correct swiftmail permission.
+  user_role_grant_permissions('sitemanager', [
+    'use text format mail_html',
+    'administer social swiftmail',
+  ]);
 }
 
 /**
@@ -32,4 +39,15 @@ function social_swiftmail_update_8001(&$sandbox) {
   // Alter mailsystem settings.
   $mailsystem_settings = \Drupal::configFactory()->getEditable('mailsystem.settings');
   $mailsystem_settings->set('theme', 'default')->save();
+}
+
+/**
+ * Set swiftmail permissions for sitemanagers settings.
+ */
+function social_swiftmail_update_8002() {
+  // Give SM the correct permission.
+  user_role_grant_permissions('sitemanager', [
+    'use text format mail_html',
+    'administer social swiftmail',
+  ]);
 }

--- a/modules/social_features/social_swiftmail/social_swiftmail.install
+++ b/modules/social_features/social_swiftmail/social_swiftmail.install
@@ -24,7 +24,6 @@ function social_swiftmail_install() {
   $mailsystem_settings->set('modules.swiftmailer.none.sender', 'social_swiftmailer')->save();
   $mailsystem_settings->set('modules.swiftmailer.none.formatter', 'social_swiftmailer')->save();
 
-
   // Give SM the correct swiftmail permission.
   user_role_grant_permissions('sitemanager', [
     'use text format mail_html',

--- a/modules/social_features/social_swiftmail/social_swiftmail.module
+++ b/modules/social_features/social_swiftmail/social_swiftmail.module
@@ -37,10 +37,12 @@ function social_swiftmail_preprocess_swiftmailer(array &$variables) {
   $variables['link'] = $link;
   $variables['border_radius'] = $border_radius;
 
+  // Check if custom e-mail setting for branding removal is enabled.
   $social_swiftmail_config = \Drupal::config('social_swiftmail.settings');
-  if ($social_swiftmail_config->get('remove_open_social_branding') === 1) {
+  if ($social_swiftmail_config->get('remove_open_social_branding') === TRUE) {
     $site_config = \Drupal::config('system.site');
-
+    // When branding should be removed, check if the default site settings are
+    // set and override variables.
     if ($site_config) {
       $variables['site_link'] = TRUE;
       $variables['site_name'] = $site_config->get('name');

--- a/modules/social_features/social_swiftmail/social_swiftmail.module
+++ b/modules/social_features/social_swiftmail/social_swiftmail.module
@@ -54,16 +54,14 @@ function social_swiftmail_preprocess_swiftmailer(array &$variables) {
     $variables['site_slogan'] = '"' . t('Make your people bloom') . '"';
   }
 
-  // Add variables header and footer if set.
-  if ($social_swiftmail_config->get('template_header')) {
-    $template_header = $social_swiftmail_config->get('template_header');
-    $template_header = [
+  // Add variables header if set.
+  if (($header_config = $social_swiftmail_config->get('template_header'))
+    && (!empty($header_config['value']) && !empty($header_config['format']))) {
+    $variables['header'] = \Drupal::service('renderer')->renderRoot([
       '#type' => 'processed_text',
-      '#text' => $template_header,
-      '#format' => 'mail_html',
-    ];
-
-    $variables['header'] = \Drupal::service('renderer')->renderRoot($template_header);
+      '#text' => $header_config['value'],
+      '#format' => $header_config['format'],
+    ]);
   }
 
   $message = &$variables['message'];

--- a/modules/social_features/social_swiftmail/social_swiftmail.module
+++ b/modules/social_features/social_swiftmail/social_swiftmail.module
@@ -54,14 +54,28 @@ function social_swiftmail_preprocess_swiftmailer(array &$variables) {
     $variables['site_slogan'] = '"' . t('Make your people bloom') . '"';
   }
 
-  // Add variables header if set.
+  // Check if a custom e-mail header is set and apply the configuration
+  // to the render array.
   if (($header_config = $social_swiftmail_config->get('template_header'))
     && (!empty($header_config['value']) && !empty($header_config['format']))) {
-    $variables['header'] = \Drupal::service('renderer')->renderRoot([
+    $header_markup = [
       '#type' => 'processed_text',
       '#text' => $header_config['value'],
       '#format' => $header_config['format'],
-    ]);
+    ];
+    $variables['header'] = \Drupal::service('renderer')->renderRoot($header_markup);
+  }
+
+  // Check if a custom e-mail footer is set and apply the configuration
+  // to the render array.
+  if (($footer_config = $social_swiftmail_config->get('template_footer'))
+    && (!empty($footer_config['value']) && !empty($footer_config['format']))) {
+    $footer_markup = [
+      '#type' => 'processed_text',
+      '#text' => $footer_config['value'],
+      '#format' => $footer_config['format'],
+    ];
+    $variables['footer'] = \Drupal::service('renderer')->renderRoot($footer_markup);
   }
 
   $message = &$variables['message'];

--- a/modules/social_features/social_swiftmail/src/Form/SocialSwiftmailSettingsForm.php
+++ b/modules/social_features/social_swiftmail/src/Form/SocialSwiftmailSettingsForm.php
@@ -46,18 +46,22 @@ class SocialSwiftmailSettingsForm extends ConfigFormBase {
       '#title' => $this->t('Template configuration'),
       '#open' => FALSE,
     ];
+
+    $template_header = $config->get('template_header');
     $form['template']['template_header'] = [
       '#title' => $this->t('Template header'),
       '#type' => 'text_format',
-      '#default_value' => $config->get('template_header') ?: '',
-      '#format' => $config->get('template_header_format') ?: 'mail_html',
+      '#default_value' => $template_header['value'] ?: '',
+      '#format' => $template_header['format'] ?: 'mail_html',
       '#description' => $this->t('Enter information you want to show in the email notifications header'),
     ];
+
+    $template_footer = $config->get('template_footer');
     $form['template']['template_footer'] = [
       '#title' => $this->t('Template footer'),
       '#type' => 'text_format',
-      '#default_value' => $config->get('template_footer') ?: '',
-      '#format' => $config->get('template_footer_format') ?: 'mail_html',
+      '#default_value' => $template_footer['value'] ?: '',
+      '#format' => $template_footer['format'] ?: 'mail_html',
       '#description' => $this->t('Enter information you want to show in the email notifications footer'),
     ];
 
@@ -74,15 +78,9 @@ class SocialSwiftmailSettingsForm extends ConfigFormBase {
     $config = $this->config('social_swiftmail.settings');
     $config->set('remove_open_social_branding', $form_state->getValue('remove_open_social_branding'));
 
-    // Get the template header settings.
-    $template_header = $form_state->getValue('template_header');
-    $config->set('template_header', $template_header['value']);
-    $config->set('template_header_format', $template_header['format']);
-
-    // Get the template footer settings.
-    $template_footer = $form_state->getValue('template_footer');
-    $config->set('template_footer', $template_footer['value']);
-    $config->set('template_footer_format', $template_footer['format']);
+    // Get the template header and footer settings.
+    $config->set('template_header', $form_state->getValue('template_header'));
+    $config->set('template_footer', $form_state->getValue('template_footer'));
 
     $config->save();
   }

--- a/modules/social_features/social_swiftmail/src/Form/SocialSwiftmailSettingsForm.php
+++ b/modules/social_features/social_swiftmail/src/Form/SocialSwiftmailSettingsForm.php
@@ -15,7 +15,7 @@ class SocialSwiftmailSettingsForm extends ConfigFormBase {
   /**
    * {@inheritdoc}
    */
-  protected function getEditableConfigNames(): array {
+  protected function getEditableConfigNames() {
     return [
       'social_swiftmail.settings',
     ];
@@ -24,14 +24,14 @@ class SocialSwiftmailSettingsForm extends ConfigFormBase {
   /**
    * {@inheritdoc}
    */
-  public function getFormId(): string {
+  public function getFormId() {
     return 'social_swiftmail_form';
   }
 
   /**
    * {@inheritdoc}
    */
-  public function buildForm(array $form, FormStateInterface $form_state): array {
+  public function buildForm(array $form, FormStateInterface $form_state) {
     $config = $this->config('social_swiftmail.settings');
 
     $form['remove_open_social_branding'] = [
@@ -67,7 +67,7 @@ class SocialSwiftmailSettingsForm extends ConfigFormBase {
   /**
    * {@inheritdoc}
    */
-  public function submitForm(array &$form, FormStateInterface $form_state): void {
+  public function submitForm(array &$form, FormStateInterface $form_state) {
     parent::submitForm($form, $form_state);
 
     // Save config.

--- a/modules/social_features/social_swiftmail/src/Form/SocialSwiftmailSettingsForm.php
+++ b/modules/social_features/social_swiftmail/src/Form/SocialSwiftmailSettingsForm.php
@@ -53,6 +53,9 @@ class SocialSwiftmailSettingsForm extends ConfigFormBase {
       '#type' => 'text_format',
       '#default_value' => $template_header['value'] ?: '',
       '#format' => $template_header['format'] ?: 'mail_html',
+      '#allowed_formats' => [
+        'mail_html',
+      ],
       '#description' => $this->t('Enter information you want to show in the email notifications header'),
     ];
 
@@ -62,6 +65,9 @@ class SocialSwiftmailSettingsForm extends ConfigFormBase {
       '#type' => 'text_format',
       '#default_value' => $template_footer['value'] ?: '',
       '#format' => $template_footer['format'] ?: 'mail_html',
+      '#allowed_formats' => [
+        'mail_html',
+      ],
       '#description' => $this->t('Enter information you want to show in the email notifications footer'),
     ];
 

--- a/modules/social_features/social_swiftmail/src/Form/SocialSwiftmailSettingsForm.php
+++ b/modules/social_features/social_swiftmail/src/Form/SocialSwiftmailSettingsForm.php
@@ -15,7 +15,7 @@ class SocialSwiftmailSettingsForm extends ConfigFormBase {
   /**
    * {@inheritdoc}
    */
-  protected function getEditableConfigNames() {
+  protected function getEditableConfigNames(): array {
     return [
       'social_swiftmail.settings',
     ];
@@ -24,14 +24,14 @@ class SocialSwiftmailSettingsForm extends ConfigFormBase {
   /**
    * {@inheritdoc}
    */
-  public function getFormId() {
+  public function getFormId(): string {
     return 'social_swiftmail_form';
   }
 
   /**
    * {@inheritdoc}
    */
-  public function buildForm(array $form, FormStateInterface $form_state) {
+  public function buildForm(array $form, FormStateInterface $form_state): array {
     $config = $this->config('social_swiftmail.settings');
 
     $form['remove_open_social_branding'] = [
@@ -49,15 +49,15 @@ class SocialSwiftmailSettingsForm extends ConfigFormBase {
     $form['template']['template_header'] = [
       '#title' => $this->t('Template header'),
       '#type' => 'text_format',
-      '#format' => 'mail_html',
       '#default_value' => $config->get('template_header') ?: '',
+      '#format' => $config->get('template_header_format') ?: 'mail_html',
       '#description' => $this->t('Enter information you want to show in the email notifications header'),
     ];
     $form['template']['template_footer'] = [
       '#title' => $this->t('Template footer'),
       '#type' => 'text_format',
-      '#format' => 'mail_html',
       '#default_value' => $config->get('template_footer') ?: '',
+      '#format' => $config->get('template_footer_format') ?: 'mail_html',
       '#description' => $this->t('Enter information you want to show in the email notifications footer'),
     ];
 
@@ -67,14 +67,23 @@ class SocialSwiftmailSettingsForm extends ConfigFormBase {
   /**
    * {@inheritdoc}
    */
-  public function submitForm(array &$form, FormStateInterface $form_state) {
+  public function submitForm(array &$form, FormStateInterface $form_state): void {
     parent::submitForm($form, $form_state);
 
     // Save config.
     $config = $this->config('social_swiftmail.settings');
     $config->set('remove_open_social_branding', $form_state->getValue('remove_open_social_branding'));
-    $config->set('template_header', $form_state->getValue('template_header')['value']);
-    $config->set('template_footer', $form_state->getValue('template_footer')['value']);
+
+    // Get the template header settings.
+    $template_header = $form_state->getValue('template_header');
+    $config->set('template_header', $template_header['value']);
+    $config->set('template_header_format', $template_header['format']);
+
+    // Get the template footer settings.
+    $template_footer = $form_state->getValue('template_footer');
+    $config->set('template_footer', $template_footer['value']);
+    $config->set('template_footer_format', $template_footer['format']);
+
     $config->save();
   }
 

--- a/themes/socialbase/templates/swiftmailer.html.twig
+++ b/themes/socialbase/templates/swiftmailer.html.twig
@@ -357,14 +357,26 @@
                     <tr>
                         <td class="wrapper">
                             <table border="0" cellpadding="0" cellspacing="0">
+                                {% if header %}
                                 <tr>
                                     <td>
-                                        {% if header %}
-                                            {{ header }}
-                                        {% endif %}
+                                       {{ header }}
+                                    </td>
+                                </tr>
+                                {% endif %}
+                                <tr>
+                                    <td>
                                         {{ body }}
                                     </td>
                                 </tr>
+                                {% if footer %}
+                                    <tr>
+                                        <td>
+                                            {{ footer }}
+                                        </td>
+                                    </tr>
+                                {% endif %}
+
                             </table>
                         </td>
                     </tr>


### PR DESCRIPTION
## Problems
Multiple problems occurred with the custom e-mail settings.

1. The applied text format settings in the template configuration of the Social Swiftmail are not saved correctly.
2. Custom headers and/or footer were not always displayed when set.
3. The setting for removal of the Open Social branding in e-mails wasn't respected.
4. Permissions for the custom e-mail template settings aren't set.


## Solution
1. The text format settings are added to the form submit and configuration. The settings are now also added to the form and checked if they are set for a before applying the default when they aren't. The settings is also checked when building the e-mail markup.
2. Both the header and footer configuration settings are now checked in the _social_swiftmail.module_ if they are set and the header/footer are added to the render array when applicable.
3. Make sure the configuration check is a boolean like it's set in the schema.
4. Set the permissions for the configuration route and the Mail HTML path.

## Issue tracker
Bugs introduced with: https://www.drupal.org/project/social/issues/3019458

## How to test

### No. 1
- [ ] Go to the Social Swiftmail settings, _/admin/config/opensocial/swiftmail_.
- [ ] Set the Text format to any other then the default (Mail HTML) and save the form.
- [ ] When returning to the configuration form, see that the Text format is set to the new setting.

### No. 2
- [ ] Using the settings from no. 1 with a custom header/footer.
- [ ] Test an email via the Swift email tester and see that the header/footer is applied.
- [ ] Interact with a users content and see that the header/footer is applied in the activity emails.

### No. 3
- [ ]  Go to the Social Swiftmail settings, _/admin/config/opensocial/swiftmail_ and set the option to remove the branding.
- [ ] Send some emails and see that the branding of Open Social is removed.

### No. 4
- [ ] Go to the Social Swiftmail settings, _/admin/config/opensocial/swiftmail_ and see that you can access it as a site manager.
- [ ] Also not that you can select the Mail HTML text format.