### PR TITLE
Updated the logic to render notification colors and added a method in notifications service to get status of a notification.

### DIFF
--- a/modules/custom/activity_creator/activity.page.inc
+++ b/modules/custom/activity_creator/activity.page.inc
@@ -21,6 +21,10 @@ use Drupal\Core\Link;
  *   An associative array containing:
  *   - elements: An associative array containing the user information and any
  *   - attributes: HTML attributes for the containing element.
+ *
+ * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
+ * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
+ * @throws \Drupal\Core\Entity\EntityMalformedException
  */
 function template_preprocess_activity(array &$variables) {
   // Fetch Activity Entity Object.
@@ -110,15 +114,17 @@ function template_preprocess_activity(array &$variables) {
 
   $variables['full_url'] = $full_url;
 
-  $status = $activity->get('field_activity_status')->getValue();
-
-  switch ($status['0']['value']) {
-    case ACTIVITY_STATUS_SEEN:
-      $status_class = 'bg-white';
+  /** @var \Drupal\activity_creator\ActivityNotifications $activity_notification_service */
+  $activity_notification_service = \Drupal::service('activity_creator.activity_notifications');
+  $status = $activity_notification_service->getActivityStatus($activity);
+  // Add bg classes according to notification status.
+  switch ($status) {
+    case ACTIVITY_STATUS_RECEIVED:
+      $status_class = 'bg-gray-lightest';
       break;
 
     default:
-      $status_class = 'bg-gray-lightest';
+      $status_class = 'bg-white';
       break;
   }
 

--- a/modules/custom/activity_creator/activity.page.inc
+++ b/modules/custom/activity_creator/activity.page.inc
@@ -116,7 +116,8 @@ function template_preprocess_activity(array &$variables) {
 
   /** @var \Drupal\activity_creator\ActivityNotifications $activity_notification_service */
   $activity_notification_service = \Drupal::service('activity_creator.activity_notifications');
-  $status = $activity_notification_service->getActivityStatus($activity);
+  // Get the notification status of the current user.
+  $status = $activity_notification_service->getActivityStatus($activity, \Drupal::currentUser());
   // Add bg classes according to notification status.
   switch ($status) {
     case ACTIVITY_STATUS_RECEIVED:

--- a/modules/custom/activity_creator/src/ActivityNotifications.php
+++ b/modules/custom/activity_creator/src/ActivityNotifications.php
@@ -278,17 +278,20 @@ class ActivityNotifications extends ControllerBase {
    *
    * @param \Drupal\activity_creator\Entity\Activity $activity
    *   Activity entity.
+   * @param \Drupal\Core\Session\AccountInterface $account
+   *   Activity Notification of current account.
    *
    * @return mixed
    *   FALSE or the status of activity depending upon the execution of query.
    */
-  public function getActivityStatus(Activity $activity) {
+  public function getActivityStatus(Activity $activity, AccountInterface $account) {
     // Get the user ID.
     if (!empty($id = $activity->id())) {
       try {
         $query = $this->database->select('activity_notification_status', 'ans')
           ->fields('ans', ['status'])
-          ->condition('aid', $id);
+          ->condition('aid', $id)
+          ->condition('uid', $account->id());
         return $query->execute()->fetchField();
       }
       catch (\Exception $exception) {

--- a/modules/custom/activity_creator/src/ActivityNotifications.php
+++ b/modules/custom/activity_creator/src/ActivityNotifications.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\activity_creator;
 
+use Drupal\activity_creator\Entity\Activity;
 use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\Database\Connection;
 use Drupal\Core\Entity\EntityBase;
@@ -269,6 +270,32 @@ class ActivityNotifications extends ControllerBase {
       return TRUE;
     }
 
+    return FALSE;
+  }
+
+  /**
+   * Returns the activity notification status.
+   *
+   * @param \Drupal\activity_creator\Entity\Activity $activity
+   *   Activity entity.
+   *
+   * @return mixed
+   *   FALSE or the status of activity depending upon the execution of query.
+   */
+  public function getActivityStatus(Activity $activity) {
+    // Get the user ID.
+    if (!empty($id = $activity->id())) {
+      try {
+        $query = $this->database->select('activity_notification_status', 'ans')
+          ->fields('ans', ['status'])
+          ->condition('aid', $id);
+        return $query->execute()->fetchField();
+      }
+      catch (\Exception $exception) {
+        // Log the exception to watchdog.
+        $this->getLogger('default')->error($exception->getMessage());
+      }
+    }
     return FALSE;
   }
 

--- a/modules/custom/activity_creator/src/Controller/NotificationsController.php
+++ b/modules/custom/activity_creator/src/Controller/NotificationsController.php
@@ -70,13 +70,15 @@ class NotificationsController extends ControllerBase {
     $view->setDisplay('block_1');
     $rendered_view = $view->render();
 
-    // Set the notification count.
-    $notification_count = $this->activities->markAllNotificationsAsSeen($this->currentUser()) ? 0 : count($this->activities->getNotifications($this->currentUser()));
-
     // Create a response.
     $response = new AjaxResponse();
+    // Attach the view before marking the notification as seen.
+    // This makes sure to render the correct background color of notifications.
+    // @see social/modules/custom/activity_creator/activity.page.inc L#117
     $response->addCommand(new HtmlCommand('.js-notification-center-wrapper', $rendered_view));
-    // Update the notification count to mark as read.
+
+    // Update the notification count to mark as seen.
+    $notification_count = $this->activities->markAllNotificationsAsSeen($this->currentUser()) ? 0 : count($this->activities->getNotifications($this->currentUser()));
     $response->addCommand(new HtmlCommand('.notification-bell .badge', $notification_count));
 
     return $response;


### PR DESCRIPTION
## Problem
Notifications stay grey even after you have seen them. This is confusing and disables user to differentiate b/w new notification and old notification.

## Solution
Change the logic for background colour in https://github.com/goalgorilla/open_social/blob/8.x-8.x/modules/custom/activity_creator/activity.page.inc#L113

1. Read status from activity_notification_status table
2. Notifications with status 1 will have grey colour
3. Others should have white colour

## Issue tracker
https://www.drupal.org/project/social/issues/3098141

## How to test
- [x] Trigger a notification for a user
- [x] Run cron
- [x] Check notification via notification center
- [ ] The colour of already received and newly received notifications should be grey and white respectively.

## Release notes
N.A

## Change Record
N.A

## Translations
N.A
