### PR TITLE
Issue #3108050 by sjoerdvandervis: Order groups alphabetically on people overview

### DIFF
--- a/modules/social_features/social_user/social_user.module
+++ b/modules/social_features/social_user/social_user.module
@@ -126,7 +126,7 @@ function social_user_form_views_exposed_form_alter(&$form, FormStateInterface $f
 }
 
 /**
- * Returns array with titles of all groups.
+ * Returns array with titles of all groups, ordered by their label.
  */
 function _social_user_get_groups() {
   $data = &drupal_static(__FUNCTION__);

--- a/modules/social_features/social_user/social_user.module
+++ b/modules/social_features/social_user/social_user.module
@@ -135,6 +135,7 @@ function _social_user_get_groups() {
     $data = \Drupal::database()
       ->select('groups_field_data', 'gfd')
       ->fields('gfd', ['id', 'label'])
+      ->orderBy('label')
       ->execute()
       ->fetchAllKeyed(0, 1);
   }


### PR DESCRIPTION
## Problem
Once a CM, SM or admin goes to `/admin/people` , the filter for Group is ordered by the group ID. This makes it hard for a community with a lot of groups to find the users in the groups you are looking for.

## Solution
Order the groups alphabetically.

## Issue tracker
https://www.drupal.org/project/social/issues/3108050

## How to test
- [ ] Go to `/admin/people` and see that the Group filter is now in alphabetical order.

## Release Notes
Groups on the site manager people overview are now ordered alphabetically. This makes it easier to find the right group to filter on.