### PR TITLE
Issue #3102806 by Kingdutch: Remove features from Social User Export

### DIFF
--- a/modules/social_features/social_user_export/config/features_removal/system.action.user_export_user_action.yml
+++ b/modules/social_features/social_user_export/config/features_removal/system.action.user_export_user_action.yml
@@ -1,0 +1,10 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - social_user_export
+id: user_export_user_action
+label: 'Export the selected user(s) to CSV'
+type: user
+plugin: social_user_export_user_action
+configuration: {  }

--- a/modules/social_features/social_user_export/social_user_export.features.yml
+++ b/modules/social_features/social_user_export/social_user_export.features.yml
@@ -1,1 +1,0 @@
-bundle: social


### PR DESCRIPTION
## Problem
See problem definition in [#3092272: [Meta] [PP-1] Moving away from features.](https://www.drupal.org/project/social/issues/3092272)

## Solution
Remove the `module.features.yml` file
- Move the default editable config from `hook_install()` into a module's `config/install/*.yml` file.
- If `hook_install` alters configuration from other modules, consider whether we should include the config file in the profile's `config/install` folder to overwrite it instead
- Remove any `_module_set_defaults` function

## Issue tracker
https://www.drupal.org/project/social/issues/3102806

## How to test
- [ ] Enable all changed modules
- [ ] See that none of them install configuration provided by other modules
- [ ] Change configuration for each module
- [ ] Revert features
