### PR TITLE
Issue #3066600 make sure EO can add enrollees to their event

### DIFF
--- a/modules/social_features/social_event/modules/social_event_managers/social_event_managers.routing.yml
+++ b/modules/social_features/social_event/modules/social_event_managers/social_event_managers.routing.yml
@@ -12,7 +12,7 @@ social_event_managers.add_enrollees:
     _form: '\Drupal\social_event_managers\Form\SocialEventManagersAddEnrolleeForm'
     _title: 'Add enrollees'
   requirements:
-    _permission: 'manage everything enrollments'
+    _enrollee_permission: 'manage everything enrollments'
 
 route_callbacks:
   - 'social_event_managers.route_subscriber:routes'

--- a/modules/social_features/social_event/modules/social_event_managers/social_event_managers.services.yml
+++ b/modules/social_features/social_event/modules/social_event_managers/social_event_managers.services.yml
@@ -9,3 +9,8 @@ services:
     arguments: ['@module_handler']
     tags:
       - { name: 'event_subscriber' }
+
+  social_event_managers.add_enrollee.permission:
+    class: 'Drupal\social_event_managers\Access\AddEnrolleeAccessCheck'
+    tags:
+      - { name: 'access_check', applies_to: '_enrollee_permission', priority: 249 }

--- a/modules/social_features/social_event/modules/social_event_managers/src/Access/AddEnrolleeAccessCheck.php
+++ b/modules/social_features/social_event/modules/social_event_managers/src/Access/AddEnrolleeAccessCheck.php
@@ -5,11 +5,9 @@ namespace Drupal\social_event_managers\Access;
 use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Access\AccessResultAllowed;
 use Drupal\Core\Access\AccessResultForbidden;
-use Drupal\Core\Access\AccessResultInterface;
 use Drupal\Core\Routing\Access\AccessInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\Session\AccountInterface;
-use Drupal\group\Entity\GroupTypeInterface;
 use Drupal\node\Entity\Node;
 use Drupal\node\NodeInterface;
 use Drupal\social_event_managers\SocialEventManagersAccessHelper;
@@ -19,6 +17,7 @@ use Symfony\Component\Routing\Route;
  * Determines access to routes based on manage everything enrollments.
  */
 class AddEnrolleeAccessCheck implements AccessInterface {
+
   /**
    * Checks access.
    *
@@ -80,4 +79,5 @@ class AddEnrolleeAccessCheck implements AccessInterface {
     // clear accordingly.
     return AccessResult::neutral();
   }
+  
 }

--- a/modules/social_features/social_event/modules/social_event_managers/src/Access/AddEnrolleeAccessCheck.php
+++ b/modules/social_features/social_event/modules/social_event_managers/src/Access/AddEnrolleeAccessCheck.php
@@ -79,5 +79,5 @@ class AddEnrolleeAccessCheck implements AccessInterface {
     // clear accordingly.
     return AccessResult::neutral();
   }
-  
+
 }

--- a/modules/social_features/social_event/modules/social_event_managers/src/Access/AddEnrolleeAccessCheck.php
+++ b/modules/social_features/social_event/modules/social_event_managers/src/Access/AddEnrolleeAccessCheck.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Drupal\social_event_managers\Access;
+
+use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Access\AccessResultAllowed;
+use Drupal\Core\Access\AccessResultForbidden;
+use Drupal\Core\Access\AccessResultInterface;
+use Drupal\Core\Routing\Access\AccessInterface;
+use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\group\Entity\GroupTypeInterface;
+use Drupal\node\Entity\Node;
+use Drupal\node\NodeInterface;
+use Drupal\social_event_managers\SocialEventManagersAccessHelper;
+use Symfony\Component\Routing\Route;
+
+/**
+ * Determines access to routes based on manage everything enrollments.
+ */
+class AddEnrolleeAccessCheck implements AccessInterface {
+  /**
+   * Checks access.
+   *
+   * @param \Symfony\Component\Routing\Route $route
+   *   The route to check against.
+   * @param \Drupal\Core\Routing\RouteMatchInterface $route_match
+   *   The parametrized route.
+   * @param \Drupal\Core\Session\AccountInterface $account
+   *   The account to check access for.
+   *
+   * @return \Drupal\Core\Access\AccessResultInterface
+   *   The access result.
+   */
+  public function access(Route $route, RouteMatchInterface $route_match, AccountInterface $account) {
+    $permission = $route->getRequirement('_enrollee_permission');
+
+    // Don't interfere if no permission was specified.
+    // Or it's not the permission we are looking for.
+    if ($permission === NULL || $permission !== 'manage everything enrollments') {
+      return AccessResult::neutral();
+    }
+
+    // Don't interfere if no group was specified.
+    $parameters = $route_match->getParameters();
+    if (!$parameters->has('node')) {
+      return AccessResult::neutral();
+    }
+    // Don't interfere if the group isn't a real group.
+    $node = $parameters->get('node');
+    if (!is_null($node) && (!$node instanceof Node)) {
+      $node = Node::load($node);
+    }
+
+    if (!$node instanceof NodeInterface) {
+      return AccessResult::neutral();
+    }
+
+    // A user with this access can definitely do everything.
+    if ($account->hasPermission('manage everything enrollments')) {
+      return AccessResult::allowed();
+    }
+    $type = $node->getType();
+    // Don't interfere if it's not an event.
+    if ($type !== 'event') {
+      return AccessResult::neutral();
+    }
+    // AN Users aren't allowed anything.
+    if (!$account->isAuthenticated()) {
+      return AccessResult::forbidden();
+    }
+
+    // Lets return the correct access for our Event Manager.
+    $managers_access = SocialEventManagersAccessHelper::getEntityAccessResult($node, 'update', $account);
+    if ($managers_access instanceof AccessResultAllowed || $managers_access instanceof AccessResultForbidden) {
+      return $managers_access->addCacheableDependency($node);
+    }
+    // We allow it but lets add the group as dependency to the cache
+    // now because field value might be edited and cache should
+    // clear accordingly.
+    return AccessResult::neutral();
+  }
+}


### PR DESCRIPTION
## Problem
Event Organisers get an access denied on adding enrollees, also the Add Enrollee button is gone.

## Solution
I've created a custom access check that doens't look at Roles & Permissions alone but uses the Service that already was available that checks whether or not a user is able to add enrollees to an event.

## Issue tracker
https://www.drupal.org/project/social/issues/3066600

## How to test
- [x] Enable the social_event_managers module
- [x] Create a new event as chrishall
- [x] Add yourself and Robert Andrews as Organisers
- [x] See that after creation you see the manage enrollees tab
- [x] See that when you visit that tab you can now add enrollees to your event
- [x] See that when you login as Robert Andrews and you follow the same steps it works the same
- [x] See that when you login as SM/CM you are also able to add people to the event
- [x] See that when you login as a different LU you can't add people to the event

## Release notes
There was an issue where Event Organisers weren't able to add people to their events. This is now solved so next to Site Managers & Content Managers, Event Organisers can fully manage their events as well.