### PR TITLE
TB-2773: Replaced triple for each loop with a database query to extract file's parent properties.

### DIFF
--- a/modules/custom/download_count/download_count.module
+++ b/modules/custom/download_count/download_count.module
@@ -9,9 +9,10 @@
 
 use Drupal\Component\Utility\Unicode;
 use Drupal\Core\Database\Database;
-use Drupal\Core\Entity\EntityStorageInterface;
+use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Cache\Cache;
 use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\Core\Session\AccountInterface;
 
 /**
  * Implements hook_help().
@@ -25,9 +26,9 @@ function download_count_help($route_name, RouteMatchInterface $route_match) {
 }
 
 /**
- * Implements hook_file_access().
+ * Implements hook_ENTITY_TYPE_access().
  */
-function download_count_file_access($entity, $operation, $account) {
+function download_count_file_access(EntityInterface $entity, $operation, AccountInterface $account) {
   if ($operation == 'download') {
     $flood = \Drupal::flood();
     $config = \Drupal::config('download_count.settings');
@@ -62,23 +63,21 @@ function download_count_file_access($entity, $operation, $account) {
     // Count the download.
     $ip = Drupal::request()->getClientIp();
     $referrer = isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : t('Direct download');
-    $references = file_get_file_references($entity, NULL, EntityStorageInterface::FIELD_LOAD_REVISION, NULL);
-    foreach ($references as $entity_map) {
-      foreach ($entity_map as $referencing_entities) {
-        foreach ($referencing_entities as $referencing_entity) {
-          $entity_type = $referencing_entity->getEntityTypeId();
-          $entity_id = $referencing_entity->id();
-        }
-      }
-    }
-    if (!empty($entity_type) && !empty($entity_id)) {
+    // Get the entity type and entity id of file parent.
+    $file_usage_data = \Drupal::database()->select('file_usage', 'fu')
+      ->fields('fu', ['id', 'type'])
+      ->condition('fid', $entity->id())
+      ->execute()
+      ->fetchAssoc();
+
+    if (!empty($file_usage_data)) {
       $connection = Database::getConnection();
       $connection->insert('download_count')
         ->fields([
           'fid' => $entity->id(),
           'uid' => $account->id(),
-          'type' => $entity_type,
-          'id' => $entity_id,
+          'type' => $file_usage_data['type'],
+          'id' => $file_usage_data['id'],
           'ip_address' => $ip,
           'referrer' => $referrer,
           'timestamp' => $time,


### PR DESCRIPTION
## Problem
A triple foreach loop was getting used for extracting the file's parent properties like type and id.

## Solution
Replace with a database query.

## Issue tracker
https://getopensocial.atlassian.net/browse/TB-2773

## How to test
1. Download a file and observe the **download_count** table. The download count for that file id should increase upon each download.

## Release notes
N.A

## Change Record
N.A