### PR TITLE
Issue #3102731 by Kingdutch: Cover image for nodes doesn't receive pr…

### DIFF
--- a/themes/socialbase/templates/node/node--hero.html.twig
+++ b/themes/socialbase/templates/node/node--hero.html.twig
@@ -71,12 +71,8 @@
 {%
   set cover_classes = [
   'cover',
-  group_hero_styled_image_url ? 'cover-img cover-img-gradient',
+  hero_styled_image_url ? 'cover-img cover-img-gradient',
 ]
-%}
-
-{%
-  set cover_wrap_classes = group_hero_small ? 'cover-wrap small' : 'cover-wrap'
 %}
 
 <div{{ attributes.addClass(cover_classes) }} {% if hero_styled_image_url %} style="background-image: url('{{ hero_styled_image_url }}');" {% endif %}>


### PR DESCRIPTION
…oper classes

<h2>Problem</h2>

When the node--hero template was created this was not tested with browser wide images. The <code>group_hero_styled_image_url</code> variable used to determine if the <code>cover-img</code> class should be added does not exist. For nodes this should be <code>hero_styled_image_url</code>.

On a tangential node <code>cover_wrap_classes</code> is defined but never used and <code>group_hero_small</code> or <code>hero_small</code> don't exist in this context.

<h2>Solution</h2>

Change <code>group_hero_styled_image_url</code> to <code>hero_styled_image_url</code> and remove <code>cover_wrap_classes</code>.

## Issue tracker
https://www.drupal.org/project/social/issues/3102731

## How to test
- [ ] Use a node cover that is not in a container

## Screenshots
Before
![social-broken-cover-hero](https://user-images.githubusercontent.com/327697/71352517-d51c6d00-2576-11ea-89c9-ef74cfe21ef5.png)

After
![social-expected-cover-hero](https://user-images.githubusercontent.com/327697/71352527-d8aff400-2576-11ea-9350-99ab2790ebf5.png)

## Release notes
Cover images are now properly stretched across a hero that stretches the entire width of the page instead of repeating at our default container width.
