### PR TITLE
Issue #3108035 by Kingdutch: Hero styling is not properly scoped

### DIFF
--- a/themes/socialbase/assets/css/admin-toolbar.css
+++ b/themes/socialbase/assets/css/admin-toolbar.css
@@ -1,16 +1,13 @@
 .toolbar-vertical #block-filter:target {
-  -webkit-transform: translateY(39px) translateX(0);
-          transform: translateY(39px) translateX(0);
+  transform: translateY(39px) translateX(0);
 }
 
 .toolbar-vertical .off-canvas-right {
-  -webkit-transform: translateY(39px) translateX(280px);
-          transform: translateY(39px) translateX(280px);
+  transform: translateY(39px) translateX(280px);
 }
 
 .toolbar-vertical .off-canvas-right.is-open {
-  -webkit-transform: translateY(39px) translateX(0);
-          transform: translateY(39px) translateX(0);
+  transform: translateY(39px) translateX(0);
 }
 
 .toolbar-fixed .navbar-default {
@@ -25,12 +22,10 @@
 
 @media (min-width: 900px) {
   .toolbar-vertical .off-canvas-right {
-    -webkit-transform: none;
-            transform: none;
+    transform: none;
   }
   .toolbar-vertical .off-canvas-right.is-open {
-    -webkit-transform: none;
-            transform: none;
+    transform: none;
   }
 }
 

--- a/themes/socialbase/assets/css/ajax.css
+++ b/themes/socialbase/assets/css/ajax.css
@@ -3,22 +3,18 @@
  */
 @-webkit-keyframes glyphicon-spin {
   0% {
-    -webkit-transform: rotate(0deg);
-            transform: rotate(0deg);
+    transform: rotate(0deg);
   }
   100% {
-    -webkit-transform: rotate(359deg);
-            transform: rotate(359deg);
+    transform: rotate(359deg);
   }
 }
 @keyframes glyphicon-spin {
   0% {
-    -webkit-transform: rotate(0deg);
-            transform: rotate(0deg);
+    transform: rotate(0deg);
   }
   100% {
-    -webkit-transform: rotate(359deg);
-            transform: rotate(359deg);
+    transform: rotate(359deg);
   }
 }
 
@@ -41,7 +37,6 @@ html.js .btn .ajax-throbber {
 html.js .input-group-addon .glyphicon {
   color: #777777;
   opacity: .5;
-  -webkit-transition: 150ms color, 150ms opacity;
   transition: 150ms color, 150ms opacity;
 }
 

--- a/themes/socialbase/assets/css/autocomplete.css
+++ b/themes/socialbase/assets/css/autocomplete.css
@@ -1,6 +1,5 @@
 .ui-autocomplete.ui-widget-content {
-  -webkit-box-shadow: 0 0 6px rgba(0, 0, 0, 0.16), 0 6px 12px rgba(0, 0, 0, 0.32);
-          box-shadow: 0 0 6px rgba(0, 0, 0, 0.16), 0 6px 12px rgba(0, 0, 0, 0.32);
+  box-shadow: 0 0 6px rgba(0, 0, 0, 0.16), 0 6px 12px rgba(0, 0, 0, 0.32);
   background: white;
   padding: 0;
   list-style: none;
@@ -24,8 +23,6 @@
 
 .ui-autocomplete.ui-widget-content .ui-menu-item > a {
   padding: 7px 10px;
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
 }
 
@@ -34,19 +31,14 @@
 }
 
 .ui-autocomplete.ui-widget-content .ui-menu-item .mention__avatar {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 24px;
-          flex: 0 0 24px;
+  flex: 0 0 24px;
   max-width: 24px;
   margin-right: 10px;
 }
 
 .ui-autocomplete.ui-widget-content .ui-menu-item .mention__name {
-  -ms-flex-item-align: center;
-      align-self: center;
-  -webkit-box-flex: 1;
-      -ms-flex-positive: 1;
-          flex-grow: 1;
+  align-self: center;
+  flex-grow: 1;
 }
 
 .ui-autocomplete.ui-widget-content .ui-menu-item:hover {

--- a/themes/socialbase/assets/css/badge.css
+++ b/themes/socialbase/assets/css/badge.css
@@ -48,12 +48,8 @@ a .badge {
 }
 
 .badge__container {
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
-  -webkit-box-align: center;
-      -ms-flex-align: center;
-          align-items: center;
+  align-items: center;
 }
 
 .badge__icon {

--- a/themes/socialbase/assets/css/base.css
+++ b/themes/socialbase/assets/css/base.css
@@ -45,8 +45,7 @@ textarea {
   color: inherit;
   font: inherit;
   margin: 0;
-  -webkit-box-shadow: none;
-          box-shadow: none;
+  box-shadow: none;
   line-height: inherit;
 }
 
@@ -84,8 +83,7 @@ input {
 
 input[type="checkbox"],
 input[type="radio"] {
-  -webkit-box-sizing: border-box;
-          box-sizing: border-box;
+  box-sizing: border-box;
   padding: 0;
 }
 
@@ -96,8 +94,7 @@ input[type="number"]::-webkit-outer-spin-button {
 
 input[type="search"] {
   -webkit-appearance: textfield;
-  -webkit-box-sizing: content-box;
-          box-sizing: content-box;
+  box-sizing: content-box;
 }
 
 input[type="search"]::-webkit-search-cancel-button,
@@ -125,8 +122,7 @@ optgroup {
 }
 
 *, *:before, *:after {
-  -webkit-box-sizing: border-box;
-          box-sizing: border-box;
+  box-sizing: border-box;
 }
 
 html {
@@ -147,7 +143,6 @@ body {
 
 .fade {
   opacity: 0;
-  -webkit-transition: opacity .15s linear;
   transition: opacity .15s linear;
 }
 
@@ -167,12 +162,9 @@ body {
   position: relative;
   height: 0;
   overflow: hidden;
-  -webkit-transition-property: height, visibility;
   transition-property: height, visibility;
-  -webkit-transition-duration: 0.35s;
-          transition-duration: 0.35s;
-  -webkit-transition-timing-function: ease;
-          transition-timing-function: ease;
+  transition-duration: 0.35s;
+  transition-timing-function: ease;
 }
 
 code,
@@ -191,8 +183,7 @@ kbd kbd {
   padding: 0;
   font-size: 100%;
   font-weight: bold;
-  -webkit-box-shadow: none;
-          box-shadow: none;
+  box-shadow: none;
 }
 
 pre {
@@ -215,28 +206,23 @@ pre code {
 }
 
 .z-depth-0 {
-  -webkit-box-shadow: none;
-          box-shadow: none;
+  box-shadow: none;
 }
 
 .z-depth-1 {
-  -webkit-box-shadow: 0 0 1px rgba(0, 0, 0, 0.11), 0 1px 2px rgba(0, 0, 0, 0.22);
-          box-shadow: 0 0 1px rgba(0, 0, 0, 0.11), 0 1px 2px rgba(0, 0, 0, 0.22);
+  box-shadow: 0 0 1px rgba(0, 0, 0, 0.11), 0 1px 2px rgba(0, 0, 0, 0.22);
 }
 
 .z-depth-2 {
-  -webkit-box-shadow: 0 -1px 0 #e0e0e0, 0 0 2px rgba(0, 0, 0, 0.12), 0 2px 4px rgba(0, 0, 0, 0.24);
-          box-shadow: 0 -1px 0 #e0e0e0, 0 0 2px rgba(0, 0, 0, 0.12), 0 2px 4px rgba(0, 0, 0, 0.24);
+  box-shadow: 0 -1px 0 #e0e0e0, 0 0 2px rgba(0, 0, 0, 0.12), 0 2px 4px rgba(0, 0, 0, 0.24);
 }
 
 .z-depth-3 {
-  -webkit-box-shadow: 0 0 4px rgba(0, 0, 0, 0.14), 0 4px 8px rgba(0, 0, 0, 0.28);
-          box-shadow: 0 0 4px rgba(0, 0, 0, 0.14), 0 4px 8px rgba(0, 0, 0, 0.28);
+  box-shadow: 0 0 4px rgba(0, 0, 0, 0.14), 0 4px 8px rgba(0, 0, 0, 0.28);
 }
 
 .z-depth-4 {
-  -webkit-box-shadow: 0 0 6px rgba(0, 0, 0, 0.16), 0 6px 12px rgba(0, 0, 0, 0.32);
-          box-shadow: 0 0 6px rgba(0, 0, 0, 0.16), 0 6px 12px rgba(0, 0, 0, 0.32);
+  box-shadow: 0 0 6px rgba(0, 0, 0, 0.16), 0 6px 12px rgba(0, 0, 0, 0.32);
 }
 
 h1, h2, h3, h4, h5, h6,
@@ -245,7 +231,6 @@ h1, h2, h3, h4, h5, h6,
   font-weight: 500;
   line-height: 1.1;
   margin: 1rem 0 0.5rem;
-  -webkit-transition: 0.3s;
   transition: 0.3s;
 }
 
@@ -653,9 +638,7 @@ th {
 }
 
 .vbo-table .btn-group--operations {
-  -webkit-box-pack: left;
-      -ms-flex-pack: left;
-          justify-content: left;
+  justify-content: left;
 }
 
 .vbo-table .form-no-label.checkbox label {
@@ -672,7 +655,6 @@ th {
   font-weight: normal;
   text-align: center;
   vertical-align: middle;
-  -ms-touch-action: manipulation;
   touch-action: manipulation;
   cursor: pointer;
   background-image: none;
@@ -685,7 +667,6 @@ th {
   -ms-user-select: none;
   user-select: none;
   text-transform: uppercase;
-  -webkit-transition: .3s ease-out;
   transition: .3s ease-out;
   outline: 0;
 }
@@ -1024,8 +1005,7 @@ sub {
 }
 
 .align-center {
-  -ms-flex-item-align: center;
-      align-self: center;
+  align-self: center;
 }
 
 .block {
@@ -1056,8 +1036,7 @@ sub {
 
 .img-elevated {
   display: inline-block;
-  -webkit-box-shadow: 0 0 4px rgba(0, 0, 0, 0.14), 0 4px 8px rgba(0, 0, 0, 0.28);
-          box-shadow: 0 0 4px rgba(0, 0, 0, 0.14), 0 4px 8px rgba(0, 0, 0, 0.28);
+  box-shadow: 0 0 4px rgba(0, 0, 0, 0.14), 0 4px 8px rgba(0, 0, 0, 0.28);
 }
 
 p + p .img-elevated {
@@ -1097,11 +1076,8 @@ img.align-center {
 }
 
 .img-grid {
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
-  -ms-flex-wrap: wrap;
-      flex-wrap: wrap;
+  flex-wrap: wrap;
   padding-bottom: 10px;
 }
 

--- a/themes/socialbase/assets/css/block--informblock.css
+++ b/themes/socialbase/assets/css/block--informblock.css
@@ -1,12 +1,7 @@
 .block-data-policy {
-  -webkit-box-align: center;
-      -ms-flex-align: center;
-          align-items: center;
+  align-items: center;
   cursor: pointer;
-  -webkit-box-orient: unset;
-  -webkit-box-direction: unset;
-      -ms-flex-direction: unset;
-          flex-direction: unset;
+  flex-direction: unset;
   padding: 1rem;
 }
 
@@ -15,18 +10,14 @@
 }
 
 .block-data-policy .card__title {
-  -webkit-box-flex: 2;
-      -ms-flex: 2;
-          flex: 2;
+  flex: 2;
   padding: 0 0.75rem 0 0;
   text-align: left !important;
 }
 
 .block-data-policy footer {
   border-left: 2px solid #e6e6e6;
-  -webkit-box-flex: fit-content;
-      -ms-flex: fit-content;
-          flex: fit-content;
+  flex: fit-content;
   padding: 0 0 0 0.75rem;
   margin-top: 0;
 }
@@ -37,14 +28,9 @@
 
 @media (min-width: 900px) {
   .block-data-policy {
-    -webkit-box-align: normal;
-        -ms-flex-align: normal;
-            align-items: normal;
+    align-items: normal;
     cursor: default;
-    -webkit-box-orient: vertical;
-    -webkit-box-direction: normal;
-        -ms-flex-direction: column;
-            flex-direction: column;
+    flex-direction: column;
     padding: inherit;
   }
   .block-data-policy .card__block {
@@ -55,17 +41,13 @@
     border-radius: inherit;
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;
-    -webkit-box-flex: 0;
-        -ms-flex: none;
-            flex: none;
+    flex: none;
     padding: 15px 1.25rem;
     text-align: center !important;
   }
   .block-data-policy footer {
     border-left: none;
-    -webkit-box-flex: 0;
-        -ms-flex: none;
-            flex: none;
+    flex: none;
     padding: 1.25rem;
     margin-top: -1.25rem;
   }

--- a/themes/socialbase/assets/css/button.css
+++ b/themes/socialbase/assets/css/button.css
@@ -8,8 +8,7 @@
   font-weight: normal;
   text-align: center;
   vertical-align: middle;
-  -ms-touch-action: manipulation;
-      touch-action: manipulation;
+  touch-action: manipulation;
   cursor: pointer;
   background-image: none;
   border: 1px solid transparent;
@@ -20,7 +19,6 @@
      -moz-user-select: none;
       -ms-user-select: none;
           user-select: none;
-  -webkit-transition: .3s ease-out;
   transition: .3s ease-out;
   outline: 0;
 }
@@ -50,8 +48,7 @@
 fieldset[disabled] .btn {
   cursor: not-allowed;
   opacity: .65;
-  -webkit-box-shadow: none;
-          box-shadow: none;
+  box-shadow: none;
 }
 
 .btn a {
@@ -78,8 +75,7 @@ a.btn {
 fieldset[disabled] .btn-link {
   background-color: transparent;
   border-color: transparent;
-  -webkit-box-shadow: none;
-          box-shadow: none;
+  box-shadow: none;
 }
 
 .btn-link[disabled]:hover, .btn-link[disabled]:focus,
@@ -158,22 +154,16 @@ input[type="button"].btn-block {
 }
 
 .btn-raised {
-  -webkit-box-shadow: 0 0 2px rgba(0, 0, 0, 0.12), 0 2px 4px rgba(0, 0, 0, 0.24);
-          box-shadow: 0 0 2px rgba(0, 0, 0, 0.12), 0 2px 4px rgba(0, 0, 0, 0.24);
-  -webkit-transition: .15s ease-out, -webkit-box-shadow;
-  transition: .15s ease-out, -webkit-box-shadow;
+  box-shadow: 0 0 2px rgba(0, 0, 0, 0.12), 0 2px 4px rgba(0, 0, 0, 0.24);
   transition: box-shadow, .15s ease-out;
-  transition: box-shadow, .15s ease-out, -webkit-box-shadow;
 }
 
 .btn-raised:active, .btn-raised.active, .btn-raised:hover {
-  -webkit-box-shadow: 0 0 6px rgba(0, 0, 0, 0.16), 0 6px 12px rgba(0, 0, 0, 0.32);
-          box-shadow: 0 0 6px rgba(0, 0, 0, 0.16), 0 6px 12px rgba(0, 0, 0, 0.32);
+  box-shadow: 0 0 6px rgba(0, 0, 0, 0.16), 0 6px 12px rgba(0, 0, 0, 0.32);
 }
 
 .btn-raised.disabled, .btn-raised[disabled] {
-  -webkit-box-shadow: 0 -1px 0 #e0e0e0, 0 0 2px rgba(0, 0, 0, 0.12), 0 2px 4px rgba(0, 0, 0, 0.24);
-          box-shadow: 0 -1px 0 #e0e0e0, 0 0 2px rgba(0, 0, 0, 0.12), 0 2px 4px rgba(0, 0, 0, 0.24);
+  box-shadow: 0 -1px 0 #e0e0e0, 0 0 2px rgba(0, 0, 0, 0.12), 0 2px 4px rgba(0, 0, 0, 0.24);
 }
 
 .btn-icon-toggle {
@@ -217,13 +207,11 @@ input[type="button"].btn-block {
   padding: 7px;
   border-radius: 50%;
   border: 0;
-  -webkit-box-shadow: 0 0 4px rgba(0, 0, 0, 0.14), 0 4px 8px rgba(0, 0, 0, 0.28);
-          box-shadow: 0 0 4px rgba(0, 0, 0, 0.14), 0 4px 8px rgba(0, 0, 0, 0.28);
+  box-shadow: 0 0 4px rgba(0, 0, 0, 0.14), 0 4px 8px rgba(0, 0, 0, 0.28);
 }
 
 .btn-floating:active, .btn-floating.active, .btn-floating:hover {
-  -webkit-box-shadow: 0 0 6px rgba(0, 0, 0, 0.16), 0 6px 12px rgba(0, 0, 0, 0.32);
-          box-shadow: 0 0 6px rgba(0, 0, 0, 0.16), 0 6px 12px rgba(0, 0, 0, 0.32);
+  box-shadow: 0 0 6px rgba(0, 0, 0, 0.16), 0 6px 12px rgba(0, 0, 0, 0.32);
 }
 
 .btn-floating.btn-lg, .btn-group-lg > .btn-floating.btn {
@@ -232,8 +220,7 @@ input[type="button"].btn-block {
 }
 
 .btn-floating.disabled, .btn-floating[disabled] {
-  -webkit-box-shadow: 0 0 4px rgba(0, 0, 0, 0.14), 0 4px 8px rgba(0, 0, 0, 0.28);
-          box-shadow: 0 0 4px rgba(0, 0, 0, 0.14), 0 4px 8px rgba(0, 0, 0, 0.28);
+  box-shadow: 0 0 4px rgba(0, 0, 0, 0.14), 0 4px 8px rgba(0, 0, 0, 0.28);
 }
 
 .btn-group,
@@ -353,8 +340,7 @@ input[type="button"].btn-block {
 }
 
 .btn-group.open .dropdown-toggle.btn-link {
-  -webkit-box-shadow: none;
-          box-shadow: none;
+  box-shadow: none;
 }
 
 .btn-lg .caret, .btn-group-lg > .btn .caret {
@@ -397,12 +383,8 @@ input[type="button"].btn-block {
 
 .btn-group--operations {
   width: 100%;
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
-  -webkit-box-pack: center;
-      -ms-flex-pack: center;
-          justify-content: center;
+  justify-content: center;
 }
 
 .block-group-add-event-block,

--- a/themes/socialbase/assets/css/cards.css
+++ b/themes/socialbase/assets/css/cards.css
@@ -1,19 +1,11 @@
 .card {
-  -webkit-box-shadow: 0 -1px 0 #e0e0e0, 0 0 2px rgba(0, 0, 0, 0.12), 0 2px 4px rgba(0, 0, 0, 0.24);
-          box-shadow: 0 -1px 0 #e0e0e0, 0 0 2px rgba(0, 0, 0, 0.12), 0 2px 4px rgba(0, 0, 0, 0.24);
+  box-shadow: 0 -1px 0 #e0e0e0, 0 0 2px rgba(0, 0, 0, 0.12), 0 2px 4px rgba(0, 0, 0, 0.24);
   position: relative;
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
-  -webkit-box-orient: vertical;
-  -webkit-box-direction: normal;
-      -ms-flex-direction: column;
-          flex-direction: column;
+  flex-direction: column;
   margin-bottom: 0.75rem;
   background-clip: padding-box;
-  -webkit-box-flex: 1;
-      -ms-flex-positive: 1;
-          flex-grow: 1;
+  flex-grow: 1;
 }
 
 .card__title {
@@ -37,9 +29,7 @@
 
 .card__block {
   position: relative;
-  -webkit-box-flex: 1;
-      -ms-flex: 1 1 auto;
-          flex: 1 1 auto;
+  flex: 1 1 auto;
   padding: 1.25rem;
 }
 
@@ -105,7 +95,6 @@
   font-size: 0.875rem;
   margin-left: 24px;
   float: right;
-  -webkit-transition: color .3s ease;
   transition: color .3s ease;
 }
 

--- a/themes/socialbase/assets/css/ckeditor.css
+++ b/themes/socialbase/assets/css/ckeditor.css
@@ -14,8 +14,7 @@ kbd kbd {
   padding: 0;
   font-size: 100%;
   font-weight: bold;
-  -webkit-box-shadow: none;
-          box-shadow: none;
+  box-shadow: none;
 }
 
 pre {
@@ -38,8 +37,7 @@ pre code {
 }
 
 *, *:before, *:after {
-  -webkit-box-sizing: border-box;
-          box-sizing: border-box;
+  box-sizing: border-box;
 }
 
 html {
@@ -64,7 +62,6 @@ h1, h2, h3, h4, h5, h6,
   font-weight: 500;
   line-height: 1.1;
   margin: 1rem 0 0.5rem;
-  -webkit-transition: 0.3s;
   transition: 0.3s;
 }
 
@@ -472,9 +469,7 @@ th {
 }
 
 .vbo-table .btn-group--operations {
-  -webkit-box-pack: left;
-      -ms-flex-pack: left;
-          justify-content: left;
+  justify-content: left;
 }
 
 .vbo-table .form-no-label.checkbox label {
@@ -491,7 +486,6 @@ th {
   font-weight: normal;
   text-align: center;
   vertical-align: middle;
-  -ms-touch-action: manipulation;
   touch-action: manipulation;
   cursor: pointer;
   background-image: none;
@@ -504,7 +498,6 @@ th {
   -ms-user-select: none;
   user-select: none;
   text-transform: uppercase;
-  -webkit-transition: .3s ease-out;
   transition: .3s ease-out;
   outline: 0;
 }
@@ -843,8 +836,7 @@ sub {
 }
 
 .align-center {
-  -ms-flex-item-align: center;
-      align-self: center;
+  align-self: center;
 }
 
 .block {
@@ -875,8 +867,7 @@ sub {
 
 .img-elevated {
   display: inline-block;
-  -webkit-box-shadow: 0 0 4px rgba(0, 0, 0, 0.14), 0 4px 8px rgba(0, 0, 0, 0.28);
-          box-shadow: 0 0 4px rgba(0, 0, 0, 0.14), 0 4px 8px rgba(0, 0, 0, 0.28);
+  box-shadow: 0 0 4px rgba(0, 0, 0, 0.14), 0 4px 8px rgba(0, 0, 0, 0.28);
 }
 
 p + p .img-elevated {
@@ -916,11 +907,8 @@ img.align-center {
 }
 
 .img-grid {
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
-  -ms-flex-wrap: wrap;
-      flex-wrap: wrap;
+  flex-wrap: wrap;
   padding-bottom: 10px;
 }
 
@@ -1014,8 +1002,7 @@ img.align-center {
   font-weight: normal;
   text-align: center;
   vertical-align: middle;
-  -ms-touch-action: manipulation;
-      touch-action: manipulation;
+  touch-action: manipulation;
   cursor: pointer;
   background-image: none;
   border: 1px solid transparent;
@@ -1026,7 +1013,6 @@ img.align-center {
      -moz-user-select: none;
       -ms-user-select: none;
           user-select: none;
-  -webkit-transition: .3s ease-out;
   transition: .3s ease-out;
   outline: 0;
 }
@@ -1056,8 +1042,7 @@ img.align-center {
 fieldset[disabled] .btn {
   cursor: not-allowed;
   opacity: .65;
-  -webkit-box-shadow: none;
-          box-shadow: none;
+  box-shadow: none;
 }
 
 .btn a {
@@ -1084,8 +1069,7 @@ a.btn {
 fieldset[disabled] .btn-link {
   background-color: transparent;
   border-color: transparent;
-  -webkit-box-shadow: none;
-          box-shadow: none;
+  box-shadow: none;
 }
 
 .btn-link[disabled]:hover, .btn-link[disabled]:focus,
@@ -1164,22 +1148,16 @@ input[type="button"].btn-block {
 }
 
 .btn-raised {
-  -webkit-box-shadow: 0 0 2px rgba(0, 0, 0, 0.12), 0 2px 4px rgba(0, 0, 0, 0.24);
-          box-shadow: 0 0 2px rgba(0, 0, 0, 0.12), 0 2px 4px rgba(0, 0, 0, 0.24);
-  -webkit-transition: .15s ease-out, -webkit-box-shadow;
-  transition: .15s ease-out, -webkit-box-shadow;
+  box-shadow: 0 0 2px rgba(0, 0, 0, 0.12), 0 2px 4px rgba(0, 0, 0, 0.24);
   transition: box-shadow, .15s ease-out;
-  transition: box-shadow, .15s ease-out, -webkit-box-shadow;
 }
 
 .btn-raised:active, .btn-raised.active, .btn-raised:hover {
-  -webkit-box-shadow: 0 0 6px rgba(0, 0, 0, 0.16), 0 6px 12px rgba(0, 0, 0, 0.32);
-          box-shadow: 0 0 6px rgba(0, 0, 0, 0.16), 0 6px 12px rgba(0, 0, 0, 0.32);
+  box-shadow: 0 0 6px rgba(0, 0, 0, 0.16), 0 6px 12px rgba(0, 0, 0, 0.32);
 }
 
 .btn-raised.disabled, .btn-raised[disabled] {
-  -webkit-box-shadow: 0 -1px 0 #e0e0e0, 0 0 2px rgba(0, 0, 0, 0.12), 0 2px 4px rgba(0, 0, 0, 0.24);
-          box-shadow: 0 -1px 0 #e0e0e0, 0 0 2px rgba(0, 0, 0, 0.12), 0 2px 4px rgba(0, 0, 0, 0.24);
+  box-shadow: 0 -1px 0 #e0e0e0, 0 0 2px rgba(0, 0, 0, 0.12), 0 2px 4px rgba(0, 0, 0, 0.24);
 }
 
 .btn-icon-toggle {
@@ -1223,13 +1201,11 @@ input[type="button"].btn-block {
   padding: 7px;
   border-radius: 50%;
   border: 0;
-  -webkit-box-shadow: 0 0 4px rgba(0, 0, 0, 0.14), 0 4px 8px rgba(0, 0, 0, 0.28);
-          box-shadow: 0 0 4px rgba(0, 0, 0, 0.14), 0 4px 8px rgba(0, 0, 0, 0.28);
+  box-shadow: 0 0 4px rgba(0, 0, 0, 0.14), 0 4px 8px rgba(0, 0, 0, 0.28);
 }
 
 .btn-floating:active, .btn-floating.active, .btn-floating:hover {
-  -webkit-box-shadow: 0 0 6px rgba(0, 0, 0, 0.16), 0 6px 12px rgba(0, 0, 0, 0.32);
-          box-shadow: 0 0 6px rgba(0, 0, 0, 0.16), 0 6px 12px rgba(0, 0, 0, 0.32);
+  box-shadow: 0 0 6px rgba(0, 0, 0, 0.16), 0 6px 12px rgba(0, 0, 0, 0.32);
 }
 
 .btn-floating.btn-lg, .btn-group-lg > .btn-floating.btn {
@@ -1238,8 +1214,7 @@ input[type="button"].btn-block {
 }
 
 .btn-floating.disabled, .btn-floating[disabled] {
-  -webkit-box-shadow: 0 0 4px rgba(0, 0, 0, 0.14), 0 4px 8px rgba(0, 0, 0, 0.28);
-          box-shadow: 0 0 4px rgba(0, 0, 0, 0.14), 0 4px 8px rgba(0, 0, 0, 0.28);
+  box-shadow: 0 0 4px rgba(0, 0, 0, 0.14), 0 4px 8px rgba(0, 0, 0, 0.28);
 }
 
 .btn-group,
@@ -1359,8 +1334,7 @@ input[type="button"].btn-block {
 }
 
 .btn-group.open .dropdown-toggle.btn-link {
-  -webkit-box-shadow: none;
-          box-shadow: none;
+  box-shadow: none;
 }
 
 .btn-lg .caret, .btn-group-lg > .btn .caret {
@@ -1403,12 +1377,8 @@ input[type="button"].btn-block {
 
 .btn-group--operations {
   width: 100%;
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
-  -webkit-box-pack: center;
-      -ms-flex-pack: center;
-          justify-content: center;
+  justify-content: center;
 }
 
 .block-group-add-event-block,

--- a/themes/socialbase/assets/css/comment.css
+++ b/themes/socialbase/assets/css/comment.css
@@ -9,8 +9,6 @@ a[id^="comment-"] {
   position: relative;
   margin-top: 1em;
   line-height: 1.2;
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
   width: 100%;
 }
@@ -27,14 +25,11 @@ a[id^="comment-"] {
   margin-right: 8px;
   width: 38px;
   height: 38px;
-  -ms-flex-negative: 0;
-      flex-shrink: 0;
+  flex-shrink: 0;
 }
 
 .comment__content {
-  -webkit-box-flex: 1;
-      -ms-flex: 1;
-          flex: 1;
+  flex: 1;
 }
 
 .comment__author {
@@ -122,9 +117,7 @@ a[id^="comment-"] {
  */
 
 .comment-attachments {
-  -webkit-box-flex: 1;
-      -ms-flex: 1 0 100%;
-          flex: 1 0 100%;
+  flex: 1 0 100%;
 }
 
 .comment-attachments .btn {

--- a/themes/socialbase/assets/css/datepicker.css
+++ b/themes/socialbase/assets/css/datepicker.css
@@ -25,8 +25,7 @@ input[type='text'].form-time {
   min-width: 160px;
   margin: 4px 0;
   text-align: left;
-  -webkit-box-shadow: 0 6px 12px rgba(0, 0, 0, 0.175);
-          box-shadow: 0 6px 12px rgba(0, 0, 0, 0.175);
+  box-shadow: 0 6px 12px rgba(0, 0, 0, 0.175);
   background-clip: padding-box;
   font-size: 0.875rem;
   padding: 4px;

--- a/themes/socialbase/assets/css/dropdown.css
+++ b/themes/socialbase/assets/css/dropdown.css
@@ -34,8 +34,7 @@
   font-size: 0.875rem;
   text-align: left;
   background-color: #fff;
-  -webkit-box-shadow: 0 0 6px rgba(0, 0, 0, 0.16), 0 6px 12px rgba(0, 0, 0, 0.32);
-          box-shadow: 0 0 6px rgba(0, 0, 0, 0.16), 0 6px 12px rgba(0, 0, 0, 0.32);
+  box-shadow: 0 0 6px rgba(0, 0, 0, 0.16), 0 6px 12px rgba(0, 0, 0, 0.32);
   background-clip: padding-box;
 }
 
@@ -155,8 +154,7 @@
 }
 
 .dropdown-menu .media-left {
-  -ms-flex-negative: 0;
-      flex-shrink: 0;
+  flex-shrink: 0;
 }
 
 .dropdown-menu .media-left img {

--- a/themes/socialbase/assets/css/file.css
+++ b/themes/socialbase/assets/css/file.css
@@ -1,6 +1,4 @@
 .file {
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
   font-size: 0.75rem;
   margin: 10px 0;
@@ -32,9 +30,7 @@
      -moz-user-select: none;
       -ms-user-select: none;
           user-select: none;
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 32px;
-          flex: 0 0 32px;
+  flex: 0 0 32px;
 }
 
 .file-icon .node-file__icon {
@@ -42,9 +38,7 @@
 }
 
 .file-link {
-  -webkit-box-flex: 1;
-      -ms-flex: 1;
-          flex: 1;
+  flex: 1;
   white-space: normal;
   word-break: break-word;
 }
@@ -69,14 +63,9 @@
   padding-left: 0;
   list-style: none;
   margin-bottom: 0;
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
-  -ms-flex-wrap: wrap;
-      flex-wrap: wrap;
-  -webkit-box-pack: justify;
-      -ms-flex-pack: justify;
-          justify-content: space-between;
+  flex-wrap: wrap;
+  justify-content: space-between;
 }
 
 .card-files__title {
@@ -84,19 +73,15 @@
 }
 
 .card-file {
-  -webkit-box-shadow: 0 0 1px rgba(0, 0, 0, 0.11), 0 1px 2px rgba(0, 0, 0, 0.22);
-          box-shadow: 0 0 1px rgba(0, 0, 0, 0.11), 0 1px 2px rgba(0, 0, 0, 0.22);
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 47.5%;
-          flex: 0 0 47.5%;
+  box-shadow: 0 0 1px rgba(0, 0, 0, 0.11), 0 1px 2px rgba(0, 0, 0, 0.22);
+  flex: 0 0 47.5%;
   margin-bottom: 13px;
   font-size: 0.75rem;
   background: #f3f3f3;
 }
 
 .card-file:hover {
-  -webkit-box-shadow: 0 -1px 0 #e0e0e0, 0 0 2px rgba(0, 0, 0, 0.12), 0 2px 4px rgba(0, 0, 0, 0.24);
-          box-shadow: 0 -1px 0 #e0e0e0, 0 0 2px rgba(0, 0, 0, 0.12), 0 2px 4px rgba(0, 0, 0, 0.24);
+  box-shadow: 0 -1px 0 #e0e0e0, 0 0 2px rgba(0, 0, 0, 0.12), 0 2px 4px rgba(0, 0, 0, 0.24);
 }
 
 .card-file__link {
@@ -137,11 +122,8 @@
 }
 
 .card-file__type {
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
-  -ms-flex-wrap: wrap;
-      flex-wrap: wrap;
+  flex-wrap: wrap;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -169,9 +151,7 @@
 }
 
 .card-file__count {
-  -webkit-box-flex: 1;
-      -ms-flex: 1 0 100%;
-          flex: 1 0 100%;
+  flex: 1 0 100%;
   white-space: nowrap;
   margin: 5px 0 0 24px;
 }
@@ -184,13 +164,10 @@
 
 @media (min-width: 900px) {
   .card-files__grid {
-    -webkit-box-pack: start;
-        -ms-flex-pack: start;
-            justify-content: flex-start;
+    justify-content: flex-start;
   }
   .card-file {
-    -ms-flex-preferred-size: 23%;
-        flex-basis: 23%;
+    flex-basis: 23%;
     margin-right: 2%;
   }
   .card-file:nth-child(4n+4) {

--- a/themes/socialbase/assets/css/form-controls.css
+++ b/themes/socialbase/assets/css/form-controls.css
@@ -8,10 +8,7 @@
   font-size: inherit;
   line-height: 1.5;
   background-image: none;
-  -webkit-transition: border-color ease-in-out .15s, -webkit-box-shadow ease-in-out .15s;
-  transition: border-color ease-in-out .15s, -webkit-box-shadow ease-in-out .15s;
   transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s;
-  transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s, -webkit-box-shadow ease-in-out .15s;
 }
 
 .form-control::-moz-placeholder {
@@ -42,8 +39,7 @@ textarea.form-control {
 }
 
 input[type="search"] {
-  -webkit-box-sizing: border-box;
-          box-sizing: border-box;
+  box-sizing: border-box;
 }
 
 input[type="radio"],
@@ -115,7 +111,6 @@ input[type="search"] {
   display: inline-block;
   line-height: 21px;
   font-size: 0.875rem;
-  -webkit-transition: .28s ease;
   transition: .28s ease;
   -webkit-user-select: none;
      -moz-user-select: none;
@@ -133,7 +128,6 @@ input[type="search"] {
   width: 16px;
   height: 16px;
   z-index: 0;
-  -webkit-transition: .28s ease;
   transition: .28s ease;
 }
 
@@ -147,8 +141,7 @@ input[type="search"] {
   border-radius: 50%;
   border: 2px solid #555555;
   z-index: -1;
-  -webkit-transform: scale(0);
-          transform: scale(0);
+  transform: scale(0);
 }
 
 [type="radio"]:checked + label:before {
@@ -158,8 +151,7 @@ input[type="search"] {
 [type="radio"]:checked + label:after {
   border-radius: 50%;
   z-index: 0;
-  -webkit-transform: scale(0.5);
-          transform: scale(0.5);
+  transform: scale(0.5);
 }
 
 /* Disabled style */
@@ -197,7 +189,6 @@ input[type="search"] {
   left: 0;
   position: absolute;
   /* .1s delay is for check animation */
-  -webkit-transition: border .25s, background-color .25s, width .20s .1s, height .20s .1s, top .20s .1s, left .20s .1s;
   transition: border .25s, background-color .25s, width .20s .1s, height .20s .1s, top .20s .1s, left .20s .1s;
   z-index: 1;
 }
@@ -208,9 +199,7 @@ input[type="search"] {
   border: 3px solid transparent;
   left: 6px;
   top: 10px;
-  -webkit-transform: rotateZ(37deg);
-          transform: rotateZ(37deg);
-  -webkit-transform-origin: 20% 40%;
+  transform: rotateZ(37deg);
   transform-origin: 100% 100%;
 }
 
@@ -232,13 +221,10 @@ input[type="search"] {
   border-left: 2px solid transparent;
   border-right: 2px solid white;
   border-bottom: 2px solid white;
-  -webkit-transform: rotateZ(37deg);
-          transform: rotateZ(37deg);
+  transform: rotateZ(37deg);
   margin-top: 2px;
-  -webkit-transition: .2s;
   transition: .2s;
-  -webkit-transform-origin: 100% 100%;
-          transform-origin: 100% 100%;
+  transform-origin: 100% 100%;
 }
 
 [type="checkbox"]:checked + label:after {
@@ -295,22 +281,16 @@ input[type="search"] {
 }
 
 .switch {
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
   width: 100%;
 }
 
 .switch__label {
-  -webkit-box-flex: 1;
-      -ms-flex: 1 1 auto;
-          flex: 1 1 auto;
+  flex: 1 1 auto;
 }
 
 .switch__options {
-  -webkit-box-flex: 1;
-      -ms-flex: 1 0 150px;
-          flex: 1 0 150px;
+  flex: 1 0 150px;
   text-align: right;
 }
 
@@ -333,15 +313,13 @@ input[type="search"] {
   background-color: #777777;
   border-radius: 15px;
   margin-right: 10px;
-  -webkit-transition: background 0.3s ease;
   transition: background 0.3s ease;
   vertical-align: middle;
   margin: 0 16px;
 }
 
 .switch .lever:after {
-  -webkit-box-shadow: 0 0 1px rgba(0, 0, 0, 0.11), 0 1px 2px rgba(0, 0, 0, 0.22);
-          box-shadow: 0 0 1px rgba(0, 0, 0, 0.11), 0 1px 2px rgba(0, 0, 0, 0.22);
+  box-shadow: 0 0 1px rgba(0, 0, 0, 0.11), 0 1px 2px rgba(0, 0, 0, 0.22);
   content: "";
   position: absolute;
   display: inline-block;
@@ -351,15 +329,11 @@ input[type="search"] {
   border-radius: 21px;
   left: -5px;
   top: -3px;
-  -webkit-transition: left 0.3s ease, background .3s ease, -webkit-box-shadow 0.1s ease;
-  transition: left 0.3s ease, background .3s ease, -webkit-box-shadow 0.1s ease;
   transition: left 0.3s ease, background .3s ease, box-shadow 0.1s ease;
-  transition: left 0.3s ease, background .3s ease, box-shadow 0.1s ease, -webkit-box-shadow 0.1s ease;
 }
 
 input[type=checkbox]:not(:disabled) ~ .lever:active:after {
-  -webkit-box-shadow: 0 1px 3px 1px rgba(0, 0, 0, 0.4), 0 0 0 15px rgba(0, 0, 0, 0.08);
-          box-shadow: 0 1px 3px 1px rgba(0, 0, 0, 0.4), 0 0 0 15px rgba(0, 0, 0, 0.08);
+  box-shadow: 0 1px 3px 1px rgba(0, 0, 0, 0.4), 0 0 0 15px rgba(0, 0, 0, 0.08);
 }
 
 .switch input[type=checkbox]:checked + .lever:after {

--- a/themes/socialbase/assets/css/form-elements.css
+++ b/themes/socialbase/assets/css/form-elements.css
@@ -43,11 +43,8 @@ label {
 }
 
 .form-group-inline {
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
-  -ms-flex-wrap: wrap;
-      flex-wrap: wrap;
+  flex-wrap: wrap;
 }
 
 .form-group-inline .form-group {
@@ -55,28 +52,21 @@ label {
 }
 
 .form-group-inline .form-item {
-  -webkit-box-flex: 1;
-      -ms-flex: 1;
-          flex: 1;
+  flex: 1;
 }
 
 .form-group-inline .btn {
   margin-left: 8px;
   margin-bottom: 5px;
-  -ms-flex-negative: 0;
-      flex-shrink: 0;
+  flex-shrink: 0;
 }
 
 .form-group-inline--right {
-  -webkit-box-pack: end;
-      -ms-flex-pack: end;
-          justify-content: flex-end;
+  justify-content: flex-end;
 }
 
 .form-group-inline--right .button--primary {
-  -webkit-box-ordinal-group: 11;
-      -ms-flex-order: 10;
-          order: 10;
+  order: 10;
 }
 
 .form-no-label label + .form-required {
@@ -123,21 +113,14 @@ span.form-required {
 }
 
 .views-exposed-form__actions {
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
-  -ms-flex-wrap: wrap;
-      flex-wrap: wrap;
-  -webkit-box-pack: justify;
-      -ms-flex-pack: justify;
-          justify-content: space-between;
+  flex-wrap: wrap;
+  justify-content: space-between;
   margin-bottom: 0;
 }
 
 .views-exposed-form__actions .btn-default {
-  -webkit-box-ordinal-group: 11;
-      -ms-flex-order: 10;
-          order: 10;
+  order: 10;
 }
 
 .views-exposed-form__actions .btn-flat {
@@ -145,23 +128,16 @@ span.form-required {
 }
 
 .form--default .form-actions {
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
-  -ms-flex-wrap: wrap;
-      flex-wrap: wrap;
-  -webkit-box-pack: start;
-      -ms-flex-pack: start;
-          justify-content: flex-start;
+  flex-wrap: wrap;
+  justify-content: flex-start;
 }
 
 .form--default .form-actions .btn-group--primary,
 .form--default .form-actions .btn-primary {
   margin-left: auto;
   margin-right: 0;
-  -webkit-box-ordinal-group: 11;
-      -ms-flex-order: 10;
-          order: 10;
+  order: 10;
 }
 
 .form-item--error-message {

--- a/themes/socialbase/assets/css/form-horizontal.css
+++ b/themes/socialbase/assets/css/form-horizontal.css
@@ -4,56 +4,40 @@
 
 @media (min-width: 600px) {
   .form-horizontal .form-group {
-    display: -webkit-box;
-    display: -ms-flexbox;
     display: flex;
-    -ms-flex-wrap: wrap;
-        flex-wrap: wrap;
-    -webkit-box-align: start;
-        -ms-flex-align: start;
-            align-items: flex-start;
+    flex-wrap: wrap;
+    align-items: flex-start;
   }
   .form-horizontal .help-block {
-    -ms-flex-preferred-size: 100%;
-        flex-basis: 100%;
+    flex-basis: 100%;
   }
   .form-horizontal .control-label {
     margin-bottom: 0;
     padding-top: 7px;
     line-height: 1.5;
-    -webkit-box-flex: 1;
-        -ms-flex: 1 1 auto;
-            flex: 1 1 auto;
+    flex: 1 1 auto;
     padding-right: 1em;
   }
   .form-horizontal .control-label + .form-control,
   .form-horizontal .control-label + .select-wrapper {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 1 auto;
-            flex: 0 1 auto;
+    flex: 0 1 auto;
     width: auto;
   }
   .form-horizontal .control-label--wide {
-    -webkit-box-flex: 3;
-        -ms-flex: 3 1 70%;
-            flex: 3 1 70%;
+    flex: 3 1 70%;
   }
   .form-horizontal .control-label--wide + .form-control,
   .form-horizontal .control-label--wide + .select-wrapper {
-    -webkit-box-flex: 1;
-        -ms-flex: 1 1 30%;
-            flex: 1 1 30%;
+    flex: 1 1 30%;
   }
 }
 
 @media (min-width: 1200px) {
   .form-horizontal .control-label--wide {
-    -ms-flex-preferred-size: 80%;
-        flex-basis: 80%;
+    flex-basis: 80%;
   }
   .form-horizontal .control-label--wide + .form-control,
   .form-horizontal .control-label--wide + .select-wrapper {
-    -ms-flex-preferred-size: 20%;
-        flex-basis: 20%;
+    flex-basis: 20%;
   }
 }

--- a/themes/socialbase/assets/css/form-post-create.css
+++ b/themes/socialbase/assets/css/form-post-create.css
@@ -1,18 +1,11 @@
 .form--post-create {
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
-  -ms-flex-wrap: wrap;
-      flex-wrap: wrap;
-  -webkit-box-pack: end;
-      -ms-flex-pack: end;
-          justify-content: flex-end;
+  flex-wrap: wrap;
+  justify-content: flex-end;
 }
 
 .form--post-create .field--name-field-post {
-  -webkit-box-flex: 1;
-      -ms-flex: 1 0 100%;
-          flex: 1 0 100%;
+  flex: 1 0 100%;
 }
 
 .form--post-create .field--name-field-post .filter-wrapper {
@@ -24,9 +17,7 @@
 }
 
 .form--post-create .field--name-field-post-image {
-  -webkit-box-flex: 1;
-      -ms-flex: 1 1 100%;
-          flex: 1 1 100%;
+  flex: 1 1 100%;
   position: relative;
 }
 
@@ -37,18 +28,13 @@
 
 .form--post-create .field--name-field-post-image .preview {
   display: inline-block;
-  -webkit-box-shadow: 0 0 4px rgba(0, 0, 0, 0.14), 0 4px 8px rgba(0, 0, 0, 0.28);
-          box-shadow: 0 0 4px rgba(0, 0, 0, 0.14), 0 4px 8px rgba(0, 0, 0, 0.28);
+  box-shadow: 0 0 4px rgba(0, 0, 0, 0.14), 0 4px 8px rgba(0, 0, 0, 0.28);
   width: auto;
 }
 
 .form--post-create .field--name-field-post-image .image-widget {
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
-  -webkit-box-pack: end;
-      -ms-flex-pack: end;
-          justify-content: flex-end;
+  justify-content: flex-end;
   position: relative;
   margin-bottom: 1rem;
 }
@@ -69,20 +55,14 @@
 }
 
 .form--post-create .field--name-field-post-visibility {
-  -webkit-box-flex: 1;
-      -ms-flex: 1 1 auto;
-          flex: 1 1 auto;
-  -ms-flex-item-align: end;
-      align-self: flex-end;
+  flex: 1 1 auto;
+  align-self: flex-end;
 }
 
 .form--post-create .btn-primary {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 1 auto;
-          flex: 0 1 auto;
+  flex: 0 1 auto;
   margin-left: 0.5rem;
-  -ms-flex-item-align: end;
-      align-self: flex-end;
+  align-self: flex-end;
 }
 
 @media (min-width: 600px) {
@@ -93,8 +73,7 @@
     right: auto;
   }
   .form--post-create .field--name-field-post-image {
-    -ms-flex-preferred-size: auto;
-        flex-basis: auto;
+    flex-basis: auto;
     margin-bottom: 0;
   }
   .form--post-create .field--name-field-post-image .btn-default {
@@ -102,14 +81,10 @@
     margin-bottom: 0;
   }
   .form--post-create .field--name-field-post-visibility {
-    -webkit-box-flex: 0;
-        -ms-flex-positive: 0;
-            flex-grow: 0;
+    flex-grow: 0;
   }
   .form--post-create .btn-primary {
-    -webkit-box-flex: 0;
-        -ms-flex-positive: 0;
-            flex-grow: 0;
+    flex-grow: 0;
   }
 }
 

--- a/themes/socialbase/assets/css/group-managers.css
+++ b/themes/socialbase/assets/css/group-managers.css
@@ -2,19 +2,12 @@
   padding: 0;
 }@media (min-width: 900px) {
   .view--group-managers {
-    display: -webkit-box;
-    display: -ms-flexbox;
     display: flex;
-    -ms-flex-wrap: wrap;
-        flex-wrap: wrap;
-    -webkit-box-pack: justify;
-        -ms-flex-pack: justify;
-            justify-content: space-between;
+    flex-wrap: wrap;
+    justify-content: space-between;
     padding: 1.25rem;
   }
   .view--group-managers .card__block {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 48%;
-            flex: 0 0 48%;
+    flex: 0 0 48%;
   }
 }

--- a/themes/socialbase/assets/css/hero.css
+++ b/themes/socialbase/assets/css/hero.css
@@ -34,36 +34,24 @@
   left: 0;
   bottom: 0;
   right: 0;
-  background: -webkit-gradient(linear, left top, left bottom, from(rgba(0, 0, 0, 0.1)), to(rgba(34, 34, 34, 0.7)));
   background: linear-gradient(rgba(0, 0, 0, 0.1) 0%, rgba(34, 34, 34, 0.7) 100%);
 }
 
 .cover-wrap {
   width: 100%;
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
-  -webkit-box-orient: vertical;
-  -webkit-box-direction: normal;
-      -ms-flex-direction: column;
-          flex-direction: column;
-  -webkit-box-pack: center;
-      -ms-flex-pack: center;
-          justify-content: center;
+  flex-direction: column;
+  justify-content: center;
   position: relative;
   z-index: 2;
   min-height: 300px;
-  -webkit-box-align: stretch;
-      -ms-flex-align: stretch;
-          align-items: stretch;
+  align-items: stretch;
 }
 
 /* IE11 */
 
 .cover-with-canvas .cover-wrap {
-  -webkit-box-pack: justify;
-      -ms-flex-pack: justify;
-          justify-content: space-between;
+  justify-content: space-between;
 }
 
 .node-unpublished .status:before {
@@ -75,7 +63,7 @@
   display: block;
 }
 
-.page-title {
+.cover .page-title {
   font-weight: 700;
   text-shadow: 0 1px 3px rgba(0, 0, 0, 0.5);
   text-align: center;
@@ -95,17 +83,12 @@
 }
 
 .hero-footer__cta {
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
-  -webkit-box-pack: end;
-      -ms-flex-pack: end;
-          justify-content: flex-end;
+  justify-content: flex-end;
 }
 
 .hero-avatar {
-  -webkit-box-shadow: 0 0 1px rgba(0, 0, 0, 0.11), 0 1px 2px rgba(0, 0, 0, 0.22);
-          box-shadow: 0 0 1px rgba(0, 0, 0, 0.11), 0 1px 2px rgba(0, 0, 0, 0.22);
+  box-shadow: 0 0 1px rgba(0, 0, 0, 0.11), 0 1px 2px rgba(0, 0, 0, 0.22);
   margin: auto;
   width: 128px;
   height: 128px;
@@ -121,9 +104,7 @@
 }
 
 .block-social-profile .hero-footer {
-  -webkit-box-pack: center;
-      -ms-flex-pack: center;
-          justify-content: center;
+  justify-content: center;
 }
 
 .block-social-profile .hero-footer__text {
@@ -131,12 +112,8 @@
 }
 
 .block-social-profile .hero-footer__cta {
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
-  -webkit-box-pack: end;
-      -ms-flex-pack: end;
-          justify-content: flex-end;
+  justify-content: flex-end;
   padding-top: 1rem;
   padding-left: 1rem;
 }
@@ -201,7 +178,6 @@
   line-height: 38px;
   speak: none;
   pointer-events: none;
-  -webkit-transition: 0.3s;
   transition: 0.3s;
 }
 
@@ -232,29 +208,21 @@
     position: absolute;
     bottom: 0;
   }
-  .page-title {
+  .cover .page-title {
     max-width: 900px;
   }
   .hero-footer {
-    display: -webkit-box;
-    display: -ms-flexbox;
     display: flex;
-    -webkit-box-align: center;
-        -ms-flex-align: center;
-            align-items: center;
+    align-items: center;
   }
   .hero-footer__text {
     padding-right: 1rem;
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 50%;
-            flex: 0 0 50%;
+    flex: 0 0 50%;
     max-width: 50%;
     margin-left: 25%;
   }
   .block-social-profile .hero-footer__text {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 auto;
-            flex: 0 0 auto;
+    flex: 0 0 auto;
     max-width: unset;
     margin-left: 0;
   }
@@ -263,18 +231,14 @@
 @media (min-width: 900px) {
   .hero-footer__cta {
     padding-left: 1rem;
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 25%;
-            flex: 0 0 25%;
+    flex: 0 0 25%;
     max-width: 25%;
   }
   .block-social-profile .hero-footer__cta {
     padding: 0;
     position: absolute;
     right: 0;
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 auto;
-            flex: 0 0 auto;
+    flex: 0 0 auto;
     max-width: unset;
   }
   .hero-canvas {

--- a/themes/socialbase/assets/css/image-widget.css
+++ b/themes/socialbase/assets/css/image-widget.css
@@ -22,7 +22,6 @@
   background: rgba(0, 0, 0, 0.2);
   border: 0;
   padding: 0;
-  -webkit-transition: 0.3s background-color;
   transition: 0.3s background-color;
 }
 
@@ -31,36 +30,27 @@
 }
 
 .btn--post-remove-image:hover .btn-icon {
-  -webkit-transform: rotate(90deg);
-          transform: rotate(90deg);
+  transform: rotate(90deg);
 }
 
 .btn--post-remove-image .btn-icon {
   fill: white;
   height: 32px;
   width: 32px;
-  -webkit-transition: 0.3s -webkit-transform;
-  transition: 0.3s -webkit-transform;
   transition: 0.3s transform;
-  transition: 0.3s transform, 0.3s -webkit-transform;
 }
 
 @media (min-width: 600px) {
   .form-type-managed-file .image-widget {
-    display: -webkit-box;
-    display: -ms-flexbox;
     display: flex;
   }
   .form-type-managed-file .image-widget .preview {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 auto;
-            flex: 0 0 auto;
+    flex: 0 0 auto;
   }
   .form-type-managed-file .image-widget .file--image {
     margin-bottom: 0.5rem;
   }
   .form--post-create .field--name-field-post-image.container-post-image {
-    -ms-flex-preferred-size: 100%;
-        flex-basis: 100%;
+    flex-basis: 100%;
   }
 }

--- a/themes/socialbase/assets/css/input-groups.css
+++ b/themes/socialbase/assets/css/input-groups.css
@@ -47,10 +47,7 @@
 }
 
 .input-group-addon {
-  -webkit-transition: border-color ease-in-out .15s, -webkit-box-shadow ease-in-out .15s;
-  transition: border-color ease-in-out .15s, -webkit-box-shadow ease-in-out .15s;
   transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s;
-  transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s, -webkit-box-shadow ease-in-out .15s;
   padding: 6px 12px;
   font-size: 16px;
   font-weight: normal;

--- a/themes/socialbase/assets/css/layout.css
+++ b/themes/socialbase/assets/css/layout.css
@@ -8,12 +8,9 @@
 }
 
 .row {
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
   width: 100%;
-  -ms-flex-wrap: wrap;
-      flex-wrap: wrap;
+  flex-wrap: wrap;
 }
 
 .main-container {
@@ -27,8 +24,7 @@
 }
 
 .region--title {
-  -ms-flex-preferred-size: 100%;
-      flex-basis: 100%;
+  flex-basis: 100%;
   max-width: 100%;
 }
 
@@ -42,24 +38,21 @@
 .layout--with-complementary > .region--content {
   padding-left: 1em;
   padding-right: 1em;
-  -ms-flex-preferred-size: 100%;
-      flex-basis: 100%;
+  flex-basis: 100%;
   max-width: 100%;
 }
 
 .region--complementary {
   padding-left: 1em;
   padding-right: 1em;
-  -ms-flex-preferred-size: 100%;
-      flex-basis: 100%;
+  flex-basis: 100%;
   max-width: 100%;
 }
 
 .layout--with-two-columns .region--content,
 .layout--with-two-columns .region--sidebar-first,
 .layout--with-two-columns .region--sidebar-second {
-  -ms-flex-preferred-size: 100%;
-      flex-basis: 100%;
+  flex-basis: 100%;
   padding-left: 1em;
   padding-right: 1em;
 }
@@ -69,8 +62,7 @@
 .layout--with-three-columns .region--sidebar-second {
   padding-left: 1em;
   padding-right: 1em;
-  -ms-flex-preferred-size: 100%;
-      flex-basis: 100%;
+  flex-basis: 100%;
 }
 
 .region--complementary-bottom {
@@ -88,38 +80,26 @@
     margin-top: 1rem;
   }
   .layout--with-complementary > .region--content {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 66.66667%;
-            flex: 0 0 66.66667%;
+    flex: 0 0 66.66667%;
     max-width: 66.66667%;
-    -webkit-box-ordinal-group: 2;
-        -ms-flex-order: 1;
-            order: 1;
+    order: 1;
   }
   .region--complementary {
     margin-top: 1rem;
-    -webkit-box-flex: 0;
-        -ms-flex: 0 1 33.33333%;
-            flex: 0 1 33.33333%;
-    -webkit-box-ordinal-group: 3;
-        -ms-flex-order: 2;
-            order: 2;
+    flex: 0 1 33.33333%;
+    order: 2;
     max-width: 33.33333%;
   }
   .layout--with-two-columns .region--content,
   .layout--with-two-columns .region--sidebar-first,
   .layout--with-two-columns .region--sidebar-second {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 50%;
-            flex: 0 0 50%;
+    flex: 0 0 50%;
     max-width: 50%;
   }
   .layout--with-three-columns .region--content,
   .layout--with-three-columns .region--sidebar-first,
   .layout--with-three-columns .region--sidebar-second {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 33.33333%;
-            flex: 0 0 33.33333%;
+    flex: 0 0 33.33333%;
     max-width: 33.33333%;
   }
   .region--complementary-bottom {

--- a/themes/socialbase/assets/css/like.css
+++ b/themes/socialbase/assets/css/like.css
@@ -8,12 +8,8 @@
 }
 
 .vote__wrapper {
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
-  -webkit-box-align: center;
-      -ms-flex-align: center;
-          align-items: center;
+  align-items: center;
 }
 
 .vote-like {
@@ -29,7 +25,6 @@
   fill: transparent;
   stroke: #4d4d4d;
   stroke-width: 15px;
-  -webkit-transition: 0.3s;
   transition: 0.3s;
   vertical-align: text-top;
 }
@@ -71,14 +66,9 @@ svg[class^="icon-vote"] {
 }
 
 .view--who-liked .row {
-  -ms-flex-wrap: nowrap;
-      flex-wrap: nowrap;
-  -webkit-box-pack: start;
-      -ms-flex-pack: start;
-          justify-content: flex-start;
-  -webkit-box-align: center;
-      -ms-flex-align: center;
-          align-items: center;
+  flex-wrap: nowrap;
+  justify-content: flex-start;
+  align-items: center;
   border-bottom: 1px solid #e6e6e6;
   padding: 0.5rem 0;
 }
@@ -88,9 +78,7 @@ svg[class^="icon-vote"] {
 }
 
 .view--who-liked .views-field-rendered-entity-1 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 54px;
-          flex: 0 0 54px;
+  flex: 0 0 54px;
 }
 
 .view--who-liked .views-field-rendered-entity-1 a:focus {
@@ -98,9 +86,7 @@ svg[class^="icon-vote"] {
 }
 
 .view--who-liked .views-field-name {
-  -webkit-box-flex: 2;
-      -ms-flex: 2 1 auto;
-          flex: 2 1 auto;
+  flex: 2 1 auto;
   min-width: 0;
 }
 
@@ -123,17 +109,14 @@ svg[class^="icon-vote"] {
   .vote-like a:hover .icon-vote {
     stroke: black;
     fill: transparent;
-    -webkit-transform: scale(1.3);
-            transform: scale(1.3);
-    -webkit-transition: 0.3s;
+    transform: scale(1.3);
     transition: 0.3s;
   }
   .vote-like a:hover.voted-like .icon-vote,
   .vote-like a:hover.disable-status .icon-vote {
     fill: #4d4d4d;
     stroke: #4d4d4d;
-    -webkit-transform: none;
-            transform: none;
+    transform: none;
   }
 }
 
@@ -151,8 +134,7 @@ svg[class^="icon-vote"] {
     font-weight: normal;
     text-align: center;
     vertical-align: middle;
-    -ms-touch-action: manipulation;
-        touch-action: manipulation;
+    touch-action: manipulation;
     cursor: pointer;
     background-image: none;
     border: 1px solid transparent;
@@ -164,7 +146,6 @@ svg[class^="icon-vote"] {
        -moz-user-select: none;
         -ms-user-select: none;
             user-select: none;
-    -webkit-transition: .3s ease-out;
     transition: .3s ease-out;
     outline: 0;
   }
@@ -175,9 +156,7 @@ svg[class^="icon-vote"] {
     width: 100%;
   }
   .vote__wrapper {
-    -webkit-box-pack: justify;
-        -ms-flex-pack: justify;
-            justify-content: space-between;
+    justify-content: space-between;
   }
   .vote-like {
     margin-right: 10px;

--- a/themes/socialbase/assets/css/list.css
+++ b/themes/socialbase/assets/css/list.css
@@ -1,10 +1,6 @@
 .list-item {
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
-  -webkit-box-pack: center;
-      -ms-flex-pack: center;
-          justify-content: center;
+  justify-content: center;
   width: 100%;
   padding-top: 0.625rem;
   padding-bottom: 0.625rem;
@@ -14,9 +10,7 @@
 .list-item__avatar {
   width: 24px;
   height: 24px;
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 24px;
-          flex: 0 0 24px;
+  flex: 0 0 24px;
   margin-right: 10px;
   border-radius: 50%;
   margin-top: 2px;
@@ -25,31 +19,23 @@
 .list-item__avatar--medium {
   width: 44px;
   height: 44px;
-  -ms-flex-preferred-size: 44px;
-      flex-basis: 44px;
+  flex-basis: 44px;
 }
 
 .list-item--withlabel {
-  -ms-flex-wrap: wrap;
-      flex-wrap: wrap;
-  -webkit-box-pack: start;
-      -ms-flex-pack: start;
-          justify-content: flex-start;
+  flex-wrap: wrap;
+  justify-content: flex-start;
 }
 
 .list-item__label {
   margin-right: 20px;
   font-weight: 500;
-  -ms-flex-preferred-size: 100%;
-      flex-basis: 100%;
-  -ms-flex-item-align: start;
-      align-self: flex-start;
+  flex-basis: 100%;
+  align-self: flex-start;
 }
 
 .list-item__text {
-  -webkit-box-flex: 1;
-      -ms-flex-positive: 1;
-          flex-grow: 1;
+  flex-grow: 1;
   max-width: 100%;
   margin: 0;
   line-height: 1.25;
@@ -63,9 +49,7 @@
   padding-left: 1rem;
   padding-right: 1rem;
   margin-bottom: -1px;
-  -webkit-box-pack: start;
-      -ms-flex-pack: start;
-          justify-content: flex-start;
+  justify-content: flex-start;
 }
 
 .list-item--visibility .form-group label {
@@ -111,7 +95,6 @@
 
 @media (min-width: 600px) {
   .list-item__label {
-    -ms-flex-preferred-size: 180px;
-        flex-basis: 180px;
+    flex-basis: 180px;
   }
 }

--- a/themes/socialbase/assets/css/media.css
+++ b/themes/socialbase/assets/css/media.css
@@ -8,18 +8,12 @@
 }
 
 .media {
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
-  -webkit-box-align: start;
-      -ms-flex-align: start;
-          align-items: flex-start;
+  align-items: flex-start;
 }
 
 .media-body {
-  -webkit-box-flex: 1;
-      -ms-flex: 1;
-          flex: 1;
+  flex: 1;
   min-width: 85px;
 }
 
@@ -38,15 +32,11 @@
 }
 
 .media-middle {
-  -webkit-box-align: center;
-      -ms-flex-align: center;
-          align-items: center;
+  align-items: center;
 }
 
 .media-bottom {
-  -webkit-box-align: end;
-      -ms-flex-align: end;
-          align-items: flex-end;
+  align-items: flex-end;
 }
 
 .media-heading {

--- a/themes/socialbase/assets/css/message.css
+++ b/themes/socialbase/assets/css/message.css
@@ -10,21 +10,15 @@
 
 .message {
   font-weight: 300;
-  -webkit-transition: -webkit-box-shadow 0.3s;
-  transition: -webkit-box-shadow 0.3s;
   transition: box-shadow 0.3s;
-  transition: box-shadow 0.3s, -webkit-box-shadow 0.3s;
 }
 
 .message:hover, .message:focus {
-  -webkit-box-shadow: 0 0 4px rgba(0, 0, 0, 0.14), 0 4px 8px rgba(0, 0, 0, 0.28);
-          box-shadow: 0 0 4px rgba(0, 0, 0, 0.14), 0 4px 8px rgba(0, 0, 0, 0.28);
+  box-shadow: 0 0 4px rgba(0, 0, 0, 0.14), 0 4px 8px rgba(0, 0, 0, 0.28);
 }
 
 .message .avatar {
-  -webkit-box-flex: 64px;
-      -ms-flex: 64px 0 0px;
-          flex: 64px 0 0;
+  flex: 64px 0 0;
 }
 
 .message__inbox-body {
@@ -42,31 +36,23 @@
 
 .message__excerpt .message__owner {
   padding-right: 0.5em;
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 auto;
-          flex: 0 0 auto;
+  flex: 0 0 auto;
   white-space: nowrap;
 }
 
 .message__heading {
-  -webkit-box-align: center;
-      -ms-flex-align: center;
-          align-items: center;
+  align-items: center;
   padding: 1.25rem 0 0.5rem;
   border-bottom: 1px solid #e6e6e6;
   margin-bottom: 0.5rem;
 }
 
 .message__recipients {
-  -webkit-box-align: center;
-      -ms-flex-align: center;
-          align-items: center;
+  align-items: center;
 }
 
 .message__back-btn {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 38px;
-          flex: 0 0 38px;
+  flex: 0 0 38px;
 }
 
 .private-message-thread-messages {
@@ -96,12 +82,8 @@
 }
 
 .message__by-me {
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
-  -webkit-box-pack: end;
-      -ms-flex-pack: end;
-          justify-content: flex-end;
+  justify-content: flex-end;
 }
 
 .message__by-me .message__message-body {
@@ -185,14 +167,10 @@
 
 @media (min-width: 900px) {
   .message__excerpt {
-    display: -webkit-box;
-    display: -ms-flexbox;
     display: flex;
   }
   .message__message-excerpt {
-    -webkit-box-flex: 1;
-        -ms-flex-positive: 1;
-            flex-grow: 1;
+    flex-grow: 1;
     text-overflow: ellipsis;
     overflow: hidden;
     white-space: nowrap;

--- a/themes/socialbase/assets/css/meta.css
+++ b/themes/socialbase/assets/css/meta.css
@@ -1,9 +1,6 @@
 .metainfo {
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
-  -ms-flex-wrap: wrap;
-      flex-wrap: wrap;
+  flex-wrap: wrap;
   position: relative;
   margin-bottom: 30px;
   line-height: 1.4;
@@ -19,9 +16,7 @@
 }
 
 .metainfo__content {
-  -webkit-box-flex: 1;
-      -ms-flex: 1;
-          flex: 1;
+  flex: 1;
   font-size: 0.875rem;
 }
 
@@ -46,19 +41,14 @@
 }
 
 .metainfo__properties {
-  -webkit-box-flex: 1;
-      -ms-flex: 1 1 100%;
-          flex: 1 1 100%;
+  flex: 1 1 100%;
   margin: 20px 0 40px;
 }
 
 .meta-engage {
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
   margin-bottom: 1rem;
-  -ms-flex-wrap: wrap;
-      flex-wrap: wrap;
+  flex-wrap: wrap;
 }
 
 .meta-engage .badge {
@@ -68,8 +58,7 @@
 .meta-follow {
   margin-right: 0;
   margin-left: auto;
-  -ms-flex-preferred-size: 100%;
-      flex-basis: 100%;
+  flex-basis: 100%;
   margin-bottom: 1rem;
 }
 
@@ -113,16 +102,12 @@
 
 @media (min-width: 600px) {
   .meta-engage {
-    -ms-flex-wrap: nowrap;
-        flex-wrap: nowrap;
+    flex-wrap: nowrap;
     margin-bottom: 2rem;
   }
   .meta-follow {
-    -ms-flex-preferred-size: auto;
-        flex-basis: auto;
-    -webkit-box-ordinal-group: 11;
-        -ms-flex-order: 10;
-            order: 10;
+    flex-basis: auto;
+    order: 10;
     margin-bottom: 0;
   }
 }

--- a/themes/socialbase/assets/css/modal.css
+++ b/themes/socialbase/assets/css/modal.css
@@ -19,26 +19,22 @@
 @-webkit-keyframes fadein_scale {
   from {
     opacity: 0;
-    -webkit-transform: translateY(-30px);
-            transform: translateY(-30px);
+    transform: translateY(-30px);
   }
   to {
     opacity: 1;
-    -webkit-transform: translateY(0);
-            transform: translateY(0);
+    transform: translateY(0);
   }
 }
 
 @keyframes fadein_scale {
   from {
     opacity: 0;
-    -webkit-transform: translateY(-30px);
-            transform: translateY(-30px);
+    transform: translateY(-30px);
   }
   to {
     opacity: 1;
-    -webkit-transform: translateY(0);
-            transform: translateY(0);
+    transform: translateY(0);
   }
 }
 
@@ -84,8 +80,7 @@
   z-index: 1050;
   background-color: #fff;
   border: 1px solid rgba(0, 0, 0, 0.2);
-  -webkit-box-shadow: 0 3px 9px rgba(0, 0, 0, 0.5);
-          box-shadow: 0 3px 9px rgba(0, 0, 0, 0.5);
+  box-shadow: 0 3px 9px rgba(0, 0, 0, 0.5);
   background-clip: padding-box;
   -webkit-backface-visibility: hidden;
           backface-visibility: hidden;
@@ -94,15 +89,9 @@
 }
 
 .ui-dialog-titlebar {
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
-  -webkit-box-align: center;
-      -ms-flex-align: center;
-          align-items: center;
-  -webkit-box-pack: justify;
-      -ms-flex-pack: justify;
-          justify-content: space-between;
+  align-items: center;
+  justify-content: space-between;
   padding: 1rem;
   border-bottom: 1px solid #e6e6e6;
 }
@@ -129,7 +118,6 @@
   border: 0;
   outline: 0;
   -webkit-appearance: none;
-  -webkit-transition: 0.3s;
   transition: 0.3s;
   position: relative;
 }
@@ -154,11 +142,8 @@
 .ui-dialog-content {
   position: relative;
   overflow: auto;
-  -webkit-box-shadow: none;
-          box-shadow: none;
-  -webkit-box-flex: 1;
-      -ms-flex: 1 1 auto;
-          flex: 1 1 auto;
+  box-shadow: none;
+  flex: 1 1 auto;
   padding: 1rem;
 }
 
@@ -180,17 +165,12 @@
 }
 
 .modal.fade .modal-dialog {
-  -webkit-transform: translate(0, -25%);
-          transform: translate(0, -25%);
-  -webkit-transition: -webkit-transform 0.3s ease-out;
-  transition: -webkit-transform 0.3s ease-out;
+  transform: translate(0, -25%);
   transition: transform 0.3s ease-out;
-  transition: transform 0.3s ease-out, -webkit-transform 0.3s ease-out;
 }
 
 .modal.in .modal-dialog {
-  -webkit-transform: translate(0, 0);
-          transform: translate(0, 0);
+  transform: translate(0, 0);
 }
 
 .modal-open .modal {
@@ -210,8 +190,7 @@
   border: 1px solid #999;
   border: 1px solid rgba(0, 0, 0, 0.2);
   border-radius: 12px;
-  -webkit-box-shadow: 0 3px 9px rgba(0, 0, 0, 0.5);
-          box-shadow: 0 3px 9px rgba(0, 0, 0, 0.5);
+  box-shadow: 0 3px 9px rgba(0, 0, 0, 0.5);
   background-clip: padding-box;
   outline: 0;
 }
@@ -248,15 +227,9 @@
 }
 
 .social-dialog .form-actions {
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
-  -webkit-box-pack: justify;
-      -ms-flex-pack: justify;
-          justify-content: space-between;
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 50%;
-          flex: 0 0 50%;
+  justify-content: space-between;
+  flex: 0 0 50%;
   margin-bottom: 0;
 }
 
@@ -271,9 +244,7 @@
 }
 
 .social-dialog .pull-left {
-  -webkit-box-ordinal-group: 0;
-      -ms-flex-order: -1;
-          order: -1;
+  order: -1;
   margin-left: 0 !important;
   margin-right: 1rem;
 }

--- a/themes/socialbase/assets/css/morrisjs.css
+++ b/themes/socialbase/assets/css/morrisjs.css
@@ -4,8 +4,7 @@
 }
 
 .morris-hover.morris-default-style {
-  -webkit-box-shadow: 0 0 4px rgba(0, 0, 0, 0.14), 0 4px 8px rgba(0, 0, 0, 0.28);
-          box-shadow: 0 0 4px rgba(0, 0, 0, 0.14), 0 4px 8px rgba(0, 0, 0, 0.28);
+  box-shadow: 0 0 4px rgba(0, 0, 0, 0.14), 0 4px 8px rgba(0, 0, 0, 0.28);
   border-radius: 10px;
   padding: 6px;
   background: rgba(255, 255, 255, 0.8);

--- a/themes/socialbase/assets/css/nav-tabs.css
+++ b/themes/socialbase/assets/css/nav-tabs.css
@@ -7,7 +7,6 @@
   margin-right: 2px;
   line-height: 1.5;
   border: 1px solid transparent;
-  -webkit-transition: all 0.3s;
   transition: all 0.3s;
   font-weight: 500;
   position: relative;
@@ -60,23 +59,17 @@
 
 .tabs-left,
 .tabs-right {
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
 }
 
 .tabs-left .nav-tabs,
 .tabs-right .nav-tabs {
-  -webkit-box-flex: 1;
-      -ms-flex: 1 1 auto;
-          flex: 1 1 auto;
+  flex: 1 1 auto;
 }
 
 .tabs-left > .tab-content,
 .tabs-right > .tab-content {
-  -webkit-box-flex: 1;
-      -ms-flex: 1 1 75%;
-          flex: 1 1 75%;
+  flex: 1 1 75%;
   overflow: auto;
 }
 

--- a/themes/socialbase/assets/css/navbar.css
+++ b/themes/socialbase/assets/css/navbar.css
@@ -37,30 +37,21 @@
 }
 
 .container--navbar {
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
 }
 
 .navbar-user {
   margin-left: auto;
-  -webkit-box-ordinal-group: 2;
-      -ms-flex-order: 1;
-          order: 1;
+  order: 1;
 }
 
 .navbar-header {
-  -webkit-box-ordinal-group: 1;
-      -ms-flex-order: 0;
-          order: 0;
+  order: 0;
 }
 
 .navbar-nav {
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
-  -ms-flex-wrap: wrap;
-      flex-wrap: wrap;
+  flex-wrap: wrap;
 }
 
 .navbar-nav > li > a {
@@ -79,9 +70,7 @@
   overflow-x: visible;
   border-top: 1px solid transparent;
   -webkit-overflow-scrolling: touch;
-  -webkit-box-ordinal-group: 3;
-      -ms-flex-order: 2;
-          order: 2;
+  order: 2;
   max-height: 340px;
 }
 
@@ -90,8 +79,7 @@
 }
 
 .navbar-fixed-top {
-  -webkit-box-shadow: 0 0 4px rgba(0, 0, 0, 0.14), 0 4px 8px rgba(0, 0, 0, 0.28);
-          box-shadow: 0 0 4px rgba(0, 0, 0, 0.14), 0 4px 8px rgba(0, 0, 0, 0.28);
+  box-shadow: 0 0 4px rgba(0, 0, 0, 0.14), 0 4px 8px rgba(0, 0, 0, 0.28);
   position: fixed;
   top: 0;
   right: 0;
@@ -161,7 +149,6 @@
 .navbar-default .navbar-nav > .open > a,
 .navbar-default .navbar-nav > .open > a:focus,
 .navbar-default .navbar-nav > .open > a:hover {
-  -webkit-transition: color .2s ease, background-color .2s ease;
   transition: color .2s ease, background-color .2s ease;
 }
 
@@ -179,9 +166,7 @@
   width: 50px;
   height: 50px;
   padding: 0;
-  -webkit-transform-origin: 50%;
-          transform-origin: 50%;
-  -webkit-transition: all 0.7s cubic-bezier(0.4, 0, 0.2, 1);
+  transform-origin: 50%;
   transition: all 0.7s cubic-bezier(0.4, 0, 0.2, 1);
   z-index: 10;
 }
@@ -190,7 +175,6 @@
   position: absolute;
   top: 14px;
   left: 13px;
-  -webkit-transition: 0.2s ease-in-out;
   transition: 0.2s ease-in-out;
   pointer-events: none;
 }
@@ -232,23 +216,18 @@
 }
 
 .navbar-secondary {
-  -webkit-box-shadow: 0 -1px 0 #e0e0e0, 0 0 2px rgba(0, 0, 0, 0.12), 0 2px 4px rgba(0, 0, 0, 0.24);
-          box-shadow: 0 -1px 0 #e0e0e0, 0 0 2px rgba(0, 0, 0, 0.12), 0 2px 4px rgba(0, 0, 0, 0.24);
+  box-shadow: 0 -1px 0 #e0e0e0, 0 0 2px rgba(0, 0, 0, 0.12), 0 2px 4px rgba(0, 0, 0, 0.24);
   z-index: 1;
   min-height: 46px;
 }
 
 .navbar-secondary .navbar-nav {
-  -webkit-box-pack: center;
-      -ms-flex-pack: center;
-          justify-content: center;
-  -ms-flex-wrap: nowrap;
-      flex-wrap: nowrap;
+  justify-content: center;
+  flex-wrap: nowrap;
   font-size: 16px;
 }
 
 .navbar-secondary .navbar-nav a {
-  -webkit-transition: all 0.3s;
   transition: all 0.3s;
   white-space: nowrap;
   opacity: 0.75;
@@ -266,15 +245,11 @@
 
 @media (min-width: 900px) {
   .navbar-user {
-    -webkit-box-ordinal-group: 11;
-        -ms-flex-order: 10;
-            order: 10;
+    order: 10;
   }
   .block-social-language,
   .block-language {
-    -webkit-box-ordinal-group: 5;
-        -ms-flex-order: 4;
-            order: 4;
+    order: 4;
     margin-left: auto;
   }
   .block-social-language a.dropdown-toggle,
@@ -299,8 +274,6 @@
     padding-right: 0;
   }
   .navbar-collapse.collapse {
-    display: -webkit-box !important;
-    display: -ms-flexbox !important;
     display: flex !important;
     height: auto !important;
     padding-bottom: 0;
@@ -327,18 +300,14 @@
     z-index: 1050;
     pointer-events: none;
     opacity: 0;
-    -webkit-transition: all 0.3s ease-in-out;
     transition: all 0.3s ease-in-out;
   }
   .search-take-over .form-group {
     margin: auto;
     width: 80%;
     max-width: 600px;
-    display: -webkit-box;
-    display: -ms-flexbox;
     display: flex;
-    -ms-flex-wrap: wrap;
-        flex-wrap: wrap;
+    flex-wrap: wrap;
   }
   .search-take-over .form-text {
     font-size: 1.625em;
@@ -351,21 +320,13 @@
     border-bottom: 2px solid;
     font-weight: 500;
     max-width: none;
-    -webkit-box-flex: 1;
-        -ms-flex: 1 1 80%;
-            flex: 1 1 80%;
+    flex: 1 1 80%;
     min-width: 0;
   }
   .search-take-over .form-submit {
-    display: -webkit-box;
-    display: -ms-flexbox;
     display: flex;
-    -webkit-box-align: center;
-        -ms-flex-align: center;
-            align-items: center;
-    -webkit-box-pack: center;
-        -ms-flex-pack: center;
-            justify-content: center;
+    align-items: center;
+    justify-content: center;
     width: 60px;
     height: 60px;
     min-width: 60px;
@@ -375,17 +336,14 @@
     font-size: 0;
     text-indent: -9999px;
     cursor: pointer;
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 60px;
-            flex: 0 0 60px;
+    flex: 0 0 60px;
   }
   .search-take-over .form-submit svg {
     width: 50px;
     height: 50px;
   }
   .search-take-over .social-search-suggestions {
-    -ms-flex-preferred-size: 100%;
-        flex-basis: 100%;
+    flex-basis: 100%;
   }
   .btn--close-search-take-over {
     background-color: transparent;
@@ -397,9 +355,7 @@
     top: 80px;
     right: 80px;
     opacity: 0;
-    -webkit-transform: translate(10px, 0) rotate(90deg);
-            transform: translate(10px, 0) rotate(90deg);
-    -webkit-transition: all 0.5s ease-in-out 0.5s;
+    transform: translate(10px, 0) rotate(90deg);
     transition: all 0.5s ease-in-out 0.5s;
     outline: 0;
   }
@@ -415,11 +371,9 @@
     pointer-events: all;
   }
   .mode-search .navbar__open-search-block {
-    -webkit-transform: scale(70);
-            transform: scale(70);
+    transform: scale(70);
     -moz-transform: scale(70) rotate(0.02deg);
-    -webkit-box-shadow: 0 0 4px rgba(0, 0, 0, 0.14), 0 4px 8px rgba(0, 0, 0, 0.28);
-            box-shadow: 0 0 4px rgba(0, 0, 0, 0.14), 0 4px 8px rgba(0, 0, 0, 0.28);
+    box-shadow: 0 0 4px rgba(0, 0, 0, 0.14), 0 4px 8px rgba(0, 0, 0, 0.28);
   }
   .mode-search .navbar-nav__icon {
     opacity: 0;
@@ -429,8 +383,7 @@
     pointer-events: none;
   }
   .mode-search .btn--close-search-take-over {
-    -webkit-transform: none;
-            transform: none;
+    transform: none;
     opacity: 1;
     pointer-events: all;
   }
@@ -458,12 +411,8 @@
             user-select: none;
     overflow-x: scroll;
     overflow-y: hidden;
-    display: -webkit-box;
-    display: -ms-flexbox;
     display: flex;
-    -webkit-box-pack: start;
-        -ms-flex-pack: start;
-            justify-content: flex-start;
+    justify-content: flex-start;
   }
   .navbar-scrollable .navbar-nav::-webkit-scrollbar {
     display: none;
@@ -482,14 +431,12 @@
 
 @media (max-width: 899px) {
   .container--navbar {
-    -ms-flex-wrap: wrap;
-        flex-wrap: wrap;
+    flex-wrap: wrap;
   }
   .navbar-fixed-top .navbar-nav .open .dropdown-menu {
     background-color: #fff;
     border: 0;
-    -webkit-box-shadow: 0 0 6px rgba(0, 0, 0, 0.16), 0 6px 12px rgba(0, 0, 0, 0.32);
-            box-shadow: 0 0 6px rgba(0, 0, 0, 0.16), 0 6px 12px rgba(0, 0, 0, 0.32);
+    box-shadow: 0 0 6px rgba(0, 0, 0, 0.16), 0 6px 12px rgba(0, 0, 0, 0.32);
     position: fixed;
     top: auto;
     margin: 0;
@@ -505,19 +452,12 @@
             backface-visibility: hidden;
   }
   .navbar-collapse {
-    -webkit-box-flex: 1;
-        -ms-flex: 1 0 100%;
-            flex: 1 0 100%;
+    flex: 1 0 100%;
   }
   .navbar-collapse .navbar-nav {
     margin: 6.5px 0;
-    -webkit-box-orient: vertical;
-    -webkit-box-direction: normal;
-        -ms-flex-direction: column;
-            flex-direction: column;
-    -webkit-box-ordinal-group: 2;
-        -ms-flex-order: 1;
-            order: 1;
+    flex-direction: column;
+    order: 1;
   }
   .navbar-collapse .navbar-nav > li > a {
     padding: 5px 15px;
@@ -533,8 +473,7 @@
     float: none;
     max-width: none;
     padding-top: 0;
-    -webkit-box-shadow: none;
-            box-shadow: none;
+    box-shadow: none;
   }
   .navbar-collapse .dropdown-menu li a {
     padding: 5px 15px 5px 30px;

--- a/themes/socialbase/assets/css/offcanvas.css
+++ b/themes/socialbase/assets/css/offcanvas.css
@@ -1,13 +1,10 @@
 #block-filter:target {
-  -webkit-transform: translateX(0);
-          transform: translateX(0);
-  -webkit-box-shadow: 0 0 8px rgba(0, 0, 0, 0.18), 0 8px 16px rgba(0, 0, 0, 0.45);
-          box-shadow: 0 0 8px rgba(0, 0, 0, 0.18), 0 8px 16px rgba(0, 0, 0, 0.45);
+  transform: translateX(0);
+  box-shadow: 0 0 8px rgba(0, 0, 0, 0.18), 0 8px 16px rgba(0, 0, 0, 0.45);
 }
 
 .off-canvas-xs-only {
-  -webkit-box-shadow: 0 -1px 0 #e0e0e0, 0 0 2px rgba(0, 0, 0, 0.12), 0 2px 4px rgba(0, 0, 0, 0.24);
-          box-shadow: 0 -1px 0 #e0e0e0, 0 0 2px rgba(0, 0, 0, 0.12), 0 2px 4px rgba(0, 0, 0, 0.24);
+  box-shadow: 0 -1px 0 #e0e0e0, 0 0 2px rgba(0, 0, 0, 0.12), 0 2px 4px rgba(0, 0, 0, 0.24);
   position: relative;
   margin-bottom: 0.75rem;
   background-clip: padding-box;
@@ -66,24 +63,18 @@
     height: 100%;
     background-color: white;
     padding: 1.25rem;
-    -webkit-box-shadow: 0 8px 17px 0 transparent, 0 6px 20px 0 transparent;
-            box-shadow: 0 8px 17px 0 transparent, 0 6px 20px 0 transparent;
+    box-shadow: 0 8px 17px 0 transparent, 0 6px 20px 0 transparent;
     z-index: 4;
     -webkit-backface-visibility: hidden;
             backface-visibility: hidden;
-    -webkit-transition: -webkit-transform 0.5s, -webkit-box-shadow 0.3s;
-    transition: -webkit-transform 0.5s, -webkit-box-shadow 0.3s;
     transition: transform 0.5s, box-shadow 0.3s;
-    transition: transform 0.5s, box-shadow 0.3s, -webkit-transform 0.5s, -webkit-box-shadow 0.3s;
   }
   .off-canvas-right {
-    -webkit-transform: translateX(290px);
-            transform: translateX(290px);
+    transform: translateX(290px);
     right: 0;
   }
   .off-canvas-xs-only {
-    -webkit-box-shadow: 0 0 8px rgba(0, 0, 0, 0.18), 0 8px 16px rgba(0, 0, 0, 0.45);
-            box-shadow: 0 0 8px rgba(0, 0, 0, 0.18), 0 8px 16px rgba(0, 0, 0, 0.45);
+    box-shadow: 0 0 8px rgba(0, 0, 0, 0.18), 0 8px 16px rgba(0, 0, 0, 0.45);
     position: fixed;
   }
   .views-exposed-form {

--- a/themes/socialbase/assets/css/page-preview.css
+++ b/themes/socialbase/assets/css/page-preview.css
@@ -8,8 +8,7 @@
   margin-top: 50px;
   left: 0;
   width: 100%;
-  -webkit-transform: translateY(-100%);
-          transform: translateY(-100%);
+  transform: translateY(-100%);
   z-index: 9;
 }
 

--- a/themes/socialbase/assets/css/password.css
+++ b/themes/socialbase/assets/css/password.css
@@ -19,7 +19,6 @@
 .password-strength__indicator {
   height: 100%;
   width: 0;
-  -webkit-transition: width 0.5s ease-out;
   transition: width 0.5s ease-out;
 }
 
@@ -50,16 +49,11 @@
 
 @media (min-width: 600px) {
   .section-password {
-    display: -webkit-box;
-    display: -ms-flexbox;
     display: flex;
-    -ms-flex-wrap: wrap;
-        flex-wrap: wrap;
+    flex-wrap: wrap;
   }
   .form-group--password {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 58.33333%;
-            flex: 0 0 58.33333%;
+    flex: 0 0 58.33333%;
     max-width: 58.33333%;
   }
   #edit-pass .password-strength,
@@ -72,8 +66,6 @@
     padding-left: 1rem;
   }
   .password-suggestions {
-    -webkit-box-flex: 100%;
-        -ms-flex: 100%;
-            flex: 100%;
+    flex: 100%;
   }
 }

--- a/themes/socialbase/assets/css/photoswipe-gallery.css
+++ b/themes/socialbase/assets/css/photoswipe-gallery.css
@@ -1,28 +1,18 @@
 .photoswipe-gallery-custom {
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
-  -ms-flex-wrap: wrap;
-      flex-wrap: wrap;
+  flex-wrap: wrap;
 }
 
 .photoswipe-gallery-custom .field--item {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 125px;
-          flex: 0 0 125px;
+  flex: 0 0 125px;
   height: 125px;
   margin: 0 .75rem .75rem 0;
   font-size: 12px;
 }
 
 .photoswipe-gallery-custom .file-tile {
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
-  -webkit-box-orient: vertical;
-  -webkit-box-direction: normal;
-      -ms-flex-direction: column;
-          flex-direction: column;
+  flex-direction: column;
   height: 100%;
   padding: .75rem;
   border: 1px solid #adadad;
@@ -42,21 +32,14 @@
 }
 
 .photoswipe-gallery-custom .file-metadata {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 auto;
-          flex: 0 0 auto;
-  display: -webkit-box;
-  display: -ms-flexbox;
+  flex: 0 0 auto;
   display: flex;
-  -webkit-box-pack: justify;
-      -ms-flex-pack: justify;
-          justify-content: space-between;
+  justify-content: space-between;
 }
 
 @media (min-width: 600px) {
   .photoswipe-gallery-custom .field--item {
-    -ms-flex-preferred-size: 140px;
-        flex-basis: 140px;
+    flex-basis: 140px;
     height: 140px;
   }
 }

--- a/themes/socialbase/assets/css/popover.css
+++ b/themes/socialbase/assets/css/popover.css
@@ -110,8 +110,7 @@
   word-wrap: normal;
   font-size: 0.875rem;
   background-clip: padding-box;
-  -webkit-box-shadow: 0 5px 10px rgba(0, 0, 0, 0.2);
-          box-shadow: 0 5px 10px rgba(0, 0, 0, 0.2);
+  box-shadow: 0 5px 10px rgba(0, 0, 0, 0.2);
 }
 
 .popover.top {

--- a/themes/socialbase/assets/css/print.css
+++ b/themes/socialbase/assets/css/print.css
@@ -5,8 +5,7 @@
   *:after {
     background: transparent !important;
     color: #000 !important;
-    -webkit-box-shadow: none !important;
-            box-shadow: none !important;
+    box-shadow: none !important;
     text-shadow: none !important;
   }
   a,

--- a/themes/socialbase/assets/css/select2.css
+++ b/themes/socialbase/assets/css/select2.css
@@ -10,8 +10,7 @@
 }
 
 .select2-container--social .select2-search--dropdown .select2-search__field {
-  -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
-          box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
+  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
   background-color: #fff;
   border: 1px solid #ccc;
   border-radius: 4px;
@@ -99,12 +98,8 @@
 }
 
 .select2-container--social.select2-container--focus .select2-selection, .select2-container--social.select2-container--open .select2-selection {
-  -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(102, 175, 233, 0.6);
-          box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(102, 175, 233, 0.6);
-  -webkit-transition: border-color ease-in-out 0.15s, -webkit-box-shadow ease-in-out 0.15s;
-  transition: border-color ease-in-out 0.15s, -webkit-box-shadow ease-in-out 0.15s;
+  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(102, 175, 233, 0.6);
   transition: border-color ease-in-out 0.15s, box-shadow ease-in-out 0.15s;
-  transition: border-color ease-in-out 0.15s, box-shadow ease-in-out 0.15s, -webkit-box-shadow ease-in-out 0.15s;
 }
 
 .select2-container--social.select2-container--open .select2-selection .select2-selection__arrow b {
@@ -138,7 +133,6 @@
 
 .select2-container--social.select2-container--disabled .select2-selection {
   border-color: #ccc;
-  -webkit-box-shadow: none;
   box-shadow: none;
 }
 
@@ -158,15 +152,13 @@
 }
 
 .select2-container--social .select2-dropdown {
-  -webkit-box-shadow: 0 6px 12px rgba(0, 0, 0, 0.175);
-          box-shadow: 0 6px 12px rgba(0, 0, 0, 0.175);
+  box-shadow: 0 6px 12px rgba(0, 0, 0, 0.175);
   overflow-x: hidden;
   margin-top: -1px;
 }
 
 .select2-container--social .select2-dropdown--above {
-  -webkit-box-shadow: 0px -6px 12px rgba(0, 0, 0, 0.175);
-          box-shadow: 0px -6px 12px rgba(0, 0, 0, 0.175);
+  box-shadow: 0px -6px 12px rgba(0, 0, 0, 0.175);
   margin-top: 1px;
 }
 
@@ -230,7 +222,6 @@
 }
 
 .select2-container--social .select2-selection--multiple .select2-selection__rendered {
-  -webkit-box-sizing: border-box;
   box-sizing: border-box;
   display: block;
   line-height: 1.42857143;
@@ -460,7 +451,6 @@
 
 .has-warning .select2-container--focus .select2-selection,
 .has-warning .select2-container--open .select2-selection {
-  -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px #c0a16b;
   box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px #c0a16b;
   border-color: #66512c;
 }
@@ -480,7 +470,6 @@
 
 .has-error .select2-container--focus .select2-selection,
 .has-error .select2-container--open .select2-selection {
-  -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px #ce8483;
   box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px #ce8483;
   border-color: #843534;
 }
@@ -500,7 +489,6 @@
 
 .has-success .select2-container--focus .select2-selection,
 .has-success .select2-container--open .select2-selection {
-  -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px #67b168;
   box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px #67b168;
   border-color: #2b542c;
 }

--- a/themes/socialbase/assets/css/social-linking.css
+++ b/themes/socialbase/assets/css/social-linking.css
@@ -1,9 +1,5 @@
 .form-group--social-linking {
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
-  -webkit-box-pack: justify;
-      -ms-flex-pack: justify;
-          justify-content: space-between;
+  justify-content: space-between;
   width: 100%;
 }

--- a/themes/socialbase/assets/css/spinner.css
+++ b/themes/socialbase/assets/css/spinner.css
@@ -35,11 +35,9 @@
 
 @keyframes sk-bouncedelay {
   0%, 80%, 100% {
-    -webkit-transform: scale(0);
     transform: scale(0);
   }
   40% {
-    -webkit-transform: scale(1);
     transform: scale(1);
   }
 }

--- a/themes/socialbase/assets/css/stream.css
+++ b/themes/socialbase/assets/css/stream.css
@@ -34,8 +34,7 @@
   height: 8px;
   position: absolute;
   background: #777777;
-  -webkit-box-shadow: 0 0 1px rgba(0, 0, 0, 0.11), 0 1px 2px rgba(0, 0, 0, 0.22);
-          box-shadow: 0 0 1px rgba(0, 0, 0, 0.11), 0 1px 2px rgba(0, 0, 0, 0.22);
+  box-shadow: 0 0 1px rgba(0, 0, 0, 0.11), 0 1px 2px rgba(0, 0, 0, 0.22);
   border-radius: 50%;
   border: 1px solid #fff;
 }
@@ -81,8 +80,6 @@
 .card--stream .comment {
   font-size: 0.875rem;
   position: relative;
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
   width: 100%;
 }
@@ -90,8 +87,7 @@
 .card--stream .comment__avatar {
   margin-right: 8px;
   width: 44px;
-  -ms-flex-negative: 0;
-      flex-shrink: 0;
+  flex-shrink: 0;
 }
 
 .teaser--stream {
@@ -154,8 +150,6 @@
   }
   .teaser--stream .teaser__image {
     height: 200px;
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 200px;
-            flex: 0 0 200px;
+    flex: 0 0 200px;
   }
 }

--- a/themes/socialbase/assets/css/teaser.css
+++ b/themes/socialbase/assets/css/teaser.css
@@ -1,13 +1,7 @@
 .teaser {
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
-  -ms-flex-wrap: wrap;
-      flex-wrap: wrap;
-  -webkit-box-orient: horizontal;
-  -webkit-box-direction: normal;
-      -ms-flex-direction: row;
-          flex-direction: row;
+  flex-wrap: wrap;
+  flex-direction: row;
 }
 
 .teaser__image {
@@ -29,12 +23,8 @@
   background: none;
   width: 100%;
   height: 100%;
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
-  -webkit-box-align: center;
-      -ms-flex-align: center;
-          align-items: center;
+  align-items: center;
 }
 
 .teaser__teaser-type-icon {
@@ -58,30 +48,19 @@
 }
 
 .teaser__body {
-  -webkit-box-flex: 1;
-      -ms-flex: 1;
-          flex: 1;
-  display: -webkit-box;
-  display: -ms-flexbox;
+  flex: 1;
   display: flex;
   overflow: hidden;
-  -webkit-box-orient: vertical;
-  -webkit-box-direction: normal;
-      -ms-flex-direction: column;
-          flex-direction: column;
+  flex-direction: column;
 }
 
 .teaser__content {
-  -webkit-box-flex: 1;
-      -ms-flex: 1;
-          flex: 1;
+  flex: 1;
   padding: 20px;
   position: relative;
 }
 
 .teaser__content-line {
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
   max-width: 100%;
   font-size: 0.875rem;
@@ -90,9 +69,7 @@
 .teaser__content-type-icon {
   width: 14px;
   height: 14px;
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 14px;
-          flex: 0 0 14px;
+  flex: 0 0 14px;
   line-height: 21px;
   margin-top: 3px;
   fill: #555555;
@@ -101,33 +78,26 @@
 
 .teaser__content-text {
   line-height: 21px;
-  -webkit-box-flex: 1;
-      -ms-flex-positive: 1;
-          flex-grow: 1;
+  flex-grow: 1;
   text-overflow: ellipsis;
   overflow-x: hidden;
   white-space: nowrap;
 }
 
 .teaser__published {
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
   min-width: 0;
 }
 
 .teaser__published-author {
-  -webkit-box-flex: 1;
-      -ms-flex-positive: 1;
-          flex-grow: 1;
+  flex-grow: 1;
   text-overflow: ellipsis;
   overflow: hidden;
   white-space: nowrap;
 }
 
 .teaser__published-date {
-  -ms-flex-negative: 0;
-      flex-shrink: 0;
+  flex-shrink: 0;
   margin-right: 4px;
 }
 
@@ -142,16 +112,13 @@
 
 @media (min-width: 600px) {
   .teaser {
-    -ms-flex-wrap: nowrap;
-        flex-wrap: nowrap;
+    flex-wrap: nowrap;
     height: 220px;
   }
   .teaser__image {
     display: block;
     height: 220px;
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 220px;
-            flex: 0 0 220px;
+    flex: 0 0 220px;
     position: relative;
     overflow: hidden;
     width: auto;
@@ -182,7 +149,6 @@
     display: block;
     position: absolute;
     content: '';
-    background-image: -webkit-gradient(linear, left top, left bottom, color-stop(40%, rgba(0, 0, 0, 0)), color-stop(70%, rgba(0, 0, 0, 0.1)), to(rgba(34, 34, 34, 0.5)));
     background-image: linear-gradient(rgba(0, 0, 0, 0) 40%, rgba(0, 0, 0, 0.1) 70%, rgba(34, 34, 34, 0.5) 100%);
     height: 100%;
     width: 100%;

--- a/themes/socialbase/assets/css/timepicker.css
+++ b/themes/socialbase/assets/css/timepicker.css
@@ -2,8 +2,7 @@
   overflow-y: auto;
   height: 180px;
   min-width: 160px;
-  -webkit-box-shadow: 0 6px 12px rgba(0, 0, 0, 0.175);
-          box-shadow: 0 6px 12px rgba(0, 0, 0, 0.175);
+  box-shadow: 0 6px 12px rgba(0, 0, 0, 0.175);
   background-clip: padding-box;
   outline: none;
   z-index: 1000;

--- a/themes/socialbase/assets/css/tour.css
+++ b/themes/socialbase/assets/css/tour.css
@@ -8,7 +8,6 @@
   padding: 7px 13px;
   height: 45px;
   width: 45px;
-  -webkit-transition: .3s background-color ease;
   transition: .3s background-color ease;
 }
 
@@ -87,8 +86,7 @@
 .joyride-content-wrapper {
   background: white;
   color: #4d4d4d;
-  -webkit-box-shadow: 0 0 15px rgba(0, 0, 0, 0.5);
-          box-shadow: 0 0 15px rgba(0, 0, 0, 0.5);
+  box-shadow: 0 0 15px rgba(0, 0, 0, 0.5);
   padding: 20px 50px 35px 20px;
 }
 

--- a/themes/socialbase/components/04-organisms/hero/hero.scss
+++ b/themes/socialbase/components/04-organisms/hero/hero.scss
@@ -89,7 +89,6 @@
 
 }
 
-
 /* IE11 */
 @media all and (-ms-high-contrast:none) {
   *::-ms-backdrop, .cover-wrap { min-height: 410px; }
@@ -115,7 +114,7 @@
   display: block;
 }
 
-.page-title {
+.cover .page-title {
   font-weight: 700;
   text-shadow: 0 1px 3px rgba(0, 0, 0, .5);
   text-align: center;
@@ -215,8 +214,6 @@
 
 
 }
-
-
 
 .hero-footer-icon {
   fill: white;

--- a/themes/socialblue/assets/css/brand.css
+++ b/themes/socialblue/assets/css/brand.css
@@ -441,28 +441,28 @@ html:not(.js) .navbar-default .dropdown:focus > a .navbar-nav__icon, html:not(.j
   background-color: #ffc142;
 }
 
-.socialblue--sky .teaser__tag {
+.phase .teaser__tag {
   color: #29abe2;
 }
 
-.socialblue--sky .teaser__tag a:hover, .socialblue--sky .teaser__tag a:active, .socialblue--sky .teaser__tag a:focus {
+.phase .teaser__tag a:hover, .phase .teaser__tag a:active, .phase .teaser__tag a:focus {
   color: #ffc142;
 }
 
-.socialblue--sky .badge-primary {
+.phase .badge-primary {
   background: #29abe2;
 }
 
-.socialblue--sky .hero__banner-static .hero__tag {
+.phase .hero__banner-static .hero__tag {
   color: #29abe2;
 }
 
-.socialblue--sky .hero__banner-static .hero__tag a,
-.socialblue--sky .hero__banner-static .hero__tag span {
+.phase .hero__banner-static .hero__tag a,
+.phase .hero__banner-static .hero__tag span {
   color: #29abe2;
 }
 
-.socialblue--sky .hero__banner-static .hero__tag a:hover, .socialblue--sky .hero__banner-static .hero__tag a:active, .socialblue--sky .hero__banner-static .hero__tag a:focus {
+.phase .hero__banner-static .hero__tag a:hover, .phase .hero__banner-static .hero__tag a:active, .phase .hero__banner-static .hero__tag a:focus {
   color: #ffc142;
 }
 

--- a/themes/socialblue/assets/css/hero--sky.css
+++ b/themes/socialblue/assets/css/hero--sky.css
@@ -19,20 +19,13 @@
 
 .socialblue--sky .hero-footer,
 .socialblue--sky .hero-footer__header {
-  -ms-flex-wrap: wrap;
-      flex-wrap: wrap;
+  flex-wrap: wrap;
 }
 
 .socialblue--sky .hero__banner .hero-footer__share {
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
-  -webkit-box-pack: end;
-      -ms-flex-pack: end;
-          justify-content: flex-end;
-  -webkit-box-align: center;
-      -ms-flex-align: center;
-          align-items: center;
+  justify-content: flex-end;
+  align-items: center;
 }
 
 .socialblue--sky .hero__banner .hero-footer__share > span {
@@ -42,18 +35,13 @@
 }
 
 .socialblue--sky .hero__banner .shariff.card__block {
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
-  -webkit-box-flex: 0;
-      -ms-flex: none;
-          flex: none;
+  flex: none;
   padding: 0;
 }
 
 .socialblue--sky .hero__banner .shariff.card__block .orientation-horizontal {
-  -ms-flex-wrap: inherit;
-      flex-wrap: inherit;
+  flex-wrap: inherit;
   margin: 0 -.5rem;
 }
 
@@ -69,15 +57,9 @@
 }
 
 .socialblue--sky .hero__banner .shariff.card__block .orientation-horizontal a {
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
-  -webkit-box-align: center;
-      -ms-flex-align: center;
-          align-items: center;
-  -webkit-box-pack: center;
-      -ms-flex-pack: center;
-          justify-content: center;
+  align-items: center;
+  justify-content: center;
 }
 
 .socialblue--sky .hero__banner .shariff.card__block .orientation-horizontal .fab {
@@ -104,20 +86,13 @@
 
 .socialblue--sky .hero__banner .hero-footer__list ul li,
 .socialblue--sky .hero__banner .hero__info-list li {
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
-  -webkit-box-align: center;
-      -ms-flex-align: center;
-          align-items: center;
+  align-items: center;
 }
 
 .socialblue--sky .hero__banner .hero-footer__list ul {
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
-  -ms-flex-wrap: wrap;
-      flex-wrap: wrap;
+  flex-wrap: wrap;
   margin: 0 -23px;
 }
 
@@ -138,9 +113,7 @@
 }
 
 .socialblue--sky .hero__banner .hero-footer__list .meta-engage {
-  -webkit-box-align: center;
-      -ms-flex-align: center;
-          align-items: center;
+  align-items: center;
   margin-bottom: 0;
 }
 
@@ -158,8 +131,7 @@
 .socialblue--sky .hero__banner .hero-footer__list .meta-follow {
   margin-left: 0;
   margin-bottom: 0;
-  -ms-flex-preferred-size: auto;
-      flex-basis: auto;
+  flex-basis: auto;
 }
 
 .socialblue--sky .hero__banner .hero-footer__list .vote__count {
@@ -201,9 +173,7 @@
 
 .socialblue--sky .hero__banner-static .metainfo {
   margin-bottom: 1.5rem;
-  -webkit-box-align: center;
-      -ms-flex-align: center;
-          align-items: center;
+  align-items: center;
 }
 
 .socialblue--sky .hero__banner-static .metainfo__content {
@@ -254,17 +224,12 @@
 .socialblue--sky .hero__banner-static .hero-footer {
   padding-top: 1rem;
   padding-bottom: 1.25rem;
-  -webkit-box-orient: vertical;
-  -webkit-box-direction: normal;
-      -ms-flex-direction: column;
-          flex-direction: column;
+  flex-direction: column;
 }
 
 .socialblue--sky .hero__banner-static .hero-footer > * {
   margin-bottom: 1rem;
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 100%;
-          flex: 0 0 100%;
+  flex: 0 0 100%;
   max-width: 100%;
 }
 
@@ -287,9 +252,7 @@
 }
 
 .socialblue--sky .hero__banner-static .hero-footer__cta {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 100%;
-          flex: 0 0 100%;
+  flex: 0 0 100%;
   max-width: 100%;
   padding-top: 1rem;
 }
@@ -325,13 +288,8 @@
 }
 
 .socialblue--sky.path-node:not(.page-node-type-topic) .hero__banner-static .hero-footer__header {
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
-  -webkit-box-orient: vertical;
-  -webkit-box-direction: normal;
-      -ms-flex-direction: column;
-          flex-direction: column;
+  flex-direction: column;
   padding-bottom: 2.5rem;
   margin-bottom: 1.25rem;
   border-bottom: 1px solid #d5d6d2;
@@ -383,9 +341,7 @@
     font-size: 1.25rem;
   }
   .socialblue--sky .hero__banner-static .hero-footer {
-    -webkit-box-align: inherit;
-        -ms-flex-align: inherit;
-            align-items: inherit;
+    align-items: inherit;
     padding-bottom: 2.5rem;
   }
   main:not(.is-navbar-secondary) .socialblue--sky .hero__banner-static .hero-footer {
@@ -399,18 +355,11 @@
     padding-top: 75px;
   }
   .socialblue--sky.path-node:not(.page-node-type-topic) .hero__banner-static .hero-footer__header {
-    -webkit-box-orient: horizontal;
-    -webkit-box-direction: normal;
-        -ms-flex-direction: row;
-            flex-direction: row;
-    -webkit-box-align: end;
-        -ms-flex-align: end;
-            align-items: flex-end;
+    flex-direction: row;
+    align-items: flex-end;
   }
   .socialblue--sky.path-node:not(.page-node-type-topic) .hero__banner-static .hero-footer__text {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 100%;
-            flex: 0 0 100%;
+    flex: 0 0 100%;
     max-width: 100%;
     margin-right: 0;
   }
@@ -441,44 +390,29 @@
     font-size: 2.25rem;
   }
   .socialblue--sky .hero__banner-static .hero-footer {
-    -webkit-box-orient: horizontal;
-    -webkit-box-direction: normal;
-        -ms-flex-direction: row;
-            flex-direction: row;
-    -webkit-box-align: center;
-        -ms-flex-align: center;
-            align-items: center;
-    -webkit-box-pack: justify;
-        -ms-flex-pack: justify;
-            justify-content: space-between;
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
   }
   .socialblue--sky .hero__banner-static .hero-footer > * {
     margin-bottom: 0;
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 auto;
-            flex: 0 0 auto;
+    flex: 0 0 auto;
     max-width: inherit;
   }
   .socialblue--sky .hero__banner-static .hero-footer__list a {
     font-size: 1rem;
   }
   .socialblue--sky .hero__banner-static .hero-footer__cta {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 35%;
-            flex: 0 0 35%;
+    flex: 0 0 35%;
     max-width: 35%;
     padding-top: 0;
   }
   .socialblue--sky.path-node:not(.page-node-type-topic) .hero__banner-static .hero-footer__header {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 100%;
-            flex: 0 0 100%;
+    flex: 0 0 100%;
     max-width: 100%;
   }
   .socialblue--sky.path-node:not(.page-node-type-topic) .hero__banner-static .hero-footer__text {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 65%;
-            flex: 0 0 65%;
+    flex: 0 0 65%;
     max-width: 65%;
   }
   .socialblue--sky main:not(.is-navbar-secondary) .hero__full .hero-footer__bottom {

--- a/themes/socialblue/assets/css/hero.css
+++ b/themes/socialblue/assets/css/hero.css
@@ -3,43 +3,43 @@
   background-color: #29abe2;
 }
 
-.page-title {
+.cover .page-title {
   color: white;
 }
 
-.hero-avatar {
+.cover .hero-avatar {
   border-radius: 50%;
   border: 2px solid white;
 }
 
-.hero-canvas {
+.cover .hero-canvas {
   border-radius: 10px;
   background-color: rgba(51, 51, 51, 0.8);
   color: white;
 }
 
-.hero-form[role='search'] .form-control {
+.cover .hero-form[role='search'] .form-control {
   border-radius: 5px;
 }
 
-.hero-form[role='search'] .form-control:focus, .hero-form[role='search'] .form-control:active,
-.hero-form[role='search'] .form-control:focus ~ .search-icon,
-.hero-form[role='search'] .form-control:active ~ .search-icon {
+.cover .hero-form[role='search'] .form-control:focus, .cover .hero-form[role='search'] .form-control:active,
+.cover .hero-form[role='search'] .form-control:focus ~ .search-icon,
+.cover .hero-form[role='search'] .form-control:active ~ .search-icon {
   box-shadow: 0 2px 0 0 #1f80aa;
 }
 
-.hero-form[role='search'] .form-submit,
-.hero-form[role='search'] .search-icon {
+.cover .hero-form[role='search'] .form-submit,
+.cover .hero-form[role='search'] .search-icon {
   border-radius: 0 5px 5px 0;
 }
 
-.hero-form[role='search'] .search-icon {
+.cover .hero-form[role='search'] .search-icon {
   fill: #29abe2;
   background: white;
 }
 
 @media (min-width: 600px) {
-  .hero-avatar {
+  .cover .hero-avatar {
     border-width: 3px;
   }
 }

--- a/themes/socialblue/assets/css/preview.css
+++ b/themes/socialblue/assets/css/preview.css
@@ -48,8 +48,7 @@ kbd {
   color: #fff;
   background-color: #333;
   border-radius: 3px;
-  -webkit-box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.25);
-          box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.25);
+  box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.25);
 }
 
 pre {
@@ -496,7 +495,6 @@ body {
 .badge-default {
   background-color: #e6e6e6;
   color: #4d4d4d;
-  -webkit-transition: 0.3s;
   transition: 0.3s;
 }
 
@@ -507,7 +505,6 @@ body {
 .badge-primary {
   background-color: #29abe2;
   color: #fff;
-  -webkit-transition: 0.3s;
   transition: 0.3s;
 }
 
@@ -518,7 +515,6 @@ body {
 .badge-secondary {
   background-color: #1f80aa;
   color: #fff;
-  -webkit-transition: 0.3s;
   transition: 0.3s;
 }
 
@@ -529,7 +525,6 @@ body {
 .badge-accent {
   background-color: #ffc142;
   color: #4d4d4d;
-  -webkit-transition: 0.3s;
   transition: 0.3s;
 }
 
@@ -540,7 +535,6 @@ body {
 .badge-success {
   background-color: #5cb85c;
   color: #fff;
-  -webkit-transition: 0.3s;
   transition: 0.3s;
 }
 
@@ -551,7 +545,6 @@ body {
 .badge-info {
   background-color: #33b5e5;
   color: #fff;
-  -webkit-transition: 0.3s;
   transition: 0.3s;
 }
 
@@ -562,7 +555,6 @@ body {
 .badge-warning {
   background-color: #f80;
   color: #fff;
-  -webkit-transition: 0.3s;
   transition: 0.3s;
 }
 
@@ -573,7 +565,6 @@ body {
 .badge-danger {
   background-color: #d9534f;
   color: #fff;
-  -webkit-transition: 0.3s;
   transition: 0.3s;
 }
 
@@ -963,8 +954,7 @@ fieldset[disabled] .btn--twitter.focus {
 .form-control:focus {
   border-color: #29abe2;
   outline: 0;
-  -webkit-box-shadow: 0 2px 0 0 #29abe2;
-          box-shadow: 0 2px 0 0 #29abe2;
+  box-shadow: 0 2px 0 0 #29abe2;
 }
 
 .form-control::-moz-placeholder {
@@ -999,8 +989,7 @@ fieldset[disabled] .form-control {
 }
 
 [type="radio"]:focus + label:before {
-  -webkit-box-shadow: 0 0 3px 2px #56bde8;
-          box-shadow: 0 0 3px 2px #56bde8;
+  box-shadow: 0 0 3px 2px #56bde8;
 }
 
 [type="checkbox"]:checked + label:after {
@@ -1020,31 +1009,25 @@ fieldset[disabled] .form-control {
 
 @-webkit-keyframes scale-form-control {
   0% {
-    -webkit-transform: scale(1);
-            transform: scale(1);
+    transform: scale(1);
   }
   50% {
-    -webkit-transform: scale(1.1);
-            transform: scale(1.1);
+    transform: scale(1.1);
   }
   100% {
-    -webkit-transform: scale(1);
-            transform: scale(1);
+    transform: scale(1);
   }
 }
 
 @keyframes scale-form-control {
   0% {
-    -webkit-transform: scale(1);
-            transform: scale(1);
+    transform: scale(1);
   }
   50% {
-    -webkit-transform: scale(1.1);
-            transform: scale(1.1);
+    transform: scale(1.1);
   }
   100% {
-    -webkit-transform: scale(1);
-            transform: scale(1);
+    transform: scale(1);
   }
 }
 
@@ -1057,8 +1040,7 @@ fieldset[disabled] .form-control {
 }
 
 input[type=checkbox]:checked:not(:disabled) ~ .lever:active:after {
-  -webkit-box-shadow: 0 1px 3px 1px rgba(0, 0, 0, 0.4), 0 0 0 15px rgba(29, 120, 158, 0.1);
-          box-shadow: 0 1px 3px 1px rgba(0, 0, 0, 0.4), 0 0 0 15px rgba(29, 120, 158, 0.1);
+  box-shadow: 0 1px 3px 1px rgba(0, 0, 0, 0.4), 0 0 0 15px rgba(29, 120, 158, 0.1);
 }
 
 .input-group .select-wrapper:first-child .form-control:first-child {
@@ -1100,8 +1082,7 @@ html.js .input-group-addon .glyphicon.glyphicon-spin {
 }
 
 .has-error .form-control:focus {
-  -webkit-box-shadow: 0 2px 0 0 #a94442;
-          box-shadow: 0 2px 0 0 #a94442;
+  box-shadow: 0 2px 0 0 #a94442;
   border-color: #a94442;
 }
 
@@ -1257,7 +1238,6 @@ html.js .input-group-addon .glyphicon.glyphicon-spin {
 }
 
 .navbar-scrollable:after {
-  background: -webkit-gradient(linear, left top, right top, from(rgba(31, 128, 170, 0)), to(#1f80aa));
   background: linear-gradient(to right, rgba(31, 128, 170, 0), #1f80aa);
 }
 
@@ -1335,85 +1315,42 @@ html.js .input-group-addon .glyphicon.glyphicon-spin {
   font-weight: 500;
 }
 
-.socialblue--sky [id='section-comments'] .card__block {
-  margin-top: -.625rem;
-}
-
-.socialblue--sky .comment__text {
-  margin-bottom: 0;
-}
-
-.socialblue--sky .comment__text p {
-  margin-bottom: 1rem;
-  line-height: 1.5rem;
-}
-
-.socialblue--sky .comment {
-  margin-top: 1.75rem;
-}
-
-.socialblue--sky .comment:first-child {
-  margin-top: 0;
-}
-
-.socialblue--sky .comments {
-  margin-top: 1rem;
-}
-
-.socialblue--sky .comments .comment__reply-btn,
-.socialblue--sky .comments .vote-widget--like-and-dislike,
-.socialblue--sky .comment .comment__reply-btn,
-.socialblue--sky .comment .vote-widget--like-and-dislike {
-  font-size: .875rem;
-}
-
-.socialblue--sky .comments .vote-like,
-.socialblue--sky .comment .vote-like {
-  margin-right: 5px;
-}
-
-.socialblue--sky .comment__reply-btn a {
-  font-weight: 700;
-  text-transform: uppercase;
-}
-
 .cover {
   color: white;
   background-color: #29abe2;
 }
 
-.page-title {
+.cover .page-title {
   color: white;
 }
 
-.hero-avatar {
+.cover .hero-avatar {
   border-radius: 50%;
   border: 2px solid white;
 }
 
-.hero-canvas {
+.cover .hero-canvas {
   border-radius: 10px;
   background-color: rgba(51, 51, 51, 0.8);
   color: white;
 }
 
-.hero-form[role='search'] .form-control {
+.cover .hero-form[role='search'] .form-control {
   border-radius: 5px;
 }
 
-.hero-form[role='search'] .form-control:focus, .hero-form[role='search'] .form-control:active,
-.hero-form[role='search'] .form-control:focus ~ .search-icon,
-.hero-form[role='search'] .form-control:active ~ .search-icon {
-  -webkit-box-shadow: 0 2px 0 0 #1f80aa;
-          box-shadow: 0 2px 0 0 #1f80aa;
+.cover .hero-form[role='search'] .form-control:focus, .cover .hero-form[role='search'] .form-control:active,
+.cover .hero-form[role='search'] .form-control:focus ~ .search-icon,
+.cover .hero-form[role='search'] .form-control:active ~ .search-icon {
+  box-shadow: 0 2px 0 0 #1f80aa;
 }
 
-.hero-form[role='search'] .form-submit,
-.hero-form[role='search'] .search-icon {
+.cover .hero-form[role='search'] .form-submit,
+.cover .hero-form[role='search'] .search-icon {
   border-radius: 0 5px 5px 0;
 }
 
-.hero-form[role='search'] .search-icon {
+.cover .hero-form[role='search'] .search-icon {
   fill: #29abe2;
   background: white;
 }
@@ -1449,12 +1386,18 @@ html.js .input-group-addon .glyphicon.glyphicon-spin {
 }
 
 .field--name-field-introduction-text a:not(.btn),
+.field--name-field-featured-items-description a:not(.btn),
+.field--name-field-featured-description a:not(.btn),
+.field--name-field-accord-description a:not(.btn),
 .body-text a:not(.btn) {
   text-decoration: underline;
   color: #33b5e5;
 }
 
 .field--name-field-introduction-text a:not(.btn):hover,
+.field--name-field-featured-items-description a:not(.btn):hover,
+.field--name-field-featured-description a:not(.btn):hover,
+.field--name-field-accord-description a:not(.btn):hover,
 .body-text a:not(.btn):hover {
   color: #178ab4;
 }
@@ -1464,8 +1407,7 @@ html.js .input-group-addon .glyphicon.glyphicon-spin {
 }
 
 [type="radio"]:focus + label:before {
-  -webkit-box-shadow: 0 0 3px 2px #29abe2;
-          box-shadow: 0 0 3px 2px #29abe2;
+  box-shadow: 0 0 3px 2px #29abe2;
 }
 
 [type="checkbox"]:checked + label:after,
@@ -1505,8 +1447,7 @@ html.js .input-group-addon .glyphicon.glyphicon-spin {
 .hero-form[role='search'] .form-control:focus, .hero-form[role='search'] .form-control:active,
 .hero-form[role='search'] .form-control:focus ~ .search-icon,
 .hero-form[role='search'] .form-control:active ~ .search-icon {
-  -webkit-box-shadow: 0 2px 0 0 #1f80aa;
-          box-shadow: 0 2px 0 0 #1f80aa;
+  box-shadow: 0 2px 0 0 #1f80aa;
 }
 
 .hero-form[role='search'] .search-icon {
@@ -1515,8 +1456,7 @@ html.js .input-group-addon .glyphicon.glyphicon-spin {
 
 .form-control:focus {
   border-color: #29abe2;
-  -webkit-box-shadow: 0 2px 0 0 #29abe2;
-          box-shadow: 0 2px 0 0 #29abe2;
+  box-shadow: 0 2px 0 0 #29abe2;
 }
 
 .select2-container--social.select2-container--focus .select2-selection, .select2-container--social.select2-container--open .select2-selection, .select2-container--social .select2-dropdown {
@@ -1548,7 +1488,6 @@ html.js .input-group-addon .glyphicon.glyphicon-spin {
 .btn-primary.dropdown-toggle:hover {
   background-color: #29abe2;
   border-color: #29abe2;
-  background-image: -webkit-gradient(linear, left top, left bottom, from(rgba(0, 0, 0, 0.2)), to(rgba(0, 0, 0, 0.2)));
   background-image: linear-gradient(to bottom, rgba(0, 0, 0, 0.2) 0%, rgba(0, 0, 0, 0.2) 100%);
 }
 
@@ -1570,7 +1509,6 @@ fieldset[disabled]
 .btn-primary.focus {
   background-color: #29abe2;
   border-color: #29abe2;
-  background-image: -webkit-gradient(linear, left top, left bottom, from(rgba(0, 0, 0, 0.2)), to(rgba(0, 0, 0, 0.2)));
   background-image: linear-gradient(to bottom, rgba(0, 0, 0, 0.2) 0%, rgba(0, 0, 0, 0.2) 100%);
 }
 
@@ -1583,7 +1521,6 @@ fieldset[disabled]
 .open > .btn-secondary.dropdown-toggle, .btn-secondary.dropdown-toggle:hover {
   background-color: #1f80aa;
   border-color: #1f80aa;
-  background-image: -webkit-gradient(linear, left top, left bottom, from(rgba(0, 0, 0, 0.2)), to(rgba(0, 0, 0, 0.2)));
   background-image: linear-gradient(to bottom, rgba(0, 0, 0, 0.2) 0%, rgba(0, 0, 0, 0.2) 100%);
 }
 
@@ -1593,7 +1530,6 @@ fieldset[disabled] .btn-secondary:focus,
 fieldset[disabled] .btn-secondary.focus {
   background-color: #1f80aa;
   border-color: #1f80aa;
-  background-image: -webkit-gradient(linear, left top, left bottom, from(rgba(0, 0, 0, 0.2)), to(rgba(0, 0, 0, 0.2)));
   background-image: linear-gradient(to bottom, rgba(0, 0, 0, 0.2) 0%, rgba(0, 0, 0, 0.2) 100%);
 }
 
@@ -1611,7 +1547,6 @@ fieldset[disabled] .btn-secondary.focus {
 .open > .btn-accent.dropdown-toggle, .btn-accent.dropdown-toggle:hover {
   background-color: #ffc142;
   border-color: #ffc142;
-  background-image: -webkit-gradient(linear, left top, left bottom, from(rgba(0, 0, 0, 0.2)), to(rgba(0, 0, 0, 0.2)));
   background-image: linear-gradient(to bottom, rgba(0, 0, 0, 0.2) 0%, rgba(0, 0, 0, 0.2) 100%);
 }
 
@@ -1621,7 +1556,6 @@ fieldset[disabled] .btn-accent:focus,
 fieldset[disabled] .btn-accent.focus {
   background-color: #ffc142;
   border-color: #ffc142;
-  background-image: -webkit-gradient(linear, left top, left bottom, from(rgba(0, 0, 0, 0.2)), to(rgba(0, 0, 0, 0.2)));
   background-image: linear-gradient(to bottom, rgba(0, 0, 0, 0.2) 0%, rgba(0, 0, 0, 0.2) 100%);
 }
 
@@ -1662,6 +1596,12 @@ fieldset[disabled] .btn-accent.focus {
 
 .field--name-field-introduction-text a:not(.btn),
 .field--name-field-introduction-text a:not(.btn):hover,
+.field--name-field-featured-items-description a:not(.btn),
+.field--name-field-featured-items-description a:not(.btn):hover,
+.field--name-field-featured-description a:not(.btn),
+.field--name-field-featured-description a:not(.btn):hover,
+.field--name-field-accord-description a:not(.btn),
+.field--name-field-accord-description a:not(.btn):hover,
 .body-text a:not(.btn),
 .body-text a:not(.btn):hover {
   color: #33b5e5;
@@ -1673,8 +1613,7 @@ blockquote {
 
 .input-group .form-control:focus ~ .input-group-addon {
   border-color: #29abe2;
-  -webkit-box-shadow: 0 2px 0 0 #29abe2;
-          box-shadow: 0 2px 0 0 #29abe2;
+  box-shadow: 0 2px 0 0 #29abe2;
 }
 
 .navbar-secondary {
@@ -1691,12 +1630,10 @@ blockquote {
 }
 
 .navbar-scrollable:before {
-  background: -webkit-gradient(linear, left top, right top, from(#1f7ea7), to(transparent));
   background: linear-gradient(90deg, #1f7ea7, transparent);
 }
 
 .navbar-scrollable:after {
-  background: -webkit-gradient(linear, right top, left top, from(#1f7ea7), to(transparent));
   background: linear-gradient(-90deg, #1f7ea7, transparent);
 }
 
@@ -1943,7 +1880,7 @@ html:not(.js) .navbar-default .dropdown:focus > a .navbar-nav__icon, html:not(.j
     background-color: rgba(0, 0, 0, 0.5);
     border-radius: 0 0 10px 0;
   }
-  .hero-avatar {
+  .cover .hero-avatar {
     border-width: 3px;
   }
 }
@@ -1954,26 +1891,17 @@ html:not(.js) .navbar-default .dropdown:focus > a .navbar-nav__icon, html:not(.j
   }
   .search-take-over .form-text:focus {
     border-color: #ffffff;
-    -webkit-box-shadow: 0 2px 0 0 #ffffff;
-            box-shadow: 0 2px 0 0 #ffffff;
+    box-shadow: 0 2px 0 0 #ffffff;
   }
   .nav-tabs > li.active > a, .nav-tabs > li.active > a:hover, .nav-tabs > li.active > a:focus {
     border-bottom: 2px solid #29abe2;
-  }
-  .socialblue--sky [id='section-comments'] .card__block {
-    padding-left: 3.75rem;
-    padding-right: 3.75rem;
-  }
-  .socialblue--sky .comment__reply-btn {
-    margin-right: 1rem;
   }
   .search-take-over .form-text {
     color: #ffffff;
   }
   .search-take-over .form-text:focus {
     border-color: #ffffff;
-    -webkit-box-shadow: 0 2px 0 0 #ffffff;
-            box-shadow: 0 2px 0 0 #ffffff;
+    box-shadow: 0 2px 0 0 #ffffff;
   }
   .btn--close-search-take-over svg,
   .search-take-over svg {

--- a/themes/socialblue/assets/css/teaser--sky.css
+++ b/themes/socialblue/assets/css/teaser--sky.css
@@ -22,7 +22,6 @@
 
 .socialblue--sky .teaser__tag a {
   font-weight: 700;
-  -webkit-transition: .3s ease-out;
   transition: .3s ease-out;
 }
 
@@ -37,9 +36,7 @@
 }
 
 .socialblue--sky .teaser--tile .teaser__content {
-  -webkit-box-flex: 0;
-      -ms-flex: none;
-          flex: none;
+  flex: none;
   padding-bottom: 10px;
 }
 
@@ -48,15 +45,9 @@
 }
 
 .socialblue--sky .teaser__header {
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
-  -webkit-box-align: center;
-      -ms-flex-align: center;
-          align-items: center;
-  -webkit-box-pack: justify;
-      -ms-flex-pack: justify;
-          justify-content: space-between;
+  align-items: center;
+  justify-content: space-between;
 }
 
 .socialblue--sky .teaser__header .teaser__badge {

--- a/themes/socialblue/components/04-organisms/hero/hero.scss
+++ b/themes/socialblue/components/04-organisms/hero/hero.scss
@@ -4,50 +4,50 @@
 .cover {
   color: white;
   background-color: $brand-primary;
-}
 
-.page-title {
-	color: white;
-}
-
-.hero-avatar {
-  border-radius: 50%;
-  border: 2px solid white;
-
-  @include for-tablet-portrait-up {
-    border-width: 3px;
+  .page-title {
+    color: white;
   }
 
-}
+  .hero-avatar {
+    border-radius: 50%;
+    border: 2px solid white;
 
-.hero-canvas {
-  border-radius: $border-radius-base;
-  background-color: rgba($gray-dark, 0.8);
-  color: white;
-}
-
-.hero-form[role='search'] {
-
-  .form-control {
-    border-radius: $input-border-radius;
-
-    &:focus,
-    &:active,
-    &:focus ~ .search-icon,
-    &:active ~ .search-icon {
-      box-shadow: 0 2px 0 0 $brand-secondary;
+    @include for-tablet-portrait-up {
+      border-width: 3px;
     }
 
   }
 
-  .form-submit,
-  .search-icon {
-    border-radius: 0 $input-border-radius $input-border-radius 0;
+  .hero-canvas {
+    border-radius: $border-radius-base;
+    background-color: rgba($gray-dark, 0.8);
+    color: white;
   }
 
-  .search-icon {
-    fill: $brand-primary;
-    background: white;
-  }
+  .hero-form[role='search'] {
 
+    .form-control {
+      border-radius: $input-border-radius;
+
+      &:focus,
+      &:active,
+      &:focus ~ .search-icon,
+      &:active ~ .search-icon {
+        box-shadow: 0 2px 0 0 $brand-secondary;
+      }
+
+    }
+
+    .form-submit,
+    .search-icon {
+      border-radius: 0 $input-border-radius $input-border-radius 0;
+    }
+
+    .search-icon {
+      fill: $brand-primary;
+      background: white;
+    }
+
+  }
 }


### PR DESCRIPTION
<h2>Problem</h2>

Some hero styles are declared in <code>hero.scss</code> that affect the page title. However, this is set to a generic page title selector and not scoped to the hero block. This causes issues if a page title element is displayed outside of the hero while the hero css is loaded on the page.

<h2>Solution</h2>
The <code>cover</code> class is consistently used as top level class for hero elements. Ideally we'd use a new class for the scoping but that requires editing a lot more heroes and could break other custom hero elements that live outside of Open Social. So to fix this the <code>.page-title</code> class (and other generic classes) are scoped to <code>.cover</code> if they're not already scoped to a hero specific element.

## Issue tracker
https://www.drupal.org/project/social/issues/3108035

## How to test
- [ ] Create a dashboard with the AN Hero block
- [ ] The new dashboard page title block should look correct.

## Release notes
The styles for heroes are now properly scoped so that they don't accidentally affect elements outside of the hero.
