### PR TITLE
Issue #3090562 by rolki: Likes are not available for several users on IE11

### DIFF
--- a/modules/social_features/social_comment_upload/js/comment-upload.js
+++ b/modules/social_features/social_comment_upload/js/comment-upload.js
@@ -66,7 +66,6 @@
             .index($(this).parent());
           var options = {
             index: $index,
-            bgOpacity: 0.7,
             showHideOpacity: true,
             mainClass : 'pswp--minimal--dark',
             barsSize : {top: 0, bottom: 0},


### PR DESCRIPTION
## Problem
Likes are not available for several users on IE11

## Solution
Remove duplicate entries from the js options (`modules/social_features/social_comment_upload/js/comment-upload.js`), because it's broke other scripts.

## Issue tracker
https://www.drupal.org/project/social/issues/3090562
https://getopensocial.atlassian.net/browse/YANG-1360

## How to test
* Go to the site by IE11
* Go to any page with comments and like/dislike functionality
* The likes/dislike functionality should work correctly

## Release notes
A duplicate value in the Javascript for Social Comments caused scripts to stop working in Internet Explorer 11. The duplicate values have been removed.