### PR TITLE
Issue #3088530: make EventType::createContent() compatible with parent method

### DIFF
--- a/modules/custom/social_demo/src/Plugin/DemoContent/EventType.php
+++ b/modules/custom/social_demo/src/Plugin/DemoContent/EventType.php
@@ -20,13 +20,13 @@ class EventType extends DemoTaxonomyTerm {
   /**
    * {@inheritdoc}
    */
-  public function createContent() {
+  public function createContent($generate = FALSE, $max = NULL) {
     // Check if event types are enabled.
     if (!\Drupal::moduleHandler()->moduleExists('social_event_type')) {
       return;
     }
 
-    return parent::createContent();
+    return parent::createContent($generate, $max);
   }
 
   /**


### PR DESCRIPTION
## Problem
When running command drush sda event_type you will see fatal error:

Fatal error: Declaration of Drupal\social_demo\Plugin\DemoContent\EventType::createContent() must be compatible with Drupal\social_demo\DemoTaxonomyTerm::createContent($generate = false, $max = NULL) in /var/www/html/profiles/contrib/social/modules/custom/social_demo/src/Plugin/DemoContent/EventType.php on line 18

## Solution
Make the method compatible with parent method.

## Issue tracker
https://www.drupal.org/project/social/issues/3088530

## How to test
- [ ] Enable `social_demo` and `social_event_type`
- [ ] Run `drush sda event_type` and you will see error.
- [ ] Run it again on this branch and there won't be an error and the content is created.

## Release notes
Generating demo event types did not work because of a fatal error. This has now been resolved by making the method compatible with the parent method.