### PR TITLE
Issue #3085504: Improve performance of ConfigOverrides in Social Lazy Load

### DIFF
--- a/modules/custom/social_lazy_loading/social_lazy_loading_images/social_lazy_loading_images.services.yml
+++ b/modules/custom/social_lazy_loading/social_lazy_loading_images/social_lazy_loading_images.services.yml
@@ -1,6 +1,5 @@
 services:
   social_lazy_loading_images.overrider:
     class: Drupal\social_lazy_loading_images\SocialLazyLoadingImageDisplayOverride
-    arguments: ['@config.factory']
     tags:
       - { name: config.factory.override, priority: 200 }

--- a/modules/custom/social_lazy_loading/social_lazy_loading_images/src/SocialLazyLoadingImageDisplayOverride.php
+++ b/modules/custom/social_lazy_loading/social_lazy_loading_images/src/SocialLazyLoadingImageDisplayOverride.php
@@ -3,7 +3,6 @@
 namespace Drupal\social_lazy_loading_images;
 
 use Drupal\Core\Cache\CacheableMetadata;
-use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Config\ConfigFactoryOverrideInterface;
 use Drupal\Core\Config\StorageInterface;
 
@@ -13,23 +12,6 @@ use Drupal\Core\Config\StorageInterface;
  * @package Drupal\social_lazy_loading_images
  */
 class SocialLazyLoadingImageDisplayOverride implements ConfigFactoryOverrideInterface {
-
-  /**
-   * The config factory.
-   *
-   * @var \Drupal\Core\Config\ConfigFactoryInterface
-   */
-  protected $configFactory;
-
-  /**
-   * Constructs the configuration override.
-   *
-   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
-   *   The configuration factory.
-   */
-  public function __construct(ConfigFactoryInterface $config_factory) {
-    $this->configFactory = $config_factory;
-  }
 
   /**
    * {@inheritdoc}
@@ -82,38 +64,11 @@ class SocialLazyLoadingImageDisplayOverride implements ConfigFactoryOverrideInte
     ];
 
     foreach ($config_fields as $config_name => $field_name) {
-      $this->addImageOverride($config_name, $field_name, $overrides);
+      $overrides[$config_name]['dependencies']['module']['lazy'] = 'lazy';
+      $overrides[$config_name]['content'][$field_name]['third_party_settings']['lazy'] = ['lazy_image' => '1'];
     }
 
     return $overrides;
-  }
-
-  /**
-   * Alters the filter settings for the text format.
-   *
-   * @param string $config_name
-   *   A config name to override.
-   * @param string $field_name
-   *   A field to override.
-   * @param array $overrides
-   *   An override configuration.
-   */
-  protected function addImageOverride($config_name, $field_name, array &$overrides) {
-    if (!empty($config_name) && !empty($field_name)) {
-      $config = $this->configFactory->getEditable($config_name);
-      $dependencies = $config->getOriginal('dependencies.module');
-      $overrides[$config_name]['dependencies']['module'] = $dependencies;
-      $overrides[$config_name]['dependencies']['module'][] = 'lazy';
-
-      $settings = $config->getOriginal('content.' . $field_name . 'third_party_settings');
-
-      $overrides[$config_name]['content'][$field_name]['third_party_settings'] = $settings;
-      $overrides[$config_name]['content'][$field_name]['third_party_settings'] = [
-        'lazy' => [
-          'lazy_image' => '1',
-        ],
-      ];
-    }
   }
 
   /**

--- a/modules/custom/social_lazy_loading/social_lazy_loading_images/src/SocialLazyLoadingImageDisplayOverride.php
+++ b/modules/custom/social_lazy_loading/social_lazy_loading_images/src/SocialLazyLoadingImageDisplayOverride.php
@@ -64,8 +64,10 @@ class SocialLazyLoadingImageDisplayOverride implements ConfigFactoryOverrideInte
     ];
 
     foreach ($config_fields as $config_name => $field_name) {
-      $overrides[$config_name]['dependencies']['module']['lazy'] = 'lazy';
-      $overrides[$config_name]['content'][$field_name]['third_party_settings']['lazy'] = ['lazy_image' => '1'];
+      if (in_array($config_name, $names)) {
+        $overrides[$config_name]['dependencies']['module']['lazy'] = 'lazy';
+        $overrides[$config_name]['content'][$field_name]['third_party_settings']['lazy'] = ['lazy_image' => '1'];
+      }
     }
 
     return $overrides;

--- a/modules/custom/social_lazy_loading/src/SocialLazyLoadingTextFormatOverride.php
+++ b/modules/custom/social_lazy_loading/src/SocialLazyLoadingTextFormatOverride.php
@@ -3,7 +3,6 @@
 namespace Drupal\social_lazy_loading;
 
 use Drupal\Core\Cache\CacheableMetadata;
-use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Config\ConfigFactoryOverrideInterface;
 use Drupal\Core\Config\StorageInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
@@ -23,23 +22,13 @@ class SocialLazyLoadingTextFormatOverride implements ConfigFactoryOverrideInterf
   protected $moduleHandler;
 
   /**
-   * The config factory.
-   *
-   * @var \Drupal\Core\Config\ConfigFactoryInterface
-   */
-  protected $configFactory;
-
-  /**
    * Constructs the configuration override.
    *
    * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
    *   The module handler.
-   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
-   *   The configuration factory.
    */
-  public function __construct(ModuleHandlerInterface $module_handler, ConfigFactoryInterface $config_factory) {
+  public function __construct(ModuleHandlerInterface $module_handler) {
     $this->moduleHandler = $module_handler;
-    $this->configFactory = $config_factory;
   }
 
   /**
@@ -90,11 +79,7 @@ class SocialLazyLoadingTextFormatOverride implements ConfigFactoryOverrideInterf
     $config_name = 'filter.format.' . $text_format;
 
     if ($convert_url) {
-      $config = $this->configFactory->getEditable($config_name);
-      $dependencies = $config->getOriginal('dependencies.module');
-      $overrides[$config_name]['dependencies']['module'] = $dependencies;
-      $overrides[$config_name]['dependencies']['module'][] = 'lazy';
-
+      $overrides[$config_name]['dependencies']['module']['lazy'] = 'lazy';
       $overrides[$config_name]['filters']['lazy_filter'] = [
         'id' => 'lazy_filter',
         'provider' => 'lazy',


### PR DESCRIPTION
## Problem
The `SocialLazyLoadingImageDisplayOverride` and `SocialLazyLoadingTextFormatOverride` are checking for existing config. This is adding an extra few 100ms to a page request as this code is executed via `lazy_is_enabled()` in `lazy.module`.

## Solution
Let's remove the configfactory injects inside these overrides and simplify the code a bit.

![blackfire-comparison](https://user-images.githubusercontent.com/2848293/66135157-c8345100-e5f9-11e9-8773-0caccc7ca2e6.png)

## Issue tracker
https://www.drupal.org/project/social/issues/3085504

## How to test
- [ ] Profile `lazy_is_enabled`
- [ ] Check the difference
- [ ] Make sure lazy loading is still working as expected.

## Release notes
The configuration overrides in Social Lazy Load are optimised by removing existing configuration checks.