### PR TITLE
Issue #3106782 by robertragas, sjoerdvandervis: Changed z-index to be able to use the admin toolbar

### DIFF
--- a/themes/socialbase/assets/css/admin-toolbar.css
+++ b/themes/socialbase/assets/css/admin-toolbar.css
@@ -15,7 +15,7 @@
 
 .toolbar-fixed .navbar-default {
   position: relative;
-  z-index: 10;
+  z-index: 100;
 }
 
 .toolbar-fixed .main-container,

--- a/themes/socialbase/assets/css/navbar.css
+++ b/themes/socialbase/assets/css/navbar.css
@@ -266,11 +266,15 @@
 
 @media (min-width: 900px) {
   .navbar-user {
-    order: 10;
+    -webkit-box-ordinal-group: 11;
+        -ms-flex-order: 10;
+            order: 10;
   }
   .block-social-language,
   .block-language {
-    order: 4;
+    -webkit-box-ordinal-group: 5;
+        -ms-flex-order: 4;
+            order: 4;
     margin-left: auto;
   }
   .block-social-language a.dropdown-toggle,

--- a/themes/socialbase/components/04-organisms/admin-toolbar/admin-toolbar.scss
+++ b/themes/socialbase/components/04-organisms/admin-toolbar/admin-toolbar.scss
@@ -25,7 +25,7 @@
 // make sure we can see both menu's
 .toolbar-fixed .navbar-default {
   position: relative;
-  z-index: 10;
+  z-index: 100;
 }
 .toolbar-fixed .main-container,
 .toolbar-vertical .main-container {


### PR DESCRIPTION
## Problem
The explore dropdown menu is shown behind the event map when it's enabled (see screenshot below).

## Solution
Adjust our manual z-index on the navbar so that both the admin toolbar and the regular OS menu are shown correctly.

## Issue tracker
https://www.drupal.org/project/social/issues/3106782

## How to test
- [x] Make sure you have the social_geolocation module enabled and that you see the event map on `All events`;
- [x] Log in as a CM / SM and go to the All events page;
- [x] See that the explore menu now falls over the event map instead of behind.

## Screenshots
### Before
![Screenshot 2020-01-16 at 10 52 12](https://user-images.githubusercontent.com/19951173/72514116-5e5d5180-384e-11ea-94e3-1db75a48fbb2.png)

### After
![Screenshot 2020-01-16 at 10 52 35](https://user-images.githubusercontent.com/19951173/72514145-6e753100-384e-11ea-8012-286cdb1fe009.png)
