### PR TITLE
Issue #3086434 by sjoerdvandervis: Flexible groups on landing pages

### DIFF
--- a/modules/social_features/social_group/modules/social_group_flexible_group/config/install/core.entity_form_display.group.flexible_group.default.yml
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/config/install/core.entity_form_display.group.flexible_group.default.yml
@@ -100,6 +100,7 @@ content:
       preview_image_style: social_x_large
       crop_preview_image_style: crop_thumbnail
       crop_list:
+        - hero_small
         - hero
         - teaser
       progress_indicator: throbber

--- a/modules/social_features/social_landing_page/config/optional/core.entity_view_display.group.flexible_group.featured.yml
+++ b/modules/social_features/social_landing_page/config/optional/core.entity_view_display.group.flexible_group.featured.yml
@@ -1,0 +1,50 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.group.featured
+    - field.field.group.flexible_group.field_group_address
+    - field.field.group.flexible_group.field_group_description
+    - field.field.group.flexible_group.field_group_image
+    - field.field.group.flexible_group.field_group_location
+    - group.type.flexible_group
+    - image.style.social_featured
+  module:
+    - address
+    - image
+    - social_group_flexible_group
+id: group.flexible_group.featured
+targetEntityType: group
+bundle: flexible_group
+mode: featured
+content:
+  field_group_address:
+    type: address_plain
+    weight: 1
+    region: content
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+  field_group_image:
+    type: image
+    weight: 0
+    region: content
+    label: hidden
+    settings:
+      image_style: social_featured
+      image_link: content
+    third_party_settings: {  }
+  field_group_location:
+    type: string
+    weight: 2
+    region: content
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+hidden:
+  changed: true
+  created: true
+  field_group_description: true
+  label: true
+  uid: true


### PR DESCRIPTION
## Problem
When a Flexible group is added as featured content on a landing page, the image is not displayed correctly.

## Solution
The flexible group had no display mode for Featured. This is fixed by adding an optional configuration to the social_landing_page module, which defines that the image, address and location name are shown when the flexible group is used as featured content. Furthermore, a crop type is added when adding a new flexible group (`hero_small`), as this is used as image when using the flexible group as featured content.

## Issue tracker
https://www.drupal.org/project/social/issues/3086434

## How to test
- [ ] When doing a clean install, make sure you have both `social_group_flexible_group` and `social_landing_page` enabled;
- [ ] Add a flexible group and see that when uploading an image, 3 crop types are now available;
- [ ] Add a landing page and add the newly created group as featured content to the new landing page;
- [ ] Visit the landing page and see that the image of the flexible group is now shown.
