### PR TITLE
Issue #3109065 by ribel: Fix hero image display for book and basic pages

### DIFF
--- a/modules/social_features/social_book/config/install/core.entity_view_display.node.book.hero.yml
+++ b/modules/social_features/social_book/config/install/core.entity_view_display.node.book.hero.yml
@@ -1,0 +1,58 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.teaser
+    - field.field.node.book.body
+    - field.field.node.book.field_book_comments
+    - field.field.node.book.field_book_image
+    - field.field.node.book.field_content_visibility
+    - field.field.node.book.field_files
+    - image.style.social_xx_large
+    - node.type.book
+  module:
+    - image
+    - options
+    - user
+id: node.book.hero
+targetEntityType: node
+bundle: book
+mode: hero
+content:
+  field_book_image:
+    type: image
+    weight: 0
+    label: above
+    settings:
+      image_style: social_xx_large
+      image_link: ''
+    third_party_settings: {  }
+  field_content_visibility:
+    type: list_default
+    weight: 1
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+  links:
+    weight: 2
+    settings: {  }
+    third_party_settings: {  }
+  flag_follow_content:
+    weight: 3
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  shariff_field:
+    weight: 4
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+hidden:
+  body: true
+  field_book_comments: true
+  field_files: true
+  groups: true
+  groups_type_closed_group: true
+  groups_type_open_group: true
+  groups_type_public_group: true
+  search_api_excerpt: true

--- a/modules/social_features/social_book/config/install/core.entity_view_display.node.book.hero.yml
+++ b/modules/social_features/social_book/config/install/core.entity_view_display.node.book.hero.yml
@@ -2,7 +2,7 @@ langcode: en
 status: true
 dependencies:
   config:
-    - core.entity_view_mode.node.teaser
+    - core.entity_view_mode.node.hero
     - field.field.node.book.body
     - field.field.node.book.field_book_comments
     - field.field.node.book.field_book_image

--- a/modules/social_features/social_page/config/install/core.entity_view_display.node.page.hero.yml
+++ b/modules/social_features/social_page/config/install/core.entity_view_display.node.page.hero.yml
@@ -2,7 +2,7 @@ langcode: en
 status: true
 dependencies:
   config:
-    - core.entity_view_mode.node.teaser
+    - core.entity_view_mode.node.hero
     - field.field.node.page.body
     - field.field.node.page.field_content_visibility
     - field.field.node.page.field_files

--- a/modules/social_features/social_page/config/install/core.entity_view_display.node.page.hero.yml
+++ b/modules/social_features/social_page/config/install/core.entity_view_display.node.page.hero.yml
@@ -1,0 +1,59 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.teaser
+    - field.field.node.page.body
+    - field.field.node.page.field_content_visibility
+    - field.field.node.page.field_files
+    - field.field.node.page.field_page_comments
+    - field.field.node.page.field_page_image
+    - image.style.social_xx_large
+    - node.type.page
+  module:
+    - image
+    - options
+    - user
+id: node.page.hero
+targetEntityType: node
+bundle: page
+mode: hero
+content:
+  field_content_visibility:
+    type: list_default
+    weight: 2
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    region: content
+  field_page_image:
+    type: image
+    weight: 0
+    label: above
+    settings:
+      image_style: social_xx_large
+      image_link: ''
+    third_party_settings: {  }
+    region: content
+  flag_follow_content:
+    weight: 10
+    region: content
+  links:
+    weight: 1
+    settings: {  }
+    third_party_settings: {  }
+    region: content
+  shariff_field:
+    weight: 4
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+hidden:
+  body: true
+  field_files: true
+  field_page_comments: true
+  groups: true
+  groups_type_closed_group: true
+  groups_type_open_group: true
+  groups_type_public_group: true
+  search_api_excerpt: true


### PR DESCRIPTION
## Problem
Book and basic pages do not show the banner hero image

## Solution
Add hero view modes with image for those content types

## Issue tracker
https://www.drupal.org/project/social/issues/3109065

## How to test
- [ ] Make sure that new configs apply
- [ ] Upload image for book and page
- [ ] You should see hero image in SKY style

