### PR TITLE
Issue #3101762 by Kingdutch: social_sharing_update_8001 can fail if b…

### DIFF
--- a/modules/social_features/social_sharing/social_sharing.install
+++ b/modules/social_features/social_sharing/social_sharing.install
@@ -26,14 +26,12 @@ function social_sharing_update_8001() {
   // Default shariff settings.
   _social_sharing_shariff_settings();
 
-  $blocks = [
+  $blocks = Block::loadMultiple([
     'addtoanybuttons',
     'addtoanybuttons_2',
-  ];
+  ]);
 
-  foreach ($blocks as $block_id) {
-    $block = Block::load($block_id);
-
+  foreach ($blocks as $block) {
     try {
       $block->delete();
     }


### PR DESCRIPTION
…lock doesn't exist

<h2>Problem</h2>

<code>social_sharing_update_8001</code> calls a function on <code>Block::load</code>'s result without checking for NULL.

<h2>Solution</h2>
Optimise the block loading so that we can loop over the result array. If the blocks don't exist the foreach loop skips the empty array, avoiding the error scenario.

## Issue tracker
https://www.drupal.org/project/social/issues/3101762

## How to test
- [ ] Run the update hook when the addtoany blocks are removed already

## Release notes
Update hook 8001 for the Social Sharing module no longer fails if the addtoany blocks are already removed.
