### PR TITLE
Issue by makishima: Fix failing behat tests related with /stream on enterprise sites

### DIFF
--- a/tests/behat/features/capabilities/like/like-post-stream.feature
+++ b/tests/behat/features/capabilities/like/like-post-stream.feature
@@ -40,7 +40,6 @@ Feature: Like post stream
     And I press "Post"
     Then I should see the success message "Your post has been posted."
     And I should see "This is a public post."
-    Then I should be on "/stream"
 
     Given I am an anonymous user
     And I am on the homepage

--- a/tests/behat/features/capabilities/post/post-comments.feature
+++ b/tests/behat/features/capabilities/post/post-comments.feature
@@ -19,7 +19,6 @@ Feature: Comment on a Post
    Then I should see the success message "Your post has been posted."
     And I should see "This is a community post." in the "Main content front"
     And I should see "PostUser1" in the "Main content front"
-    And I should be on "/stream"
 
         # Scenario: Post a comment on this private post
   Given I am logged in as "PostUser2"

--- a/tests/behat/features/capabilities/post/post-create.feature
+++ b/tests/behat/features/capabilities/post/post-create.feature
@@ -18,7 +18,6 @@ Feature: Create Post
    Then I should see the success message "Your post has been posted."
     And I should see "This is a public post."
     And I should see "PostCreateUser1" in the "Main content front"
-    And I should be on "/stream"
 
         # Scenario: Succesfully create a private post
    When I fill in "Say something to the Community" with "This is a community post."
@@ -27,7 +26,6 @@ Feature: Create Post
    Then I should see the success message "Your post has been posted."
     And I should see "This is a community post."
     And I should see "PostCreateUser1" in the "Main content front"
-    And I should be on "/stream"
 
         # Scenario: edit the post
    When I click the xth "1" element with the css ".dropdown-toggle" in the "Main content"

--- a/tests/behat/features/capabilities/post/post-photo-create.feature
+++ b/tests/behat/features/capabilities/post/post-photo-create.feature
@@ -21,7 +21,6 @@ Feature: Create Post with Photo
    Then I should see the success message "Your post has been posted."
     And I should see "This post with a photo."
     And I should see "PostPhotoCreate1" in the "Main content front"
-    And I should be on "/stream"
 
         # Scenario: edit the post
    When I click the xth "1" element with the css ".dropdown-toggle" in the "Main content"


### PR DESCRIPTION
## Problem
Four behat tests are failing on all enterprise sites on step: _And I should be on "/stream"_ .

- like-post-stream.feature
- post-comments.feature
- post-create.feature
- post-photo-create.feature

This problem occurs when the Redirect module is enabled (social_path_manager module requires it in the dependencies)

## Solution
Fix those behat tests in distro by removing step: _And I should be on "/stream"_

## Issue tracker
- https://jira.goalgorilla.com/browse/YANG-1265

## How to test
- [ ] Enable social_path_manager module 
- [ ] Run distribution behat tests: 
  - like-post-stream.feature
  - post-comments.feature
  - post-create.feature
  - post-photo-create.feature
- [ ] Behat test should pass

## Release notes
Improve behat tests related with /stream
