### PR TITLE
issue #3087651 - see all results button translatable on autocomplete

### DIFF
--- a/modules/social_features/social_search/modules/social_search_autocomplete/js/src/components/SearchSuggestions.jsx
+++ b/modules/social_features/social_search/modules/social_search_autocomplete/js/src/components/SearchSuggestions.jsx
@@ -23,7 +23,7 @@ function SearchSuggestions(props) {
       <div className="search-suggestions">{results}</div>
       <div className="search-suggestions__all">
         <a href={searchUrl} className="btn btn-default btn-raised">
-          See all results
+          {Drupal.t('See all results')}
         </a>
       </div>
     </React.Fragment>


### PR DESCRIPTION
## Problem
On the autocomplete search "See all results" is not translated.

## Solution
Make "See all results" translatable in Javascript file

## Issue tracker
https://www.drupal.org/project/social/issues/3087651

## How to test
- [ ] Change the language
- [ ] Autocomplete search
- [ ] The button text should be translated

## Release notes
On the autocomplete search "See all results" is now translated.
