### PR TITLE
Comment admin page WSOD when a comment type doesn't have the field_comment_body field

### DIFF
--- a/modules/social_features/social_comment/src/Form/SocialCommentAdminOverview.php
+++ b/modules/social_features/social_comment/src/Form/SocialCommentAdminOverview.php
@@ -184,7 +184,15 @@ class SocialCommentAdminOverview extends FormBase {
     foreach ($comments as $comment) {
       // Get a render array for the comment body field. We'll render it in the
       // table.
-      $comment_body = $comment->field_comment_body->view('full');
+      if ($comment->hasField('field_comment_body')) {
+        $comment_body = $comment->field_comment_body->view('full');
+      }
+      elseif ($comment->hasField('comment_body')) {
+        $comment_body = $comment->comment_body->view('full');
+      }
+      else {
+        $comment_body = $this->t('n/a');
+      }
 
       $options[$comment->id()] = [
         'title' => ['data' => ['#title' => $comment->getSubject() ?: $comment->id()]],


### PR DESCRIPTION
## Problem
The comment admin page (`SocialCommentAdminOverview`) will WSOD if you have a custom comment type that doesn't use the field_comment_body field. Error message:

```
Error: Call to a member function view() on null in Drupal\social_comment\Form\SocialCommentAdminOverview->buildForm() (line 188 of profiles/contrib/social/modules/social_features/social_comment/src/Form/SocialCommentAdminOverview.php).
```

## Solution
Check for the core `comment_body` field, and if not, just use "n/a" for the comment body

## Issue tracker
https://www.drupal.org/project/social/issues/3100773

## How to test
- [ ] Create a custom comment type and make sure it doesn't have the field_comment_body field
- [ ] VIsit /admin/content/comments and you should see a WSOD