### PR TITLE
Issue #3082600 by robertragas: replace html escape with xss filter as…

### DIFF
--- a/modules/social_features/social_search/src/Form/SearchContentForm.php
+++ b/modules/social_features/social_search/src/Form/SearchContentForm.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\social_search\Form;
 
-use Drupal\Component\Utility\Html;
+use Drupal\Component\Utility\Xss;
 use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
 use Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
@@ -86,7 +86,7 @@ class SearchContentForm extends FormBase implements ContainerInjectionInterface 
     }
     else {
       // Redirect to the search content page with filters in the GET parameters.
-      $search_input = Html::escape($form_state->getValue('search_input_content'));
+      $search_input = Xss::filter($form_state->getValue('search_input_content'));
       $search_input = preg_replace('/[\/]+/', ' ', $search_input);
       $search_content_page = Url::fromRoute("view.$search_all_view.page", ['keys' => $search_input]);
     }

--- a/modules/social_features/social_search/src/Form/SearchHeroForm.php
+++ b/modules/social_features/social_search/src/Form/SearchHeroForm.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\social_search\Form;
 
-use Drupal\Component\Utility\Html;
+use Drupal\Component\Utility\Xss;
 use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
 use Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
@@ -101,7 +101,7 @@ class SearchHeroForm extends FormBase implements ContainerInjectionInterface {
     }
     else {
       // Redirect to the search page with filters in the GET parameters.
-      $search_input = Html::escape($form_state->getValue('search_input'));
+      $search_input = Xss::filter($form_state->getValue('search_input'));
       $search_input = preg_replace('/[\/]+/', ' ', $search_input);
       $new_route = "view.{$route_parts[1]}.page";
       $search_group_page = Url::fromRoute($new_route, ['keys' => $search_input]);


### PR DESCRIPTION
## Problem
Currently the search input escapes html which make it impossible to search for content in language that use special characters like ', which is commonly used in French.

## Solution
Replace the html escape with a Xss:filter as this also protects the input against attacks.

## Issue tracker
https://www.drupal.org/project/social/issues/3082600

## How to test
- [x]  Create content that has quotes in the title (h'allo)
- [x]  Search for this content and see it will cut off after the h and not able to find the content
- [x]  Try with this solution and see it can be found now
- [x]  Try to execute xss within the input box and url bar.

I used the cheatsheet here
https://www.owasp.org/index.php/XSS_Filter_Evasion_Cheat_Sheet

## Release notes
We have fixed and issue where the search input would get trimmed due to special characters like an apostrophe resulting in not being able to find the right content. Now these special characters are usable in search words.