### PR TITLE
3105096 - make sure to only show the login message for an anonymous user

### DIFF
--- a/modules/social_features/social_user/social_user.module
+++ b/modules/social_features/social_user/social_user.module
@@ -200,7 +200,8 @@ function social_user_form_user_register_form_alter(&$form, FormStateInterface $f
       ];
     }
 
-    // Only show for anonymous.
+    // Ensure this is not shown for site managers when creating accounts through
+    // the admin interface.
     if (TRUE === \Drupal::currentUser()->isAnonymous()) {
       $login_link = Link::createFromRoute(new TranslatableMarkup('Log in'), 'user.login', [], $link_options)->toString();
 

--- a/modules/social_features/social_user/social_user.module
+++ b/modules/social_features/social_user/social_user.module
@@ -201,7 +201,7 @@ function social_user_form_user_register_form_alter(&$form, FormStateInterface $f
     }
 
     // Only show for anonymous.
-    if (true === \Drupal::currentUser()->isAnonymous()) {
+    if (TRUE === \Drupal::currentUser()->isAnonymous()) {
       $login_link = Link::createFromRoute(new TranslatableMarkup('Log in'), 'user.login', [], $link_options)->toString();
 
       $form['account']['login-link'] = [

--- a/modules/social_features/social_user/social_user.module
+++ b/modules/social_features/social_user/social_user.module
@@ -202,7 +202,7 @@ function social_user_form_user_register_form_alter(&$form, FormStateInterface $f
 
     // Ensure this is not shown for site managers when creating accounts through
     // the admin interface.
-    if (TRUE === \Drupal::currentUser()->isAnonymous()) {
+    if (\Drupal::currentUser()->isAnonymous()) {
       $login_link = Link::createFromRoute(new TranslatableMarkup('Log in'), 'user.login', [], $link_options)->toString();
 
       $form['account']['login-link'] = [

--- a/modules/social_features/social_user/social_user.module
+++ b/modules/social_features/social_user/social_user.module
@@ -200,15 +200,18 @@ function social_user_form_user_register_form_alter(&$form, FormStateInterface $f
       ];
     }
 
-    $login_link = Link::createFromRoute(new TranslatableMarkup('Log in'), 'user.login', [], $link_options)->toString();
+    // Only show for anonymous.
+    if (true === \Drupal::currentUser()->isAnonymous()) {
+      $login_link = Link::createFromRoute(new TranslatableMarkup('Log in'), 'user.login', [], $link_options)->toString();
 
-    $form['account']['login-link'] = [
-      '#markup' => new TranslatableMarkup("Have an account already? @link", ["@link" => $login_link]),
-      '#weight' => 1000,
-      '#cache' => [
-        'contexts' => ['url.query_args'],
-      ],
-    ];
+      $form['account']['login-link'] = [
+        '#markup' => new TranslatableMarkup("Have an account already? @link", ["@link" => $login_link]),
+        '#weight' => 1000,
+        '#cache' => [
+          'contexts' => ['url.query_args'],
+        ],
+      ];
+    }
   }
 
   // Add an extra validation option, to check for existing data.


### PR DESCRIPTION
## Problem
Whenever a SM creates a new user, at the bottom of the form there's a message asking if the user already has an account with a link to the login page. This is weird since the user is already logged in. This message is for anonymous users only

## Solution
Make sure the message is only shown to anonymous users

## Issue tracker
- https://www.drupal.org/project/social/issues/3105096

## How to test
- [ ] Login as a SM+ and create a new user
- [ ] Notice the message mentioned above at the bottom of the form
- [ ] Notice the same message as an anonymous user on /user/register
- [ ] Checkout this branch
- [ ] Notice that the message is no longer there for the SM+, but it IS there for the AN

## Screenshots
If this Pull Request makes visual changes then please include some screenshots that show what has changed here. 

## Release notes
As a SM I no longer see a message and a link to the login form whenever I was adding a new user.
