### PR TITLE
Manage Members page errors when group has no members

### DIFF
--- a/modules/social_features/social_group/src/Plugin/views/field/SocialGroupViewsBulkOperationsBulkForm.php
+++ b/modules/social_features/social_group/src/Plugin/views/field/SocialGroupViewsBulkOperationsBulkForm.php
@@ -70,7 +70,7 @@ class SocialGroupViewsBulkOperationsBulkForm extends ViewsBulkOperationsBulkForm
 
     parent::viewsForm($form, $form_state);
 
-    if ($this->view->id() !== 'group_manage_members') {
+    if ($this->view->id() !== 'group_manage_members' || empty($form['output'][0]['#rows'])) {
       return;
     }
 


### PR DESCRIPTION
## Problem

When a group has no members, the Manage Members page errors with the following error message:

```
Error: Call to a member function getArguments() on null in Drupal\social_group\Plugin\views\field\SocialGroupViewsBulkOperationsBulkForm->viewsForm() (line 120 of profiles/contrib/social/modules/social_features/social_group/src/Plugin/views/field/SocialGroupViewsBulkOperationsBulkForm.php).
```

## Solution

Skip processing the SocialGroupViewsBulkOperationsBulkForm when there are no results in the group_manage_members view.

## Issue tracker

https://www.drupal.org/project/social/issues/3089990

## How to test
- [ ] Create an OpenSocial group
- [ ] Go to the "Manage Members" tab
- [ ] Remove all members
- [ ] Error page should display as described above
