### PR TITLE
Update php in Travis configuration to 7.3.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ before_install:
   # Installing hirak/prestissimo allows composer to parallelise downloads which speeds up the composer install.
   - composer global require hirak/prestissimo
   - echo "TRAVIS_BRANCH=$TRAVIS_BRANCH, PR=$PR, BRANCH=$BRANCH, COMMIT=$COMMIT"
-  - if [ "$TEST_SUITE" = "install_update" ]; then composer require goalgorilla/open_social:5.0.0 --prefer-dist; fi
+  - if [ "$TEST_SUITE" = "install_update" ]; then composer require goalgorilla/open_social:6.0.0 --prefer-dist; fi
   - if [ "$TRAVIS_PULL_REQUEST" != "false" ] && [ "$TRAVIS_PULL_REQUEST_SLUG" != "goalgorilla/open_social" ]; then composer config repositories.social git https://github.com/$TRAVIS_PULL_REQUEST_SLUG.git; fi
   - if [ "$TEST_SUITE" != "install_update" ]; then composer require goalgorilla/open_social:dev-${BRANCH}#${COMMIT} --prefer-dist; fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ addons:
 language: php
 
 php:
-  - 7.1
+  - 7.3
 
 env:
   global:


### PR DESCRIPTION
## Problem
1. We still use PHP 7.1 instead of PHP 7.3 in Travis set-up.
2. Install update is failing on OS 5.0.0.

## Solution
1. Let's update. It shouldn't have any effect other than on the composer install.
2. Let's use OS 6.0.0 instead.

## Issue tracker
n/a

## How to test
- [ ] Check code change
- [ ] Check if travis passes

## Release notes
N/a