### PR TITLE
Issue #3082658: Fix condition that allow removing Open Social branding in e-mail

### DIFF
--- a/modules/social_features/social_swiftmail/social_swiftmail.module
+++ b/modules/social_features/social_swiftmail/social_swiftmail.module
@@ -40,7 +40,8 @@ function social_swiftmail_preprocess_swiftmailer(array &$variables) {
 
   // Check if custom e-mail setting for branding removal is enabled.
   $social_swiftmail_config = \Drupal::config('social_swiftmail.settings');
-  if ($social_swiftmail_config->get('remove_open_social_branding') === TRUE) {
+  $remove_open_social_branding = $social_swiftmail_config->get('remove_open_social_branding');
+  if ($remove_open_social_branding == 1) {
     $site_config = \Drupal::config('system.site');
     // When branding should be removed, check if the default site settings are
     // set and override variables.


### PR DESCRIPTION
Fix condition that allow removing Open Social branding from email

## Problem
When checking "Remove Open Social Branding" under Home Administration Configuration Open Social Settings, the email messages still go out containing the Open Social branding.

Open Social
"Make your people bloom"
Copyright © 2019.

## Solution
The solution was to tweak the condition that evaluates the setting.

## Issue tracker
https://www.drupal.org/project/social/issues/3082658

## How to test
- [ ] Apply the patch.
- [ ] Go to /admin/config/swiftmailer/test and send yourself a test message
- [ ] You should receive the message without the Open Social branding

## Release notes
Fix condition that allow removing Open Social branding from email

