### PR TITLE
Issue #2929368: hide create content button if user do not have permission

### DIFF
--- a/modules/social_features/social_user/src/Plugin/Block/AccountHeaderBlock.php
+++ b/modules/social_features/social_user/src/Plugin/Block/AccountHeaderBlock.php
@@ -152,6 +152,9 @@ class AccountHeaderBlock extends BlockBase implements ContainerFactoryPluginInte
       // Add the create links as children of the create content menu item.
       $menu_items['create'] += $create_links;
 
+      // Check if user can create content.
+      $menu_items['create']['#access'] = $this->renderer->render($create_links) ? TRUE : FALSE;
+
       $account_name = $account->getDisplayName();
 
       $menu_items['account_box'] = [


### PR DESCRIPTION
hide create content button if user do not have permissions to create content

## Problem
When permissions to create page, book, group, topic and event are disabled, the "+" icon should not be displayed in the header.

## Solution
hide create content button if user do not have permissions to create content

## Issue tracker
https://www.drupal.org/project/social/issues/2929368

## How to test
- [ ] Login as LU
- [ ] Make sure that the "+" button is visible
- [ ] Login as Admin
- [ ] Remove permissions to create content from LU
- [ ] Login as LU
- [ ] Make sure that the "+" button is not visible

## Release notes
Hide create content button if user do not have permissions to create content
