### PR TITLE
Replace features with config management for Social Landing Page

### DIFF
--- a/modules/social_features/social_landing_page/config/features_removal/core.base_field_override.node.landing_page.promote.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/core.base_field_override.node.landing_page.promote.yml
@@ -1,0 +1,21 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.landing_page
+id: node.landing_page.promote
+field_name: promote
+entity_type: node
+bundle: landing_page
+label: 'Promoted to front page'
+description: ''
+required: false
+translatable: true
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/modules/social_features/social_landing_page/config/features_removal/core.entity_form_display.node.landing_page.default.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/core.entity_form_display.node.landing_page.default.yml
@@ -1,0 +1,103 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.landing_page.field_content_visibility
+    - field.field.node.landing_page.field_landing_page_section
+    - node.type.landing_page
+  module:
+    - field_group
+    - paragraphs
+    - path
+third_party_settings:
+  field_group:
+    group_content:
+      children:
+        - title
+        - field_content_visibility
+      parent_name: ''
+      weight: 0
+      format_type: fieldset
+      format_settings:
+        label: Title
+        description: ''
+        required_fields: true
+        id: title
+        classes: card
+      label: Title
+    group_sections:
+      children:
+        - field_landing_page_section
+      parent_name: ''
+      weight: 1
+      format_type: fieldset
+      format_settings:
+        label: Sections
+        description: ''
+        required_fields: true
+        id: sections
+        classes: card
+      label: Sections
+id: node.landing_page.default
+targetEntityType: node
+bundle: landing_page
+mode: default
+content:
+  created:
+    type: datetime_timestamp
+    weight: 4
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_content_visibility:
+    type: options_buttons
+    weight: 2
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_landing_page_section:
+    type: entity_reference_paragraphs
+    weight: 2
+    settings:
+      title: Section
+      title_plural: Sections
+      edit_mode: preview
+      add_mode: dropdown
+      form_display_mode: default
+      default_paragraph_type: _none
+    third_party_settings: {  }
+    region: content
+  path:
+    type: path
+    weight: 7
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 120
+    region: content
+    third_party_settings: {  }
+  title:
+    type: string_textfield
+    weight: 1
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  uid:
+    type: entity_reference_autocomplete
+    weight: 3
+    settings:
+      match_operator: CONTAINS
+      size: 60
+      placeholder: ''
+    region: content
+    third_party_settings: {  }
+hidden:
+  groups: true
+  promote: true
+  sticky: true

--- a/modules/social_features/social_landing_page/config/features_removal/core.entity_form_display.paragraph.accordion.default.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/core.entity_form_display.paragraph.accordion.default.yml
@@ -1,0 +1,47 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.accordion.field_accord_description
+    - field.field.paragraph.accordion.field_accord_item
+    - field.field.paragraph.accordion.field_accord_title
+    - paragraphs.paragraphs_type.accordion
+  module:
+    - paragraphs
+    - text
+id: paragraph.accordion.default
+targetEntityType: paragraph
+bundle: accordion
+mode: default
+content:
+  field_accord_description:
+    weight: 1
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+    type: text_textarea
+    region: content
+  field_accord_item:
+    type: entity_reference_paragraphs
+    weight: 2
+    settings:
+      title: Paragraph
+      title_plural: Paragraphs
+      edit_mode: open
+      add_mode: dropdown
+      form_display_mode: default
+      default_paragraph_type: ''
+    third_party_settings: {  }
+    region: content
+  field_accord_title:
+    weight: 0
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+hidden:
+  created: true
+  status: true

--- a/modules/social_features/social_landing_page/config/features_removal/core.entity_form_display.paragraph.accordion_item.default.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/core.entity_form_display.paragraph.accordion_item.default.yml
@@ -1,0 +1,33 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.accordion_item.field_accord_item_description
+    - field.field.paragraph.accordion_item.field_accord_item_title
+    - paragraphs.paragraphs_type.accordion_item
+  module:
+    - text
+id: paragraph.accordion_item.default
+targetEntityType: paragraph
+bundle: accordion_item
+mode: default
+content:
+  field_accord_item_description:
+    weight: 1
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+    type: text_textarea
+    region: content
+  field_accord_item_title:
+    weight: 0
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+hidden:
+  created: true
+  status: true

--- a/modules/social_features/social_landing_page/config/features_removal/core.entity_form_display.paragraph.block.default.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/core.entity_form_display.paragraph.block.default.yml
@@ -1,0 +1,53 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.block.field_block_link
+    - field.field.paragraph.block.field_block_reference
+    - field.field.paragraph.block.field_block_reference_secondary
+    - field.field.paragraph.block.field_block_title
+    - paragraphs.paragraphs_type.block
+  module:
+    - link
+    - social_landing_page
+id: paragraph.block.default
+targetEntityType: paragraph
+bundle: block
+mode: default
+content:
+  field_block_link:
+    weight: 3
+    settings:
+      placeholder_url: ''
+      placeholder_title: ''
+    third_party_settings: {  }
+    type: link_default
+    region: content
+  field_block_reference:
+    weight: 1
+    settings:
+      plugin_id: ''
+      settings: {  }
+    third_party_settings: {  }
+    type: block_field_default
+    region: content
+  field_block_reference_secondary:
+    weight: 2
+    settings:
+      plugin_id: ''
+      settings: {  }
+    third_party_settings: {  }
+    type: block_field_default
+    region: content
+  field_block_title:
+    weight: 0
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+hidden:
+  created: true
+  status: true
+  uid: true

--- a/modules/social_features/social_landing_page/config/features_removal/core.entity_form_display.paragraph.button.default.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/core.entity_form_display.paragraph.button.default.yml
@@ -1,0 +1,41 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.button.field_button_link_an
+    - field.field.paragraph.button.field_button_link_lu
+    - field.field.paragraph.button.field_button_style
+    - paragraphs.paragraphs_type.button
+  module:
+    - link
+id: paragraph.button.default
+targetEntityType: paragraph
+bundle: button
+mode: default
+content:
+  field_button_link_an:
+    weight: 0
+    settings:
+      placeholder_url: ''
+      placeholder_title: ''
+    third_party_settings: {  }
+    type: link_default
+    region: content
+  field_button_link_lu:
+    weight: 1
+    settings:
+      placeholder_url: ''
+      placeholder_title: ''
+    third_party_settings: {  }
+    type: link_default
+    region: content
+  field_button_style:
+    weight: 2
+    settings: {  }
+    third_party_settings: {  }
+    type: options_select
+    region: content
+hidden:
+  created: true
+  status: true
+  uid: true

--- a/modules/social_features/social_landing_page/config/features_removal/core.entity_form_display.paragraph.featured.default.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/core.entity_form_display.paragraph.featured.default.yml
@@ -1,0 +1,55 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.featured.field_featured_description
+    - field.field.paragraph.featured.field_featured_items
+    - field.field.paragraph.featured.field_featured_link
+    - field.field.paragraph.featured.field_featured_title
+    - paragraphs.paragraphs_type.featured
+  module:
+    - dynamic_entity_reference
+    - link
+    - text
+id: paragraph.featured.default
+targetEntityType: paragraph
+bundle: featured
+mode: default
+content:
+  field_featured_description:
+    weight: 1
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+    type: text_textarea
+    region: content
+  field_featured_items:
+    weight: 2
+    settings:
+      match_operator: CONTAINS
+      size: 40
+      placeholder: ''
+    third_party_settings: {  }
+    type: dynamic_entity_reference_default
+    region: content
+  field_featured_link:
+    weight: 3
+    settings:
+      placeholder_url: ''
+      placeholder_title: ''
+    third_party_settings: {  }
+    type: link_default
+    region: content
+  field_featured_title:
+    weight: 0
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+hidden:
+  created: true
+  status: true
+  uid: true

--- a/modules/social_features/social_landing_page/config/features_removal/core.entity_form_display.paragraph.featured_item.default.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/core.entity_form_display.paragraph.featured_item.default.yml
@@ -1,0 +1,55 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.featured_item.field_featured_item_description
+    - field.field.paragraph.featured_item.field_featured_item_image
+    - field.field.paragraph.featured_item.field_featured_item_link
+    - field.field.paragraph.featured_item.field_featured_item_title
+    - image.style.thumbnail
+    - paragraphs.paragraphs_type.featured_item
+  module:
+    - image
+    - link
+    - text
+id: paragraph.featured_item.default
+targetEntityType: paragraph
+bundle: featured_item
+mode: default
+content:
+  field_featured_item_description:
+    weight: 2
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+    type: text_textarea
+    region: content
+  field_featured_item_image:
+    weight: 1
+    settings:
+      progress_indicator: throbber
+      preview_image_style: thumbnail
+    third_party_settings: {  }
+    type: image_image
+    region: content
+  field_featured_item_link:
+    weight: 3
+    settings:
+      placeholder_url: ''
+      placeholder_title: ''
+    third_party_settings: {  }
+    type: link_default
+    region: content
+  field_featured_item_title:
+    weight: 0
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+hidden:
+  created: true
+  status: true
+  uid: true

--- a/modules/social_features/social_landing_page/config/features_removal/core.entity_form_display.paragraph.featured_items.default.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/core.entity_form_display.paragraph.featured_items.default.yml
@@ -1,0 +1,55 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.featured_items.field_featured_items_description
+    - field.field.paragraph.featured_items.field_featured_items_items
+    - field.field.paragraph.featured_items.field_featured_items_title
+    - paragraphs.paragraphs_type.featured_items
+  module:
+    - paragraphs
+    - text
+id: paragraph.featured_items.default
+targetEntityType: paragraph
+bundle: featured_items
+mode: default
+content:
+  field_featured_items_description:
+    weight: 1
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+    type: text_textarea
+    region: content
+  field_featured_items_items:
+    type: paragraphs
+    weight: 2
+    settings:
+      title: Item
+      title_plural: Items
+      edit_mode: open
+      closed_mode: preview
+      autocollapse: none
+      closed_mode_threshold: 0
+      add_mode: button
+      form_display_mode: default
+      default_paragraph_type: featured_item
+      features:
+        collapse_edit_all: collapse_edit_all
+        duplicate: '0'
+        add_above: '0'
+    third_party_settings: {  }
+    region: content
+  field_featured_items_title:
+    weight: 0
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+hidden:
+  created: true
+  status: true
+  uid: true

--- a/modules/social_features/social_landing_page/config/features_removal/core.entity_form_display.paragraph.hero.default.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/core.entity_form_display.paragraph.hero.default.yml
@@ -1,0 +1,66 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.hero.field_hero_buttons
+    - field.field.paragraph.hero.field_hero_image
+    - field.field.paragraph.hero.field_hero_subtitle
+    - field.field.paragraph.hero.field_hero_title
+    - image.style.medium
+    - paragraphs.paragraphs_type.hero
+  module:
+    - image_widget_crop
+    - paragraphs
+id: paragraph.hero.default
+targetEntityType: paragraph
+bundle: hero
+mode: default
+content:
+  field_hero_buttons:
+    type: paragraphs
+    weight: 5
+    settings:
+      title: Button
+      title_plural: Buttons
+      edit_mode: closed
+      closed_mode: preview
+      autocollapse: all
+      add_mode: button
+      form_display_mode: default
+      default_paragraph_type: button
+    third_party_settings: {  }
+    region: content
+  field_hero_image:
+    weight: 0
+    settings:
+      show_default_crop: true
+      warn_multiple_usages: true
+      preview_image_style: medium
+      crop_preview_image_style: crop_thumbnail
+      crop_list:
+        - hero_landing
+      progress_indicator: throbber
+      show_crop_area: false
+    third_party_settings: {  }
+    type: image_widget_crop
+    region: content
+  field_hero_subtitle:
+    weight: 2
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  field_hero_title:
+    weight: 1
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+hidden:
+  created: true
+  status: true
+  uid: true

--- a/modules/social_features/social_landing_page/config/features_removal/core.entity_form_display.paragraph.hero_small.default.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/core.entity_form_display.paragraph.hero_small.default.yml
@@ -1,0 +1,66 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.hero_small.field_hero_small_buttons
+    - field.field.paragraph.hero_small.field_hero_small_image
+    - field.field.paragraph.hero_small.field_hero_small_subtitle
+    - field.field.paragraph.hero_small.field_hero_small_title
+    - image.style.medium
+    - paragraphs.paragraphs_type.hero_small
+  module:
+    - image_widget_crop
+    - paragraphs
+id: paragraph.hero_small.default
+targetEntityType: paragraph
+bundle: hero_small
+mode: default
+content:
+  field_hero_small_buttons:
+    type: paragraphs
+    weight: 5
+    settings:
+      title: Button
+      title_plural: Buttons
+      edit_mode: closed
+      closed_mode: preview
+      autocollapse: all
+      add_mode: button
+      form_display_mode: default
+      default_paragraph_type: button
+    third_party_settings: {  }
+    region: content
+  field_hero_small_image:
+    weight: 0
+    settings:
+      show_default_crop: true
+      warn_multiple_usages: true
+      preview_image_style: medium
+      crop_preview_image_style: crop_thumbnail
+      crop_list:
+        - hero_small_landing
+      progress_indicator: throbber
+      show_crop_area: false
+    third_party_settings: {  }
+    type: image_widget_crop
+    region: content
+  field_hero_small_subtitle:
+    weight: 2
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  field_hero_small_title:
+    weight: 1
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+hidden:
+  created: true
+  status: true
+  uid: true

--- a/modules/social_features/social_landing_page/config/features_removal/core.entity_form_display.paragraph.introduction.default.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/core.entity_form_display.paragraph.introduction.default.yml
@@ -1,0 +1,53 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.introduction.field_introduction_link_an
+    - field.field.paragraph.introduction.field_introduction_link_lu
+    - field.field.paragraph.introduction.field_introduction_text
+    - field.field.paragraph.introduction.field_introduction_title
+    - paragraphs.paragraphs_type.introduction
+  module:
+    - link
+    - text
+id: paragraph.introduction.default
+targetEntityType: paragraph
+bundle: introduction
+mode: default
+content:
+  field_introduction_link_an:
+    weight: 2
+    settings:
+      placeholder_url: ''
+      placeholder_title: ''
+    third_party_settings: {  }
+    type: link_default
+    region: content
+  field_introduction_link_lu:
+    weight: 3
+    settings:
+      placeholder_url: ''
+      placeholder_title: ''
+    third_party_settings: {  }
+    type: link_default
+    region: content
+  field_introduction_text:
+    weight: 1
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+    type: text_textarea
+    region: content
+  field_introduction_title:
+    weight: 0
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+hidden:
+  created: true
+  status: true
+  uid: true

--- a/modules/social_features/social_landing_page/config/features_removal/core.entity_form_display.paragraph.section.default.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/core.entity_form_display.paragraph.section.default.yml
@@ -1,0 +1,31 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.section.field_section_paragraph
+    - paragraphs.paragraphs_type.section
+  module:
+    - paragraphs
+id: paragraph.section.default
+targetEntityType: paragraph
+bundle: section
+mode: default
+content:
+  field_section_paragraph:
+    type: paragraphs
+    weight: 0
+    settings:
+      title: Section
+      title_plural: Sections
+      edit_mode: open
+      closed_mode: preview
+      autocollapse: none
+      add_mode: button
+      form_display_mode: default
+      default_paragraph_type: _none
+    third_party_settings: {  }
+    region: content
+hidden:
+  created: true
+  status: true
+  uid: true

--- a/modules/social_features/social_landing_page/config/features_removal/core.entity_view_display.group.closed_group.featured.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/core.entity_view_display.group.closed_group.featured.yml
@@ -1,0 +1,49 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.group.featured
+    - field.field.group.closed_group.field_group_address
+    - field.field.group.closed_group.field_group_description
+    - field.field.group.closed_group.field_group_image
+    - field.field.group.closed_group.field_group_location
+    - group.type.closed_group
+    - image.style.social_featured
+  module:
+    - address
+    - image
+id: group.closed_group.featured
+targetEntityType: group
+bundle: closed_group
+mode: featured
+content:
+  field_group_address:
+    type: address_plain
+    weight: 1
+    region: content
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+  field_group_image:
+    type: image
+    weight: 0
+    region: content
+    label: hidden
+    settings:
+      image_style: social_featured
+      image_link: content
+    third_party_settings: {  }
+  field_group_location:
+    type: string
+    weight: 2
+    region: content
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+hidden:
+  changed: true
+  created: true
+  field_group_description: true
+  label: true
+  uid: true

--- a/modules/social_features/social_landing_page/config/features_removal/core.entity_view_display.group.open_group.featured.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/core.entity_view_display.group.open_group.featured.yml
@@ -1,0 +1,49 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.group.featured
+    - field.field.group.open_group.field_group_address
+    - field.field.group.open_group.field_group_description
+    - field.field.group.open_group.field_group_image
+    - field.field.group.open_group.field_group_location
+    - group.type.open_group
+    - image.style.social_featured
+  module:
+    - address
+    - image
+id: group.open_group.featured
+targetEntityType: group
+bundle: open_group
+mode: featured
+content:
+  field_group_address:
+    type: address_plain
+    weight: 1
+    region: content
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+  field_group_image:
+    type: image
+    weight: 0
+    region: content
+    label: hidden
+    settings:
+      image_style: social_featured
+      image_link: content
+    third_party_settings: {  }
+  field_group_location:
+    type: string
+    weight: 2
+    region: content
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+hidden:
+  changed: true
+  created: true
+  field_group_description: true
+  label: true
+  uid: true

--- a/modules/social_features/social_landing_page/config/features_removal/core.entity_view_display.group.public_group.featured.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/core.entity_view_display.group.public_group.featured.yml
@@ -1,0 +1,49 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.group.featured
+    - field.field.group.public_group.field_group_address
+    - field.field.group.public_group.field_group_description
+    - field.field.group.public_group.field_group_image
+    - field.field.group.public_group.field_group_location
+    - group.type.public_group
+    - image.style.social_featured
+  module:
+    - address
+    - image
+id: group.public_group.featured
+targetEntityType: group
+bundle: public_group
+mode: featured
+content:
+  field_group_address:
+    type: address_plain
+    weight: 1
+    region: content
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+  field_group_image:
+    type: image
+    weight: 0
+    region: content
+    label: hidden
+    settings:
+      image_style: social_featured
+      image_link: content
+    third_party_settings: {  }
+  field_group_location:
+    type: string
+    weight: 2
+    region: content
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+hidden:
+  changed: true
+  created: true
+  field_group_description: true
+  label: true
+  uid: true

--- a/modules/social_features/social_landing_page/config/features_removal/core.entity_view_display.node.event.featured.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/core.entity_view_display.node.event.featured.yml
@@ -1,0 +1,91 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.featured
+    - field.field.node.event.body
+    - field.field.node.event.field_content_visibility
+    - field.field.node.event.field_event_address
+    - field.field.node.event.field_event_comments
+    - field.field.node.event.field_event_date
+    - field.field.node.event.field_event_date_end
+    - field.field.node.event.field_event_image
+    - field.field.node.event.field_event_location
+    - field.field.node.event.field_files
+    - image.style.social_featured
+    - node.type.event
+  module:
+    - address
+    - image
+    - user
+id: node.event.featured
+targetEntityType: node
+bundle: event
+mode: featured
+content:
+  field_event_address:
+    type: address_plain
+    weight: 2
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    region: content
+  field_event_image:
+    type: image
+    weight: 0
+    region: content
+    label: hidden
+    settings:
+      image_style: social_featured
+      image_link: content
+    third_party_settings: {  }
+  field_event_location:
+    type: string
+    weight: 1
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    region: content
+  groups:
+    label: above
+    weight: -5
+    region: content
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+  groups_type_closed_group:
+    label: above
+    weight: -5
+    region: content
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+  groups_type_open_group:
+    label: above
+    weight: -5
+    region: content
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+  groups_type_public_group:
+    label: above
+    weight: -5
+    region: content
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+hidden:
+  body: true
+  field_content_visibility: true
+  field_event_comments: true
+  field_event_date: true
+  field_event_date_end: true
+  field_files: true
+  flag_follow_content: true
+  like_and_dislike: true
+  links: true

--- a/modules/social_features/social_landing_page/config/features_removal/core.entity_view_display.node.landing_page.default.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/core.entity_view_display.node.landing_page.default.yml
@@ -1,0 +1,64 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.landing_page.field_content_visibility
+    - field.field.node.landing_page.field_landing_page_section
+    - node.type.landing_page
+  module:
+    - entity_reference_revisions
+    - user
+id: node.landing_page.default
+targetEntityType: node
+bundle: landing_page
+mode: default
+content:
+  field_landing_page_section:
+    type: entity_reference_revisions_entity_view
+    weight: 101
+    label: hidden
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
+    region: content
+  flag_follow_content:
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  groups:
+    label: above
+    weight: -5
+    region: content
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+  groups_type_closed_group:
+    label: above
+    weight: -5
+    region: content
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+  groups_type_open_group:
+    label: above
+    weight: -5
+    region: content
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+  groups_type_public_group:
+    label: above
+    weight: -5
+    region: content
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+hidden:
+  field_content_visibility: true
+  links: true

--- a/modules/social_features/social_landing_page/config/features_removal/core.entity_view_display.node.landing_page.featured.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/core.entity_view_display.node.landing_page.featured.yml
@@ -1,0 +1,53 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.featured
+    - field.field.node.landing_page.field_content_visibility
+    - field.field.node.landing_page.field_landing_page_section
+    - node.type.landing_page
+  module:
+    - user
+id: node.landing_page.featured
+targetEntityType: node
+bundle: landing_page
+mode: featured
+content:
+  groups:
+    label: above
+    weight: 0
+    region: content
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+  groups_type_closed_group:
+    label: above
+    weight: 1
+    region: content
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+  groups_type_open_group:
+    label: above
+    weight: 2
+    region: content
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+  groups_type_public_group:
+    label: above
+    weight: 3
+    region: content
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+hidden:
+  field_content_visibility: true
+  field_landing_page_section: true
+  flag_follow_content: true
+  links: true
+  private_message_link: true

--- a/modules/social_features/social_landing_page/config/features_removal/core.entity_view_display.node.landing_page.teaser.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/core.entity_view_display.node.landing_page.teaser.yml
@@ -1,0 +1,56 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.teaser
+    - field.field.node.landing_page.field_content_visibility
+    - field.field.node.landing_page.field_landing_page_section
+    - node.type.landing_page
+  module:
+    - user
+id: node.landing_page.teaser
+targetEntityType: node
+bundle: landing_page
+mode: teaser
+content:
+  flag_follow_content:
+    weight: 10
+    region: content
+  groups:
+    label: above
+    weight: -5
+    region: content
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+  groups_type_closed_group:
+    label: above
+    weight: -5
+    region: content
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+  groups_type_open_group:
+    label: above
+    weight: -5
+    region: content
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+  groups_type_public_group:
+    label: above
+    weight: -5
+    region: content
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+  links:
+    weight: 100
+    region: content
+hidden:
+  field_content_visibility: true
+  field_landing_page_section: true

--- a/modules/social_features/social_landing_page/config/features_removal/core.entity_view_display.node.page.featured.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/core.entity_view_display.node.page.featured.yml
@@ -1,0 +1,68 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.featured
+    - field.field.node.page.body
+    - field.field.node.page.field_content_visibility
+    - field.field.node.page.field_files
+    - field.field.node.page.field_page_comments
+    - field.field.node.page.field_page_image
+    - image.style.social_featured
+    - node.type.page
+  module:
+    - image
+    - user
+id: node.page.featured
+targetEntityType: node
+bundle: page
+mode: featured
+content:
+  field_page_image:
+    type: image
+    weight: 4
+    region: content
+    label: above
+    settings:
+      image_style: social_featured
+      image_link: content
+    third_party_settings: {  }
+  groups:
+    type: entity_reference_label
+    weight: 0
+    region: content
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+  groups_type_closed_group:
+    type: entity_reference_label
+    weight: 1
+    region: content
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+  groups_type_open_group:
+    type: entity_reference_label
+    weight: 2
+    region: content
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+  groups_type_public_group:
+    type: entity_reference_label
+    weight: 3
+    region: content
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+hidden:
+  body: true
+  field_content_visibility: true
+  field_files: true
+  field_page_comments: true
+  flag_follow_content: true
+  links: true

--- a/modules/social_features/social_landing_page/config/features_removal/core.entity_view_display.node.topic.featured.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/core.entity_view_display.node.topic.featured.yml
@@ -1,0 +1,78 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.featured
+    - field.field.node.topic.body
+    - field.field.node.topic.field_content_visibility
+    - field.field.node.topic.field_files
+    - field.field.node.topic.field_topic_comments
+    - field.field.node.topic.field_topic_image
+    - field.field.node.topic.field_topic_type
+    - image.style.social_featured
+    - node.type.topic
+  module:
+    - image
+    - user
+id: node.topic.featured
+targetEntityType: node
+bundle: topic
+mode: featured
+content:
+  field_topic_image:
+    type: image
+    weight: 0
+    region: content
+    label: hidden
+    settings:
+      image_style: social_featured
+      image_link: content
+    third_party_settings: {  }
+  field_topic_type:
+    type: entity_reference_label
+    weight: 1
+    region: content
+    label: hidden
+    settings:
+      link: true
+    third_party_settings: {  }
+  groups:
+    label: above
+    weight: -5
+    region: content
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+  groups_type_closed_group:
+    label: above
+    weight: -5
+    region: content
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+  groups_type_open_group:
+    label: above
+    weight: -5
+    region: content
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+  groups_type_public_group:
+    label: above
+    weight: -5
+    region: content
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+hidden:
+  body: true
+  field_content_visibility: true
+  field_files: true
+  field_topic_comments: true
+  flag_follow_content: true
+  like_and_dislike: true
+  links: true

--- a/modules/social_features/social_landing_page/config/features_removal/core.entity_view_display.paragraph.accordion.default.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/core.entity_view_display.paragraph.accordion.default.yml
@@ -1,0 +1,41 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.accordion.field_accord_description
+    - field.field.paragraph.accordion.field_accord_item
+    - field.field.paragraph.accordion.field_accord_title
+    - paragraphs.paragraphs_type.accordion
+  module:
+    - entity_reference_revisions
+    - text
+id: paragraph.accordion.default
+targetEntityType: paragraph
+bundle: accordion
+mode: default
+content:
+  field_accord_description:
+    weight: 1
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    type: text_default
+    region: content
+  field_accord_item:
+    type: entity_reference_revisions_entity_view
+    weight: 2
+    label: hidden
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
+    region: content
+  field_accord_title:
+    weight: 0
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+hidden: {  }

--- a/modules/social_features/social_landing_page/config/features_removal/core.entity_view_display.paragraph.accordion_item.default.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/core.entity_view_display.paragraph.accordion_item.default.yml
@@ -1,0 +1,30 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.accordion_item.field_accord_item_description
+    - field.field.paragraph.accordion_item.field_accord_item_title
+    - paragraphs.paragraphs_type.accordion_item
+  module:
+    - text
+id: paragraph.accordion_item.default
+targetEntityType: paragraph
+bundle: accordion_item
+mode: default
+content:
+  field_accord_item_description:
+    weight: 1
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    type: text_default
+    region: content
+  field_accord_item_title:
+    weight: 0
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+hidden: {  }

--- a/modules/social_features/social_landing_page/config/features_removal/core.entity_view_display.paragraph.block.default.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/core.entity_view_display.paragraph.block.default.yml
@@ -1,0 +1,52 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.block.field_block_link
+    - field.field.paragraph.block.field_block_reference
+    - field.field.paragraph.block.field_block_reference_secondary
+    - field.field.paragraph.block.field_block_title
+    - paragraphs.paragraphs_type.block
+  module:
+    - block_field
+    - link
+id: paragraph.block.default
+targetEntityType: paragraph
+bundle: block
+mode: default
+content:
+  field_block_link:
+    weight: 3
+    label: hidden
+    settings:
+      trim_length: 80
+      url_only: false
+      url_plain: false
+      rel: ''
+      target: ''
+    third_party_settings: {  }
+    type: link
+    region: content
+  field_block_reference:
+    weight: 1
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    type: block_field
+    region: content
+  field_block_reference_secondary:
+    weight: 2
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    type: block_field
+    region: content
+  field_block_title:
+    weight: 0
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+hidden: {  }

--- a/modules/social_features/social_landing_page/config/features_removal/core.entity_view_display.paragraph.block.preview.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/core.entity_view_display.paragraph.block.preview.yml
@@ -1,0 +1,53 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.paragraph.preview
+    - field.field.paragraph.block.field_block_link
+    - field.field.paragraph.block.field_block_reference
+    - field.field.paragraph.block.field_block_reference_secondary
+    - field.field.paragraph.block.field_block_title
+    - paragraphs.paragraphs_type.block
+  module:
+    - link
+    - social_landing_page
+id: paragraph.block.preview
+targetEntityType: paragraph
+bundle: block
+mode: preview
+content:
+  field_block_link:
+    weight: 3
+    label: inline
+    settings:
+      trim_length: 80
+      url_only: false
+      url_plain: false
+      rel: ''
+      target: ''
+    third_party_settings: {  }
+    type: link
+    region: content
+  field_block_reference:
+    type: block_label
+    weight: 1
+    region: content
+    label: inline
+    settings: {  }
+    third_party_settings: {  }
+  field_block_reference_secondary:
+    type: block_label
+    weight: 2
+    region: content
+    label: inline
+    settings: {  }
+    third_party_settings: {  }
+  field_block_title:
+    type: string
+    weight: 0
+    region: content
+    label: inline
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+hidden: {  }

--- a/modules/social_features/social_landing_page/config/features_removal/core.entity_view_display.paragraph.button.default.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/core.entity_view_display.paragraph.button.default.yml
@@ -1,0 +1,48 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.button.field_button_link_an
+    - field.field.paragraph.button.field_button_link_lu
+    - field.field.paragraph.button.field_button_style
+    - paragraphs.paragraphs_type.button
+  module:
+    - link
+    - options
+id: paragraph.button.default
+targetEntityType: paragraph
+bundle: button
+mode: default
+content:
+  field_button_link_an:
+    weight: 0
+    label: hidden
+    settings:
+      trim_length: 80
+      url_only: false
+      url_plain: false
+      rel: ''
+      target: ''
+    third_party_settings: {  }
+    type: link
+    region: content
+  field_button_link_lu:
+    weight: 1
+    label: hidden
+    settings:
+      trim_length: 80
+      url_only: false
+      url_plain: false
+      rel: ''
+      target: ''
+    third_party_settings: {  }
+    type: link
+    region: content
+  field_button_style:
+    weight: 2
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    type: list_key
+    region: content
+hidden: {  }

--- a/modules/social_features/social_landing_page/config/features_removal/core.entity_view_display.paragraph.button.preview.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/core.entity_view_display.paragraph.button.preview.yml
@@ -1,0 +1,49 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.paragraph.preview
+    - field.field.paragraph.button.field_button_link_an
+    - field.field.paragraph.button.field_button_link_lu
+    - field.field.paragraph.button.field_button_style
+    - paragraphs.paragraphs_type.button
+  module:
+    - link
+    - options
+id: paragraph.button.preview
+targetEntityType: paragraph
+bundle: button
+mode: preview
+content:
+  field_button_link_an:
+    weight: 0
+    label: above
+    settings:
+      trim_length: 80
+      url_only: false
+      url_plain: false
+      rel: ''
+      target: ''
+    third_party_settings: {  }
+    type: link
+    region: content
+  field_button_link_lu:
+    weight: 1
+    label: above
+    settings:
+      trim_length: 80
+      url_only: false
+      url_plain: false
+      rel: ''
+      target: ''
+    third_party_settings: {  }
+    type: link
+    region: content
+  field_button_style:
+    weight: 2
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    type: list_default
+    region: content
+hidden: {  }

--- a/modules/social_features/social_landing_page/config/features_removal/core.entity_view_display.paragraph.featured.default.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/core.entity_view_display.paragraph.featured.default.yml
@@ -1,0 +1,116 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.featured.field_featured_description
+    - field.field.paragraph.featured.field_featured_items
+    - field.field.paragraph.featured.field_featured_link
+    - field.field.paragraph.featured.field_featured_title
+    - paragraphs.paragraphs_type.featured
+  module:
+    - dynamic_entity_reference
+    - link
+    - text
+id: paragraph.featured.default
+targetEntityType: paragraph
+bundle: featured
+mode: default
+content:
+  field_featured_description:
+    weight: 1
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    type: text_default
+    region: content
+  field_featured_items:
+    weight: 2
+    label: hidden
+    settings:
+      node:
+        view_mode: featured
+      group:
+        view_mode: featured
+      profile:
+        view_mode: featured
+      activity:
+        view_mode: default
+        link: false
+      comment:
+        view_mode: default
+        link: false
+      crop:
+        view_mode: default
+        link: false
+      block_content:
+        view_mode: default
+        link: false
+      menu_link_content:
+        view_mode: default
+        link: false
+      event_enrollment:
+        view_mode: default
+        link: false
+      file:
+        view_mode: default
+        link: false
+      flagging:
+        view_mode: default
+        link: false
+      font:
+        view_mode: default
+        link: false
+      group_content:
+        view_mode: default
+        link: false
+      mentions:
+        view_mode: default
+        link: false
+      message:
+        view_mode: default
+        link: false
+      paragraph:
+        view_mode: default
+        link: false
+      post:
+        view_mode: default
+        link: false
+      search_api_task:
+        view_mode: default
+        link: false
+      taxonomy_term:
+        view_mode: default
+        link: false
+      user:
+        view_mode: default
+        link: false
+      vote:
+        view_mode: default
+        link: false
+      vote_result:
+        view_mode: default
+        link: false
+    third_party_settings: {  }
+    type: dynamic_entity_reference_entity_view
+    region: content
+  field_featured_link:
+    weight: 3
+    label: hidden
+    settings:
+      trim_length: 80
+      url_only: false
+      url_plain: false
+      rel: ''
+      target: ''
+    third_party_settings: {  }
+    type: link
+    region: content
+  field_featured_title:
+    weight: 0
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+hidden: {  }

--- a/modules/social_features/social_landing_page/config/features_removal/core.entity_view_display.paragraph.featured.preview.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/core.entity_view_display.paragraph.featured.preview.yml
@@ -1,0 +1,117 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.paragraph.preview
+    - field.field.paragraph.featured.field_featured_description
+    - field.field.paragraph.featured.field_featured_items
+    - field.field.paragraph.featured.field_featured_link
+    - field.field.paragraph.featured.field_featured_title
+    - paragraphs.paragraphs_type.featured
+  module:
+    - dynamic_entity_reference
+    - link
+    - text
+id: paragraph.featured.preview
+targetEntityType: paragraph
+bundle: featured
+mode: preview
+content:
+  field_featured_description:
+    weight: 1
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    type: text_default
+    region: content
+  field_featured_items:
+    weight: 2
+    label: above
+    settings:
+      node:
+        view_mode: featured
+      group:
+        view_mode: featured
+      profile:
+        view_mode: featured
+      activity:
+        view_mode: default
+        link: false
+      comment:
+        view_mode: default
+        link: false
+      crop:
+        view_mode: default
+        link: false
+      block_content:
+        view_mode: default
+        link: false
+      menu_link_content:
+        view_mode: default
+        link: false
+      event_enrollment:
+        view_mode: default
+        link: false
+      file:
+        view_mode: default
+        link: false
+      flagging:
+        view_mode: default
+        link: false
+      font:
+        view_mode: default
+        link: false
+      group_content:
+        view_mode: default
+        link: false
+      mentions:
+        view_mode: default
+        link: false
+      message:
+        view_mode: default
+        link: false
+      paragraph:
+        view_mode: default
+        link: false
+      post:
+        view_mode: default
+        link: false
+      search_api_task:
+        view_mode: default
+        link: false
+      taxonomy_term:
+        view_mode: default
+        link: false
+      user:
+        view_mode: default
+        link: false
+      vote:
+        view_mode: default
+        link: false
+      vote_result:
+        view_mode: default
+        link: false
+    third_party_settings: {  }
+    type: dynamic_entity_reference_entity_view
+    region: content
+  field_featured_link:
+    weight: 3
+    label: inline
+    settings:
+      trim_length: 80
+      url_only: false
+      url_plain: false
+      rel: ''
+      target: ''
+    third_party_settings: {  }
+    type: link
+    region: content
+  field_featured_title:
+    weight: 0
+    label: inline
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+hidden: {  }

--- a/modules/social_features/social_landing_page/config/features_removal/core.entity_view_display.paragraph.featured_item.default.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/core.entity_view_display.paragraph.featured_item.default.yml
@@ -1,0 +1,56 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.featured_item.field_featured_item_description
+    - field.field.paragraph.featured_item.field_featured_item_image
+    - field.field.paragraph.featured_item.field_featured_item_link
+    - field.field.paragraph.featured_item.field_featured_item_title
+    - image.style.social_large
+    - paragraphs.paragraphs_type.featured_item
+  module:
+    - image
+    - link
+    - text
+id: paragraph.featured_item.default
+targetEntityType: paragraph
+bundle: featured_item
+mode: default
+content:
+  field_featured_item_description:
+    weight: 2
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    type: text_default
+    region: content
+  field_featured_item_image:
+    weight: 3
+    label: hidden
+    settings:
+      image_style: social_large
+      image_link: ''
+    third_party_settings: {  }
+    type: image
+    region: content
+  field_featured_item_link:
+    weight: 1
+    label: hidden
+    settings:
+      trim_length: 80
+      url_only: false
+      url_plain: false
+      rel: ''
+      target: ''
+    third_party_settings: {  }
+    type: link
+    region: content
+  field_featured_item_title:
+    weight: 0
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+hidden: {  }

--- a/modules/social_features/social_landing_page/config/features_removal/core.entity_view_display.paragraph.featured_items.default.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/core.entity_view_display.paragraph.featured_items.default.yml
@@ -1,0 +1,41 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.featured_items.field_featured_items_description
+    - field.field.paragraph.featured_items.field_featured_items_items
+    - field.field.paragraph.featured_items.field_featured_items_title
+    - paragraphs.paragraphs_type.featured_items
+  module:
+    - entity_reference_revisions
+    - text
+id: paragraph.featured_items.default
+targetEntityType: paragraph
+bundle: featured_items
+mode: default
+content:
+  field_featured_items_description:
+    weight: 1
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    type: text_default
+    region: content
+  field_featured_items_items:
+    type: entity_reference_revisions_entity_view
+    weight: 2
+    label: hidden
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
+    region: content
+  field_featured_items_title:
+    weight: 0
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+hidden: {  }

--- a/modules/social_features/social_landing_page/config/features_removal/core.entity_view_display.paragraph.hero.default.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/core.entity_view_display.paragraph.hero.default.yml
@@ -1,0 +1,53 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.hero.field_hero_buttons
+    - field.field.paragraph.hero.field_hero_image
+    - field.field.paragraph.hero.field_hero_subtitle
+    - field.field.paragraph.hero.field_hero_title
+    - image.style.social_landing_hero
+    - paragraphs.paragraphs_type.hero
+  module:
+    - entity_reference_revisions
+    - image
+id: paragraph.hero.default
+targetEntityType: paragraph
+bundle: hero
+mode: default
+content:
+  field_hero_buttons:
+    type: entity_reference_revisions_entity_view
+    weight: 5
+    label: hidden
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
+    region: content
+  field_hero_image:
+    weight: 0
+    label: hidden
+    settings:
+      image_style: social_landing_hero
+      image_link: ''
+    third_party_settings: {  }
+    type: image
+    region: content
+  field_hero_subtitle:
+    weight: 2
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  field_hero_title:
+    weight: 1
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+hidden: {  }

--- a/modules/social_features/social_landing_page/config/features_removal/core.entity_view_display.paragraph.hero.preview.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/core.entity_view_display.paragraph.hero.preview.yml
@@ -1,0 +1,54 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.paragraph.preview
+    - field.field.paragraph.hero.field_hero_buttons
+    - field.field.paragraph.hero.field_hero_image
+    - field.field.paragraph.hero.field_hero_subtitle
+    - field.field.paragraph.hero.field_hero_title
+    - image.style.social_featured
+    - paragraphs.paragraphs_type.hero
+  module:
+    - entity_reference_revisions
+    - image
+id: paragraph.hero.preview
+targetEntityType: paragraph
+bundle: hero
+mode: preview
+content:
+  field_hero_buttons:
+    type: entity_reference_revisions_entity_view
+    weight: 5
+    region: content
+    label: above
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
+  field_hero_image:
+    weight: 0
+    label: above
+    settings:
+      image_style: social_featured
+      image_link: ''
+    third_party_settings: {  }
+    type: image
+    region: content
+  field_hero_subtitle:
+    weight: 2
+    label: inline
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  field_hero_title:
+    weight: 1
+    label: inline
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+hidden: {  }

--- a/modules/social_features/social_landing_page/config/features_removal/core.entity_view_display.paragraph.hero_small.default.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/core.entity_view_display.paragraph.hero_small.default.yml
@@ -1,0 +1,53 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.hero_small.field_hero_small_buttons
+    - field.field.paragraph.hero_small.field_hero_small_image
+    - field.field.paragraph.hero_small.field_hero_small_subtitle
+    - field.field.paragraph.hero_small.field_hero_small_title
+    - image.style.social_landing_hero_small
+    - paragraphs.paragraphs_type.hero_small
+  module:
+    - entity_reference_revisions
+    - image
+id: paragraph.hero_small.default
+targetEntityType: paragraph
+bundle: hero_small
+mode: default
+content:
+  field_hero_small_buttons:
+    type: entity_reference_revisions_entity_view
+    weight: 5
+    label: hidden
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
+    region: content
+  field_hero_small_image:
+    weight: 0
+    label: hidden
+    settings:
+      image_style: social_landing_hero_small
+      image_link: ''
+    third_party_settings: {  }
+    type: image
+    region: content
+  field_hero_small_subtitle:
+    weight: 2
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  field_hero_small_title:
+    weight: 1
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+hidden: {  }

--- a/modules/social_features/social_landing_page/config/features_removal/core.entity_view_display.paragraph.hero_small.preview.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/core.entity_view_display.paragraph.hero_small.preview.yml
@@ -1,0 +1,54 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.paragraph.preview
+    - field.field.paragraph.hero_small.field_hero_small_buttons
+    - field.field.paragraph.hero_small.field_hero_small_image
+    - field.field.paragraph.hero_small.field_hero_small_subtitle
+    - field.field.paragraph.hero_small.field_hero_small_title
+    - image.style.social_featured
+    - paragraphs.paragraphs_type.hero_small
+  module:
+    - entity_reference_revisions
+    - image
+id: paragraph.hero_small.preview
+targetEntityType: paragraph
+bundle: hero_small
+mode: preview
+content:
+  field_hero_small_buttons:
+    type: entity_reference_revisions_entity_view
+    weight: 5
+    region: content
+    label: above
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
+  field_hero_small_image:
+    weight: 0
+    label: above
+    settings:
+      image_style: social_featured
+      image_link: ''
+    third_party_settings: {  }
+    type: image
+    region: content
+  field_hero_small_subtitle:
+    weight: 2
+    label: inline
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  field_hero_small_title:
+    weight: 1
+    label: inline
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+hidden: {  }

--- a/modules/social_features/social_landing_page/config/features_removal/core.entity_view_display.paragraph.introduction.default.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/core.entity_view_display.paragraph.introduction.default.yml
@@ -1,0 +1,57 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.introduction.field_introduction_link_an
+    - field.field.paragraph.introduction.field_introduction_link_lu
+    - field.field.paragraph.introduction.field_introduction_text
+    - field.field.paragraph.introduction.field_introduction_title
+    - paragraphs.paragraphs_type.introduction
+  module:
+    - link
+    - text
+id: paragraph.introduction.default
+targetEntityType: paragraph
+bundle: introduction
+mode: default
+content:
+  field_introduction_link_an:
+    weight: 2
+    label: hidden
+    settings:
+      trim_length: 80
+      url_only: false
+      url_plain: false
+      rel: ''
+      target: ''
+    third_party_settings: {  }
+    type: link
+    region: content
+  field_introduction_link_lu:
+    weight: 3
+    label: hidden
+    settings:
+      trim_length: 80
+      url_only: false
+      url_plain: false
+      rel: ''
+      target: ''
+    third_party_settings: {  }
+    type: link
+    region: content
+  field_introduction_text:
+    weight: 1
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    type: text_default
+    region: content
+  field_introduction_title:
+    weight: 0
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+hidden: {  }

--- a/modules/social_features/social_landing_page/config/features_removal/core.entity_view_display.paragraph.introduction.preview.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/core.entity_view_display.paragraph.introduction.preview.yml
@@ -1,0 +1,58 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.paragraph.preview
+    - field.field.paragraph.introduction.field_introduction_link_an
+    - field.field.paragraph.introduction.field_introduction_link_lu
+    - field.field.paragraph.introduction.field_introduction_text
+    - field.field.paragraph.introduction.field_introduction_title
+    - paragraphs.paragraphs_type.introduction
+  module:
+    - link
+    - text
+id: paragraph.introduction.preview
+targetEntityType: paragraph
+bundle: introduction
+mode: preview
+content:
+  field_introduction_link_an:
+    weight: 2
+    label: inline
+    settings:
+      trim_length: 80
+      url_only: false
+      url_plain: false
+      rel: ''
+      target: ''
+    third_party_settings: {  }
+    type: link
+    region: content
+  field_introduction_link_lu:
+    weight: 3
+    label: inline
+    settings:
+      trim_length: 80
+      url_only: false
+      url_plain: false
+      rel: ''
+      target: ''
+    third_party_settings: {  }
+    type: link
+    region: content
+  field_introduction_text:
+    weight: 1
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    type: text_default
+    region: content
+  field_introduction_title:
+    weight: 0
+    label: inline
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+hidden: {  }

--- a/modules/social_features/social_landing_page/config/features_removal/core.entity_view_display.paragraph.section.default.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/core.entity_view_display.paragraph.section.default.yml
@@ -1,0 +1,23 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.section.field_section_paragraph
+    - paragraphs.paragraphs_type.section
+  module:
+    - entity_reference_revisions
+id: paragraph.section.default
+targetEntityType: paragraph
+bundle: section
+mode: default
+content:
+  field_section_paragraph:
+    type: entity_reference_revisions_entity_view
+    weight: 0
+    label: hidden
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
+    region: content
+hidden: {  }

--- a/modules/social_features/social_landing_page/config/features_removal/core.entity_view_display.paragraph.section.preview.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/core.entity_view_display.paragraph.section.preview.yml
@@ -1,0 +1,24 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.paragraph.preview
+    - field.field.paragraph.section.field_section_paragraph
+    - paragraphs.paragraphs_type.section
+  module:
+    - entity_reference_revisions
+id: paragraph.section.preview
+targetEntityType: paragraph
+bundle: section
+mode: preview
+content:
+  field_section_paragraph:
+    type: entity_reference_revisions_entity_view
+    weight: 0
+    label: above
+    settings:
+      view_mode: preview
+      link: ''
+    third_party_settings: {  }
+    region: content
+hidden: {  }

--- a/modules/social_features/social_landing_page/config/features_removal/core.entity_view_display.profile.profile.featured.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/core.entity_view_display.profile.profile.featured.yml
@@ -1,0 +1,63 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.profile.featured
+    - field.field.profile.profile.field_profile_address
+    - field.field.profile.profile.field_profile_banner_image
+    - field.field.profile.profile.field_profile_expertise
+    - field.field.profile.profile.field_profile_first_name
+    - field.field.profile.profile.field_profile_function
+    - field.field.profile.profile.field_profile_image
+    - field.field.profile.profile.field_profile_interests
+    - field.field.profile.profile.field_profile_last_name
+    - field.field.profile.profile.field_profile_organization
+    - field.field.profile.profile.field_profile_phone_number
+    - field.field.profile.profile.field_profile_profile_tag
+    - field.field.profile.profile.field_profile_self_introduction
+    - field.field.profile.profile.field_profile_show_email
+    - image.style.social_featured
+    - profile.type.profile
+  module:
+    - image
+id: profile.profile.featured
+targetEntityType: profile
+bundle: profile
+mode: featured
+content:
+  field_profile_first_name:
+    type: string
+    weight: 1
+    region: content
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+  field_profile_image:
+    weight: 0
+    label: hidden
+    settings:
+      image_style: social_featured
+      image_link: ''
+    third_party_settings: {  }
+    type: image
+    region: content
+  field_profile_last_name:
+    type: string
+    weight: 2
+    region: content
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+hidden:
+  field_profile_address: true
+  field_profile_banner_image: true
+  field_profile_expertise: true
+  field_profile_function: true
+  field_profile_interests: true
+  field_profile_organization: true
+  field_profile_phone_number: true
+  field_profile_profile_tag: true
+  field_profile_self_introduction: true
+  field_profile_show_email: true

--- a/modules/social_features/social_landing_page/config/features_removal/core.entity_view_mode.group.featured.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/core.entity_view_mode.group.featured.yml
@@ -1,0 +1,9 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - group
+id: group.featured
+label: Featured
+targetEntityType: group
+cache: true

--- a/modules/social_features/social_landing_page/config/features_removal/core.entity_view_mode.node.featured.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/core.entity_view_mode.node.featured.yml
@@ -1,0 +1,9 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.featured
+label: Featured
+targetEntityType: node
+cache: true

--- a/modules/social_features/social_landing_page/config/features_removal/core.entity_view_mode.profile.featured.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/core.entity_view_mode.profile.featured.yml
@@ -1,0 +1,9 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - profile
+id: profile.featured
+label: Featured
+targetEntityType: profile
+cache: true

--- a/modules/social_features/social_landing_page/config/features_removal/crop.type.hero_landing.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/crop.type.hero_landing.yml
@@ -1,0 +1,11 @@
+langcode: en
+status: true
+dependencies: {  }
+label: 'Hero Landing'
+id: hero_landing
+description: 'Header image for Landing Page Hero section.'
+aspect_ratio: '150:37'
+soft_limit_width: 1500
+soft_limit_height: 370
+hard_limit_width: null
+hard_limit_height: null

--- a/modules/social_features/social_landing_page/config/features_removal/crop.type.hero_small_landing.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/crop.type.hero_small_landing.yml
@@ -1,0 +1,11 @@
+langcode: en
+status: true
+dependencies: {  }
+label: 'Hero Small Landing'
+id: hero_small_landing
+description: 'Header image for Landing Page Hero small section.'
+aspect_ratio: '150:37'
+soft_limit_width: 1500
+soft_limit_height: 370
+hard_limit_width: null
+hard_limit_height: null

--- a/modules/social_features/social_landing_page/config/features_removal/field.field.node.landing_page.field_content_visibility.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/field.field.node.landing_page.field_content_visibility.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_content_visibility
+    - node.type.landing_page
+  module:
+    - entity_access_by_field
+id: node.landing_page.field_content_visibility
+field_name: field_content_visibility
+entity_type: node
+bundle: landing_page
+label: Visibility
+description: ''
+required: true
+translatable: false
+default_value: null
+default_value_callback: ''
+settings: {  }
+field_type: entity_access_field

--- a/modules/social_features/social_landing_page/config/features_removal/field.field.node.landing_page.field_landing_page_section.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/field.field.node.landing_page.field_landing_page_section.yml
@@ -1,0 +1,33 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_landing_page_section
+    - node.type.landing_page
+    - paragraphs.paragraphs_type.section
+  module:
+    - entity_reference_revisions
+id: node.landing_page.field_landing_page_section
+field_name: field_landing_page_section
+entity_type: node
+bundle: landing_page
+label: Sections
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:paragraph'
+  handler_settings:
+    negate: 0
+    target_bundles:
+      section: section
+    target_bundles_drag_drop:
+      section:
+        enabled: true
+        weight: 3
+      featured:
+        weight: 4
+        enabled: false
+field_type: entity_reference_revisions

--- a/modules/social_features/social_landing_page/config/features_removal/field.field.paragraph.accordion.field_accord_description.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/field.field.paragraph.accordion.field_accord_description.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_accord_description
+    - paragraphs.paragraphs_type.accordion
+  module:
+    - text
+id: paragraph.accordion.field_accord_description
+field_name: field_accord_description
+entity_type: paragraph
+bundle: accordion
+label: Description
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: text_long

--- a/modules/social_features/social_landing_page/config/features_removal/field.field.paragraph.accordion.field_accord_item.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/field.field.paragraph.accordion.field_accord_item.yml
@@ -1,0 +1,30 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_accord_item
+    - paragraphs.paragraphs_type.accordion
+    - paragraphs.paragraphs_type.accordion_item
+  module:
+    - entity_reference_revisions
+id: paragraph.accordion.field_accord_item
+field_name: field_accord_item
+entity_type: paragraph
+bundle: accordion
+label: 'Accordion item'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:paragraph'
+  handler_settings:
+    negate: 0
+    target_bundles:
+      accordion_item: accordion_item
+    target_bundles_drag_drop:
+      accordion_item:
+        enabled: true
+        weight: 20
+field_type: entity_reference_revisions

--- a/modules/social_features/social_landing_page/config/features_removal/field.field.paragraph.accordion.field_accord_title.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/field.field.paragraph.accordion.field_accord_title.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_accord_title
+    - paragraphs.paragraphs_type.accordion
+id: paragraph.accordion.field_accord_title
+field_name: field_accord_title
+entity_type: paragraph
+bundle: accordion
+label: Title
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/modules/social_features/social_landing_page/config/features_removal/field.field.paragraph.accordion_item.field_accord_item_description.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/field.field.paragraph.accordion_item.field_accord_item_description.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_accord_item_description
+    - paragraphs.paragraphs_type.accordion_item
+  module:
+    - text
+id: paragraph.accordion_item.field_accord_item_description
+field_name: field_accord_item_description
+entity_type: paragraph
+bundle: accordion_item
+label: Description
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: text_long

--- a/modules/social_features/social_landing_page/config/features_removal/field.field.paragraph.accordion_item.field_accord_item_title.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/field.field.paragraph.accordion_item.field_accord_item_title.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_accord_item_title
+    - paragraphs.paragraphs_type.accordion_item
+id: paragraph.accordion_item.field_accord_item_title
+field_name: field_accord_item_title
+entity_type: paragraph
+bundle: accordion_item
+label: Title
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/modules/social_features/social_landing_page/config/features_removal/field.field.paragraph.block.field_block_link.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/field.field.paragraph.block.field_block_link.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_block_link
+    - paragraphs.paragraphs_type.block
+  module:
+    - link
+id: paragraph.block.field_block_link
+field_name: field_block_link
+entity_type: paragraph
+bundle: block
+label: Link
+description: 'Optional link. Sometimes blocks already contain more link.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  link_type: 17
+  title: 1
+field_type: link

--- a/modules/social_features/social_landing_page/config/features_removal/field.field.paragraph.block.field_block_reference.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/field.field.paragraph.block.field_block_reference.yml
@@ -1,0 +1,25 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_block_reference
+    - paragraphs.paragraphs_type.block
+  module:
+    - block_field
+id: paragraph.block.field_block_reference
+field_name: field_block_reference
+entity_type: paragraph
+bundle: block
+label: Primary
+description: 'Select a Block from a list to include'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  plugin_ids:
+    'views_block:activity_stream-block_stream_homepage': 'views_block:activity_stream-block_stream_homepage'
+    'views_block:activity_stream-block_stream_homepage_without_post': 'views_block:activity_stream-block_stream_homepage_without_post'
+    'views_block:community_activities-block_stream_landing_with_post': 'views_block:community_activities-block_stream_landing_with_post'
+    'views_block:community_activities-block_stream_landing': 'views_block:community_activities-block_stream_landing'
+field_type: block_field

--- a/modules/social_features/social_landing_page/config/features_removal/field.field.paragraph.block.field_block_reference_secondary.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/field.field.paragraph.block.field_block_reference_secondary.yml
@@ -1,0 +1,26 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_block_reference_secondary
+    - paragraphs.paragraphs_type.block
+  module:
+    - block_field
+id: paragraph.block.field_block_reference_secondary
+field_name: field_block_reference_secondary
+entity_type: paragraph
+bundle: block
+label: Secondary
+description: 'A secondary block will be printed in a side column, keep in mind it will take 1/3'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  plugin_ids:
+    'views_block:upcoming_events-block_community_events': 'views_block:upcoming_events-block_community_events'
+    'views_block:latest_topics-block_latest_topics': 'views_block:latest_topics-block_latest_topics'
+    'views_block:newest_groups-block_newest_groups': 'views_block:newest_groups-block_newest_groups'
+    'views_block:newest_users-block_newest_users': 'views_block:newest_users-block_newest_users'
+    activity_overview_block: activity_overview_block
+field_type: block_field

--- a/modules/social_features/social_landing_page/config/features_removal/field.field.paragraph.block.field_block_title.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/field.field.paragraph.block.field_block_title.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_block_title
+    - paragraphs.paragraphs_type.block
+id: paragraph.block.field_block_title
+field_name: field_block_title
+entity_type: paragraph
+bundle: block
+label: Title
+description: 'Optional field, title can be printed from block or overridden here. Uncheck <em>Display title</em> if using this field'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/modules/social_features/social_landing_page/config/features_removal/field.field.paragraph.button.field_button_link_an.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/field.field.paragraph.button.field_button_link_an.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_button_link_an
+    - paragraphs.paragraphs_type.button
+  module:
+    - link
+id: paragraph.button.field_button_link_an
+field_name: field_button_link_an
+entity_type: paragraph
+bundle: button
+label: 'Link for Anonymous User'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  link_type: 17
+  title: 1
+field_type: link

--- a/modules/social_features/social_landing_page/config/features_removal/field.field.paragraph.button.field_button_link_lu.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/field.field.paragraph.button.field_button_link_lu.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_button_link_lu
+    - paragraphs.paragraphs_type.button
+  module:
+    - link
+id: paragraph.button.field_button_link_lu
+field_name: field_button_link_lu
+entity_type: paragraph
+bundle: button
+label: 'Link for Logged In User'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  link_type: 17
+  title: 1
+field_type: link

--- a/modules/social_features/social_landing_page/config/features_removal/field.field.paragraph.button.field_button_style.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/field.field.paragraph.button.field_button_style.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_button_style
+    - paragraphs.paragraphs_type.button
+  module:
+    - options
+id: paragraph.button.field_button_style
+field_name: field_button_style
+entity_type: paragraph
+bundle: button
+label: Style
+description: 'Style for button see:<a href="http://styleguide.getopensocial.com/section-atoms.html#kssref-atoms-button-style">styleguide</a>.'
+required: true
+translatable: false
+default_value:
+  -
+    value: btn-default
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/modules/social_features/social_landing_page/config/features_removal/field.field.paragraph.featured.field_featured_description.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/field.field.paragraph.featured.field_featured_description.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_featured_description
+    - paragraphs.paragraphs_type.featured
+  module:
+    - text
+id: paragraph.featured.field_featured_description
+field_name: field_featured_description
+entity_type: paragraph
+bundle: featured
+label: Description
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: text_long

--- a/modules/social_features/social_landing_page/config/features_removal/field.field.paragraph.featured.field_featured_items.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/field.field.paragraph.featured.field_featured_items.yml
@@ -1,0 +1,98 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_featured_items
+    - paragraphs.paragraphs_type.featured
+  module:
+    - dynamic_entity_reference
+id: paragraph.featured.field_featured_items
+field_name: field_featured_items
+entity_type: paragraph
+bundle: featured
+label: Items
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  node:
+    handler: views
+    handler_settings:
+      view:
+        view_name: featured_content_reference
+        display_name: entity_reference_1
+        arguments: {  }
+  group:
+    handler: views
+    handler_settings:
+      view:
+        view_name: featured_group_reference
+        display_name: entity_reference_1
+        arguments: {  }
+  profile:
+    handler: views
+    handler_settings:
+      view:
+        view_name: featured_profile_reference
+        display_name: entity_reference_1
+        arguments: {  }
+  activity:
+    handler: 'default:activity'
+    handler_settings: {  }
+  comment:
+    handler: 'default:comment'
+    handler_settings: {  }
+  crop:
+    handler: 'default:crop'
+    handler_settings: {  }
+  block_content:
+    handler: 'default:block_content'
+    handler_settings: {  }
+  menu_link_content:
+    handler: 'default:menu_link_content'
+    handler_settings: {  }
+  event_enrollment:
+    handler: 'default:event_enrollment'
+    handler_settings: {  }
+  file:
+    handler: 'default:file'
+    handler_settings: {  }
+  flagging:
+    handler: 'default:flagging'
+    handler_settings: {  }
+  font:
+    handler: 'default:font'
+    handler_settings: {  }
+  group_content:
+    handler: 'default:group_content'
+    handler_settings: {  }
+  mentions:
+    handler: 'default:mentions'
+    handler_settings: {  }
+  message:
+    handler: 'default:message'
+    handler_settings: {  }
+  paragraph:
+    handler: 'default:paragraph'
+    handler_settings: {  }
+  post:
+    handler: 'default:post'
+    handler_settings: {  }
+  search_api_task:
+    handler: 'default:search_api_task'
+    handler_settings: {  }
+  taxonomy_term:
+    handler: 'default:taxonomy_term'
+    handler_settings: {  }
+  user:
+    handler: 'default:user'
+    handler_settings: {  }
+  vote:
+    handler: 'default:vote'
+    handler_settings: {  }
+  vote_result:
+    handler: 'default:vote_result'
+    handler_settings: {  }
+field_type: dynamic_entity_reference

--- a/modules/social_features/social_landing_page/config/features_removal/field.field.paragraph.featured.field_featured_link.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/field.field.paragraph.featured.field_featured_link.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_featured_link
+    - paragraphs.paragraphs_type.featured
+  module:
+    - link
+id: paragraph.featured.field_featured_link
+field_name: field_featured_link
+entity_type: paragraph
+bundle: featured
+label: Link
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  link_type: 17
+  title: 1
+field_type: link

--- a/modules/social_features/social_landing_page/config/features_removal/field.field.paragraph.featured.field_featured_title.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/field.field.paragraph.featured.field_featured_title.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_featured_title
+    - paragraphs.paragraphs_type.featured
+id: paragraph.featured.field_featured_title
+field_name: field_featured_title
+entity_type: paragraph
+bundle: featured
+label: Title
+description: 'Section title'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/modules/social_features/social_landing_page/config/features_removal/field.field.paragraph.featured_item.field_featured_item_description.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/field.field.paragraph.featured_item.field_featured_item_description.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_featured_item_description
+    - paragraphs.paragraphs_type.featured_item
+  module:
+    - text
+id: paragraph.featured_item.field_featured_item_description
+field_name: field_featured_item_description
+entity_type: paragraph
+bundle: featured_item
+label: Description
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: text_long

--- a/modules/social_features/social_landing_page/config/features_removal/field.field.paragraph.featured_item.field_featured_item_image.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/field.field.paragraph.featured_item.field_featured_item_image.yml
@@ -1,0 +1,37 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_featured_item_image
+    - paragraphs.paragraphs_type.featured_item
+  module:
+    - image
+id: paragraph.featured_item.field_featured_item_image
+field_name: field_featured_item_image
+entity_type: paragraph
+bundle: featured_item
+label: Image
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  file_directory: '[date:custom:Y]-[date:custom:m]'
+  file_extensions: 'png gif jpg jpeg'
+  max_filesize: ''
+  max_resolution: 4096x4096
+  min_resolution: ''
+  alt_field: true
+  alt_field_required: false
+  title_field: false
+  title_field_required: false
+  default_image:
+    uuid: ''
+    alt: ''
+    title: ''
+    width: null
+    height: null
+  handler: 'default:file'
+  handler_settings: {  }
+field_type: image

--- a/modules/social_features/social_landing_page/config/features_removal/field.field.paragraph.featured_item.field_featured_item_link.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/field.field.paragraph.featured_item.field_featured_item_link.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_featured_item_link
+    - paragraphs.paragraphs_type.featured_item
+  module:
+    - link
+id: paragraph.featured_item.field_featured_item_link
+field_name: field_featured_item_link
+entity_type: paragraph
+bundle: featured_item
+label: Link
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  link_type: 17
+  title: 1
+field_type: link

--- a/modules/social_features/social_landing_page/config/features_removal/field.field.paragraph.featured_item.field_featured_item_title.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/field.field.paragraph.featured_item.field_featured_item_title.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_featured_item_title
+    - paragraphs.paragraphs_type.featured_item
+id: paragraph.featured_item.field_featured_item_title
+field_name: field_featured_item_title
+entity_type: paragraph
+bundle: featured_item
+label: Title
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/modules/social_features/social_landing_page/config/features_removal/field.field.paragraph.featured_items.field_featured_items_description.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/field.field.paragraph.featured_items.field_featured_items_description.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_featured_items_description
+    - paragraphs.paragraphs_type.featured_items
+  module:
+    - text
+id: paragraph.featured_items.field_featured_items_description
+field_name: field_featured_items_description
+entity_type: paragraph
+bundle: featured_items
+label: Description
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: text_long

--- a/modules/social_features/social_landing_page/config/features_removal/field.field.paragraph.featured_items.field_featured_items_items.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/field.field.paragraph.featured_items.field_featured_items_items.yml
@@ -1,0 +1,51 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_featured_items_items
+    - paragraphs.paragraphs_type.featured_item
+    - paragraphs.paragraphs_type.featured_items
+  module:
+    - entity_reference_revisions
+id: paragraph.featured_items.field_featured_items_items
+field_name: field_featured_items_items
+entity_type: paragraph
+bundle: featured_items
+label: Items
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:paragraph'
+  handler_settings:
+    negate: 0
+    target_bundles:
+      featured_item: featured_item
+    target_bundles_drag_drop:
+      block:
+        weight: 9
+        enabled: false
+      button:
+        weight: 10
+        enabled: false
+      featured:
+        weight: 11
+        enabled: false
+      featured_item:
+        enabled: true
+        weight: 12
+      featured_items:
+        weight: 13
+        enabled: false
+      hero:
+        weight: 14
+        enabled: false
+      introduction:
+        weight: 15
+        enabled: false
+      section:
+        weight: 16
+        enabled: false
+field_type: entity_reference_revisions

--- a/modules/social_features/social_landing_page/config/features_removal/field.field.paragraph.featured_items.field_featured_items_title.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/field.field.paragraph.featured_items.field_featured_items_title.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_featured_items_title
+    - paragraphs.paragraphs_type.featured_items
+id: paragraph.featured_items.field_featured_items_title
+field_name: field_featured_items_title
+entity_type: paragraph
+bundle: featured_items
+label: Title
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/modules/social_features/social_landing_page/config/features_removal/field.field.paragraph.hero.field_hero_buttons.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/field.field.paragraph.hero.field_hero_buttons.yml
@@ -1,0 +1,45 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_hero_buttons
+    - paragraphs.paragraphs_type.button
+    - paragraphs.paragraphs_type.hero
+  module:
+    - entity_reference_revisions
+id: paragraph.hero.field_hero_buttons
+field_name: field_hero_buttons
+entity_type: paragraph
+bundle: hero
+label: Buttons
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:paragraph'
+  handler_settings:
+    negate: 0
+    target_bundles:
+      button: button
+    target_bundles_drag_drop:
+      block:
+        weight: 7
+        enabled: false
+      button:
+        enabled: true
+        weight: 8
+      featured:
+        weight: 9
+        enabled: false
+      hero:
+        weight: 10
+        enabled: false
+      introduction:
+        weight: 11
+        enabled: false
+      section:
+        weight: 12
+        enabled: false
+field_type: entity_reference_revisions

--- a/modules/social_features/social_landing_page/config/features_removal/field.field.paragraph.hero.field_hero_image.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/field.field.paragraph.hero.field_hero_image.yml
@@ -1,0 +1,37 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_hero_image
+    - paragraphs.paragraphs_type.hero
+  module:
+    - image
+id: paragraph.hero.field_hero_image
+field_name: field_hero_image
+entity_type: paragraph
+bundle: hero
+label: Image
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  file_directory: '[date:custom:Y]-[date:custom:m]'
+  file_extensions: 'png gif jpg jpeg'
+  max_filesize: ''
+  max_resolution: 4096x4096
+  min_resolution: ''
+  alt_field: true
+  alt_field_required: false
+  title_field: false
+  title_field_required: false
+  default_image:
+    uuid: ''
+    alt: ''
+    title: ''
+    width: null
+    height: null
+  handler: 'default:file'
+  handler_settings: {  }
+field_type: image

--- a/modules/social_features/social_landing_page/config/features_removal/field.field.paragraph.hero.field_hero_subtitle.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/field.field.paragraph.hero.field_hero_subtitle.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_hero_subtitle
+    - paragraphs.paragraphs_type.hero
+id: paragraph.hero.field_hero_subtitle
+field_name: field_hero_subtitle
+entity_type: paragraph
+bundle: hero
+label: Subtitle
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/modules/social_features/social_landing_page/config/features_removal/field.field.paragraph.hero.field_hero_title.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/field.field.paragraph.hero.field_hero_title.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_hero_title
+    - paragraphs.paragraphs_type.hero
+id: paragraph.hero.field_hero_title
+field_name: field_hero_title
+entity_type: paragraph
+bundle: hero
+label: Title
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/modules/social_features/social_landing_page/config/features_removal/field.field.paragraph.hero_small.field_hero_small_buttons.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/field.field.paragraph.hero_small.field_hero_small_buttons.yml
@@ -1,0 +1,45 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_hero_small_buttons
+    - paragraphs.paragraphs_type.button
+    - paragraphs.paragraphs_type.hero_small
+  module:
+    - entity_reference_revisions
+id: paragraph.hero_small.field_hero_small_buttons
+field_name: field_hero_small_buttons
+entity_type: paragraph
+bundle: hero_small
+label: Buttons
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:paragraph'
+  handler_settings:
+    negate: 0
+    target_bundles:
+      button: button
+    target_bundles_drag_drop:
+      block:
+        weight: 7
+        enabled: false
+      button:
+        enabled: true
+        weight: 8
+      featured:
+        weight: 9
+        enabled: false
+      hero:
+        weight: 10
+        enabled: false
+      introduction:
+        weight: 11
+        enabled: false
+      section:
+        weight: 12
+        enabled: false
+field_type: entity_reference_revisions

--- a/modules/social_features/social_landing_page/config/features_removal/field.field.paragraph.hero_small.field_hero_small_image.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/field.field.paragraph.hero_small.field_hero_small_image.yml
@@ -1,0 +1,37 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_hero_small_image
+    - paragraphs.paragraphs_type.hero_small
+  module:
+    - image
+id: paragraph.hero_small.field_hero_small_image
+field_name: field_hero_small_image
+entity_type: paragraph
+bundle: hero_small
+label: Image
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  file_directory: '[date:custom:Y]-[date:custom:m]'
+  file_extensions: 'png gif jpg jpeg'
+  max_filesize: ''
+  max_resolution: 4096x4096
+  min_resolution: ''
+  alt_field: true
+  alt_field_required: false
+  title_field: false
+  title_field_required: false
+  default_image:
+    uuid: ''
+    alt: ''
+    title: ''
+    width: null
+    height: null
+  handler: 'default:file'
+  handler_settings: {  }
+field_type: image

--- a/modules/social_features/social_landing_page/config/features_removal/field.field.paragraph.hero_small.field_hero_small_subtitle.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/field.field.paragraph.hero_small.field_hero_small_subtitle.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_hero_small_subtitle
+    - paragraphs.paragraphs_type.hero_small
+id: paragraph.hero_small.field_hero_small_subtitle
+field_name: field_hero_small_subtitle
+entity_type: paragraph
+bundle: hero_small
+label: Subtitle
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/modules/social_features/social_landing_page/config/features_removal/field.field.paragraph.hero_small.field_hero_small_title.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/field.field.paragraph.hero_small.field_hero_small_title.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_hero_small_title
+    - paragraphs.paragraphs_type.hero_small
+id: paragraph.hero_small.field_hero_small_title
+field_name: field_hero_small_title
+entity_type: paragraph
+bundle: hero_small
+label: Title
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/modules/social_features/social_landing_page/config/features_removal/field.field.paragraph.introduction.field_introduction_link_an.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/field.field.paragraph.introduction.field_introduction_link_an.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_introduction_link_an
+    - paragraphs.paragraphs_type.introduction
+  module:
+    - link
+id: paragraph.introduction.field_introduction_link_an
+field_name: field_introduction_link_an
+entity_type: paragraph
+bundle: introduction
+label: 'Link for Anonymous User'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  link_type: 17
+  title: 1
+field_type: link

--- a/modules/social_features/social_landing_page/config/features_removal/field.field.paragraph.introduction.field_introduction_link_lu.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/field.field.paragraph.introduction.field_introduction_link_lu.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_introduction_link_lu
+    - paragraphs.paragraphs_type.introduction
+  module:
+    - link
+id: paragraph.introduction.field_introduction_link_lu
+field_name: field_introduction_link_lu
+entity_type: paragraph
+bundle: introduction
+label: 'Link for Logged In User'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  link_type: 17
+  title: 1
+field_type: link

--- a/modules/social_features/social_landing_page/config/features_removal/field.field.paragraph.introduction.field_introduction_text.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/field.field.paragraph.introduction.field_introduction_text.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_introduction_text
+    - paragraphs.paragraphs_type.introduction
+  module:
+    - text
+id: paragraph.introduction.field_introduction_text
+field_name: field_introduction_text
+entity_type: paragraph
+bundle: introduction
+label: Text
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: text_long

--- a/modules/social_features/social_landing_page/config/features_removal/field.field.paragraph.introduction.field_introduction_title.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/field.field.paragraph.introduction.field_introduction_title.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_introduction_title
+    - paragraphs.paragraphs_type.introduction
+id: paragraph.introduction.field_introduction_title
+field_name: field_introduction_title
+entity_type: paragraph
+bundle: introduction
+label: Title
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/modules/social_features/social_landing_page/config/features_removal/field.field.paragraph.section.field_section_paragraph.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/field.field.paragraph.section.field_section_paragraph.yml
@@ -1,0 +1,59 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_section_paragraph
+    - paragraphs.paragraphs_type.accordion
+    - paragraphs.paragraphs_type.block
+    - paragraphs.paragraphs_type.featured
+    - paragraphs.paragraphs_type.hero
+    - paragraphs.paragraphs_type.hero_small
+    - paragraphs.paragraphs_type.introduction
+    - paragraphs.paragraphs_type.section
+  module:
+    - entity_reference_revisions
+id: paragraph.section.field_section_paragraph
+field_name: field_section_paragraph
+entity_type: paragraph
+bundle: section
+label: Reference
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:paragraph'
+  handler_settings:
+    negate: 0
+    target_bundles:
+      featured: featured
+      featured_items: featured_items
+      block: block
+      hero: hero
+      hero_small: hero_small
+      introduction: introduction
+      accordion: accordion
+    target_bundles_drag_drop:
+      section:
+        weight: 3
+        enabled: false
+      featured:
+        enabled: true
+        weight: 4
+      block:
+        enabled: true
+        weight: 4
+      hero:
+        enabled: true
+        weight: 5
+      hero_small:
+        enabled: true
+        weight: 6
+      introduction:
+        enabled: true
+        weight: 7
+      accordion:
+        enabled: true
+        weight: 8
+field_type: entity_reference_revisions

--- a/modules/social_features/social_landing_page/config/features_removal/field.storage.node.field_landing_page_section.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/field.storage.node.field_landing_page_section.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - entity_reference_revisions
+    - node
+    - paragraphs
+id: node.field_landing_page_section
+field_name: field_landing_page_section
+entity_type: node
+type: entity_reference_revisions
+settings:
+  target_type: paragraph
+module: entity_reference_revisions
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/social_features/social_landing_page/config/features_removal/field.storage.paragraph.field_accord_description.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/field.storage.paragraph.field_accord_description.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+    - text
+id: paragraph.field_accord_description
+field_name: field_accord_description
+entity_type: paragraph
+type: text_long
+settings: {  }
+module: text
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/social_features/social_landing_page/config/features_removal/field.storage.paragraph.field_accord_item.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/field.storage.paragraph.field_accord_item.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - entity_reference_revisions
+    - paragraphs
+id: paragraph.field_accord_item
+field_name: field_accord_item
+entity_type: paragraph
+type: entity_reference_revisions
+settings:
+  target_type: paragraph
+module: entity_reference_revisions
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/social_features/social_landing_page/config/features_removal/field.storage.paragraph.field_accord_item_description.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/field.storage.paragraph.field_accord_item_description.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+    - text
+id: paragraph.field_accord_item_description
+field_name: field_accord_item_description
+entity_type: paragraph
+type: text_long
+settings: {  }
+module: text
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/social_features/social_landing_page/config/features_removal/field.storage.paragraph.field_accord_item_title.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/field.storage.paragraph.field_accord_item_title.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+id: paragraph.field_accord_item_title
+field_name: field_accord_item_title
+entity_type: paragraph
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/social_features/social_landing_page/config/features_removal/field.storage.paragraph.field_accord_title.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/field.storage.paragraph.field_accord_title.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+id: paragraph.field_accord_title
+field_name: field_accord_title
+entity_type: paragraph
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/social_features/social_landing_page/config/features_removal/field.storage.paragraph.field_block_link.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/field.storage.paragraph.field_block_link.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - link
+    - paragraphs
+id: paragraph.field_block_link
+field_name: field_block_link
+entity_type: paragraph
+type: link
+settings: {  }
+module: link
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/social_features/social_landing_page/config/features_removal/field.storage.paragraph.field_block_reference.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/field.storage.paragraph.field_block_reference.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - block_field
+    - paragraphs
+id: paragraph.field_block_reference
+field_name: field_block_reference
+entity_type: paragraph
+type: block_field
+settings: {  }
+module: block_field
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/social_features/social_landing_page/config/features_removal/field.storage.paragraph.field_block_reference_secondary.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/field.storage.paragraph.field_block_reference_secondary.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - block_field
+    - paragraphs
+id: paragraph.field_block_reference_secondary
+field_name: field_block_reference_secondary
+entity_type: paragraph
+type: block_field
+settings: {  }
+module: block_field
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/social_features/social_landing_page/config/features_removal/field.storage.paragraph.field_block_title.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/field.storage.paragraph.field_block_title.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+id: paragraph.field_block_title
+field_name: field_block_title
+entity_type: paragraph
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/social_features/social_landing_page/config/features_removal/field.storage.paragraph.field_button_link_an.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/field.storage.paragraph.field_button_link_an.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - link
+    - paragraphs
+id: paragraph.field_button_link_an
+field_name: field_button_link_an
+entity_type: paragraph
+type: link
+settings: {  }
+module: link
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/social_features/social_landing_page/config/features_removal/field.storage.paragraph.field_button_link_lu.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/field.storage.paragraph.field_button_link_lu.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - link
+    - paragraphs
+id: paragraph.field_button_link_lu
+field_name: field_button_link_lu
+entity_type: paragraph
+type: link
+settings: {  }
+module: link
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/social_features/social_landing_page/config/features_removal/field.storage.paragraph.field_button_style.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/field.storage.paragraph.field_button_style.yml
@@ -1,0 +1,32 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - options
+    - paragraphs
+id: paragraph.field_button_style
+field_name: field_button_style
+entity_type: paragraph
+type: list_string
+settings:
+  allowed_values:
+    -
+      value: btn-default
+      label: 'Default style'
+    -
+      value: btn-primary
+      label: 'Primary style'
+    -
+      value: btn-accent
+      label: 'Accent style'
+    -
+      value: btn-flat
+      label: 'Flat style'
+  allowed_values_function: ''
+module: options
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/social_features/social_landing_page/config/features_removal/field.storage.paragraph.field_featured_description.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/field.storage.paragraph.field_featured_description.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+    - text
+id: paragraph.field_featured_description
+field_name: field_featured_description
+entity_type: paragraph
+type: text_long
+settings: {  }
+module: text
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/social_features/social_landing_page/config/features_removal/field.storage.paragraph.field_featured_item_description.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/field.storage.paragraph.field_featured_item_description.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+    - text
+id: paragraph.field_featured_item_description
+field_name: field_featured_item_description
+entity_type: paragraph
+type: text_long
+settings: {  }
+module: text
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/social_features/social_landing_page/config/features_removal/field.storage.paragraph.field_featured_item_image.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/field.storage.paragraph.field_featured_item_image.yml
@@ -1,0 +1,29 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - file
+    - image
+    - paragraphs
+id: paragraph.field_featured_item_image
+field_name: field_featured_item_image
+entity_type: paragraph
+type: image
+settings:
+  uri_scheme: private
+  default_image:
+    uuid: ''
+    alt: ''
+    title: ''
+    width: null
+    height: null
+  target_type: file
+  display_field: false
+  display_default: false
+module: image
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/social_features/social_landing_page/config/features_removal/field.storage.paragraph.field_featured_item_link.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/field.storage.paragraph.field_featured_item_link.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - link
+    - paragraphs
+id: paragraph.field_featured_item_link
+field_name: field_featured_item_link
+entity_type: paragraph
+type: link
+settings: {  }
+module: link
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/social_features/social_landing_page/config/features_removal/field.storage.paragraph.field_featured_item_title.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/field.storage.paragraph.field_featured_item_title.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+id: paragraph.field_featured_item_title
+field_name: field_featured_item_title
+entity_type: paragraph
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/social_features/social_landing_page/config/features_removal/field.storage.paragraph.field_featured_items.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/field.storage.paragraph.field_featured_items.yml
@@ -1,0 +1,26 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - dynamic_entity_reference
+    - group
+    - node
+    - paragraphs
+    - profile
+id: paragraph.field_featured_items
+field_name: field_featured_items
+entity_type: paragraph
+type: dynamic_entity_reference
+settings:
+  exclude_entity_types: false
+  entity_type_ids:
+    node: node
+    group: group
+    profile: profile
+module: dynamic_entity_reference
+locked: false
+cardinality: 3
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/social_features/social_landing_page/config/features_removal/field.storage.paragraph.field_featured_items_description.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/field.storage.paragraph.field_featured_items_description.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+    - text
+id: paragraph.field_featured_items_description
+field_name: field_featured_items_description
+entity_type: paragraph
+type: text_long
+settings: {  }
+module: text
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/social_features/social_landing_page/config/features_removal/field.storage.paragraph.field_featured_items_items.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/field.storage.paragraph.field_featured_items_items.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - entity_reference_revisions
+    - paragraphs
+id: paragraph.field_featured_items_items
+field_name: field_featured_items_items
+entity_type: paragraph
+type: entity_reference_revisions
+settings:
+  target_type: paragraph
+module: entity_reference_revisions
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/social_features/social_landing_page/config/features_removal/field.storage.paragraph.field_featured_items_title.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/field.storage.paragraph.field_featured_items_title.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+id: paragraph.field_featured_items_title
+field_name: field_featured_items_title
+entity_type: paragraph
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/social_features/social_landing_page/config/features_removal/field.storage.paragraph.field_featured_link.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/field.storage.paragraph.field_featured_link.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - link
+    - paragraphs
+id: paragraph.field_featured_link
+field_name: field_featured_link
+entity_type: paragraph
+type: link
+settings: {  }
+module: link
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/social_features/social_landing_page/config/features_removal/field.storage.paragraph.field_featured_title.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/field.storage.paragraph.field_featured_title.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+id: paragraph.field_featured_title
+field_name: field_featured_title
+entity_type: paragraph
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/social_features/social_landing_page/config/features_removal/field.storage.paragraph.field_hero_buttons.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/field.storage.paragraph.field_hero_buttons.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - entity_reference_revisions
+    - paragraphs
+id: paragraph.field_hero_buttons
+field_name: field_hero_buttons
+entity_type: paragraph
+type: entity_reference_revisions
+settings:
+  target_type: paragraph
+module: entity_reference_revisions
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/social_features/social_landing_page/config/features_removal/field.storage.paragraph.field_hero_image.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/field.storage.paragraph.field_hero_image.yml
@@ -1,0 +1,29 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - file
+    - image
+    - paragraphs
+id: paragraph.field_hero_image
+field_name: field_hero_image
+entity_type: paragraph
+type: image
+settings:
+  uri_scheme: public
+  default_image:
+    uuid: ''
+    alt: ''
+    title: ''
+    width: null
+    height: null
+  target_type: file
+  display_field: false
+  display_default: false
+module: image
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/social_features/social_landing_page/config/features_removal/field.storage.paragraph.field_hero_small_buttons.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/field.storage.paragraph.field_hero_small_buttons.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - entity_reference_revisions
+    - paragraphs
+id: paragraph.field_hero_small_buttons
+field_name: field_hero_small_buttons
+entity_type: paragraph
+type: entity_reference_revisions
+settings:
+  target_type: paragraph
+module: entity_reference_revisions
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/social_features/social_landing_page/config/features_removal/field.storage.paragraph.field_hero_small_image.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/field.storage.paragraph.field_hero_small_image.yml
@@ -1,0 +1,29 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - file
+    - image
+    - paragraphs
+id: paragraph.field_hero_small_image
+field_name: field_hero_small_image
+entity_type: paragraph
+type: image
+settings:
+  uri_scheme: public
+  default_image:
+    uuid: ''
+    alt: ''
+    title: ''
+    width: null
+    height: null
+  target_type: file
+  display_field: false
+  display_default: false
+module: image
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/social_features/social_landing_page/config/features_removal/field.storage.paragraph.field_hero_small_subtitle.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/field.storage.paragraph.field_hero_small_subtitle.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+id: paragraph.field_hero_small_subtitle
+field_name: field_hero_small_subtitle
+entity_type: paragraph
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/social_features/social_landing_page/config/features_removal/field.storage.paragraph.field_hero_small_title.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/field.storage.paragraph.field_hero_small_title.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+id: paragraph.field_hero_small_title
+field_name: field_hero_small_title
+entity_type: paragraph
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/social_features/social_landing_page/config/features_removal/field.storage.paragraph.field_hero_subtitle.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/field.storage.paragraph.field_hero_subtitle.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+id: paragraph.field_hero_subtitle
+field_name: field_hero_subtitle
+entity_type: paragraph
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/social_features/social_landing_page/config/features_removal/field.storage.paragraph.field_hero_title.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/field.storage.paragraph.field_hero_title.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+id: paragraph.field_hero_title
+field_name: field_hero_title
+entity_type: paragraph
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/social_features/social_landing_page/config/features_removal/field.storage.paragraph.field_introduction_link_an.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/field.storage.paragraph.field_introduction_link_an.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - link
+    - paragraphs
+id: paragraph.field_introduction_link_an
+field_name: field_introduction_link_an
+entity_type: paragraph
+type: link
+settings: {  }
+module: link
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/social_features/social_landing_page/config/features_removal/field.storage.paragraph.field_introduction_link_lu.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/field.storage.paragraph.field_introduction_link_lu.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - link
+    - paragraphs
+id: paragraph.field_introduction_link_lu
+field_name: field_introduction_link_lu
+entity_type: paragraph
+type: link
+settings: {  }
+module: link
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/social_features/social_landing_page/config/features_removal/field.storage.paragraph.field_introduction_text.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/field.storage.paragraph.field_introduction_text.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+    - text
+id: paragraph.field_introduction_text
+field_name: field_introduction_text
+entity_type: paragraph
+type: text_long
+settings: {  }
+module: text
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/social_features/social_landing_page/config/features_removal/field.storage.paragraph.field_introduction_title.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/field.storage.paragraph.field_introduction_title.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+id: paragraph.field_introduction_title
+field_name: field_introduction_title
+entity_type: paragraph
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/social_features/social_landing_page/config/features_removal/field.storage.paragraph.field_section_paragraph.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/field.storage.paragraph.field_section_paragraph.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - entity_reference_revisions
+    - paragraphs
+id: paragraph.field_section_paragraph
+field_name: field_section_paragraph
+entity_type: paragraph
+type: entity_reference_revisions
+settings:
+  target_type: paragraph
+module: entity_reference_revisions
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/social_features/social_landing_page/config/features_removal/image.style.social_featured.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/image.style.social_featured.yml
@@ -1,0 +1,31 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - crop.type.hero
+  module:
+    - crop
+    - image_effects
+name: social_featured
+label: 'social featured (600×200)'
+effects:
+  c128d01a-9b44-49fa-bf2c-ca93b46741ce:
+    uuid: c128d01a-9b44-49fa-bf2c-ca93b46741ce
+    id: crop_crop
+    weight: 1
+    data:
+      crop_type: hero
+  cf5ba283-0961-46c1-b885-2fcae0bc43a0:
+    uuid: cf5ba283-0961-46c1-b885-2fcae0bc43a0
+    id: image_scale_and_crop
+    weight: 2
+    data:
+      width: 600
+      height: 200
+      anchor: center-center
+  cd38284a-a147-4ce4-8033-2cbd4160b745:
+    uuid: cd38284a-a147-4ce4-8033-2cbd4160b745
+    id: image_effects_auto_orient
+    weight: 3
+    data:
+      scan_exif: true

--- a/modules/social_features/social_landing_page/config/features_removal/image.style.social_landing_hero.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/image.style.social_landing_hero.yml
@@ -1,0 +1,31 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - crop.type.hero_landing
+  module:
+    - crop
+    - image_effects
+name: social_landing_hero
+label: 'social landing hero (1500×370)'
+effects:
+  d9ddbeef-d61b-466e-b856-f549dd551390:
+    uuid: d9ddbeef-d61b-466e-b856-f549dd551390
+    id: crop_crop
+    weight: -9
+    data:
+      crop_type: hero_landing
+  24fa75ed-0989-425f-ba23-26693a7d2ea5:
+    uuid: 24fa75ed-0989-425f-ba23-26693a7d2ea5
+    id: image_effects_auto_orient
+    weight: -10
+    data:
+      scan_exif: true
+  758d4ae8-0fe7-4751-b0e1-ac3209451371:
+    uuid: 758d4ae8-0fe7-4751-b0e1-ac3209451371
+    id: image_scale_and_crop
+    weight: -8
+    data:
+      width: 1500
+      height: 370
+      anchor: center-center

--- a/modules/social_features/social_landing_page/config/features_removal/image.style.social_landing_hero_small.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/image.style.social_landing_hero_small.yml
@@ -1,0 +1,31 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - crop.type.hero_small_landing
+  module:
+    - crop
+    - image_effects
+name: social_landing_hero_small
+label: 'social landing hero_small (1500×185)'
+effects:
+  3a056b0c-351f-11e9-b210-d663bd873d93:
+    uuid: 3a056b0c-351f-11e9-b210-d663bd873d93
+    id: crop_crop
+    weight: -9
+    data:
+      crop_type: hero_small_landing
+  3a056dbe-351f-11e9-b210-d663bd873d93:
+    uuid: 3a056dbe-351f-11e9-b210-d663bd873d93
+    id: image_effects_auto_orient
+    weight: -10
+    data:
+      scan_exif: true
+  3a056f58-351f-11e9-b210-d663bd873d93:
+    uuid: 3a056f58-351f-11e9-b210-d663bd873d93
+    id: image_scale_and_crop
+    weight: -8
+    data:
+      width: 1500
+      height: 185
+      anchor: center-center

--- a/modules/social_features/social_landing_page/config/features_removal/node.type.landing_page.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/node.type.landing_page.yml
@@ -1,0 +1,16 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - menu_ui
+third_party_settings:
+  menu_ui:
+    available_menus: {  }
+    parent: ''
+name: 'Landing page'
+type: landing_page
+description: 'Use landing pages for your dynamic content, such as a home page.'
+help: ''
+new_revision: false
+preview_mode: 1
+display_submitted: false

--- a/modules/social_features/social_landing_page/config/features_removal/paragraphs.paragraphs_type.accordion.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/paragraphs.paragraphs_type.accordion.yml
@@ -1,0 +1,8 @@
+langcode: en
+status: true
+dependencies: {  }
+id: accordion
+label: Accordion
+icon_uuid: null
+description: ''
+behavior_plugins: {  }

--- a/modules/social_features/social_landing_page/config/features_removal/paragraphs.paragraphs_type.accordion_item.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/paragraphs.paragraphs_type.accordion_item.yml
@@ -1,0 +1,8 @@
+langcode: en
+status: true
+dependencies: {  }
+id: accordion_item
+label: 'Accordion item'
+icon_uuid: null
+description: ''
+behavior_plugins: {  }

--- a/modules/social_features/social_landing_page/config/features_removal/paragraphs.paragraphs_type.block.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/paragraphs.paragraphs_type.block.yml
@@ -1,0 +1,8 @@
+langcode: en
+status: true
+dependencies: {  }
+id: block
+label: Block
+icon_uuid: null
+description: 'Reference some block'
+behavior_plugins: {  }

--- a/modules/social_features/social_landing_page/config/features_removal/paragraphs.paragraphs_type.button.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/paragraphs.paragraphs_type.button.yml
@@ -1,0 +1,8 @@
+langcode: en
+status: true
+dependencies: {  }
+id: button
+label: Button
+icon_uuid: null
+description: 'Contain one link field for Logged in user and one for Anonymous, button style can be selected.'
+behavior_plugins: {  }

--- a/modules/social_features/social_landing_page/config/features_removal/paragraphs.paragraphs_type.featured.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/paragraphs.paragraphs_type.featured.yml
@@ -1,0 +1,8 @@
+langcode: en
+status: true
+dependencies: {  }
+id: featured
+label: 'Featured Content'
+icon_uuid: 1bb5de6e-f2f3-4ef3-a547-62bb971fdf37
+description: 'Create featured items block, editor will be able to provide title, items to show and a link like see all.'
+behavior_plugins: {  }

--- a/modules/social_features/social_landing_page/config/features_removal/paragraphs.paragraphs_type.featured_item.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/paragraphs.paragraphs_type.featured_item.yml
@@ -1,0 +1,8 @@
+langcode: en
+status: true
+dependencies: {  }
+id: featured_item
+label: 'Featured Item'
+icon_uuid: null
+description: ''
+behavior_plugins: {  }

--- a/modules/social_features/social_landing_page/config/features_removal/paragraphs.paragraphs_type.featured_items.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/paragraphs.paragraphs_type.featured_items.yml
@@ -1,0 +1,8 @@
+langcode: en
+status: true
+dependencies: {  }
+id: featured_items
+label: 'Featured Items'
+icon_uuid: null
+description: ''
+behavior_plugins: {  }

--- a/modules/social_features/social_landing_page/config/features_removal/paragraphs.paragraphs_type.hero.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/paragraphs.paragraphs_type.hero.yml
@@ -1,0 +1,8 @@
+langcode: en
+status: true
+dependencies: {  }
+id: hero
+label: Hero
+icon_uuid: null
+description: 'A section with a background image and buttons (optional). Looks good on top of each page. Also nice as a seperator.'
+behavior_plugins: {  }

--- a/modules/social_features/social_landing_page/config/features_removal/paragraphs.paragraphs_type.hero_small.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/paragraphs.paragraphs_type.hero_small.yml
@@ -1,0 +1,8 @@
+langcode: en
+status: true
+dependencies: {  }
+id: hero_small
+label: Hero small
+icon_uuid: null
+description: 'A section similiar to the Hero, but a bit smaller, so it takes up less room in the view port'
+behavior_plugins: {  }

--- a/modules/social_features/social_landing_page/config/features_removal/paragraphs.paragraphs_type.introduction.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/paragraphs.paragraphs_type.introduction.yml
@@ -1,0 +1,8 @@
+langcode: en
+status: true
+dependencies: {  }
+id: introduction
+label: Introduction
+icon_uuid: null
+description: 'Provide textual block with some link.'
+behavior_plugins: {  }

--- a/modules/social_features/social_landing_page/config/features_removal/paragraphs.paragraphs_type.section.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/paragraphs.paragraphs_type.section.yml
@@ -1,0 +1,8 @@
+langcode: en
+status: true
+dependencies: {  }
+id: section
+label: Section
+icon_uuid: accf3442-783f-4fd9-803c-0a2a0f1d0f10
+description: 'A block section where can be selected a block or a paragraph'
+behavior_plugins: {  }

--- a/modules/social_features/social_landing_page/config/features_removal/views.view.community_activities.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/views.view.community_activities.yml
@@ -1,0 +1,287 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - activity_creator
+    - activity_viewer
+    - options
+    - social_post
+id: community_activities
+label: 'Community activities'
+module: views
+description: ''
+tag: social_landing_page
+base_table: activity_field_data
+base_field: id
+core: 8.x
+display:
+  default:
+    display_plugin: default
+    id: default
+    display_title: Master
+    position: 0
+    display_options:
+      access:
+        type: none
+        options: {  }
+      cache:
+        type: tag
+        options: {  }
+      query:
+        type: views_query
+        options:
+          disable_sql_rewrite: false
+          distinct: true
+          replica: false
+          query_comment: ''
+          query_tags: {  }
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      pager:
+        type: mini
+        options:
+          items_per_page: 5
+          offset: 0
+          id: 0
+          total_pages: null
+          tags:
+            previous: ‹‹
+            next: ››
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+      style:
+        type: default
+      row:
+        type: 'entity:activity'
+        options:
+          relationship: none
+          view_mode: default
+      fields:
+        rendered_entity:
+          table: activity
+          field: rendered_entity
+          id: rendered_entity
+          entity_type: null
+          entity_field: null
+          plugin_id: rendered_entity
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          view_mode: default
+      filters:
+        field_activity_destinations_value:
+          id: field_activity_destinations_value
+          table: activity__field_activity_destinations
+          field: field_activity_destinations_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: or
+          value:
+            stream_home: stream_home
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          plugin_id: list_field
+        activity_post_visibility_access_filter:
+          id: activity_post_visibility_access_filter
+          table: activity
+          field: activity_post_visibility_access_filter
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: '='
+          value: ''
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: activity
+          plugin_id: activity_post_visibility_access
+      sorts:
+        created:
+          id: created
+          table: activity_field_data
+          field: created
+          relationship: none
+          group_type: group
+          admin_label: ''
+          order: DESC
+          exposed: false
+          expose:
+            label: ''
+          granularity: second
+          entity_type: activity
+          entity_field: created
+          plugin_id: date
+      title: 'Community activities'
+      header: {  }
+      defaults:
+        header: false
+      footer: {  }
+      empty: {  }
+      relationships: {  }
+      arguments: {  }
+      display_extenders: {  }
+      css_class: 'stream-landing stream'
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+    cache_metadata:
+      max-age: -1
+      contexts:
+      - 'languages:language_interface'
+      - url.query_args
+      tags:
+      - 'config:core.entity_view_display.activity.activity.default'
+      - 'config:core.entity_view_display.activity.activity.notification'
+      - 'config:core.entity_view_display.activity.activity.notification_archive'
+  block_stream_landing:
+    display_plugin: block
+    id: block_stream_landing
+    display_title: 'Community activities block'
+    position: 3
+    display_options:
+      display_extenders: {  }
+      display_description: ''
+    cache_metadata:
+      max-age: -1
+      contexts:
+      - 'languages:language_interface'
+      - url.query_args
+      tags:
+        - 'config:core.entity_view_display.activity.activity.default'
+        - 'config:core.entity_view_display.activity.activity.notification'
+        - 'config:core.entity_view_display.activity.activity.notification_archive'
+  block_stream_landing_with_post:
+    display_plugin: block
+    id: block_stream_landing_with_post
+    display_title: 'Community activities block'
+    position: 3
+    display_options:
+      display_extenders: {  }
+      display_description: ''
+      header:
+        post_form:
+          id: post_form
+          table: views
+          field: post_form
+          relationship: none
+          group_type: group
+          admin_label: ''
+          empty: true
+          block_id: post_block
+          plugin_id: social_post_post_form
+      defaults:
+        header: false
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_interface'
+      tags:
+        - 'config:core.entity_view_display.activity.activity.default'
+        - 'config:core.entity_view_display.activity.activity.notification'
+        - 'config:core.entity_view_display.activity.activity.notification_archive'

--- a/modules/social_features/social_landing_page/config/features_removal/views.view.featured_content_reference.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/views.view.featured_content_reference.yml
@@ -1,0 +1,242 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - user
+id: featured_content_reference
+label: 'Featured content reference'
+module: views
+description: 'Custom selection handler for content that will be selected as featured.'
+tag: ''
+base_table: node_field_data
+base_field: nid
+core: 8.x
+display:
+  default:
+    display_plugin: default
+    id: default
+    display_title: Master
+    position: 0
+    display_options:
+      access:
+        type: perm
+        options:
+          perm: 'access content'
+      cache:
+        type: tag
+        options: {  }
+      query:
+        type: views_query
+        options:
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_comment: ''
+          query_tags: {  }
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      pager:
+        type: mini
+        options:
+          items_per_page: 10
+          offset: 0
+          id: 0
+          total_pages: null
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          tags:
+            previous: ‹‹
+            next: ››
+      style:
+        type: default
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          uses_fields: false
+      row:
+        type: fields
+        options:
+          inline: {  }
+          separator: ''
+          hide_empty: false
+          default_field_elements: true
+      fields:
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: false
+            ellipsis: false
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: node
+          entity_field: title
+          plugin_id: field
+      filters:
+        status:
+          value: '1'
+          table: node_field_data
+          field: status
+          plugin_id: boolean
+          entity_type: node
+          entity_field: status
+          id: status
+          expose:
+            operator: ''
+          group: 1
+        nid:
+          id: nid
+          table: node_access
+          field: nid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: '='
+          value: ''
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          plugin_id: node_access
+      sorts:
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          order: ASC
+          entity_type: node
+          entity_field: title
+          plugin_id: standard
+          relationship: none
+          group_type: group
+          admin_label: ''
+          exposed: false
+          expose:
+            label: ''
+      header: {  }
+      footer: {  }
+      empty: {  }
+      relationships: {  }
+      arguments: {  }
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url.query_args
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }
+  entity_reference_1:
+    display_plugin: entity_reference
+    id: entity_reference_1
+    display_title: 'Entity Reference'
+    position: 1
+    display_options:
+      display_extenders: {  }
+      style:
+        type: entity_reference
+        options:
+          search_fields:
+            title: title
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }

--- a/modules/social_features/social_landing_page/config/features_removal/views.view.featured_group_reference.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/views.view.featured_group_reference.yml
@@ -1,0 +1,192 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - group
+id: featured_group_reference
+label: 'Featured group reference'
+module: views
+description: 'Custom selection handler for group that will be selected as featured.'
+tag: ''
+base_table: groups_field_data
+base_field: id
+core: 8.x
+display:
+  default:
+    display_plugin: default
+    id: default
+    display_title: Master
+    position: 0
+    display_options:
+      access:
+        type: none
+        options: {  }
+      cache:
+        type: tag
+        options: {  }
+      query:
+        type: views_query
+        options:
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_comment: ''
+          query_tags: {  }
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      pager:
+        type: mini
+        options:
+          items_per_page: 10
+          offset: 0
+          id: 0
+          total_pages: null
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          tags:
+            previous: ‹‹
+            next: ››
+      style:
+        type: default
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          uses_fields: false
+      row:
+        type: fields
+        options:
+          inline: {  }
+          separator: ''
+          hide_empty: false
+          default_field_elements: true
+      fields:
+        label:
+          id: label
+          table: groups_field_data
+          field: label
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: null
+          entity_field: label
+          plugin_id: field
+      filters: {  }
+      sorts:
+        label:
+          id: label
+          table: groups_field_data
+          field: label
+          relationship: none
+          group_type: group
+          admin_label: ''
+          order: ASC
+          exposed: false
+          expose:
+            label: ''
+          entity_type: group
+          entity_field: label
+          plugin_id: standard
+      header: {  }
+      footer: {  }
+      empty: {  }
+      relationships: {  }
+      arguments: {  }
+      display_extenders: {  }
+      filter_groups:
+        operator: AND
+        groups: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url.query_args
+      tags: {  }
+  entity_reference_1:
+    display_plugin: entity_reference
+    id: entity_reference_1
+    display_title: 'Entity Reference'
+    position: 1
+    display_options:
+      display_extenders: {  }
+      style:
+        type: entity_reference
+        options:
+          search_fields:
+            label: label
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+      tags: {  }

--- a/modules/social_features/social_landing_page/config/features_removal/views.view.featured_profile_reference.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/views.view.featured_profile_reference.yml
@@ -1,0 +1,346 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.profile.field_profile_first_name
+    - field.storage.profile.field_profile_last_name
+    - profile.type.profile
+  module:
+    - profile
+    - user
+id: featured_profile_reference
+label: 'Featured profile reference'
+module: views
+description: ''
+tag: ''
+base_table: profile
+base_field: profile_id
+core: 8.x
+display:
+  default:
+    display_plugin: default
+    id: default
+    display_title: Master
+    position: 0
+    display_options:
+      access:
+        type: none
+        options: {  }
+      cache:
+        type: tag
+        options: {  }
+      query:
+        type: views_query
+        options:
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_comment: ''
+          query_tags: {  }
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      pager:
+        type: mini
+        options:
+          items_per_page: 10
+          offset: 0
+          id: 0
+          total_pages: null
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          tags:
+            previous: ‹‹
+            next: ››
+      style:
+        type: default
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          uses_fields: false
+      row:
+        type: fields
+        options:
+          inline: {  }
+          separator: ''
+          hide_empty: false
+          default_field_elements: true
+      fields:
+        name:
+          id: name
+          table: users_field_data
+          field: name
+          relationship: uid
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: user_name
+          settings:
+            link_to_entity: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: user
+          entity_field: name
+          plugin_id: field
+        field_profile_first_name:
+          id: field_profile_first_name
+          table: profile__field_profile_first_name
+          field: field_profile_first_name
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+        field_profile_last_name:
+          id: field_profile_last_name
+          table: profile__field_profile_last_name
+          field: field_profile_last_name
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+      filters:
+        type:
+          id: type
+          table: profile
+          field: type
+          value:
+            profile: profile
+          entity_type: profile
+          entity_field: type
+          plugin_id: bundle
+      sorts: {  }
+      header: {  }
+      footer: {  }
+      empty: {  }
+      relationships:
+        uid:
+          id: uid
+          table: profile
+          field: uid
+          relationship: none
+          group_type: group
+          admin_label: User
+          required: true
+          entity_type: profile
+          entity_field: uid
+          plugin_id: standard
+      arguments: {  }
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url.query_args
+      tags:
+        - 'config:field.storage.profile.field_profile_first_name'
+        - 'config:field.storage.profile.field_profile_last_name'
+  entity_reference_1:
+    display_plugin: entity_reference
+    id: entity_reference_1
+    display_title: 'Entity Reference'
+    position: 1
+    display_options:
+      display_extenders: {  }
+      style:
+        type: entity_reference
+        options:
+          search_fields:
+            name: name
+            field_profile_first_name: field_profile_first_name
+            field_profile_last_name: field_profile_last_name
+      row:
+        type: entity_reference
+        options:
+          default_field_elements: true
+          inline:
+            name: name
+            field_profile_first_name: field_profile_first_name
+            field_profile_last_name: field_profile_last_name
+          separator: '  - '
+          hide_empty: false
+      pager:
+        type: none
+        options:
+          offset: 0
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+      tags:
+        - 'config:field.storage.profile.field_profile_first_name'
+        - 'config:field.storage.profile.field_profile_last_name'

--- a/modules/social_features/social_landing_page/social_landing_page.features.yml
+++ b/modules/social_features/social_landing_page/social_landing_page.features.yml
@@ -1,2 +1,0 @@
-bundle: social
-required: true


### PR DESCRIPTION
Removes the features file and adds default configuration as settings
file in the config/install folder.

## Problem
See problem definition in #3092272: [Meta] Moving away from features. The fact that this configuration is in a feature means that login help text gets overwritten.

## Solution
Remove the social_landing_page.features.yml file
Move the default editable config from hook_install() into a config/install/*.yml file.
Remove any _module_set_defaults function

## Issue tracker
https://www.drupal.org/project/social/issues/3095540
https://getopensocial.atlassian.net/browse/TB-3457

## How to test
- [ ] Enable the module
- [ ] Change settings
- [ ] Revert features

## Release notes
The social_landing_page module is no longer managed by features.
