### PR TITLE
Flexible group several fixes see issue for d.org issues & Optional UI install.

### DIFF
--- a/modules/social_features/social_group/modules/social_group_flexible_group/config/install/core.entity_view_display.group.flexible_group.hero.yml
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/config/install/core.entity_view_display.group.flexible_group.hero.yml
@@ -4,6 +4,7 @@ dependencies:
   config:
     - core.entity_view_mode.group.hero
     - field.field.group.flexible_group.field_group_address
+    - field.field.group.flexible_group.field_group_allowed_join_method
     - field.field.group.flexible_group.field_group_allowed_visibility
     - field.field.group.flexible_group.field_group_description
     - field.field.group.flexible_group.field_group_image
@@ -53,6 +54,7 @@ content:
 hidden:
   changed: true
   created: true
+  field_group_allowed_join_method: true
   field_group_allowed_visibility: true
   field_group_description: true
   uid: true

--- a/modules/social_features/social_group/modules/social_group_flexible_group/config/install/core.entity_view_display.group.flexible_group.small_teaser.yml
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/config/install/core.entity_view_display.group.flexible_group.small_teaser.yml
@@ -4,6 +4,7 @@ dependencies:
   config:
     - core.entity_view_mode.group.small_teaser
     - field.field.group.flexible_group.field_group_address
+    - field.field.group.flexible_group.field_group_allowed_join_method
     - field.field.group.flexible_group.field_group_allowed_visibility
     - field.field.group.flexible_group.field_group_description
     - field.field.group.flexible_group.field_group_image
@@ -26,6 +27,7 @@ hidden:
   changed: true
   created: true
   field_group_address: true
+  field_group_allowed_join_method: true
   field_group_allowed_visibility: true
   field_group_description: true
   field_group_image: true

--- a/modules/social_features/social_group/modules/social_group_flexible_group/config/install/core.entity_view_display.group.flexible_group.stream.yml
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/config/install/core.entity_view_display.group.flexible_group.stream.yml
@@ -4,6 +4,7 @@ dependencies:
   config:
     - core.entity_view_mode.group.stream
     - field.field.group.flexible_group.field_group_address
+    - field.field.group.flexible_group.field_group_allowed_join_method
     - field.field.group.flexible_group.field_group_allowed_visibility
     - field.field.group.flexible_group.field_group_description
     - field.field.group.flexible_group.field_group_image
@@ -18,6 +19,7 @@ hidden:
   changed: true
   created: true
   field_group_address: true
+  field_group_allowed_join_method: true
   field_group_allowed_visibility: true
   field_group_description: true
   field_group_image: true

--- a/modules/social_features/social_group/modules/social_group_flexible_group/config/install/core.entity_view_display.group.flexible_group.teaser.yml
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/config/install/core.entity_view_display.group.flexible_group.teaser.yml
@@ -4,6 +4,7 @@ dependencies:
   config:
     - core.entity_view_mode.group.teaser
     - field.field.group.flexible_group.field_group_address
+    - field.field.group.flexible_group.field_group_allowed_join_method
     - field.field.group.flexible_group.field_group_allowed_visibility
     - field.field.group.flexible_group.field_group_description
     - field.field.group.flexible_group.field_group_image
@@ -61,5 +62,6 @@ hidden:
   changed: true
   created: true
   field_group_address: true
+  field_group_allowed_join_method: true
   field_group_allowed_visibility: true
   uid: true

--- a/modules/social_features/social_group/modules/social_group_flexible_group/config/install/field.field.group.flexible_group.field_group_address.yml
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/config/install/field.field.group.flexible_group.field_group_address.yml
@@ -6,7 +6,6 @@ dependencies:
     - group.type.flexible_group
   module:
     - address
-    - social_group_flexible_group
 id: group.flexible_group.field_group_address
 field_name: field_group_address
 entity_type: group

--- a/modules/social_features/social_group/modules/social_group_flexible_group/config/install/field.field.group.flexible_group.field_group_description.yml
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/config/install/field.field.group.flexible_group.field_group_description.yml
@@ -5,7 +5,6 @@ dependencies:
     - field.storage.group.field_group_description
     - group.type.flexible_group
   module:
-    - social_group_flexible_group
     - text
 id: group.flexible_group.field_group_description
 field_name: field_group_description

--- a/modules/social_features/social_group/modules/social_group_flexible_group/config/install/field.field.group.flexible_group.field_group_image.yml
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/config/install/field.field.group.flexible_group.field_group_image.yml
@@ -6,7 +6,6 @@ dependencies:
     - group.type.flexible_group
   module:
     - image
-    - social_group_flexible_group
 id: group.flexible_group.field_group_image
 field_name: field_group_image
 entity_type: group

--- a/modules/social_features/social_group/modules/social_group_flexible_group/config/install/field.field.group.flexible_group.field_group_location.yml
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/config/install/field.field.group.flexible_group.field_group_location.yml
@@ -4,8 +4,6 @@ dependencies:
   config:
     - field.storage.group.field_group_location
     - group.type.flexible_group
-  module:
-    - social_group_flexible_group
 id: group.flexible_group.field_group_location
 field_name: field_group_location
 entity_type: group

--- a/modules/social_features/social_group/modules/social_group_flexible_group/config/install/field.field.group_content.flexible_group-group_membership.group_roles.yml
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/config/install/field.field.group_content.flexible_group-group_membership.group_roles.yml
@@ -4,8 +4,6 @@ dependencies:
   config:
     - field.storage.group_content.group_roles
     - group.content_type.flexible_group-group_membership
-  module:
-    - social_group_flexible_group
 id: group_content.flexible_group-group_membership.group_roles
 field_name: group_roles
 entity_type: group_content

--- a/modules/social_features/social_group/modules/social_group_flexible_group/config/install/group.role.flexible_group-83776d798.yml
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/config/install/group.role.flexible_group-83776d798.yml
@@ -6,8 +6,6 @@ dependencies:
   enforced:
     config:
       - user.role.contentmanager
-  module:
-    - social_group_flexible_group
 id: flexible_group-83776d798
 label: 'Content manager'
 weight: 3

--- a/modules/social_features/social_group/modules/social_group_flexible_group/config/install/group.role.flexible_group-a416e6833.yml
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/config/install/group.role.flexible_group-a416e6833.yml
@@ -6,8 +6,6 @@ dependencies:
   enforced:
     config:
       - user.role.administrator
-  module:
-    - social_group_flexible_group
 id: flexible_group-a416e6833
 label: Administrator
 weight: 2

--- a/modules/social_features/social_group/modules/social_group_flexible_group/config/install/group.role.flexible_group-anonymous.yml
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/config/install/group.role.flexible_group-anonymous.yml
@@ -13,3 +13,8 @@ permissions_ui: false
 permissions:
   - 'view group'
   - 'view group stream page'
+  - 'view group_node:event content'
+  - 'view group_node:event entity'
+  - 'view group_node:topic entity'
+  - 'view group_node:topic content'
+  - 'view group_membership content'

--- a/modules/social_features/social_group/modules/social_group_flexible_group/config/install/group.role.flexible_group-anonymous.yml
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/config/install/group.role.flexible_group-anonymous.yml
@@ -3,8 +3,6 @@ status: true
 dependencies:
   config:
     - group.type.flexible_group
-  module:
-    - social_group_flexible_group
 id: flexible_group-anonymous
 label: Anonymous
 weight: -102

--- a/modules/social_features/social_group/modules/social_group_flexible_group/config/install/group.role.flexible_group-ba5854c29.yml
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/config/install/group.role.flexible_group-ba5854c29.yml
@@ -6,8 +6,6 @@ dependencies:
   enforced:
     config:
       - user.role.sitemanager
-  module:
-    - social_group_flexible_group
 id: flexible_group-ba5854c29
 label: 'Site manager'
 weight: 4

--- a/modules/social_features/social_group/modules/social_group_flexible_group/config/install/group.role.flexible_group-group_admin.yml
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/config/install/group.role.flexible_group-group_admin.yml
@@ -3,8 +3,6 @@ status: true
 dependencies:
   config:
     - group.type.flexible_group
-  module:
-    - social_group_flexible_group
 id: flexible_group-group_admin
 label: 'Group Admin'
 weight: 6

--- a/modules/social_features/social_group/modules/social_group_flexible_group/config/install/group.role.flexible_group-group_manager.yml
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/config/install/group.role.flexible_group-group_manager.yml
@@ -3,8 +3,6 @@ status: true
 dependencies:
   config:
     - group.type.flexible_group
-  module:
-    - social_group_flexible_group
 id: flexible_group-group_manager
 label: 'Group Manager'
 weight: -99

--- a/modules/social_features/social_group/modules/social_group_flexible_group/config/install/group.role.flexible_group-member.yml
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/config/install/group.role.flexible_group-member.yml
@@ -3,8 +3,6 @@ status: true
 dependencies:
   config:
     - group.type.flexible_group
-  module:
-    - social_group_flexible_group
 id: flexible_group-member
 label: Member
 weight: -100

--- a/modules/social_features/social_group/modules/social_group_flexible_group/config/install/group.role.flexible_group-outsider.yml
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/config/install/group.role.flexible_group-outsider.yml
@@ -3,8 +3,6 @@ status: true
 dependencies:
   config:
     - group.type.flexible_group
-  module:
-    - social_group_flexible_group
 id: flexible_group-outsider
 label: Outsider
 weight: -101

--- a/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.api.php
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.api.php
@@ -11,7 +11,7 @@
  */
 
 /**
- * Alter an array of routes that require content visibility acces checks.
+ * Alter an array of routes that require content visibility access checks.
  *
  * @param array $content_routes
  *   List of routes that required flexible group content visibility checks.

--- a/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.module
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.module
@@ -261,6 +261,13 @@ function social_group_flexible_group_views_query_alter(ViewExecutable $view, Que
 
   $account = \Drupal::currentUser();
 
+  if (!$account->isAnonymous()) {
+    // Don't trigger page cache, this will cache it for AN
+    // but with LU data.
+    // Dynamic page cache handles this.
+    \Drupal::service('page_cache_kill_switch')->trigger();
+  }
+
   // Don't check, they can see it all.
   if ($account->hasPermission('manage all groups')) {
     return;
@@ -295,10 +302,22 @@ function social_group_flexible_group_views_query_alter(ViewExecutable $view, Que
 
   // AN users can only see flexible groups that are public.
   if ($account->isAnonymous()) {
+    // Add context so for AN it will have a different cache.
+    $view->element['#cache']['contexts'][] = 'user.roles:anonymous';
+    $query->setGroupOperator('OR');
+    // Secret group also alters the query, so lets do it better.
+    if (\Drupal::moduleHandler()->moduleExists('social_group_secret')) {
+      $query->addWhere(1, 'groups_field_data.type', ['flexible_group'], 'NOT IN');
+      $query->addWhere(2, 'groups_field_data.type', ['flexible_group', 'secret_group', 'closed_group', 'open_group'], 'NOT IN');
+      $query->addWhere($new_where, 'field_group_allowed_visibility_value', ['public'], 'IN');
+      $query->addWhere($new_where, 'groups_field_data.type', ['flexible_group'], 'IN');
+      return;
+    }
+
     // Make sure we remove flexible group as an option so only public groups
     // are part of this clause.
     $query->addWhere($current_where, 'groups_field_data.type', ['flexible_group'], 'NOT IN');
-    $query->setGroupOperator('OR');
+
     // OR it is a flexible group but than we only want groups
     // that have the public content visibility for AN users.
     $query->setWhereGroup('AND', $new_where);

--- a/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.module
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.module
@@ -308,7 +308,12 @@ function social_group_flexible_group_views_query_alter(ViewExecutable $view, Que
     // Secret group also alters the query, so lets do it better.
     if (\Drupal::moduleHandler()->moduleExists('social_group_secret')) {
       $query->addWhere(1, 'groups_field_data.type', ['flexible_group'], 'NOT IN');
-      $query->addWhere(2, 'groups_field_data.type', ['flexible_group', 'secret_group', 'closed_group', 'open_group'], 'NOT IN');
+      $query->addWhere(2, 'groups_field_data.type', [
+        'flexible_group',
+        'secret_group',
+        'closed_group',
+        'open_group'
+      ], 'NOT IN');
       $query->addWhere($new_where, 'field_group_allowed_visibility_value', ['public'], 'IN');
       $query->addWhere($new_where, 'groups_field_data.type', ['flexible_group'], 'IN');
       return;

--- a/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.module
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.module
@@ -312,7 +312,7 @@ function social_group_flexible_group_views_query_alter(ViewExecutable $view, Que
         'flexible_group',
         'secret_group',
         'closed_group',
-        'open_group'
+        'open_group',
       ], 'NOT IN');
       $query->addWhere($new_where, 'field_group_allowed_visibility_value', ['public'], 'IN');
       $query->addWhere($new_where, 'groups_field_data.type', ['flexible_group'], 'IN');

--- a/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.module
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.module
@@ -284,12 +284,10 @@ function social_group_flexible_group_views_query_alter(ViewExecutable $view, Que
   $query->addTable('group__field_group_allowed_visibility', $rel, $join, $alias);
 
   /** @var \Drupal\views\Plugin\views\query\Sql $query */
-  $group = count($query->where);
+  $current_where = count($query->where);
 
   // Make sure we add one new group with a where clause.
-  while (isset($query->where[$group])) {
-    $group++;
-  }
+  $new_where = $current_where + 1;
 
   // We need to add our group by using a query tag.
   // Otherwise views doesn't accept it.
@@ -297,7 +295,15 @@ function social_group_flexible_group_views_query_alter(ViewExecutable $view, Que
 
   // AN users can only see flexible groups that are public.
   if ($account->isAnonymous()) {
-    $query->addWhere($group, 'field_group_allowed_visibility_value', ['public'], 'IN');
+    // Make sure we remove flexible group as an option so only public groups
+    // are part of this clause.
+    $query->addWhere($current_where, 'groups_field_data.type', ['flexible_group'], 'NOT IN');
+    $query->setGroupOperator('OR');
+    // OR it is a flexible group but than we only want groups
+    // that have the public content visibility for AN users.
+    $query->setWhereGroup('AND', $new_where);
+    $query->addWhere($new_where, 'field_group_allowed_visibility_value', ['public'], 'IN');
+    $query->addWhere($new_where, 'groups_field_data.type', ['flexible_group'], 'IN');
     return;
   }
 }

--- a/modules/social_features/social_group/modules/social_group_flexible_group/src/Access/FlexibleGroupContentAccessCheck.php
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/src/Access/FlexibleGroupContentAccessCheck.php
@@ -2,7 +2,6 @@
 
 namespace Drupal\social_group_flexible_group\Access;
 
-use Drupal\group\Access\GroupAccessResult;
 use Drupal\group\Entity\GroupInterface;
 use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Routing\Access\AccessInterface;
@@ -53,15 +52,7 @@ class FlexibleGroupContentAccessCheck implements AccessInterface {
     $type = $group->getGroupType();
     // Don't interfere if the group isn't a flexible group.
     if ($type instanceof GroupTypeInterface && $type->id() !== 'flexible_group') {
-      if (!empty($group_permission)) {
-        return GroupAccessResult::allowedIfHasGroupPermissions($group, $account, [$group_permission]);
-      }
-
-      $condition1 = $account->hasPermission('manage all groups');
-      $condition2 = $group->hasPermission('administer members', $account);
-      $condition3 = $group->getMember($account);
-
-      return AccessResult::allowedIf($condition1 || $condition2 || $condition3);
+      return AccessResult::allowed();
     }
 
     // A user with this access can definitely do everything.

--- a/modules/social_features/social_group/modules/social_group_flexible_group/src/Access/FlexibleGroupContentAccessCheck.php
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/src/Access/FlexibleGroupContentAccessCheck.php
@@ -35,19 +35,19 @@ class FlexibleGroupContentAccessCheck implements AccessInterface {
 
     // Don't interfere if no permission was specified.
     if ($permission === NULL) {
-      return AccessResult::neutral();
+      return AccessResult::allowed();
     }
 
     // Don't interfere if no group was specified.
     $parameters = $route_match->getParameters();
     if (!$parameters->has('group')) {
-      return AccessResult::neutral();
+      return AccessResult::allowed();
     }
 
     // Don't interfere if the group isn't a real group.
     $group = $parameters->get('group');
     if (!$group instanceof GroupInterface) {
-      return AccessResult::neutral();
+      return AccessResult::allowed();
     }
 
     $type = $group->getGroupType();

--- a/modules/social_features/social_group/modules/social_group_flexible_group/src/SocialGroupFlexibleGroupConfigOverride.php
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/src/SocialGroupFlexibleGroupConfigOverride.php
@@ -159,18 +159,25 @@ class SocialGroupFlexibleGroupConfigOverride implements ConfigFactoryOverrideInt
 
     $config_name = 'views.view.newest_groups';
 
+    $displays = [
+      'page_all_groups',
+      'block_newest_groups',
+    ];
+
     if (in_array($config_name, $names)) {
-      $overrides[$config_name] = [
-        'display' => [
-          'block_newest_groups' => [
-            'cache_metadata' => [
-              'contexts' => [
-                'user' => 'user',
+      foreach ($displays as $display_name) {
+        $overrides[$config_name] = [
+          'display' => [
+            $display_name=> [
+              'cache_metadata' => [
+                'contexts' => [
+                  'user' => 'user',
+                ],
               ],
             ],
           ],
-        ],
-      ];
+        ];
+      }
     }
 
     $config_name = 'block.block.views_block__group_managers_block_list_managers';

--- a/modules/social_features/social_group/modules/social_group_flexible_group/src/SocialGroupFlexibleGroupConfigOverride.php
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/src/SocialGroupFlexibleGroupConfigOverride.php
@@ -168,7 +168,7 @@ class SocialGroupFlexibleGroupConfigOverride implements ConfigFactoryOverrideInt
       foreach ($displays as $display_name) {
         $overrides[$config_name] = [
           'display' => [
-            $display_name=> [
+            $display_name => [
               'cache_metadata' => [
                 'contexts' => [
                   'user' => 'user',

--- a/modules/social_features/social_group/modules/social_group_secret/social_group_secret.module
+++ b/modules/social_features/social_group/modules/social_group_secret/social_group_secret.module
@@ -58,7 +58,6 @@ function social_group_secret_views_query_alter(ViewExecutable $view, QueryPlugin
   if (social_group_secret_can_view_secret_groups($account)) {
     return;
   }
-
   /** @var \Drupal\group\GroupMembershipLoaderInterface $service */
   $service = \Drupal::service('group.membership_loader');
 
@@ -93,6 +92,8 @@ function social_group_secret_views_query_alter(ViewExecutable $view, QueryPlugin
     }
   }
   else {
+    // Add context so for AN it will have a different cache.
+    $view->element['#cache']['contexts'][] = 'user.roles:anonymous';
     $query->addWhere($group, 'groups_field_data.type', ['secret_group'], 'NOT IN');
   }
 }

--- a/modules/social_features/social_group/modules/social_group_secret/src/SocialGroupSecretConfigOverride.php
+++ b/modules/social_features/social_group/modules/social_group_secret/src/SocialGroupSecretConfigOverride.php
@@ -159,18 +159,25 @@ class SocialGroupSecretConfigOverride implements ConfigFactoryOverrideInterface 
 
     $config_name = 'views.view.newest_groups';
 
+    $displays = [
+      'page_all_groups',
+      'block_newest_groups',
+    ];
+
     if (in_array($config_name, $names)) {
-      $overrides[$config_name] = [
-        'display' => [
-          'block_newest_groups' => [
-            'cache_metadata' => [
-              'contexts' => [
-                'user' => 'user',
+      foreach ($displays as $display_name) {
+        $overrides[$config_name] = [
+          'display' => [
+            $display_name=> [
+              'cache_metadata' => [
+                'contexts' => [
+                  'user' => 'user',
+                ],
               ],
             ],
           ],
-        ],
-      ];
+        ];
+      }
     }
 
     return $overrides;

--- a/modules/social_features/social_group/modules/social_group_secret/src/SocialGroupSecretConfigOverride.php
+++ b/modules/social_features/social_group/modules/social_group_secret/src/SocialGroupSecretConfigOverride.php
@@ -168,7 +168,7 @@ class SocialGroupSecretConfigOverride implements ConfigFactoryOverrideInterface 
       foreach ($displays as $display_name) {
         $overrides[$config_name] = [
           'display' => [
-            $display_name=> [
+            $display_name => [
               'cache_metadata' => [
                 'contexts' => [
                   'user' => 'user',

--- a/social.profile
+++ b/social.profile
@@ -146,6 +146,8 @@ function social_form_install_configure_form_alter(&$form, FormStateInterface $fo
     'dynamic_page_cache' => t('Cache pages for any user (highly recommended)'),
     'social_lets_connect_contact' => t('Adds Open Social Links to the main menu.'),
     'social_lets_connect_usage' => t('Shares usage data to the Open Social team.'),
+    'social_group_flexible_group' => t('Flexible group functionality'),
+    'social_group_secret' => t('Secret group functionality'),
   ];
 
   // Checkboxes to enable Optional modules.
@@ -161,6 +163,7 @@ function social_form_install_configure_form_alter(&$form, FormStateInterface $fo
       'social_search_autocomplete',
       'social_lets_connect_contact',
       'social_lets_connect_usage',
+      'social_group_flexible_group',
     ],
   ];
 


### PR DESCRIPTION
## Problem
Flexible group and secret group are not available to enable during installation. Mostly curious to see if there are any regressions with these module(s) enabled.

## Solution
Let's add those options and let's install flexible group by default.

## Issue tracker
https://www.drupal.org/project/social/issues/3081610
https://www.drupal.org/project/social/issues/3074028
https://www.drupal.org/project/social/issues/3074032

## How to test
- [ ] Travis is passing
- [ ] You can install it when doing a UI installation.
- [ ] Issues are tested. 

## Release notes
We have fixed several individual tickets and have added flexible groups to the profile for installation through UI.