### PR TITLE
Issue #3087778 by agami4: Add space between subtitle and buttons for the small hero banner

### DIFF
--- a/modules/social_features/social_landing_page/css/social_landing_page.section.hero_small.css
+++ b/modules/social_features/social_landing_page/css/social_landing_page.section.hero_small.css
@@ -44,7 +44,7 @@
   overflow: hidden;
 }
 .paragraph--hero-small .cover-small .page-subtitle {
-  margin: 0 0 5px;
+  margin: 0 0 1rem;
   font-weight: normal;
   font-size: 18px;
   max-height: 18px;

--- a/modules/social_features/social_landing_page/css/social_landing_page.section.hero_small.scss
+++ b/modules/social_features/social_landing_page/css/social_landing_page.section.hero_small.scss
@@ -42,7 +42,7 @@
       overflow: hidden;
     }
     .page-subtitle {
-      margin: 0 0 5px;
+      margin: 0 0 1rem;
       font-weight: normal;
       font-size: 18px;
       max-height: 18px;


### PR DESCRIPTION
## Problem
The small hero landing page spacing of elements is off

## Solution
Add more spaces between subtitle and buttons

## Issue tracker
https://www.drupal.org/project/social/issues/3087778

## How to test
- [ ] Create the small hero banner on the landing page
- [ ] Open this landing page on the IE11

## Release notes
Add space between subtitle and button for the small hero banner on the landing page
