### PR TITLE
Follow content types are never actually checked

### DIFF
--- a/modules/social_features/social_follow_content/social_follow_content.module
+++ b/modules/social_features/social_follow_content/social_follow_content.module
@@ -95,7 +95,7 @@ function social_follow_content_comment_insert(EntityInterface $entity) {
 
   \Drupal::moduleHandler()->alter('social_follow_content_types', $types);
 
-  if (empty($types)) {
+  if (!in_array($entity->bundle(), $types)) {
     return;
   }
 


### PR DESCRIPTION
## Problem
The social_follow_content module comes with a hook to alter the content types that get auto-followed when commented on. However, the types themseleves are never actually checked so all content types are automatically followed.

## Solution
Check if the commented on node's type is in the types array before auto-following.

## Issue tracker
https://www.drupal.org/project/social/issues/3100728

## How to test
- [x] Enable commenting on a new content type
- [x] Comment on a node of said content type
- [x] You will be set to follow automatically despite not having adding the type in an implementation of `hook_social_follow_content_types_alter()`

## Change Record
There's a pretty good chance that there are people out there unwittingly taking advantage of this bug to auto-follow their own custom content types in their OS installations. Fixing this bug will break that functionality for them. Not sure what the best way to handle this is? Release notes maybe... or maybe we reverse the hook and make it an exclude? Open to suggestions but for now this PR just adds what I believe to be the functionality described by the hook documentation.