### PR TITLE
Improved the bulk operation actions description text.

### DIFF
--- a/modules/social_features/social_event/modules/social_event_managers/src/Plugin/views/field/SocialEventManagersViewsBulkOperationsBulkForm.php
+++ b/modules/social_features/social_event/modules/social_event_managers/src/Plugin/views/field/SocialEventManagersViewsBulkOperationsBulkForm.php
@@ -186,7 +186,7 @@ class SocialEventManagersViewsBulkOperationsBulkForm extends ViewsBulkOperations
 
     // Render select all results checkbox.
     if (!empty($wrapper['select_all'])) {
-      $wrapper['select_all']['#title'] = $this->t('Select / unselect all @count results in this view', [
+      $wrapper['select_all']['#title'] = $this->t('Select / unselect all @count members across all the pages', [
         '@count' => $this->tempStoreData['total_results'] ? ' ' . $this->tempStoreData['total_results'] : '',
       ]);
       // Styling attributes for the select box.

--- a/modules/social_features/social_group/src/Plugin/views/field/SocialGroupViewsBulkOperationsBulkForm.php
+++ b/modules/social_features/social_group/src/Plugin/views/field/SocialGroupViewsBulkOperationsBulkForm.php
@@ -107,7 +107,7 @@ class SocialGroupViewsBulkOperationsBulkForm extends ViewsBulkOperationsBulkForm
 
     // Render select all results checkbox.
     if (!empty($wrapper['select_all'])) {
-      $wrapper['select_all']['#title'] = $this->t('Select / unselect all @count results in this view', [
+      $wrapper['select_all']['#title'] = $this->t('Select / unselect all @count members across all the pages', [
         '@count' => $this->tempStoreData['total_results'] ? ' ' . $this->tempStoreData['total_results'] : '',
       ]);
       // Styling attributes for the select box.
@@ -142,7 +142,7 @@ class SocialGroupViewsBulkOperationsBulkForm extends ViewsBulkOperationsBulkForm
 
     // Update the clear submit button.
     if (!empty($wrapper['multipage']['clear'])) {
-      $wrapper['multipage']['clear']['#value'] = $this->t('Clear all selected members');
+      $wrapper['multipage']['clear']['#value'] = $this->t('Clear selection on all pages');
       $wrapper['multipage']['clear']['#attributes']['class'][] = 'btn-default dropdown-toggle waves-effect waves-btn margin-top-l margin-left-m';
     }
 

--- a/translations.php
+++ b/translations.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile
 
 /**
  * @file
@@ -20,3 +21,7 @@ die('This file should not be run directly.');
 // Changed in version X.Y
 // new TranslatableMarkup('Example');
 // new PluralTranslatableMarkup($count, '1 example', '@count examples');.
+
+// Changed in version 7.2.
+new TranslatableMarkup('Select / unselect all @count results in this view');
+new TranslatableMarkup('Clear all selected members');


### PR DESCRIPTION
## Problem
The text "Select / unselect all @count results in this view'" and "Clear selected Members" in Manage members tab in groups are a bit misleading and can be improved for better reading.

## Solution
//s "Select / unselect all @count results in this view'" to "Select / unselect all @count members across all the pages"
//s "Clear all selected members" to "Clear selection"

## Issue tracker
https://www.drupal.org/project/social/issues/3094403

## How to test
- [ ] Go to manage members tab in a group
- [ ] Verify that the checkbox for selecting all members text "Select / unselect all  {count} members across all the pages"
- [ ] On the same page verify that the button for clear the selections have "Clear selection" label.
- [ ] Enable social_event_managers module.
- [ ]  Go Manage Enrollments tab in an event
- [ ] Verify that the checkbox for selecting all members text "Select / unselect all  {count} members across all the pages"
- [ ] On the same page verify that the button for clear the selections have "Clear selection" label.

## Release notes
N.A

## Change Record
N.A
