### PR TITLE
Issue #3089936: Select all of VBO and the selected member count in gr…

### DIFF
--- a/modules/social_features/social_group/css/vbo_form.css
+++ b/modules/social_features/social_group/css/vbo_form.css
@@ -1,7 +1,6 @@
 .form-item-select-all {
-  position: absolute !important;
-  right: 40rem;
-  padding: 19px 0;
+  left: 1rem;
+  padding: 19px 0 0 0;
 }
 
 #edit-multipage .btn {


### PR DESCRIPTION
…oup manage members overlaps.

## Problem
Select all of VBO and the selected member count in group manage members overlaps when a language with long words like German is used and is therefor unreadable and not easy to use.

## Solution
The fields are aligned next to eachother. The fields should be stacked so longer the translated texts in languages that have a longer word count fit.

## Issue tracker
https://www.drupal.org/project/social/issues/3089936

