### PR TITLE
Issue #3005853 by agami4: Disable autocomplete for date field

### DIFF
--- a/themes/socialbase/templates/form/input--form-control--date.html.twig
+++ b/themes/socialbase/templates/form/input--form-control--date.html.twig
@@ -1,4 +1,4 @@
 {% extends "input--form-control.html.twig" %}
 
-{% set attributes = attributes.setAttribute('step', 300) %}
+{% set attributes = attributes.setAttribute('step', 300).setAttribute('autocomplete', 'off') %}
 


### PR DESCRIPTION
## Problem
When creating an event you have the option to select a date. This date nicely shows a pop-up calendar, but this is not visible at first because of the autocomplete completely blocking it. This is very annoying and easily fixable but turning off the autocomplete for this field.

## Solution
Disable autocomplete for date field

## Issue tracker
https://www.drupal.org/project/social/issues/3005853

## How to test
- [ ] Create a new event and click to the date field

## Release notes
The autocomplete was disabled for a date field.