### PR TITLE
Issue #3105639: Added hook_theme_suggestions_alter to add landing page template on 404.

### DIFF
--- a/modules/social_features/social_landing_page/social_landing_page.module
+++ b/modules/social_features/social_landing_page/social_landing_page.module
@@ -144,16 +144,15 @@ function social_landing_page_preprocess_page(&$variables) {
   // EG: on: /node/%node/enrollments.
   if (!is_null($nid) && !is_object($nid)) {
     $node = Node::load($nid);
-  }
-
-  // Here we remove class for landing page.
-  if (isset($variables['node']) && $node->bundle() === 'landing_page') {
-    if ($variables['content_attributes'] instanceof Attribute) {
-      $variables['content_attributes']->removeClass('layout--with-complementary');
-    }
-    else {
-      $variables['content_attributes'] = new Attribute();
-      $variables['content_attributes']->addClass('container');
+    // Here we remove class for landing page.
+    if (isset($variables['node']) && $node->bundle() === 'landing_page') {
+      if ($variables['content_attributes'] instanceof Attribute) {
+        $variables['content_attributes']->removeClass('layout--with-complementary');
+      }
+      else {
+        $variables['content_attributes'] = new Attribute();
+        $variables['content_attributes']->addClass('container');
+      }
     }
   }
 }
@@ -315,4 +314,21 @@ function social_landing_page_social_user_account_header_create_links($context) {
       '#weight' => 400,
     ] + Url::fromRoute('node.add', ['node_type' => 'landing_page'])->toRenderArray(),
   ];
+}
+
+/**
+ * Implements hook_theme_suggestions_HOOK_alter().
+ */
+function social_landing_page_theme_suggestions_page_alter(array &$suggestions, array $variables) {
+  // Get Request Object.
+  $request = \Drupal::request();
+
+  // If there is HTTP Exception..
+  if ($exception = $request->attributes->get('exception')) {
+    // Get the status code.
+    $status_code = $exception->getStatusCode();
+    if ($status_code == 404) {
+      $suggestions[] = 'page__node__landing_page';
+    }
+  }
 }


### PR DESCRIPTION
## Problem
Landing Page Template is not picked up when using it as 404 page.

## Solution
Use hook_theme_suggestions_HOOK_alter() to use page__node__landing_page as template.

## Issue tracker
https://www.drupal.org/project/social/issues/3105639

## How to test
- [x] Enable Social Landing Page module
- [x] Create a landing page module
- [x] Add a hero section
- [x] Set it as 404 page
- [x] Visit a malformed URL

## Screenshots
**Before**:
![image](https://user-images.githubusercontent.com/8435994/72153268-6f800b80-33d3-11ea-9b38-8df2b11e22c0.png)

**After**:
![image](https://user-images.githubusercontent.com/8435994/72153199-39428c00-33d3-11ea-92c6-5a42872954ab.png)


## Release notes
N.A

## Change Record
N.A

## Translations
N.A
