### PR TITLE
Issue #3067268: Add a .browserslistrc file to the repository

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,0 +1,1 @@
+> 1%, last 2 versions, not dead


### PR DESCRIPTION
<h2>Problem</h2>

Passing <code>browsers</code> configuration to tools such as Autoprefixer and Babel is deprecated. Instead it is recommended to either add a <code>browsers</code> key to a <code>package.json</code> file or add a <code>.browserslistrc</code> file. This file can be in any directory above where the tools are run.

<h2>Solution</h2>
Since we have many modules and themes in Open Social that should all support the same browser set I suggest adding a <code>.browserslistrc</code> to the root of the project. This will then be picked up by any tool that needs it that works on code for Open Social. 

The alternative of adding an entry to <code>package.json</code> files is harder to maintain and can lead to inconsistencies between features.

The chosen value in the file is similar to what is currently in use. Except that it adds the `not dead` requirement. As per https://github.com/browserslist/browserslist#queries this means that the following browsers are explicitly not supported IE 10, IE_Mob 10, BlackBerry 10, BlackBerry 7, and OperaMobile 12.1.

This results in output being targetted with support for the following browsers (at the time of commit):
```
and_chr 75
and_ff 67
and_qq 1.2
and_uc 11.8
android 67
baidu 7.12
chrome 75
chrome 74
edge 18
edge 17
firefox 67
firefox 66
ie 11
ie_mob 11
ios_saf 12.2
ios_saf 12.0-12.1
kaios 2.5
op_mini all
op_mob 46
opera 58
opera 57
safari 12.1
safari 12
samsung 9.2
samsung 8.2
```

## Issue tracker
https://www.drupal.org/project/social/issues/3067268

## How to test
- [ ] Not needed

## Release notes
No release notes, internal tooling.

## Change Record
No change record needed. This does not affect our current workflow yet but will be required to transition to goalgorilla/sweet-pea.
