### PR TITLE
Issue #3066730 by robertragas, kingdutch: Hide language switcher when…

### DIFF
--- a/modules/custom/social_language/src/Plugin/Block/LanguageSwitcherBlock.php
+++ b/modules/custom/social_language/src/Plugin/Block/LanguageSwitcherBlock.php
@@ -2,6 +2,8 @@
 
 namespace Drupal\social_language\Plugin\Block;
 
+use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Session\AccountInterface;
 use Drupal\language\Plugin\Block\LanguageBlock;
 use Drupal\Core\Url;
 
@@ -21,6 +23,27 @@ use Drupal\Core\Url;
  * )
  */
 class LanguageSwitcherBlock extends LanguageBlock {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function blockAccess(AccountInterface $account) {
+    $access = parent::blockAccess($account);
+    return $access->andIf(AccessResult::allowedIf(count($this->getLanguageSwitchLinks()) > 1));
+  }
+
+  /**
+   * Create language switch links for the current page for our block.
+   *
+   * @return array
+   *   A keyed array of links ready to be themed.
+   */
+  protected function getLanguageSwitchLinks() {
+    // Generate the routes for the current page.
+    $route_name = $this->pathMatcher->isFrontPage() ? '<front>' : '<current>';
+    $type = $this->getDerivativeId();
+    return $this->languageManager->getLanguageSwitchLinks($type, Url::fromRoute($route_name));
+  }
 
   /**
    * {@inheritdoc}

--- a/modules/custom/social_language/src/Plugin/Block/LanguageSwitcherBlock.php
+++ b/modules/custom/social_language/src/Plugin/Block/LanguageSwitcherBlock.php
@@ -29,7 +29,13 @@ class LanguageSwitcherBlock extends LanguageBlock {
    */
   protected function blockAccess(AccountInterface $account) {
     $access = parent::blockAccess($account);
-    return $access->andIf(AccessResult::allowedIf(count($this->getLanguageSwitchLinks()) > 1));
+
+    $allowSwitch = FALSE;
+    if (($languageSwitch = $this->getLanguageSwitchLinks()) !== FALSE) {
+      $allowSwitch = (count($languageSwitch) > 1);
+    }
+
+    return $access->andIf(AccessResult::allowedIf($allowSwitch));
   }
 
   /**


### PR DESCRIPTION
## Problem
When you would use a module to unset certain languages, the language switcher still shows up. To make this language switcher more flexible we should hide it when only 1 language is available.

## Solution
Create an access check to disallow access to the language switcher if only 1 language has been found.

## Issue tracker
https://www.drupal.org/node/3066730

## How to test
- [ ] Enable multiple language
- [ ] unset a language with a hook like the access language has to disable language for specific roles.
- [ ] Notice that the language switcher is gone now where it would normally show

`/**
 * Implements hook_language_switch_links_alter().
 */
function language_access_language_switch_links_alter(array &$links, $type, Url $url) {
  $languages = \Drupal::languageManager()->getLanguages();
  foreach ($languages as $language) {
    if (!\Drupal::currentUser()->hasPermission('access language ' . $language->getId())) {
      if (isset($links[$language->getId()])) {
        unset($links[$language->getId()]);
      }
    }
  }
}`

## Release notes
When unsetting a language because you don't want a user to have access to it, it still show in the language switcher. We have added an access check to hide this switcher when only 1 language is active for the specific role.

