### PR TITLE
Issue #3096602 by agami4: Update position of css style for menu on the mobile

### DIFF
--- a/themes/socialbase/assets/css/admin-toolbar.css
+++ b/themes/socialbase/assets/css/admin-toolbar.css
@@ -10,9 +10,14 @@
   transform: translateY(39px) translateX(0);
 }
 
+.toolbar-vertical .navbar-default,
 .toolbar-fixed .navbar-default {
   position: relative;
-  z-index: 100;
+}
+
+.toolbar-vertical .toolbar .toolbar-bar,
+.toolbar-fixed .toolbar .toolbar-bar {
+  z-index: 1080;
 }
 
 .toolbar-fixed .main-container,
@@ -26,12 +31,5 @@
   }
   .toolbar-vertical .off-canvas-right.is-open {
     transform: none;
-  }
-}
-
-@media (max-width: 599px) {
-  .toolbar-vertical .navbar-default {
-    position: relative;
-    z-index: 1;
   }
 }

--- a/themes/socialbase/components/00-config/_variables.scss
+++ b/themes/socialbase/components/00-config/_variables.scss
@@ -7,6 +7,7 @@ $zindex-modal-background:  1040;
 $zindex-modal:             1050;
 $zindex-tour-backdrop:     1060;
 $zindex-tour:              1070;
+$zindex-admin-menu:        1080;
 
 @import 'variables/colors';
 @import 'variables/components';

--- a/themes/socialbase/components/04-organisms/admin-toolbar/admin-toolbar.scss
+++ b/themes/socialbase/components/04-organisms/admin-toolbar/admin-toolbar.scss
@@ -22,19 +22,22 @@
 
 }
 
-// make sure we can see both menu's
-.toolbar-fixed .navbar-default {
-  position: relative;
-  z-index: 100;
+.toolbar-vertical,
+.toolbar-fixed {
+  // The vertical or fixed toolbar is already fixed so the navbar needs to be
+  // made to just sit on the page.
+  .navbar-default {
+    position: relative;
+  }
+
+  // The admin toolbar needs to have a higher z-index than the normal menu.
+  // Lowering the z-index of the normal menu causes other issues.
+  .toolbar .toolbar-bar {
+    z-index: $zindex-admin-menu;
+  }
 }
+
 .toolbar-fixed .main-container,
 .toolbar-vertical .main-container {
   padding-top: 0;
-}
-
-@include for-phone-only {
-  .toolbar-vertical .navbar-default {
-    position: relative;
-    z-index: 1;
-  }
 }

--- a/themes/socialbase/templates/block/block--system-branding-block.html.twig
+++ b/themes/socialbase/templates/block/block--system-branding-block.html.twig
@@ -30,14 +30,6 @@
     </a>
   {% endif %}
 
-  <button href="#" data-toggle="collapse" data-target="#main-navigation" type="button" aria-expanded="false" class="navbar-toggle collapsed">
-    <span>{% trans %} Menu {% endtrans %}</span>
-    <span class="sr-only">
-      {% trans %} Toggle navigation {% endtrans %}
-    </span>
-
-  </button>
-
 </div>
 
 

--- a/themes/socialbase/templates/block/block--system-menu-block--main.html.twig
+++ b/themes/socialbase/templates/block/block--system-menu-block--main.html.twig
@@ -34,6 +34,13 @@
  */
 #}
 
+<button href="#" data-toggle="collapse" data-target="#main-navigation" type="button" aria-expanded="false" class="navbar-toggle collapsed">
+  <span>{% trans %} Menu {% endtrans %}</span>
+  <span class="sr-only">
+    {% trans %} Toggle navigation {% endtrans %}
+  </span>
+</button>
+
 <div id="main-navigation" class="collapse navbar-collapse">
   <div class="navbar-search">{{ content.links.search_block }}</div>
   {% block content %}
@@ -50,4 +57,3 @@
     </div>
   {% endif %}
 </div>
-


### PR DESCRIPTION
## Problem
When the admin toolbar is visible the z-index of the main menu is changed. This is done to ensure the admin toolbar is shown on top of the main menu. However, this also causes the main menu to appear under certain page elements.

This happens in all browsers

## Solution
Don't try to change the z-index of the main menu when the admin bar is present, but instead properly update the admin toolbar's z-index.

## Issue tracker
https://www.drupal.org/project/social/issues/3096602
https://getopensocial.atlassian.net/browse/YANG-1776

Also affected https://www.drupal.org/node/3106782 where a slightly different fix was previously applied.

## How to test
- [ ] Login as user with access to the admin toolbar
- [ ] Open the menu on a mobile device
- [ ] See that the menu is under certain elements on the page.

## Release notes
The main menu no longer appear under page content on mobile devices when a user has access to the administrative menus.

## Screenshots
![afbeelding](https://user-images.githubusercontent.com/327697/78050624-cc5ce380-737c-11ea-8e60-0ad989cbf6d6.png)

![afbeelding](https://user-images.githubusercontent.com/327697/78050643-d252c480-737c-11ea-8a90-ecffd825b813.png)


