### PR TITLE
Issue #3101792 by agami4: Update private messages on mobile

### DIFF
--- a/themes/socialbase/assets/css/message.css
+++ b/themes/socialbase/assets/css/message.css
@@ -83,6 +83,7 @@
 }
 
 .private-message-full {
+  width: 100%;
   margin-bottom: 2rem;
 }
 

--- a/themes/socialbase/components/04-organisms/message/message.scss
+++ b/themes/socialbase/components/04-organisms/message/message.scss
@@ -95,6 +95,7 @@
 }
 
 .private-message-full {
+  width: 100%;
   margin-bottom: 2rem;
 
   @include for-tablet-portrait-up {


### PR DESCRIPTION
## Problem
The private messages are not on the full width on mobile devices

## Solution
Update width for the private messages on mobile devices

## Issue tracker
https://www.drupal.org/project/social/issues/3101792

## How to test
- [ ] Need to send a private message to any user

## Release notes
The private messages have full width (width: 100%) on the mobile devices
