### PR TITLE
reply to this comment button bring you to the commented post

### DIFF
--- a/modules/social_features/social_comment/social_comment.tokens.inc
+++ b/modules/social_features/social_comment/social_comment.tokens.inc
@@ -161,14 +161,11 @@ function social_comment_tokens($type, $tokens, array $data, array $options, Bubb
                 }
 
                 if ($name === 'comment_reply_link_html') {
-                  $replacements[$original] = Url::fromRoute('comment.reply', [
-                    'entity_type' => $comment->getCommentedEntityTypeId(),
-                    'entity' => $comment->getCommentedEntityId(),
-                    'field_name' => $comment->getFieldName(),
-                    'pid' => $comment->id(),
-                  ])->toString();
+                  /** @var \Drupal\Core\Entity\Entity $entity */
+                  $entity = $comment->getCommentedEntity();
+                  $url_options = ['absolute' => TRUE];
+                  $replacements[$original] = $entity->toUrl('canonical', $url_options)->toString();
                 }
-
               }
             }
           }


### PR DESCRIPTION
## Problem
I received a notification about activity on one of my posts, and clicked the button to reply to the comment. It took me to a normal comment screen, but when I tried to submit the comment I got an error. It looks like the page I was sent to was for a "Reply" which isn't an option for comments on a post.

## Solution
Change the link in the email to reply to the post instead of the comment on the post

## Issue tracker
https://getopensocial.atlassian.net/secure/RapidBoard.jspa?rapidView=96&projectKey=GPI&modal=detail&selectedIssue=TB-2945&quickFilter=344

## How to test
- [ ] 
- [ ] 
- [ ] 
