### PR TITLE
Issue #3102298 by agami4: Update top and bottom spaces for the accordion block

### DIFF
--- a/modules/social_features/social_landing_page/css/social_landing_page.section.accordion.css
+++ b/modules/social_features/social_landing_page/css/social_landing_page.section.accordion.css
@@ -1,5 +1,5 @@
 .paragraph--type--accordion {
-  padding: 100px 1rem 150px;
+  padding: 65px 1rem 100px;
 }
 .paragraph--type--accordion .card__title {
   padding: 0;

--- a/modules/social_features/social_landing_page/css/social_landing_page.section.accordion.scss
+++ b/modules/social_features/social_landing_page/css/social_landing_page.section.accordion.scss
@@ -1,5 +1,5 @@
 .paragraph--type--accordion {
-  padding: 100px 1rem 150px;
+  padding: 65px 1rem 100px;
 
   .card__title {
     padding: 0;


### PR DESCRIPTION
<h2>Problem:</h2>
Including the Accordion section in a landing page takes up huge chunks of empty space. This is disruptive to the page flow and causes the need for excessive scrolling.

<h2>Solution:</h2>
Reduce the top and bottom space around accordions

## Issue tracker
https://www.drupal.org/project/social/issues/3102298

## How to test
- [ ] Go to the 'Landing page' and create an accordion block

## Release notes
The top and bottom spacing for accordion blocks have been reduced because it was taking up excessive space on landing pages.