### PR TITLE
issue #3081129 by albertoalaejos: Event enrollment list shows the sam…

### DIFF
--- a/modules/custom/social_demo/content/entity/event-enrollment.yml
+++ b/modules/custom/social_demo/content/entity/event-enrollment.yml
@@ -35,10 +35,10 @@
   uuid: 8732ecf2-ef53-11e5-9ce9-5e5517507c66
   title: paulharris @ National Education Day
   langcode: und
-  uid: 44fc2f3a-da2f-11e5-b5d2-0a1d41d68578
+  uid: 44fc2be8-da2f-11e5-b5d2-0a1d41d68578
   field_event: 3a2c693e-deef-11e5-b86d-9a79f06e9478
   field_enrollment_status: 1
-  field_account: 44fc2f3a-da2f-11e5-b5d2-0a1d41d68578
+  field_account: 44fc2be8-da2f-11e5-b5d2-0a1d41d68578
 8732f2c4-ef53-11e5-9ce9-5e5517507c66:
   uuid: 8732f2c4-ef53-11e5-9ce9-5e5517507c66
   title: michelleclark @ National Education Day
@@ -99,10 +99,10 @@
   uuid: 57518078-eabe-11e5-9ce9-5e5517507c66
   title: paulharris @ Local Meetup Springfield
   langcode: und
-  uid: 44fc2f3a-da2f-11e5-b5d2-0a1d41d68578
+  uid: 44fc2be8-da2f-11e5-b5d2-0a1d41d68578
   field_event: 3a2c6dee-deef-11e5-b86d-9a79f06e9478
   field_enrollment_status: 1
-  field_account: 44fc2f3a-da2f-11e5-b5d2-0a1d41d68578
+  field_account: 44fc2be8-da2f-11e5-b5d2-0a1d41d68578
 575183a2-eabe-11e5-9ce9-5e5517507c66:
   uuid: 575183a2-eabe-11e5-9ce9-5e5517507c66
   title: chrishall @ Charity Run Springfield

--- a/modules/custom/social_demo/content/entity/event-enrollment.yml
+++ b/modules/custom/social_demo/content/entity/event-enrollment.yml
@@ -27,10 +27,10 @@
   uuid: 57517e8e-eabe-11e5-9ce9-5e5517507c66
   title: susanwilliams @ National Education Day
   langcode: und
-  uid: 44fc2be8-da2f-11e5-b5d2-0a1d41d68578
+  uid: 44fc2486-da2f-11e5-b5d2-0a1d41d68578
   field_event: 3a2c693e-deef-11e5-b86d-9a79f06e9478
   field_enrollment_status: 1
-  field_account: 44fc2be8-da2f-11e5-b5d2-0a1d41d68578
+  field_account: 44fc2486-da2f-11e5-b5d2-0a1d41d68578
 8732ecf2-ef53-11e5-9ce9-5e5517507c66:
   uuid: 8732ecf2-ef53-11e5-9ce9-5e5517507c66
   title: paulharris @ National Education Day
@@ -67,10 +67,10 @@
   uuid: 8732fa62-ef53-11e5-9ce9-5e5517507c66
   title: susanwilliams @ Charity Run Springfield
   langcode: und
-  uid: 44fc2be8-da2f-11e5-b5d2-0a1d41d68578
+  uid: 44fc2486-da2f-11e5-b5d2-0a1d41d68578
   field_event: 3a2c6c40-deef-11e5-b86d-9a79f06e9478
   field_enrollment_status: 1
-  field_account: 44fc2be8-da2f-11e5-b5d2-0a1d41d68578
+  field_account: 44fc2486-da2f-11e5-b5d2-0a1d41d68578
 8732fbf2-ef53-11e5-9ce9-5e5517507c66:
   uuid: 8732fbf2-ef53-11e5-9ce9-5e5517507c66
   title: thomaswhite @ Charity Run Springfield


### PR DESCRIPTION
Event enrollment list shows the same person twice

## Problem
There is an event with demo content that shows the same enrollment twice

## Solution
Fix event-enrollment demo content

## Issue tracker
https://www.drupal.org/project/social/issues/3081129

## How to test
- [ ] run /var/www/scripts/social/install/install_script.sh
- [ ] login as Admin
- [ ] visit /node/13/enrollments
- [ ] make sure that there is a list of five different people enrolled.
