### PR TITLE
Feature/unpublished posts reachable by site manager

### DIFF
--- a/modules/custom/activity_creator/src/Entity/Activity.php
+++ b/modules/custom/activity_creator/src/Entity/Activity.php
@@ -199,6 +199,29 @@ class Activity extends ContentEntityBase implements ActivityInterface {
    * @return \Drupal\Core\Url|string
    *   Returns empty string or URL object of related entity canonical url.
    */
+  public function getRelatedEntity() {
+
+    $related_object = $this->get('field_activity_entity')->getValue();
+    if (!empty($related_object)) {
+      $target_type = $related_object['0']['target_type'];
+      $target_id = $related_object['0']['target_id'];
+      $entity_storage = \Drupal::entityTypeManager()
+        ->getStorage($target_type);
+      $entity = $entity_storage->load($target_id);
+      return $entity;
+    }
+    else {
+      return null;
+    }
+
+  }
+
+  /**
+   * Get related entity url.
+   *
+   * @return \Drupal\Core\Url|string
+   *   Returns empty string or URL object of related entity canonical url.
+   */
   public function getRelatedEntityUrl() {
     $link = "";
     $related_object = $this->get('field_activity_entity')->getValue();

--- a/modules/custom/activity_creator/src/Entity/Activity.php
+++ b/modules/custom/activity_creator/src/Entity/Activity.php
@@ -194,10 +194,10 @@ class Activity extends ContentEntityBase implements ActivityInterface {
   }
 
   /**
-   * Get related entity url.
+   * Get related entity.
    *
-   * @return \Drupal\Core\Url|string
-   *   Returns empty string or URL object of related entity canonical url.
+   * @return \Drupal\Core\Entity
+   *   Returns NULL or Entity object.
    */
   public function getRelatedEntity() {
 
@@ -205,14 +205,11 @@ class Activity extends ContentEntityBase implements ActivityInterface {
     if (!empty($related_object)) {
       $target_type = $related_object['0']['target_type'];
       $target_id = $related_object['0']['target_id'];
-      $entity_storage = \Drupal::entityTypeManager()
-        ->getStorage($target_type);
+      $entity_storage = $this->entityTypeManager()->getStorage($target_type);
       $entity = $entity_storage->load($target_id);
       return $entity;
     }
-    else {
-      return null;
-    }
+    return NULL;
 
   }
 

--- a/modules/custom/activity_viewer/src/Plugin/views/filter/ActivityFilterPersonalisedHomepage.php
+++ b/modules/custom/activity_viewer/src/Plugin/views/filter/ActivityFilterPersonalisedHomepage.php
@@ -160,7 +160,7 @@ class ActivityFilterPersonalisedHomepage extends FilterPluginBase {
     $post_status = db_or();
     $post_status->condition('post.status', 1, '=');
 
-    if ($account->hasPermission('view unpublished post entities')){
+    if ($account->hasPermission('view unpublished post entities')) {
       $post_status->condition('post.status', 0, '=');
     }
     $post_status->condition('activity__field_activity_entity.field_activity_entity_target_type', 'post', '!=');

--- a/modules/custom/activity_viewer/src/Plugin/views/filter/ActivityFilterPersonalisedHomepage.php
+++ b/modules/custom/activity_viewer/src/Plugin/views/filter/ActivityFilterPersonalisedHomepage.php
@@ -39,6 +39,7 @@ class ActivityFilterPersonalisedHomepage extends FilterPluginBase {
    */
   public function query() {
     $account = $this->view->getUser();
+    $roles = $account->getRoles();
     $group_memberships = social_group_get_all_group_members($account->id());
 
     // Add tables and joins.
@@ -159,6 +160,10 @@ class ActivityFilterPersonalisedHomepage extends FilterPluginBase {
 
     $post_status = db_or();
     $post_status->condition('post.status', 1, '=');
+
+    if (in_array("contentmanager", $roles) || in_array("administrator", $roles)){
+      $post_status->condition('post.status', 0, '=');
+    }
     $post_status->condition('activity__field_activity_entity.field_activity_entity_target_type', 'post', '!=');
     $and_wrapper->condition($post_status);
 

--- a/modules/custom/activity_viewer/src/Plugin/views/filter/ActivityFilterPersonalisedHomepage.php
+++ b/modules/custom/activity_viewer/src/Plugin/views/filter/ActivityFilterPersonalisedHomepage.php
@@ -39,7 +39,6 @@ class ActivityFilterPersonalisedHomepage extends FilterPluginBase {
    */
   public function query() {
     $account = $this->view->getUser();
-    $roles = $account->getRoles();
     $group_memberships = social_group_get_all_group_members($account->id());
 
     // Add tables and joins.
@@ -161,7 +160,7 @@ class ActivityFilterPersonalisedHomepage extends FilterPluginBase {
     $post_status = db_or();
     $post_status->condition('post.status', 1, '=');
 
-    if (in_array("contentmanager", $roles) || in_array("administrator", $roles)){
+    if ($account->hasPermission('view unpublished post entities')){
       $post_status->condition('post.status', 0, '=');
     }
     $post_status->condition('activity__field_activity_entity.field_activity_entity_target_type', 'post', '!=');

--- a/modules/custom/activity_viewer/src/Plugin/views/filter/ActivityPostVisibilityAccess.php
+++ b/modules/custom/activity_viewer/src/Plugin/views/filter/ActivityPostVisibilityAccess.php
@@ -39,7 +39,6 @@ class ActivityPostVisibilityAccess extends FilterPluginBase {
    */
   public function query() {
     $account = $this->view->getUser();
-    $roles = $account->getRoles();
 
     $open_groups = social_group_get_all_open_groups();
     $group_memberships = social_group_get_all_group_members($account->id());
@@ -154,7 +153,7 @@ class ActivityPostVisibilityAccess extends FilterPluginBase {
     $post_status = db_or();
     $post_status->condition('post.status', 1, '=');
 
-    if (in_array("contentmanager", $roles) || in_array("administrator", $roles)){
+    if ($account->hasPermission('view unpublished post entities')){
       $post_status->condition('post.status', 0, '=');
     }
     $post_status->condition('activity__field_activity_entity.field_activity_entity_target_type', 'post', '!=');

--- a/modules/custom/activity_viewer/src/Plugin/views/filter/ActivityPostVisibilityAccess.php
+++ b/modules/custom/activity_viewer/src/Plugin/views/filter/ActivityPostVisibilityAccess.php
@@ -39,6 +39,7 @@ class ActivityPostVisibilityAccess extends FilterPluginBase {
    */
   public function query() {
     $account = $this->view->getUser();
+    $roles = $account->getRoles();
 
     $open_groups = social_group_get_all_open_groups();
     $group_memberships = social_group_get_all_group_members($account->id());
@@ -152,6 +153,10 @@ class ActivityPostVisibilityAccess extends FilterPluginBase {
 
     $post_status = db_or();
     $post_status->condition('post.status', 1, '=');
+
+    if (in_array("contentmanager", $roles) || in_array("administrator", $roles)){
+      $post_status->condition('post.status', 0, '=');
+    }
     $post_status->condition('activity__field_activity_entity.field_activity_entity_target_type', 'post', '!=');
     $and_wrapper->condition($post_status);
 

--- a/modules/custom/activity_viewer/src/Plugin/views/filter/ActivityPostVisibilityAccess.php
+++ b/modules/custom/activity_viewer/src/Plugin/views/filter/ActivityPostVisibilityAccess.php
@@ -153,7 +153,7 @@ class ActivityPostVisibilityAccess extends FilterPluginBase {
     $post_status = db_or();
     $post_status->condition('post.status', 1, '=');
 
-    if ($account->hasPermission('view unpublished post entities')){
+    if ($account->hasPermission('view unpublished post entities')) {
       $post_status->condition('post.status', 0, '=');
     }
     $post_status->condition('activity__field_activity_entity.field_activity_entity_target_type', 'post', '!=');

--- a/modules/social_features/social_post/social_post.install
+++ b/modules/social_features/social_post/social_post.install
@@ -88,7 +88,7 @@ function _social_post_get_permissions($role) {
 }
 
 /**
- * Grant permission to administer post entities to contentmanager and sitemanager.
+ * Grant permission to administer post entities to CM and SM.
  */
 function social_post_update_8601() {
   user_role_grant_permissions('contentmanager', ['administer post entities']);

--- a/modules/social_features/social_post/social_post.install
+++ b/modules/social_features/social_post/social_post.install
@@ -75,6 +75,7 @@ function _social_post_get_permissions($role) {
     'delete any post entities',
     'edit any post entities',
     'view unpublished post entities',
+    'administer post entities',
   ]);
 
   // Site manager.
@@ -84,4 +85,12 @@ function _social_post_get_permissions($role) {
     return $permissions[$role];
   }
   return [];
+}
+
+/**
+ * Grant permission to administer post entities to contentmanager and sitemanager.
+ */
+function social_group_update_8601() {
+  user_role_grant_permissions('contentmanager', ['administer post entities']);
+  user_role_grant_permissions('sitemanager', ['administer post entities']);
 }

--- a/modules/social_features/social_post/social_post.install
+++ b/modules/social_features/social_post/social_post.install
@@ -90,7 +90,7 @@ function _social_post_get_permissions($role) {
 /**
  * Grant permission to administer post entities to contentmanager and sitemanager.
  */
-function social_group_update_8601() {
+function social_post_update_8601() {
   user_role_grant_permissions('contentmanager', ['administer post entities']);
   user_role_grant_permissions('sitemanager', ['administer post entities']);
 }

--- a/modules/social_features/social_post/social_post.module
+++ b/modules/social_features/social_post/social_post.module
@@ -224,7 +224,7 @@ function social_post_preprocess_activity(&$variables) {
   $activity = $variables['elements']['#activity'];
   $post = $activity->getRelatedEntity();
   if (!empty($post) && $post->getEntityTypeId() === "post") {
-    $variables['post'] = true;
+    $variables['post'] = TRUE;
     $variables['published'] = $post->isPublished();
   }
 }
@@ -235,7 +235,7 @@ function social_post_preprocess_activity(&$variables) {
 function social_post_preprocess_post__activity(&$variables) {
   $account = \Drupal::currentUser();
 
-  if(!$variables["published"] && !$account->hasPermission('edit any post entities')) {
+  if (!$variables["published"] && !$account->hasPermission('edit any post entities')) {
     unset($variables["content"]["links"]);
   }
 }

--- a/modules/social_features/social_post/social_post.module
+++ b/modules/social_features/social_post/social_post.module
@@ -220,6 +220,13 @@ function social_post_preprocess_activity(&$variables) {
     $variables['visibility_label'] = social_post_get_visibility_details($post->get('field_visibility')->value, 'label');
 
   }
+
+  $activity = $variables['elements']['#activity'];
+  $post = $activity->getRelatedEntity();
+  if (!empty($post) && $post->getEntityTypeId() === "post") {
+    $variables['post'] = true;
+    $variables['published'] = $post->isPublished();
+  }
 }
 
 /**

--- a/modules/social_features/social_post/social_post.module
+++ b/modules/social_features/social_post/social_post.module
@@ -218,6 +218,18 @@ function social_post_preprocess_activity(&$variables) {
 
     $variables['visibility_icon'] = social_post_get_visibility_details($post->get('field_visibility')->value, 'icon');
     $variables['visibility_label'] = social_post_get_visibility_details($post->get('field_visibility')->value, 'label');
+
+  }
+}
+
+/**
+ * Implements hook_preprocess_post__activity().
+ */
+function social_post_preprocess_post__activity(&$variables) {
+  $account = \Drupal::currentUser();
+
+  if(!$variables["published"] && !$account->hasPermission('edit any post entities')) {
+    unset($variables["content"]["links"]);
   }
 }
 

--- a/modules/social_features/social_post/src/PostListBuilder.php
+++ b/modules/social_features/social_post/src/PostListBuilder.php
@@ -22,6 +22,8 @@ class PostListBuilder extends EntityListBuilder {
     $header['post'] = $this->t('Post');
     $header['author'] = $this->t('Author');
     $header['created'] = $this->t('Created');
+    $header['status'] = $this->t('Status');
+
     return $header + parent::buildHeader();
   }
 
@@ -38,6 +40,8 @@ class PostListBuilder extends EntityListBuilder {
     }
     $row['author'] = $entity->getOwner()->toLink();
     $row['created'] = \Drupal::service('date.formatter')->format($entity->getCreatedTime(), 'small');
+    $row['status'] = $entity->isPublished() ? "published" : "unpublished";
+
     return $row + parent::buildRow($entity);
   }
 

--- a/modules/social_features/social_post/src/PostListBuilder.php
+++ b/modules/social_features/social_post/src/PostListBuilder.php
@@ -40,7 +40,7 @@ class PostListBuilder extends EntityListBuilder {
     }
     $row['author'] = $entity->getOwner()->toLink();
     $row['created'] = \Drupal::service('date.formatter')->format($entity->getCreatedTime(), 'small');
-    $row['status'] = $entity->isPublished() ? "published" : "unpublished";
+    $row['status'] = $entity->isPublished() ? t("published") : t("unpublished");
 
     return $row + parent::buildRow($entity);
   }

--- a/themes/socialbase/assets/css/post.css
+++ b/themes/socialbase/assets/css/post.css
@@ -1,0 +1,14 @@
+.post-unpublished img {
+  opacity: 0.5;
+}
+
+.post-unpublished .badge-default {
+  background-color: #777777;
+  color: white;
+  margin-left: 5px;
+  font-size: 100%;
+}
+
+.post-unpublished * {
+  color: #9b9b9b;
+}

--- a/themes/socialbase/assets/css/stream.css
+++ b/themes/socialbase/assets/css/stream.css
@@ -23,6 +23,10 @@
   z-index: 2;
 }
 
+.stream-item .pull-right {
+  z-index: 2;
+}
+
 .stream-icon {
   top: 19px;
   left: 4px;
@@ -100,6 +104,21 @@
 
 .teaser--stream:last-child {
   margin-bottom: -1.25rem;
+}
+
+.post-unpublished img {
+  opacity: 0.5;
+}
+
+.post-unpublished .badge-default {
+  background-color: #777777;
+  color: white;
+  margin-left: 5px;
+  font-size: 100%;
+}
+
+.post-unpublished * {
+  color: #9b9b9b;
 }
 
 @media (min-width: 600px) {

--- a/themes/socialbase/components/04-organisms/post/post.scss
+++ b/themes/socialbase/components/04-organisms/post/post.scss
@@ -1,0 +1,18 @@
+@import 'settings';
+
+.post-unpublished {
+  img {
+    opacity: 0.5;
+  }
+  .badge-default {
+    background-color: $gray-light;
+    color: white;
+    margin-left: 5px;
+    font-size: 100%;
+  }
+  * {
+    color: #9b9b9b;
+  }
+}
+
+

--- a/themes/socialbase/components/04-organisms/stream/stream.scss
+++ b/themes/socialbase/components/04-organisms/stream/stream.scss
@@ -33,6 +33,10 @@
     z-index: 2; //prevents post visibility dropdown from showing under next card in stream
   }
 
+  .pull-right {
+    z-index: 2;
+  }
+
 }
 
 .stream-icon {
@@ -152,4 +156,19 @@
 
   }
 
+}
+
+.post-unpublished {
+  img {
+    opacity: 0.5;
+  }
+  .badge-default {
+    background-color: $gray-light;
+    color: white;
+    margin-left: 5px;
+    font-size: 100%;
+  }
+  * {
+    color: #9b9b9b;
+  }
 }

--- a/themes/socialbase/socialbase.libraries.yml
+++ b/themes/socialbase/socialbase.libraries.yml
@@ -316,6 +316,11 @@ photoswipe.image:
     /libraries/photoswipe/dist/photoswipe-ui-default.min.js: { minified: true }
     assets/js/photoswipe.min.js: { minified: true }
 
+post:
+  css:
+    component:
+      assets/css/post.css: {}
+
 ### 2.4 Templates
 layout:
   css:

--- a/themes/socialbase/templates/activity/activity.html.twig
+++ b/themes/socialbase/templates/activity/activity.html.twig
@@ -16,6 +16,15 @@
  */
 #}
 
+{{ attach_library('socialbase/stream') }}
+
+{%
+  set classes = [
+  'media',
+  not published ? 'post-unpublished',
+]
+%}
+
 <li {{ attributes.addClass('stream-item') }}>
 
   <i class="stream-icon"></i>
@@ -26,7 +35,7 @@
 
       <div class="media-wrapper">
 
-        <div class="media">
+        <div {{ attributes.addClass(classes) }}>
 
           <div class="media-left avatar">
             {% if actor %}
@@ -41,13 +50,19 @@
               {% endif %}
 
               <div class="post-date">
-                  {{ date }}
-                  {% if visibility_icon and visibility_label %}
-                      <svg class="margin-left-s icon-visibility">
-                        <use xlink:href="#icon-{{ visibility_icon }}"></use>
-                      </svg>
-                      <strong>{{ visibility_label }}</strong>
-                  {% endif %}
+                {{ date }}
+                {% if visibility_icon and visibility_label %}
+                  <svg class="margin-left-s icon-visibility">
+                    <use xlink:href="#icon-{{ visibility_icon }}"></use>
+                  </svg>
+                  <strong>{{ visibility_label }}</strong>
+                {% endif %}
+                {% if not published %}
+                  <span class="badge badge-default badge--pill">
+                    {% trans %} unpublished {% endtrans %}
+                  </span>
+                {% endif %}
+
               </div>
             </div>
 

--- a/themes/socialbase/templates/activity/activity.html.twig
+++ b/themes/socialbase/templates/activity/activity.html.twig
@@ -25,7 +25,7 @@
 ]
 %}
 
-<li {{ attributes.addClass('stream-item') }}>
+<li class="stream-item">
 
   <i class="stream-icon"></i>
 

--- a/themes/socialbase/templates/activity/activity.html.twig
+++ b/themes/socialbase/templates/activity/activity.html.twig
@@ -21,7 +21,7 @@
 {%
   set classes = [
   'media',
-  not published ? 'post-unpublished',
+  post and not published ? 'post-unpublished',
 ]
 %}
 
@@ -57,7 +57,7 @@
                   </svg>
                   <strong>{{ visibility_label }}</strong>
                 {% endif %}
-                {% if not published %}
+                {% if post and not published %}
                   <span class="badge badge-default badge--pill">
                     {% trans %} unpublished {% endtrans %}
                   </span>

--- a/themes/socialbase/templates/post/post--activity.html.twig
+++ b/themes/socialbase/templates/post/post--activity.html.twig
@@ -31,10 +31,6 @@
   {{ content.links }}
 {% endif %}
 
-{% if not published %}
-  <div class="node--unpublished__label">{% trans %} unpublished {% endtrans %}</div>
-{% endif %}
-
 <div{{ attributes.addClass(classes) }}>
 
 

--- a/themes/socialbase/templates/post/post--activity.html.twig
+++ b/themes/socialbase/templates/post/post--activity.html.twig
@@ -27,7 +27,7 @@
   ]
 %}
 
-{% if published or user.hasPermission('administer nodes') %}
+{% if content.links %}
   {{ content.links }}
 {% endif %}
 

--- a/themes/socialbase/templates/post/post--activity.html.twig
+++ b/themes/socialbase/templates/post/post--activity.html.twig
@@ -27,7 +27,7 @@
   ]
 %}
 
-{% if published %}
+{% if published or user.hasPermission('administer nodes') %}
   {{ content.links }}
 {% endif %}
 

--- a/themes/socialbase/templates/post/post.html.twig
+++ b/themes/socialbase/templates/post/post.html.twig
@@ -17,12 +17,21 @@
 #}
 
 {{ attach_library('socialbase/comment') }}
+{{ attach_library('socialbase/post') }}
 {{ attach_library('socialbase/page-node')}}
+
+{%
+  set classes = [
+  'media',
+  not published ? 'post-unpublished',
+]
+%}
+
 <div class="card">
   <div class="card__block">
 
     <div class="media-wrapper">
-      <div class="media">
+      <div {{ attributes.addClass(classes) }}>
         <div class="media-left avatar">
           {% if author_picture %}
             {{ author_picture }}
@@ -34,26 +43,26 @@
               {{ content.user_id }}
             {% endif %}
             <div class="post-date">
-                {{ date }}
-                {% if visibility_icon and visibility_label %}
-                    <svg class="margin-left-s icon-visibility">
-                        <use xlink:href="#icon-{{ visibility_icon }}"></use>
-                    </svg>
-                    <strong>{{ visibility_label }}</strong>
-                {% endif %}
+              {{ date }}
+              {% if visibility_icon and visibility_label %}
+                <svg class="margin-left-s icon-visibility">
+                  <use xlink:href="#icon-{{ visibility_icon }}"></use>
+                </svg>
+                <strong>{{ visibility_label }}</strong>
+              {% endif %}
+              {% if not published %}
+                <span class="badge badge-default badge--pill">
+                  {% trans %} unpublished {% endtrans %}
+                </span>
+              {% endif %}
             </div>
           </div>
         </div>
       </div>
-
-      {% if published %}
-        {{ content.links }}
+      {% if content.links %}
+          {{ content.links }}
       {% endif %}
-  </div>
-    {% if not published %}
-    <div class="node--unpublished__label">{% trans %} unpublished {% endtrans %}</div>
-    {% endif %}
-
+    </div>
     <div class="margin-top-s iframe-container">
 
       {{ content|without('links', 'field_post_comments', 'like_and_dislike', 'field_post_image', 'user_id') }}


### PR DESCRIPTION
## Problem
Unpublished posts are not reachable for Site manager to make them published again

## Solution
CM and SM have now access to post administration.
Post becomes editable for CM and SM.
Edit option in post view only visible for those with permissions (currently CM and SM)
Unpublished posts only visible for CM and SM
Unpublished posts greyed out and new design for unpublished label

## Issue tracker
https://jira.goalgorilla.com/browse/DS-5644
https://www.drupal.org/project/social/issues/3068038

## How to test
- [ ] Update database - drush updb -y
- [ ] Log in as user x
- [ ] Create a post
- [ ] Log in as CM
- [ ] Click on Content
- [ ] Check if you can see posts list and the status column.
- [ ] Unpublish the post created by user x
- [ ] Go to /home, /explore and post View
- [ ] Check that you can see the unpublished post
- [ ] Check if you see the unpublished label
- [ ] You should see the edit option by clicking the arrow in any post
- [ ] Login as user X
- [ ] Check that the unpublished post is not visible any more
- [ ] Create another post
- [ ] Repeat the process as SM

## Release notes
SM & CM should now be able to access the administrative overview for posts, on this overview we have a list of posts and its author and content available now including the status. Also we made sure we fixed any activity items shown for unpublished posts are neatly not shown anymore.