### PR TITLE
issue #3069371 by albertoalaejos: The mention in a email notification…

### DIFF
--- a/modules/social_features/social_activity/social_activity.tokens.inc
+++ b/modules/social_features/social_activity/social_activity.tokens.inc
@@ -69,12 +69,12 @@ function social_activity_tokens($type, $tokens, array $data, array $options, Bub
                   ['absolute' => TRUE]
                 )->toString();
 
-                $string_parts = preg_split("/(\[\~\d+\])/", $summary, -1, PREG_SPLIT_DELIM_CAPTURE  | PREG_SPLIT_NO_EMPTY);
+                $string_parts = preg_split("/(\[\~\d+\])/", $summary, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY);
 
                 $summary = "";
                 foreach ($string_parts as $string_part) {
-                  if (strpos($string_part, '[~') !== false
-                    && strpos($string_part, ']') !== false) {
+                  if (strpos($string_part, '[~') !== FALSE
+                    && strpos($string_part, ']') !== FALSE) {
                     $profile_id = substr($string_part, 2, -1);
                     $query = Database::getConnection()->select('profile', 'p');
                     $query->fields('p', ['uid']);
@@ -83,11 +83,11 @@ function social_activity_tokens($type, $tokens, array $data, array $options, Bub
                     if (!empty($user_id)) {
                       $user = User::load($user_id);
                       $mention = $user->getDisplayName();
-                      $summary.=$mention;
+                      $summary .= $mention;
                     }
                   }
                   else {
-                    $summary.=$string_part;
+                    $summary .= $string_part;
                   }
                 }
 

--- a/modules/social_features/social_activity/social_activity.tokens.inc
+++ b/modules/social_features/social_activity/social_activity.tokens.inc
@@ -5,8 +5,10 @@
  * Builds placeholder replacement tokens for Social Activity module.
  */
 
+use Drupal\Core\Database\Database;
 use Drupal\Core\Render\BubbleableMetadata;
 use Drupal\Core\Url;
+use Drupal\user\Entity\User;
 
 /**
  * Implements hook_token_info().
@@ -66,6 +68,28 @@ function social_activity_tokens($type, $tokens, array $data, array $options, Bub
                   ['post' => $entity->id()],
                   ['absolute' => TRUE]
                 )->toString();
+
+                $string_parts = preg_split("/(\[\~\d+\])/", $summary, -1, PREG_SPLIT_DELIM_CAPTURE  | PREG_SPLIT_NO_EMPTY);
+
+                $summary = "";
+                foreach ($string_parts as $string_part) {
+                  if (strpos($string_part, '[~') !== false
+                    && strpos($string_part, ']') !== false) {
+                    $profile_id = substr($string_part, 2, -1);
+                    $query = Database::getConnection()->select('profile', 'p');
+                    $query->fields('p', ['uid']);
+                    $query->condition('profile_id', $profile_id);
+                    $user_id = $query->execute()->fetchField();
+                    if (!empty($user_id)) {
+                      $user = User::load($user_id);
+                      $mention = $user->getDisplayName();
+                      $summary.=$mention;
+                    }
+                  }
+                  else {
+                    $summary.=$string_part;
+                  }
+                }
 
                 $info = [
                   '#theme' => 'message_post_teaser',


### PR DESCRIPTION
## Problem
The new email notifications show a piece of the post/comment/reply. When mentioning someone in the post, it is shown as a number (e.g. [~45]) in the email notification.

## Solution
Replace the number (which is the profile id) with its related username before the email is sent.

## Issue tracker
https://www.drupal.org/project/social/issues/3069371

## How to test
- [ ] Login as LU
- [ ] Post in a group including mentions in the post
- [ ] Check that email notifications are sent (social_mailcatcher)
- [ ] Make sure that the mention does not show as a number anymore