### PR TITLE
Issue #3086219: Prevent notice in social_group_secret_form_node_form_alter()

### DIFF
--- a/modules/social_features/social_group/modules/social_group_secret/social_group_secret.module
+++ b/modules/social_features/social_group/modules/social_group_secret/social_group_secret.module
@@ -165,7 +165,9 @@ function social_group_secret_form_node_form_alter(&$form, FormStateInterface $fo
   }
 
   $user = \Drupal::currentUser();
-  $current_group = $form["groups"]["widget"]['#default_value'][0];
+  if (!empty($form["groups"]["widget"]['#default_value'])) {
+    $current_group = $form["groups"]["widget"]['#default_value'][0];
+  }
   $secret_group = t('Secret group')->__toString();
 
   // The options are either a list of group ids when there is only a single
@@ -175,7 +177,7 @@ function social_group_secret_form_node_form_alter(&$form, FormStateInterface $fo
     $groups = Group::loadMultiple($group_ids);
     /** @var \Drupal\group\Entity\Group $group */
     foreach ($groups as $group) {
-      if ($group->id() === $current_group) {
+      if (isset($current_group) && $group->id() === $current_group) {
         continue;
       }
 
@@ -203,7 +205,7 @@ function social_group_secret_form_node_form_alter(&$form, FormStateInterface $fo
         break;
       }
 
-      if ($group->id() === $current_group) {
+      if (isset($current_group) && $group->id() === $current_group) {
         continue;
       }
 


### PR DESCRIPTION
## Problem
When you edit a node which is posted in the community (so not in any group) and the secret group module is enabled you'll see a notice on every edit node page.

```
Notice: Undefined offset: 0 in social_group_secret_form_node_form_alter() (line 168 of profiles/contrib/social/modules/social_features/social_group/modules/social_group_secret/social_group_secret.module).
```

## Solution
Made the code defensive.

## Issue tracker
https://www.drupal.org/project/social/issues/3086219

## How to test
- [ ] Check code changes.
- [ ] Verify that the secret group edit forms still work as expected.

## Release notes
When a node wasn't posted in any group and the secret group module is enabled there was be a notice on the node form. This has now been solved.