### PR TITLE
issue #3031547 by albertoalaejos, jaapjan: Unpublished event is not showing in…

### DIFF
--- a/modules/social_features/social_event/config/install/views.view.upcoming_events.yml
+++ b/modules/social_features/social_event/config/install/views.view.upcoming_events.yml
@@ -561,17 +561,6 @@ display:
       display_description: ''
       path: community-events
       filters:
-        status:
-          value: '1'
-          table: node_field_data
-          field: status
-          plugin_id: boolean
-          entity_type: node
-          entity_field: status
-          id: status
-          expose:
-            operator: ''
-          group: 1
         type:
           id: type
           table: node_field_data


### PR DESCRIPTION
Unpublished event is not showing in the events overview for CM+

## Problem
On the events overview page, as a CM+ you want to see unpublished content. This is currently not the case.

The overview explicitly filters out unpublished content even though an access check is done per content item, restricting access for people that may not see unpublished content.

## Solution
Remove status filter of upcoming events view in the config file.

## Issue tracker
https://www.drupal.org/project/social/issues/3031547

## How to test
- [x] Log in as LU
- [x] Create an event
- [x] Unpublish the event
- [x] Log in as CM+
- [x] Go to /community-events
- [x] Check that the unpublished event is on the list of upcoming events.
- [x] Log in as different LU
- [x] Go to /community-events
- [x] You should not be able to see the unpublished event in the list.
