### PR TITLE
#3077289 - Secret group doesnt have defaults for visbility settings

### DIFF
--- a/modules/social_features/social_group/social_group.module
+++ b/modules/social_features/social_group/social_group.module
@@ -1582,6 +1582,12 @@ function social_group_get_allowed_visibility_options_per_group_type($group_type_
       $visibility_options['group'] = FALSE;
       break;
 
+    case 'secret_group':
+      $visibility_options['public'] = FALSE;
+      $visibility_options['community'] = FALSE;
+      $visibility_options['group'] = TRUE;
+      break;
+
     case 'flexible_group':
       if (empty($group)) {
         $group = _social_group_get_current_group();
@@ -1609,9 +1615,11 @@ function social_group_get_allowed_visibility_options_per_group_type($group_type_
         }
         else {
           /** @var \Drupal\node\Entity\Node $entity */
-          $current_visibility = $entity->get('field_content_visibility')->getString();
-          if ($current_visibility !== 'public') {
-            $visibility_options['public'] = FALSE;
+          if ($entity->hasField('field_content_visibility')) {
+            $current_visibility = $entity->get('field_content_visibility')->getString();
+            if ($current_visibility !== 'public') {
+              $visibility_options['public'] = FALSE;
+            }
           }
         }
       }


### PR DESCRIPTION
## Problem & Solution
Secret group doenst have defaults for visibility settings, also added a defensive check for when other group types, it needs to have the field available on the entity for us to check it.

## Issue tracker
https://www.drupal.org/project/social/issues/3077289

## How to test
- [x] Enable secret groups, see that for the Post form it has group members as only option.

## Release notes
We have made sure there are sane defaults for the secret group which is now available in Open Social.
