### PR TITLE
YANG-1689: Fix theming for social birthday block

### DIFF
--- a/modules/social_features/social_core/social_core.module
+++ b/modules/social_features/social_core/social_core.module
@@ -243,6 +243,13 @@ function social_core_preprocess_block(&$variables) {
       $link->setOption('use_more', FALSE);
       break;
 
+    case 'birthday-block_upcoming_birthdays':
+      $variables['subtitle'] = t('in the community');
+      $variables['view_all_path'] = Url::fromRoute('view.birthday.upcoming_birthdays');
+      $variables['button_text'] = $more_link;
+      $link->setOption('use_more', FALSE);
+      break;
+
     case 'events-block_events_on_profile':
       if ($account instanceof UserInterface) {
         $variables['subtitle'] = t('for this user');

--- a/themes/socialbase/src/Plugin/Alter/ThemeSuggestions.php
+++ b/themes/socialbase/src/Plugin/Alter/ThemeSuggestions.php
@@ -48,6 +48,7 @@ class ThemeSuggestions extends BaseThemeSuggestions {
           'group_members-block_newest_members',
           'upcoming_events-upcoming_events_group',
           'latest_topics-group_topics_block',
+          'birthday-block_upcoming_birthdays',
         ];
         if (in_array($block_id, $blocks_id)) {
           $suggestions = [$variables['theme_hook_original'] . '__' . 'views_block__sidebar'];


### PR DESCRIPTION
## Problem
The birthday small block has the wrong styles

## Solution
Update styles and layout for the birthday small block

## Issue tracker
https://getopensocial.atlassian.net/browse/YANG-1689

## How to test
- [ ] Display the birthday small block on the sidebar
- [ ] You can see the birthday small block on the home page

## Release notes
Updated layout and display the birthday small block on the sidebar
