### PR TITLE
Replace features with config management for Social Comment

### DIFF
--- a/modules/social_features/social_comment/config/features_removal/comment.type.comment.yml
+++ b/modules/social_features/social_comment/config/features_removal/comment.type.comment.yml
@@ -1,0 +1,7 @@
+langcode: en
+status: true
+dependencies: {  }
+id: comment
+label: Comment
+target_entity_type_id: node
+description: 'Default comment type.'

--- a/modules/social_features/social_comment/config/features_removal/core.entity_form_display.comment.comment.default.yml
+++ b/modules/social_features/social_comment/config/features_removal/core.entity_form_display.comment.comment.default.yml
@@ -1,0 +1,26 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - comment.type.comment
+    - field.field.comment.comment.field_comment_body
+id: comment.comment.default
+targetEntityType: comment
+bundle: comment
+mode: default
+content:
+  field_comment_body:
+    weight: 0
+    settings:
+      rows: 5
+      placeholder: 'Add a comment'
+    third_party_settings: {  }
+    type: string_textarea
+    region: content
+  author:
+    weight: 1
+    settings: {  }
+    third_party_settings: {  }
+    region: content
+hidden:
+  subject: true

--- a/modules/social_features/social_comment/config/features_removal/core.entity_view_display.comment.comment.activity.yml
+++ b/modules/social_features/social_comment/config/features_removal/core.entity_view_display.comment.comment.activity.yml
@@ -1,0 +1,33 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - comment.type.comment
+    - core.entity_view_mode.comment.activity
+    - field.field.comment.comment.field_comment_body
+  module:
+    - text
+id: comment.comment.activity
+targetEntityType: comment
+bundle: comment
+mode: activity
+content:
+  field_comment_body:
+    weight: 0
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    type: text_default
+    region: content
+  like_and_dislike:
+    weight: 2
+    settings: {  }
+    third_party_settings: {  }
+    region: content
+  links:
+    weight: 1
+    settings: {  }
+    third_party_settings: {  }
+    region: content
+hidden:
+  search_api_excerpt: true

--- a/modules/social_features/social_comment/config/features_removal/core.entity_view_display.comment.comment.activity_comment.yml
+++ b/modules/social_features/social_comment/config/features_removal/core.entity_view_display.comment.comment.activity_comment.yml
@@ -1,0 +1,29 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - comment.type.comment
+    - core.entity_view_mode.comment.activity_comment
+    - field.field.comment.comment.field_comment_body
+  module:
+    - text
+id: comment.comment.activity_comment
+targetEntityType: comment
+bundle: comment
+mode: activity_comment
+content:
+  field_comment_body:
+    weight: 0
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    type: text_default
+    region: content
+  links:
+    weight: 1
+    settings: {  }
+    third_party_settings: {  }
+    region: content
+hidden:
+  like_and_dislike: true
+  search_api_excerpt: true

--- a/modules/social_features/social_comment/config/features_removal/core.entity_view_display.comment.comment.default.yml
+++ b/modules/social_features/social_comment/config/features_removal/core.entity_view_display.comment.comment.default.yml
@@ -1,0 +1,32 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - comment.type.comment
+    - field.field.comment.comment.field_comment_body
+  module:
+    - text
+id: comment.comment.default
+targetEntityType: comment
+bundle: comment
+mode: default
+content:
+  field_comment_body:
+    weight: 0
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    type: text_default
+    region: content
+  like_and_dislike:
+    weight: 3
+    settings: {  }
+    third_party_settings: {  }
+    region: content
+  links:
+    weight: 2
+    settings: {  }
+    third_party_settings: {  }
+    region: content
+hidden:
+  search_api_excerpt: true

--- a/modules/social_features/social_comment/config/features_removal/core.entity_view_mode.comment.activity.yml
+++ b/modules/social_features/social_comment/config/features_removal/core.entity_view_mode.comment.activity.yml
@@ -1,0 +1,9 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - comment
+id: comment.activity
+label: Activity
+targetEntityType: comment
+cache: true

--- a/modules/social_features/social_comment/config/features_removal/core.entity_view_mode.comment.activity_comment.yml
+++ b/modules/social_features/social_comment/config/features_removal/core.entity_view_mode.comment.activity_comment.yml
@@ -1,0 +1,9 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - comment
+id: comment.activity_comment
+label: 'Activity comment'
+targetEntityType: comment
+cache: true

--- a/modules/social_features/social_comment/config/features_removal/core.entity_view_mode.comment.full.yml
+++ b/modules/social_features/social_comment/config/features_removal/core.entity_view_mode.comment.full.yml
@@ -1,0 +1,9 @@
+langcode: en
+status: false
+dependencies:
+  module:
+    - comment
+id: comment.full
+label: 'Full comment'
+targetEntityType: comment
+cache: true

--- a/modules/social_features/social_comment/config/features_removal/field.field.comment.comment.field_comment_body.yml
+++ b/modules/social_features/social_comment/config/features_removal/field.field.comment.comment.field_comment_body.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - comment.type.comment
+    - field.storage.comment.field_comment_body
+  module:
+    - text
+id: comment.comment.field_comment_body
+field_name: field_comment_body
+entity_type: comment
+bundle: comment
+label: Comment
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: text_long

--- a/modules/social_features/social_comment/config/features_removal/field.storage.comment.comment_body.yml
+++ b/modules/social_features/social_comment/config/features_removal/field.storage.comment.comment_body.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - comment
+    - text
+id: comment.comment_body
+field_name: comment_body
+entity_type: comment
+type: text_long
+settings: {  }
+module: text
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: true
+custom_storage: false

--- a/modules/social_features/social_comment/config/features_removal/field.storage.comment.field_comment_body.yml
+++ b/modules/social_features/social_comment/config/features_removal/field.storage.comment.field_comment_body.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - comment
+    - text
+id: comment.field_comment_body
+field_name: field_comment_body
+entity_type: comment
+type: text_long
+settings: {  }
+module: text
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/social_features/social_comment/config/features_removal/system.action.comment_publish_action.yml
+++ b/modules/social_features/social_comment/config/features_removal/system.action.comment_publish_action.yml
@@ -1,0 +1,10 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - comment
+id: comment_publish_action
+label: 'Publish comment'
+type: comment
+plugin: comment_publish_action
+configuration: {  }

--- a/modules/social_features/social_comment/config/features_removal/system.action.comment_save_action.yml
+++ b/modules/social_features/social_comment/config/features_removal/system.action.comment_save_action.yml
@@ -1,0 +1,10 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - comment
+id: comment_save_action
+label: 'Save comment'
+type: comment
+plugin: comment_save_action
+configuration: {  }

--- a/modules/social_features/social_comment/config/features_removal/system.action.comment_unpublish_action.yml
+++ b/modules/social_features/social_comment/config/features_removal/system.action.comment_unpublish_action.yml
@@ -1,0 +1,10 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - comment
+id: comment_unpublish_action
+label: 'Unpublish comment'
+type: comment
+plugin: comment_unpublish_action
+configuration: {  }

--- a/modules/social_features/social_comment/social_comment.features.yml
+++ b/modules/social_features/social_comment/social_comment.features.yml
@@ -1,2 +1,0 @@
-bundle: social
-required: true


### PR DESCRIPTION
Removes the features file and adds default configuration as settings
file in the config/install folder.

## Problem
See problem definition in #3092272: [Meta] Moving away from features. The fact that this configuration is in a feature means that login help text gets overwritten.

## Solution
Remove the social_comment.features.yml file
Move the default editable config from hook_install() into a config/install/*.yml file.
Remove any _module_set_defaults function

## Issue tracker
https://www.drupal.org/project/social/issues/3096746
https://getopensocial.atlassian.net/browse/TB-3458

## How to test
- [ ]  Enable the module
- [ ]  Enable email notifications
- [ ]  Revert features
- [ ]  Emails notifications should keep enabled

## Release notes
The social_comment module is no longer managed by features.

