### PR TITLE
Added conditional check to account object to be null.

### DIFF
--- a/modules/social_features/social_profile/modules/social_profile_privacy/social_profile_privacy.module
+++ b/modules/social_features/social_profile/modules/social_profile_privacy/social_profile_privacy.module
@@ -145,8 +145,7 @@ function social_profile_privacy_form_alter(&$form, FormStateInterface $form_stat
       $settings_form_id = $field_groups['settings_form_id'];
       $profile = $form_state->getFormObject()->getEntity();
       $account = \Drupal::routeMatch()->getParameter('user');
-
-      $uid = $account->id();
+      $uid = $account ? $account->id() : NULL;
       if (empty($uid)) {
         $uid = $profile->get('uid')->target_id;
       }


### PR DESCRIPTION
## Problem
In social_profile_privacy_form_alter(), $account is not checked for being NULL when the parameter user is not found in URL. This blocks any user to edit profiles.

## Solution
Add a null check.

## Issue tracker
https://www.drupal.org/project/social/issues/3085803

## How to test
- [x] Enabled social_profile_privacy module.
- [x] Login in as SM or admin
- [x] Go to profile listing
- [x] Try to edit any profile.

## Release notes
Introduces an empty check in social_profile_privacy_form_alter in social_profile_privacy module.

## Change Record
N.A