### PR TITLE
Issue #3075818 by Kingdutch: Exports don't support applications runni…

### DIFF
--- a/modules/social_features/social_event/modules/social_event_enrolments_export/src/Plugin/Action/ExportEnrolments.php
+++ b/modules/social_features/social_event/modules/social_event_enrolments_export/src/Plugin/Action/ExportEnrolments.php
@@ -49,10 +49,9 @@ class ExportEnrolments extends ExportUser {
   /**
    * {@inheritdoc}
    */
-  public function getFileTemporaryPath() {
+  protected function generateFilePath() : string {
     $hash = md5(microtime(TRUE));
-    $filename = 'export-enrollments-' . substr($hash, 20, 12) . '.csv';
-    return file_directory_temp() . '/' . $filename;
+    return 'export-enrollments-' . substr($hash, 20, 12) . '.csv';
   }
 
   /**

--- a/modules/social_features/social_group/modules/social_group_members_export/src/Plugin/Action/ExportMember.php
+++ b/modules/social_features/social_group/modules/social_group_members_export/src/Plugin/Action/ExportMember.php
@@ -48,10 +48,9 @@ class ExportMember extends ExportUser {
   /**
    * {@inheritdoc}
    */
-  public function getFileTemporaryPath() {
+  protected function generateFilePath() : string {
     $hash = md5(microtime(TRUE));
-    $filename = 'export-members-' . substr($hash, 20, 12) . '.csv';
-    return file_directory_temp() . '/' . $filename;
+    return 'export-members-' . substr($hash, 20, 12) . '.csv';
   }
 
 }


### PR DESCRIPTION
…ng on multiple servers

This changes the way the file path for exports are determined. By only
storing the path relative to the temporary directory it's possible for
the location of the temporary directory to change. This can happen when
multiple web-servers handle the same export and use a file mount of a
shared file system. In this case the mounting point could be on a
different path containing the export file. Storing the absolute path at
the start of the export would break in this case.

This commit also changes the visibility of the path functions because
these are implementation details of the export and should not be queried
outside of the export.

<h2>Problem</h2>
The UserExport (and MemberExport and EventExport) store the full path to the export file on the first tick of the export. However, if the export happens on an install that is served by multiple instances with a loadbalancer (e.g. Pantheon) then the name of file mounts could change. This breaks the export while it's being performed.

<h2>Solution</h2>
Only determine the file name and path relative to the temporary directory in the first tick. In each subsequent tick re-create the full-path from this relative path and the temporary directory for that application instance. This ensures that if a different application instance handles the request the proper path to the shared file mount is used.

## Issue tracker
https://www.drupal.org/project/social/issues/3075818

## How to test
- [ ] Export a lot of users (1500+) on a distributed system (e.g. Pantheon)

## Release notes
Exports of large quantities of entities no longer fail on Open Social set-ups with multiple webservers serving the same export.

## Change Record
https://www.drupal.org/node/3075827
