### PR TITLE
Issue #3089919: Filters in admin people don't apply when using select…

### DIFF
--- a/modules/social_features/social_user/config/install/views.view.user_admin_people.yml
+++ b/modules/social_features/social_user/config/install/views.view.user_admin_people.yml
@@ -215,7 +215,7 @@ display:
           batch_size: 10
           form_step: true
           buttons: false
-          clear_on_exposed: false
+          clear_on_exposed: true
           action_title: Action
           selected_actions:
             comment_delete_action: 0


### PR DESCRIPTION
… all checkbox

## Problem
When using the select all users in this view, the filters applied to the selection aren't taken into consideration.

## Solution
The issue originates from the latest version VBO module which has been implemented in: https://www.drupal.org/project/social/issues/3088371
The solution is to apply the workaround described in https://www.drupal.org/project/views_bulk_operations/issues/3063892#comment-13159258

## Issue tracker
https://www.drupal.org/project/social/issues/3089919

## How to test
- [ ] Go to admin people
- [ ] See that when you make a selection
- [ ] Add an exposed filter
- [ ] The exposed filter data didnt change the selection
-- [ ] This should work now.

## Release notes
When using the select all users in this view, the filters applied to the selection aren't taken into consideration. We now ensure we clear the selection data whenever you filter, to ensure there are no wrong results in the exported data.