### PR TITLE
Issue #3067525 search autocomplete separator comma

### DIFF
--- a/modules/social_features/social_search/modules/social_search_autocomplete/config/install/views.view.search_all_autocomplete.yml
+++ b/modules/social_features/social_search/modules/social_search_autocomplete/config/install/views.view.search_all_autocomplete.yml
@@ -289,7 +289,7 @@ display:
             set_precision: false
             precision: 0
             decimal: .
-            separator: ','
+            separator: ''
             format_plural: false
             format_plural_string: !!binary MQNAY291bnQ=
             prefix: ''
@@ -680,7 +680,7 @@ display:
             set_precision: false
             precision: 0
             decimal: .
-            separator: ','
+            separator: ''
             format_plural: false
             format_plural_string: !!binary MQNAY291bnQ=
             prefix: node/
@@ -763,7 +763,7 @@ display:
             set_precision: false
             precision: 0
             decimal: .
-            separator: ','
+            separator: ''
             format_plural: false
             format_plural_string: !!binary MQNAY291bnQ=
             prefix: user/
@@ -846,7 +846,7 @@ display:
             set_precision: false
             precision: 0
             decimal: .
-            separator: ','
+            separator: ''
             format_plural: false
             format_plural_string: !!binary MQNAY291bnQ=
             prefix: group/

--- a/modules/social_features/social_search/modules/social_search_autocomplete/social_search_autocomplete.post_update.php
+++ b/modules/social_features/social_search/modules/social_search_autocomplete/social_search_autocomplete.post_update.php
@@ -23,3 +23,20 @@ function social_search_autocomplete_post_update_user_search_suggestions_type() {
     ->setData($config)
     ->save(TRUE);
 }
+
+/**
+ * Fix delimiters.
+ */
+function social_search_autocomplete_post_update_user_search_suggestions_delimiter() {
+  // Normally loading a configuration file entirely in an update hook is bad
+  // practice because its state is undefined. However, in this case the file is
+  // huge with quite a few changes and this update hook will only run for sites
+  // that used the pre-release version of this module.
+  $config_file = drupal_get_path('module', 'social_search_autocomplete') . '/config/install/views.view.search_all_autocomplete.yml';
+  $config = Yaml::parseFile($config_file);
+
+  \Drupal::configFactory()
+    ->getEditable('views.view.search_all_autocomplete')
+    ->setData($config)
+    ->save(TRUE);
+}


### PR DESCRIPTION
## Problem
If you have more than 1000 users
and if you search for a user who has nid 1006
the search result displays /user/1,006

## Solution
Make sure there is no separator. 

## Issue tracker
https://www.drupal.org/project/social/issues/3067525
## How to test
- [ ] Test the results for search autocomplete for a user group or node that has an id higher than 1000 and see there is no comma anymore

## Release notes
If you have more than 1000 users, groups or pieces of content the search autocomplete has a comma in the URL which causes a wrong link to the piece of content.