### PR TITLE
Issue #3085183 by makishima: Remove superfluous functionality in the social_profile module that sets the default country for users

### DIFF
--- a/modules/social_features/social_profile/social_profile.module
+++ b/modules/social_features/social_profile/social_profile.module
@@ -425,14 +425,6 @@ function social_profile_user_insert(UserInterface $account) {
         'uid' => $account->id(),
       ];
 
-      // Get all field instances for the profile entity and check if the address
-      // field exists.
-      $instances = \Drupal::service('entity_field.manager')->getFieldDefinitions('profile', $profile_type->id());
-      if (array_key_exists('field_profile_address', $instances)) {
-        // Set the users default country to the site default country.
-        $default_values['field_profile_address'][0]['country_code'] = \Drupal::config('system.date')->get('country.default');
-      }
-
       // Create a profile.
       $profile = Profile::create($default_values);
       $profile->save();


### PR DESCRIPTION
## Problem
When creating a new user, the country field in the profile has a default value that is equal to the default country of the site, but should be set to "None" value.

## Solution
Remove superfluous functionality in the social_profile module that sets the default country for users from the default country on the site.

## Issue tracker
https://www.drupal.org/project/social/issues/3085183
https://getopensocial.atlassian.net/browse/YANG-1451

## How to test
- [ ] Create new user
- [ ] Go to user profile, check the Country field, make sure the value is set to  "- None -"

