### PR TITLE
Issue #3073513 : prevent notices in the search when filter isn't used

### DIFF
--- a/modules/social_features/social_search/src/Plugin/views/filter/SocialDate.php
+++ b/modules/social_features/social_search/src/Plugin/views/filter/SocialDate.php
@@ -31,6 +31,7 @@ class SocialDate extends DateTimeDate {
     }
 
     // Fallback for exposed operator.
+    $operatorfromurl = NULL;
     if ($operator === NULL && $this->realField === 'created') {
       // Check if we have it in the query.
       $operatorfromurl = \Drupal::request()->query->get('created_op');
@@ -39,6 +40,10 @@ class SocialDate extends DateTimeDate {
         $input['created_op'] = $operatorfromurl;
         $this->view->exposed_raw_input = $this->view->getExposedInput();
       }
+    }
+
+    if ($operator === NULL && $operatorfromurl === NULL) {
+      return FALSE;
     }
 
     $return = parent::acceptExposedInput($input);


### PR DESCRIPTION
## Problem
When going to the user search and not using the filter you get a lot of notices.
<img width="1525" alt="notices-in-search" src="https://user-images.githubusercontent.com/2848293/62701034-929d2e00-b9e3-11e9-8de8-dae8fa9bf843.png">


## Solution
We should not call parent::acceptExposedInput when operator is NULL.

## Issue tracker
https://www.drupal.org/project/social/issues/3073513

## How to test
- [x] Go to search users. Don't user the filter for registration date.
- [x] You should see notices (make sure notice error are turned on in your settings/services.yml file)
- [x] Go to this branch and notices are gone.
- [x] Test the filter with all sort of combinations.
- [x] Test the filter on events as well

## Release notes
Not necessary since the filter is not yet released (still only in dev branch)
