### PR TITLE
Issue #3086462 by agami4: Fix overlapping text on the dropdown notification menu

### DIFF
--- a/themes/socialbase/assets/css/dropdown.css
+++ b/themes/socialbase/assets/css/dropdown.css
@@ -224,6 +224,8 @@ html:not(.js) .dropdown .dropdown-toggle {
   z-index: -1;
 }
 
+/* IE11 */
+
 @media (min-width: 600px) {
   .dropdown-menu .divider.mobile {
     display: none;
@@ -244,6 +246,12 @@ html:not(.js) .dropdown .dropdown-toggle {
   .scrollable-menu {
     height: auto;
     max-height: 450px;
+  }
+}
+
+@media (min-width: 600px) and (-ms-high-contrast: none) {
+  *::-ms-backdrop, .dropdown-menu .media-body {
+    padding-right: 17px;
   }
 }
 

--- a/themes/socialbase/components/03-molecules/dropdown/dropdown.scss
+++ b/themes/socialbase/components/03-molecules/dropdown/dropdown.scss
@@ -363,3 +363,8 @@ html:not(.js) {
     }
   }
 }
+
+/* IE11 */
+@media (min-width: 600px) and (-ms-high-contrast:none) {
+  *::-ms-backdrop, .dropdown-menu .media-body { padding-right: 17px; }
+}


### PR DESCRIPTION
## Problem
Message text overlaps on the dropdown notification menu

## Solution
Add more space on the right side to the message on the notification menu

## Issue tracker
https://www.drupal.org/project/social/issues/3086462

## How to test
- [ ] Open Distro demo on the IE11 and open dropdown notification menu

## Release notes
Fixed overlapping text on the dropdown notification menu

## Change Record
If this Pull Request changes the way that developers should do things or introduces a new API for developers then a change record to document this is needed. Please provide a draft for a change record or a link to an unpublished change record below. [Existing change records](https://www.drupal.org/list-changes/social) can be consulted as example.
