### PR TITLE
Issue #3098067 by rolki: Only the last 7 private messages are displayed

### DIFF
--- a/modules/social_features/social_private_message/config/install/core.entity_view_display.private_message_thread.private_message_thread.default.yml
+++ b/modules/social_features/social_private_message/config/install/core.entity_view_display.private_message_thread.private_message_thread.default.yml
@@ -34,7 +34,7 @@ content:
     region: content
     label: hidden
     settings:
-      message_count: 7
+      message_count: 30
       ajax_previous_load_count: 5
       ajax_refresh_rate: 120
       message_order: asc


### PR DESCRIPTION
## Problem
Can't see a list all messages in private channel

## Solution
Change `message_count` limit from 7 to 30 messages

## Issue tracker
https://getopensocial.atlassian.net/browse/YANG-1254
https://www.drupal.org/project/social/issues/3098067

## How to test
Create a private channel with somebody and try to write more than 7 messages

## Notes
The number of messages has been increased, because version 1.2 and 1.3 of the `https://www.drupal.org/project/private_message` module does not provide the ability to load old messages, but only shows the last 7.
Such functionality is provided in version 2.0, but version 2.0 is not compatible with social_private_messages, and additional time is required to fix the problems. And this is the simplest and fastest solution.