### PR TITLE
Issue #3087741: Color scheme should apply to ideation module

### DIFF
--- a/themes/socialblue/assets/css/brand.css
+++ b/themes/socialblue/assets/css/brand.css
@@ -431,6 +431,22 @@ html:not(.js) .navbar-default .dropdown:focus > a .navbar-nav__icon, html:not(.j
   fill: #ffc142;
 }
 
+.badge.badge-active {
+  background-color: #ffc142;
+}
+
+.phase.phase-past:not(:last-child):before {
+  background-color: #ffc142;
+}
+
+.phase.phase-past .phase-past--icon .checkmark-icon {
+  fill: #ffc142;
+}
+
+.phase.phase-active:before {
+  background-color: #ffc142;
+}
+
 @media (min-width: 900px) {
   .search-take-over .form-text {
     color: #ffffff;

--- a/themes/socialblue/components/brand.scss
+++ b/themes/socialblue/components/brand.scss
@@ -520,3 +520,25 @@ html:not(.js) .navbar-default {
     }
   }
 }
+
+.badge.badge-active {
+  background-color: $brand-accent;
+}
+
+.phase {
+  &.phase-past {
+    &:not(:last-child):before {
+      background-color: $brand-accent;
+    }
+
+    .phase-past--icon .checkmark-icon {
+      fill: $brand-accent;
+    }
+  }
+
+  &.phase-active {
+    &:before {
+      background-color: $brand-accent;
+    }
+  }
+}


### PR DESCRIPTION
## Problem
I want to change the color scheme but it doesn't affect some particular parts of the ideation module

## Solution
Add particular parts of the ideation module to the brand file

## Issue tracker
https://www.drupal.org/project/social/issues/3087741

## How to test
- [ ] https://getopensocial.atlassian.net/browse/YANG-1611

## Release notes
The ideation extension now properly respects theme color settings set by sitemanagers.

**Maintainer note:** The ideation extension is not currently public so this probably doesn't affect distribution users.
