### PR TITLE
Add untranslatable string to the list

### DIFF
--- a/translations.php
+++ b/translations.php
@@ -33,6 +33,7 @@ new TranslatableMarkup('Clear all selected members');
 // schema or a string not passed through `TranslatableMarkup`.
 // These should be removed once the underlying issue is identified and fixed.
 new TranslatableMarkup("Title & image");
+new TranslatableMarkup("Names and profile image");
 new TranslatableMarkup("Date & time");
 new TranslatableMarkup("Attachments");
 new TranslatableMarkup("Add attachment");


### PR DESCRIPTION
## Problem
"Names and profile image" is not yet translatable

## Solution
Adding this string to the translations.php file makes it indexable by Weblate and eventually translatable on the website.

## Issue tracker
n/a

## How to test
n/a

## Release notes
n/a

## Change Record
n/a

## Translations
n/a
