### PR TITLE
Issue #3101326 by robertragas: Update the config to include notificat…

### DIFF
--- a/modules/social_features/social_activity/config/install/message.template.create_content_in_joined_group.yml
+++ b/modules/social_features/social_activity/config/install/message.template.create_content_in_joined_group.yml
@@ -10,6 +10,8 @@ third_party_settings:
       group_content-closed_group-group_node-topic: group_content-closed_group-group_node-topic
       group_content-open_group-group_node-event: group_content-open_group-group_node-event
       group_content-open_group-group_node-topic: group_content-open_group-group_node-topic
+      group_content-public_group-group_node-event: group_content-public_group-group_node-event
+      group_content-public_group-group_node-topic: group_content-public_group-group_node-topic
       post-photo: post-photo
       post-post: post-post
     activity_action: create_entitiy_action

--- a/modules/social_features/social_group/modules/social_group_flexible_group/src/SocialGroupFlexibleGroupConfigOverride.php
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/src/SocialGroupFlexibleGroupConfigOverride.php
@@ -194,6 +194,16 @@ class SocialGroupFlexibleGroupConfigOverride implements ConfigFactoryOverrideInt
       ];
     }
 
+    $config_name = 'message.template.create_content_in_joined_group';
+
+    if (in_array($config_name, $names, FALSE)) {
+      $overrides[$config_name]['third_party_settings']['activity_logger']['activity_bundle_entities'] =
+        [
+          'group_content-flexible_group-group_node-event' => 'group_content-flexible_group-group_node-event',
+          'group_content-flexible_group-group_node-topic' => 'group_content-flexible_group-group_node-topic',
+        ];
+    }
+
     $config_name = 'views.view.group_managers';
 
     if (in_array($config_name, $names, FALSE)) {

--- a/modules/social_features/social_group/modules/social_group_secret/src/SocialGroupSecretConfigOverride.php
+++ b/modules/social_features/social_group/modules/social_group_secret/src/SocialGroupSecretConfigOverride.php
@@ -157,6 +157,16 @@ class SocialGroupSecretConfigOverride implements ConfigFactoryOverrideInterface 
       }
     }
 
+    $config_name = 'message.template.create_content_in_joined_group';
+
+    if (in_array($config_name, $names, FALSE)) {
+      $overrides[$config_name]['third_party_settings']['activity_logger']['activity_bundle_entities'] =
+        [
+          'group_content-secret_group-group_node-event' => 'group_content-secret_group-group_node-event',
+          'group_content-secret_group-group_node-topic' => 'group_content-secret_group-group_node-topic',
+        ];
+    }
+
     $config_name = 'views.view.newest_groups';
 
     $displays = [


### PR DESCRIPTION
…ions for creating content in public, secret and flexible groups

## Problem
When creating an event or topic within public, secret or flexible group we are not getting any notification in the notification centre or even emails.

This is being caused by the message template not being triggered.

## Solution
Add the correct bundles to the config and for groups that are optional include them in the config override.

## Issue tracker
https://www.drupal.org/project/social/issues/3101326

## How to test
- [x] Create a public, secret or flexible group and add 1 additional member to it
- [x] Create a topic and run the cron
- [x] Note that there is no email notification or notification in the account menu. You can also see the in the queue table or message table that there are no new entries.
- [x] Apply patch and try again

## Release notes
We solved an issue with the message template item "A person created a post, event or topic in a group I joined" where it would not trigger for secret, flexible and public groups resulting in no notifications being sent when someone would create content in the group. 