### PR TITLE
Issue #3092275 by Kingdutch: Remove features from Social Tagging module

### DIFF
--- a/modules/social_features/social_search/social_search.module
+++ b/modules/social_features/social_search/social_search.module
@@ -284,3 +284,30 @@ function _social_search_retrigger_profile(User $user) {
     }
   }
 }
+
+/**
+ * Re-saves search indices.
+ *
+ * This triggers the save for all search indexes which triggers updates of
+ * fields and processors.
+ *
+ * @param array $index_ids
+ *   An array of index IDs to re-save or NULL to re-save all indices.
+ *
+ * @throws \Drupal\Core\Entity\EntityStorageException
+ */
+function social_search_resave_search_indexes(array $index_ids = NULL) {
+  // We load all indexes, we assume there will never be hundreds of search
+  // indexes which would create its own problems for a site.
+  $indexes = Index::loadMultiple($index_ids);
+
+  /** @var \Drupal\search_api\IndexInterface $index */
+  foreach ($indexes as $index) {
+    // No need to disable and enable the index here, this worked around a
+    // validation of the Search Settings form that prevented the save from being
+    // triggered. However, this validation is not present in the entity save
+    // logic. So a simple call to `save()` will trigger the reprocessing of
+    // fields and processors.
+    $index->save();
+  }
+}

--- a/modules/social_features/social_tagging/config/features_removal/taxonomy.vocabulary.social_tagging.yml
+++ b/modules/social_features/social_tagging/config/features_removal/taxonomy.vocabulary.social_tagging.yml
@@ -1,0 +1,11 @@
+langcode: en
+status: true
+dependencies:
+  enforced:
+    module:
+    - social_tagging
+name: 'Content tags'
+vid: social_tagging
+description: 'Categories and terms used to tag content'
+hierarchy: 0
+weight: 0

--- a/modules/social_features/social_tagging/config/install/social_tagging.settings.yml
+++ b/modules/social_features/social_tagging/config/install/social_tagging.settings.yml
@@ -1,0 +1,3 @@
+enable_content_tagging: true
+allow_category_split: true
+tag_node_type_landing_page: false

--- a/modules/social_features/social_tagging/config/schema/social_tagging.schema.yml
+++ b/modules/social_features/social_tagging/config/schema/social_tagging.schema.yml
@@ -1,0 +1,13 @@
+social_tagging.settings:
+  type: config_object
+  label: 'Social Tagging Settings'
+  mapping:
+    enable_content_tagging:
+      type: boolean
+      label: 'Determines whether content tagging is enabled for users.'
+    allow_category_split:
+      type: boolean
+      label: 'Determines whether the top level taxonomy items are considered categories for tagging.'
+    tag_node_type_landing_page:
+      type: boolean
+      label: 'Determines whether the landing page node type has tagging enabled.'

--- a/modules/social_features/social_tagging/social_tagging.features.yml
+++ b/modules/social_features/social_tagging/social_tagging.features.yml
@@ -1,2 +1,0 @@
-bundle: social
-required: true

--- a/modules/social_features/social_tagging/social_tagging.install
+++ b/modules/social_features/social_tagging/social_tagging.install
@@ -6,33 +6,40 @@
  */
 
 use Drupal\Core\Entity\EntityStorageException;
-use Drupal\search_api\Entity\Index;
-use Drupal\user\Entity\User;
 
 /**
  * Install the module.
  */
 function social_tagging_install() {
-  _social_tagging_set_defaults();
+  _social_tagging_assign_default_permissions();
 
   // Update field definitions.
-  _social_tagging_field_defenitions_update();
+  _social_tagging_field_definitions_update();
 
-  // Toggle the index content.
+  // If the search module is enabled trigger updating of the indexes affected
+  // by tagging.
   try {
-    _social_tagging_index_toggle('social_content');
+    if (\Drupal::moduleHandler()->moduleExists('social_search')) {
+      social_search_resave_search_indexes(['social_content', 'social_groups']);
+    }
   }
   catch (EntityStorageException $e) {
     \Drupal::logger('social_tagging')->info($e->getMessage());
   }
+}
 
-  // Toggle the index groups.
-  try {
-    _social_tagging_index_toggle('social_groups');
-  }
-  catch (EntityStorageException $e) {
-    \Drupal::logger('social_tagging')->info($e->getMessage());
-  }
+/**
+ * Assign the default permissions for this module.
+ */
+function _social_tagging_assign_default_permissions() {
+  $permissions = [
+    'administer social_tagging',
+    'delete terms in social_tagging',
+    'edit terms in social_tagging',
+  ];
+
+  // SM should be able to change the permissions.
+  user_role_grant_permissions('sitemanager', $permissions);
 }
 
 /**
@@ -49,10 +56,13 @@ function social_tagging_update_8001() {
  */
 function social_tagging_update_8002() {
   // Update field definitions.
-  _social_tagging_field_defenitions_update();
+  _social_tagging_field_definitions_update();
   // Toggle the index groups.
   try {
-    _social_tagging_index_toggle('social_groups');
+    // If the search module is enabled we need to update the group index.
+    if (\Drupal::moduleHandler()->moduleExists('social_search')) {
+      social_search_resave_search_indexes(['social_groups']);
+    }
   }
   catch (EntityStorageException $e) {
     \Drupal::logger('social_tagging')->info($e->getMessage());
@@ -60,65 +70,9 @@ function social_tagging_update_8002() {
 }
 
 /**
- * Function that sets the default configuration value(s) for this module.
- */
-function _social_tagging_set_defaults() {
-  $permissions = [
-    'administer social_tagging',
-    'delete terms in social_tagging',
-    'edit terms in social_tagging',
-  ];
-
-  // Set allow to true, since that's the case by default.
-  $config = \Drupal::getContainer()->get('config.factory')->getEditable('social_tagging.settings');
-  $config->set('enable_content_tagging', 1)->save();
-  $config->set('allow_category_split', 1)->save();
-  $config->set('tag_node_type_landing_page', FALSE)->save();
-  // SM should be able to change the permissions.
-  user_role_grant_permissions('sitemanager', $permissions);
-}
-
-/**
- * Turn an index off and on.
- *
- * @param string $index_id
- *   The index that needs to be disabled and enabled.
- *
- * @throws \Drupal\Core\Entity\EntityStorageException
- */
-function _social_tagging_index_toggle($index_id) {
-  /* @var Drupal\search_api\Entity\Index $index */
-  $index = Index::load($index_id);
-  if (!$index instanceof Index) {
-    \Drupal::logger('social_tagging')->info('Invalid search index');
-    return;
-  }
-  \Drupal::logger('social_tagging')->info('Loaded search index');
-
-  // If currently enabled we will first disabled and enable the index.
-  if ($index !== NULL && $index->status()) {
-    \Drupal::logger('social_tagging')->info('Search index exists');
-
-    // Elevate permissions so we can index *all* the items.
-    $accountSwitcher = Drupal::service('account_switcher');
-    $account = User::load(1);
-    $accountSwitcher->switchTo($account);
-
-    // Disable and enable the index so the tagging field is properly added.
-    $index->disable()->save();
-    \Drupal::logger('social_tagging')->info('Search index disabled');
-    $index->enable()->save();
-    \Drupal::logger('social_tagging')->info('Search index enabled');
-
-    // Restore user account.
-    $accountSwitcher->switchBack();
-  }
-}
-
-/**
  * Update the field definitions on install, or in an update hook.
  */
-function _social_tagging_field_defenitions_update() {
+function _social_tagging_field_definitions_update() {
   // Create field storage for the 'Highlight' base field.
   \Drupal::entityTypeManager()->clearCachedDefinitions();
   \Drupal::service('entity.definition_update_manager')->applyUpdates();


### PR DESCRIPTION
<h2>Problem</h2>
See problem definition in [#3092272]. The fact that this configuration is in a feature means that site managers can't change the name of the taxonomies.

<h2>Solution</h2>
<ul>
  <li>Remove the <code>social_tagging.features.yml</code> file</li>
  <li>Move the default editable config from <code>social_tagging_install()</code> into a <code>config/install/*.yml</code> file.
  <li>Remove the _social_tagging_set_defaults function</li>
</ul>

## Issue tracker
https://www.drupal.org/project/social/issues/3092275

## How to test
-  [ ] Enable the Social Tagging module
-  [ ] Change the name of the content tags vocabulary
-  [ ] Revert features

## Release notes
The social_tagging module is no longer managed by features. This fixes an issue where the Content Types vocabulary could not be changed. 

