### PR TITLE
Issue #3108292 by sjoerdvandervis: Add caret to language switcher

### DIFF
--- a/themes/socialbase/templates/system/links--language-block.html.twig
+++ b/themes/socialbase/templates/system/links--language-block.html.twig
@@ -39,6 +39,7 @@
       {%- if heading -%}
         <a href="" data-toggle="dropdown" aria-expanded="true" aria-haspopup="true" role="button" class="dropdown-toggle clearfix" title="{{ heading.text }}">
           {{ heading.text }}
+          <span class="caret"></span>
         </a>
       {%- endif -%}
       <ul{{ attributes }}>


### PR DESCRIPTION
## Problem
The language switch block is a dropdown when placed in the menu, but it is not really clear that it actually is a dropdown.

## Solution
Add a dropdown caret to the block heading, so that it's clear that this is a dropdown menu.

## Issue tracker
https://www.drupal.org/project/social/issues/3108292

## How to test
- [ ] Set multiple languages for your OS install;
- [ ] Add the language switch block to the header region;
- [ ] Check that the language selector now has a dropdown icon next to it.

## Screenshots
### Before
![Screenshot 2020-01-23 at 14 44 08](https://user-images.githubusercontent.com/19951173/72990263-25921f00-3df0-11ea-900f-d3ec4046f616.png)

### After
![Screenshot 2020-01-23 at 14 44 44](https://user-images.githubusercontent.com/19951173/72990295-32167780-3df0-11ea-8a15-012d38051942.png)
