### PR TITLE
Issue #3092481 by Kingdutch: Remove features from Social Topic module

### DIFF
--- a/modules/social_features/social_topic/config/install/social_topic.settings.yml
+++ b/modules/social_features/social_topic/config/install/social_topic.settings.yml
@@ -1,0 +1,1 @@
+social_topic_type_select_changer: 8

--- a/modules/social_features/social_topic/schema/social_topic.schema.yml
+++ b/modules/social_features/social_topic/schema/social_topic.schema.yml
@@ -1,0 +1,7 @@
+social_topic.settings:
+  type: config_object
+  label: 'Social Topic Settings'
+  mapping:
+    social_topic_type_select_changer:
+      type: integer
+      label: 'The number of terms at which point to topic type chooser will switch from radio buttons to dropdown.'

--- a/modules/social_features/social_topic/social_topic.features.yml
+++ b/modules/social_features/social_topic/social_topic.features.yml
@@ -1,2 +1,0 @@
-bundle: social
-required: true

--- a/modules/social_features/social_topic/social_topic.install
+++ b/modules/social_features/social_topic/social_topic.install
@@ -34,11 +34,6 @@ function social_topic_install() {
     ]);
     $term->save();
   }
-
-  // Set default topic type settings.
-  $config = \Drupal::configFactory()->getEditable('social_topic.settings');
-  $config->set('social_topic_type_select_changer', 8);
-  $config->save();
 }
 
 /**


### PR DESCRIPTION
Removes the features file and adds default configuration as settings
file in the config/install folder.

<h2>Problem</h2>
See problem definition in [#3092272]. The fact that this configuration is in a feature means that site managers can't change the name of the taxonomies.

<h2>Solution</h2>
<ul>
  <li>Remove the <code>social_topic.features.yml</code> file</li>
  <li>Move the default editable config from <code>hook_install()</code> into a <code>config/install/*.yml</code> file.
  <li>Remove any _module_set_defaults function</li>
</ul>


## Issue tracker
<paste a link to the drupal.org issue queue item, or any other issue tracker if applicable>

## How to test
- [ ] Enable the module
- [ ] Change the name of the topic types vocabulary
- [ ] Revert features


## Release notes
The social_tp[oc module is no longer managed by features. This fixes an issue where the Topic Types vocabulary names could not be changed.
