### PR TITLE
TB-2767: Replaced individual ::load calls in loop with ::loadMultiple.

### DIFF
--- a/modules/social_features/social_group/social_group.module
+++ b/modules/social_features/social_group/social_group.module
@@ -480,7 +480,7 @@ function social_group_group_insert(GroupInterface $group) {
       // Then we grant this user de Group Admin role.
       $grant_group_admin = TRUE;
     }
-    // When a CM+ creates a group, he is given the group_manager role
+    // When a CM+ creates a group, it is given the group_manager role
     // alongside the group_admin role to keep the full control over the group.
     if ($grant_group_admin) {
       // Delete the initial created membership.
@@ -1299,7 +1299,7 @@ function social_group_block_access(Block $block, $operation, AccountInterface $a
     }
     elseif (!$group->getMember($user)) {
       // If it is closed and the current user is not an member of this group,
-      // then he is not allowed to see these blocks.
+      // then it is not allowed to see these blocks.
       $forbidden_blocks = [
         'views_block:upcoming_events-upcoming_events_group',
         'views_block:latest_topics-group_topics_block',
@@ -1362,7 +1362,7 @@ function _social_group_delete_group() {
     // See /social_group/src/Controller/DeleteGroup.php for further process.
     $batch = [
       'title' => t('Deleting the group and all the content within the group...'),
-      'init_message' => t("Preparing to delete the group and all it\'s topic\'s, event\'s and post\'s..."),
+      'init_message' => t("Preparing to delete the group and all it's topic's, event's and post's..."),
       'operations' => [
         [
           '\Drupal\social_group\Controller\DeleteGroup::deleteGroupAndContent',
@@ -1399,7 +1399,7 @@ function social_group_get_all_groups() {
  * Get all group memberships for a certain user.
  *
  * @param int $uid
- *   The UID for which we fetch the groups he is member of.
+ *   The UID for which we fetch the groups it is member of.
  *
  * @return array
  *   List of group IDs the user is member of.
@@ -1706,7 +1706,7 @@ function social_group_social_user_account_header_create_links($context) {
   // Create url to create a group.
   $route_add_group = Url::fromRoute('entity.group.add_page');
 
-  // If we have a user to work with, we can check if we should redirect him to
+  // If we have a user to work with, we can check if we should redirect it to
   // the create group overview or a single group.
   // If we do not have a user we'll default to the overview.
   if (!empty($context['user'])) {

--- a/modules/social_features/social_group/src/Controller/DeleteGroup.php
+++ b/modules/social_features/social_group/src/Controller/DeleteGroup.php
@@ -19,16 +19,16 @@ class DeleteGroup {
    */
   public static function deleteGroupAndContent($nids, $posts, &$context) {
     $results = [];
-    // Load each node and delete it.
-    foreach ($nids as $nid) {
-      $node = Node::load($nid);
+    // Load all nodes and delete them.
+    $nodes = Node::loadMultiple($nids);
+    foreach ($nodes as $node) {
       $message = t('Delete @type "@title"', ['@type' => $node->getType(), '@title' => $node->getTitle()]);
       $results[] = $node->delete();
     }
     // Load each post and delete it.
-    foreach ($posts as $post_id) {
-      $post = Post::load($post_id);
-      $message = t("Deleting @type\'s", ['@type' => $post->bundle()]);
+    $posts = Post::loadMultiple($posts);
+    foreach ($posts as $post) {
+      $message = t("Deleting @type's", ['@type' => $post->bundle()]);
       $results[] = $post->delete();
     }
     $context['message'] = $message;


### PR DESCRIPTION
## Problem
We had calls Entity::load() in a foreach at \Drupal\social_group\Controller\DeleteGroup::deleteGroupAndContent lines 24 and 30.

## Solution
Replace them with Entity::loadMultiple() outside the loop.

## Issue tracker
https://getopensocial.atlassian.net/browse/TB-2767

## How to test
- [ ] Delete any group.
- [ ] Observe the batch messages.
- [ ] Behaviour should be same.

## Release notes
N.A
## Change Record
N.A