### PR TITLE
Issue #3081555 by jaapjan: add BubbleableMetadata.

### DIFF
--- a/modules/custom/activity_creator/src/ActivityFactory.php
+++ b/modules/custom/activity_creator/src/ActivityFactory.php
@@ -5,6 +5,7 @@ namespace Drupal\activity_creator;
 use Drupal\activity_creator\Entity\Activity;
 use Drupal\Component\Render\FormattableMarkup;
 use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\Render\BubbleableMetadata;
 use Drupal\language\ConfigurableLanguageManagerInterface;
 use Drupal\message\Entity\Message;
 use Drupal\activity_creator\Plugin\ActivityDestinationManager;
@@ -498,18 +499,20 @@ class ActivityFactory extends ControllerBase {
       'clear' => $clear,
     ];
 
+    $bubbleable_metadata = new BubbleableMetadata();
     foreach ($output as $key => $value) {
       if (is_string($value)) {
         $output[$key] = \Drupal::token()
-          ->replace($value, ['message' => $message], $options);
+          ->replace($value, ['message' => $message], $options, $bubbleable_metadata);
       }
       else {
         if (isset($value['value'])) {
           $output[$key] = \Drupal::token()
-            ->replace($value['value'], ['message' => $message], $options);
+            ->replace($value['value'], ['message' => $message], $options, $bubbleable_metadata);
         }
       }
     }
+    $bubbleable_metadata->applyTo($output);
 
     return $output;
   }

--- a/modules/social_features/social_event/social_event.tokens.inc
+++ b/modules/social_features/social_event/social_event.tokens.inc
@@ -112,7 +112,8 @@ function get_link_to_event_from_enrollment($object_id, $as_link = FALSE) {
     // Check if the event still exists.
     if ($event !== NULL) {
       if ($as_link) {
-        return $event->toUrl('canonical')->toString();
+        $url_string = $event->toUrl('canonical')->toString(TRUE);
+        return $url_string->getGeneratedUrl();
       }
 
       return Link::fromTextAndUrl($event->getTitle(), $event->toUrl('canonical'))->toString();


### PR DESCRIPTION
## Problem
When using the JSON API you could encounter some error messages like:
```
The controller result claims to be providing relevant cache metadata, but leaked metadata was detected. Please ensure you are not rendering content too early.
This has to do with early rendering. Most likely in the toUrl->toString calls on entities.
```

## Solution
Let's rewrite the code.

## Issue tracker
https://www.drupal.org/project/social/issues/3081555

## How to test
- [ ] Test JSON API POST event enrolment and there should not be any error.
- [ ] See https://www.lullabot.com/articles/early-rendering-a-lesson-in-debugging-drupal-8

## Release notes
In the token handling of event enrolments there was some leaked cacheable metadata. This has now been solved.

## Change Record
n/a