### PR TITLE
Issue #3087098: Event date filter shouldn't apply to others. 

### DIFF
--- a/modules/social_features/social_search/src/Plugin/views/filter/SocialDate.php
+++ b/modules/social_features/social_search/src/Plugin/views/filter/SocialDate.php
@@ -30,6 +30,15 @@ class SocialDate extends DateTimeDate {
       $operator = $this->operator;
     }
 
+    // Custom override to ensure that when users
+    // filter on something different than the event type
+    // we also don't use an event field filter.
+    if (!empty($input['type']) && $input['type'] !== 'event') {
+      $input['field_event_date']['value'] = '';
+      $input['field_event_date']['max'] = '';
+      $input['field_event_date']['min'] = '';
+    }
+
     // Fallback for exposed operator.
     $operatorfromurl = NULL;
     if ($operator === NULL && $this->realField === 'created') {


### PR DESCRIPTION
## Problem
When filtering on Event, adding a start date exposed filter value and then switching to topic/event ensures this filter also applies to the others.

## Solution
We now check this in the AcceptedExposed input to ensure we only allow these values as input when "event" is selected.

## Issue tracker
- [ ] https://www.drupal.org/project/social/issues/3087098
- [ ] https://getopensocial.atlassian.net/browse/DS-6909

## How to test
- [x] Filter on events as AN, add a date filter value 
- [x] See that you see Events
- [x] Switch to Topics
- [x] Search, and no topics are shown
- [x] Reset the filter, now select Topic and see you have values
- [x] Switch to this branch, see that it should now be solved :) 

## Release notes
We ensure that searching for something else than Events in the search now gives the expected results.