### PR TITLE
Add developer demo content folder and some demo files [skip ci]

### DIFF
--- a/modules/custom/social_demo/developer/content/entity/event.yml
+++ b/modules/custom/social_demo/developer/content/entity/event.yml
@@ -1,0 +1,17 @@
+88e337ea-f512-4afd-a1ba-08d29ed6ba491:
+  uuid: 88e337ea-f512-4afd-a1ba-08d29ed6ba491
+  title: Pizza meeting
+  type: event
+  langcode: und
+  uid: 44fc2f3a-da2f-11e5-b5d2-0a1d41d68578
+  body: >
+    <p>Just eat a pizza!</p>
+  field_event_address:
+    country_code: GB
+    locality: London
+    postal_code: W1D 3BT
+    address_line1: 16 Carlisle St
+  field_event_date: +52 day|10:00
+  field_event_date_end: +52 day|14:00
+  field_event_location: SOHO BUSINESS CLUB
+  field_content_visibility: community

--- a/modules/custom/social_demo/developer/content/entity/topic.yml
+++ b/modules/custom/social_demo/developer/content/entity/topic.yml
@@ -1,0 +1,113 @@
+---
+426a6ea6-decd-11e5-b86d-9a79f06e94781:
+  uuid: 426a6ea6-decd-11e5-b86d-9a79f06e94781
+  title: Intro call
+  type: topic
+  langcode: und
+  uid: 44fc2f3a-da2f-11e5-b5d2-0a1d41d68578
+  body: >
+    <p>Hereby the notes of our latest intro call.</p>
+  field_topic_type: Discussion
+  image:
+  image_alt:
+  field_content_visibility: community
+426a6ea6-decd-11e5-b86d-9a79f06e94781a:
+  uuid: 426a6ea6-decd-11e5-b86d-9a79f06e94781a
+  title: Intro call
+  type: topic
+  langcode: und
+  uid: 44fc2f3a-da2f-11e5-b5d2-0a1d41d68578
+  body: >
+    <p>Hereby the notes of our latest intro call.</p>
+  field_topic_type: Discussion
+  image:
+  image_alt:
+  field_content_visibility: community
+426a6ea6-decd-11e5-b86d-9a79f06e94782:
+  uuid: 426a6ea6-decd-11e5-b86d-9a79f06e94782
+  title: Intro call
+  type: topic
+  langcode: und
+  uid: 44fc2f3a-da2f-11e5-b5d2-0a1d41d68578
+  body: >
+    <p>Hereby the notes of our latest intro call. The intro call was a great success!</p>
+  field_topic_type: Discussion
+  image:
+  image_alt:
+  field_content_visibility: community
+426a6ea6-decd-11e5-b86d-9a79f06e94783:
+  uuid: 426a6ea6-decd-11e5-b86d-9a79f06e94783
+  title: Lets plan a call for introduction
+  type: topic
+  langcode: und
+  uid: 44fc2f3a-da2f-11e5-b5d2-0a1d41d68578
+  body: >
+    <p>Hereby the notes of our latest intro call. The intro call was a great success!</p>
+  field_topic_type: Discussion
+  image:
+  image_alt:
+  field_content_visibility: community
+426a6ea6-decd-11e5-b86d-9a79f06e94784:
+  uuid: 426a6ea6-decd-11e5-b86d-9a79f06e94784
+  title: Pizza
+  type: topic
+  langcode: und
+  uid: 44fc2f3a-da2f-11e5-b5d2-0a1d41d68578
+  body: >
+    <p>Lets talk about Pizza's.</p>
+  field_topic_type: Discussion
+  image:
+  image_alt:
+  field_content_visibility: community
+426a6ea6-decd-11e5-b86d-9a79f06e94785:
+  uuid: 426a6ea6-decd-11e5-b86d-9a79f06e94785
+  title: Monthly call January 2019
+  created: 1 February 2019|12:00
+  type: topic
+  langcode: und
+  uid: 44fc2f3a-da2f-11e5-b5d2-0a1d41d68578
+  body: >
+    <p>Monthly call January 2019</p>
+  field_topic_type: Discussion
+  image:
+  image_alt:
+  field_content_visibility: community
+426a6ea6-decd-11e5-b86d-9a79f06e94786:
+  uuid: 426a6ea6-decd-11e5-b86d-9a79f06e94786
+  title: Monthly call February 2019
+  created: 1 March 2019|12:00
+  type: topic
+  langcode: und
+  uid: 44fc2f3a-da2f-11e5-b5d2-0a1d41d68578
+  body: >
+    <p>Monthly call February 2019</p>
+  field_topic_type: Discussion
+  image:
+  image_alt:
+  field_content_visibility: community
+426a6ea6-decd-11e5-b86d-9a79f06e94787:
+  uuid: 426a6ea6-decd-11e5-b86d-9a79f06e94787
+  title: Monthly call March 2019
+  created: 1 April 2019|12:00
+  type: topic
+  langcode: und
+  uid: 44fc2f3a-da2f-11e5-b5d2-0a1d41d68578
+  body: >
+    <p>Monthly call March 2019</p>
+  field_topic_type: Discussion
+  image:
+  image_alt:
+  field_content_visibility: community
+426a6ea6-decd-11e5-b86d-9a79f06e94788:
+  uuid: 426a6ea6-decd-11e5-b86d-9a79f06e94788
+  title: All the calls of 2019
+  created: 1 May 2019|12:00
+  type: topic
+  langcode: und
+  uid: 44fc2f3a-da2f-11e5-b5d2-0a1d41d68578
+  body: >
+    <p>Monthly call January 2019, Monthly call February 2019, Monthly call March 2019</p>
+  field_topic_type: Discussion
+  image:
+  image_alt:
+  field_content_visibility: community


### PR DESCRIPTION
## Problem
When you need to test certain use-cases it can be handy to have demo content ready. Example is testing the [search relevancy](https://github.com/goalgorilla/open_social/pull/1431) sorting.

## Solution
Let's add a developer content folder in social_demo.

You can now create demo content with `drush sda topic event --profile=developer`

## Issue tracker
n/a

## How to test
- [ ] Test demo content creation first create all the usual demo content.
- [ ] Then: `drush sda topic event --profile=developer`
- [ ] Demo content should be there. 

## Release notes
Not necessary.