### PR TITLE
#3098456: Add language as a column to the user export

### DIFF
--- a/modules/custom/social_language/src/Plugin/UserExportPlugin/UserLanguage.php
+++ b/modules/custom/social_language/src/Plugin/UserExportPlugin/UserLanguage.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Drupal\social_language\Plugin\UserExportPlugin;
+
+use Drupal\Core\Database\Connection;
+use Drupal\Core\Datetime\DateFormatterInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Language\LanguageManagerInterface;
+use Drupal\social_user_export\Plugin\UserExportPluginBase;
+use Drupal\user\UserInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Provides a 'UserLanguage' user export row.
+ *
+ * @UserExportPlugin(
+ *  id = "user_language",
+ *  label = @Translation("Language"),
+ *  weight = -340,
+ * )
+ */
+class UserLanguage extends UserExportPluginBase {
+
+  /**
+   * The language manager service.
+   *
+   * @var \Drupal\Core\Language\LanguageManagerInterface
+   */
+  public $languageManager;
+
+  /**
+   * UserExportPluginBase constructor.
+   *
+   * @param array $configuration
+   *   A configuration array containing information about the plugin instance.
+   * @param string $plugin_id
+   *   The plugin_id for the plugin instance.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager.
+   * @param \Drupal\Core\Datetime\DateFormatterInterface $date_formatter
+   *   The date formatter.
+   * @param \Drupal\Core\Database\Connection $database
+   *   The database connection.
+   * @param \Drupal\Core\Language\LanguageManagerInterface $language_manager
+   *   The group helper service.
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager, DateFormatterInterface $date_formatter, Connection $database, LanguageManagerInterface $language_manager) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition, $entity_type_manager, $date_formatter, $database);
+
+    $this->languageManager = $language_manager;
+  }
+
+  /**
+   * The create method.
+   *
+   * @param \Symfony\Component\DependencyInjection\ContainerInterface $container
+   *   Container interface.
+   * @param array $configuration
+   *   An array of configuration.
+   * @param string $plugin_id
+   *   The plugin id.
+   * @param mixed $plugin_definition
+   *   The plugin definition.
+   *
+   * @return \Drupal\Core\Plugin\ContainerFactoryPluginInterface|\Drupal\social_user_export\Plugin\UserExportPluginBase
+   *   Returns the UserExportPluginBase.
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('entity_type.manager'),
+      $container->get('date.formatter'),
+      $container->get('database'),
+      $container->get('language_manager')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getHeader() {
+    return $this->t('Language');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getValue(UserInterface $entity):string {
+    return $this->languageManager->getLanguage($entity->getPreferredLangcode())->getName();
+  }
+
+}

--- a/modules/custom/social_language/src/Plugin/UserExportPlugin/UserLanguage.php
+++ b/modules/custom/social_language/src/Plugin/UserExportPlugin/UserLanguage.php
@@ -44,7 +44,7 @@ class UserLanguage extends UserExportPluginBase {
    * @param \Drupal\Core\Database\Connection $database
    *   The database connection.
    * @param \Drupal\Core\Language\LanguageManagerInterface $language_manager
-   *   The group helper service.
+   *   The language manager service.
    */
   public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager, DateFormatterInterface $date_formatter, Connection $database, LanguageManagerInterface $language_manager) {
     parent::__construct($configuration, $plugin_id, $plugin_definition, $entity_type_manager, $date_formatter, $database);

--- a/modules/custom/social_language/src/Plugin/UserExportPlugin/UserLanguageCode.php
+++ b/modules/custom/social_language/src/Plugin/UserExportPlugin/UserLanguageCode.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Drupal\social_language\Plugin\UserExportPlugin;
+
+use Drupal\social_user_export\Plugin\UserExportPluginBase;
+use Drupal\user\UserInterface;
+
+/**
+ * Provides a 'UserLanguageCode' user export row.
+ *
+ * @UserExportPlugin(
+ *  id = "user_language_code",
+ *  label = @Translation("Language code"),
+ *  weight = -340,
+ * )
+ */
+class UserLanguageCode extends UserExportPluginBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getHeader() {
+    return $this->t('Language code');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getValue(UserInterface $entity):string {
+    return $entity->getPreferredLangcode();
+  }
+
+}


### PR DESCRIPTION
## Problem
The user export does not contain the users (preferred) language. Specially for multilingual platforms this is useful information.

## Solution
Added the preferred language of the user to the export. Defaults to the site default when it is not known.

## Issue tracker
https://www.drupal.org/project/social/issues/3098456

## How to test
- [ ] Enable Social Language, don't add any other language
- [ ] Export user(s)
- [ ] Observe the user(s) have the site default language as value in the "Language" column
- [ ] Add a language, assign it to one or more users
- [ ] Export user(s)
- [ ] Observe the user(s) have their preferred language or otherwise thesite default language as value in the "Language" column

## Release notes
It's important to know which language your users prefer in your communication to them. We now add the language, if known, to the user export.

## Change Record
n/a

## Translations
n/a