### PR TITLE
Issue #3108601 by ronaldtebrake, royharink: Ensure editting for comments through AJAX is not enabled

### DIFF
--- a/modules/custom/social_ajax_comments/social_ajax_comments.module
+++ b/modules/custom/social_ajax_comments/social_ajax_comments.module
@@ -138,9 +138,10 @@ function social_ajax_comments_comment_links_alter(array &$links, CommentInterfac
   // We need the custom checks to override what Ajax comments does for us.
   // Mainly because of UX flaws in the edit form that opens up.
   // For now we don't support edit ajax actions nor unpublishing.
-  $links['comment']['#links']['comment-edit']['attributes']['class'] = [];
-  $links['comment']['#links']['comment-edit']['url'] = Url::fromRoute('entity.comment.edit_form', ['comment' => $entity->id()]);
-
+  if (!empty($links['comment']['#links']['comment-edit'])) {
+    $links['comment']['#links']['comment-edit']['attributes']['class'] = [];
+    $links['comment']['#links']['comment-edit']['url'] = Url::fromRoute('entity.comment.edit_form', ['comment' => $entity->id()]);
+  }
   // For post comments we need to render better data wrapper's so
   // Ajax replace works on the right ID.
   if ($entity->isPublished() && $account->hasPermission('administer comments') && $bundle === 'post_comment') {

--- a/modules/custom/social_ajax_comments/social_ajax_comments.module
+++ b/modules/custom/social_ajax_comments/social_ajax_comments.module
@@ -137,21 +137,19 @@ function social_ajax_comments_comment_links_alter(array &$links, CommentInterfac
   // Url::fromRoute()->toRenderable doesn't fully take care of access checks.
   // We need the custom checks to override what Ajax comments does for us.
   // Mainly because of UX flaws in the edit form that opens up.
-  if ($entity->isPublished() && $account->hasPermission('administer comments')) {
-    // For now we don't support edit ajax actions nor unpublishing.
-    $links['comment']['#links']['comment-edit']['attributes']['class'] = [];
-    $links['comment']['#links']['comment-edit']['url'] = Url::fromRoute('entity.comment.edit_form', ['comment' => $entity->id()]);
+  // For now we don't support edit ajax actions nor unpublishing.
+  $links['comment']['#links']['comment-edit']['attributes']['class'] = [];
+  $links['comment']['#links']['comment-edit']['url'] = Url::fromRoute('entity.comment.edit_form', ['comment' => $entity->id()]);
 
-    // For post comments we need to render better data wrapper's so
-    // Ajax replace works on the right ID.
-    if ($bundle === 'post_comment') {
-      $wrapper_id = Html::getId(
-        $commented_entity->getEntityTypeId() . '-' . $commented_entity->bundle() . '-' . 'field_post_comments' . '-' . $commented_entity->id()
-      );
-      $links['comment']['#links']['comment-edit']['attributes']['data-wrapper-html-id'] = $wrapper_id;
-      $links['comment']['#links']['comment-unpublish']['attributes']['data-wrapper-html-id'] = $wrapper_id;
-      $links['comment']['#links']['comment-delete']['attributes']['data-wrapper-html-id'] = $wrapper_id;
-    }
+  // For post comments we need to render better data wrapper's so
+  // Ajax replace works on the right ID.
+  if ($entity->isPublished() && $account->hasPermission('administer comments') && $bundle === 'post_comment') {
+    $wrapper_id = Html::getId(
+      $commented_entity->getEntityTypeId() . '-' . $commented_entity->bundle() . '-' . 'field_post_comments' . '-' . $commented_entity->id()
+    );
+    $links['comment']['#links']['comment-edit']['attributes']['data-wrapper-html-id'] = $wrapper_id;
+    $links['comment']['#links']['comment-unpublish']['attributes']['data-wrapper-html-id'] = $wrapper_id;
+    $links['comment']['#links']['comment-delete']['attributes']['data-wrapper-html-id'] = $wrapper_id;
   }
 }
 


### PR DESCRIPTION
## Problem
When you want to edit a comment through Ajax, it results in UX issues. It tries to load the Author, comment section, creation date etc. So the entire edit form. This needs to be a follow up where we load this in a modal popup. 

## Solution
We ensure that the Edit link still points to the old edit form page, instead of making it an Ajax link.

## Issue tracker
https://www.drupal.org/project/social/issues/3108601

## How to test
- [x] Try editting a comment in the stream and on a node and see you get redirected to the Edit form page like you are used to.

## Release notes
None needed, since this is a regression of Ajax comments and the scope of that story already was limited to only adding and deleting of comments through Ajax.