### PR TITLE
Issue #3100539 by sjoerdvandervis: Make the description of the Reply-to field more explanatory

### DIFF
--- a/modules/social_features/social_user/src/Plugin/Action/SocialSendEmail.php
+++ b/modules/social_features/social_user/src/Plugin/Action/SocialSendEmail.php
@@ -213,7 +213,7 @@ class SocialSendEmail extends ViewsBulkOperationsActionBase implements Container
     $form['reply'] = [
       '#type' => 'email',
       '#title' => $this->t('Reply-to'),
-      '#description' => $this->t('A Reply-To address is the email address that receives messages sent from those who select Reply in their email clients.'),
+      '#description' => $this->t('The email you are about to send is sent from the platform\'s email address. If you wish to receive replies on this email on your own email address, please specify your email address in this field.'),
     ];
 
     $form['subject'] = [

--- a/modules/social_features/social_user/src/Plugin/Action/SocialSendEmail.php
+++ b/modules/social_features/social_user/src/Plugin/Action/SocialSendEmail.php
@@ -213,7 +213,7 @@ class SocialSendEmail extends ViewsBulkOperationsActionBase implements Container
     $form['reply'] = [
       '#type' => 'email',
       '#title' => $this->t('Reply-to'),
-      '#description' => $this->t('The email you are about to send is sent from the platform\'s email address. If you wish to receive replies on this email on your own email address, please specify your email address in this field.'),
+      '#description' => $this->t("The email you are about to send is sent from the platform's email address. If you wish to receive replies on this email on your own email address, please specify your email address in this field."),
     ];
 
     $form['subject'] = [

--- a/translations.php
+++ b/translations.php
@@ -28,6 +28,7 @@ die('This file should not be run directly.');
 // Changed in version 7.2.
 new TranslatableMarkup('Select / unselect all @count results in this view');
 new TranslatableMarkup('Clear all selected members');
+new TranslatableMarkup('A Reply-To address is the email address that receives messages sent from those who select Reply in their email clients.');
 
 // These strings have been added because they were not being picked
 // up by the POTX tool. This usually indicates an issue with configuration


### PR DESCRIPTION
## Problem
When sending an email to a group of people from within groups, the following text is the description of the Reply-to field:

`A Reply-To address is the email address that receives messages sent from those who select Reply in their email clients.`

For users with smaller technical knowledge, this could be confusing or not sufficient enough.

## Solution
Change the translatable to be more explanatory about what the field is about:

`The email you are about to send is sent from the platform's email address. If you wish to receive replies on this email on your own email address, please specify your email address in this field.`

## Issue tracker
[https://www.drupal.org/project/social/issues/3100539]
(https://www.drupal.org/project/social/issues/3100539)

## How to test
- [ ] Login as a group manager and go to the Manage members tab for a group;
- [ ] Select some users to send an email to and choose the bulk action to send an email;
- [ ] See that the description of the Reply-to field has been adjusted to be more explanatory.

## Translations
- [ ] Changed source string has been added to the `translations.php` file.
