### PR TITLE
Issue #3109064 by sjoerdvandervis: Move the image in events in Sky flavour to correspond with topics

### DIFF
--- a/themes/socialblue/templates/node/event/node--event--hero--sky.html.twig
+++ b/themes/socialblue/templates/node/event/node--event--hero--sky.html.twig
@@ -2,6 +2,7 @@
 
 {% block card_prefix %}
 {% endblock %}
+
 {% block card_suffix %}
   {% if node_image %}
     <div class="hero-image">

--- a/themes/socialblue/templates/node/event/node--event--hero--sky.html.twig
+++ b/themes/socialblue/templates/node/event/node--event--hero--sky.html.twig
@@ -1,14 +1,13 @@
 {% extends "node--hero--sky.html.twig" %}
 
 {% block card_prefix %}
+{% endblock %}
+{% block card_suffix %}
   {% if node_image %}
     <div class="hero-image">
       {{ node_image }}
     </div>
   {% endif %}
-{% endblock %}
-
-{% block card_suffix %}
 {% endblock %}
 
 {% block nodefull_specialfields %}


### PR DESCRIPTION
## Problem
In the Sky flavour, in topics the image is rendered below the topic title, while with events, the image is rendered before the event title.

## Solution
Move the image from the card_prefix block to the card_suffix block, just like with topics.

## Issue tracker
https://www.drupal.org/project/social/issues/3109064

## How to test
- [ ] Enable the Sky flavour
- [ ] Check out an Event and see that the event title is rendered above the image
- [ ] See that for topics, the topic rendering has not changed.