### PR TITLE
Issue #3085176: move social_post_update hook to post_update

### DIFF
--- a/modules/social_features/social_post/social_post.install
+++ b/modules/social_features/social_post/social_post.install
@@ -86,11 +86,3 @@ function _social_post_get_permissions($role) {
   }
   return [];
 }
-
-/**
- * Grant permission to administer post entities to CM and SM.
- */
-function social_post_update_8601() {
-  user_role_grant_permissions('contentmanager', ['administer post entities']);
-  user_role_grant_permissions('sitemanager', ['administer post entities']);
-}

--- a/modules/social_features/social_post/social_post.post_update.php
+++ b/modules/social_features/social_post/social_post.post_update.php
@@ -36,3 +36,11 @@ function social_post_post_update_remove_orphaned_posts() {
   $entities = $storage_handler->loadMultiple($pids);
   $storage_handler->delete($entities);
 }
+
+/**
+ * Grant permission to administer post entities to CM and SM.
+ */
+function social_post_post_update_8601_administer_post_permissions() {
+  user_role_grant_permissions('contentmanager', ['administer post entities']);
+  user_role_grant_permissions('sitemanager', ['administer post entities']);
+}


### PR DESCRIPTION
## Problem
The function social_post_update_8601 is being executed with every database update. Because the module is called social_post Drupal actually thinks its a hook_post_update. See: https://www.drupal.org/project/drupal/issues/2880361

## Solution
It’s changing configuration, this should happen in a post_update hook and not an update hook. So moving it to social_post_post_update_8601_administer_post_permissions in social_post.post_update.php solves the issue for now.

## Issue tracker
https://www.drupal.org/project/social/issues/3085176

## How to test
- [ ] Run database update hooks. Notice social_post is only executing once.

## Release notes
Due to naming conventions the social_post_update_8601 was being executed in every database update. We've moved the function to a post_update so it should only execute once.
