### PR TITLE
#3065010 - Lazy load images

### DIFF
--- a/modules/custom/social_lazy_loading/README.txt
+++ b/modules/custom/social_lazy_loading/README.txt
@@ -1,0 +1,5 @@
+We use the lazy module for:
+- Inline images & iFrames in the WYSIWYG editor. This works by adding processing functions to a text format.
+
+We use the Blazy module for:
+- Image formatters so all our image fields are rendered lazy loading style

--- a/modules/custom/social_lazy_loading/README.txt
+++ b/modules/custom/social_lazy_loading/README.txt
@@ -1,5 +1,3 @@
 We use the lazy module for:
 - Inline images & iFrames in the WYSIWYG editor. This works by adding processing functions to a text format.
-
-We use the Blazy module for:
-- Image formatters so all our image fields are rendered lazy loading style
+- Image fields

--- a/modules/custom/social_lazy_loading/composer.json
+++ b/modules/custom/social_lazy_loading/composer.json
@@ -5,5 +5,6 @@
   "require": {
     "vardot/blazy": "^1.8",
     "drupal/lazy": "2.0",
+    "drupal/blazy": "^1.0"
   }
 }

--- a/modules/custom/social_lazy_loading/composer.json
+++ b/modules/custom/social_lazy_loading/composer.json
@@ -4,7 +4,6 @@
   "description": "Provides lazy loading based on blazy.",
   "require": {
     "vardot/blazy": "^1.8",
-    "drupal/lazy": "2.0",
-    "drupal/blazy": "^1.0"
+    "drupal/lazy": "2.0"
   }
 }

--- a/modules/custom/social_lazy_loading/social_lazy_loading.install
+++ b/modules/custom/social_lazy_loading/social_lazy_loading.install
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * @file
+ * Install, update and uninstall functions for the social_lazy_loading module.
+ */
+
+/**
+ * Implements hook_install().
+ *
+ * Perform actions related to the installation of social_language.
+ */
+function social_lazy_loading() {
+  // Enable the submodule, it's standalone so don't depend on it.
+  install_lazy_loading_images();
+}
+
+/**
+ * Function that enables the lazy loading images module.
+ */
+function install_lazy_loading_images() {
+  $module = [
+    'social_lazy_loading_images',
+  ];
+
+  \Drupal::service('module_installer')->install($module);
+}
+
+/**
+ * Implements hook_update_N().
+ */
+function social_lazy_loading_update_8601() {
+  install_lazy_loading_images();
+}

--- a/modules/custom/social_lazy_loading/social_lazy_loading_images/social_lazy_loading_images.info.yml
+++ b/modules/custom/social_lazy_loading/social_lazy_loading_images/social_lazy_loading_images.info.yml
@@ -4,4 +4,4 @@ description: 'Module for lazy loading images using the blazy library.'
 core: '8.x'
 package: Social
 dependencies:
-  - drupal:blazy
+  - drupal:lazy

--- a/modules/custom/social_lazy_loading/social_lazy_loading_images/social_lazy_loading_images.info.yml
+++ b/modules/custom/social_lazy_loading/social_lazy_loading_images/social_lazy_loading_images.info.yml
@@ -1,0 +1,7 @@
+name: 'Social Lazy Loading Image'
+type: module
+description: 'Module for lazy loading images using the blazy library.'
+core: '8.x'
+package: Social
+dependencies:
+  - drupal:blazy

--- a/modules/custom/social_lazy_loading/social_lazy_loading_images/social_lazy_loading_images.services.yml
+++ b/modules/custom/social_lazy_loading/social_lazy_loading_images/social_lazy_loading_images.services.yml
@@ -1,0 +1,6 @@
+services:
+  social_lazy_loading.overrider:
+    class: \Drupal\social_lazy_loading_images\SocialLazyLoadingImageDisplayOverride
+    arguments: ['@config.factory']
+    tags:
+      - {name: config.factory.override, priority: 200}

--- a/modules/custom/social_lazy_loading/social_lazy_loading_images/src/SocialLazyLoadingImageDisplayOverride.php
+++ b/modules/custom/social_lazy_loading/social_lazy_loading_images/src/SocialLazyLoadingImageDisplayOverride.php
@@ -136,7 +136,7 @@ class SocialLazyLoadingImageDisplayOverride implements ConfigFactoryOverrideInte
    * {@inheritdoc}
    */
   public function getCacheSuffix() {
-    return 'SocialLazyLoadingTextFormatOverride';
+    return 'SocialLazyLoadingImageDisplayOverride';
   }
 
 }

--- a/modules/custom/social_lazy_loading/social_lazy_loading_images/src/SocialLazyLoadingImageDisplayOverride.php
+++ b/modules/custom/social_lazy_loading/social_lazy_loading_images/src/SocialLazyLoadingImageDisplayOverride.php
@@ -6,7 +6,6 @@ use Drupal\Core\Cache\CacheableMetadata;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Config\ConfigFactoryOverrideInterface;
 use Drupal\Core\Config\StorageInterface;
-use Drupal\Core\Extension\ModuleHandlerInterface;
 
 /**
  * Class SocialLazyLoadingTextFormatOverride.
@@ -39,20 +38,20 @@ class SocialLazyLoadingImageDisplayOverride implements ConfigFactoryOverrideInte
     $overrides = [];
 
     $config_fields = [
-      // Event
+      // Event.
       'core.entity_view_display.node.event.teaser' => 'field_event_image',
       'core.entity_view_display.node.event.hero' => 'field_event_image',
       'core.entity_view_display.node.event.activity' => 'field_event_image',
       'core.entity_view_display.node.event.activity_comment' => 'field_event_image',
-      // Topic
+      // Topic.
       'core.entity_view_display.node.topic.teaser' => 'field_topic_image',
       'core.entity_view_display.node.topic.activity' => 'field_topic_image',
       'core.entity_view_display.node.topic.activity_comment' => 'field_topic_image',
-      // Page
+      // Page.
       'core.entity_view_display.node.page.teaser' => 'field_page_image',
       'core.entity_view_display.node.page.activity' => 'field_page_image',
       'core.entity_view_display.node.page.activity_comment' => 'field_page_image',
-      // Groups
+      // Groups.
       'core.entity_view_display.group.open_group.teaser' => 'field_group_image',
       'core.entity_view_display.group.open_group.hero' => 'field_group_image',
       'core.entity_view_display.group.secret_group.teaser' => 'field_group_image',
@@ -63,16 +62,15 @@ class SocialLazyLoadingImageDisplayOverride implements ConfigFactoryOverrideInte
       'core.entity_view_display.group.public_group.hero' => 'field_group_image',
       'core.entity_view_display.group.closed_group.teaser' => 'field_group_image',
       'core.entity_view_display.group.closed_group.hero' => 'field_group_image',
-      // Posts
+      // Posts.
       'core.entity_view_display.post.photo.activity' => 'field_post_image',
       'core.entity_view_display.post.photo.activity_comment' => 'field_post_image',
       'core.entity_view_display.post.photo.default' => 'field_post_image',
-      // Comments dont have image fields.
-      // Books
+      // Books.
       'core.entity_view_display.node.book.teaser' => 'field_book_image',
       'core.entity_view_display.node.book.activity' => 'field_book_image',
       'core.entity_view_display.node.book.activity_comment' => 'field_book_image',
-      // Profile
+      // Profile.
       'core.entity_view_display.profile.profile.compact' => 'field_profile_image',
       'core.entity_view_display.profile.profile.compact_notification' => 'field_profile_image',
       'core.entity_view_display.profile.profile.compact_teaser' => 'field_profile_image',

--- a/modules/custom/social_lazy_loading/social_lazy_loading_images/src/SocialLazyLoadingImageDisplayOverride.php
+++ b/modules/custom/social_lazy_loading/social_lazy_loading_images/src/SocialLazyLoadingImageDisplayOverride.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Drupal\social_lazy_loading_images;
+
+use Drupal\Core\Cache\CacheableMetadata;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Config\ConfigFactoryOverrideInterface;
+use Drupal\Core\Config\StorageInterface;
+use Drupal\Core\Extension\ModuleHandlerInterface;
+
+/**
+ * Class SocialLazyLoadingTextFormatOverride.
+ *
+ * @package Drupal\social_lazy_loading_images
+ */
+class SocialLazyLoadingImageDisplayOverride implements ConfigFactoryOverrideInterface {
+
+  /**
+   * The config factory.
+   *
+   * @var \Drupal\Core\Config\ConfigFactoryInterface
+   */
+  protected $configFactory;
+
+  /**
+   * Constructs the configuration override.
+   *
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   The configuration factory.
+   */
+  public function __construct(ConfigFactoryInterface $config_factory) {
+    $this->configFactory = $config_factory;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function loadOverrides($names) {
+    $overrides = [];
+
+    return $overrides;
+  }
+
+  /**
+   * Alters the filter settings for the text format.
+   *
+   * @param string $text_format
+   *   A config name.
+   * @param bool $convert_url
+   *   TRUE if filter should be used.
+   * @param array $overrides
+   *   An override configuration.
+   */
+  protected function addFilterOverride($text_format, $convert_url, array &$overrides) {
+    $config_name = 'filter.format.' . $text_format;
+
+    if ($convert_url) {
+      $config = $this->configFactory->getEditable($config_name);
+      $dependencies = $config->getOriginal('dependencies.module');
+      $overrides[$config_name]['dependencies']['module'] = $dependencies;
+      $overrides[$config_name]['dependencies']['module'][] = 'blazy';
+
+      $overrides[$config_name]['filters']['lazy_filter'] = [
+        'id' => 'lazy_filter',
+        'provider' => 'lazy',
+        'status' => TRUE,
+        'weight' => 999,
+        'settings' => [],
+      ];
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCacheableMetadata($name) {
+    return new CacheableMetadata();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function createConfigObject($name, $collection = StorageInterface::DEFAULT_COLLECTION) {
+    return NULL;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCacheSuffix() {
+    return 'SocialLazyLoadingTextFormatOverride';
+  }
+
+}

--- a/modules/custom/social_lazy_loading/social_lazy_loading_images/src/SocialLazyLoadingImageDisplayOverride.php
+++ b/modules/custom/social_lazy_loading/social_lazy_loading_images/src/SocialLazyLoadingImageDisplayOverride.php
@@ -38,34 +38,82 @@ class SocialLazyLoadingImageDisplayOverride implements ConfigFactoryOverrideInte
   public function loadOverrides($names) {
     $overrides = [];
 
+    $config_fields = [
+      // Event
+      'core.entity_view_display.node.event.teaser' => 'field_event_image',
+      'core.entity_view_display.node.event.hero' => 'field_event_image',
+      'core.entity_view_display.node.event.activity' => 'field_event_image',
+      'core.entity_view_display.node.event.activity_comment' => 'field_event_image',
+      // Topic
+      'core.entity_view_display.node.topic.teaser' => 'field_topic_image',
+      'core.entity_view_display.node.topic.activity' => 'field_topic_image',
+      'core.entity_view_display.node.topic.activity_comment' => 'field_topic_image',
+      // Page
+      'core.entity_view_display.node.page.teaser' => 'field_page_image',
+      'core.entity_view_display.node.page.activity' => 'field_page_image',
+      'core.entity_view_display.node.page.activity_comment' => 'field_page_image',
+      // Groups
+      'core.entity_view_display.group.open_group.teaser' => 'field_group_image',
+      'core.entity_view_display.group.open_group.hero' => 'field_group_image',
+      'core.entity_view_display.group.secret_group.teaser' => 'field_group_image',
+      'core.entity_view_display.group.secret_group.hero' => 'field_group_image',
+      'core.entity_view_display.group.flexible_group.teaser' => 'field_group_image',
+      'core.entity_view_display.group.flexible_group.hero' => 'field_group_image',
+      'core.entity_view_display.group.public_group.teaser' => 'field_group_image',
+      'core.entity_view_display.group.public_group.hero' => 'field_group_image',
+      'core.entity_view_display.group.closed_group.teaser' => 'field_group_image',
+      'core.entity_view_display.group.closed_group.hero' => 'field_group_image',
+      // Posts
+      'core.entity_view_display.post.photo.activity' => 'field_post_image',
+      'core.entity_view_display.post.photo.activity_comment' => 'field_post_image',
+      'core.entity_view_display.post.photo.default' => 'field_post_image',
+      // Comments dont have image fields.
+      // Books
+      'core.entity_view_display.node.book.teaser' => 'field_book_image',
+      'core.entity_view_display.node.book.activity' => 'field_book_image',
+      'core.entity_view_display.node.book.activity_comment' => 'field_book_image',
+      // Profile
+      'core.entity_view_display.profile.profile.compact' => 'field_profile_image',
+      'core.entity_view_display.profile.profile.compact_notification' => 'field_profile_image',
+      'core.entity_view_display.profile.profile.compact_teaser' => 'field_profile_image',
+      'core.entity_view_display.profile.profile.hero' => 'field_profile_image',
+      'core.entity_view_display.profile.profile.small' => 'field_profile_image',
+      'core.entity_view_display.profile.profile.small_teaser' => 'field_profile_image',
+      'core.entity_view_display.profile.profile.table' => 'field_profile_image',
+      'core.entity_view_display.profile.profile.teaser' => 'field_profile_image',
+    ];
+
+    foreach ($config_fields as $config_name => $field_name) {
+      $this->addImageOverride($config_name, $field_name, $overrides);
+    }
+
     return $overrides;
   }
 
   /**
    * Alters the filter settings for the text format.
    *
-   * @param string $text_format
-   *   A config name.
-   * @param bool $convert_url
-   *   TRUE if filter should be used.
+   * @param string $config_name
+   *   A config name to override.
+   * @param string $field_name
+   *   A field to override.
    * @param array $overrides
    *   An override configuration.
    */
-  protected function addFilterOverride($text_format, $convert_url, array &$overrides) {
-    $config_name = 'filter.format.' . $text_format;
-
-    if ($convert_url) {
+  protected function addImageOverride($config_name, $field_name, array &$overrides) {
+    if (!empty($config_name) && !empty($field_name)) {
       $config = $this->configFactory->getEditable($config_name);
       $dependencies = $config->getOriginal('dependencies.module');
       $overrides[$config_name]['dependencies']['module'] = $dependencies;
-      $overrides[$config_name]['dependencies']['module'][] = 'blazy';
+      $overrides[$config_name]['dependencies']['module'][] = 'lazy';
 
-      $overrides[$config_name]['filters']['lazy_filter'] = [
-        'id' => 'lazy_filter',
-        'provider' => 'lazy',
-        'status' => TRUE,
-        'weight' => 999,
-        'settings' => [],
+      $settings = $config->getOriginal('content.' . $field_name . 'third_party_settings');
+
+      $overrides[$config_name]['content'][$field_name]['third_party_settings'] = $settings;
+      $overrides[$config_name]['content'][$field_name]['third_party_settings'] = [
+        'lazy' => [
+          'lazy_image' => '1',
+        ],
       ];
     }
   }


### PR DESCRIPTION
## Problem
Images that aren't necessarily shown to a user are loaded on a full page load. We can also load them after the page is shown. Here comes the lazy loading!

## Solution
We use the lazy loading module to override our image fields and add the lazy loading capability to it.

## Issue tracker
- [ ] https://www.drupal.org/node/3065010

## How to test
- [x] Enable social_lazy_loading and see that for the following it should work:
- [x] Events, pages, books, topics, user & profiles, groups.
- [x] Check all overviews
- [x] Check streams
- [x] Check search

For all of the above the images should be lazy loaded with exception of the images in your viewport or those that are background urls (like the hero).

## Release notes
We have a new addition to our lazy loading module, images that are provided by Open Social can be lazy loaded now by enabling the social_lazy_loading_images module.