### PR TITLE
#3091105: Prevent fatal error by checking if the commented entity still exists

### DIFF
--- a/modules/social_features/social_comment/src/Form/SocialCommentAdminOverview.php
+++ b/modules/social_features/social_comment/src/Form/SocialCommentAdminOverview.php
@@ -217,12 +217,17 @@ class SocialCommentAdminOverview extends FormBase {
         'title' => $this->t('Delete'),
         'url' => $comment->toUrl('delete-form', $comment_uri_options),
       ];
-      if ($this->moduleHandler->moduleExists('content_translation') && $this->moduleHandler->invoke('content_translation', 'translate_access', [$comment])->isAllowed()) {
+
+      // Add a 'Translate' operations link if the comment is translatable.
+      if ($this->moduleHandler->moduleExists('content_translation') &&
+        $comment->getCommentedEntity() instanceof ContentEntityInterface &&
+        $this->moduleHandler->invoke('content_translation', 'translate_access', [$comment])->isAllowed()) {
         $links['translate'] = [
           'title' => $this->t('Translate'),
           'url' => $comment->toUrl('drupal:content-translation-overview', $comment_uri_options),
         ];
       }
+
       $options[$comment->id()]['operations']['data'] = [
         '#type' => 'operations',
         '#links' => $links,


### PR DESCRIPTION
## Problem
On the admin comment overview page we show all the comments.

We also try to render a "translate" operations link if the content translation is turned on. However when a content item is deleted, but the reference for some reason stays behind in the comment an access check for the translate link will fail.

## Solution
An extra check is added to make sure the commented entity still exists.

## Issue tracker
https://www.drupal.org/project/social/issues/3091105

## How to test
- [ ] Place a comment on a node
- [ ] Remove the node, but keep the reference to it in a comment
- [ ] Observe that /admin/content/comment works

## Release notes
In a rare occasion where the commented entity no longer exists, but the reference to it in the comment does, a fatal error might occur on the comment admin overview page.