### PR TITLE
Issue #3047912 by jaapjan: remove check text step in group-edit-type.feature

### DIFF
--- a/tests/behat/features/capabilities/group/group-edit-type.feature
+++ b/tests/behat/features/capabilities/group/group-edit-type.feature
@@ -46,8 +46,6 @@ Feature: Edit group type after creation
       And I wait for AJAX to finish
     Then I should see "Please note that changing the group type will also change the visibility of the group content and the way users can join the group"
       And I press "Save"
-    # TODO: Uncomment this step - https://www.drupal.org/project/social/issues/3047912
-    # Then I should see "Updating Group Content..."
       And I wait for the batch job to finish
     Then I should see "Nescafe"
 


### PR DESCRIPTION
## Problem
We are not testing the text. I think we should just remove this actually. It might have failed because the batch processed too quickly. Important thing is that the type is changed. That is what we are testing.

## Solution
Commented step and text is removed.

## Release notes
Not necessary.