### PR TITLE
Replace features with config management for Social Book

### DIFF
--- a/modules/social_features/social_book/config/features_removal/core.base_field_override.node.book.promote.yml
+++ b/modules/social_features/social_book/config/features_removal/core.base_field_override.node.book.promote.yml
@@ -1,0 +1,21 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.book
+id: node.book.promote
+field_name: promote
+entity_type: node
+bundle: book
+label: 'Promoted to front page'
+description: ''
+required: false
+translatable: true
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/modules/social_features/social_book/config/features_removal/core.entity_form_display.node.book.default.yml
+++ b/modules/social_features/social_book/config/features_removal/core.entity_form_display.node.book.default.yml
@@ -1,0 +1,150 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.book.body
+    - field.field.node.book.field_book_comments
+    - field.field.node.book.field_book_image
+    - field.field.node.book.field_content_visibility
+    - field.field.node.book.field_files
+    - image.style.social_x_large
+    - node.type.book
+  module:
+    - comment
+    - field_group
+    - file
+    - image_widget_crop
+    - path
+    - text
+third_party_settings:
+  field_group:
+    group_visibility:
+      children:
+        - field_content_visibility
+      parent_name: ''
+      weight: 2
+      label: Visibility
+      format_type: fieldset
+      format_settings:
+        label: Visibility
+        required_fields: true
+        id: visibility
+        classes: 'card'
+    group_description:
+      children:
+        - body
+      parent_name: ''
+      weight: 1
+      label: Description
+      format_type: fieldset
+      format_settings:
+        description: ''
+        classes: ''
+        id: ''
+        required_fields: true
+    group_title:
+      children:
+        - title
+        - field_book_image
+      parent_name: ''
+      weight: 0
+      label: Content
+      format_type: fieldset
+      format_settings:
+        description: ''
+        classes: ''
+        id: ''
+        required_fields: true
+    group_attachments:
+      children:
+        - field_files
+      parent_name: ''
+      weight: 3
+      label: Attachments
+      format_type: fieldset
+      format_settings:
+        description: ''
+        classes: ''
+        id: ''
+        required_fields: true
+id: node.book.default
+targetEntityType: node
+bundle: book
+mode: default
+content:
+  body:
+    type: text_textarea_with_summary
+    weight: 6
+    settings:
+      rows: 9
+      summary_rows: 3
+      placeholder: ''
+    third_party_settings: {  }
+  created:
+    type: datetime_timestamp
+    weight: 5
+    settings: {  }
+    third_party_settings: {  }
+  field_book_comments:
+    weight: 9
+    settings: {  }
+    third_party_settings: {  }
+    type: comment_default
+  field_book_image:
+    weight: 2
+    settings:
+      show_crop_area: true
+      show_default_crop: true
+      preview_image_style: social_x_large
+      crop_preview_image_style: crop_thumbnail
+      crop_list:
+        - hero
+        - teaser
+      progress_indicator: throbber
+    third_party_settings: {  }
+    type: image_widget_crop
+  field_content_visibility:
+    weight: 8
+    settings: {  }
+    third_party_settings: {  }
+    type: options_buttons
+  field_files:
+    weight: 10
+    settings:
+      progress_indicator: throbber
+    third_party_settings: {  }
+    type: file_generic
+  path:
+    type: path
+    weight: 8
+    settings: {  }
+    third_party_settings: {  }
+  promote:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 6
+    third_party_settings: {  }
+  sticky:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 7
+    third_party_settings: {  }
+  title:
+    type: string_textfield
+    weight: 1
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  uid:
+    type: entity_reference_autocomplete
+    weight: 4
+    settings:
+      match_operator: CONTAINS
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+hidden:
+  groups: true

--- a/modules/social_features/social_book/config/features_removal/core.entity_view_display.node.book.activity.yml
+++ b/modules/social_features/social_book/config/features_removal/core.entity_view_display.node.book.activity.yml
@@ -1,0 +1,49 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.activity
+    - field.field.node.book.body
+    - field.field.node.book.field_book_comments
+    - field.field.node.book.field_book_image
+    - field.field.node.book.field_content_visibility
+    - field.field.node.book.field_files
+    - image.style.social_x_large
+    - node.type.book
+  module:
+    - image
+    - social_core
+    - user
+id: node.book.activity
+targetEntityType: node
+bundle: book
+mode: activity
+content:
+  field_book_comments:
+    type: comment_node
+    weight: 2
+    label: above
+    settings:
+      num_comments: 2
+      always_show_all_comments: false
+    third_party_settings: {  }
+  field_book_image:
+    type: image
+    weight: 0
+    label: above
+    settings:
+      image_style: social_x_large
+      image_link: content
+    third_party_settings: {  }
+  links:
+    weight: 1
+    settings: {  }
+    third_party_settings: {  }
+hidden:
+  body: true
+  field_content_visibility: true
+  field_files: true
+  flag_follow_content: true
+  groups: true
+  groups_type_closed_group: true
+  groups_type_open_group: true

--- a/modules/social_features/social_book/config/features_removal/core.entity_view_display.node.book.activity_comment.yml
+++ b/modules/social_features/social_book/config/features_removal/core.entity_view_display.node.book.activity_comment.yml
@@ -1,0 +1,41 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.activity_comment
+    - field.field.node.book.body
+    - field.field.node.book.field_book_comments
+    - field.field.node.book.field_book_image
+    - field.field.node.book.field_content_visibility
+    - field.field.node.book.field_files
+    - image.style.social_x_large
+    - node.type.book
+  module:
+    - image
+    - user
+id: node.book.activity_comment
+targetEntityType: node
+bundle: book
+mode: activity_comment
+content:
+  field_book_image:
+    type: image
+    weight: 0
+    label: above
+    settings:
+      image_style: social_x_large
+      image_link: content
+    third_party_settings: {  }
+  links:
+    weight: 1
+    settings: {  }
+    third_party_settings: {  }
+hidden:
+  body: true
+  field_book_comments: true
+  field_content_visibility: true
+  field_files: true
+  flag_follow_content: true
+  groups: true
+  groups_type_closed_group: true
+  groups_type_open_group: true

--- a/modules/social_features/social_book/config/features_removal/core.entity_view_display.node.book.default.yml
+++ b/modules/social_features/social_book/config/features_removal/core.entity_view_display.node.book.default.yml
@@ -1,0 +1,50 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.book.body
+    - field.field.node.book.field_book_comments
+    - field.field.node.book.field_book_image
+    - field.field.node.book.field_content_visibility
+    - field.field.node.book.field_files
+    - node.type.book
+  module:
+    - file
+    - group_core_comments
+    - text
+    - user
+id: node.book.default
+targetEntityType: node
+bundle: book
+mode: default
+content:
+  body:
+    label: hidden
+    type: text_default
+    weight: 0
+    settings: {  }
+    third_party_settings: {  }
+  field_book_comments:
+    type: comment_group_content
+    weight: 2
+    label: above
+    settings:
+      pager_id: 0
+    third_party_settings: {  }
+  field_files:
+    type: file_default
+    weight: 3
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+  links:
+    weight: 4
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+hidden:
+  field_book_image: true
+  field_content_visibility: true
+  groups: true
+  groups_type_closed_group: true
+  groups_type_open_group: true

--- a/modules/social_features/social_book/config/features_removal/core.entity_view_display.node.book.search_index.yml
+++ b/modules/social_features/social_book/config/features_removal/core.entity_view_display.node.book.search_index.yml
@@ -1,0 +1,41 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.search_index
+    - field.field.node.book.body
+    - field.field.node.book.field_book_comments
+    - field.field.node.book.field_book_image
+    - field.field.node.book.field_content_visibility
+    - field.field.node.book.field_files
+    - node.type.book
+  module:
+    - comment
+    - text
+    - user
+id: node.book.search_index
+targetEntityType: node
+bundle: book
+mode: search_index
+content:
+  body:
+    label: hidden
+    type: text_default
+    weight: 0
+    settings: {  }
+    third_party_settings: {  }
+  field_book_comments:
+    type: comment_default
+    weight: 1
+    label: above
+    settings:
+      pager_id: 0
+    third_party_settings: {  }
+hidden:
+  field_book_image: true
+  field_content_visibility: true
+  field_files: true
+  links: true
+  groups: true
+  groups_type_closed_group: true
+  groups_type_open_group: true

--- a/modules/social_features/social_book/config/features_removal/core.entity_view_display.node.book.teaser.yml
+++ b/modules/social_features/social_book/config/features_removal/core.entity_view_display.node.book.teaser.yml
@@ -1,0 +1,46 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.teaser
+    - field.field.node.book.body
+    - field.field.node.book.field_book_comments
+    - field.field.node.book.field_book_image
+    - field.field.node.book.field_content_visibility
+    - field.field.node.book.field_files
+    - image.style.social_x_large
+    - node.type.book
+  module:
+    - image
+    - options
+    - user
+id: node.book.teaser
+targetEntityType: node
+bundle: book
+mode: teaser
+content:
+  field_book_image:
+    type: image
+    weight: 0
+    label: above
+    settings:
+      image_style: social_x_large
+      image_link: content
+    third_party_settings: {  }
+  field_content_visibility:
+    type: list_default
+    weight: 3
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+  links:
+    weight: 2
+    settings: {  }
+    third_party_settings: {  }
+hidden:
+  body: true
+  field_book_comments: true
+  field_files: true
+  groups: true
+  groups_type_closed_group: true
+  groups_type_open_group: true

--- a/modules/social_features/social_book/config/features_removal/field.field.node.book.body.yml
+++ b/modules/social_features/social_book/config/features_removal/field.field.node.book.body.yml
@@ -1,0 +1,21 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.body
+    - node.type.book
+  module:
+    - text
+id: node.book.body
+field_name: body
+entity_type: node
+bundle: book
+label: Body
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  display_summary: true
+field_type: text_with_summary

--- a/modules/social_features/social_book/config/features_removal/field.field.node.book.field_book_comments.yml
+++ b/modules/social_features/social_book/config/features_removal/field.field.node.book.field_book_comments.yml
@@ -1,0 +1,32 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_book_comments
+    - node.type.book
+  module:
+    - comment
+id: node.book.field_book_comments
+field_name: field_book_comments
+entity_type: node
+bundle: book
+label: Comments
+description: ''
+required: false
+translatable: false
+default_value:
+  -
+    status: 1
+    cid: 0
+    last_comment_timestamp: 0
+    last_comment_name: null
+    last_comment_uid: 0
+    comment_count: 0
+default_value_callback: ''
+settings:
+  default_mode: 1
+  per_page: 50
+  anonymous: 0
+  form_location: true
+  preview: 0
+field_type: comment

--- a/modules/social_features/social_book/config/features_removal/field.field.node.book.field_book_image.yml
+++ b/modules/social_features/social_book/config/features_removal/field.field.node.book.field_book_image.yml
@@ -1,0 +1,37 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_book_image
+    - node.type.book
+  module:
+    - image
+id: node.book.field_book_image
+field_name: field_book_image
+entity_type: node
+bundle: book
+label: Image
+description: 'Crop your image to select which part of your image to show on display.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  file_directory: '[date:custom:Y]-[date:custom:m]'
+  file_extensions: 'png gif jpg jpeg'
+  max_filesize: ''
+  max_resolution: 4096x4096
+  min_resolution: ''
+  alt_field: true
+  alt_field_required: false
+  title_field: false
+  title_field_required: false
+  default_image:
+    uuid: ''
+    alt: ''
+    title: ''
+    width: null
+    height: null
+  handler: 'default:file'
+  handler_settings: {  }
+field_type: image

--- a/modules/social_features/social_book/config/features_removal/field.storage.node.field_book_comments.yml
+++ b/modules/social_features/social_book/config/features_removal/field.storage.node.field_book_comments.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - comment
+    - node
+id: node.field_book_comments
+field_name: field_book_comments
+entity_type: node
+type: comment
+settings:
+  comment_type: comment
+module: comment
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/social_features/social_book/config/features_removal/field.storage.node.field_book_image.yml
+++ b/modules/social_features/social_book/config/features_removal/field.storage.node.field_book_image.yml
@@ -1,0 +1,29 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - file
+    - image
+    - node
+id: node.field_book_image
+field_name: field_book_image
+entity_type: node
+type: image
+settings:
+  uri_scheme: public
+  default_image:
+    uuid: ''
+    alt: ''
+    title: ''
+    width: null
+    height: null
+  target_type: file
+  display_field: false
+  display_default: false
+module: image
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/social_features/social_book/config/features_removal/node.type.book.yml
+++ b/modules/social_features/social_book/config/features_removal/node.type.book.yml
@@ -1,0 +1,21 @@
+langcode: en
+status: true
+dependencies:
+  enforced:
+    module:
+      - book
+  module:
+    - menu_ui
+third_party_settings:
+  menu_ui:
+    available_menus:
+      - footer
+      - main
+    parent: 'main:'
+name: 'Book page'
+type: book
+description: '<em>Books</em> have a built-in hierarchical navigation. Use for handbooks or tutorials.'
+help: ''
+new_revision: false
+preview_mode: 1
+display_submitted: false

--- a/modules/social_features/social_book/social_book.features.yml
+++ b/modules/social_features/social_book/social_book.features.yml
@@ -1,5 +1,0 @@
-bundle: social
-excluded:
-  - field.storage.node.field_content_visibility
-  - field.storage.node.field_files
-required: true


### PR DESCRIPTION
Removes the features file and adds default configuration as settings
file in the config/install folder.

## Problem
See problem definition in #3092272: [Meta] Moving away from features. The fact that this configuration is in a feature means that login help text gets overwritten.

## Solution
Remove the social_book.features.yml file
Move the default editable config from hook_install() into a config/install/*.yml file.
Remove any _module_set_defaults function

## Issue tracker
https://www.drupal.org/project/social/issues/3096747
https://getopensocial.atlassian.net/browse/TB-3459

## How to test
- [ ]  Enable the module
- [ ]  Enable email notifications
- [ ]  Revert features
- [ ]  Emails notifications should keep enabled

## Release notes
The social_book module is no longer managed by features.