### PR TITLE
Issue #3076279 by agami4: Update dropdown width

### DIFF
--- a/themes/socialbase/assets/css/dropdown.css
+++ b/themes/socialbase/assets/css/dropdown.css
@@ -26,7 +26,7 @@
   z-index: 1000;
   display: none;
   float: left;
-  min-width: 160px;
+  min-width: 275px;
   max-width: 500px;
   padding: 5px 0;
   margin: 2px 0 0;

--- a/themes/socialbase/components/03-molecules/dropdown/dropdown.scss
+++ b/themes/socialbase/components/03-molecules/dropdown/dropdown.scss
@@ -53,7 +53,7 @@
   z-index: $zindex-dropdown;
   display: none; // none by default, but block on "open" of the menu
   float: left;
-  min-width: 160px;
+  min-width: 275px;
   max-width: 500px;
   padding: 5px 0;
   margin: 2px 0 0; // override default ul


### PR DESCRIPTION
## Problem
If dropdown of notification menu does not have messages, arrow on 'All notifications' button jumps to a new row

## Solution
Should increase width for this dropdown

## Issue tracker
https://www.drupal.org/project/social/issues/3076279

## How to test
- [x] Open dropdown of notification menu
- [x] If you have messages, please remove those messages and you can see 'min-width' 275px for dropdown
- [x] Arrow on 'All notifications' button doest not jump to a new row

## Release notes
Update 'min-width' for all dropdown.

