### PR TITLE
Update PR template to mention `translations.php`

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,3 +15,6 @@
 
 ## Change Record
 If this Pull Request changes the way that developers should do things or introduces a new API for developers then a change record to document this is needed. Please provide a draft for a change record or a link to an unpublished change record below. [Existing change records](https://www.drupal.org/list-changes/social) can be consulted as example.
+
+## Translations
+- [ ] Changed or removed source strings are added to the `translations.php` file.


### PR DESCRIPTION
For more info, check #1600.

## Problem
No one knows about the `translations.php` file and what it is for.

## Solution
By adding a step to the PR template, people will (likely) no longer forget it.

## Issue tracker
n/a

## How to test
n/a

## Release notes
n/a