### PR TITLE
Issue #3071035 by Kingdutch: Geolocation Maps Markers use incorrect c…

### DIFF
--- a/themes/socialblue/assets/css/badge.css
+++ b/themes/socialblue/assets/css/badge.css
@@ -14,7 +14,6 @@
 .badge-default {
   background-color: #e6e6e6;
   color: #4d4d4d;
-  -webkit-transition: 0.3s;
   transition: 0.3s;
 }
 
@@ -25,7 +24,6 @@
 .badge-primary {
   background-color: #29abe2;
   color: #fff;
-  -webkit-transition: 0.3s;
   transition: 0.3s;
 }
 
@@ -36,7 +34,6 @@
 .badge-secondary {
   background-color: #1f80aa;
   color: #fff;
-  -webkit-transition: 0.3s;
   transition: 0.3s;
 }
 
@@ -47,7 +44,6 @@
 .badge-accent {
   background-color: #ffc142;
   color: #4d4d4d;
-  -webkit-transition: 0.3s;
   transition: 0.3s;
 }
 
@@ -58,7 +54,6 @@
 .badge-success {
   background-color: #5cb85c;
   color: #fff;
-  -webkit-transition: 0.3s;
   transition: 0.3s;
 }
 
@@ -69,7 +64,6 @@
 .badge-info {
   background-color: #33b5e5;
   color: #fff;
-  -webkit-transition: 0.3s;
   transition: 0.3s;
 }
 
@@ -80,7 +74,6 @@
 .badge-warning {
   background-color: #f80;
   color: #fff;
-  -webkit-transition: 0.3s;
   transition: 0.3s;
 }
 
@@ -91,7 +84,6 @@
 .badge-danger {
   background-color: #d9534f;
   color: #fff;
-  -webkit-transition: 0.3s;
   transition: 0.3s;
 }
 

--- a/themes/socialblue/assets/css/base.css
+++ b/themes/socialblue/assets/css/base.css
@@ -48,8 +48,7 @@ kbd {
   color: #fff;
   background-color: #333;
   border-radius: 3px;
-  -webkit-box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.25);
-          box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.25);
+  box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.25);
 }
 
 pre {

--- a/themes/socialblue/assets/css/brand.css
+++ b/themes/socialblue/assets/css/brand.css
@@ -3,8 +3,7 @@
 }
 
 [type="radio"]:focus + label:before {
-  -webkit-box-shadow: 0 0 3px 2px #29abe2;
-          box-shadow: 0 0 3px 2px #29abe2;
+  box-shadow: 0 0 3px 2px #29abe2;
 }
 
 [type="checkbox"]:checked + label:after,
@@ -44,8 +43,7 @@
 .hero-form[role='search'] .form-control:focus, .hero-form[role='search'] .form-control:active,
 .hero-form[role='search'] .form-control:focus ~ .search-icon,
 .hero-form[role='search'] .form-control:active ~ .search-icon {
-  -webkit-box-shadow: 0 2px 0 0 #1f80aa;
-          box-shadow: 0 2px 0 0 #1f80aa;
+  box-shadow: 0 2px 0 0 #1f80aa;
 }
 
 .hero-form[role='search'] .search-icon {
@@ -54,8 +52,7 @@
 
 .form-control:focus {
   border-color: #29abe2;
-  -webkit-box-shadow: 0 2px 0 0 #29abe2;
-          box-shadow: 0 2px 0 0 #29abe2;
+  box-shadow: 0 2px 0 0 #29abe2;
 }
 
 .select2-container--social.select2-container--focus .select2-selection, .select2-container--social.select2-container--open .select2-selection, .select2-container--social .select2-dropdown {
@@ -87,7 +84,6 @@
 .btn-primary.dropdown-toggle:hover {
   background-color: #29abe2;
   border-color: #29abe2;
-  background-image: -webkit-gradient(linear, left top, left bottom, from(rgba(0, 0, 0, 0.2)), to(rgba(0, 0, 0, 0.2)));
   background-image: linear-gradient(to bottom, rgba(0, 0, 0, 0.2) 0%, rgba(0, 0, 0, 0.2) 100%);
 }
 
@@ -109,7 +105,6 @@ fieldset[disabled]
 .btn-primary.focus {
   background-color: #29abe2;
   border-color: #29abe2;
-  background-image: -webkit-gradient(linear, left top, left bottom, from(rgba(0, 0, 0, 0.2)), to(rgba(0, 0, 0, 0.2)));
   background-image: linear-gradient(to bottom, rgba(0, 0, 0, 0.2) 0%, rgba(0, 0, 0, 0.2) 100%);
 }
 
@@ -122,7 +117,6 @@ fieldset[disabled]
 .open > .btn-secondary.dropdown-toggle, .btn-secondary.dropdown-toggle:hover {
   background-color: #1f80aa;
   border-color: #1f80aa;
-  background-image: -webkit-gradient(linear, left top, left bottom, from(rgba(0, 0, 0, 0.2)), to(rgba(0, 0, 0, 0.2)));
   background-image: linear-gradient(to bottom, rgba(0, 0, 0, 0.2) 0%, rgba(0, 0, 0, 0.2) 100%);
 }
 
@@ -132,7 +126,6 @@ fieldset[disabled] .btn-secondary:focus,
 fieldset[disabled] .btn-secondary.focus {
   background-color: #1f80aa;
   border-color: #1f80aa;
-  background-image: -webkit-gradient(linear, left top, left bottom, from(rgba(0, 0, 0, 0.2)), to(rgba(0, 0, 0, 0.2)));
   background-image: linear-gradient(to bottom, rgba(0, 0, 0, 0.2) 0%, rgba(0, 0, 0, 0.2) 100%);
 }
 
@@ -150,7 +143,6 @@ fieldset[disabled] .btn-secondary.focus {
 .open > .btn-accent.dropdown-toggle, .btn-accent.dropdown-toggle:hover {
   background-color: #ffc142;
   border-color: #ffc142;
-  background-image: -webkit-gradient(linear, left top, left bottom, from(rgba(0, 0, 0, 0.2)), to(rgba(0, 0, 0, 0.2)));
   background-image: linear-gradient(to bottom, rgba(0, 0, 0, 0.2) 0%, rgba(0, 0, 0, 0.2) 100%);
 }
 
@@ -160,7 +152,6 @@ fieldset[disabled] .btn-accent:focus,
 fieldset[disabled] .btn-accent.focus {
   background-color: #ffc142;
   border-color: #ffc142;
-  background-image: -webkit-gradient(linear, left top, left bottom, from(rgba(0, 0, 0, 0.2)), to(rgba(0, 0, 0, 0.2)));
   background-image: linear-gradient(to bottom, rgba(0, 0, 0, 0.2) 0%, rgba(0, 0, 0, 0.2) 100%);
 }
 
@@ -212,8 +203,7 @@ blockquote {
 
 .input-group .form-control:focus ~ .input-group-addon {
   border-color: #29abe2;
-  -webkit-box-shadow: 0 2px 0 0 #29abe2;
-          box-shadow: 0 2px 0 0 #29abe2;
+  box-shadow: 0 2px 0 0 #29abe2;
 }
 
 .navbar-secondary {
@@ -230,12 +220,10 @@ blockquote {
 }
 
 .navbar-scrollable:before {
-  background: -webkit-gradient(linear, left top, right top, from(#1f7ea7), to(transparent));
   background: linear-gradient(90deg, #1f7ea7, transparent);
 }
 
 .navbar-scrollable:after {
-  background: -webkit-gradient(linear, right top, left top, from(#1f7ea7), to(transparent));
   background: linear-gradient(-90deg, #1f7ea7, transparent);
 }
 
@@ -388,11 +376,11 @@ html:not(.js) .navbar-default .dropdown:focus > a .navbar-nav__icon, html:not(.j
 }
 
 .leaflet-popup-content .card__text > a {
-  color: #ffffff;
+  color: #33b5e5;
 }
 
 .leaflet-popup-content .card__text > a:after {
-  color: #ffffff;
+  color: #33b5e5;
 }
 
 .card__featured-items .teaser__info svg {
@@ -411,8 +399,7 @@ html:not(.js) .navbar-default .dropdown:focus > a .navbar-nav__icon, html:not(.j
   }
   .search-take-over .form-text:focus {
     border-color: #ffffff;
-    -webkit-box-shadow: 0 2px 0 0 #ffffff;
-            box-shadow: 0 2px 0 0 #ffffff;
+    box-shadow: 0 2px 0 0 #ffffff;
   }
   .btn--close-search-take-over svg,
   .search-take-over svg {

--- a/themes/socialblue/assets/css/dropdown.css
+++ b/themes/socialblue/assets/css/dropdown.css
@@ -6,7 +6,10 @@
   font-weight: 300;
 }
 
-.dropdown-menu > .disabled > a, .dropdown-menu > .disabled > a:hover, .dropdown-menu > .disabled > a:focus, .dropdown-menu > .disabled > span, .dropdown-menu > .disabled > span:hover, .dropdown-menu > .disabled > span:focus {
+.dropdown-menu > .disabled > a, .dropdown-menu > .disabled > a:hover, .dropdown-menu > .disabled > a:focus,
+.dropdown-menu > .disabled > span,
+.dropdown-menu > .disabled > span:hover,
+.dropdown-menu > .disabled > span:focus {
   color: #777;
 }
 

--- a/themes/socialblue/assets/css/form-controls.css
+++ b/themes/socialblue/assets/css/form-controls.css
@@ -8,8 +8,7 @@
 .form-control:focus {
   border-color: #29abe2;
   outline: 0;
-  -webkit-box-shadow: 0 2px 0 0 #29abe2;
-          box-shadow: 0 2px 0 0 #29abe2;
+  box-shadow: 0 2px 0 0 #29abe2;
 }
 
 .form-control::-moz-placeholder {
@@ -59,8 +58,7 @@ input[type='range']::-moz-range-thumb {
 }
 
 [type="radio"]:focus + label:before {
-  -webkit-box-shadow: 0 0 3px 2px #56bde8;
-          box-shadow: 0 0 3px 2px #56bde8;
+  box-shadow: 0 0 3px 2px #56bde8;
 }
 
 [type="checkbox"]:checked + label:after {
@@ -80,31 +78,25 @@ input[type='range']::-moz-range-thumb {
 
 @-webkit-keyframes scale-form-control {
   0% {
-    -webkit-transform: scale(1);
-            transform: scale(1);
+    transform: scale(1);
   }
   50% {
-    -webkit-transform: scale(1.1);
-            transform: scale(1.1);
+    transform: scale(1.1);
   }
   100% {
-    -webkit-transform: scale(1);
-            transform: scale(1);
+    transform: scale(1);
   }
 }
 
 @keyframes scale-form-control {
   0% {
-    -webkit-transform: scale(1);
-            transform: scale(1);
+    transform: scale(1);
   }
   50% {
-    -webkit-transform: scale(1.1);
-            transform: scale(1.1);
+    transform: scale(1.1);
   }
   100% {
-    -webkit-transform: scale(1);
-            transform: scale(1);
+    transform: scale(1);
   }
 }
 
@@ -117,8 +109,7 @@ input[type='range']::-moz-range-thumb {
 }
 
 input[type=checkbox]:checked:not(:disabled) ~ .lever:active:after {
-  -webkit-box-shadow: 0 1px 3px 1px rgba(0, 0, 0, 0.4), 0 0 0 15px rgba(29, 120, 158, 0.1);
-          box-shadow: 0 1px 3px 1px rgba(0, 0, 0, 0.4), 0 0 0 15px rgba(29, 120, 158, 0.1);
+  box-shadow: 0 1px 3px 1px rgba(0, 0, 0, 0.4), 0 0 0 15px rgba(29, 120, 158, 0.1);
 }
 
 .input-group .select-wrapper:first-child .form-control:first-child {

--- a/themes/socialblue/assets/css/form-elements.css
+++ b/themes/socialblue/assets/css/form-elements.css
@@ -15,8 +15,7 @@ html.js .input-group-addon .glyphicon.glyphicon-spin {
 }
 
 .has-error .form-control:focus {
-  -webkit-box-shadow: 0 2px 0 0 #a94442;
-          box-shadow: 0 2px 0 0 #a94442;
+  box-shadow: 0 2px 0 0 #a94442;
   border-color: #a94442;
 }
 

--- a/themes/socialblue/assets/css/hero.css
+++ b/themes/socialblue/assets/css/hero.css
@@ -25,8 +25,7 @@
 .hero-form[role='search'] .form-control:focus, .hero-form[role='search'] .form-control:active,
 .hero-form[role='search'] .form-control:focus ~ .search-icon,
 .hero-form[role='search'] .form-control:active ~ .search-icon {
-  -webkit-box-shadow: 0 2px 0 0 #1f80aa;
-          box-shadow: 0 2px 0 0 #1f80aa;
+  box-shadow: 0 2px 0 0 #1f80aa;
 }
 
 .hero-form[role='search'] .form-submit,

--- a/themes/socialblue/assets/css/input-groups.css
+++ b/themes/socialblue/assets/css/input-groups.css
@@ -1,8 +1,7 @@
 .input-group .form-control:focus ~ .input-group-addon {
   border-color: #29abe2;
   border-bottom: 1px solid #29abe2;
-  -webkit-box-shadow: 0 2px 0 0 #29abe2;
-          box-shadow: 0 2px 0 0 #29abe2;
+  box-shadow: 0 2px 0 0 #29abe2;
 }
 
 .input-group-addon {

--- a/themes/socialblue/assets/css/kss.css
+++ b/themes/socialblue/assets/css/kss.css
@@ -43,8 +43,7 @@
   max-height: none;
   -o-object-fit: contain;
      object-fit: contain;
-  -webkit-transform: none;
-          transform: none;
+  transform: none;
   overflow: auto;
   padding: 20px;
   background-color: #f3f3f3;
@@ -109,8 +108,7 @@
 }
 
 #kss-node .kss-toolbar a {
-  -webkit-box-sizing: content-box;
-          box-sizing: content-box;
+  box-sizing: content-box;
   display: inline-block;
   width: 16px;
   height: 16px;
@@ -149,14 +147,12 @@
   margin-bottom: 5px;
   border: solid 1px #666;
   padding: 8px 10px 6px;
-  -webkit-box-shadow: 2px 2px 2px rgba(0, 0, 0, 0.25);
-          box-shadow: 2px 2px 2px rgba(0, 0, 0, 0.25);
+  box-shadow: 2px 2px 2px rgba(0, 0, 0, 0.25);
   white-space: nowrap;
   color: #000;
   background: #fff;
   cursor: help;
   opacity: 0;
-  -webkit-transition: opacity 0.25s;
   transition: opacity 0.25s;
   height: 1px;
   width: 1px;
@@ -311,8 +307,7 @@
 #kss-node.kss-guides-mode .kss-modifier__example-footer:before,
 #kss-node.kss-guides-mode .kss-modifier__example-footer:after {
   z-index: -1;
-  -webkit-box-sizing: border-box;
-          box-sizing: border-box;
+  box-sizing: border-box;
   content: '';
   position: absolute;
   width: 5px;

--- a/themes/socialblue/assets/css/navbar.css
+++ b/themes/socialblue/assets/css/navbar.css
@@ -126,7 +126,6 @@
 }
 
 .navbar-scrollable:after {
-  background: -webkit-gradient(linear, left top, right top, from(rgba(31, 128, 170, 0)), to(#1f80aa));
   background: linear-gradient(to right, rgba(31, 128, 170, 0), #1f80aa);
 }
 
@@ -136,8 +135,7 @@
   }
   .search-take-over .form-text:focus {
     border-color: #ffffff;
-    -webkit-box-shadow: 0 2px 0 0 #ffffff;
-            box-shadow: 0 2px 0 0 #ffffff;
+    box-shadow: 0 2px 0 0 #ffffff;
   }
 }
 

--- a/themes/socialblue/assets/css/pagination.css
+++ b/themes/socialblue/assets/css/pagination.css
@@ -48,6 +48,5 @@
 }
 
 .mini-pager {
-  background-image: -webkit-gradient(linear, left top, left bottom, from(transparent), to(#f3f3f3));
   background-image: linear-gradient(transparent, #f3f3f3);
 }

--- a/themes/socialblue/assets/css/preview.css
+++ b/themes/socialblue/assets/css/preview.css
@@ -48,8 +48,7 @@ kbd {
   color: #fff;
   background-color: #333;
   border-radius: 3px;
-  -webkit-box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.25);
-          box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.25);
+  box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.25);
 }
 
 pre {
@@ -496,7 +495,6 @@ body {
 .badge-default {
   background-color: #e6e6e6;
   color: #4d4d4d;
-  -webkit-transition: 0.3s;
   transition: 0.3s;
 }
 
@@ -507,7 +505,6 @@ body {
 .badge-primary {
   background-color: #29abe2;
   color: #fff;
-  -webkit-transition: 0.3s;
   transition: 0.3s;
 }
 
@@ -518,7 +515,6 @@ body {
 .badge-secondary {
   background-color: #1f80aa;
   color: #fff;
-  -webkit-transition: 0.3s;
   transition: 0.3s;
 }
 
@@ -529,7 +525,6 @@ body {
 .badge-accent {
   background-color: #ffc142;
   color: #4d4d4d;
-  -webkit-transition: 0.3s;
   transition: 0.3s;
 }
 
@@ -540,7 +535,6 @@ body {
 .badge-success {
   background-color: #5cb85c;
   color: #fff;
-  -webkit-transition: 0.3s;
   transition: 0.3s;
 }
 
@@ -551,7 +545,6 @@ body {
 .badge-info {
   background-color: #33b5e5;
   color: #fff;
-  -webkit-transition: 0.3s;
   transition: 0.3s;
 }
 
@@ -562,7 +555,6 @@ body {
 .badge-warning {
   background-color: #f80;
   color: #fff;
-  -webkit-transition: 0.3s;
   transition: 0.3s;
 }
 
@@ -573,7 +565,6 @@ body {
 .badge-danger {
   background-color: #d9534f;
   color: #fff;
-  -webkit-transition: 0.3s;
   transition: 0.3s;
 }
 
@@ -958,8 +949,7 @@ fieldset[disabled] .btn--twitter.focus {
 .form-control:focus {
   border-color: #29abe2;
   outline: 0;
-  -webkit-box-shadow: 0 2px 0 0 #29abe2;
-          box-shadow: 0 2px 0 0 #29abe2;
+  box-shadow: 0 2px 0 0 #29abe2;
 }
 
 .form-control::-moz-placeholder {
@@ -1009,8 +999,7 @@ input[type='range']::-moz-range-thumb {
 }
 
 [type="radio"]:focus + label:before {
-  -webkit-box-shadow: 0 0 3px 2px #56bde8;
-          box-shadow: 0 0 3px 2px #56bde8;
+  box-shadow: 0 0 3px 2px #56bde8;
 }
 
 [type="checkbox"]:checked + label:after {
@@ -1030,31 +1019,25 @@ input[type='range']::-moz-range-thumb {
 
 @-webkit-keyframes scale-form-control {
   0% {
-    -webkit-transform: scale(1);
-            transform: scale(1);
+    transform: scale(1);
   }
   50% {
-    -webkit-transform: scale(1.1);
-            transform: scale(1.1);
+    transform: scale(1.1);
   }
   100% {
-    -webkit-transform: scale(1);
-            transform: scale(1);
+    transform: scale(1);
   }
 }
 
 @keyframes scale-form-control {
   0% {
-    -webkit-transform: scale(1);
-            transform: scale(1);
+    transform: scale(1);
   }
   50% {
-    -webkit-transform: scale(1.1);
-            transform: scale(1.1);
+    transform: scale(1.1);
   }
   100% {
-    -webkit-transform: scale(1);
-            transform: scale(1);
+    transform: scale(1);
   }
 }
 
@@ -1067,8 +1050,7 @@ input[type='range']::-moz-range-thumb {
 }
 
 input[type=checkbox]:checked:not(:disabled) ~ .lever:active:after {
-  -webkit-box-shadow: 0 1px 3px 1px rgba(0, 0, 0, 0.4), 0 0 0 15px rgba(29, 120, 158, 0.1);
-          box-shadow: 0 1px 3px 1px rgba(0, 0, 0, 0.4), 0 0 0 15px rgba(29, 120, 158, 0.1);
+  box-shadow: 0 1px 3px 1px rgba(0, 0, 0, 0.4), 0 0 0 15px rgba(29, 120, 158, 0.1);
 }
 
 .input-group .select-wrapper:first-child .form-control:first-child {
@@ -1110,8 +1092,7 @@ html.js .input-group-addon .glyphicon.glyphicon-spin {
 }
 
 .has-error .form-control:focus {
-  -webkit-box-shadow: 0 2px 0 0 #a94442;
-          box-shadow: 0 2px 0 0 #a94442;
+  box-shadow: 0 2px 0 0 #a94442;
   border-color: #a94442;
 }
 
@@ -1267,7 +1248,6 @@ html.js .input-group-addon .glyphicon.glyphicon-spin {
 }
 
 .navbar-scrollable:after {
-  background: -webkit-gradient(linear, left top, right top, from(rgba(31, 128, 170, 0)), to(#1f80aa));
   background: linear-gradient(to right, rgba(31, 128, 170, 0), #1f80aa);
 }
 
@@ -1372,8 +1352,7 @@ html.js .input-group-addon .glyphicon.glyphicon-spin {
 .hero-form[role='search'] .form-control:focus, .hero-form[role='search'] .form-control:active,
 .hero-form[role='search'] .form-control:focus ~ .search-icon,
 .hero-form[role='search'] .form-control:active ~ .search-icon {
-  -webkit-box-shadow: 0 2px 0 0 #1f80aa;
-          box-shadow: 0 2px 0 0 #1f80aa;
+  box-shadow: 0 2px 0 0 #1f80aa;
 }
 
 .hero-form[role='search'] .form-submit,
@@ -1432,8 +1411,7 @@ html.js .input-group-addon .glyphicon.glyphicon-spin {
 }
 
 [type="radio"]:focus + label:before {
-  -webkit-box-shadow: 0 0 3px 2px #29abe2;
-          box-shadow: 0 0 3px 2px #29abe2;
+  box-shadow: 0 0 3px 2px #29abe2;
 }
 
 [type="checkbox"]:checked + label:after,
@@ -1473,8 +1451,7 @@ html.js .input-group-addon .glyphicon.glyphicon-spin {
 .hero-form[role='search'] .form-control:focus, .hero-form[role='search'] .form-control:active,
 .hero-form[role='search'] .form-control:focus ~ .search-icon,
 .hero-form[role='search'] .form-control:active ~ .search-icon {
-  -webkit-box-shadow: 0 2px 0 0 #1f80aa;
-          box-shadow: 0 2px 0 0 #1f80aa;
+  box-shadow: 0 2px 0 0 #1f80aa;
 }
 
 .hero-form[role='search'] .search-icon {
@@ -1483,8 +1460,7 @@ html.js .input-group-addon .glyphicon.glyphicon-spin {
 
 .form-control:focus {
   border-color: #29abe2;
-  -webkit-box-shadow: 0 2px 0 0 #29abe2;
-          box-shadow: 0 2px 0 0 #29abe2;
+  box-shadow: 0 2px 0 0 #29abe2;
 }
 
 .select2-container--social.select2-container--focus .select2-selection, .select2-container--social.select2-container--open .select2-selection, .select2-container--social .select2-dropdown {
@@ -1516,7 +1492,6 @@ html.js .input-group-addon .glyphicon.glyphicon-spin {
 .btn-primary.dropdown-toggle:hover {
   background-color: #29abe2;
   border-color: #29abe2;
-  background-image: -webkit-gradient(linear, left top, left bottom, from(rgba(0, 0, 0, 0.2)), to(rgba(0, 0, 0, 0.2)));
   background-image: linear-gradient(to bottom, rgba(0, 0, 0, 0.2) 0%, rgba(0, 0, 0, 0.2) 100%);
 }
 
@@ -1538,7 +1513,6 @@ fieldset[disabled]
 .btn-primary.focus {
   background-color: #29abe2;
   border-color: #29abe2;
-  background-image: -webkit-gradient(linear, left top, left bottom, from(rgba(0, 0, 0, 0.2)), to(rgba(0, 0, 0, 0.2)));
   background-image: linear-gradient(to bottom, rgba(0, 0, 0, 0.2) 0%, rgba(0, 0, 0, 0.2) 100%);
 }
 
@@ -1551,7 +1525,6 @@ fieldset[disabled]
 .open > .btn-secondary.dropdown-toggle, .btn-secondary.dropdown-toggle:hover {
   background-color: #1f80aa;
   border-color: #1f80aa;
-  background-image: -webkit-gradient(linear, left top, left bottom, from(rgba(0, 0, 0, 0.2)), to(rgba(0, 0, 0, 0.2)));
   background-image: linear-gradient(to bottom, rgba(0, 0, 0, 0.2) 0%, rgba(0, 0, 0, 0.2) 100%);
 }
 
@@ -1561,7 +1534,6 @@ fieldset[disabled] .btn-secondary:focus,
 fieldset[disabled] .btn-secondary.focus {
   background-color: #1f80aa;
   border-color: #1f80aa;
-  background-image: -webkit-gradient(linear, left top, left bottom, from(rgba(0, 0, 0, 0.2)), to(rgba(0, 0, 0, 0.2)));
   background-image: linear-gradient(to bottom, rgba(0, 0, 0, 0.2) 0%, rgba(0, 0, 0, 0.2) 100%);
 }
 
@@ -1579,7 +1551,6 @@ fieldset[disabled] .btn-secondary.focus {
 .open > .btn-accent.dropdown-toggle, .btn-accent.dropdown-toggle:hover {
   background-color: #ffc142;
   border-color: #ffc142;
-  background-image: -webkit-gradient(linear, left top, left bottom, from(rgba(0, 0, 0, 0.2)), to(rgba(0, 0, 0, 0.2)));
   background-image: linear-gradient(to bottom, rgba(0, 0, 0, 0.2) 0%, rgba(0, 0, 0, 0.2) 100%);
 }
 
@@ -1589,7 +1560,6 @@ fieldset[disabled] .btn-accent:focus,
 fieldset[disabled] .btn-accent.focus {
   background-color: #ffc142;
   border-color: #ffc142;
-  background-image: -webkit-gradient(linear, left top, left bottom, from(rgba(0, 0, 0, 0.2)), to(rgba(0, 0, 0, 0.2)));
   background-image: linear-gradient(to bottom, rgba(0, 0, 0, 0.2) 0%, rgba(0, 0, 0, 0.2) 100%);
 }
 
@@ -1641,8 +1611,7 @@ blockquote {
 
 .input-group .form-control:focus ~ .input-group-addon {
   border-color: #29abe2;
-  -webkit-box-shadow: 0 2px 0 0 #29abe2;
-          box-shadow: 0 2px 0 0 #29abe2;
+  box-shadow: 0 2px 0 0 #29abe2;
 }
 
 .navbar-secondary {
@@ -1659,12 +1628,10 @@ blockquote {
 }
 
 .navbar-scrollable:before {
-  background: -webkit-gradient(linear, left top, right top, from(#1f7ea7), to(transparent));
   background: linear-gradient(90deg, #1f7ea7, transparent);
 }
 
 .navbar-scrollable:after {
-  background: -webkit-gradient(linear, right top, left top, from(#1f7ea7), to(transparent));
   background: linear-gradient(-90deg, #1f7ea7, transparent);
 }
 
@@ -1707,6 +1674,15 @@ blockquote {
   color: #f3f3f3;
   fill: #f3f3f3;
   background-color: #1f1f1f;
+}
+
+html:not(.js) .navbar-default .dropdown:focus > a, html:not(.js) .navbar-default .dropdown:hover > a {
+  color: #f3f3f3;
+  background-color: #1f1f1f;
+}
+
+html:not(.js) .navbar-default .dropdown:focus > a .navbar-nav__icon, html:not(.js) .navbar-default .dropdown:hover > a .navbar-nav__icon {
+  fill: #f3f3f3;
 }
 
 .navbar-nav__icon {
@@ -1808,11 +1784,11 @@ blockquote {
 }
 
 .leaflet-popup-content .card__text > a {
-  color: #ffffff;
+  color: #33b5e5;
 }
 
 .leaflet-popup-content .card__text > a:after {
-  color: #ffffff;
+  color: #33b5e5;
 }
 
 .card__featured-items .teaser__info svg {
@@ -1846,8 +1822,7 @@ blockquote {
   }
   .search-take-over .form-text:focus {
     border-color: #ffffff;
-    -webkit-box-shadow: 0 2px 0 0 #ffffff;
-            box-shadow: 0 2px 0 0 #ffffff;
+    box-shadow: 0 2px 0 0 #ffffff;
   }
   .nav-tabs > li.active > a, .nav-tabs > li.active > a:hover, .nav-tabs > li.active > a:focus {
     border-bottom: 2px solid #29abe2;
@@ -1857,8 +1832,7 @@ blockquote {
   }
   .search-take-over .form-text:focus {
     border-color: #ffffff;
-    -webkit-box-shadow: 0 2px 0 0 #ffffff;
-            box-shadow: 0 2px 0 0 #ffffff;
+    box-shadow: 0 2px 0 0 #ffffff;
   }
   .btn--close-search-take-over svg,
   .search-take-over svg {

--- a/themes/socialblue/assets/css/styleguide.css
+++ b/themes/socialblue/assets/css/styleguide.css
@@ -16,7 +16,6 @@
   height: 30px;
   text-align: left;
   border-radius: 5px 5px 0 0;
-  background: -webkit-gradient(linear, left top, left bottom, from(#f3f3f3), to(#e6e6e6));
   background: linear-gradient(#f3f3f3, #e6e6e6);
 }
 
@@ -141,8 +140,7 @@
   max-height: none;
   -o-object-fit: contain;
      object-fit: contain;
-  -webkit-transform: none;
-          transform: none;
+  transform: none;
   overflow: auto;
   padding: 20px;
   background-color: #f3f3f3;
@@ -207,8 +205,7 @@
 }
 
 #kss-node .kss-toolbar a {
-  -webkit-box-sizing: content-box;
-          box-sizing: content-box;
+  box-sizing: content-box;
   display: inline-block;
   width: 16px;
   height: 16px;
@@ -247,14 +244,12 @@
   margin-bottom: 5px;
   border: solid 1px #666;
   padding: 8px 10px 6px;
-  -webkit-box-shadow: 2px 2px 2px rgba(0, 0, 0, 0.25);
-          box-shadow: 2px 2px 2px rgba(0, 0, 0, 0.25);
+  box-shadow: 2px 2px 2px rgba(0, 0, 0, 0.25);
   white-space: nowrap;
   color: #000;
   background: #fff;
   cursor: help;
   opacity: 0;
-  -webkit-transition: opacity 0.25s;
   transition: opacity 0.25s;
   height: 1px;
   width: 1px;
@@ -409,8 +404,7 @@
 #kss-node.kss-guides-mode .kss-modifier__example-footer:before,
 #kss-node.kss-guides-mode .kss-modifier__example-footer:after {
   z-index: -1;
-  -webkit-box-sizing: border-box;
-          box-sizing: border-box;
+  box-sizing: border-box;
   content: '';
   position: absolute;
   width: 5px;
@@ -523,7 +517,6 @@
   display: inline-block;
   font-size: 14px;
   color: #555555;
-  -webkit-transition: color 0.5s;
   transition: color 0.5s;
   padding-top: 0;
   padding-bottom: 0;
@@ -537,7 +530,6 @@
   width: 3px;
   height: 100%;
   background-color: #f3f3f3;
-  -webkit-transition: background-color .3s, width .3s;
   transition: background-color .3s, width .3s;
 }
 

--- a/themes/socialblue/assets/css/toc.css
+++ b/themes/socialblue/assets/css/toc.css
@@ -13,7 +13,6 @@
   display: inline-block;
   font-size: 14px;
   color: #555555;
-  -webkit-transition: color 0.5s;
   transition: color 0.5s;
   padding-top: 0;
   padding-bottom: 0;
@@ -27,7 +26,6 @@
   width: 3px;
   height: 100%;
   background-color: #f3f3f3;
-  -webkit-transition: background-color .3s, width .3s;
   transition: background-color .3s, width .3s;
 }
 

--- a/themes/socialblue/assets/css/waves.css
+++ b/themes/socialblue/assets/css/waves.css
@@ -19,8 +19,7 @@
 }
 
 .waves-btn {
-  -webkit-transform: translateZ(0);
-          transform: translateZ(0);
+  transform: translateZ(0);
   -webkit-mask-image: none;
   border-radius: 10px;
 }

--- a/themes/socialblue/components/brand.scss
+++ b/themes/socialblue/components/brand.scss
@@ -464,9 +464,9 @@ html:not(.js) .navbar-default {
 
 .leaflet-popup-content .card__text {
   > a {
-    color: $navbar-default-link-color;
+    color: $link-color;
     &:after {
-      color: $navbar-default-link-color;
+      color: $link-color;
     }
   }
 }


### PR DESCRIPTION
…olor for title text

<h2>Problem</h2>

The pop-ups of the markers use the navigation link text which can conflict with the card background color that is used. Instead the default link color should be used because it's meant to be used with the cards.


<h2>Solution</h2>
Change the title color to use the default link-color in brand.scss

## Issue tracker
https://www.drupal.org/project/social/issues/3071035

## How to test
- [ ] Enable the Social Geolocation Maps module
- [ ] Create an event with an address
- [ ] Visit /community-evens
- [ ] See that the title of the pop-up of the marker is now visible

## Release notes
The color used for the title on location markers on the event map was sometimes the same as the card background color which caused links to be invisible. This color now utilises the default link color which should be configured to work correctly in multiple places.

