### PR TITLE
Issue #3088305: Prevent empty (direct and digest) e-mails in some cases

### DIFF
--- a/modules/custom/activity_send/modules/activity_send_email/src/Plugin/ActivityDestination/EmailActivityDestination.php
+++ b/modules/custom/activity_send/modules/activity_send_email/src/Plugin/ActivityDestination/EmailActivityDestination.php
@@ -56,7 +56,7 @@ class EmailActivityDestination extends SendActivityDestinationBase {
       $value = $activity_factory->getMessageText($message, $langcode);
 
       // Text for email.
-      if (!empty($value[2])) {
+      if (!empty($value[2]) && is_string($value[2])) {
         $text = $value[2];
       }
       // Default text.
@@ -65,7 +65,7 @@ class EmailActivityDestination extends SendActivityDestinationBase {
       }
     }
 
-    return $text;
+    return is_string($text) ? $text : NULL;
   }
 
 }


### PR DESCRIPTION
## Problem
In some cases empty notification e-mails are being send by the system. The reason is that `\Drupal\activity_creator\ActivityFactory::getMessageText` is returning an array (formatted text) instead of expected string. There are checks in place which should prevent sending empty e-mails. However these checks are checking if the value is empty (e.g. `if (!empty($value))`). In other words if it's an array it will pass it through to the e-mail templates and send it to the user. Our twig template will just turn the array into a `&nbsp;`.

## Solution
Let's change the fallback mechanism for e-mails to always return a string or NULL.

The `\Drupal\activity_send_email\Plugin\ActivityDestination\EmailActivityDestination::getSendEmailOutputText` is being used by direct and digest e-mails.

This change should fix the issue and prevent this from happening in the future.

## Issue tracker
https://www.drupal.org/project/social/issues/3088305

## How to test
- [ ] Ask for test database from Jaap or test on SaaS clients 6.2.0 release.
- [ ] Verify this happens by checking mail logs.
- [ ] Apply the fix and see it is solved.

## Release notes
In some cases users would receive empty e-mails. This has now been solved!
