### PR TITLE
Travis issues occured due to core patch not working - Make it green again!

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ before_install:
   # Installing hirak/prestissimo allows composer to parallelise downloads which speeds up the composer install.
   - composer global require hirak/prestissimo
   - echo "TRAVIS_BRANCH=$TRAVIS_BRANCH, PR=$PR, BRANCH=$BRANCH, COMMIT=$COMMIT"
-  - if [ "$TEST_SUITE" = "install_update" ]; then composer require goalgorilla/open_social:6.0.0 --prefer-dist; fi
+  - if [ "$TEST_SUITE" = "install_update" ]; then composer require goalgorilla/open_social:dev-8.x-6.x --prefer-dist; fi
   - if [ "$TRAVIS_PULL_REQUEST" != "false" ] && [ "$TRAVIS_PULL_REQUEST_SLUG" != "goalgorilla/open_social" ]; then composer config repositories.social git https://github.com/$TRAVIS_PULL_REQUEST_SLUG.git; fi
   - if [ "$TEST_SUITE" != "install_update" ]; then composer require goalgorilla/open_social:dev-${BRANCH}#${COMMIT} --prefer-dist; fi
 


### PR DESCRIPTION
## Problem
We don't lock a core version, which means when core releases updates our patches on 6.0.0 might fail. Which usually isn't an issue because we can control it ourselves in updates, but with travis we test the update path of Open Social and do this from a tagged version. 
Therefor it will always fail on the composer install with the latest core version.

## Solution
Test the update path from 8.x-6.x-dev, allowing us to backport any core patches when necessary.

## Issue tracker
- not needed

## How to test
- [ ] See that travis turns green.

## Release notes
Not needed

