### PR TITLE
Issue #3105396 by robertragas, bramtenhove: change the regex for dete…

### DIFF
--- a/modules/custom/mentions/src/Plugin/Filter/MentionsFilter.php
+++ b/modules/custom/mentions/src/Plugin/Filter/MentionsFilter.php
@@ -177,7 +177,8 @@ class MentionsFilter extends FilterBase implements ContainerFactoryPluginInterfa
       $mention = $this->mentionsManager->createInstance($mention_type);
 
       if ($mention instanceof MentionsPluginInterface) {
-        $pattern = '/(?:' . preg_quote($input_settings['prefix']) . ')([a-zA-Z0-9_]+)' . preg_quote($input_settings['suffix']) . '/';
+        $pattern = '/(?:' . preg_quote($input_settings['prefix']) . ')([ a-z0-9@+_.\'-]+)' . preg_quote($input_settings['suffix']) . '/';
+
         preg_match_all($pattern, $text, $matches, PREG_SET_ORDER);
 
         foreach ($matches as $match) {


### PR DESCRIPTION
…ction usernames in mentions so it's special characters that are also allowed during registration

## Problem
When you mention a user with a space or dot in the username the mention will not get converted correctly.

As to quote the label under the username registration.

Several special characters are allowed, including space, period (.), hyphen (-), apostrophe ('), underscore (_), and the @ sign.

When we check the regex that is being used.

/(?:\[~)([a-zA-Z0-9_]+)\]/

This does not take the special characters into account that the label says you can use.

## Solution
Change the regex to allow more characters

## Issue tracker
https://www.drupal.org/project/social/issues/3105396

## How to test
- [ ] Create a user with a dot or space in the username. 
- [ ] Mention this user in a post and see it does not get converted
- [ ] Check out to this code and do a cache clear
- [ ] See it works now for the older ones, but also new ones.

## Release notes
We have fixed a bug that caused usernames with special characters in their username not being able to be mentioned.