### PR TITLE
Issue #3103209 by agami4: Remove styles for the strong HTML tag

### DIFF
--- a/modules/custom/social_font/social_font.module
+++ b/modules/custom/social_font/social_font.module
@@ -5,6 +5,7 @@
  * Contains social_font.module.
  */
 
+use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\file\Entity\File;
 use Drupal\social_font\Entity\Font;
@@ -78,7 +79,7 @@ function social_font_render($font_id = NULL) {
         }
       }
       $css .= social_font_fontfiles_render($fonts);
-      $css .= "} body { font-family: '" . $fontname . "', " . $fallback . " !important; }";
+      $css .= "} body { font-family: '" . $fontname . "', " . $fallback . " !important; font-weight: initial !important; }";
     }
   }
 

--- a/modules/custom/social_font/social_font.module
+++ b/modules/custom/social_font/social_font.module
@@ -5,7 +5,6 @@
  * Contains social_font.module.
  */
 
-use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\file\Entity\File;
 use Drupal\social_font\Entity\Font;

--- a/modules/custom/social_font/social_font.module
+++ b/modules/custom/social_font/social_font.module
@@ -78,7 +78,11 @@ function social_font_render($font_id = NULL) {
         }
       }
       $css .= social_font_fontfiles_render($fonts);
-      $css .= "} body { font-family: '" . $fontname . "', " . $fallback . " !important; font-weight: initial !important; }";
+      $css .= "} body { font-family: '" . $fontname . "', " . $fallback . " !important; } ";
+      // font-weight is reset because uploaded fonts don't yet support
+      // multiple font-weights which breaks strong tags.
+      // TODO: See issue #3045765.
+      $css .= "strong { font-weight: initial !important; }";
     }
   }
 

--- a/themes/socialblue/assets/css/base.css
+++ b/themes/socialblue/assets/css/base.css
@@ -48,7 +48,8 @@ kbd {
   color: #fff;
   background-color: #333;
   border-radius: 3px;
-  box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.25);
+  -webkit-box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.25);
+          box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.25);
 }
 
 pre {
@@ -60,10 +61,6 @@ pre {
 
 blockquote {
   border-left: 3px solid #29abe2;
-}
-
-strong {
-  font-weight: 500;
 }
 
 .text-primary {

--- a/themes/socialblue/assets/css/base.css
+++ b/themes/socialblue/assets/css/base.css
@@ -63,6 +63,10 @@ blockquote {
   border-left: 3px solid #29abe2;
 }
 
+strong {
+  font-weight: 500;
+}
+
 .text-primary {
   color: #29abe2;
 }

--- a/themes/socialblue/assets/css/base.css
+++ b/themes/socialblue/assets/css/base.css
@@ -48,8 +48,7 @@ kbd {
   color: #fff;
   background-color: #333;
   border-radius: 3px;
-  -webkit-box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.25);
-          box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.25);
+  box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.25);
 }
 
 pre {

--- a/themes/socialblue/components/01-base/text/_text.scss
+++ b/themes/socialblue/components/01-base/text/_text.scss
@@ -3,10 +3,6 @@ blockquote {
   border-left: 3px solid $brand-primary;
 }
 
-strong {
-	font-weight: $font-weight-strong;
-}
-
 @include text-emphasis-variant('.text-primary', $brand-primary);
 @include text-emphasis-variant('.text-success', $state-success-text);
 @include text-emphasis-variant('.text-info', $state-info-text);

--- a/themes/socialblue/components/01-base/text/_text.scss
+++ b/themes/socialblue/components/01-base/text/_text.scss
@@ -3,6 +3,10 @@ blockquote {
   border-left: 3px solid $brand-primary;
 }
 
+strong {
+  font-weight: $font-weight-strong;
+}
+
 @include text-emphasis-variant('.text-primary', $brand-primary);
 @include text-emphasis-variant('.text-success', $state-success-text);
 @include text-emphasis-variant('.text-info', $state-info-text);


### PR DESCRIPTION
## Problem
When the custom font doesn't have a font-weight 500, bold (strong HTML element) text looks like a simple text.

## Solution
Remove font-weight 500 for the strong HTML tag

## Issue tracker
https://www.drupal.org/project/social/issues/3103209

## How to test
- [ ] Go to the Top CT and add bold text to the content