### PR TITLE
Issue #3086229: Download count: Invalidate file cache tags only when needed

### DIFF
--- a/modules/custom/download_count/download_count.module
+++ b/modules/custom/download_count/download_count.module
@@ -29,15 +29,11 @@ function download_count_help($route_name, RouteMatchInterface $route_match) {
  * Implements hook_ENTITY_TYPE_access().
  */
 function download_count_file_access(EntityInterface $entity, $operation, AccountInterface $account) {
-  if ($operation == 'download') {
+  if ($operation === 'download') {
     $flood = \Drupal::flood();
     $config = \Drupal::config('download_count.settings');
     $flood_window = $config->get('download_count_flood_window');
     $time = \Drupal::time()->getRequestTime();
-
-    // Invalidate file field formatter.
-    $cache_tag = 'file:' . $entity->id();
-    Cache::invalidateTags([$cache_tag]);
 
     if ($account->hasPermission('skip download counts')) {
       return;
@@ -59,6 +55,10 @@ function download_count_file_access(EntityInterface $entity, $operation, Account
         return;
       }
     }
+
+    // Invalidate file field formatter.
+    $cache_tag = 'file:' . $entity->id();
+    Cache::invalidateTags([$cache_tag]);
 
     // Count the download.
     $ip = Drupal::request()->getClientIp();


### PR DESCRIPTION
## Problem
In download count module we implement hook_ENTITY_TYPE_access for files which adds a file download count for every downloaded file. However this code is also triggered for comment attachments. Depending on the settings or user permissions some files are excluded and the download count won't be adjusted. The file cache tags are invalidated for every file download.

## Solution
Let's do the invalidating of the cache tags only when the file download count is actually changed.

## Issue tracker
https://www.drupal.org/project/social/issues/3086229

## How to test
- [ ] Check code changes and logic explanation
- [ ] Enable social_download_count and dependencies
- [ ] Login as LU
- [ ] Create topic with multiple file attachments.
- [ ] Add a comment (with attachment) image and make sure to check with breakpoints when the code is actually executed (for all of them)
- [ ] Verify the settings (Flood + Exclude extensions) and make sure the feature is working as expected.

## Release notes
The download count should only invalidate the file cache for a file download if the file download usage is updated.