### PR TITLE
Replace features with config management for Social Content Report

### DIFF
--- a/modules/social_features/social_content_report/config/features_removal/core.entity_form_display.flagging.report_comment.default.yml
+++ b/modules/social_features/social_content_report/config/features_removal/core.entity_form_display.flagging.report_comment.default.yml
@@ -1,0 +1,32 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.flagging.report_comment.field_other_reason
+    - field.field.flagging.report_comment.field_reason
+    - field.field.flagging.report_comment.field_status
+    - flag.flag.report_comment
+  enforced:
+    module:
+      - social_content_report
+id: flagging.report_comment.default
+targetEntityType: flagging
+bundle: report_comment
+mode: default
+content:
+  field_other_reason:
+    type: string_textarea
+    weight: 1
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+  field_reason:
+    weight: 0
+    settings: {  }
+    third_party_settings: {  }
+    type: options_buttons
+    region: content
+hidden:
+  field_status: true

--- a/modules/social_features/social_content_report/config/features_removal/core.entity_form_display.flagging.report_node.default.yml
+++ b/modules/social_features/social_content_report/config/features_removal/core.entity_form_display.flagging.report_node.default.yml
@@ -1,0 +1,32 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.flagging.report_node.field_other_reason
+    - field.field.flagging.report_node.field_reason
+    - field.field.flagging.report_node.field_status
+    - flag.flag.report_node
+  enforced:
+    module:
+      - social_content_report
+id: flagging.report_node.default
+targetEntityType: flagging
+bundle: report_node
+mode: default
+content:
+  field_other_reason:
+    type: string_textarea
+    weight: 1
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+  field_reason:
+    weight: 0
+    settings: {  }
+    third_party_settings: {  }
+    type: options_buttons
+    region: content
+hidden:
+  field_status: true

--- a/modules/social_features/social_content_report/config/features_removal/core.entity_form_display.flagging.report_post.default.yml
+++ b/modules/social_features/social_content_report/config/features_removal/core.entity_form_display.flagging.report_post.default.yml
@@ -1,0 +1,32 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.flagging.report_post.field_other_reason
+    - field.field.flagging.report_post.field_reason
+    - field.field.flagging.report_post.field_status
+    - flag.flag.report_post
+  enforced:
+    module:
+      - social_content_report
+id: flagging.report_post.default
+targetEntityType: flagging
+bundle: report_post
+mode: default
+content:
+  field_other_reason:
+    type: string_textarea
+    weight: 1
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+  field_reason:
+    weight: 0
+    settings: {  }
+    third_party_settings: {  }
+    type: options_buttons
+    region: content
+hidden:
+  field_status: true

--- a/modules/social_features/social_content_report/config/features_removal/core.entity_view_display.flagging.report_comment.default.yml
+++ b/modules/social_features/social_content_report/config/features_removal/core.entity_view_display.flagging.report_comment.default.yml
@@ -1,0 +1,42 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.flagging.report_comment.field_other_reason
+    - field.field.flagging.report_comment.field_reason
+    - field.field.flagging.report_comment.field_status
+    - flag.flag.report_comment
+  enforced:
+    module:
+      - social_content_report
+id: flagging.report_comment.default
+targetEntityType: flagging
+bundle: report_comment
+mode: default
+content:
+  field_other_reason:
+    type: basic_string
+    weight: 1
+    region: content
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+  field_reason:
+    weight: 0
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+    region: content
+  field_status:
+    weight: 2
+    label: above
+    settings:
+      format: default
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    type: boolean
+    region: content
+hidden: {  }

--- a/modules/social_features/social_content_report/config/features_removal/core.entity_view_display.flagging.report_node.default.yml
+++ b/modules/social_features/social_content_report/config/features_removal/core.entity_view_display.flagging.report_node.default.yml
@@ -1,0 +1,42 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.flagging.report_node.field_other_reason
+    - field.field.flagging.report_node.field_reason
+    - field.field.flagging.report_node.field_status
+    - flag.flag.report_node
+  enforced:
+    module:
+      - social_content_report
+id: flagging.report_node.default
+targetEntityType: flagging
+bundle: report_node
+mode: default
+content:
+  field_other_reason:
+    type: basic_string
+    weight: 1
+    region: content
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+  field_reason:
+    weight: 0
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+    region: content
+  field_status:
+    weight: 2
+    label: above
+    settings:
+      format: default
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    type: boolean
+    region: content
+hidden: {  }

--- a/modules/social_features/social_content_report/config/features_removal/core.entity_view_display.flagging.report_post.default.yml
+++ b/modules/social_features/social_content_report/config/features_removal/core.entity_view_display.flagging.report_post.default.yml
@@ -1,0 +1,42 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.flagging.report_post.field_other_reason
+    - field.field.flagging.report_post.field_reason
+    - field.field.flagging.report_post.field_status
+    - flag.flag.report_post
+  enforced:
+    module:
+      - social_content_report
+id: flagging.report_post.default
+targetEntityType: flagging
+bundle: report_post
+mode: default
+content:
+  field_other_reason:
+    type: basic_string
+    weight: 1
+    region: content
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+  field_reason:
+    weight: 0
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+    region: content
+  field_status:
+    weight: 2
+    label: above
+    settings:
+      format: default
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    type: boolean
+    region: content
+hidden: {  }

--- a/modules/social_features/social_content_report/config/features_removal/field.field.flagging.report_comment.field_other_reason.yml
+++ b/modules/social_features/social_content_report/config/features_removal/field.field.flagging.report_comment.field_other_reason.yml
@@ -1,0 +1,21 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.flagging.field_other_reason
+    - flag.flag.report_comment
+  enforced:
+    module:
+      - social_content_report
+id: flagging.report_comment.field_other_reason
+field_name: field_other_reason
+entity_type: flagging
+bundle: report_comment
+label: 'Other Reason'
+description: 'Please describe in detail what you find inappropriate about this content. Your report will only be visible to the content moderation team.'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string_long

--- a/modules/social_features/social_content_report/config/features_removal/field.field.flagging.report_comment.field_reason.yml
+++ b/modules/social_features/social_content_report/config/features_removal/field.field.flagging.report_comment.field_reason.yml
@@ -1,0 +1,31 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.flagging.field_reason
+    - flag.flag.report_comment
+    - taxonomy.vocabulary.report_reasons
+  enforced:
+    module:
+      - social_content_report
+id: flagging.report_comment.field_reason
+field_name: field_reason
+entity_type: flagging
+bundle: report_comment
+label: Reason
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      report_reasons: report_reasons
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/modules/social_features/social_content_report/config/features_removal/field.field.flagging.report_comment.field_status.yml
+++ b/modules/social_features/social_content_report/config/features_removal/field.field.flagging.report_comment.field_status.yml
@@ -1,0 +1,25 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.flagging.field_status
+    - flag.flag.report_comment
+  enforced:
+    module:
+      - social_content_report
+id: flagging.report_comment.field_status
+field_name: field_status
+entity_type: flagging
+bundle: report_comment
+label: Status
+description: ''
+required: true
+translatable: true
+default_value:
+  -
+    value: 1
+default_value_callback: ''
+settings:
+  on_label: Active
+  off_label: Closed
+field_type: boolean

--- a/modules/social_features/social_content_report/config/features_removal/field.field.flagging.report_node.field_other_reason.yml
+++ b/modules/social_features/social_content_report/config/features_removal/field.field.flagging.report_node.field_other_reason.yml
@@ -1,0 +1,21 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.flagging.field_other_reason
+    - flag.flag.report_node
+  enforced:
+    module:
+      - social_content_report
+id: flagging.report_node.field_other_reason
+field_name: field_other_reason
+entity_type: flagging
+bundle: report_node
+label: 'Other Reason'
+description: 'Please describe in detail what you find inappropriate about this content. Your report will only be visible to the content moderation team.'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string_long

--- a/modules/social_features/social_content_report/config/features_removal/field.field.flagging.report_node.field_reason.yml
+++ b/modules/social_features/social_content_report/config/features_removal/field.field.flagging.report_node.field_reason.yml
@@ -1,0 +1,31 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.flagging.field_reason
+    - flag.flag.report_node
+    - taxonomy.vocabulary.report_reasons
+  enforced:
+    module:
+      - social_content_report
+id: flagging.report_node.field_reason
+field_name: field_reason
+entity_type: flagging
+bundle: report_node
+label: Reason
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      report_reasons: report_reasons
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/modules/social_features/social_content_report/config/features_removal/field.field.flagging.report_node.field_status.yml
+++ b/modules/social_features/social_content_report/config/features_removal/field.field.flagging.report_node.field_status.yml
@@ -1,0 +1,25 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.flagging.field_status
+    - flag.flag.report_node
+  enforced:
+    module:
+      - social_content_report
+id: flagging.report_node.field_status
+field_name: field_status
+entity_type: flagging
+bundle: report_node
+label: Status
+description: ''
+required: true
+translatable: false
+default_value:
+  -
+    value: 1
+default_value_callback: ''
+settings:
+  on_label: Active
+  off_label: Closed
+field_type: boolean

--- a/modules/social_features/social_content_report/config/features_removal/field.field.flagging.report_post.field_other_reason.yml
+++ b/modules/social_features/social_content_report/config/features_removal/field.field.flagging.report_post.field_other_reason.yml
@@ -1,0 +1,21 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.flagging.field_other_reason
+    - flag.flag.report_post
+  enforced:
+    module:
+      - social_content_report
+id: flagging.report_post.field_other_reason
+field_name: field_other_reason
+entity_type: flagging
+bundle: report_post
+label: 'Other Reason'
+description: 'Please describe in detail what you find inappropriate about this content. Your report will only be visible to the content moderation team.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string_long

--- a/modules/social_features/social_content_report/config/features_removal/field.field.flagging.report_post.field_reason.yml
+++ b/modules/social_features/social_content_report/config/features_removal/field.field.flagging.report_post.field_reason.yml
@@ -1,0 +1,31 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.flagging.field_reason
+    - flag.flag.report_post
+    - taxonomy.vocabulary.report_reasons
+  enforced:
+    module:
+      - social_content_report
+id: flagging.report_post.field_reason
+field_name: field_reason
+entity_type: flagging
+bundle: report_post
+label: Reason
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      report_reasons: report_reasons
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/modules/social_features/social_content_report/config/features_removal/field.field.flagging.report_post.field_status.yml
+++ b/modules/social_features/social_content_report/config/features_removal/field.field.flagging.report_post.field_status.yml
@@ -1,0 +1,25 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.flagging.field_status
+    - flag.flag.report_post
+  enforced:
+    module:
+      - social_content_report
+id: flagging.report_post.field_status
+field_name: field_status
+entity_type: flagging
+bundle: report_post
+label: Status
+description: ''
+required: true
+translatable: true
+default_value:
+  -
+    value: 1
+default_value_callback: ''
+settings:
+  on_label: Active
+  off_label: Closed
+field_type: boolean

--- a/modules/social_features/social_content_report/config/features_removal/field.storage.flagging.field_other_reason.yml
+++ b/modules/social_features/social_content_report/config/features_removal/field.storage.flagging.field_other_reason.yml
@@ -1,0 +1,21 @@
+langcode: en
+status: true
+dependencies:
+  enforced:
+    module:
+      - social_content_report
+  module:
+    - flag
+id: flagging.field_other_reason
+field_name: field_other_reason
+entity_type: flagging
+type: string_long
+settings:
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/social_features/social_content_report/config/features_removal/field.storage.flagging.field_reason.yml
+++ b/modules/social_features/social_content_report/config/features_removal/field.storage.flagging.field_reason.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  enforced:
+    module:
+      - social_content_report
+  module:
+    - flag
+    - taxonomy
+id: flagging.field_reason
+field_name: field_reason
+entity_type: flagging
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/social_features/social_content_report/config/features_removal/field.storage.flagging.field_status.yml
+++ b/modules/social_features/social_content_report/config/features_removal/field.storage.flagging.field_status.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - flag
+  enforced:
+    module:
+      - social_content_report
+id: flagging.field_status
+field_name: field_status
+entity_type: flagging
+type: boolean
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/social_features/social_content_report/config/features_removal/flag.flag.report_comment.yml
+++ b/modules/social_features/social_content_report/config/features_removal/flag.flag.report_comment.yml
@@ -1,0 +1,39 @@
+langcode: en
+status: true
+dependencies:
+  enforced:
+    module:
+      - social_content_report
+  module:
+    - comment
+id: report_comment
+label: 'Report inappropriate comment'
+bundles: {  }
+entity_type: comment
+global: false
+weight: 0
+flag_short: 'Report as inappropriate'
+flag_long: ''
+flag_message: 'Your report has been submitted.'
+unflag_short: 'Update or remove report'
+unflag_long: ''
+unflag_message: 'Your report is removed.'
+unflag_denied_text: Reported
+flag_type: 'entity:comment'
+link_type: field_entry
+flagTypeConfig:
+  show_in_links: {  }
+  show_as_field: false
+  show_on_form: false
+  show_contextual_link: false
+  extra_permissions:
+    owner: '0'
+    parent_owner: '0'
+linkTypeConfig:
+  flag_confirmation: 'Report as inappropriate'
+  unflag_confirmation: 'Remove report'
+  flag_create_button: Report
+  flag_delete_button: 'Remove report'
+  form_behavior: modal
+  edit_flagging: 'Edit report details'
+  flag_update_button: 'Update report'

--- a/modules/social_features/social_content_report/config/features_removal/flag.flag.report_node.yml
+++ b/modules/social_features/social_content_report/config/features_removal/flag.flag.report_node.yml
@@ -1,0 +1,38 @@
+langcode: en
+status: true
+dependencies:
+  enforced:
+    module:
+      - social_content_report
+  module:
+    - node
+id: report_node
+label: 'Report inappropriate nodes'
+bundles: {  }
+entity_type: node
+global: false
+weight: 0
+flag_short: 'Report as inappropriate'
+flag_long: ''
+flag_message: 'Your report has been submitted.'
+unflag_short: 'Update or remove report'
+unflag_long: ''
+unflag_message: 'Your report is removed.'
+unflag_denied_text: Reported
+flag_type: 'entity:node'
+link_type: field_entry
+flagTypeConfig:
+  show_in_links: {  }
+  show_as_field: false
+  show_on_form: false
+  show_contextual_link: false
+  extra_permissions:
+    owner: '0'
+linkTypeConfig:
+  flag_confirmation: 'Report as inappropriate'
+  unflag_confirmation: 'Remove report'
+  flag_create_button: Report
+  flag_delete_button: 'Remove report'
+  form_behavior: modal
+  edit_flagging: 'Edit report details'
+  flag_update_button: 'Update report'

--- a/modules/social_features/social_content_report/config/features_removal/flag.flag.report_post.yml
+++ b/modules/social_features/social_content_report/config/features_removal/flag.flag.report_post.yml
@@ -1,0 +1,38 @@
+langcode: en
+status: true
+dependencies:
+  enforced:
+    module:
+      - social_content_report
+  module:
+    - social_post
+id: report_post
+label: 'Report inappropriate post'
+bundles: {  }
+entity_type: post
+global: false
+weight: 0
+flag_short: 'Report as inappropriate'
+flag_long: ''
+flag_message: 'Your report has been submitted.'
+unflag_short: 'Update or remove report'
+unflag_long: ''
+unflag_message: 'Your report is removed.'
+unflag_denied_text: Reported
+flag_type: 'entity:post'
+link_type: field_entry
+flagTypeConfig:
+  show_in_links: {  }
+  show_as_field: false
+  show_on_form: false
+  show_contextual_link: false
+  extra_permissions:
+    owner: '0'
+linkTypeConfig:
+  flag_confirmation: 'Report as inappropriate'
+  unflag_confirmation: 'Remove report'
+  flag_create_button: Report
+  flag_delete_button: 'Remove report'
+  form_behavior: modal
+  edit_flagging: 'Edit report details'
+  flag_update_button: 'Update report'

--- a/modules/social_features/social_content_report/config/features_removal/message.template.content_reported.yml
+++ b/modules/social_features/social_content_report/config/features_removal/message.template.content_reported.yml
@@ -1,0 +1,38 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - activity_logger
+third_party_settings:
+  activity_logger:
+    activity_bundle_entities:
+      flagging-report_comment: flagging-report_comment
+      flagging-report_node: flagging-report_node
+      flagging-report_post: flagging-report_post
+    activity_action: create_entitiy_action
+    activity_context: content_report_activity_context
+    activity_destinations:
+      notifications: notifications
+      email: email
+    activity_create_direct: 0
+    activity_aggregate: 0
+    activity_entity_condition: ''
+template: content_reported
+label: 'Inappropriate content reported'
+description: 'A user reported inappropriate content'
+text:
+  -
+    value: "<p><a href=\"[message:author:url:absolute]\">[message:author:display-name]</a> reported <a href=\"[social_content_report:content_url]\">content</a> as inappropriate</p>\n"
+    format: basic_html
+  -
+    value: "<p><a href=\"[message:author:url:absolute]\">[message:author:display-name]</a> reported <a href=\"[social_content_report:content_url]\">content</a> as inappropriate</p>\n"
+    format: full_html
+  -
+    value: "<p><a href=\"[message:author:url:absolute]\">[message:author:display-name]</a> reported <a href=\"[social_content_report:content_url]\">content</a> as inappropriate</p>\n"
+    format: basic_html
+settings:
+  'token options':
+    clear: false
+    'token replace': true
+  purge_override: false
+  purge_methods: {  }

--- a/modules/social_features/social_content_report/config/features_removal/taxonomy.vocabulary.report_reasons.yml
+++ b/modules/social_features/social_content_report/config/features_removal/taxonomy.vocabulary.report_reasons.yml
@@ -1,0 +1,11 @@
+langcode: en
+status: true
+dependencies:
+  enforced:
+    module:
+      - social_content_report
+name: 'Report reasons'
+vid: report_reasons
+description: 'A list of reasons users can choose from for reporting content.'
+hierarchy: 0
+weight: 0

--- a/modules/social_features/social_content_report/config/features_removal/views.view.report_overview.yml
+++ b/modules/social_features/social_content_report/config/features_removal/views.view.report_overview.yml
@@ -1,0 +1,1685 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.flagging.field_other_reason
+    - field.storage.flagging.field_reason
+    - flag.flag.report_comment
+    - flag.flag.report_node
+    - flag.flag.report_post
+    - system.menu.admin
+  enforced:
+    module:
+      - social_content_report
+  module:
+    - comment
+    - flag
+    - node
+    - social_content_report
+    - social_post
+    - user
+id: report_overview
+label: 'Report overview'
+module: views
+description: ''
+tag: ''
+base_table: flagging
+base_field: id
+core: 8.x
+display:
+  default:
+    display_plugin: default
+    id: default
+    display_title: Master
+    position: 0
+    display_options:
+      access:
+        type: perm
+        options:
+          perm: 'view inappropriate reports'
+      cache:
+        type: tag
+        options: {  }
+      query:
+        type: views_query
+        options:
+          disable_sql_rewrite: true
+          distinct: false
+          replica: false
+          query_comment: ''
+          query_tags: {  }
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      pager:
+        type: full
+        options:
+          items_per_page: 25
+          offset: 0
+          id: 0
+          total_pages: null
+          tags:
+            previous: ‹‹
+            next: ››
+            first: '« First'
+            last: 'Last »'
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          quantity: 9
+      style:
+        type: table
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          override: true
+          sticky: false
+          caption: ''
+          summary: ''
+          description: ''
+          columns:
+            uid: uid
+            created: created
+            entity_type: entity_type
+            user_id: user_id
+            changed: changed
+            uid_1: uid_1
+            changed_1: changed_1
+            uid_2: uid_2
+            changed_2: changed_2
+            nothing: nothing
+            nothing_1: nothing_1
+            field_reason: field_reason
+            field_other_reason: field_other_reason
+            view_comment: view_comment
+            view_post: view_post
+            view_node: view_node
+            edit_comment: edit_comment
+            edit_post: edit_post
+            edit_node: edit_node
+            dropbutton: dropbutton
+          info:
+            uid:
+              sortable: true
+              default_sort_order: desc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            created:
+              sortable: true
+              default_sort_order: desc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            entity_type:
+              sortable: true
+              default_sort_order: desc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            user_id:
+              sortable: false
+              default_sort_order: desc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            changed:
+              sortable: false
+              default_sort_order: desc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            uid_1:
+              sortable: false
+              default_sort_order: desc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            changed_1:
+              sortable: false
+              default_sort_order: desc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            uid_2:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            changed_2:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            nothing:
+              sortable: true
+              default_sort_order: desc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            nothing_1:
+              sortable: true
+              default_sort_order: desc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            field_reason:
+              sortable: true
+              default_sort_order: desc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            field_other_reason:
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            view_comment:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            view_post:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            view_node:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            edit_comment:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            edit_post:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            edit_node:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            dropbutton:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+          default: created
+          empty_table: false
+      row:
+        type: fields
+        options:
+          default_field_elements: true
+          inline: {  }
+          separator: ''
+          hide_empty: false
+      fields:
+        uid:
+          id: uid
+          table: flagging
+          field: uid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: Reporter
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: author
+          settings: {  }
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: flagging
+          entity_field: uid
+          plugin_id: field
+        created:
+          id: created
+          table: flagging
+          field: created
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: Reported
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: timestamp
+          settings:
+            date_format: medium
+            custom_date_format: ''
+            timezone: ''
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: flagging
+          entity_field: created
+          plugin_id: field
+        entity_bundle_type:
+          id: entity_bundle_type
+          table: flagging
+          field: entity_bundle_type
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: 'Content Type'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          entity_type: flagging
+          plugin_id: flagging_entity_bundle_type
+        user_id:
+          id: user_id
+          table: post_field_data
+          field: user_id
+          relationship: flag_report_post
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: true
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: post
+          entity_field: user_id
+          plugin_id: field
+        changed:
+          id: changed
+          table: post_field_data
+          field: changed
+          relationship: flag_report_post
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: timestamp
+          settings:
+            date_format: medium
+            custom_date_format: ''
+            timezone: ''
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: post
+          entity_field: changed
+          plugin_id: field
+        uid_1:
+          id: uid_1
+          table: comment_field_data
+          field: uid
+          relationship: flag_report_comment
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: true
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: comment
+          entity_field: uid
+          plugin_id: field
+        changed_1:
+          id: changed_1
+          table: comment_field_data
+          field: changed
+          relationship: flag_report_comment
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: timestamp
+          settings:
+            date_format: medium
+            custom_date_format: ''
+            timezone: ''
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: comment
+          entity_field: changed
+          plugin_id: field
+        uid_2:
+          id: uid_2
+          table: node_field_data
+          field: uid
+          relationship: flag_report_node
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: true
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: node
+          entity_field: uid
+          plugin_id: field
+        changed_2:
+          id: changed_2
+          table: node_field_data
+          field: changed
+          relationship: flag_report_node
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: timestamp
+          settings:
+            date_format: medium
+            custom_date_format: ''
+            timezone: ''
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: node
+          entity_field: changed
+          plugin_id: field
+        nothing:
+          id: nothing
+          table: views
+          field: nothing
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: Author
+          exclude: false
+          alter:
+            alter_text: true
+            text: "{{ user_id }}\r\n{{ uid_1 }}\r\n{{ uid_2 }}"
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: false
+          plugin_id: custom
+        nothing_1:
+          id: nothing_1
+          table: views
+          field: nothing
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: Updated
+          exclude: false
+          alter:
+            alter_text: true
+            text: "{{ changed }}\r\n{{ changed_1 }}\r\n{{ changed_2 }}"
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: false
+          plugin_id: custom
+        field_reason:
+          id: field_reason
+          table: flagging__field_reason
+          field: field_reason
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: Reason
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: false
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+        field_other_reason:
+          id: field_other_reason
+          table: flagging__field_other_reason
+          field: field_other_reason
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: Description
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: basic_string
+          settings: {  }
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+        view_comment:
+          id: view_comment
+          table: comment
+          field: view_comment
+          relationship: flag_report_comment
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          text: 'View Comment'
+          output_url_as_text: false
+          absolute: false
+          entity_type: comment
+          plugin_id: entity_link
+        view_post:
+          id: view_post
+          table: post
+          field: view_post
+          relationship: flag_report_post
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          text: 'View Post'
+          output_url_as_text: false
+          absolute: false
+          entity_type: post
+          plugin_id: entity_link
+        view_node:
+          id: view_node
+          table: node
+          field: view_node
+          relationship: flag_report_node
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          text: 'View Content'
+          output_url_as_text: false
+          absolute: false
+          entity_type: node
+          plugin_id: entity_link
+        edit_comment:
+          id: edit_comment
+          table: comment
+          field: edit_comment
+          relationship: flag_report_comment
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          text: 'Edit Comment'
+          output_url_as_text: false
+          absolute: false
+          entity_type: comment
+          plugin_id: entity_link_edit
+        edit_post:
+          id: edit_post
+          table: post
+          field: edit_post
+          relationship: flag_report_post
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          text: 'Edit Post'
+          output_url_as_text: false
+          absolute: false
+          entity_type: post
+          plugin_id: entity_link_edit
+        edit_node:
+          id: edit_node
+          table: node
+          field: edit_node
+          relationship: flag_report_node
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          text: 'Edit Content'
+          output_url_as_text: false
+          absolute: false
+          entity_type: node
+          plugin_id: entity_link_edit
+        close_report:
+          id: close_report
+          table: flagging
+          field: close_report
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          text: 'Close Report'
+          entity_type: flagging
+          plugin_id: flagging_link_close
+        dropbutton:
+          id: dropbutton
+          table: views
+          field: dropbutton
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: Operations
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          fields:
+            view_comment: view_comment
+            view_post: view_post
+            view_node: view_node
+            edit_comment: edit_comment
+            edit_post: edit_post
+            edit_node: edit_node
+            close_report: close_report
+            uid: '0'
+            created: '0'
+            entity_bundle_type: '0'
+            user_id: '0'
+            changed: '0'
+            uid_1: '0'
+            changed_1: '0'
+            uid_2: '0'
+            changed_2: '0'
+            nothing: '0'
+            nothing_1: '0'
+            field_reason: '0'
+            field_other_reason: '0'
+          destination: true
+          plugin_id: dropbutton
+      filters:
+        flag_id:
+          id: flag_id
+          table: flagging
+          field: flag_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: in
+          value:
+            report_comment: report_comment
+            report_node: report_node
+            report_post: report_post
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: flagging
+          entity_field: flag_id
+          plugin_id: bundle
+        field_status_value:
+          id: field_status_value
+          table: flagging__field_status
+          field: field_status_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: '='
+          value: '1'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          plugin_id: boolean
+      sorts:
+        created:
+          id: created
+          table: flagging
+          field: created
+          relationship: none
+          group_type: group
+          admin_label: ''
+          order: DESC
+          exposed: false
+          expose:
+            label: ''
+          granularity: second
+          entity_type: flagging
+          entity_field: created
+          plugin_id: date
+      title: 'Report overview'
+      header: {  }
+      footer: {  }
+      empty:
+        area:
+          id: area
+          table: views
+          field: area
+          relationship: none
+          group_type: group
+          admin_label: ''
+          empty: true
+          tokenize: false
+          content:
+            value: 'No reports available.'
+            format: basic_html
+          plugin_id: text
+      relationships:
+        flag_report_post:
+          id: flag_report_post
+          table: flagging
+          field: flag_report_post
+          relationship: none
+          group_type: group
+          admin_label: Post
+          required: false
+          entity_type: flagging
+          plugin_id: standard
+        flag_report_comment:
+          id: flag_report_comment
+          table: flagging
+          field: flag_report_comment
+          relationship: none
+          group_type: group
+          admin_label: Comment
+          required: false
+          entity_type: flagging
+          plugin_id: standard
+        flag_report_node:
+          id: flag_report_node
+          table: flagging
+          field: flag_report_node
+          relationship: none
+          group_type: group
+          admin_label: Content
+          required: false
+          entity_type: flagging
+          plugin_id: standard
+      arguments: {  }
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url.query_args
+        - user.permissions
+      tags:
+        - 'config:field.storage.flagging.field_other_reason'
+        - 'config:field.storage.flagging.field_reason'
+  overview:
+    display_plugin: page
+    id: overview
+    display_title: Overview
+    position: 1
+    display_options:
+      display_extenders: {  }
+      path: admin/content/reports
+      menu:
+        type: normal
+        title: Reports
+        description: ''
+        expanded: true
+        parent: system.admin_content
+        weight: 0
+        context: '0'
+        menu_name: admin
+      display_description: ''
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url.query_args
+        - user.permissions
+      tags:
+        - 'config:field.storage.flagging.field_other_reason'
+        - 'config:field.storage.flagging.field_reason'

--- a/modules/social_features/social_content_report/social_content_report.features.yml
+++ b/modules/social_features/social_content_report/social_content_report.features.yml
@@ -1,4 +1,0 @@
-bundle: social
-excluded:
-  - social_content_report.settings
-required: true

--- a/modules/social_features/social_content_report/social_content_report.install
+++ b/modules/social_features/social_content_report/social_content_report.install
@@ -44,6 +44,8 @@ function social_content_report_install() {
   }
 
   // Store the default selected term(s) in the config.
+  // The configuration is updated here because we can't know the IDs of the terms before
+  // they are created. This means that a static configuration file can't be used.
   \Drupal::configFactory()->getEditable('social_content_report.settings')
     ->set('reasons_with_text', $default_values)
     ->save();


### PR DESCRIPTION
Removes the features file and adds default configuration as settings
file in the config/install folder.

## Problem
See problem definition in #3092272: [Meta] Moving away from features. The fact that this configuration is in a feature means that login help text gets overwritten.

## Solution
Remove the social_content_report.features.yml file
Move the default editable config from hook_install() into a config/install/*.yml file.
Remove any _module_set_defaults function

## Issue tracker
https://www.drupal.org/project/social/issues/3096748
https://getopensocial.atlassian.net/browse/TB-3460

## How to test
- [ ]  Enable the module
- [ ]  Enable email notifications
- [ ]  Revert features
- [ ]  Emails notifications should keep enabled

## Release notes
The social_content_report module is no longer managed by features.