### PR TITLE
Issue #3071335 by ronaldtebrake: implement patch for lazy loading

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -84,7 +84,8 @@
                 "Notice: Undefined index: value in MessageTemplate->getText()": "https://www.drupal.org/files/issues/2018-09-16/undefined-index-value-3000026-2.patch"
             },
             "drupal/lazy": {
-                "Make sure we grab active config for lazy settings": "https://www.drupal.org/files/issues/2019-05-23/3056630-2.patch"
+                "Make sure we grab active config for lazy settings": "https://www.drupal.org/files/issues/2019-05-23/3056630-2.patch",
+                "Make sure lazy doesnt do anything on cron": "https://www.drupal.org/files/issues/2019-07-30/3071331-lazy-cron-empty-path-2.patch"
             }
         }
     },

--- a/drupal-org.make
+++ b/drupal-org.make
@@ -58,6 +58,7 @@ projects[image_widget_crop][patch][] = "https://www.drupal.org/files/issues/2019
 projects[lazy][type] = module
 projects[lazy][version] = 2.0
 projects[lazy][patch][] = "https://www.drupal.org/files/issues/2019-05-23/3056630-2.patch"
+projects[lazy][patch][] = "https://www.drupal.org/files/issues/2019-07-30/3071331-lazy-cron-empty-path-2.patch"
 projects[like_and_dislike][type] = module
 projects[like_and_dislike][version] = 1.0-alpha2
 projects[like_and_dislike][patch][] = "https://www.drupal.org/files/issues/2848080-2-preview-fails-on-node.patch"


### PR DESCRIPTION
## Problem
When a message is rendered on the cron using a filter format that has lazy loading enabled it will reach function `lazy_disabled_by_path`

`$path_alias = \Drupal::service('path.alias_manager')->getAliasByPath($current_path);`
if `$current_path` doesn't start with a slash it will result in a `InvalidArgumentException: Source path has to start with a slash. in Drupal\Core\Path\AliasManager->getAliasByPath() (line 186 of /app/html/core/lib/Drupal/Core/Path/AliasManager.php).`

In our case it's because a message is rendered with a token as part of the href. 
See part of the configuration below

```
value: '<p><a href="[social_event:enrolled_event_url]">[social_event:enrolled_user]</a> has enrolled to the event [social_event:event_iam_organizing] you are organizing</p>'
    format: full_html
```

## Solution
Implemented a check in lazy loading, similar to what the path module does and where it actually goes wrong.

## Issue tracker
https://www.drupal.org/project/social/issues/3071335
https://www.drupal.org/project/lazy/issues/3071331

## How to test
- [ ] Ronald will show you ;) 

## Release notes
An issue with lazy loading resulted in notifications not being rendered correctly on drush cron.