### PR TITLE
Issue #3106356: Duplicate fields in CSV export when Anonymous Event e…

### DIFF
--- a/modules/social_features/social_event/modules/social_event_an_enroll_enrolments_export/social_event_an_enroll_enrolments_export.module
+++ b/modules/social_features/social_event/modules/social_event_an_enroll_enrolments_export/social_event_an_enroll_enrolments_export.module
@@ -11,3 +11,22 @@
 function social_event_an_enroll_enrolments_export_social_event_managers_action_social_event_an_enroll_enrolments_export_action_finish($success) {
   return social_event_enrolments_export_social_event_managers_action_social_event_enrolments_export_enrollments_action_finish($success);
 }
+
+/**
+ * Implements hook_social_user_export_plugin_info_alter().
+ */
+function social_event_an_enroll_enrolments_export_social_user_export_plugin_info_alter(array &$plugins) {
+  $plugins_overrides = [
+    'enrolment_display_name' => 'display_name',
+    'enrolment_user_email' => 'user_email',
+    'enrolment_user_first_name' => 'user_first_name',
+    'enrolment_user_last_name' => 'user_last_name',
+    'enrolment_user_registration' => 'user_registration',
+  ];
+
+  foreach ($plugins_overrides as $override => $plugin) {
+    if ($plugins[$plugin]) {
+      unset($plugins[$plugin]);
+    }
+  }
+}


### PR DESCRIPTION
…nrolment export module is enabled.

## Problem
When the Social Event Anonymous Enrolments Export module is enabled the following fields are duplicate in the CSV export:

- Display name
- Email
- First name
- Last name
- Registration date

## Solution
Disabled the extended plugins that are duplicated.

## Issue tracker
https://www.drupal.org/project/social/issues/3106356

## How to test
- [x] Make sure the Social Event Anonymous Enrolments Export module is enabled.
- [x] Go to the people overview, select some and export them as CSV.
- [ ] Download the CSV and check the content, see that the listed fields are only added once.
- [ ] Now go to an event with some enrollees (users and anonymous) and create an export of these users.
- [ ] Download the CSV and check the content, see that the listed fields are only added once.
