### PR TITLE
Issue #3109183 by agami4:  Fix title of the event page on mobile

### DIFF
--- a/themes/socialblue/assets/css/hero--sky.css
+++ b/themes/socialblue/assets/css/hero--sky.css
@@ -188,6 +188,7 @@
 
 .socialblue--sky .hero__banner--static .teaser__title {
   margin: 0 0 1rem;
+  max-height: none;
 }
 
 .socialblue--sky .hero__banner--static .teaser__title a {

--- a/themes/socialblue/components/04-organisms/hero/hero--sky.scss
+++ b/themes/socialblue/components/04-organisms/hero/hero--sky.scss
@@ -195,6 +195,7 @@
 
     .teaser__title {
       margin: 0 0 1rem;
+      max-height: none;
 
       @include for-tablet-landscape-up {
         font-size: 2.25rem;


### PR DESCRIPTION
## Problem
The Event title doesn't scale well on mobile

## Solution
Rewrite styles for the title on the hero banner. (max-height: none)

## Issue tracker
https://www.drupal.org/project/social/issues/3109183

## How to test
- [ ] Open the event page on the mobile mode and check how the title display

## Release notes
<describe the release notes>
