### PR TITLE
fix private messages sorting

### DIFF
--- a/modules/social_features/social_private_message/social_private_message.module
+++ b/modules/social_features/social_private_message/social_private_message.module
@@ -414,6 +414,28 @@ function social_private_message_preprocess_field(&$variables) {
 }
 
 /**
+ * Prepares variables for private_message_thread templates.
+ *
+ * Default template: private-message-thread.html.twig.
+ *
+ * @param array $variables
+ *   An associative array containing:
+ *   - elements: An array of elements to display in view mode.
+ *   - private_message_thread: The private messsage thread object.
+ *   - view_mode: View mode; e.g., 'full', 'teaser', etc.
+ */
+function social_private_message_preprocess_private_message_thread(array &$variables) {
+
+  /** @var \Drupal\Core\Datetime\DateFormatterInterface $formatter */
+  $date_formatter = \Drupal::service('date.formatter');
+  $updated_time = $variables['elements']['#private_message_thread']->getUpdatedTime();
+  $variables['content']['updated'] = $date_formatter->formatDiff($updated_time, time(), [
+    'granularity' => 1,
+    'return_as_object' => TRUE,
+  ]);
+}
+
+/**
  * Implements hook_user_cancel().
  */
 function social_private_message_user_cancel($edit, $account, $method) {

--- a/themes/socialbase/components/04-organisms/message/message.scss
+++ b/themes/socialbase/components/04-organisms/message/message.scss
@@ -1,7 +1,7 @@
 @import 'settings';
 
 // make sure the date is positioned top right of the message
-.message__created {
+.message__created, .message__updated {
   font-size: $font-size-xs;
   color: $gray-light;
   line-height: $line-height-base * $font-size-base;

--- a/themes/socialbase/templates/private_message/private-message-thread.html.twig
+++ b/themes/socialbase/templates/private_message/private-message-thread.html.twig
@@ -32,7 +32,9 @@
         </div>
         <div class="media-body message__inbox-body">
           {{ content.membernames }} <span class="read-indicator"></span>
-          {{ content.last_message }}
+          <div class="message__updated">
+            {{ content.updated }} {{ 'ago' }}
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Problem
The private messages are not in a chronological classification.
Private messages are sorted based on last updated time, but the private messages inbox view show the creation time, which does not always match the updated time.

## Solution
Show the last updated time instead of creation time.

## Issue tracker
https://getopensocial.atlassian.net/browse/TB-2919

## How to test
- [ ] Go to /user/inbox
- [ ] Make sure that private messages are sorted in the correct order.
