### PR TITLE
DS-6012 by jaapjan: LU can see his own unpublished comment [WIP]

### DIFF
--- a/modules/social_features/social_comment/social_comment.install
+++ b/modules/social_features/social_comment/social_comment.install
@@ -56,6 +56,7 @@ function _social_comment_get_permissions($role) {
     'edit own comments',
     'delete own comments',
     'administer own comments',
+    'view own unpublished comments'
   ]);
 
   // Content manager.
@@ -98,4 +99,11 @@ function social_comment_update_8002() {
   // hook was not added at that point so this must be rectified now.
   user_role_grant_permissions('contentmanager', ['administer comments']);
   user_role_grant_permissions('sitemanager', ['administer comments']);
+}
+
+/**
+ * Enable 'view own unpublished comments' permission for authenticated.
+ */
+function social_comment_update_8601() {
+  user_role_grant_permissions('authenticated', ['view own unpublished comments']);
 }

--- a/modules/social_features/social_comment/social_comment.module
+++ b/modules/social_features/social_comment/social_comment.module
@@ -236,17 +236,24 @@ function social_comment_preprocess_comment(&$variables) {
  *
  * Allow users to delete their own comments.
  */
-function social_comment_comment_access(EntityInterface $entity, $operation, AccountInterface $account) {
+function social_comment_comment_access(CommentInterface $comment, $operation, AccountInterface $account) {
   if ($operation == 'delete') {
     if ($account->hasPermission('administer comments', $account)) {
       return AccessResult::allowed()->cachePerPermissions();
     }
     else {
-      return AccessResult::allowedIf($account->hasPermission('delete own comments', $account) && ($account->id() == $entity->getOwnerId()))
+      return AccessResult::allowedIf($account->hasPermission('delete own comments', $account) && ($account->id() == $comment->getOwnerId()))
         ->cachePerPermissions()
         ->cachePerUser()
-        ->addCacheableDependency($entity);
+        ->addCacheableDependency($comment);
     }
+  }
+  if ($operation === 'view' && !$comment->isPublished()) {
+    $access = AccessResult::allowedIf($account->hasPermission('view own unpublished comments', $account) && ($account->id() === $comment->getOwnerId()))
+      ->cachePerPermissions()
+      ->cachePerUser()
+      ->addCacheableDependency($comment);
+    return $access;
   }
 }
 

--- a/modules/social_features/social_comment/social_comment.permissions.yml
+++ b/modules/social_features/social_comment/social_comment.permissions.yml
@@ -1,4 +1,6 @@
 delete own comments:
   title: 'Delete own comments'
+view own unpublished comments:
+  title: 'View own unpublished comments'
 administer own comments:
   title: 'Administer own comment settings'

--- a/modules/social_features/social_post/src/Plugin/Field/FieldFormatter/CommentPostActivityFormatter.php
+++ b/modules/social_features/social_post/src/Plugin/Field/FieldFormatter/CommentPostActivityFormatter.php
@@ -43,6 +43,9 @@ class CommentPostActivityFormatter extends CommentPostFormatter {
       ->addMetaData('field_name', $field_name);
 
     if (!$this->currentUser->hasPermission('administer comments')) {
+      if ($this->currentUser->hasPermission('view own unpublished comments')) {
+        // TODO Write exception here.
+      }
       $query->condition('c.status', CommentInterface::PUBLISHED);
     }
 

--- a/modules/social_features/social_post/src/Plugin/Field/FieldFormatter/CommentPostFormatter.php
+++ b/modules/social_features/social_post/src/Plugin/Field/FieldFormatter/CommentPostFormatter.php
@@ -205,6 +205,10 @@ class CommentPostFormatter extends CommentDefaultFormatter {
     $comments_order = $this->getSetting('order');
 
     if (!$this->currentUser->hasPermission('administer comments')) {
+      if ($this->currentUser->hasPermission('view own unpublished comments')) {
+        // TODO Write exception here.
+
+      }
       $query->condition('c.status', CommentInterface::PUBLISHED);
     }
     if ($mode == CommentManagerInterface::COMMENT_MODE_FLAT) {


### PR DESCRIPTION
## Problem
LU Can not see comments which are unpublished by CM or SM.

## Solution
After a comment is unpublished by CM+, a LU should be able to see it in the same way as CM+ does.

This needs to be done in the following tasks:

- [ ] Add permission 'view own unpublished comments'.
- [ ] Add `social_comment_comment_access` which checks for that permission and returns right access.

Changes are needed to make sure the thread is loaded correctly. This most likely need to be done in all the Comment Field Formatter plugins or the query needs to be altered correctly (e.g. by entity_access tag which isn't working currently):

- [ ] Alter the loadThread method in a new plugin based on CommentDefaultFormatter. This can be used on nodes.
- [ ] Alter the loadThread method in `CommentPostActivityFormatter.php` and `CommentPostFormatter.php`.

This most likely needs to be done by creating conditionGroups according to the permission.

## Issue tracker
DS-6012

## How to test
- [ ] Login as SM and LU. 
- [ ] Unpublish comments and replies on nodes of the LU.
- [ ] Unpublish comments on posts of the LU.
- [ ] Verify that the LU can still see unpublished posts and that it's clear that those are unpublished.

## Release notes
Logged in users can now see their own unpublished comments.

## Change Record
n/a