### PR TITLE
Improve landing page performance and code quality

### DIFF
--- a/modules/social_features/social_landing_page/config/install/core.entity_form_display.node.landing_page.default.yml
+++ b/modules/social_features/social_landing_page/config/install/core.entity_form_display.node.landing_page.default.yml
@@ -3,6 +3,7 @@ status: true
 dependencies:
   config:
     - field.field.node.landing_page.field_content_visibility
+    - field.field.node.landing_page.field_landing_page_image
     - field.field.node.landing_page.field_landing_page_section
     - node.type.landing_page
   module:
@@ -38,6 +39,8 @@ third_party_settings:
         id: sections
         classes: card
       label: Sections
+_core:
+  default_config_hash: ZmNvrc200HUdqH2M5CVzebvr-UKPAQWa7mq4XhhrYNU
 id: node.landing_page.default
 targetEntityType: node
 bundle: landing_page
@@ -98,6 +101,7 @@ content:
     region: content
     third_party_settings: {  }
 hidden:
+  field_landing_page_image: true
   groups: true
   promote: true
   sticky: true

--- a/modules/social_features/social_landing_page/config/install/core.entity_form_display.node.landing_page.default.yml
+++ b/modules/social_features/social_landing_page/config/install/core.entity_form_display.node.landing_page.default.yml
@@ -39,8 +39,6 @@ third_party_settings:
         id: sections
         classes: card
       label: Sections
-_core:
-  default_config_hash: ZmNvrc200HUdqH2M5CVzebvr-UKPAQWa7mq4XhhrYNU
 id: node.landing_page.default
 targetEntityType: node
 bundle: landing_page

--- a/modules/social_features/social_landing_page/config/install/core.entity_view_display.node.landing_page.default.yml
+++ b/modules/social_features/social_landing_page/config/install/core.entity_view_display.node.landing_page.default.yml
@@ -3,11 +3,14 @@ status: true
 dependencies:
   config:
     - field.field.node.landing_page.field_content_visibility
+    - field.field.node.landing_page.field_landing_page_image
     - field.field.node.landing_page.field_landing_page_section
     - node.type.landing_page
   module:
     - entity_reference_revisions
     - user
+_core:
+  default_config_hash: PxrjIOmLPnhF24JSXnFk36eLtGYTMhNLryDlNU1mNTI
 id: node.landing_page.default
 targetEntityType: node
 bundle: landing_page
@@ -61,4 +64,5 @@ content:
     type: entity_reference_label
 hidden:
   field_content_visibility: true
+  field_landing_page_image: true
   links: true

--- a/modules/social_features/social_landing_page/config/install/core.entity_view_display.node.landing_page.default.yml
+++ b/modules/social_features/social_landing_page/config/install/core.entity_view_display.node.landing_page.default.yml
@@ -9,8 +9,6 @@ dependencies:
   module:
     - entity_reference_revisions
     - user
-_core:
-  default_config_hash: PxrjIOmLPnhF24JSXnFk36eLtGYTMhNLryDlNU1mNTI
 id: node.landing_page.default
 targetEntityType: node
 bundle: landing_page

--- a/modules/social_features/social_landing_page/config/install/core.entity_view_display.node.landing_page.featured.yml
+++ b/modules/social_features/social_landing_page/config/install/core.entity_view_display.node.landing_page.featured.yml
@@ -4,15 +4,28 @@ dependencies:
   config:
     - core.entity_view_mode.node.featured
     - field.field.node.landing_page.field_content_visibility
+    - field.field.node.landing_page.field_landing_page_image
     - field.field.node.landing_page.field_landing_page_section
     - node.type.landing_page
   module:
+    - image
     - user
+_core:
+  default_config_hash: nvrQu61YlL3ZU9opxUd5p1uEB7TQiKkdu5S2x_mg8Fk
 id: node.landing_page.featured
 targetEntityType: node
 bundle: landing_page
 mode: featured
 content:
+  field_landing_page_image:
+    type: image
+    weight: -1
+    region: content
+    label: above
+    settings:
+      image_style: ''
+      image_link: ''
+    third_party_settings: {  }
   groups:
     label: above
     weight: 0

--- a/modules/social_features/social_landing_page/config/install/core.entity_view_display.node.landing_page.featured.yml
+++ b/modules/social_features/social_landing_page/config/install/core.entity_view_display.node.landing_page.featured.yml
@@ -23,8 +23,8 @@ content:
     region: content
     label: above
     settings:
-      image_style: ''
-      image_link: ''
+      image_style: social_featured
+      image_link: content
     third_party_settings: {  }
   groups:
     label: above

--- a/modules/social_features/social_landing_page/config/install/core.entity_view_display.node.landing_page.featured.yml
+++ b/modules/social_features/social_landing_page/config/install/core.entity_view_display.node.landing_page.featured.yml
@@ -10,8 +10,6 @@ dependencies:
   module:
     - image
     - user
-_core:
-  default_config_hash: nvrQu61YlL3ZU9opxUd5p1uEB7TQiKkdu5S2x_mg8Fk
 id: node.landing_page.featured
 targetEntityType: node
 bundle: landing_page

--- a/modules/social_features/social_landing_page/config/install/core.entity_view_display.node.landing_page.teaser.yml
+++ b/modules/social_features/social_landing_page/config/install/core.entity_view_display.node.landing_page.teaser.yml
@@ -8,6 +8,8 @@ dependencies:
     - node.type.landing_page
   module:
     - user
+_core:
+  default_config_hash: gtv1Npbpzr6oKcXQFYd9THzeJ9-Yfb4oh_JEjoPLLXs
 id: node.landing_page.teaser
 targetEntityType: node
 bundle: landing_page

--- a/modules/social_features/social_landing_page/config/install/core.entity_view_display.node.landing_page.teaser.yml
+++ b/modules/social_features/social_landing_page/config/install/core.entity_view_display.node.landing_page.teaser.yml
@@ -8,8 +8,6 @@ dependencies:
     - node.type.landing_page
   module:
     - user
-_core:
-  default_config_hash: gtv1Npbpzr6oKcXQFYd9THzeJ9-Yfb4oh_JEjoPLLXs
 id: node.landing_page.teaser
 targetEntityType: node
 bundle: landing_page

--- a/modules/social_features/social_landing_page/config/install/core.entity_view_display.paragraph.hero.default.yml
+++ b/modules/social_features/social_landing_page/config/install/core.entity_view_display.paragraph.hero.default.yml
@@ -32,7 +32,7 @@ content:
       image_style: social_landing_hero
       image_link: ''
     third_party_settings: {  }
-    type: image
+    type: image_url
     region: content
   field_hero_subtitle:
     weight: 2

--- a/modules/social_features/social_landing_page/config/install/core.entity_view_display.paragraph.hero_small.default.yml
+++ b/modules/social_features/social_landing_page/config/install/core.entity_view_display.paragraph.hero_small.default.yml
@@ -32,7 +32,7 @@ content:
       image_style: social_landing_hero_small
       image_link: ''
     third_party_settings: {  }
-    type: image
+    type: image_url
     region: content
   field_hero_small_subtitle:
     weight: 2

--- a/modules/social_features/social_landing_page/config/install/field.field.node.landing_page.field_landing_page_image.yml
+++ b/modules/social_features/social_landing_page/config/install/field.field.node.landing_page.field_landing_page_image.yml
@@ -1,0 +1,37 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_landing_page_image
+    - node.type.landing_page
+  module:
+    - image
+id: node.landing_page.field_landing_page_image
+field_name: field_landing_page_image
+entity_type: node
+bundle: landing_page
+label: Image
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  file_directory: '[date:custom:Y]-[date:custom:m]'
+  file_extensions: 'png gif jpg jpeg'
+  max_filesize: ''
+  max_resolution: ''
+  min_resolution: ''
+  alt_field: false
+  alt_field_required: true
+  title_field: false
+  title_field_required: false
+  default_image:
+    uuid: ''
+    alt: ''
+    title: ''
+    width: null
+    height: null
+  handler: 'default:file'
+  handler_settings: {  }
+field_type: image

--- a/modules/social_features/social_landing_page/config/install/field.storage.node.field_landing_page_image.yml
+++ b/modules/social_features/social_landing_page/config/install/field.storage.node.field_landing_page_image.yml
@@ -1,0 +1,29 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - file
+    - image
+    - node
+id: node.field_landing_page_image
+field_name: field_landing_page_image
+entity_type: node
+type: image
+settings:
+  uri_scheme: public
+  default_image:
+    uuid: ''
+    alt: ''
+    title: ''
+    width: null
+    height: null
+  target_type: file
+  display_field: false
+  display_default: false
+module: image
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/social_features/social_landing_page/social_landing_page.module
+++ b/modules/social_features/social_landing_page/social_landing_page.module
@@ -8,7 +8,6 @@
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Template\Attribute;
 use Drupal\file\Entity\File;
-use Drupal\image\Entity\ImageStyle;
 use Drupal\node\NodeInterface;
 use Drupal\node\Entity\Node;
 use Drupal\paragraphs\Entity\Paragraph;
@@ -140,37 +139,6 @@ function social_landing_page_preprocess_page(&$variables) {
       $variables['content_attributes'] = new Attribute();
       $variables['content_attributes']->addClass('container');
     }
-  }
-}
-
-/**
- * Prepares variables for the paragraph.
- */
-function social_landing_page_preprocess_paragraph(&$variables) {
-  /** @var \Drupal\paragraphs\Entity\Paragraph $entity */
-  $entity = $variables['elements']['#paragraph'];
-  $bundle = $entity->bundle();
-
-  switch ($bundle) {
-    case 'hero':
-      // Add the hero styled image.
-      $image_style = 'social_landing_hero';
-      $image_field = "field_{$bundle}_image";
-      if ($entity->hasField($image_field) && !empty($entity->{$image_field}->entity)) {
-        $variables['hero_styled_image_url'] = ImageStyle::load($image_style)
-          ->buildUrl($entity->{$image_field}->entity->getFileUri());
-      }
-      break;
-
-    case 'hero_small':
-      // Add the hero styled image.
-      $image_style = 'social_landing_hero_small';
-      $image_field = "field_{$bundle}_image";
-      if ($entity->hasField($image_field) && !empty($entity->{$image_field}->entity)) {
-        $variables['hero_small_styled_image_url'] = ImageStyle::load($image_style)
-          ->buildUrl($entity->{$image_field}->entity->getFileUri());
-      }
-      break;
   }
 }
 

--- a/modules/social_features/social_landing_page/social_landing_page.module
+++ b/modules/social_features/social_landing_page/social_landing_page.module
@@ -7,9 +7,7 @@
 
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Template\Attribute;
-use Drupal\file\Entity\File;
 use Drupal\node\NodeInterface;
-use Drupal\paragraphs\Entity\Paragraph;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\Core\Url;
 
@@ -142,40 +140,99 @@ function social_landing_page_preprocess_page(&$variables) {
 }
 
 /**
+ * Implements hook_ENTITY_TYPE_presave().
+ */
+function social_landing_page_node_presave(NodeInterface $node) {
+  if ($node->bundle() === 'landing_page') {
+    social_landing_page_set_hero_image($node);
+  }
+}
+
+/**
+ * Updates the hero image for the landing page based on paragraph sections.
+ *
+ * Some displays, such as the featured view mode, require an image to be used in
+ * teasers. Landing pages don't allow this image to be specified on the form but
+ * instead use the image of the first hero section. This function will find the
+ * first hero image and set it as a teaser image.
+ *
+ * This will overwrite any values that were previously set in the
+ * field_landing_page_image field as there is no way to distinguish between a
+ * value for this field that was deliberately set (e.g. through an API call) or
+ * set by a previous call to this function.
+ *
+ * @param \Drupal\node\NodeInterface $landing_page
+ *   A landing page node to be altered.
+ */
+function social_landing_page_set_hero_image(NodeInterface $landing_page) {
+  // Shorthand some conditions so they can be easily re-used.
+  $is_updating = isset($landing_page->original);
+  $has_image = !$landing_page->get('field_landing_page_image')->isEmpty();
+
+  // Check if the sections have changed.
+  // This expression can not be simplified because $landing_page->original is
+  // undefined if $is_updating is false. Paragraphs have always changed if this
+  // is a new entity (not updating).
+  $paragraphs_changed = !$is_updating || ($is_updating && !$landing_page->get('field_landing_page_section')->equals($landing_page->original->get('field_landing_page_section')));
+
+  // If there is already an image set and the paragraphs haven't changed then we
+  // do nothing.
+  if ($has_image && !$paragraphs_changed) {
+    return;
+  }
+
+  // Find the first hero paragraph in the section paragraphs that has an image.
+  /** @var \Drupal\Core\Field\Plugin\Field\FieldType\EntityReferenceItem $section */
+  foreach ($landing_page->get('field_landing_page_section') as $section) {
+    /** @var \Drupal\entity_reference_revisions\EntityReferenceRevisionsFieldItemList $section_children */
+    $section_children = $section->entity->get('field_section_paragraph');
+
+    // Skip accidentally empty sections.
+    // Each section only holds one paragraph in Open Social but the field type
+    // could have more.
+    if ($section_children->isEmpty()) {
+      continue;
+    }
+    /** @var \Drupal\paragraphs\ParagraphInterface $paragraph */
+    $paragraph = $section_children->first()->entity;
+
+    // Check if this paragraph has the hero small image field we can use.
+    if ($paragraph->hasField('field_hero_small_image') && !$paragraph->get('field_hero_small_image')->isEmpty()) {
+      $landing_page->set('field_landing_page_image', $paragraph->get('field_hero_small_image')->getValue());
+      break;
+    }
+
+    // Check if this paragraph has the normal hero field we can use.
+    if ($paragraph->hasField('field_hero_image') && !$paragraph->get('field_hero_image')->isEmpty()) {
+      $landing_page->set('field_landing_page_image', $paragraph->get('field_hero_image')->getValue());
+      break;
+    }
+  }
+}
+
+/**
  * Implements hook_preprocess_HOOK().
  */
 function social_landing_page_preprocess_node(&$variables) {
   /** @var \Drupal\node\Entity\Node $node */
   $node = $variables['node'];
-  if ($node->getType() === 'landing_page') {
-    // If featured we need to do some magic.
-    if ($variables['view_mode'] === 'featured') {
-      $hero_image = _social_landing_page_get_hero_image($node);
-      if (!empty($hero_image)) {
-        $variables['content']['field_landing_page_image'] = [
-          '#type' => 'markup',
-          '#markup' => $hero_image,
-        ];
-      }
-    }
-
-    // Only existing nodes can be edited. Nodes in preview mode aren't editable.
-    if ($node->id() !== NULL && $node->access('update', $account)) {
-      // TODO #3096639: Replace node_edit_url with content.links.edit.
-      $variables['node_edit_url'] = [
-        '#type' => 'link',
-        '#title' => [
-          '#markup' => '<svg class="icon-gray icon-medium"><use xlink:href="#icon-edit"></use></svg>',
-          '#allowed_tags' => ['use', 'svg'],
+  // Landing page nodes need a specially positioned edit icon.
+  // Only existing nodes can be edited. Nodes in preview mode aren't editable.
+  if ($node->getType() === 'landing_page' && $node->id() !== NULL && $node->access('update', $account)) {
+    // TODO #3096639: Replace node_edit_url with content.links.edit.
+    $variables['node_edit_url'] = [
+      '#type' => 'link',
+      '#title' => [
+        '#markup' => '<svg class="icon-gray icon-medium"><use xlink:href="#icon-edit"></use></svg>',
+        '#allowed_tags' => ['use', 'svg'],
+      ],
+      '#options' => [
+        'attributes' => [
+          'title' => new TranslatableMarkup('Edit content'),
+          'class' => 'waves-effect waves-light btn btn-raised btn-default btn-floating',
         ],
-        '#options' => [
-          'attributes' => [
-            'title' => new TranslatableMarkup('Edit content'),
-            'class' => 'waves-effect waves-light btn btn-raised btn-default btn-floating',
-          ],
-        ],
-      ] + $node->toUrl('edit-form')->toRenderArray();
-    }
+      ],
+    ] + $node->toUrl('edit-form')->toRenderArray();
   }
 }
 
@@ -194,62 +251,6 @@ function social_landing_page_preprocess_field(&$variables) {
       }
     }
   }
-}
-
-/**
- * Fetches the first available hero section image from a landing page.
- *
- * @param \Drupal\node\NodeInterface $node
- *   The landing page.
- *
- * @return array
- *   Render array of the image with a link.
- *
- * @throws \Drupal\Core\Entity\EntityMalformedException
- */
-function _social_landing_page_get_hero_image(NodeInterface $node) {
-  // Must be a valid node.
-  if ($node->getType() !== 'landing_page') {
-    return [];
-  }
-
-  // Loop over the landing page sections of the landing page.
-  foreach ($node->get('field_landing_page_section') as $section) {
-    // Get the referenced paragraph.
-    $referenced = $section->getValue();
-    $paragraph_id = $referenced['target_id'];
-    // First paragraph is always of type section.
-    $paragraph_section = Paragraph::load($paragraph_id);
-
-    // Get the related paragraph (the one with the actual content)
-    $section_id = $paragraph_section->get('field_section_paragraph')->target_id;
-    $paragraph_content = Paragraph::load($section_id);
-
-    // Must be of type hero.
-    if ($paragraph_content && $paragraph_content->getType() === 'hero') {
-      $fid = $paragraph_content->get('field_hero_image')->target_id;
-      $file = File::load($fid);
-      // Check if it's an existing file.
-      if ($file instanceof File) {
-        // Build an image render array.
-        $image = [
-          '#theme' => 'image_style',
-          '#style_name' => 'social_featured',
-          '#uri' => $file->getFileUri(),
-        ];
-        // Build a link render array.
-        $build = [
-          '#title' => render($image),
-          '#type' => 'link',
-          '#url' => $node->toUrl('canonical'),
-        ];
-      }
-      // We immediately return the 1st found hero.
-      return render($build);
-    }
-  }
-
-  return [];
 }
 
 /**

--- a/modules/social_features/social_landing_page/social_landing_page.module
+++ b/modules/social_features/social_landing_page/social_landing_page.module
@@ -159,12 +159,23 @@ function social_landing_page_preprocess_node(&$variables) {
         ];
       }
     }
-    // Get current user.
-    $account = \Drupal::currentUser();
 
-    // Add node edit url for management.
-    if ($node instanceof NodeInterface && $node->access('update', $account)) {
-      $variables['node_edit_url'] = $node->toUrl('edit-form')->toString();
+    // Only existing nodes can be edited. Nodes in preview mode aren't editable.
+    if ($node->id() !== NULL && $node->access('update', $account)) {
+      // TODO #3096639: Replace node_edit_url with content.links.edit.
+      $variables['node_edit_url'] = [
+        '#type' => 'link',
+        '#title' => [
+          '#markup' => '<svg class="icon-gray icon-medium"><use xlink:href="#icon-edit"></use></svg>',
+          '#allowed_tags' => ['use', 'svg'],
+        ],
+        '#options' => [
+          'attributes' => [
+            'title' => new TranslatableMarkup('Edit content'),
+            'class' => 'waves-effect waves-light btn btn-raised btn-default btn-floating',
+          ],
+        ],
+      ] + $node->toUrl('edit-form')->toRenderArray();
     }
   }
 }

--- a/modules/social_features/social_landing_page/social_landing_page.module
+++ b/modules/social_features/social_landing_page/social_landing_page.module
@@ -9,7 +9,6 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Template\Attribute;
 use Drupal\file\Entity\File;
 use Drupal\node\NodeInterface;
-use Drupal\node\Entity\Node;
 use Drupal\paragraphs\Entity\Paragraph;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\Core\Url;
@@ -200,7 +199,7 @@ function social_landing_page_preprocess_field(&$variables) {
 /**
  * Fetches the first available hero section image from a landing page.
  *
- * @param \Drupal\node\Entity\Node $node
+ * @param \Drupal\node\NodeInterface $node
  *   The landing page.
  *
  * @return array
@@ -208,9 +207,9 @@ function social_landing_page_preprocess_field(&$variables) {
  *
  * @throws \Drupal\Core\Entity\EntityMalformedException
  */
-function _social_landing_page_get_hero_image(Node $node) {
+function _social_landing_page_get_hero_image(NodeInterface $node) {
   // Must be a valid node.
-  if (!$node instanceof Node || $node->getType() !== 'landing_page') {
+  if ($node->getType() !== 'landing_page') {
     return [];
   }
 

--- a/modules/social_features/social_landing_page/src/SocialLandingPageConfigOverride.php
+++ b/modules/social_features/social_landing_page/src/SocialLandingPageConfigOverride.php
@@ -26,10 +26,17 @@ class SocialLandingPageConfigOverride implements ConfigFactoryOverrideInterface 
     ];
     foreach ($config_names as $config_name) {
       if (in_array($config_name, $names)) {
-        $config = \Drupal::service('config.factory')->getEditable($config_name);
-        $bundles = $config->get('datasource_settings.entity:node.bundles.selected');
-        $bundles[] = 'landing_page';
-        $overrides[$config_name] = ['datasource_settings' => ['entity:node' => ['bundles' => ['selected' => $bundles]]]];
+        $overrides[$config_name] = [
+          'datasource_settings' => [
+            'entity:node' => [
+              'bundles' => [
+                'selected' => [
+                  'landing_page' => 'landing_page',
+                ],
+              ],
+            ],
+          ],
+        ];
       }
     }
     return $overrides;

--- a/modules/social_features/social_landing_page/templates/node--landing-page.html.twig
+++ b/modules/social_features/social_landing_page/templates/node--landing-page.html.twig
@@ -81,13 +81,7 @@
   {{ title_prefix }}
   {{ title_suffix }}
   <div class="hero-action-button">
-    {% if node_edit_url %}
-    <a href="{{ node_edit_url }}" title="{% trans %}Edit content{% endtrans %}" class="waves-effect waves-light btn btn-raised btn-default btn-floating">
-      <svg class="icon-gray icon-medium">
-        <use xlink:href="#icon-edit"></use>
-      </svg>
-    </a>
-    {% endif %}
+    {{ node_edit_url }}
   </div>
   {% if not node.isPublished() %}
     <div class="node--unpublished__label">{% trans %} unpublished {% endtrans %}</div>

--- a/modules/social_features/social_landing_page/templates/paragraph--hero--default.html.twig
+++ b/modules/social_features/social_landing_page/templates/paragraph--hero--default.html.twig
@@ -61,15 +61,6 @@
  #}
 <div{{ attributes.addClass(cover_classes) }} {% if hero_image %} style="background-image: url('{{ hero_image|raw }}');" {% endif %}>
   <div class="hero__bgimage-overlay"></div>
-  {% if node_edit_url %}
-    <div class="hero-action-button">
-      <a href="{{ node_edit_url }}"  title="Edit content" class="btn btn-default btn-floating waves-effect waves-circle">
-        <svg class="icon-gray icon-medium">
-          <use xlink:href="#icon-edit"></use>
-        </svg>
-      </a>
-    </div>
-  {% endif %}
 
   <div class="cover-wrap container">
     <div class="cover-small">

--- a/modules/social_features/social_landing_page/templates/paragraph--hero--default.html.twig
+++ b/modules/social_features/social_landing_page/templates/paragraph--hero--default.html.twig
@@ -41,6 +41,9 @@
 {{ attach_library('socialbase/hero')}}
 {{ attach_library('social_landing_page/section.hero')}}
 
+{# Trim field HTML and Twig debug comments from image field URL output. #}
+{% set hero_image = content.field_hero_image|render|striptags|trim %}
+
 {%
   set cover_classes = [
     'paragraph--' ~ paragraph.bundle|clean_class,
@@ -48,11 +51,15 @@
     'brand-bg-primary',
     'cover--landing',
     'hero',
-    hero_styled_image_url ? 'cover-img cover-img-gradient',
+    hero_image ? 'cover-img cover-img-gradient',
   ]
 %}
 
-<div{{ attributes.addClass(cover_classes) }} {% if hero_styled_image_url %} style="background-image: url('{{ hero_styled_image_url }}');" {% endif %}>
+{#
+ # The hero_image is output using |raw because it's already escaped in |render
+ # (|striptags and |trim remove the safe marking).
+ #}
+<div{{ attributes.addClass(cover_classes) }} {% if hero_image %} style="background-image: url('{{ hero_image|raw }}');" {% endif %}>
   <div class="hero__bgimage-overlay"></div>
   {% if node_edit_url %}
     <div class="hero-action-button">

--- a/modules/social_features/social_landing_page/templates/paragraph--hero-small--default.html.twig
+++ b/modules/social_features/social_landing_page/templates/paragraph--hero-small--default.html.twig
@@ -61,15 +61,6 @@
  #}
 <div{{ attributes.addClass(cover_classes) }} {% if hero_image %} style="background-image: url('{{ hero_image|raw }}');" {% endif %}>
   <div class="hero-small__bgimage-overlay"></div>
-  {% if node_edit_url %}
-    <div class="hero-small-action-button">
-      <a href="{{ node_edit_url }}"  title="Edit content" class="btn btn-default btn-floating waves-effect waves-circle">
-        <svg class="icon-gray icon-medium">
-          <use xlink:href="#icon-edit"></use>
-        </svg>
-      </a>
-    </div>
-  {% endif %}
 
   <div class="cover-wrap container">
     <div class="cover-small">

--- a/modules/social_features/social_landing_page/templates/paragraph--hero-small--default.html.twig
+++ b/modules/social_features/social_landing_page/templates/paragraph--hero-small--default.html.twig
@@ -41,18 +41,25 @@
 {{ attach_library('socialbase/hero')}}
 {{ attach_library('social_landing_page/section.hero_small')}}
 
+{# Trim field HTML and Twig debug comments from image field URL output. #}
+{% set hero_image = content.field_hero_small_image|render|striptags|trim %}
+
 {%
   set cover_classes = [
-  'paragraph--' ~ paragraph.bundle|clean_class,
-  'cover',
-  'brand-bg-primary',
-  'cover--landing',
-  'hero-small',
-  hero_small_styled_image_url ? 'cover-img cover-img-gradient',
-]
+    'paragraph--' ~ paragraph.bundle|clean_class,
+    'cover',
+    'brand-bg-primary',
+    'cover--landing',
+    'hero-small',
+    hero_image ? 'cover-img cover-img-gradient',
+  ]
 %}
 
-<div{{ attributes.addClass(cover_classes) }} {% if hero_small_styled_image_url %} style="background-image: url('{{ hero_small_styled_image_url }}');" {% endif %}>
+{#
+ # The hero_image is output using |raw because it's already escaped in |render
+ # (|striptags and |trim remove the safe marking).
+ #}
+<div{{ attributes.addClass(cover_classes) }} {% if hero_image %} style="background-image: url('{{ hero_image|raw }}');" {% endif %}>
   <div class="hero-small__bgimage-overlay"></div>
   {% if node_edit_url %}
     <div class="hero-small-action-button">

--- a/themes/socialbase/src/Plugin/Preprocess/Node.php
+++ b/themes/socialbase/src/Plugin/Preprocess/Node.php
@@ -197,7 +197,6 @@ class Node extends PreprocessBase {
       );
       unset($variables['content']['links']['#lazy_builder']);
     }
-
   }
 
 }


### PR DESCRIPTION
## Problem
The landing page module performed quite a bit of preprocessing that could be handled by Drupal instead. Simplifying these methods or removing them altogether reduces the amount of code that is created and simplifies caching by producing less data in more centralised locations.

## Solution
### Remove config load from LandingPageConfigOverride

We now know how to use the NestedArray::mergeDeep properly to add new items to an array without loading existing configuration. This speeds up config overrides slightly.

### Use variables instead of route parsing
    
The current node is already present in the `$variables` that is passed to the preprocess hook. It's cleaner (and more stable and performant) to use this value instead of trying to parse the value from the URL and load it manually.

### Replace preprocess hook by display mode change
    
The Drupal display modes have the possibility to show fields as URL. This mode still allows you to select a image mode. Using this method removes to need to add a custom variable to a template through a preprocess hook. This method is also more easily customised.
   
 **BREAKING CHANGE**: Because a value is removed from a template.

### Remove node_edit_url from paragraph hero's
    
 The variable isn't actually ever set for paragraphs and is probably a copy paste error from another hero template.
 
 **BREAKING CHANGE**: In case the variable was used in an extending project

### Change node_edit_link to render array
    
 The preprocess hook does not need to check what page it's on because it's not called for the edit or delete page. 

 This commit also changes the way the URL is rendered to use a render array. This causes less operations in the twig template (if statement, string append etc.) and allows the node edit URL to do its own access checking instead of doing this in a preprocess hook.

### Use NodeInterface instead of Node for argument types
    
Something can be created that implements the NodeInterface type, which we can process, but is not a Node.
    
Additionally, the `instanceof` check is not needed because this is guaranteed by our function argument type.

### Add landing page hero image field
    
This field will be used to store the image that is used for featured landing pages. This allows the featured image to be calculated when the node is saved instead of when it is viewed. This should speed up viewing performance (which is the majority of the use-cases).

### Replace _social_landing_page_get_hero_image with pre-calculated image field
    
This commit uses the newly added field_landing_page_image to provide a teaser image for landing pages. This improves the view performance by moving the calculations for which image to display into the saving of the entity instead of during every display.
    
The added benefit of using a standard name of field_{node_type}_image allows code to be simplified by removing special casings that were added for landing pages where this field was not yet available.

## Issue tracker
https://www.drupal.org/project/social/issues/3100302

## How to test
- [ ] Create a landing page with a hero section
- [ ] Edit the landing page to add itself as a featured item and save the node
- [ ] Observe that the hero's image is used as image for the featured item
- [ ] Add a new small hero above the previous hero and save the node
- [ ] Observe that the featured image has changed to use the image of the new hero
- [ ] Change the image for the small hero at the top and save the node
- [ ] Observe that the new image is shown as featured image for the landing page

Additionally 
- [ ] Play around with the landing page to see how these changes impact performance.

## Release notes
Various improvements have been made to the Social Landing Page module. These improve the overall quality of the module and prefer pre-calculated values during save over calculating values on page load. These improvements make some changes to how the landing page module renders values, if you've overridden this, please look at the issue to see what has changed in detail.