### PR TITLE
Issue #3087870 by ribel: Add routes for redirect to the user groups and topics overview pages

### DIFF
--- a/modules/social_features/social_event/src/Controller/SocialEventController.php
+++ b/modules/social_features/social_event/src/Controller/SocialEventController.php
@@ -43,9 +43,10 @@ class SocialEventController extends ControllerBase {
   }
 
   /**
-   * Redirectmyevents.
+   * Redirects users to their events page.
    *
-   * Redirect to a users events.
+   * @return \Symfony\Component\HttpFoundation\RedirectResponse
+   *   Returns a redirect to the events of the currently logged in user.
    */
   public function redirectMyEvents() {
     return $this->redirect('view.events.events_overview', [

--- a/modules/social_features/social_group/social_group.routing.yml
+++ b/modules/social_features/social_group/social_group.routing.yml
@@ -22,3 +22,10 @@ social_group.stream:
     _entity_view: 'group.stream'
   requirements:
     _group_permission: 'view group stream page'
+
+social_group.my_groups:
+  path: '/my-groups'
+  defaults:
+    _controller: '\Drupal\social_group\Controller\SocialGroupController:redirectMyGroups'
+  requirements:
+    _user_is_logged_in: 'TRUE'

--- a/modules/social_features/social_group/src/Controller/SocialGroupController.php
+++ b/modules/social_features/social_group/src/Controller/SocialGroupController.php
@@ -133,7 +133,7 @@ class SocialGroupController extends ControllerBase {
   }
 
   /**
-   * Function that checks access on the my topic pages.
+   * Function that checks access on the my groups pages.
    *
    * @param \Drupal\Core\Session\AccountInterface $account
    *   The account we need to check access for.
@@ -167,9 +167,21 @@ class SocialGroupController extends ControllerBase {
   }
 
   /**
+   * Redirects users to their groups page.
+   *
+   * @return \Symfony\Component\HttpFoundation\RedirectResponse
+   *   Returns a redirect to the groups of the currently logged in user.
+   */
+  public function redirectMyGroups() {
+    return $this->redirect('view.groups.page_user_groups', [
+      'user' => $this->currentUser()->id(),
+    ]);
+  }
+
+  /**
    * OtherGroupPage.
    *
-   * @return RedirectResponse
+   * @return \Symfony\Component\HttpFoundation\RedirectResponse
    *   Return Redirect to the group account.
    */
   public function otherGroupPage($group) {

--- a/modules/social_features/social_topic/social_topic.routing.yml
+++ b/modules/social_features/social_topic/social_topic.routing.yml
@@ -7,3 +7,9 @@ social_topic.settings:
     _permission: 'administer social_topic settings'
   options:
     _admin_route: TRUE
+social_topic.my_topics:
+  path: '/my-topics'
+  defaults:
+    _controller: '\Drupal\social_topic\Controller\SocialTopicController::redirectMyTopics'
+  requirements:
+    _user_is_logged_in: 'TRUE'

--- a/modules/social_features/social_topic/src/Controller/SocialTopicController.php
+++ b/modules/social_features/social_topic/src/Controller/SocialTopicController.php
@@ -128,4 +128,16 @@ class SocialTopicController extends ControllerBase {
     return AccessResult::allowedIfHasPermission($account, 'view topics on other profiles');
   }
 
+  /**
+   * Redirects users to their topics page.
+   *
+   * @return \Symfony\Component\HttpFoundation\RedirectResponse
+   *   Returns a redirect to the topics of the currently logged in user.
+   */
+  public function redirectMyTopics() {
+    return $this->redirect('view.topics.page_profile', [
+      'user' => $this->currentUser()->id(),
+    ]);
+  }
+
 }


### PR DESCRIPTION
## Problem
Currently, User Groups and Topics pages URLs can be accessed only with URLs in the format: `/user/ID/groups`, `/user/ID/topics`, in this way it is not possible to place them on landing pages or menu links.

## Solution
Add redirect URLs: `/my-groups`, `/my-topics`, similar like we have for `/my-events`

## Issue tracker
- https://www.drupal.org/project/social/issues/3087870

## How to test
- [ ] Login as a normal user
- [ ] Go to URL /my-groups and you should be redirected to your groups page
- [ ] Go to URL /my-topics and you should be redirected to your topics page

## Release notes
Add redirect URLs: `/my-groups`, `/my-topics` for redirect to the user groups and topics overview pages.
