### PR TITLE
Fix undefined index notice from user entity reference selection plugin

### DIFF
--- a/modules/social_features/social_profile/src/Plugin/EntityReferenceSelection/UserSelection.php
+++ b/modules/social_features/social_profile/src/Plugin/EntityReferenceSelection/UserSelection.php
@@ -9,12 +9,11 @@ use Drupal\user\Plugin\EntityReferenceSelection\UserSelection as UserSelectionBa
  * Provides specific access control for the user entity type.
  *
  * @EntityReferenceSelection(
- *   id = "social:user",
+ *   id = "social_user",
  *   label = @Translation("Social user selection"),
  *   entity_types = {"user"},
- *   group = "social",
- *   weight = 1,
- *   base_plugin_label = @Translation("Social user selection")
+ *   group = "social_user",
+ *   weight = 1
  * )
  */
 class UserSelection extends UserSelectionBase {

--- a/modules/social_features/social_profile/src/Plugin/EntityReferenceSelection/UserSelection.php
+++ b/modules/social_features/social_profile/src/Plugin/EntityReferenceSelection/UserSelection.php
@@ -9,11 +9,12 @@ use Drupal\user\Plugin\EntityReferenceSelection\UserSelection as UserSelectionBa
  * Provides specific access control for the user entity type.
  *
  * @EntityReferenceSelection(
- *   id = "social_user",
+ *   id = "social:user",
  *   label = @Translation("Social user selection"),
  *   entity_types = {"user"},
- *   group = "social_user",
- *   weight = 1
+ *   group = "social",
+ *   weight = 1,
+ *   base_plugin_label = @Translation("Social user selection")
  * )
  */
 class UserSelection extends UserSelectionBase {

--- a/modules/social_features/social_profile/src/Plugin/EntityReferenceSelection/UserSelection.php
+++ b/modules/social_features/social_profile/src/Plugin/EntityReferenceSelection/UserSelection.php
@@ -13,7 +13,8 @@ use Drupal\user\Plugin\EntityReferenceSelection\UserSelection as UserSelectionBa
  *   label = @Translation("Social user selection"),
  *   entity_types = {"user"},
  *   group = "social",
- *   weight = 1
+ *   weight = 1,
+ *   base_plugin_label = @Translation("Social user selection")
  * )
  */
 class UserSelection extends UserSelectionBase {


### PR DESCRIPTION
## Problem
The plugin definition for the UserSelection Entity Reference Selection (ERS) plugin is causing an undefined index notice on user reference field settings forms.
```
Notice: Undefined index: base_plugin_label in Drupal\Core\Field\Plugin\Field\FieldType\EntityReferenceItem->fieldSettingsForm() (line 388 of core/lib/Drupal/Core/Field/Plugin/Field/FieldType/EntityReferenceItem.php)
```

## Solution
Currently there are a couple undocumented formats in which you must structure your Entity Reference Selection plugins in order for them to appear in the list on the field settings page. The format we're using in social is technically meant for derivatives where the deriver inserts a `base_plugin_label` into the derivative definition. For backwards compatibility with existing open social config, we'll need to keep using this derivative method which means we need to add the `base_plugin_label` into our plugin definition.

## Issue tracker
https://www.drupal.org/project/social/issues/3094529

## How to test
- [ ] Create a user reference field
- [ ] Go to the field settings form, notice should be logged but may also display on-screen depending on error reporting setting
