### PR TITLE
Issue #3108614 by ronaldtebrake: Ensure correct photoswipe library is added

### DIFF
--- a/themes/socialbase/socialbase.theme
+++ b/themes/socialbase/socialbase.theme
@@ -25,6 +25,7 @@ function socialbase_library_info_alter(&$libraries, $extension) {
   // photoswipe styling with the comment styling.
   if ($extension === 'socialbase' && isset($libraries['comment']) && \Drupal::moduleHandler()->moduleExists('social_comment_upload')) {
     $libraries['comment']['dependencies'][] = 'socialbase/photoswipe-gallery';
+    $libraries['comment']['dependencies'][] = 'socialbase/photoswipe.image';
   }
 }
 


### PR DESCRIPTION
## Problem
With the Social Ajax comments and the Social Comment Update modules enabled, adding a comment with an image to a thread without previous comments that contained an image, the icon placeholders from the gallery (modal) are visible. 

## Solution
The socialbase/photoswipe.image library is loaded in template files, instead of on page load, this isn't added correctly when adding your first comment through Ajax, it is usually because without ajax the entire page is loaded. 

## Issue tracker
https://www.drupal.org/project/social/issues/3108614

## How to test
Make sure social_ajax_comments is enabled.
Make sure social_comment_upload is enabled

- [x] Go to a topic (without comments, or comments containing an image)
- [x] Create a comment WITH an image. Press Comment
- [x] See that it looks like the screenshot with 5 small white squares
- [x] Reload the page, see the 5 squares are gone, also they don't come back when posting another comment with an image.

## Release notes
We have ensured the image gallery icons aren't shown after adding a comment with Ajax.