### PR TITLE
Issue #3087783 by agami4: Add more max height for the title on the teasers

### DIFF
--- a/themes/socialbase/assets/css/teaser.css
+++ b/themes/socialbase/assets/css/teaser.css
@@ -53,7 +53,7 @@
 .teaser__title {
   margin-top: 0;
   margin-bottom: 20px;
-  max-height: 2.2em;
+  max-height: 2.5em;
   overflow: hidden;
 }
 

--- a/themes/socialbase/components/03-molecules/teaser/teaser.scss
+++ b/themes/socialbase/components/03-molecules/teaser/teaser.scss
@@ -103,7 +103,7 @@
 .teaser__title {
   margin-top: 0;
   margin-bottom: 20px;
-  max-height: 2.2em;
+  max-height: 2.5em;
   overflow: hidden;
 }
 


### PR DESCRIPTION
## Problem
Title cropped in the teasers

## Solution
Add more max height for the title on the teasers

## Issue tracker
https://www.drupal.org/project/social/issues/3087783

## How to test
- [ ] Add more text to the teasers on the Landing page

## Release notes
The title does not crop in the teaser on the Landing page