### PR TITLE
Issue #3036356 by jyoti.singh: On-going events should be still shown in event overviews

### DIFF
--- a/modules/social_features/social_event/config/install/views.view.events.yml
+++ b/modules/social_features/social_event/config/install/views.view.events.yml
@@ -76,6 +76,7 @@ display:
       row:
         type: 'entity:node'
         options:
+          relationship: none
           view_mode: teaser
       fields:
         title:
@@ -637,62 +638,6 @@ display:
           plugin_id: boolean
           entity_type: node
           entity_field: status
-        field_event_date_value:
-          id: field_event_date_value
-          table: node__field_event_date
-          field: field_event_date_value
-          relationship: none
-          group_type: group
-          admin_label: ''
-          operator: '='
-          value:
-            min: ''
-            max: ''
-            value: ''
-            type: date
-          group: 1
-          exposed: true
-          expose:
-            operator_id: field_event_date_value_op
-            label: 'Start date'
-            description: null
-            use_operator: false
-            operator: field_event_date_value_op
-            identifier: field_event_date_value
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-          is_grouped: true
-          group_info:
-            label: 'Event status'
-            description: ''
-            identifier: field_event_date_value
-            optional: false
-            widget: radios
-            multiple: false
-            remember: false
-            default_group: '1'
-            default_group_multiple: {  }
-            group_items:
-              1:
-                title: 'Upcoming events'
-                operator: '>='
-                value:
-                  type: offset
-                  value: now
-                  min: ''
-                  max: ''
-              2:
-                title: 'Events that have started or are finished'
-                operator: '<'
-                value:
-                  type: offset
-                  value: now
-                  min: ''
-                  max: ''
-          plugin_id: datetime
         event_enrolled_or_created_filter:
           id: event_enrolled_or_created_filter
           table: node
@@ -766,10 +711,72 @@ display:
             default_group_multiple: {  }
             group_items: {  }
           plugin_id: node_access
+        field_event_date_end_value:
+          id: field_event_date_end_value
+          table: node__field_event_date_end
+          field: field_event_date_end_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: '='
+          value:
+            min: ''
+            max: ''
+            value: ''
+            type: date
+          group: 1
+          exposed: true
+          expose:
+            operator_id: field_event_date_end_value_op
+            label: 'End (field_event_date_end)'
+            description: null
+            use_operator: false
+            operator: field_event_date_end_value_op
+            identifier: field_event_date_end_value
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            placeholder: null
+            min_placeholder: null
+            max_placeholder: null
+          is_grouped: true
+          group_info:
+            label: 'End (field_event_date_end)'
+            description: ''
+            identifier: field_event_date_end_value
+            optional: false
+            widget: radios
+            multiple: false
+            remember: false
+            default_group: '1'
+            default_group_multiple: {  }
+            group_items:
+              1:
+                title: 'Upcoming and ongoing events'
+                operator: '>='
+                value:
+                  type: offset
+                  value: now
+                  min: ''
+                  max: ''
+              2:
+                title: 'Past events'
+                operator: '<'
+                value:
+                  type: offset
+                  value: now
+                  min: ''
+                  max: ''
+          plugin_id: datetime
       defaults:
         filters: false
         filter_groups: false
         sorts: false
+        use_ajax: false
+        style: false
+        row: false
       filter_groups:
         operator: AND
         groups:
@@ -786,9 +793,18 @@ display:
           exposed: false
           expose:
             label: ''
-          granularity: minute
+          granularity: second
           entity_type: node
           plugin_id: event_passed_upcoming_sort
+      use_ajax: false
+      style:
+        type: default
+        options: {  }
+      row:
+        type: 'entity:node'
+        options:
+          relationship: none
+          view_mode: teaser
     cache_metadata:
       max-age: -1
       contexts:

--- a/modules/social_features/social_event/social_event.module
+++ b/modules/social_features/social_event/social_event.module
@@ -248,7 +248,7 @@ function social_event_views_data_alter(array &$data) {
     'title' => t('Event sorting (passed and upcoming)'),
     'help' => t('For upcoming events sort ASC by start date and for passed events change order to DESC.'),
     'sort' => [
-      'field' => 'field_event_date_value',
+      'field' => 'field_event_date_end_value',
       'id' => 'event_passed_upcoming_sort',
     ],
   ];


### PR DESCRIPTION
## Problem
Events that started are not visible in event overviews.

## Solution
Filter on event end date instead of start date.

## Issue tracker
https://www.drupal.org/project/social/issues/3036356

## How to test
- [ ] Create multi day event with startdate before "now".
- [ ] Make sure the event is in the overview.

## Release notes
Multi-day event dates are now shown in event overviews.
