### PR TITLE
Issue #3030224 by genzer: Don't use existing configuration on FilePrivateFieldsConfigOverride

### DIFF
--- a/modules/custom/social_file_private/social_file_private.services.yml
+++ b/modules/custom/social_file_private/social_file_private.services.yml
@@ -1,6 +1,7 @@
 services:
   social_file_private_fields.overrider:
     class: \Drupal\social_file_private\SocialFilePrivateFieldsConfigOverride
+    arguments: ['@config.factory']
     tags:
       - {name: config.factory.override, priority: 5}
   social_file_private_text_editor.overrider:

--- a/modules/custom/social_file_private/src/SocialFilePrivateFieldsConfigOverride.php
+++ b/modules/custom/social_file_private/src/SocialFilePrivateFieldsConfigOverride.php
@@ -3,6 +3,7 @@
 namespace Drupal\social_file_private;
 
 use Drupal\Core\Cache\CacheableMetadata;
+use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Config\ConfigFactoryOverrideInterface;
 use Drupal\Core\Config\StorageInterface;
 use Drupal\Core\StreamWrapper\PrivateStream;
@@ -15,6 +16,23 @@ use Drupal\Core\StreamWrapper\PrivateStream;
  * @package Drupal\social_file_private
  */
 class SocialFilePrivateFieldsConfigOverride implements ConfigFactoryOverrideInterface {
+
+  /**
+   * The config factory.
+   *
+   * @var \Drupal\Core\Config\ConfigFactoryInterface
+   */
+  protected $configFactory;
+
+  /**
+   * Constructs the configuration override.
+   *
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   The Drupal configuration factory.
+   */
+  public function __construct(ConfigFactoryInterface $config_factory) {
+    $this->configFactory = $config_factory;
+  }
 
   /**
    * Get all the file and image fields to protect.
@@ -56,8 +74,7 @@ class SocialFilePrivateFieldsConfigOverride implements ConfigFactoryOverrideInte
       $config_names = $this->getFileImageFieldsToProtect();
       foreach ($config_names as $config_name) {
         if (in_array($config_name, $names)) {
-          $config = \Drupal::service('config.factory')->getEditable($config_name);
-          $uri_scheme = $config->get('settings.uri_scheme');
+          $uri_scheme = $this->configFactory->get('settings.uri_scheme');
           if ($uri_scheme == 'public') {
             $overrides[$config_name]['settings']['uri_scheme'] = 'private';
           }


### PR DESCRIPTION
…ilePrivateFieldsConfigOverride class

## Problem
<describe the problem you're trying to solve>

## Solution
<describe the solution you're created>

## Issue tracker
https://www.drupal.org/project/social/issues/3030224

## How to test
- [ ] <enter multiple how to test steps here>

## Release notes
will follow

See also #1519 
