### PR TITLE
Issue #3092460 by Kingdutch: Remove features from Social Profile module

### DIFF
--- a/modules/social_features/social_profile/config/features_removal/core.entity_form_display.profile.profile.default.yml
+++ b/modules/social_features/social_profile/config/features_removal/core.entity_form_display.profile.profile.default.yml
@@ -1,0 +1,198 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.profile.profile.field_profile_address
+    - field.field.profile.profile.field_profile_banner_image
+    - field.field.profile.profile.field_profile_expertise
+    - field.field.profile.profile.field_profile_first_name
+    - field.field.profile.profile.field_profile_function
+    - field.field.profile.profile.field_profile_image
+    - field.field.profile.profile.field_profile_interests
+    - field.field.profile.profile.field_profile_last_name
+    - field.field.profile.profile.field_profile_organization
+    - field.field.profile.profile.field_profile_phone_number
+    - field.field.profile.profile.field_profile_profile_tag
+    - field.field.profile.profile.field_profile_self_introduction
+    - field.field.profile.profile.field_profile_show_email
+    - image.style.social_x_large
+    - profile.type.profile
+  module:
+    - address
+    - field_group
+    - image_widget_crop
+    - telephone
+    - text
+third_party_settings:
+  field_group:
+    group_profile_names_image:
+      children:
+        - field_profile_first_name
+        - field_profile_last_name
+        - field_profile_image
+        - field_profile_banner_image
+      parent_name: ''
+      weight: 0
+      label: 'Names and profile image'
+      format_type: fieldset
+      format_settings:
+        label: 'Names and profile image'
+        required_fields: true
+        id: name
+        classes: scrollspy
+    group_profile_funct_organization:
+      children:
+        - field_profile_function
+        - field_profile_organization
+      parent_name: ''
+      weight: 1
+      label: 'Function and organization'
+      format_type: fieldset
+      format_settings:
+        label: 'Function and organization'
+        required_fields: true
+        id: work
+        classes: scollspy
+    group_profile_self_intro:
+      children:
+        - field_profile_self_introduction
+        - field_profile_expertise
+        - field_profile_interests
+        - field_profile_profile_tag
+      parent_name: ''
+      weight: 3
+      label: 'Self introduction, expertise and interests'
+      format_type: fieldset
+      format_settings:
+        label: 'Self introduction, expertise and interests'
+        required_fields: true
+        id: details
+        classes: scrollspy
+    group_profile_contact_info:
+      children:
+        - field_profile_phone_number
+        - field_profile_address
+      parent_name: ''
+      weight: 2
+      label: 'Phone number and location'
+      format_type: fieldset
+      format_settings:
+        label: 'Phone number and location'
+        required_fields: true
+        id: contact
+        classes: scollspy
+id: profile.profile.default
+targetEntityType: profile
+bundle: profile
+mode: default
+content:
+  field_profile_address:
+    weight: 7
+    settings:
+      default_country: site_default
+    third_party_settings: {  }
+    type: address_default
+    region: content
+  field_profile_banner_image:
+    weight: 4
+    settings:
+      show_crop_area: true
+      show_default_crop: true
+      warn_multiple_usages: true
+      preview_image_style: social_x_large
+      crop_preview_image_style: crop_thumbnail
+      progress_indicator: throbber
+      crop_list:
+        - hero
+    third_party_settings: {  }
+    type: image_widget_crop
+    region: content
+  field_profile_expertise:
+    weight: 6
+    settings:
+      match_operator: CONTAINS
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: entity_reference_autocomplete_tags
+    region: content
+  field_profile_first_name:
+    weight: 1
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  field_profile_function:
+    weight: 2
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  field_profile_image:
+    weight: 3
+    settings:
+      show_default_crop: true
+      preview_image_style: social_x_large
+      crop_preview_image_style: crop_thumbnail
+      crop_list:
+        - profile_large
+        - teaser
+        - profile_medium
+        - profile_small
+      progress_indicator: throbber
+      show_crop_area: true
+    third_party_settings: {  }
+    type: image_widget_crop
+    region: content
+  field_profile_interests:
+    weight: 7
+    settings:
+      match_operator: CONTAINS
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: entity_reference_autocomplete_tags
+    region: content
+  field_profile_last_name:
+    weight: 2
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  field_profile_organization:
+    weight: 3
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  field_profile_phone_number:
+    weight: 6
+    settings:
+      placeholder: ''
+    third_party_settings: {  }
+    type: telephone_default
+    region: content
+  field_profile_profile_tag:
+    weight: 8
+    settings: {  }
+    third_party_settings: {  }
+    type: options_buttons
+    region: content
+  field_profile_self_introduction:
+    weight: 5
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+    type: text_textarea
+    region: content
+hidden:
+  field_profile_show_email: true

--- a/modules/social_features/social_profile/config/features_removal/core.entity_view_display.profile.profile.compact.yml
+++ b/modules/social_features/social_profile/config/features_removal/core.entity_view_display.profile.profile.compact.yml
@@ -1,0 +1,50 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.profile.compact
+    - field.field.profile.profile.field_profile_address
+    - field.field.profile.profile.field_profile_banner_image
+    - field.field.profile.profile.field_profile_expertise
+    - field.field.profile.profile.field_profile_first_name
+    - field.field.profile.profile.field_profile_function
+    - field.field.profile.profile.field_profile_image
+    - field.field.profile.profile.field_profile_interests
+    - field.field.profile.profile.field_profile_last_name
+    - field.field.profile.profile.field_profile_organization
+    - field.field.profile.profile.field_profile_phone_number
+    - field.field.profile.profile.field_profile_profile_tag
+    - field.field.profile.profile.field_profile_self_introduction
+    - field.field.profile.profile.field_profile_show_email
+    - image.style.social_medium
+    - profile.type.profile
+  module:
+    - image
+id: profile.profile.compact
+targetEntityType: profile
+bundle: profile
+mode: compact
+content:
+  field_profile_image:
+    weight: 7
+    label: hidden
+    settings:
+      image_style: social_medium
+      image_link: ''
+    third_party_settings: {  }
+    type: image
+    region: content
+hidden:
+  field_profile_address: true
+  field_profile_banner_image: true
+  field_profile_expertise: true
+  field_profile_first_name: true
+  field_profile_function: true
+  field_profile_interests: true
+  field_profile_last_name: true
+  field_profile_organization: true
+  field_profile_phone_number: true
+  field_profile_profile_tag: true
+  field_profile_self_introduction: true
+  field_profile_show_email: true
+  search_api_excerpt: true

--- a/modules/social_features/social_profile/config/features_removal/core.entity_view_display.profile.profile.compact_notification.yml
+++ b/modules/social_features/social_profile/config/features_removal/core.entity_view_display.profile.profile.compact_notification.yml
@@ -1,0 +1,50 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.profile.compact_notification
+    - field.field.profile.profile.field_profile_address
+    - field.field.profile.profile.field_profile_banner_image
+    - field.field.profile.profile.field_profile_expertise
+    - field.field.profile.profile.field_profile_first_name
+    - field.field.profile.profile.field_profile_function
+    - field.field.profile.profile.field_profile_image
+    - field.field.profile.profile.field_profile_interests
+    - field.field.profile.profile.field_profile_last_name
+    - field.field.profile.profile.field_profile_organization
+    - field.field.profile.profile.field_profile_phone_number
+    - field.field.profile.profile.field_profile_profile_tag
+    - field.field.profile.profile.field_profile_self_introduction
+    - field.field.profile.profile.field_profile_show_email
+    - image.style.social_medium
+    - profile.type.profile
+  module:
+    - image
+id: profile.profile.compact_notification
+targetEntityType: profile
+bundle: profile
+mode: compact_notification
+content:
+  field_profile_image:
+    weight: 7
+    label: hidden
+    settings:
+      image_style: social_medium
+      image_link: ''
+    third_party_settings: {  }
+    type: image
+    region: content
+hidden:
+  field_profile_address: true
+  field_profile_banner_image: true
+  field_profile_expertise: true
+  field_profile_first_name: true
+  field_profile_function: true
+  field_profile_interests: true
+  field_profile_last_name: true
+  field_profile_organization: true
+  field_profile_phone_number: true
+  field_profile_profile_tag: true
+  field_profile_self_introduction: true
+  field_profile_show_email: true
+  search_api_excerpt: true

--- a/modules/social_features/social_profile/config/features_removal/core.entity_view_display.profile.profile.compact_teaser.yml
+++ b/modules/social_features/social_profile/config/features_removal/core.entity_view_display.profile.profile.compact_teaser.yml
@@ -1,0 +1,64 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.profile.compact_teaser
+    - field.field.profile.profile.field_profile_address
+    - field.field.profile.profile.field_profile_banner_image
+    - field.field.profile.profile.field_profile_expertise
+    - field.field.profile.profile.field_profile_first_name
+    - field.field.profile.profile.field_profile_function
+    - field.field.profile.profile.field_profile_image
+    - field.field.profile.profile.field_profile_interests
+    - field.field.profile.profile.field_profile_last_name
+    - field.field.profile.profile.field_profile_organization
+    - field.field.profile.profile.field_profile_phone_number
+    - field.field.profile.profile.field_profile_profile_tag
+    - field.field.profile.profile.field_profile_self_introduction
+    - field.field.profile.profile.field_profile_show_email
+    - image.style.social_medium
+    - profile.type.profile
+  module:
+    - image
+id: profile.profile.compact_teaser
+targetEntityType: profile
+bundle: profile
+mode: compact_teaser
+content:
+  field_profile_function:
+    type: string
+    weight: 3
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    region: content
+  field_profile_image:
+    type: image
+    weight: 0
+    label: hidden
+    settings:
+      image_style: social_medium
+      image_link: ''
+    third_party_settings: {  }
+    region: content
+  field_profile_organization:
+    type: string
+    weight: 4
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    region: content
+hidden:
+  field_profile_address: true
+  field_profile_banner_image: true
+  field_profile_expertise: true
+  field_profile_first_name: true
+  field_profile_interests: true
+  field_profile_last_name: true
+  field_profile_phone_number: true
+  field_profile_profile_tag: true
+  field_profile_self_introduction: true
+  field_profile_show_email: true
+  search_api_excerpt: true

--- a/modules/social_features/social_profile/config/features_removal/core.entity_view_display.profile.profile.default.yml
+++ b/modules/social_features/social_profile/config/features_removal/core.entity_view_display.profile.profile.default.yml
@@ -1,0 +1,81 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.profile.profile.field_profile_address
+    - field.field.profile.profile.field_profile_banner_image
+    - field.field.profile.profile.field_profile_expertise
+    - field.field.profile.profile.field_profile_first_name
+    - field.field.profile.profile.field_profile_function
+    - field.field.profile.profile.field_profile_image
+    - field.field.profile.profile.field_profile_interests
+    - field.field.profile.profile.field_profile_last_name
+    - field.field.profile.profile.field_profile_organization
+    - field.field.profile.profile.field_profile_phone_number
+    - field.field.profile.profile.field_profile_profile_tag
+    - field.field.profile.profile.field_profile_self_introduction
+    - field.field.profile.profile.field_profile_show_email
+    - profile.type.profile
+  module:
+    - address
+    - text
+id: profile.profile.default
+targetEntityType: profile
+bundle: profile
+mode: default
+content:
+  field_profile_address:
+    weight: 2
+    label: visually_hidden
+    settings: {  }
+    third_party_settings: {  }
+    type: address_default
+    region: content
+  field_profile_expertise:
+    weight: 5
+    label: visually_hidden
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+    region: content
+  field_profile_interests:
+    weight: 4
+    label: visually_hidden
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+    region: content
+  field_profile_phone_number:
+    weight: 0
+    label: visually_hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  field_profile_profile_tag:
+    type: entity_reference_label
+    weight: 1
+    label: visually_hidden
+    settings:
+      link: false
+    third_party_settings: {  }
+    region: content
+  field_profile_self_introduction:
+    weight: 3
+    label: visually_hidden
+    settings: {  }
+    third_party_settings: {  }
+    type: text_default
+    region: content
+hidden:
+  field_profile_banner_image: true
+  field_profile_first_name: true
+  field_profile_function: true
+  field_profile_image: true
+  field_profile_last_name: true
+  field_profile_organization: true
+  field_profile_show_email: true
+  search_api_excerpt: true

--- a/modules/social_features/social_profile/config/features_removal/core.entity_view_display.profile.profile.hero.yml
+++ b/modules/social_features/social_profile/config/features_removal/core.entity_view_display.profile.profile.hero.yml
@@ -1,0 +1,78 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.profile.hero
+    - field.field.profile.profile.field_profile_address
+    - field.field.profile.profile.field_profile_banner_image
+    - field.field.profile.profile.field_profile_expertise
+    - field.field.profile.profile.field_profile_first_name
+    - field.field.profile.profile.field_profile_function
+    - field.field.profile.profile.field_profile_image
+    - field.field.profile.profile.field_profile_interests
+    - field.field.profile.profile.field_profile_last_name
+    - field.field.profile.profile.field_profile_organization
+    - field.field.profile.profile.field_profile_phone_number
+    - field.field.profile.profile.field_profile_profile_tag
+    - field.field.profile.profile.field_profile_self_introduction
+    - field.field.profile.profile.field_profile_show_email
+    - image.style.social_large
+    - profile.type.profile
+  module:
+    - image
+id: profile.profile.hero
+targetEntityType: profile
+bundle: profile
+mode: hero
+content:
+  field_profile_first_name:
+    weight: 0
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  field_profile_function:
+    type: string
+    weight: 3
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    region: content
+  field_profile_image:
+    weight: 2
+    label: hidden
+    settings:
+      image_style: social_large
+      image_link: ''
+    third_party_settings: {  }
+    type: image
+    region: content
+  field_profile_last_name:
+    weight: 1
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  field_profile_organization:
+    type: string
+    weight: 4
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    region: content
+hidden:
+  field_profile_address: true
+  field_profile_banner_image: true
+  field_profile_expertise: true
+  field_profile_interests: true
+  field_profile_phone_number: true
+  field_profile_profile_tag: true
+  field_profile_self_introduction: true
+  field_profile_show_email: true
+  search_api_excerpt: true

--- a/modules/social_features/social_profile/config/features_removal/core.entity_view_display.profile.profile.search_index.yml
+++ b/modules/social_features/social_profile/config/features_removal/core.entity_view_display.profile.profile.search_index.yml
@@ -1,0 +1,89 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.profile.search_index
+    - field.field.profile.profile.field_profile_address
+    - field.field.profile.profile.field_profile_banner_image
+    - field.field.profile.profile.field_profile_expertise
+    - field.field.profile.profile.field_profile_first_name
+    - field.field.profile.profile.field_profile_function
+    - field.field.profile.profile.field_profile_image
+    - field.field.profile.profile.field_profile_interests
+    - field.field.profile.profile.field_profile_last_name
+    - field.field.profile.profile.field_profile_organization
+    - field.field.profile.profile.field_profile_phone_number
+    - field.field.profile.profile.field_profile_profile_tag
+    - field.field.profile.profile.field_profile_self_introduction
+    - field.field.profile.profile.field_profile_show_email
+    - profile.type.profile
+  module:
+    - address
+    - text
+id: profile.profile.search_index
+targetEntityType: profile
+bundle: profile
+mode: search_index
+content:
+  field_profile_address:
+    weight: 5
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    type: address_default
+    region: content
+  field_profile_expertise:
+    weight: 8
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+    region: content
+  field_profile_function:
+    weight: 2
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  field_profile_interests:
+    weight: 7
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+    region: content
+  field_profile_organization:
+    weight: 3
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  field_profile_phone_number:
+    weight: 4
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  field_profile_self_introduction:
+    weight: 6
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    type: text_default
+    region: content
+hidden:
+  field_profile_image: true
+  field_profile_banner_image: true
+  field_profile_first_name: true
+  field_profile_last_name: true
+  field_profile_profile_tag: true
+  field_profile_show_email: true
+  search_api_excerpt: true

--- a/modules/social_features/social_profile/config/features_removal/core.entity_view_display.profile.profile.small.yml
+++ b/modules/social_features/social_profile/config/features_removal/core.entity_view_display.profile.profile.small.yml
@@ -1,0 +1,50 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.profile.small
+    - field.field.profile.profile.field_profile_address
+    - field.field.profile.profile.field_profile_banner_image
+    - field.field.profile.profile.field_profile_expertise
+    - field.field.profile.profile.field_profile_first_name
+    - field.field.profile.profile.field_profile_function
+    - field.field.profile.profile.field_profile_image
+    - field.field.profile.profile.field_profile_interests
+    - field.field.profile.profile.field_profile_last_name
+    - field.field.profile.profile.field_profile_organization
+    - field.field.profile.profile.field_profile_phone_number
+    - field.field.profile.profile.field_profile_profile_tag
+    - field.field.profile.profile.field_profile_self_introduction
+    - field.field.profile.profile.field_profile_show_email
+    - image.style.social_small
+    - profile.type.profile
+  module:
+    - image
+id: profile.profile.small
+targetEntityType: profile
+bundle: profile
+mode: small
+content:
+  field_profile_image:
+    type: image
+    weight: 0
+    label: hidden
+    settings:
+      image_style: social_small
+      image_link: ''
+    third_party_settings: {  }
+    region: content
+hidden:
+  field_profile_address: true
+  field_profile_banner_image: true
+  field_profile_expertise: true
+  field_profile_first_name: true
+  field_profile_function: true
+  field_profile_interests: true
+  field_profile_last_name: true
+  field_profile_organization: true
+  field_profile_phone_number: true
+  field_profile_profile_tag: true
+  field_profile_self_introduction: true
+  field_profile_show_email: true
+  search_api_excerpt: true

--- a/modules/social_features/social_profile/config/features_removal/core.entity_view_display.profile.profile.small_teaser.yml
+++ b/modules/social_features/social_profile/config/features_removal/core.entity_view_display.profile.profile.small_teaser.yml
@@ -1,0 +1,50 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.profile.small_teaser
+    - field.field.profile.profile.field_profile_address
+    - field.field.profile.profile.field_profile_banner_image
+    - field.field.profile.profile.field_profile_expertise
+    - field.field.profile.profile.field_profile_first_name
+    - field.field.profile.profile.field_profile_function
+    - field.field.profile.profile.field_profile_image
+    - field.field.profile.profile.field_profile_interests
+    - field.field.profile.profile.field_profile_last_name
+    - field.field.profile.profile.field_profile_organization
+    - field.field.profile.profile.field_profile_phone_number
+    - field.field.profile.profile.field_profile_profile_tag
+    - field.field.profile.profile.field_profile_self_introduction
+    - field.field.profile.profile.field_profile_show_email
+    - image.style.social_small
+    - profile.type.profile
+  module:
+    - image
+id: profile.profile.small_teaser
+targetEntityType: profile
+bundle: profile
+mode: small_teaser
+content:
+  field_profile_image:
+    type: image
+    weight: 0
+    label: hidden
+    settings:
+      image_style: social_small
+      image_link: ''
+    third_party_settings: {  }
+    region: content
+hidden:
+  field_profile_address: true
+  field_profile_banner_image: true
+  field_profile_expertise: true
+  field_profile_first_name: true
+  field_profile_function: true
+  field_profile_interests: true
+  field_profile_last_name: true
+  field_profile_organization: true
+  field_profile_phone_number: true
+  field_profile_profile_tag: true
+  field_profile_self_introduction: true
+  field_profile_show_email: true
+  search_api_excerpt: true

--- a/modules/social_features/social_profile/config/features_removal/core.entity_view_display.profile.profile.table.yml
+++ b/modules/social_features/social_profile/config/features_removal/core.entity_view_display.profile.profile.table.yml
@@ -1,0 +1,50 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.profile.table
+    - field.field.profile.profile.field_profile_address
+    - field.field.profile.profile.field_profile_banner_image
+    - field.field.profile.profile.field_profile_expertise
+    - field.field.profile.profile.field_profile_first_name
+    - field.field.profile.profile.field_profile_function
+    - field.field.profile.profile.field_profile_image
+    - field.field.profile.profile.field_profile_interests
+    - field.field.profile.profile.field_profile_last_name
+    - field.field.profile.profile.field_profile_organization
+    - field.field.profile.profile.field_profile_phone_number
+    - field.field.profile.profile.field_profile_profile_tag
+    - field.field.profile.profile.field_profile_self_introduction
+    - field.field.profile.profile.field_profile_show_email
+    - image.style.social_medium
+    - profile.type.profile
+  module:
+    - image
+id: profile.profile.table
+targetEntityType: profile
+bundle: profile
+mode: table
+content:
+  field_profile_image:
+    type: image
+    weight: 0
+    label: hidden
+    settings:
+      image_style: social_medium
+      image_link: ''
+    third_party_settings: {  }
+    region: content
+hidden:
+  field_profile_address: true
+  field_profile_banner_image: true
+  field_profile_expertise: true
+  field_profile_first_name: true
+  field_profile_function: true
+  field_profile_interests: true
+  field_profile_last_name: true
+  field_profile_organization: true
+  field_profile_phone_number: true
+  field_profile_profile_tag: true
+  field_profile_self_introduction: true
+  field_profile_show_email: true
+  search_api_excerpt: true

--- a/modules/social_features/social_profile/config/features_removal/core.entity_view_display.profile.profile.teaser.yml
+++ b/modules/social_features/social_profile/config/features_removal/core.entity_view_display.profile.profile.teaser.yml
@@ -1,0 +1,85 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.profile.teaser
+    - field.field.profile.profile.field_profile_address
+    - field.field.profile.profile.field_profile_banner_image
+    - field.field.profile.profile.field_profile_expertise
+    - field.field.profile.profile.field_profile_first_name
+    - field.field.profile.profile.field_profile_function
+    - field.field.profile.profile.field_profile_image
+    - field.field.profile.profile.field_profile_interests
+    - field.field.profile.profile.field_profile_last_name
+    - field.field.profile.profile.field_profile_organization
+    - field.field.profile.profile.field_profile_phone_number
+    - field.field.profile.profile.field_profile_profile_tag
+    - field.field.profile.profile.field_profile_self_introduction
+    - field.field.profile.profile.field_profile_show_email
+    - image.style.social_x_large
+    - profile.type.profile
+  module:
+    - image
+id: profile.profile.teaser
+targetEntityType: profile
+bundle: profile
+mode: teaser
+content:
+  field_profile_first_name:
+    weight: 1
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  field_profile_function:
+    weight: 3
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  field_profile_image:
+    weight: 0
+    label: hidden
+    settings:
+      image_style: social_x_large
+      image_link: ''
+    third_party_settings: {  }
+    type: image
+    region: content
+  field_profile_last_name:
+    weight: 2
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  field_profile_organization:
+    weight: 4
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  field_profile_profile_tag:
+    type: entity_reference_label
+    weight: 5
+    label: hidden
+    settings:
+      link: false
+    third_party_settings: {  }
+    region: content
+hidden:
+  field_profile_address: true
+  field_profile_banner_image: true
+  field_profile_expertise: true
+  field_profile_interests: true
+  field_profile_phone_number: true
+  field_profile_self_introduction: true
+  field_profile_show_email: true
+  search_api_excerpt: true

--- a/modules/social_features/social_profile/config/features_removal/core.entity_view_mode.profile.compact.yml
+++ b/modules/social_features/social_profile/config/features_removal/core.entity_view_mode.profile.compact.yml
@@ -1,0 +1,9 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - profile
+id: profile.compact
+label: 'Compact Avatar'
+targetEntityType: profile
+cache: true

--- a/modules/social_features/social_profile/config/features_removal/core.entity_view_mode.profile.compact_notification.yml
+++ b/modules/social_features/social_profile/config/features_removal/core.entity_view_mode.profile.compact_notification.yml
@@ -1,0 +1,9 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - profile
+id: profile.compact_notification
+label: 'Compact Notifcation'
+targetEntityType: profile
+cache: true

--- a/modules/social_features/social_profile/config/features_removal/core.entity_view_mode.profile.compact_teaser.yml
+++ b/modules/social_features/social_profile/config/features_removal/core.entity_view_mode.profile.compact_teaser.yml
@@ -1,0 +1,9 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - profile
+id: profile.compact_teaser
+label: 'Compact Teaser'
+targetEntityType: profile
+cache: true

--- a/modules/social_features/social_profile/config/features_removal/core.entity_view_mode.profile.hero.yml
+++ b/modules/social_features/social_profile/config/features_removal/core.entity_view_mode.profile.hero.yml
@@ -1,0 +1,9 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - profile
+id: profile.hero
+label: Hero
+targetEntityType: profile
+cache: true

--- a/modules/social_features/social_profile/config/features_removal/core.entity_view_mode.profile.search_index.yml
+++ b/modules/social_features/social_profile/config/features_removal/core.entity_view_mode.profile.search_index.yml
@@ -1,0 +1,9 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - profile
+id: profile.search_index
+label: 'Search Index'
+targetEntityType: profile
+cache: true

--- a/modules/social_features/social_profile/config/features_removal/core.entity_view_mode.profile.small.yml
+++ b/modules/social_features/social_profile/config/features_removal/core.entity_view_mode.profile.small.yml
@@ -1,0 +1,9 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - profile
+id: profile.small
+label: 'Small Avatar'
+targetEntityType: profile
+cache: true

--- a/modules/social_features/social_profile/config/features_removal/core.entity_view_mode.profile.small_teaser.yml
+++ b/modules/social_features/social_profile/config/features_removal/core.entity_view_mode.profile.small_teaser.yml
@@ -1,0 +1,9 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - profile
+id: profile.small_teaser
+label: 'Small Teaser'
+targetEntityType: profile
+cache: true

--- a/modules/social_features/social_profile/config/features_removal/core.entity_view_mode.profile.table.yml
+++ b/modules/social_features/social_profile/config/features_removal/core.entity_view_mode.profile.table.yml
@@ -1,0 +1,9 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - profile
+id: profile.table
+label: Table
+targetEntityType: profile
+cache: true

--- a/modules/social_features/social_profile/config/features_removal/core.entity_view_mode.profile.teaser.yml
+++ b/modules/social_features/social_profile/config/features_removal/core.entity_view_mode.profile.teaser.yml
@@ -1,0 +1,9 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - profile
+id: profile.teaser
+label: Teaser
+targetEntityType: profile
+cache: true

--- a/modules/social_features/social_profile/config/features_removal/field.field.profile.profile.field_profile_address.yml
+++ b/modules/social_features/social_profile/config/features_removal/field.field.profile.profile.field_profile_address.yml
@@ -1,0 +1,34 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.profile.field_profile_address
+    - profile.type.profile
+  module:
+    - address
+id: profile.profile.field_profile_address
+field_name: field_profile_address
+entity_type: profile
+bundle: profile
+label: Address
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  available_countries: {  }
+  fields:
+    administrativeArea: administrativeArea
+    locality: locality
+    postalCode: postalCode
+    addressLine1: addressLine1
+    dependentLocality: '0'
+    sortingCode: '0'
+    addressLine2: '0'
+    organization: '0'
+    givenName: '0'
+    additionalName: '0'
+    familyName: '0'
+  langcode_override: ''
+field_type: address

--- a/modules/social_features/social_profile/config/features_removal/field.field.profile.profile.field_profile_banner_image.yml
+++ b/modules/social_features/social_profile/config/features_removal/field.field.profile.profile.field_profile_banner_image.yml
@@ -1,0 +1,37 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.profile.field_profile_banner_image
+    - profile.type.profile
+  module:
+    - image
+id: profile.profile.field_profile_banner_image
+field_name: field_profile_banner_image
+entity_type: profile
+bundle: profile
+label: 'Banner Image'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  file_directory: '[date:custom:Y]-[date:custom:m]'
+  file_extensions: 'png gif jpg jpeg'
+  max_filesize: ''
+  max_resolution: 4096x4096
+  min_resolution: ''
+  alt_field: true
+  alt_field_required: false
+  title_field: false
+  title_field_required: false
+  default_image:
+    uuid: ''
+    alt: ''
+    title: ''
+    width: null
+    height: null
+  handler: 'default:file'
+  handler_settings: {  }
+field_type: image

--- a/modules/social_features/social_profile/config/features_removal/field.field.profile.profile.field_profile_expertise.yml
+++ b/modules/social_features/social_profile/config/features_removal/field.field.profile.profile.field_profile_expertise.yml
@@ -1,0 +1,27 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.profile.field_profile_expertise
+    - profile.type.profile
+    - taxonomy.vocabulary.expertise
+id: profile.profile.field_profile_expertise
+field_name: field_profile_expertise
+entity_type: profile
+bundle: profile
+label: Expertise
+description: 'Separate multiple values by a comma.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      expertise: expertise
+    sort:
+      field: _none
+    auto_create: true
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/modules/social_features/social_profile/config/features_removal/field.field.profile.profile.field_profile_first_name.yml
+++ b/modules/social_features/social_profile/config/features_removal/field.field.profile.profile.field_profile_first_name.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.profile.field_profile_first_name
+    - profile.type.profile
+id: profile.profile.field_profile_first_name
+field_name: field_profile_first_name
+entity_type: profile
+bundle: profile
+label: 'First name'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/modules/social_features/social_profile/config/features_removal/field.field.profile.profile.field_profile_function.yml
+++ b/modules/social_features/social_profile/config/features_removal/field.field.profile.profile.field_profile_function.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.profile.field_profile_function
+    - profile.type.profile
+id: profile.profile.field_profile_function
+field_name: field_profile_function
+entity_type: profile
+bundle: profile
+label: Function
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/modules/social_features/social_profile/config/features_removal/field.field.profile.profile.field_profile_image.yml
+++ b/modules/social_features/social_profile/config/features_removal/field.field.profile.profile.field_profile_image.yml
@@ -1,0 +1,37 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.profile.field_profile_image
+    - profile.type.profile
+  module:
+    - image
+id: profile.profile.field_profile_image
+field_name: field_profile_image
+entity_type: profile
+bundle: profile
+label: 'Profile image'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  file_directory: '[date:custom:Y]-[date:custom:m]'
+  file_extensions: 'png gif jpg jpeg'
+  max_filesize: ''
+  max_resolution: 4096x4096
+  min_resolution: ''
+  alt_field: true
+  alt_field_required: false
+  title_field: false
+  title_field_required: false
+  default_image:
+    uuid: 4eb1d927-28f4-402a-8c87-017e637f434a
+    alt: 'Default profile image'
+    title: 'Default profile image'
+    width: 200
+    height: 200
+  handler: 'default:file'
+  handler_settings: {  }
+field_type: image

--- a/modules/social_features/social_profile/config/features_removal/field.field.profile.profile.field_profile_interests.yml
+++ b/modules/social_features/social_profile/config/features_removal/field.field.profile.profile.field_profile_interests.yml
@@ -1,0 +1,27 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.profile.field_profile_interests
+    - profile.type.profile
+    - taxonomy.vocabulary.interests
+id: profile.profile.field_profile_interests
+field_name: field_profile_interests
+entity_type: profile
+bundle: profile
+label: Interests
+description: 'Separate multiple values by a comma.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      interests: interests
+    sort:
+      field: _none
+    auto_create: true
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/modules/social_features/social_profile/config/features_removal/field.field.profile.profile.field_profile_last_name.yml
+++ b/modules/social_features/social_profile/config/features_removal/field.field.profile.profile.field_profile_last_name.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.profile.field_profile_last_name
+    - profile.type.profile
+id: profile.profile.field_profile_last_name
+field_name: field_profile_last_name
+entity_type: profile
+bundle: profile
+label: 'Last name'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/modules/social_features/social_profile/config/features_removal/field.field.profile.profile.field_profile_organization.yml
+++ b/modules/social_features/social_profile/config/features_removal/field.field.profile.profile.field_profile_organization.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.profile.field_profile_organization
+    - profile.type.profile
+id: profile.profile.field_profile_organization
+field_name: field_profile_organization
+entity_type: profile
+bundle: profile
+label: Organization
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/modules/social_features/social_profile/config/features_removal/field.field.profile.profile.field_profile_phone_number.yml
+++ b/modules/social_features/social_profile/config/features_removal/field.field.profile.profile.field_profile_phone_number.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.profile.field_profile_phone_number
+    - profile.type.profile
+  module:
+    - telephone
+id: profile.profile.field_profile_phone_number
+field_name: field_profile_phone_number
+entity_type: profile
+bundle: profile
+label: 'Phone number'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: telephone

--- a/modules/social_features/social_profile/config/features_removal/field.field.profile.profile.field_profile_profile_tag.yml
+++ b/modules/social_features/social_profile/config/features_removal/field.field.profile.profile.field_profile_profile_tag.yml
@@ -1,0 +1,27 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.profile.field_profile_profile_tag
+    - profile.type.profile
+    - taxonomy.vocabulary.profile_tag
+id: profile.profile.field_profile_profile_tag
+field_name: field_profile_profile_tag
+entity_type: profile
+bundle: profile
+label: 'Profile tag'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      profile_tag: profile_tag
+    sort:
+      field: _none
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/modules/social_features/social_profile/config/features_removal/field.field.profile.profile.field_profile_self_introduction.yml
+++ b/modules/social_features/social_profile/config/features_removal/field.field.profile.profile.field_profile_self_introduction.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.profile.field_profile_self_introduction
+    - profile.type.profile
+  module:
+    - text
+id: profile.profile.field_profile_self_introduction
+field_name: field_profile_self_introduction
+entity_type: profile
+bundle: profile
+label: 'Self introduction'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: text_long

--- a/modules/social_features/social_profile/config/features_removal/field.field.profile.profile.field_profile_show_email.yml
+++ b/modules/social_features/social_profile/config/features_removal/field.field.profile.profile.field_profile_show_email.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.profile.field_profile_show_email
+    - profile.type.profile
+id: profile.profile.field_profile_show_email
+field_name: field_profile_show_email
+entity_type: profile
+bundle: profile
+label: 'Show email'
+description: ''
+required: false
+translatable: false
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/modules/social_features/social_profile/config/features_removal/field.storage.profile.field_profile_address.yml
+++ b/modules/social_features/social_profile/config/features_removal/field.storage.profile.field_profile_address.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - address
+    - profile
+id: profile.field_profile_address
+field_name: field_profile_address
+entity_type: profile
+type: address
+settings: {  }
+module: address
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/social_features/social_profile/config/features_removal/field.storage.profile.field_profile_banner_image.yml
+++ b/modules/social_features/social_profile/config/features_removal/field.storage.profile.field_profile_banner_image.yml
@@ -1,0 +1,29 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - file
+    - image
+    - profile
+id: profile.field_profile_banner_image
+field_name: field_profile_banner_image
+entity_type: profile
+type: image
+settings:
+  uri_scheme: public
+  default_image:
+    uuid: ''
+    alt: ''
+    title: ''
+    width: null
+    height: null
+  target_type: file
+  display_field: false
+  display_default: false
+module: image
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/social_features/social_profile/config/features_removal/field.storage.profile.field_profile_expertise.yml
+++ b/modules/social_features/social_profile/config/features_removal/field.storage.profile.field_profile_expertise.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - profile
+    - taxonomy
+id: profile.field_profile_expertise
+field_name: field_profile_expertise
+entity_type: profile
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/social_features/social_profile/config/features_removal/field.storage.profile.field_profile_first_name.yml
+++ b/modules/social_features/social_profile/config/features_removal/field.storage.profile.field_profile_first_name.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - profile
+id: profile.field_profile_first_name
+field_name: field_profile_first_name
+entity_type: profile
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/social_features/social_profile/config/features_removal/field.storage.profile.field_profile_function.yml
+++ b/modules/social_features/social_profile/config/features_removal/field.storage.profile.field_profile_function.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - profile
+id: profile.field_profile_function
+field_name: field_profile_function
+entity_type: profile
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/social_features/social_profile/config/features_removal/field.storage.profile.field_profile_image.yml
+++ b/modules/social_features/social_profile/config/features_removal/field.storage.profile.field_profile_image.yml
@@ -1,0 +1,29 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - file
+    - image
+    - profile
+id: profile.field_profile_image
+field_name: field_profile_image
+entity_type: profile
+type: image
+settings:
+  uri_scheme: public
+  default_image:
+    uuid: ''
+    alt: ''
+    title: ''
+    width: null
+    height: null
+  target_type: file
+  display_field: false
+  display_default: false
+module: image
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/social_features/social_profile/config/features_removal/field.storage.profile.field_profile_interests.yml
+++ b/modules/social_features/social_profile/config/features_removal/field.storage.profile.field_profile_interests.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - profile
+    - taxonomy
+id: profile.field_profile_interests
+field_name: field_profile_interests
+entity_type: profile
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/social_features/social_profile/config/features_removal/field.storage.profile.field_profile_last_name.yml
+++ b/modules/social_features/social_profile/config/features_removal/field.storage.profile.field_profile_last_name.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - profile
+id: profile.field_profile_last_name
+field_name: field_profile_last_name
+entity_type: profile
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/social_features/social_profile/config/features_removal/field.storage.profile.field_profile_organization.yml
+++ b/modules/social_features/social_profile/config/features_removal/field.storage.profile.field_profile_organization.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - profile
+id: profile.field_profile_organization
+field_name: field_profile_organization
+entity_type: profile
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/social_features/social_profile/config/features_removal/field.storage.profile.field_profile_phone_number.yml
+++ b/modules/social_features/social_profile/config/features_removal/field.storage.profile.field_profile_phone_number.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - profile
+    - telephone
+id: profile.field_profile_phone_number
+field_name: field_profile_phone_number
+entity_type: profile
+type: telephone
+settings: {  }
+module: telephone
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/social_features/social_profile/config/features_removal/field.storage.profile.field_profile_profile_tag.yml
+++ b/modules/social_features/social_profile/config/features_removal/field.storage.profile.field_profile_profile_tag.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - profile
+    - taxonomy
+id: profile.field_profile_profile_tag
+field_name: field_profile_profile_tag
+entity_type: profile
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/social_features/social_profile/config/features_removal/field.storage.profile.field_profile_self_introduction.yml
+++ b/modules/social_features/social_profile/config/features_removal/field.storage.profile.field_profile_self_introduction.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - profile
+    - text
+id: profile.field_profile_self_introduction
+field_name: field_profile_self_introduction
+entity_type: profile
+type: text_long
+settings: {  }
+module: text
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/social_features/social_profile/config/features_removal/field.storage.profile.field_profile_show_email.yml
+++ b/modules/social_features/social_profile/config/features_removal/field.storage.profile.field_profile_show_email.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - profile
+id: profile.field_profile_show_email
+field_name: field_profile_show_email
+entity_type: profile
+type: boolean
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/social_features/social_profile/config/features_removal/profile.type.profile.yml
+++ b/modules/social_features/social_profile/config/features_removal/profile.type.profile.yml
@@ -1,0 +1,13 @@
+langcode: en
+status: true
+dependencies: {  }
+id: profile
+label: Profile
+registration: false
+multiple: false
+roles:
+  authenticated: '0'
+  administrator: '0'
+allow_revisions: false
+display_label : null
+new_revision: false

--- a/modules/social_features/social_profile/config/features_removal/taxonomy.vocabulary.expertise.yml
+++ b/modules/social_features/social_profile/config/features_removal/taxonomy.vocabulary.expertise.yml
@@ -1,0 +1,7 @@
+langcode: en
+status: true
+dependencies: {  }
+name: Expertise
+vid: expertise
+description: 'A users expertises'
+weight: 0

--- a/modules/social_features/social_profile/config/features_removal/taxonomy.vocabulary.interests.yml
+++ b/modules/social_features/social_profile/config/features_removal/taxonomy.vocabulary.interests.yml
@@ -1,0 +1,7 @@
+langcode: en
+status: true
+dependencies: {  }
+name: Interests
+vid: interests
+description: 'A users interests for their profile.'
+weight: 0

--- a/modules/social_features/social_profile/config/features_removal/taxonomy.vocabulary.profile_tag.yml
+++ b/modules/social_features/social_profile/config/features_removal/taxonomy.vocabulary.profile_tag.yml
@@ -1,0 +1,7 @@
+langcode: en
+status: true
+dependencies: {  }
+name: 'Profile tag'
+vid: profile_tag
+description: 'CM can tag a user, giving options on filtering / searching users.'
+weight: 0

--- a/modules/social_features/social_profile/config/features_removal/views.view.newest_users.yml
+++ b/modules/social_features/social_profile/config/features_removal/views.view.newest_users.yml
@@ -1,0 +1,371 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.profile.small_teaser
+    - core.entity_view_mode.profile.teaser
+    - profile.type.profile
+  module:
+    - profile
+    - user
+id: newest_users
+label: 'Newest users'
+module: views
+description: 'Displays a block and page for the newest users on the platform based on Profile'
+tag: ''
+base_table: profile
+base_field: profile_id
+core: 8.x
+display:
+  default:
+    display_plugin: default
+    id: default
+    display_title: Master
+    position: 0
+    display_options:
+      access:
+        type: perm
+        options:
+          perm: 'view any profile profile'
+      cache:
+        type: tag
+        options: {  }
+      query:
+        type: views_query
+        options:
+          disable_sql_rewrite: false
+          distinct: true
+          replica: false
+          query_comment: ''
+          query_tags: {  }
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      pager:
+        type: mini
+        options:
+          items_per_page: 4
+          offset: 0
+          id: 0
+          total_pages: null
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          tags:
+            previous: ‹‹
+            next: ››
+      style:
+        type: default
+      row:
+        type: 'entity:profile'
+        options:
+          relationship: none
+          view_mode: teaser
+      fields:
+        rendered_entity:
+          table: profile
+          field: rendered_entity
+          id: rendered_entity
+          entity_type: null
+          entity_field: null
+          plugin_id: rendered_entity
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          view_mode: default
+      filters:
+        type:
+          id: type
+          table: profile
+          field: type
+          value:
+            profile: profile
+          entity_type: profile
+          entity_field: type
+          plugin_id: bundle
+        status:
+          id: status
+          table: users_field_data
+          field: status
+          relationship: uid
+          group_type: group
+          admin_label: ''
+          operator: '='
+          value: '1'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: user
+          entity_field: status
+          plugin_id: boolean
+        uid_raw:
+          id: uid_raw
+          table: users_field_data
+          field: uid_raw
+          relationship: uid
+          group_type: group
+          admin_label: filter_no_admin
+          operator: '>'
+          value:
+            min: ''
+            max: ''
+            value: '1'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: user
+          plugin_id: numeric
+      sorts:
+        created:
+          id: created
+          table: profile
+          field: created
+          relationship: none
+          group_type: group
+          admin_label: ''
+          order: DESC
+          exposed: false
+          expose:
+            label: ''
+          granularity: minute
+          entity_type: profile
+          entity_field: created
+          plugin_id: date
+      title: 'Newest members'
+      header: {  }
+      footer: {  }
+      empty: {  }
+      relationships:
+        uid:
+          id: uid
+          table: profile
+          field: uid
+          relationship: none
+          group_type: group
+          admin_label: User
+          required: true
+          entity_type: profile
+          entity_field: uid
+          plugin_id: standard
+      arguments: {  }
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_interface'
+        - url.query_args
+        - user.permissions
+      tags:
+        - 'config:core.entity_view_display.profile.profile.autocomplete_item'
+        - 'config:core.entity_view_display.profile.profile.compact'
+        - 'config:core.entity_view_display.profile.profile.compact_notification'
+        - 'config:core.entity_view_display.profile.profile.compact_teaser'
+        - 'config:core.entity_view_display.profile.profile.default'
+        - 'config:core.entity_view_display.profile.profile.hero'
+        - 'config:core.entity_view_display.profile.profile.search_index'
+        - 'config:core.entity_view_display.profile.profile.small'
+        - 'config:core.entity_view_display.profile.profile.small_teaser'
+        - 'config:core.entity_view_display.profile.profile.table'
+        - 'config:core.entity_view_display.profile.profile.teaser'
+  block_newest_users:
+    display_plugin: block
+    id: block_newest_users
+    display_title: 'Newest users block'
+    position: 2
+    display_options:
+      display_extenders: {  }
+      title: 'Newest members'
+      defaults:
+        title: false
+        pager: false
+        style: false
+        row: false
+        use_more: false
+        use_more_always: false
+        use_more_text: false
+      pager:
+        type: some
+        options:
+          items_per_page: 2
+          offset: 0
+      style:
+        type: default
+        options: {  }
+      row:
+        type: 'entity:profile'
+        options:
+          relationship: none
+          view_mode: small_teaser
+      display_description: ''
+      block_description: 'Newest users block'
+      use_more: true
+      use_more_always: true
+      use_more_text: 'All members'
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_interface'
+        - user.permissions
+      tags:
+        - 'config:core.entity_view_display.profile.profile.autocomplete_item'
+        - 'config:core.entity_view_display.profile.profile.compact'
+        - 'config:core.entity_view_display.profile.profile.compact_notification'
+        - 'config:core.entity_view_display.profile.profile.compact_teaser'
+        - 'config:core.entity_view_display.profile.profile.default'
+        - 'config:core.entity_view_display.profile.profile.hero'
+        - 'config:core.entity_view_display.profile.profile.search_index'
+        - 'config:core.entity_view_display.profile.profile.small'
+        - 'config:core.entity_view_display.profile.profile.small_teaser'
+        - 'config:core.entity_view_display.profile.profile.table'
+        - 'config:core.entity_view_display.profile.profile.teaser'
+  page_newest_users:
+    display_plugin: page
+    id: page_newest_users
+    display_title: 'Newest users page'
+    position: 1
+    display_options:
+      display_extenders: {  }
+      path: all-members
+      pager:
+        type: full
+        options:
+          items_per_page: 10
+          offset: 0
+          id: 0
+          total_pages: null
+          tags:
+            previous: ‹‹
+            next: ››
+            first: '« First'
+            last: 'Last »'
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          quantity: 9
+      defaults:
+        pager: false
+        title: false
+      display_description: ''
+      title: 'All members'
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_interface'
+        - url.query_args
+        - user.permissions
+      tags:
+        - 'config:core.entity_view_display.profile.profile.autocomplete_item'
+        - 'config:core.entity_view_display.profile.profile.compact'
+        - 'config:core.entity_view_display.profile.profile.compact_notification'
+        - 'config:core.entity_view_display.profile.profile.compact_teaser'
+        - 'config:core.entity_view_display.profile.profile.default'
+        - 'config:core.entity_view_display.profile.profile.hero'
+        - 'config:core.entity_view_display.profile.profile.search_index'
+        - 'config:core.entity_view_display.profile.profile.small'
+        - 'config:core.entity_view_display.profile.profile.small_teaser'
+        - 'config:core.entity_view_display.profile.profile.table'
+        - 'config:core.entity_view_display.profile.profile.teaser'

--- a/modules/social_features/social_profile/config/features_removal/views.view.user_information.yml
+++ b/modules/social_features/social_profile/config/features_removal/views.view.user_information.yml
@@ -1,0 +1,255 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - profile.type.profile
+  module:
+    - profile
+    - user
+id: user_information
+label: 'User information'
+module: views
+description: ''
+tag: ''
+base_table: profile
+base_field: profile_id
+core: 8.x
+display:
+  default:
+    display_plugin: default
+    id: default
+    display_title: Master
+    position: 0
+    display_options:
+      access:
+        type: perm
+        options:
+          perm: 'view any profile profile'
+      cache:
+        type: tag
+        options: {  }
+      query:
+        type: views_query
+        options:
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_comment: ''
+          query_tags: {  }
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      pager:
+        type: some
+        options:
+          items_per_page: 1
+          offset: 0
+      style:
+        type: default
+      row:
+        type: 'entity:profile'
+        options:
+          relationship: none
+          view_mode: default
+      fields:
+        rendered_entity:
+          table: profile
+          field: rendered_entity
+          id: rendered_entity
+          entity_type: null
+          entity_field: null
+          plugin_id: rendered_entity
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          view_mode: default
+      filters:
+        type:
+          id: type
+          table: profile
+          field: type
+          value:
+            profile: profile
+          entity_type: profile
+          entity_field: type
+          plugin_id: bundle
+      sorts: {  }
+      title: Information
+      header: {  }
+      footer: {  }
+      empty:
+        area:
+          id: area
+          table: views
+          field: area
+          relationship: none
+          group_type: group
+          admin_label: ''
+          empty: true
+          tokenize: true
+          content:
+            value: 'There is no profile added yet, you can <a href="/user/{{ arguments.uid }}/profile">add a profile here</a>'
+            format: basic_html
+          plugin_id: text
+      relationships:
+        uid:
+          id: uid
+          table: profile
+          field: uid
+          relationship: none
+          group_type: group
+          admin_label: User
+          required: false
+          entity_type: profile
+          entity_field: uid
+          plugin_id: standard
+        profile:
+          id: profile
+          table: users_field_data
+          field: profile
+          relationship: uid
+          group_type: group
+          admin_label: Profile
+          required: false
+          entity_type: user
+          plugin_id: standard
+      arguments:
+        uid:
+          id: uid
+          table: profile
+          field: uid
+          relationship: profile
+          group_type: group
+          admin_label: ''
+          default_action: empty
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: false
+          title: ''
+          default_argument_type: fixed
+          default_argument_options:
+            argument: ''
+          default_argument_skip_url: false
+          summary_options:
+            base_path: ''
+            count: true
+            items_per_page: 25
+            override: false
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: false
+          validate:
+            type: none
+            fail: 'not found'
+          validate_options: {  }
+          break_phrase: false
+          not: false
+          entity_type: profile
+          entity_field: uid
+          plugin_id: numeric
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_interface'
+        - url
+        - user.permissions
+      tags:
+        - 'config:core.entity_view_display.profile.profile.autocomplete_item'
+        - 'config:core.entity_view_display.profile.profile.compact'
+        - 'config:core.entity_view_display.profile.profile.compact_notification'
+        - 'config:core.entity_view_display.profile.profile.compact_teaser'
+        - 'config:core.entity_view_display.profile.profile.default'
+        - 'config:core.entity_view_display.profile.profile.hero'
+        - 'config:core.entity_view_display.profile.profile.search_index'
+        - 'config:core.entity_view_display.profile.profile.small'
+        - 'config:core.entity_view_display.profile.profile.small_teaser'
+        - 'config:core.entity_view_display.profile.profile.table'
+        - 'config:core.entity_view_display.profile.profile.teaser'
+  user_information:
+    display_plugin: page
+    id: user_information
+    display_title: Page
+    position: 1
+    display_options:
+      display_extenders: {  }
+      path: user/%user/information
+      menu:
+        type: none
+        title: Information
+        description: ''
+        expanded: false
+        parent: ''
+        weight: 0
+        context: '0'
+        menu_name: main
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_interface'
+        - url
+        - user.permissions
+      tags:
+        - 'config:core.entity_view_display.profile.profile.autocomplete_item'
+        - 'config:core.entity_view_display.profile.profile.compact'
+        - 'config:core.entity_view_display.profile.profile.compact_notification'
+        - 'config:core.entity_view_display.profile.profile.compact_teaser'
+        - 'config:core.entity_view_display.profile.profile.default'
+        - 'config:core.entity_view_display.profile.profile.hero'
+        - 'config:core.entity_view_display.profile.profile.search_index'
+        - 'config:core.entity_view_display.profile.profile.small'
+        - 'config:core.entity_view_display.profile.profile.small_teaser'
+        - 'config:core.entity_view_display.profile.profile.table'
+        - 'config:core.entity_view_display.profile.profile.teaser'

--- a/modules/social_features/social_profile/config/install/social_profile.settings.yml
+++ b/modules/social_features/social_profile/config/install/social_profile.settings.yml
@@ -1,0 +1,1 @@
+social_profile_show_email: true

--- a/modules/social_features/social_profile/social_profile.features.yml
+++ b/modules/social_features/social_profile/social_profile.features.yml
@@ -1,4 +1,0 @@
-bundle: social
-excluded:
-  - social_profile.settings
-required: true

--- a/modules/social_features/social_profile/social_profile.install
+++ b/modules/social_features/social_profile/social_profile.install
@@ -25,8 +25,7 @@ function social_profile_install() {
   _social_profile_create_menu_links();
   // Add default profile image.
   _social_profile_add_default_profile_image();
-  // Set default config.
-  _social_profile_set_default_config();
+
   // Create a profile for user 1.
   Profile::create([
     'type' => ProfileType::load('profile')->id(),
@@ -148,15 +147,6 @@ function _social_profile_create_menu_links() {
 }
 
 /**
- * Set default config.
- */
-function _social_profile_set_default_config() {
-  $config = \Drupal::configFactory()->getEditable('social_profile.settings');
-  $config->set('social_profile_show_email', 1);
-  $config->save();
-}
-
-/**
  * Implements hook_uninstall().
  */
 function social_profile_uninstall() {
@@ -188,7 +178,9 @@ function social_profile_update_8002(&$sandbox) {
  * Add social_profile.settings config. Update permissions for SM role.
  */
 function social_profile_update_8003(&$sandbox) {
-  _social_profile_set_default_config();
+  $config = \Drupal::configFactory()->getEditable('social_profile.settings');
+  $config->set('social_profile_show_email', 1);
+  $config->save();
 
   // Add permission to view profile email and administer profile settings for
   // sitemanager role.


### PR DESCRIPTION
<h2>Problem</h2>
See problem definition in [#3092272]. The fact that this configuration is in a feature means that site managers can't change the name of the taxonomies.

<h2>Solution</h2>
<ul>
  <li>Remove the <code>social_profile.features.yml</code> file</li>
  <li>Move the default editable config from <code>social_profile_install()</code> into a <code>config/install/*.yml</code> file.
  <li>Remove the _social_profile_set_defaults function</li>
</ul>

## Issue tracker
https://www.drupal.org/project/social/issues/3092275

## How to test

-  [ ] Enable the Social Profile module
-  [ ] Change the name of the interests, profile tag, and expertise vocabulary
-  [ ] Revert features


## Release notes
The social_profile module is no longer managed by features. This fixes an issue where the Interests, Profile Tags, and Expertise vocabulary names could not be changed. 

