### PR TITLE
Issue #3075687 by mdeny: Social registration fields module

### DIFF
--- a/modules/social_features/social_profile/modules/social_registration_fields/social_registration_fields.features.yml
+++ b/modules/social_features/social_profile/modules/social_registration_fields/social_registration_fields.features.yml
@@ -1,0 +1,2 @@
+bundle: social
+required: true

--- a/modules/social_features/social_profile/modules/social_registration_fields/social_registration_fields.info.yml
+++ b/modules/social_features/social_profile/modules/social_registration_fields/social_registration_fields.info.yml
@@ -1,0 +1,9 @@
+name: 'Social registration fields'
+description: 'Provides possibility to add profile fields to registration form.'
+type: module
+core: 8.x
+configure: social_registration_fields.settings
+dependencies:
+  - social:social_profile
+  - drupal:user
+package: Social

--- a/modules/social_features/social_profile/modules/social_registration_fields/social_registration_fields.links.menu.yml
+++ b/modules/social_features/social_profile/modules/social_registration_fields/social_registration_fields.links.menu.yml
@@ -1,0 +1,5 @@
+social_registration_fields.settings:
+ title: 'Registration fields settings'
+ description: 'Registration fields settings for Profile module.'
+ route_name: social_registration_fields.settings
+ parent: user.admin_index

--- a/modules/social_features/social_profile/modules/social_registration_fields/social_registration_fields.module
+++ b/modules/social_features/social_profile/modules/social_registration_fields/social_registration_fields.module
@@ -1,0 +1,136 @@
+<?php
+
+/**
+ * @file
+ * The Social registration fields module file.
+ */
+
+use Drupal\Core\Entity\Entity\EntityFormDisplay;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Render\Element;
+use Drupal\profile\Entity\Profile;
+use Drupal\profile\Entity\ProfileType;
+
+/**
+ * Implements hook_form_FORM_ID_alter().
+ */
+function social_registration_fields_form_user_register_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+  $language = \Drupal::languageManager()->getDefaultLanguage()->getId();
+  $profile_type = ProfileType::load('profile');
+
+  $property = ['profiles', $profile_type->id()];
+  $profile = $form_state->get($property);
+
+  if (empty($profile)) {
+    $profile = Profile::create([
+      'type' => $profile_type->id(),
+      'langcode' => $profile_type->language() ? $profile_type->language() : $language,
+    ]);
+
+    // Attach profile entity form.
+    $form_state->set($property, $profile);
+  }
+
+  $max_weight = 0;
+  foreach ($form['account'] as $field_key => $account_field) {
+    if (
+      is_array($account_field) &&
+      isset($account_field['#weight']) &&
+      !empty($account_field['#weight']) &&
+      $field_key !== 'captcha' &&
+      $field_key !== 'data_policy'
+    ) {
+
+      if ($account_field['#weight'] > $max_weight) {
+        $max_weight = $account_field['#weight'];
+      }
+    }
+  }
+
+  $form_state->set('form_display_' . $profile_type->id(), EntityFormDisplay::collectRenderDisplay($profile, 'default'));
+  $form['account']['entity_' . $profile_type->id()] = [
+    '#type' => 'details',
+    '#tree' => TRUE,
+    '#parents' => ['entity_' . $profile_type->id()],
+    '#weight' => $max_weight + 0.5,
+    '#open' => TRUE,
+  ];
+  $form_state
+    ->get('form_display_' . $profile_type->id())
+    ->buildForm($profile, $form['account']['entity_' . $profile_type->id()], $form_state);
+
+  $reg_fields_settings = \Drupal::config('social_registration_fields.settings')->get();
+  if (!isset($reg_fields_settings) || empty($reg_fields_settings) || !is_array($reg_fields_settings)) {
+    unset($form['account']['entity_' . $profile_type->id()]);
+  }
+
+  // Do not display profile fields if they are not in the settings array.
+  foreach ($form['account']['entity_' . $profile_type->id()] as $form_item_key => $form_item) {
+    if (!isset($reg_fields_settings[$form_item_key]) && substr($form_item_key, 0, 5) === 'field') {
+      unset($form['account']['entity_' . $profile_type->id()][$form_item_key]);
+    }
+  }
+
+  foreach ($reg_fields_settings as $reg_field_key => $reg_field_settings) {
+    if (isset($form['account']['entity_' . $profile_type->id()][$reg_field_key])) {
+      if (!$reg_field_settings['show_on_signup']) {
+        unset($form['account']['entity_' . $profile_type->id()][$reg_field_key]);
+      }
+      elseif ($reg_field_settings['mandatory']) {
+        social_registration_make_field_required($form['account']['entity_' . $profile_type->id()][$reg_field_key]);
+      }
+    }
+  }
+
+  $form['#validate'][] = 'social_registration_form_user_register_form_validate';
+  $form['actions']['submit']['#submit'][] = 'social_registration_fields_form_user_register_form_submit';
+}
+
+/**
+ * Recursively set the required attribute of a form field.
+ */
+function social_registration_make_field_required(&$elements) {
+  foreach (Element::children($elements) as $key) {
+    // Recurse through all children elements.
+    social_registration_make_field_required($elements[$key]);
+  }
+
+  $elements['#required'] = TRUE;
+}
+
+/**
+ * Extra form submission handler for the user registration form.
+ */
+function social_registration_fields_form_user_register_form_submit($form, FormStateInterface $form_state) {
+  /** @var \Drupal\Core\Session\AccountInterface $account */
+  $account = $form_state->getFormObject()->getEntity();
+
+  if ($account->id()) {
+    $storage = \Drupal::entityTypeManager()->getStorage('profile');
+    $profiles = $storage->loadByProperties(['uid' => $account->id()]);
+
+    if (!empty($profiles)) {
+      foreach ($profiles as $entity) {
+        $form_display = $form_state->get('form_display_' . $entity->bundle());
+        $form_display->extractFormValues($entity, $form['account']['entity_' . $entity->bundle()], $form_state);
+        $entity->save();
+      }
+    }
+  }
+
+  $account->save();
+}
+
+/**
+ * Extra form validation handler for the user registration form.
+ */
+function social_registration_form_user_register_form_validate(array &$form, FormStateInterface $form_state) {
+  $profiles = $form_state->get('profiles');
+  if (!empty($profiles)) {
+    foreach ($profiles as $bundle => $entity) {
+      $form_display = $form_state->get('form_display_' . $bundle);
+      $form_display->extractFormValues($entity, $form['account']['entity_' . $bundle], $form_state);
+      $form_display->validateFormValues($entity, $form['account']['entity_' . $bundle], $form_state);
+    }
+  }
+}

--- a/modules/social_features/social_profile/modules/social_registration_fields/social_registration_fields.module
+++ b/modules/social_features/social_profile/modules/social_registration_fields/social_registration_fields.module
@@ -76,10 +76,20 @@ function social_registration_fields_form_user_register_form_alter(&$form, FormSt
       if (!$reg_field_settings['show_on_signup']) {
         unset($form['account']['entity_' . $profile_type->id()][$reg_field_key]);
       }
-      elseif ($reg_field_settings['mandatory']) {
+      elseif (!empty($reg_field_settings['mandatory'])) {
         social_registration_make_field_required($form['account']['entity_' . $profile_type->id()][$reg_field_key]);
       }
     }
+  }
+
+  // TODO: Make it more dynamic and define a structure for field overrides.
+  // TODO: Remove the hard coded of machine name of address field.
+  // Get the field overrides defined in config and pass it on for modification.
+  // We are changing the address field's field_override options in 'profile'.
+  // @see https://bitbucket.org/goalgorilla/gpbr_core/src/master/config/install/social_registration_fields.settings.yml
+  if (array_key_exists('field_profile_address', $reg_fields_settings) &&
+    $field_overrides = array_column($reg_fields_settings, 'field_overrides')) {
+    social_registration_enable_field_overrides($field_overrides, $form['account']['entity_' . $profile_type->id()]['field_profile_address']);
   }
 
   $form['#validate'][] = 'social_registration_form_user_register_form_validate';
@@ -131,6 +141,34 @@ function social_registration_form_user_register_form_validate(array &$form, Form
       $form_display = $form_state->get('form_display_' . $bundle);
       $form_display->extractFormValues($entity, $form['account']['entity_' . $bundle], $form_state);
       $form_display->validateFormValues($entity, $form['account']['entity_' . $bundle], $form_state);
+    }
+  }
+}
+
+/**
+ * Apply the field overrides defined in social_registration_field.settings.
+ *
+ * @param array $field_overrides
+ *   The overrides defined in config file.
+ * @param array $address_element
+ *   'Profile' entity address field element.
+ *
+ * @see \social_registration_fields_form_user_register_form_alter()
+ */
+function social_registration_enable_field_overrides(array $field_overrides, array &$address_element) {
+  foreach ($field_overrides[0] as $property => $override) {
+    $address_element['widget'][0]['address']['#field_overrides'][$property] = $override;
+  }
+}
+
+/**
+ * Implements hook_form_FORM_ID_alter().
+ */
+function social_registration_fields_form_profile_profile_edit_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+  $reg_fields_settings = \Drupal::config('social_registration_fields.settings')->get();
+  foreach ($reg_fields_settings as $reg_field_key => $reg_field_settings) {
+    if (isset($form[$reg_field_key]) && !empty($reg_field_settings['mandatory'])) {
+      social_registration_make_field_required($form[$reg_field_key]);
     }
   }
 }

--- a/modules/social_features/social_profile/modules/social_registration_fields/social_registration_fields.routing.yml
+++ b/modules/social_features/social_profile/modules/social_registration_fields/social_registration_fields.routing.yml
@@ -1,0 +1,7 @@
+social_registration_fields.settings:
+  path: '/admin/config/people/social-registration-fields'
+  defaults:
+    _form: '\Drupal\social_registration_fields\Form\SocialRegistrationFieldsSettingsForm'
+    _title: 'Social registration fields settings'
+  requirements:
+    _permission: 'administer site configuration'

--- a/modules/social_features/social_profile/modules/social_registration_fields/social_registration_fields.routing.yml
+++ b/modules/social_features/social_profile/modules/social_registration_fields/social_registration_fields.routing.yml
@@ -4,4 +4,4 @@ social_registration_fields.settings:
     _form: '\Drupal\social_registration_fields\Form\SocialRegistrationFieldsSettingsForm'
     _title: 'Social registration fields settings'
   requirements:
-    _permission: 'administer site configuration'
+    _permission: 'administer users'

--- a/modules/social_features/social_profile/modules/social_registration_fields/src/Form/SocialRegistrationFieldsSettingsForm.php
+++ b/modules/social_features/social_profile/modules/social_registration_fields/src/Form/SocialRegistrationFieldsSettingsForm.php
@@ -1,0 +1,131 @@
+<?php
+
+namespace Drupal\social_registration_fields\Form;
+
+use Drupal\Core\Entity\EntityFieldManagerInterface;
+use Drupal\Core\Field\FieldConfigInterface;
+use Drupal\Core\Form\ConfigFormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Class SocialRegistrationFieldsSettingsForm.
+ */
+class SocialRegistrationFieldsSettingsForm extends ConfigFormBase {
+
+  /**
+   * The entity field manager.
+   *
+   * @var \Drupal\Core\Entity\EntityFieldManagerInterface
+   */
+  protected $entityFieldManager;
+
+  /**
+   * Class constructor.
+   */
+  public function __construct(ConfigFactoryInterface $config_factory, EntityFieldManagerInterface $entity_field_manager) {
+    parent::__construct($config_factory);
+    $this->entityFieldManager = $entity_field_manager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('config.factory'),
+      $container->get('entity_field.manager')
+    );
+  }
+
+  /**
+   * Config settings.
+   *
+   * @var string
+   */
+  const SETTINGS = 'social_registration_fields.settings';
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getEditableConfigNames() {
+    return [
+      static::SETTINGS,
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'social_registration_fields_settings';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    $config = $this->config(static::SETTINGS);
+
+    $field_instances = array_filter($this->entityFieldManager->getFieldDefinitions('profile', 'profile'), function ($field_definition) {
+      return ($field_definition instanceof FieldConfigInterface && $field_definition->get('field_type') !== 'text_long');
+    });
+
+    $storage = $form_state->getStorage();
+    $storage['field_instances'] = $field_instances;
+    $form_state->setStorage($storage);
+
+    $form['social_register_fields'] = [
+      '#type' => 'table',
+      '#header' => [
+        $this->t('Field label'),
+        $this->t('Show on sign-up form'),
+        $this->t('Set as mandatory'),
+      ],
+    ];
+
+    foreach ($field_instances as $field_key => $field_instance) {
+      $form['social_register_fields'][$field_key]['label'] = [
+        '#markup' => $field_instance->label(),
+      ];
+
+      $form['social_register_fields'][$field_key]['show_on_signup'] = [
+        '#type' => 'checkbox',
+        '#default_value' => $config->get($field_key)['show_on_signup'],
+        '#id' => $field_key . '_show_on_signup',
+      ];
+
+      $form['social_register_fields'][$field_key]['mandatory'] = [
+        '#type' => 'checkbox',
+        '#default_value' => $config->get($field_key)['mandatory'],
+        '#states' => [
+          'disabled' => [
+            '#' . $field_key . '_show_on_signup' => ['checked' => FALSE],
+          ],
+        ],
+      ];
+    }
+
+    return parent::buildForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    $field_instances = $form_state->getStorage()['field_instances'];
+
+    foreach ($field_instances as $field_key => $field_instance) {
+      $this->configFactory->getEditable(static::SETTINGS)
+        ->set($field_key, [
+          'show_on_signup' => $form_state->getValue('social_register_fields')[$field_key]['show_on_signup'],
+          'mandatory' => $form_state->getValue('social_register_fields')[$field_key]['mandatory'],
+        ])
+        ->save();
+    }
+
+    parent::submitForm($form, $form_state);
+  }
+
+}


### PR DESCRIPTION
## Problem
As a SM I want to see profile fields in the signup form

## Solution
Implement module which adds the possibility to display profile fields on the sign up form

## Issue tracker
https://jira.goalgorilla.com/browse/FOR-256
https://www.drupal.org/project/social/issues/3075687

## How to test
- [ ] Enable social_registration_fields module
- [ ] Go to /admin/config/people/social-registration-fields
- [ ] Set First name and Last name fields Show on sign-up form. Set First name field as a mandatory. Save the form
- [ ] Go to the sign up form
- [ ] You should see First name and Last name fields with First name field as a mandatory

## Release notes
Adds the possibility to display profile fields on the sign up form.
