### PR TITLE
Issue #3087021: Allow to add page content attributes from modules

### DIFF
--- a/modules/social_features/social_landing_page/social_landing_page.module
+++ b/modules/social_features/social_landing_page/social_landing_page.module
@@ -159,19 +159,6 @@ function social_landing_page_preprocess_page(&$variables) {
 }
 
 /**
- * Implements hook_theme_registry_alter().
- */
-function social_landing_page_theme_registry_alter(&$theme_registry) {
-  // Here we put our preprocess function after bootstrap
-  // preprocess to have content_attributes inside.
-  $original = $theme_registry['page']['preprocess functions'];
-  $key = array_search('social_landing_page_preprocess_page', $original, TRUE);
-  unset($original[$key]);
-  array_splice($original, ++$key, 0, ['social_landing_page_preprocess_page']);
-  $theme_registry['page']['preprocess functions'] = $original;
-}
-
-/**
  * Prepares variables for the paragraph.
  */
 function social_landing_page_preprocess_paragraph(&$variables) {

--- a/themes/socialbase/src/Plugin/Preprocess/Page.php
+++ b/themes/socialbase/src/Plugin/Preprocess/Page.php
@@ -22,8 +22,7 @@ class Page extends PreprocessBase {
   public function preprocess(array &$variables, $hook, array $info) {
     parent::preprocess($variables, $hook, $info);
 
-    // Add needed attributes so later in template we can manipulate with them.
-    $attributes = new Attribute();
+    $attributes = $variables['content_attributes'] instanceof Attribute ? $variables['content_attributes'] : new Attribute();
     // Default classes.
     $attributes->addClass('row', 'container');
     // If page has title.


### PR DESCRIPTION
## Problem
Currently, it is not possible to override or add attributes (classes) to page template from modules like landing page or courses.

## Solution
Allow adding page content attributes from modules by checking if attributes already exist in theme preprocess. 

## Issue tracker
https://www.drupal.org/project/social/issues/3087021

## How to test
- [x] Open Landing page
- [x] It should look the same as usual and should not have class `layout--with-complementary` as usual

## Release notes
We allow to add attributes (classes) to page template from modules and it will be not overridden by theme.

