### PR TITLE
Issue 3035308 by jcmartinez: Fix fatal error when editing content wit…

### DIFF
--- a/modules/social_features/social_group/social_group.module
+++ b/modules/social_features/social_group/social_group.module
@@ -1512,37 +1512,38 @@ function social_group_form_node_form_alter(&$form, FormStateInterface $form_stat
  * @param \Drupal\Core\Form\FormStateInterface $form_state
  *   Form state interface.
  */
-function social_group_save_group_from_node(array $form, FormStateInterface $form_state) {
-  /* @var \Drupal\node\Entity\Node $node */
-  $node = $form_state->getFormObject()->getEntity();
+ function social_group_save_group_from_node(array $form, FormStateInterface $form_state) {
+   /* @var \Drupal\node\Entity\Node $node */
+   $node = $form_state->getFormObject()->getEntity();
 
-  // Check if the created node is new or updated.
-  $is_new = NULL !== $form_state->getValue('is_new') ? $form_state->getValue('is_new') : FALSE;
+   // Check if the created node is new or updated.
+   $is_new = NULL !== $form_state->getValue('is_new') ? $form_state->getValue('is_new') : FALSE;
 
-  $original_groups = [];
-  $groups_to_add = [];
-  $groups_to_remove = [];
-  foreach ($form_state->getValue('groups') as $new_group_key => $new_group) {
-    $groups_to_add[$new_group['target_id']] = $new_group['target_id'];
-  }
-  // The node already exist so lets also change the logic accordingly.
-  if(!empty($form['groups']['widget']['#default_value'])) {
-    if ($form['#form_id'] === 'node_' . $node->bundle() . '_edit_form') {
-      $original_groups = $form['groups']['widget']['#default_value'];
-      foreach ($original_groups as $original_group_key => $original_group) {
-        if (!in_array($original_group, $groups_to_add)) {
-          $groups_to_remove[$original_group] = $original_group;
-        }
-        else {
-          unset($groups_to_add[$original_group]);
-        }
-      }
-    }
+   $original_groups = [];
+   $groups_to_add = [];
+   $groups_to_remove = [];
+   foreach ($form_state->getValue('groups') as $new_group_key => $new_group) {
+     $groups_to_add[$new_group['target_id']] = $new_group['target_id'];
+   }
+   // The node already exist so lets also change the logic accordingly.
+   if(!empty($form['groups']['widget']['#default_value'])) {
+     if ($form['#form_id'] === 'node_' . $node->bundle() . '_edit_form') {
+       $original_groups = $form['groups']['widget']['#default_value'];
+       foreach ($original_groups as $original_group_key => $original_group) {
+         if (!in_array($original_group, $groups_to_add)) {
+           $groups_to_remove[$original_group] = $original_group;
+         }
+         else {
+           unset($groups_to_add[$original_group]);
+         }
+       }
+     }
 
-  // Now make sure the relevant GroupContent is removed or added.
-  $setGroupsForNodeService = \Drupal::service('social_group.set_groups_for_node_service');
-  $setGroupsForNodeService->setGroupsForNode($node, $groups_to_remove, $groups_to_add, $original_groups, $is_new);
-}
+     // Now make sure the relevant GroupContent is removed or added.
+     $setGroupsForNodeService = \Drupal::service('social_group.set_groups_for_node_service');
+     $setGroupsForNodeService->setGroupsForNode($node, $groups_to_remove, $groups_to_add, $original_groups, $is_new);
+   }
+ }
 
 /**
  * Get the allowed visibility options for a given group type.

--- a/modules/social_features/social_group/social_group.module
+++ b/modules/social_features/social_group/social_group.module
@@ -1526,17 +1526,18 @@ function social_group_save_group_from_node(array $form, FormStateInterface $form
     $groups_to_add[$new_group['target_id']] = $new_group['target_id'];
   }
   // The node already exist so lets also change the logic accordingly.
-  if ($form['#form_id'] === 'node_' . $node->bundle() . '_edit_form') {
-    $original_groups = $form['groups']['widget']['#default_value'];
-    foreach ($original_groups as $original_group_key => $original_group) {
-      if (!in_array($original_group, $groups_to_add)) {
-        $groups_to_remove[$original_group] = $original_group;
-      }
-      else {
-        unset($groups_to_add[$original_group]);
+  if(!empty($form['groups']['widget']['#default_value'])) {
+    if ($form['#form_id'] === 'node_' . $node->bundle() . '_edit_form') {
+      $original_groups = $form['groups']['widget']['#default_value'];
+      foreach ($original_groups as $original_group_key => $original_group) {
+        if (!in_array($original_group, $groups_to_add)) {
+          $groups_to_remove[$original_group] = $original_group;
+        }
+        else {
+          unset($groups_to_add[$original_group]);
+        }
       }
     }
-  }
 
   // Now make sure the relevant GroupContent is removed or added.
   $setGroupsForNodeService = \Drupal::service('social_group.set_groups_for_node_service');

--- a/translations/pt-br.po
+++ b/translations/pt-br.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: node-gettext\n"
 "POT-Creation-Date: 2019-10-11 00:18+0000\n"
-"PO-Revision-Date: 2019-09-27 22:59+0000\n"
-"Last-Translator: Rafael Fernandes <rafael.fernandes@greenpeace.org>\n"
+"PO-Revision-Date: 2019-10-11 10:18+0000\n"
+"Last-Translator: Robert Ragas <robertragas@goalgorilla.com>\n"
 "Language-Team: Portuguese (Brazil) <https://translate.getopensocial.com/"
 "projects/open-social/distribution/pt_BR/>\n"
 "Language: pt-br\n"
@@ -173,11 +173,10 @@ msgstr[1] "1 item processado com sucesso:"
 #: modules/social_features/social_landing_page/templates/group--featured.html.twig:30
 #: themes/socialbase/templates/group/group--hero.html.twig:69
 #: themes/socialbase/templates/group/group--teaser.html.twig:79
-#, fuzzy
 msgid "1 member"
 msgid_plural "@count members"
 msgstr[0] "1 membro"
-msgstr[1] "1 membro"
+msgstr[1] "@count membros"
 
 #: modules/custom/social_node_statistics/src/Form/NodeStatisticsSettingsForm.php:52
 msgid "1 minute"


### PR DESCRIPTION
Fix fatal error when editing content with a custom content type

## Problem

Using the "Social Flexible Group" and I've created a new content type for which I have activated the group content plugin in the group types.

When I edit a node of my new content type, I get the fatal error:

```
The website encountered an unexpected error. Please try again later.
TypeError: Argument 4 passed to Drupal\social_group\SetGroupsForNodeService::setGroupsForNode() must be of the type array, null given, called in /app/html/profiles/contrib/social/modules/social_features/social_group/social_group.module on line 1542 in Drupal\social_group\SetGroupsForNodeService->setGroupsForNode() (line 52 of profiles/contrib/social/modules/social_features/social_group/src/SetGroupsForNodeService.php).
```

## Solution
I have added a line of code to evaluate whether the value exists before it's used.

## Issue tracker
https://www.drupal.org/project/social/issues/3035308

## How to test
- Enable the "Social Flexible Group" module
- Add a new content type
- Activate the content type for this group
- Create a new node for the new content type
- Edit the node

Without this fix, there will be a fatal error. With this fix there won't be a fatal error. 

## Release notes
Fix a fatal error when editing a node from a custom content type that is attached to a group.

## Change Record
N/A
