### PR TITLE
Issue #3075854 by jaapjan: defensive coding in the activity token handling

### DIFF
--- a/modules/social_features/social_activity/social_activity.tokens.inc
+++ b/modules/social_features/social_activity/social_activity.tokens.inc
@@ -49,57 +49,59 @@ function social_activity_tokens($type, $tokens, array $data, array $options, Bub
             $entity = \Drupal::entityTypeManager()->getStorage($target_type)
               ->load($target_id);
 
-            if ($target_type === 'post') {
-              /** @var \Drupal\social_post\Entity\PostInterface $entity */
-              $name = $entity->getOwner()->getDisplayName();
+            if ($entity) {
+              if ($target_type === 'post') {
+                /** @var \Drupal\social_post\Entity\PostInterface $entity */
+                $name = $entity->getOwner()->getDisplayName();
 
-              $date_formatter = \Drupal::service('date.formatter');
-              $date_format = 'social_long_date';
-              $date = $date_formatter->format($entity->getCreatedTime(), $date_format);
+                $date_formatter = \Drupal::service('date.formatter');
+                $date_format = 'social_long_date';
+                $date = $date_formatter->format($entity->getCreatedTime(), $date_format);
 
-              if ($entity->hasField('field_post') && !$entity->field_post->isEmpty()) {
-                $summary = _social_comment_get_summary($entity->field_post->value);
-              }
+                if ($entity->hasField('field_post') && !$entity->field_post->isEmpty()) {
+                  $summary = _social_comment_get_summary($entity->field_post->value);
+                }
 
-              $post_link = Url::fromRoute('entity.post.canonical',
-                ['post' => $entity->id()],
-                ['absolute' => TRUE]
-              )->toString();
-
-              $info = [
-                '#theme' => 'message_post_teaser',
-                '#name' => $name,
-                '#date' => $date,
-                '#summary' => $summary,
-                '#link' => $post_link,
-              ];
-
-              $replacements[$original] = \Drupal::service('renderer')->renderPlain($info);
-            }
-            elseif ($target_type === 'group_content') {
-              /** @var \Drupal\group\Entity\GroupContentInterface $entity */
-              $group_content_type = $entity->getGroupContentType();
-
-              if (!empty($group_content_type)) {
-                $display_name = mb_strtolower($group_content_type->label());
-              }
-
-              /* @var \Drupal\node\NodeInterface $node */
-              $node = $entity->getEntity();
-
-              if (in_array($node->getType(), ['topic', 'event'])) {
-                $link = Url::fromRoute('entity.node.canonical',
-                  ['node' => $node->id()],
+                $post_link = Url::fromRoute('entity.post.canonical',
+                  ['post' => $entity->id()],
                   ['absolute' => TRUE]
                 )->toString();
 
                 $info = [
-                  '#theme' => 'message_node_teaser',
-                  '#link' => $link,
-                  '#type' => $display_name,
+                  '#theme' => 'message_post_teaser',
+                  '#name' => $name,
+                  '#date' => $date,
+                  '#summary' => $summary,
+                  '#link' => $post_link,
                 ];
 
                 $replacements[$original] = \Drupal::service('renderer')->renderPlain($info);
+              }
+              elseif ($target_type === 'group_content') {
+                /** @var \Drupal\group\Entity\GroupContentInterface $entity */
+                $group_content_type = $entity->getGroupContentType();
+
+                if ($group_content_type !== NULL) {
+                  $display_name = mb_strtolower($group_content_type->label());
+                }
+
+                /* @var \Drupal\node\NodeInterface $node */
+                $node = $entity->getEntity();
+
+                if (in_array($node->getType(), ['topic', 'event'])) {
+                  $link = Url::fromRoute('entity.node.canonical',
+                    ['node' => $node->id()],
+                    ['absolute' => TRUE]
+                  )->toString();
+
+                  $info = [
+                    '#theme' => 'message_node_teaser',
+                    '#link' => $link,
+                    '#type' => $display_name,
+                  ];
+
+                  $replacements[$original] = \Drupal::service('renderer')->renderPlain($info);
+                }
               }
             }
           }


### PR DESCRIPTION
## Problem
Error in notification window when group or groupcontent is missing (still to be determined what exact root cause is).

## Solution
Let's make the token handling a bit more defensive.

## Issue tracker
https://www.drupal.org/project/social/issues/3075854

## How to test
- [ ] Open a site with this error.
- [ ] Apply the patch and verify that the error is solved.
- [ ] Dive some more into the root issue. Is this good enough? Why is this happening? Do we need to fix the root cause as well?

## Release notes
If there is a notification in the notification bar for a group or group content item which does not exist anymore the token replacement code should not crash. The code is now more defensive and thus will prevent the site from breaking on the menu bar resulting in missing content and blocks.

## Change Record
not needed
