### PR TITLE
Issue #3080369 by robertragas: add defensive coding to stop crashing …

### DIFF
--- a/modules/social_features/social_activity/social_activity.tokens.inc
+++ b/modules/social_features/social_activity/social_activity.tokens.inc
@@ -7,6 +7,7 @@
 
 use Drupal\Core\Render\BubbleableMetadata;
 use Drupal\Core\Url;
+use Drupal\group\Entity\GroupContentInterface;
 
 /**
  * Implements hook_token_info().
@@ -77,8 +78,7 @@ function social_activity_tokens($type, $tokens, array $data, array $options, Bub
 
                 $replacements[$original] = \Drupal::service('renderer')->renderPlain($info);
               }
-              elseif ($target_type === 'group_content') {
-                /** @var \Drupal\group\Entity\GroupContentInterface $entity */
+              elseif ($target_type === 'group_content' && $entity instanceof GroupContentInterface) {
                 $group_content_type = $entity->getGroupContentType();
 
                 if ($group_content_type !== NULL) {

--- a/modules/social_features/social_event/social_event.tokens.inc
+++ b/modules/social_features/social_event/social_event.tokens.inc
@@ -77,7 +77,9 @@ function social_event_tokens($type, $tokens, array $data, array $options, Bubble
           if (!empty($id)) {
             $enrollment_name = get_name_from_enrollment($id);
 
-            $replacements[$original] = $enrollment_name;
+            if ($enrollment_name !== NULL) {
+              $replacements[$original] = $enrollment_name;
+            }
           }
           break;
       }
@@ -146,7 +148,8 @@ function get_name_from_enrollment($id) {
 
   if (!$enrollment instanceof EventEnrollmentInterface) {
     // If there is a Uid. Lets load the user and return his display name.
-    if ($enrollment->hasField('field_account') &&
+    if ($enrollment !== NULL &&
+      $enrollment->hasField('field_account') &&
       $enrollment->getFieldValue('field_account', 'target_id') > 0) {
       $entity_storage = \Drupal::entityTypeManager()
         ->getStorage('user');


### PR DESCRIPTION
…the cronjob when sending activity emails with old deleted data

## Problem
Currently when running the cron, it will go through the queue and based on that create activities with different kind of tokens.

In our case it seems like an enrollment or person got deleted, but the cronjob didn't run yet, so now when running the cronjob it tries to get an enrollment from a non-existing entity. This results in an error message and causes the cronjob to not run, building up huge amounts.
This also resulting in more of the same errors because if the cron hasn't run for a while, the possibilities of more things that got deleted are bigger.

## Solution
Solution would be to be more defensive in coding.


## Issue tracker
https://www.drupal.org/project/social/issues/3080369

## How to test
- [ ] Create enrollments for events so that the queue gets filled with email notifications
- [ ] Delete the source (users/events) of the enrollments so it cannot retrieve the name anymore.

## Release notes
We added more defensive coding when generating email notifications for the activities. In some cases it crashes because the source has been deleted.
