### PR TITLE
Issue #3075758 by Kingdutch: Notification creation has fatal error if…

### DIFF
--- a/modules/custom/activity_creator/src/ActivityFactory.php
+++ b/modules/custom/activity_creator/src/ActivityFactory.php
@@ -282,12 +282,14 @@ class ActivityFactory extends ControllerBase {
       $comment_storage = \Drupal::entityTypeManager()->getStorage('comment');
       // @TODO: Check if comment published?
       $comment = $comment_storage->load($related_object['target_id']);
-      $parent_comment = $comment->getParentComment();
-      if (!empty($parent_comment)) {
-        $related_object = [
-          'target_type' => $parent_comment->getEntityTypeId(),
-          'target_id' => $parent_comment->id(),
-        ];
+      if ($comment) {
+        $parent_comment = $comment->getParentComment();
+        if (!empty($parent_comment)) {
+          $related_object = [
+            'target_type' => $parent_comment->getEntityTypeId(),
+            'target_id' => $parent_comment->id(),
+          ];
+        }
       }
     }
     // We return commented entity as related object for all other comments.


### PR DESCRIPTION
… comment has been deleted

<h2>Problem</h2>

https://github.com/goalgorilla/open_social/blob/8.x-7.x/modules/custom/activity_creator/src/ActivityFactory.php#L284 

This doesn't check if the comment still exists. This can cause <code>getParentEntity</code> to be called on <code>NULL</code> which causes a fatal error.

<h2>Solution</h2>
Mirror the code that's used in the next if statement and guard for a deleted comment.

## Issue tracker
https://www.drupal.org/project/social/issues/3075758

## How to test
- [ ] Disable automatic cron
- [ ] Reply to a comment
- [ ] Run cron manually
- [ ] See that no error occurs

## Release notes
An error in creating notifications could occur when a reply was deleted before its notification was created. This has been resolved.