### PR TITLE
Issue #3095296 by agami4: Add primary color for links on the paragraphs on the landing page

### DIFF
--- a/themes/socialblue/assets/css/brand.css
+++ b/themes/socialblue/assets/css/brand.css
@@ -201,6 +201,12 @@ fieldset[disabled] .btn-accent.focus {
 
 .field--name-field-introduction-text a:not(.btn),
 .field--name-field-introduction-text a:not(.btn):hover,
+.field--name-field-featured-items-description a:not(.btn),
+.field--name-field-featured-items-description a:not(.btn):hover,
+.field--name-field-featured-description a:not(.btn),
+.field--name-field-featured-description a:not(.btn):hover,
+.field--name-field-accord-description a:not(.btn),
+.field--name-field-accord-description a:not(.btn):hover,
 .body-text a:not(.btn),
 .body-text a:not(.btn):hover {
   color: #33b5e5;

--- a/themes/socialblue/assets/css/page-node.css
+++ b/themes/socialblue/assets/css/page-node.css
@@ -1,10 +1,16 @@
 .field--name-field-introduction-text a:not(.btn),
+.field--name-field-featured-items-description a:not(.btn),
+.field--name-field-featured-description a:not(.btn),
+.field--name-field-accord-description a:not(.btn),
 .body-text a:not(.btn) {
   text-decoration: underline;
   color: #33b5e5;
 }
 
 .field--name-field-introduction-text a:not(.btn):hover,
+.field--name-field-featured-items-description a:not(.btn):hover,
+.field--name-field-featured-description a:not(.btn):hover,
+.field--name-field-accord-description a:not(.btn):hover,
 .body-text a:not(.btn):hover {
   color: #178ab4;
 }

--- a/themes/socialblue/components/05-templates/page-node/page-node.scss
+++ b/themes/socialblue/components/05-templates/page-node/page-node.scss
@@ -1,6 +1,9 @@
 @import "settings";
 
 .field--name-field-introduction-text,
+.field--name-field-featured-items-description,
+.field--name-field-featured-description,
+.field--name-field-accord-description,
 .body-text {
 
   a:not(.btn) {

--- a/themes/socialblue/components/brand.scss
+++ b/themes/socialblue/components/brand.scss
@@ -209,6 +209,12 @@
 
 .field--name-field-introduction-text a:not(.btn),
 .field--name-field-introduction-text a:not(.btn):hover,
+.field--name-field-featured-items-description a:not(.btn),
+.field--name-field-featured-items-description a:not(.btn):hover,
+.field--name-field-featured-description a:not(.btn),
+.field--name-field-featured-description a:not(.btn):hover,
+.field--name-field-accord-description a:not(.btn),
+.field--name-field-accord-description a:not(.btn):hover,
 .body-text a:not(.btn),
 .body-text a:not(.btn):hover {
   color: #33b5e5;


### PR DESCRIPTION
## Problem
The links in the description of the paragraphs on the landing page don't have styles if you use custom font

## Solution
Add primary color for all links

## Issue tracker
https://www.drupal.org/project/social/issues/3095296
https://getopensocial.atlassian.net/browse/YANG-1620

## How to test
- [ ] Go to the 'Landing' page and create paragraph which has a description field and add a link

## Release notes
All links have a primary color on the description of the paragraphs on the landing page
