### PR TITLE
Add file that can store legacy translations

### DIFF
--- a/translations.php
+++ b/translations.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * @file
+ * A list of strings in older Open Social versions than current stable release.
+ *
+ * This file contains translatable strings that have been altered or changed in
+ * the Open Social distribution. By wrapping these strings in the Drupal::t() or
+ * Drupal::formatPlural function in this file, they will be picked up by the
+ * POTX tool automatically. This ensures that they can be translated in the Open
+ * Social translation workflow for older versions of Open Social.
+ *
+ * When adding texts to this file. Please specify in which version the string
+ * was changed so that it can be cleaned up in the future when all platforms
+ * are using at least that version.
+ */
+
+die('This file should not be run directly.');
+
+// Changed in version X.Y
+//new TranslatableMarkup('Example');
+//new PluralTranslatableMarkup($count, '1 example', '@count examples');


### PR DESCRIPTION
## Problem

Sometimes the latest version of Open Social changes strings. These
strings will be picked up in the translation workflow. However, the old
strings that were changed or removed will be removed from translation
source files. This can cause translations to go missing for platforms
running older version.


## Solution
To fix this we create this dummy file that can hold the old versions of
these strings so that they'll remain translatable in Weblate.

## Issue tracker
[ Internal quick-fix, no issue created ] 

## How to test
Not applicable

## Release notes
Not needed.
