### PR TITLE
Issue #3084268 by robertragas: Optimize group membership count

### DIFF
--- a/modules/social_features/social_group/social_group.module
+++ b/modules/social_features/social_group/social_group.module
@@ -319,7 +319,8 @@ function social_group_preprocess_group(array &$variables) {
   }
 
   // Count number of group members.
-  $variables['group_members'] = count($group->getMembers());
+  $group_members_count = \Drupal::service('social_group.group_members_count');
+  $variables['group_members'] = $group_members_count->getGroupMemberCount($group);
 }
 
 /**

--- a/modules/social_features/social_group/social_group.services.yml
+++ b/modules/social_features/social_group/social_group.services.yml
@@ -32,3 +32,6 @@ services:
   social_group.hero_image:
     class: Drupal\social_group\SocialGroupHero
     arguments: ['@config.factory']
+  social_group.group_members_count:
+    class: Drupal\social_group\SocialGroupMembersCount
+    arguments: ['@database']

--- a/modules/social_features/social_group/src/Controller/SocialGroupListBuilder.php
+++ b/modules/social_features/social_group/src/Controller/SocialGroupListBuilder.php
@@ -105,7 +105,8 @@ class SocialGroupListBuilder extends EntityListBuilder {
     $row['name']['data'] = $entity->toLink()->toRenderable();
     $row['type'] = $entity->getGroupType()->label();
     $row['uid'] = $entity->uid->entity->toLink();
-    $row['members'] = count($entity->getMembers());
+    $group_members_count = \Drupal::service('social_group.group_members_count');
+    $row['members'] = $group_members_count->getGroupMemberCount($entity);
     $row['created'] = $this->dateTime->format($entity->getCreatedTime(), 'short');
 
     return $row + parent::buildRow($entity);

--- a/modules/social_features/social_group/src/SocialGroupMembersCount.php
+++ b/modules/social_features/social_group/src/SocialGroupMembersCount.php
@@ -27,7 +27,7 @@ class SocialGroupMembersCount {
   protected $database;
 
   /**
-   * Constructor for SocialGroupHelperService.
+   * Constructor for SocialGroupMembersCount.
    *
    * @param \Drupal\Core\Database\Connection $connection
    *   The database connection.

--- a/modules/social_features/social_group/src/SocialGroupMembersCount.php
+++ b/modules/social_features/social_group/src/SocialGroupMembersCount.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Drupal\social_group;
+
+use Drupal\Core\Database\Connection;
+use Drupal\group\Entity\GroupInterface;
+
+/**
+ * Class SocialGroupMembersCount.
+ *
+ * @package Drupal\social_group
+ */
+class SocialGroupMembersCount {
+
+  /**
+   * A cache of group members count for a specific group.
+   *
+   * @var array
+   */
+  protected $cache;
+
+  /**
+   * The database connection object.
+   *
+   * @var \Drupal\Core\Database\Connection
+   */
+  protected $database;
+
+  /**
+   * Constructor for SocialGroupHelperService.
+   *
+   * @param \Drupal\Core\Database\Connection $connection
+   *   The database connection.
+   */
+  public function __construct(Connection $connection) {
+    $this->database = $connection;
+  }
+
+  /**
+   * Get group members count.
+   *
+   * @param \Drupal\group\Entity\GroupInterface $group
+   *   The group entity.
+   * @param bool $read_cache
+   *   Whether the per request cache should be used.
+   *
+   * @return int
+   *   Number of members in a group.
+   */
+  public function getGroupMemberCount(GroupInterface $group, $read_cache = TRUE) {
+    $cache_type = $group->getGroupType()->id();
+    $cache_id = $group->id();
+
+    if ($read_cache && is_array($this->cache[$cache_type]) && isset($this->cache[$cache_type][$cache_id])) {
+      return $this->cache[$cache_type][$cache_id];
+    }
+
+    $query = $this->database->select('group_content_field_data', 'gcfd');
+    $query->addField('gcfd', 'gid');
+    $query->condition('gcfd.gid', $group->id());
+    $query->condition('gcfd.type', $group->getGroupType()->id() . '-group_membership', 'LIKE');
+    $count = $query->countQuery()->execute()->fetchField();
+
+    // Cache the group id for this entity to optimise future calls.
+    $this->cache[$cache_type][$cache_id] = $count;
+
+    return $count;
+  }
+
+}

--- a/modules/social_features/social_group/src/SocialGroupMembersCount.php
+++ b/modules/social_features/social_group/src/SocialGroupMembersCount.php
@@ -13,13 +13,6 @@ use Drupal\group\Entity\GroupInterface;
 class SocialGroupMembersCount {
 
   /**
-   * A cache of group members count for a specific group.
-   *
-   * @var array
-   */
-  protected $cache;
-
-  /**
    * The database connection object.
    *
    * @var \Drupal\Core\Database\Connection
@@ -41,30 +34,18 @@ class SocialGroupMembersCount {
    *
    * @param \Drupal\group\Entity\GroupInterface $group
    *   The group entity.
-   * @param bool $read_cache
-   *   Whether the per request cache should be used.
    *
    * @return int
    *   Number of members in a group.
    */
-  public function getGroupMemberCount(GroupInterface $group, $read_cache = TRUE) {
-    $cache_type = $group->getGroupType()->id();
-    $cache_id = $group->id();
-
-    if ($read_cache && is_array($this->cache[$cache_type]) && isset($this->cache[$cache_type][$cache_id])) {
-      return $this->cache[$cache_type][$cache_id];
-    }
-
+  public function getGroupMemberCount(GroupInterface $group) {
+    // Additional caching not required since views does this for us.
     $query = $this->database->select('group_content_field_data', 'gcfd');
     $query->addField('gcfd', 'gid');
     $query->condition('gcfd.gid', $group->id());
     $query->condition('gcfd.type', $group->getGroupType()->id() . '-group_membership', 'LIKE');
-    $count = $query->countQuery()->execute()->fetchField();
 
-    // Cache the group id for this entity to optimise future calls.
-    $this->cache[$cache_type][$cache_id] = $count;
-
-    return $count;
+    return $query->countQuery()->execute()->fetchField();
   }
 
 }


### PR DESCRIPTION
## Problem
Currently there are two places in Open Social where a count is being done for the amount of members in a group. This shows up in the group overview, but also on user profiles or wherever a group teaser shows up.
The other one is in the admin page of groups.

What it does is get all the member entities of a group and then does a count on this. When a group has over 30k members this will cause a timeout.

## Solution
Query the database, only getting the information you need instead of all the entities and then counting them which is very heavy.

## Issue tracker
https://www.drupal.org/project/social/issues/3084268

## How to test
- [x] Clear the cache
- [x] Create a group with a lot members, I tested it with 35k
- [x] Go to the explore overview of groups and the admin overview of groups
- [x] The request will time out every single time
- [x] Check out to this branch and check again

## Release notes
We changed the way we count the group members making it more performant. Because groups are used in a lot of places of Open Social the difference should be noticeable for everybody, but especially for Open Social installations with a lot of users in groups.