### PR TITLE
Issue #3087004: VBO - 7.0 - Updates

### DIFF
--- a/modules/social_features/social_event/modules/social_event_an_enroll/social_event_an_enroll.module
+++ b/modules/social_features/social_event/modules/social_event_an_enroll/social_event_an_enroll.module
@@ -234,19 +234,6 @@ function social_event_an_enroll_form_alter(&$form, FormStateInterface $form_stat
     // Hide checkbox if feature is disabled globally.
     $form['field_event_an_enroll']['#access'] = $config->get('event_an_enroll');
   }
-
-  if ((isset($form['views_bulk_operations_bulk_form']) || strpos($form_id, 'views_form_event_manage_enrollments_page_manage_enrollments') !== FALSE) && isset($form['output'][0]['#view'])) {
-    $view = &$form['output'][0]['#view'];
-
-    // Unset the action to send emails to LU members which is replaced by
-    // config override.
-    if ($view instanceof ViewExecutable && $view->id() === 'event_manage_enrollments') {
-      $actions = &$form['header']['social_views_bulk_operations_bulk_form_enrollments_1']['actions'];
-      $action = 'social_event_managers_send_email_action';
-      $actions[$action]['#access'] = FALSE;
-      unset($actions['#links'][$action]);
-    }
-  }
 }
 
 /**

--- a/modules/social_features/social_event/modules/social_event_an_enroll/src/EventAnEnrollOverride.php
+++ b/modules/social_features/social_event/modules/social_event_an_enroll/src/EventAnEnrollOverride.php
@@ -77,6 +77,9 @@ class EventAnEnrollOverride implements ConfigFactoryOverrideInterface {
           ],
         ],
       ];
+
+      // Unset the regular Email.
+      $overrides[$config_name]['display']['default']['display_options']['fields']['social_views_bulk_operations_bulk_form_enrollments_1']['selected_actions']['social_event_managers_send_email_action'] = 0;
     }
 
     return $overrides;

--- a/modules/social_features/social_event/modules/social_event_an_enroll_enrolments_export/social_event_an_enroll_enrolments_export.module
+++ b/modules/social_features/social_event/modules/social_event_an_enroll_enrolments_export/social_event_an_enroll_enrolments_export.module
@@ -9,22 +9,6 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\views\ViewExecutable;
 
 /**
- * Implements hook_form_alter().
- */
-function social_event_an_enroll_enrolments_export_form_alter(&$form, FormStateInterface $form_state, $form_id) {
-  if ((isset($form['views_bulk_operations_bulk_form']) || strpos($form_id, 'views_form_event_manage_enrollments_page_manage_enrollments') !== FALSE) && isset($form['output'][0]['#view'])) {
-    $view = &$form['output'][0]['#view'];
-
-    if ($view instanceof ViewExecutable && $view->id() === 'event_manage_enrollments') {
-      $actions = &$form['header']['social_views_bulk_operations_bulk_form_enrollments_1']['actions'];
-      $action = 'social_event_enrolments_export_enrollments_action';
-      $actions[$action]['#access'] = FALSE;
-      unset($actions['#links'][$action]);
-    }
-  }
-}
-
-/**
  * Implements hook_social_event_managers_action_ACTION_ID_finish().
  */
 function social_event_an_enroll_enrolments_export_social_event_managers_action_social_event_an_enroll_enrolments_export_action_finish($success) {

--- a/modules/social_features/social_event/modules/social_event_an_enroll_enrolments_export/social_event_an_enroll_enrolments_export.module
+++ b/modules/social_features/social_event/modules/social_event_an_enroll_enrolments_export/social_event_an_enroll_enrolments_export.module
@@ -5,9 +5,6 @@
  * The Social Event An Enroll Enrolments Export module.
  */
 
-use Drupal\Core\Form\FormStateInterface;
-use Drupal\views\ViewExecutable;
-
 /**
  * Implements hook_social_event_managers_action_ACTION_ID_finish().
  */

--- a/modules/social_features/social_event/modules/social_event_an_enroll_enrolments_export/src/SocialEventAnEnrollEnrolmentsExportOverrides.php
+++ b/modules/social_features/social_event/modules/social_event_an_enroll_enrolments_export/src/SocialEventAnEnrollEnrolmentsExportOverrides.php
@@ -40,6 +40,8 @@ class SocialEventAnEnrollEnrolmentsExportOverrides implements ConfigFactoryOverr
           ],
         ],
       ];
+
+      $overrides[$config_name]['display']['default']['display_options']['fields']['social_views_bulk_operations_bulk_form_enrollments_1']['selected_actions']['social_event_enrolments_export_enrollments_action'] = 0;
     }
 
     return $overrides;

--- a/modules/social_features/social_event/modules/social_event_managers/social_event_managers.module
+++ b/modules/social_features/social_event/modules/social_event_managers/social_event_managers.module
@@ -140,6 +140,14 @@ function social_event_managers_form_alter(&$form, FormStateInterface $form_state
       $display_id = $view->current_display;
     }
   }
+  elseif (isset($form['social_views_bulk_operations_bulk_form_enrollments_1']) && isset($form['output'][0]['#view'])) {
+    $view = &$form['output'][0]['#view'];
+
+    if ($view instanceof ViewExecutable) {
+      $view_id = $view->id();
+      $display_id = $view->current_display;
+    }
+  }
   elseif ($form_id === 'views_bulk_operations_configure_action') {
     $data = $form_state->get('views_bulk_operations');
     $view_id = $data['view_id'];

--- a/modules/social_features/social_group/modules/social_group_members_export/src/SocialGroupMembersExportOverrides.php
+++ b/modules/social_features/social_group/modules/social_group_members_export/src/SocialGroupMembersExportOverrides.php
@@ -25,7 +25,7 @@ class SocialGroupMembersExportOverrides implements ConfigFactoryOverrideInterfac
           'default' => [
             'display_options' => [
               'fields' => [
-                'views_bulk_operations_bulk_form' => [
+                'social_views_bulk_operations_bulk_form_group' => [
                   'selected_actions' => [
                     'social_group_members_export_member_action' => 'social_group_members_export_member_action',
                   ],


### PR DESCRIPTION
## Problem
1.  Issues with installation caused a lot of the issues to appear.
2. When the Social AN Enrollment is enabled you see two "Send Email" actions on event enrollment management pages. Due to a form_alter that doesn't apply.

## Solution
1. Updated the release branch with a new composer.lock file
2. Make sure we skip the form alter, instead we use config override. This is much more stable since the form render array could change easily (let's say on a VBO update). The id of the Plugin action doesn't change unless we change our plugin.

## Issue tracker - All of them can be closed.
https://www.drupal.org/project/social/issues/3087004#comment-13293889

https://getopensocial.atlassian.net/browse/DS-6930
https://getopensocial.atlassian.net/browse/DS-6912
https://getopensocial.atlassian.net/browse/DS-6911
https://getopensocial.atlassian.net/browse/DS-6915
https://getopensocial.atlassian.net/browse/DS-6931

## How to test
- [ ] Login at: https://release-35-roo3hii-rmio5d4m7mmka.eu.platform.sh
- [ ] See that when you go to `node/5/all-enrollments`
- [ ] There is now only one "Send email action" (https://getopensocial.atlassian.net/browse/DS-6930)
- [ ] See that when you select one ore more members it updates the count correctly ( https://getopensocial.atlassian.net/browse/DS-6912 ) 
- [ ] See that there is no notice in the recent log messages anymore ( https://getopensocial.atlassian.net/browse/DS-6911 )

- [ ] See that on admin/people there is no notice anymore 
Test at: https://release-35-roo3hii-rmio5d4m7mmka.eu.platform.sh/admin/people
Close: https://getopensocial.atlassian.net/browse/DS-6931
- [ ] Enable social_group_members_export and see that group members page doesn't WSOD and export also works 
Test at: https://release-35-roo3hii-rmio5d4m7mmka.eu.platform.sh/group/1/membership
Close: https://getopensocial.atlassian.net/browse/DS-6915)

## Release notes
We have ensured when allowing for anonymous event enrollments, the actions button does not show the Send Mail options twice anymore for bulk operations on the enrollment management pages.