### PR TITLE
TB-2352 Move to Search API Processor for restricted names

### DIFF
--- a/modules/social_features/social_profile/modules/social_profile_privacy/social_profile_privacy.install
+++ b/modules/social_features/social_profile/modules/social_profile_privacy/social_profile_privacy.install
@@ -13,6 +13,9 @@ use Drupal\user\Entity\Role;
 function social_profile_privacy_install() {
   // Set some default permissions.
   _social_profile_privacy_set_permissions();
+
+  // Update our search indexes for our custom processor..
+  _social_profile_privacy_resave_search_indexes();
 }
 
 /**
@@ -59,4 +62,37 @@ function _social_profile_privacy_get_permissions($role) {
   }
 
   return $permissions[$role];
+}
+
+/**
+ * Re-saves search indices.
+ *
+ * This triggers the save for search indices that have profile entities as data.
+ * This ensures that the RestrictedNameProcessor is properly added.
+ *
+ * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
+ * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
+ * @throws \Drupal\Core\Entity\EntityStorageException
+ */
+function _social_profile_privacy_resave_search_indexes() {
+  // If the search api module is not installed we have nothing to do.
+  if (!\Drupal::moduleHandler()->moduleExists('search_api')) {
+    return;
+  }
+
+  // We load all indexes, we assume there will never be hundreds of search
+  // indexes which would create its own problems for a site.
+  $indexes = \Drupal::entityTypeManager()
+    ->getStorage('search_api_index')
+    ->loadMultiple();
+
+  /** @var \Drupal\search_api\IndexInterface $index */
+  foreach ($indexes as $index) {
+    // Check if the search index has profile entities as data source.
+    if ($index->isValidDatasource('entity:profile')) {
+      // Disable and enable the index to ensure that the RestrictedNameProcessor
+      // has the chance to add the field.
+      $index->save();
+    }
+  }
 }

--- a/modules/social_features/social_profile/modules/social_profile_privacy/social_profile_privacy.module
+++ b/modules/social_features/social_profile/modules/social_profile_privacy/social_profile_privacy.module
@@ -11,8 +11,6 @@ use Drupal\Core\Field\FieldDefinitionInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Access\AccessResult;
-use Drupal\search_api\Query\ConditionGroup;
-use Drupal\search_api\Query\QueryInterface;
 
 /**
  * Implements hook_form_FORM_ID_alter().
@@ -454,87 +452,6 @@ function social_profile_privacy_form_field_group_options() {
     unset($field_groups['group_profile_names_image']);
   }
   return $field_groups;
-}
-
-/**
- * Implements hook_search_api_query_alter().
- *
- * Ensures that when the setting is enabled to be strict with first/last name
- * display and the current user does not have the permission to bypass this
- * setting that the search queries are altered to ignore the first name/last
- * name when the target user has filled in a nickname.
- *
- * Users will not be able to find themselves by first/last name if they have
- * filled in a nickname and do not have the correct permissions. This is
- * intentional because it means that they can test how other users can find
- * them.
- */
-function social_profile_privacy_search_api_query_alter(QueryInterface &$query) {
-  // If the social profile fields module isn't enabled then we don't have
-  // anything to hide behind.
-  if (!\Drupal::moduleHandler()->moduleExists('social_profile_fields')) {
-    return;
-  }
-
-  $ids = [
-    'social_all',
-    'social_users',
-  ];
-
-  // If the current query isn't for an index with users then we're done too.
-  if (!in_array($query->getIndex()->id(), $ids)) {
-    return;
-  }
-
-  $config = \Drupal::config('social_profile_privacy.settings');
-  $account = \Drupal::currentUser();
-
-  // If the use of real names is not limited or the user can bypass this
-  // restriction then we're done too.
-  if (!$config->get('limit_search_and_mention') || $account->hasPermission('social profile privacy always show full name')) {
-    return;
-  }
-
-  $search_term = $query->getOriginalKeys();
-
-  // Conditions must match lowercase because that's how they're indexed.
-  if (is_array($search_term)) {
-    $search_term = array_map("strtolower", $search_term);
-  }
-  else {
-    $search_term = strtolower($search_term);
-  }
-
-  // If no search string was filled out, don't add the subquery.
-  if (empty($search_term)) {
-    return;
-  }
-
-  // When a user has no nickname, there can be a match for a (part of the) name.
-  $matched_name = (new ConditionGroup("AND", ['social_profile_privacy_full_name_protection']))
-    ->addCondition('field_profile_nick_name', NULL, '=')
-    ->addConditionGroup(
-      (new ConditionGroup("OR", ['social_profile_privacy_full_name_protection']))
-        ->addCondition('field_profile_first_name', $search_term, '=')
-        ->addCondition('field_profile_last_name', $search_term, '=')
-    );
-
-  // Given that a user has a nickname there can be no match for the first and
-  // last name.
-  $no_name_match = (new ConditionGroup('AND', ['social_profile_privacy_full_name_protection']))
-    ->addCondition('field_profile_nick_name', NULL, '<>')
-    ->addCondition('field_profile_first_name', $search_term, '<>')
-    ->addCondition('field_profile_last_name', $search_term, '<>');
-
-  // Results are matched only when they do not match the first name and last
-  // name, or they also match the username.
-  $full_name_restricted = (new ConditionGroup('OR', ['social_profile_privacy_full_name_protection']))
-    ->addCondition('name', $search_term)
-    ->addCondition('field_profile_nick_name', $search_term)
-    ->addConditionGroup($matched_name)
-    ->addConditionGroup($no_name_match);
-
-  $query->addConditionGroup($full_name_restricted);
 }
 
 /**

--- a/modules/social_features/social_profile/modules/social_profile_privacy/social_profile_privacy.post_update.php
+++ b/modules/social_features/social_profile/modules/social_profile_privacy/social_profile_privacy.post_update.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * @file
+ * Post update hooks for the Social Profile Privacy module.
+ */
+
+/**
+ * Re-save the All and Users indices to add restricted name field.
+ */
+function social_profile_privacy_post_update_8001_restricted_name_field() {
+  // If the search api module is not installed we have nothing to do.
+  if (!\Drupal::moduleHandler()->moduleExists('search_api')) {
+    return;
+  }
+
+  // We load all indexes, we assume there will never be hundreds of search
+  // indexes which would create its own problems for a site.
+  $indexes = \Drupal::entityTypeManager()
+    ->getStorage('search_api_index')
+    ->loadMultiple();
+
+  /** @var \Drupal\search_api\IndexInterface $index */
+  foreach ($indexes as $index) {
+    // Check if the search index has profile entities as data source.
+    if ($index->isValidDatasource('entity:profile')) {
+      // Disable and enable the index to ensure that the RestrictedNameProcessor
+      // has the chance to add the field.
+      $index->disable()->save();
+      $index->enable()->save();
+    }
+  }
+}

--- a/modules/social_features/social_profile/modules/social_profile_privacy/social_profile_privacy.post_update.php
+++ b/modules/social_features/social_profile/modules/social_profile_privacy/social_profile_privacy.post_update.php
@@ -9,25 +9,5 @@
  * Re-save the All and Users indices to add restricted name field.
  */
 function social_profile_privacy_post_update_8001_restricted_name_field() {
-  // If the search api module is not installed we have nothing to do.
-  if (!\Drupal::moduleHandler()->moduleExists('search_api')) {
-    return;
-  }
-
-  // We load all indexes, we assume there will never be hundreds of search
-  // indexes which would create its own problems for a site.
-  $indexes = \Drupal::entityTypeManager()
-    ->getStorage('search_api_index')
-    ->loadMultiple();
-
-  /** @var \Drupal\search_api\IndexInterface $index */
-  foreach ($indexes as $index) {
-    // Check if the search index has profile entities as data source.
-    if ($index->isValidDatasource('entity:profile')) {
-      // Disable and enable the index to ensure that the RestrictedNameProcessor
-      // has the chance to add the field.
-      $index->disable()->save();
-      $index->enable()->save();
-    }
-  }
+  _social_profile_privacy_resave_search_indexes();
 }

--- a/modules/social_features/social_profile/modules/social_profile_privacy/social_profile_privacy.services.yml
+++ b/modules/social_features/social_profile/modules/social_profile_privacy/social_profile_privacy.services.yml
@@ -3,3 +3,11 @@ services:
     class: Drupal\social_profile_privacy\RestrictedNameProcessorOverride
     tags:
       - { name: config.factory.override, priority: 5 }
+  social_profile_privacy.config_events_subscriber:
+    class: Drupal\social_profile_privacy\EventSubscriber\ConfigEventsSubscriber
+    arguments:
+      - '@module_handler'
+      - '@entity_type.manager'
+      - '@logger.factory'
+    tags:
+      - { name: 'event_subscriber' }

--- a/modules/social_features/social_profile/modules/social_profile_privacy/social_profile_privacy.services.yml
+++ b/modules/social_features/social_profile/modules/social_profile_privacy/social_profile_privacy.services.yml
@@ -1,0 +1,5 @@
+services:
+  social_profile_privacy.overrider:
+    class: Drupal\social_profile_privacy\RestrictedNameProcessorOverride
+    tags:
+      - { name: config.factory.override, priority: 5 }

--- a/modules/social_features/social_profile/modules/social_profile_privacy/src/EventSubscriber/ConfigEventsSubscriber.php
+++ b/modules/social_features/social_profile/modules/social_profile_privacy/src/EventSubscriber/ConfigEventsSubscriber.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace Drupal\social_profile_privacy\EventSubscriber;
+
+use Drupal\Core\Config\ConfigCrudEvent;
+use Drupal\Core\Config\ConfigEvents;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Extension\ModuleHandlerInterface;
+use Drupal\Core\Logger\LoggerChannelFactoryInterface;
+use Drupal\search_api\SearchApiException;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Class ConfigEventSubscriber.
+ *
+ * @package Drupal\social_profile_privacy\EventSubscriber
+ */
+class ConfigEventsSubscriber implements EventSubscriberInterface {
+
+  /**
+   * The Drupal module handler service.
+   *
+   * @var \Drupal\Core\Extension\ModuleHandlerInterface
+   */
+  protected $moduleHandler;
+
+  /**
+   * The Drupal entity type handler.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * A way for this module to log messages.
+   *
+   * @var \Drupal\Core\Logger\LoggerChannelInterface
+   */
+  protected $logger;
+
+  /**
+   * ConfigEventsSubscriber constructor.
+   *
+   * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
+   *   The Drupal module handler service.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The Drupal entity type handler.
+   * @param \Drupal\Core\Logger\LoggerChannelFactoryInterface $logger_channel_factory
+   *   A way for this module to log messages.
+   */
+  public function __construct(
+    ModuleHandlerInterface $module_handler,
+    EntityTypeManagerInterface $entity_type_manager,
+    LoggerChannelFactoryInterface $logger_channel_factory
+  ) {
+    $this->moduleHandler = $module_handler;
+    $this->entityTypeManager = $entity_type_manager;
+    $this->logger = $logger_channel_factory->get('social_profile_privacy');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents() {
+    return [
+      ConfigEvents::SAVE => 'configSave',
+    ];
+  }
+
+  /**
+   * React to a config object being saved.
+   *
+   * @param \Drupal\Core\Config\ConfigCrudEvent $event
+   *   Config crud event.
+   *
+   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
+   * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
+   */
+  public function configSave(ConfigCrudEvent $event) {
+    // We're only interested in the settings for this module.
+    if ($event->getConfig()->getName() !== 'social_profile_privacy.settings') {
+      return;
+    }
+
+    // We only need to act if the setting controlling our custom processor has
+    // changed.
+    if (!$event->isChanged('limit_search_and_mention')) {
+      return;
+    }
+
+    // If the search api module is not installed we have nothing to do.
+    if (!$this->moduleHandler->moduleExists('search_api')) {
+      return;
+    }
+
+    // We load all indexes, we assume there will never be hundreds of search
+    // indexes which would create its own problems for a site.
+    $indexes = $this->entityTypeManager
+      ->getStorage('search_api_index')
+      ->loadMultiple();
+
+    // Check if the search index has profile entities as data source in which
+    // case we'll have to re-index all items with the change in settings.
+    /** @var \Drupal\search_api\IndexInterface $index */
+    foreach ($indexes as $index) {
+      if ($index->isValidDatasource('entity:profile')) {
+        try {
+          $index->reindex();
+        }
+        catch (SearchApiException $exception) {
+          $this->logger->error(
+            'Could not mark index "@index" for re-indexing. @exception',
+            [
+              '@index' => $index->label(),
+              '@exception' => $exception->getMessage(),
+            ]
+          );
+        }
+      }
+    }
+  }
+
+}

--- a/modules/social_features/social_profile/modules/social_profile_privacy/src/Plugin/search_api/processor/RestrictedNameProcessor.php
+++ b/modules/social_features/social_profile/modules/social_profile_privacy/src/Plugin/search_api/processor/RestrictedNameProcessor.php
@@ -1,0 +1,197 @@
+<?php
+
+namespace Drupal\social_profile_privacy\Plugin\search_api\processor;
+
+use Drupal\search_api\Datasource\DatasourceInterface;
+use Drupal\search_api\Item\ItemInterface;
+use Drupal\search_api\Processor\ProcessorPluginBase;
+use Drupal\search_api\Processor\ProcessorProperty;
+use Drupal\search_api\Query\QueryInterface;
+
+/**
+ * The RestrictedNameProcessor adds the restricted name to search indexes.
+ *
+ * The restricted name is a field that's based on the full name of a user or
+ * the nickname, if they have it filled in. This is added to the search index
+ * because it's not possibly to search on these fields on a row by row basis.
+ * If the `limit_search_and_mention` setting is TRUE then users should not be
+ * findable by their real name if they have a nickname filled and the user
+ * searching does not have the `social profile privacy always show full name`
+ * permission.
+ *
+ * Ensures that when the setting is enabled to be strict with first/last name
+ * display and the current user does not have the permission to bypass this
+ * setting that the search queries are altered to ignore the first name/last
+ * name when the target user has filled in a nickname.
+ *
+ * Users will not be able to find themselves by first/last name if they have
+ * filled in a nickname and do not have the correct permissions. This is
+ * intentional because it means that they can test how other users can find
+ * them.
+ *
+ * This processor should run before other processors that affect indexed values
+ * such as the IgnoreCase or Tokenizer processor.
+ *
+ * @SearchApiProcessor(
+ *   id = "social_profile_privacy_restricted_name",
+ *   label = @Translation("Restricted Name"),
+ *   description = @Translation("Adds the restricted name to the index according to the privacy rules."),
+ *   stages = {
+ *     "add_properties" = 0,
+ *     "pre_index_save" = -50,
+ *     "preprocess_query" = 0,
+ *   },
+ *   locked = true,
+ *   hidden = true,
+ * )
+ */
+class RestrictedNameProcessor extends ProcessorPluginBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getPropertyDefinitions(DatasourceInterface $datasource = NULL) {
+    $properties = parent::getPropertyDefinitions($datasource);
+
+    if ($datasource && $this->supportsDataSource($datasource)) {
+      $definition = [
+        'label' => $this->t('Restricted Name'),
+        'description' => $this->t('The display name that is visible for unpriviliged users.'),
+        'type' => 'search_api_text',
+        'is_list' => FALSE,
+        'processor_id' => $this->getPluginId(),
+      ];
+      $properties['social_profile_privacy_restricted_name'] = new ProcessorProperty($definition);
+    }
+
+    return $properties;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function preIndexSave() {
+    $datasources = $this->getIndex()->getDatasources();
+
+    // Ensure that we have our "Restricted Name" field for all our supported
+    // datasources.
+    foreach ($datasources as $datasource_id => $datasource) {
+      if ($this->supportsDataSource($datasource)) {
+        $this->ensureField($datasource_id, 'social_profile_privacy_restricted_name');
+      }
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function addFieldValues(ItemInterface $item) {
+    $restricted_name = NULL;
+
+    $nickname = $this->getFirstItemField($item, 'field_profile_nick_name');
+    // If the user specified a nickname then we will default to using it as
+    // restricted name.
+    if ($nickname !== '') {
+      $restricted_name = $nickname;
+    }
+    // If the user didn't specify a nickname, we'll allow searching for
+    // first/last name.
+    else {
+      $first_name = $this->getFirstItemField($item, 'field_profile_first_name');
+      $last_name = $this->getFirstItemField($item, 'field_profile_last_name');
+
+      $full_name = trim($first_name . ' ' . $last_name);
+
+      if ($full_name !== '') {
+        $restricted_name = $full_name;
+      }
+    }
+
+    // If we have a restricted name we add it as a value for all of our
+    // restricted name fields.
+    if ($restricted_name) {
+      $fields = $this->getFieldsHelper()
+        ->filterForPropertyPath(
+          $item->getFields(),
+          $item->getDatasourceId(),
+          'social_profile_privacy_restricted_name'
+      );
+      foreach ($fields as $field) {
+        $field->addValue($restricted_name);
+      }
+    }
+
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function preprocessSearchQuery(QueryInterface $query) {
+    $config = \Drupal::config('social_profile_privacy.settings');
+    $account = \Drupal::currentUser();
+
+    // If the use of real names is not limited or the user can bypass this
+    // restriction then we're done too.
+    if (!$config->get('limit_search_and_mention') || $account->hasPermission('social profile privacy always show full name')) {
+      return;
+    }
+
+    // Get all fields available to search in.
+    $all_fields = $query->getFulltextFields() ?? $query->getIndex()->getFulltextFields();
+
+    // Remove the first name and last name from the search query, if a user has
+    // no nickname, this value will be searchable through
+    // social_profile_privacy_restricted_name. If a user has a nickname then the
+    // first and last name is not searchable.
+    $search_fields = array_diff(
+      $all_fields,
+      ['field_profile_first_name', 'field_profile_last_name']
+    );
+
+    $query->setFulltextFields($search_fields);
+  }
+
+  /**
+   * Check whether the datasource is supported by this processor.
+   *
+   * @param \Drupal\search_api\Datasource\DatasourceInterface $datasource
+   *   The data source to verify.
+   *
+   * @return bool
+   *   Whether this processor can use the datasource.
+   */
+  protected function supportsDataSource(DatasourceInterface $datasource) : bool {
+    return $datasource->getEntityTypeId() === 'profile';
+  }
+
+  /**
+   * Fetches the first value of a field for an item.
+   *
+   * @param \Drupal\search_api\Item\ItemInterface $item
+   *   The item that the field belongs to.
+   * @param string $field_name
+   *   The name of the field.
+   *
+   * @return string
+   *   The first value of the item or an empty string if no value could be
+   *   found.
+   */
+  protected function getFirstItemField(ItemInterface $item, string $field_name) : string {
+    $field = $item->getField($field_name);
+
+    // If the field doesn't exist we default to an empty string.
+    if (!$field) {
+      return '';
+    }
+
+    $field_values = $field->getValues();
+
+    // If the field has no values then we convert it to an empty string.
+    if (empty($field_values)) {
+      return '';
+    }
+
+    return reset($field_values);
+  }
+
+}

--- a/modules/social_features/social_profile/modules/social_profile_privacy/src/RestrictedNameProcessorOverride.php
+++ b/modules/social_features/social_profile/modules/social_profile_privacy/src/RestrictedNameProcessorOverride.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Drupal\social_profile_privacy;
+
+use Drupal\Core\Cache\CacheableMetadata;
+use Drupal\Core\Config\ConfigFactoryOverrideInterface;
+
+/**
+ * Adds the Restricted Name field to our required processors.
+ *
+ * @package Drupal\social_profile_privacy
+ */
+class RestrictedNameProcessorOverride implements ConfigFactoryOverrideInterface {
+
+  /**
+   * Load overrides.
+   */
+  public function loadOverrides($names) {
+    $overrides = [];
+    // Set hero title block for book content type.
+    $config_names = [
+      'search_api.index.social_all',
+      'search_api.index.social_users',
+    ];
+    foreach ($config_names as $config_name) {
+      if (in_array($config_name, $names, TRUE)) {
+        $overrides[$config_name] = [
+          'processor_settings' => [
+            'tokenizer' => [
+              'fields' => [
+                'social_profile_privacy_restricted_name' => 'social_profile_privacy_restricted_name',
+              ],
+            ],
+            'ignorecase' => [
+              'fields' => [
+                'social_profile_privacy_restricted_name' => 'social_profile_privacy_restricted_name',
+              ],
+            ],
+            'transliteration' => [
+              'fields' => [
+                'social_profile_privacy_restricted_name' => 'social_profile_privacy_restricted_name',
+              ],
+            ],
+          ],
+        ];
+      }
+    }
+    return $overrides;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCacheSuffix() {
+    return 'SocialProfileProviacy';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCacheableMetadata($name) {
+    return new CacheableMetadata();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function createConfigObject($name, $collection = StorageInterface::DEFAULT_COLLECTION) {
+    return NULL;
+  }
+
+}

--- a/modules/social_features/social_search/config/install/search_api.index.social_all.yml
+++ b/modules/social_features/social_search/config/install/search_api.index.social_all.yml
@@ -240,7 +240,7 @@ processor_settings:
   add_url: {  }
   aggregated_field: {  }
   tokenizer:
-    all_fields: false
+    all_fields: true
     fields:
       - field_group_description
       - field_profile_first_name
@@ -297,7 +297,7 @@ processor_settings:
       preprocess_index: -5
       preprocess_query: -2
   ignorecase:
-    all_fields: false
+    all_fields: true
     fields:
       - field_group_description
       - field_group_location
@@ -312,7 +312,7 @@ processor_settings:
       preprocess_index: -20
       preprocess_query: -20
   transliteration:
-    all_fields: false
+    all_fields: true
     fields:
       - field_group_description
       - field_group_location

--- a/modules/social_features/social_search/config/install/search_api.index.social_content.yml
+++ b/modules/social_features/social_search/config/install/search_api.index.social_content.yml
@@ -121,7 +121,7 @@ processor_settings:
       add_properties: 20
   tokenizer:
     plugin_id: tokenizer
-    all_fields: false
+    all_fields: true
     fields:
       - rendered_item
       - title
@@ -178,7 +178,7 @@ processor_settings:
       preprocess_query: -2
   ignorecase:
     plugin_id: ignorecase
-    all_fields: false
+    all_fields: true
     fields:
       - rendered_item
       - title
@@ -187,7 +187,7 @@ processor_settings:
       preprocess_query: -10
   transliteration:
     plugin_id: transliteration
-    all_fields: false
+    all_fields: true
     fields:
       - rendered_item
       - title

--- a/modules/social_features/social_search/config/install/search_api.index.social_groups.yml
+++ b/modules/social_features/social_search/config/install/search_api.index.social_groups.yml
@@ -93,7 +93,7 @@ processor_settings:
       add_properties: 20
   tokenizer:
     plugin_id: tokenizer
-    all_fields: false
+    all_fields: true
     fields:
       - field_group_description
       - rendered_item
@@ -150,7 +150,7 @@ processor_settings:
       preprocess_query: -2
   ignorecase:
     plugin_id: ignorecase
-    all_fields: false
+    all_fields: true
     fields:
       - field_group_description
       - label
@@ -162,7 +162,7 @@ processor_settings:
       preprocess_query: -10
   transliteration:
     plugin_id: transliteration
-    all_fields: false
+    all_fields: true
     fields:
       - field_group_description
       - label

--- a/modules/social_features/social_search/config/install/search_api.index.social_users.yml
+++ b/modules/social_features/social_search/config/install/search_api.index.social_users.yml
@@ -131,7 +131,7 @@ processor_settings:
       add_properties: 20
   tokenizer:
     plugin_id: tokenizer
-    all_fields: false
+    all_fields: true
     fields:
       - field_profile_first_name
       - field_profile_last_name
@@ -190,7 +190,7 @@ processor_settings:
       preprocess_query: -2
   ignorecase:
     plugin_id: ignorecase
-    all_fields: false
+    all_fields: true
     fields:
       - field_profile_first_name
       - field_profile_last_name
@@ -201,7 +201,7 @@ processor_settings:
       preprocess_query: -10
   transliteration:
     plugin_id: transliteration
-    all_fields: false
+    all_fields: true
     fields:
       - field_profile_first_name
       - field_profile_last_name

--- a/tests/behat/features/capabilities/profile/restricted-full-name.feature
+++ b/tests/behat/features/capabilities/profile/restricted-full-name.feature
@@ -11,7 +11,7 @@ Feature: I want to restrict full name visibility when nickname is used
     And users:
       | name   | mail                     | status | field_profile_first_name | field_profile_last_name | field_profile_nick_name |
       | user_1 | user_1@example.localhost | 1      | Open                     | User                    |                         |
-      | user_2 | user_2@example.localhost | 1      | Secretive                | User                    | Hide my name            |
+      | user_2 | user_2@example.localhost | 1      | Secretive                | Person                  | Hide my name            |
       | user_3 | user_3@example.localhost | 1      |                          |                         | Completely Anonymous    |
 
   Scenario: Extra protection for real names
@@ -25,7 +25,7 @@ Feature: I want to restrict full name visibility when nickname is used
 
     When I go to the profile of "user_2"
     Then I should see "Hide my name"
-    But I should not see "Secretive User"
+    But I should not see "Secretive Person"
 
     # Search only allows searching for real names when the nickname is not
     # filled in.
@@ -34,10 +34,15 @@ Feature: I want to restrict full name visibility when nickname is used
 
     When I search users for "Secretive"
     Then I should not see "Hide my name"
-    And I should not see "Secretive user"
+    And I should not see "Secretive Person"
 
     When I search users for "Hide my name"
     Then I should see "Hide my name"
+
+    # Searching for an exact full name should not expose it. This tests for a
+    # reported bug that allowed users to guess hidden full names.
+    When I search users for "Secretive Person"
+    Then I should not see "Hide my name"
 
     # TODO: Add test for mentioning using Javascript?
 
@@ -55,7 +60,7 @@ Feature: I want to restrict full name visibility when nickname is used
     Then I should see "Open User"
 
     When I go to the profile of "user_2"
-    Then I should see "Hide my name (Secretive User)"
+    Then I should see "Hide my name (Secretive Person)"
 
     When I go to the profile of "user_3"
     Then I should see "Completely Anonymous"
@@ -65,10 +70,10 @@ Feature: I want to restrict full name visibility when nickname is used
     Then I should see "Open User"
 
     When I search users for "Secretive"
-    Then I should see "Hide my name (Secretive User)"
+    Then I should see "Hide my name (Secretive Person)"
 
     When I search users for "Hide my name"
-    Then I should see "Hide my name (Secretive User)"
+    Then I should see "Hide my name (Secretive Person)"
 
     When I search users for "Completely"
     Then I should see "Completely Anonymous"
@@ -103,14 +108,7 @@ Feature: I want to restrict full name visibility when nickname is used
 
     When I search users for "user"
     Then I should see "Open User"
-    ###
-    # Due to a small bug in the code, a match on username is filtered out when
-    # the user has a nickname and the search also matched the full name. Even
-    # though the match on the username should always cause a result to be
-    # displayed. The bug should be fixed and the next line uncommented as a test
-    # that it works.
-    ###
-    # And I should see "Hide my name"
+    And I should see "Hide my name"
     And I should see "Completely Anonymous"
 
     # TODO: This should happen automatically see: https://github.com/goalgorilla/open_social/pull/1306
@@ -130,7 +128,7 @@ Feature: I want to restrict full name visibility when nickname is used
 
     When I go to the profile of "user_2"
     Then I should see "Hide my name"
-    And I should not see "Secretive User"
+    And I should not see "Secretive Person"
 
     # Search shows Nickname but allows searching for real name
     When I search users for "Open"


### PR DESCRIPTION
<h2>Problem</h2>
The Social Profile Privacy allows hiding of real names in search for users that have a nickname filled in. This is currently implemented using some quite complex query conditions. This leads to some edge cases where this malfunctions.

<h2>Solution</h2>
Re-implement as a Search API processor. This allows us to create a field that contains the value for restricted users and allows the value for unrestricted users to live next to it. In the query alter we can then simply disable fields the user does not have access to. This creates a more robust solution.

## Issue tracker
https://www.drupal.org/project/social/issues/3084948

## How to test
- See `restricted-full-name.feature` behat test.

## Release notes
The real name restriction has been reworked to provide a more performant and robust solution.
