### PR TITLE
Issue #3109198 by agami4: Fix display tab options on the search page on mobile mode

### DIFF
--- a/themes/socialbase/assets/css/navbar.css
+++ b/themes/socialbase/assets/css/navbar.css
@@ -440,6 +440,44 @@
   .nav > li.desktop {
     display: none;
   }
+  .navbar-scrollable {
+    overflow: hidden;
+    position: relative;
+    width: 100%;
+    height: 46px;
+  }
+  .navbar-scrollable .navbar-nav {
+    position: absolute;
+    left: 0;
+    top: 0;
+    width: 100%;
+    -webkit-overflow-scrolling: touch;
+    -webkit-user-select: none;
+       -moz-user-select: none;
+        -ms-user-select: none;
+            user-select: none;
+    overflow-x: scroll;
+    overflow-y: hidden;
+    display: -webkit-box;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-box-pack: start;
+        -ms-flex-pack: start;
+            justify-content: flex-start;
+  }
+  .navbar-scrollable .navbar-nav::-webkit-scrollbar {
+    display: none;
+  }
+  .navbar-scrollable:after {
+    content: '';
+    display: block;
+    position: absolute;
+    width: 24px;
+    height: 100%;
+    top: 0;
+    right: 0;
+    z-index: 2;
+  }
 }
 
 @media (max-width: 899px) {
@@ -507,44 +545,6 @@
   .region--content-top .search-take-over,
   .btn--close-search-take-over {
     display: none;
-  }
-  .navbar-scrollable {
-    overflow: hidden;
-    position: relative;
-    width: 100%;
-    height: 46px;
-  }
-  .navbar-scrollable .navbar-nav {
-    position: absolute;
-    left: 0;
-    top: 0;
-    width: 100%;
-    -webkit-overflow-scrolling: touch;
-    -webkit-user-select: none;
-       -moz-user-select: none;
-        -ms-user-select: none;
-            user-select: none;
-    overflow-x: scroll;
-    overflow-y: hidden;
-    display: -webkit-box;
-    display: -ms-flexbox;
-    display: flex;
-    -webkit-box-pack: start;
-        -ms-flex-pack: start;
-            justify-content: flex-start;
-  }
-  .navbar-scrollable .navbar-nav::-webkit-scrollbar {
-    display: none;
-  }
-  .navbar-scrollable:after {
-    content: '';
-    display: block;
-    position: absolute;
-    width: 24px;
-    height: 100%;
-    top: 0;
-    right: 0;
-    z-index: 2;
   }
   html:not(.js) .navbar-header:focus + .navbar-collapse, html:not(.js) .navbar-header:hover + .navbar-collapse {
     display: block;

--- a/themes/socialbase/components/03-molecules/navigation/navbar/navbar.scss
+++ b/themes/socialbase/components/03-molecules/navigation/navbar/navbar.scss
@@ -628,7 +628,7 @@
 // -------------------------
 .navbar-scrollable {
 
-  @include for-tablet-landscape-down {
+  @include for-phone-only {
 
     // Wrapper for hiding the FF scrollbar.
     overflow: hidden;

--- a/themes/socialblue/assets/css/layout--sky.css
+++ b/themes/socialblue/assets/css/layout--sky.css
@@ -2,6 +2,10 @@
   z-index: 10;
 }
 
+.socialblue--sky .region--secondary-navigation {
+  width: 100%;
+}
+
 .socialblue--sky.path-user .region--hero, .socialblue--sky.path-group .region--hero {
   max-width: 100%;
 }
@@ -25,9 +29,6 @@
     -webkit-box-ordinal-group: 2;
         -ms-flex-order: 1;
             order: 1;
-  }
-  .socialblue--sky .region--secondary-navigation {
-    width: 100%;
   }
   .socialblue--sky.path-user .layout--with-complementary .region--secondary-navigation, .socialblue--sky.path-group .layout--with-complementary .region--secondary-navigation {
     display: -webkit-box;

--- a/themes/socialblue/components/05-templates/layout/layout--sky.scss
+++ b/themes/socialblue/components/05-templates/layout/layout--sky.scss
@@ -23,9 +23,7 @@
     }
   }
   .region--secondary-navigation {
-    @include for-tablet-landscape-up {
-      width: 100%;
-    }
+    width: 100%;
   }
 
 


### PR DESCRIPTION
## Problem
Search does not show the tab options to search for Content, Groups or Users on mobile.

## Solution
Add width 100% to the secondary navigation region

## Issue tracker
https://www.drupal.org/project/social/issues/3109198

## How to test
- [ ] Go to the search page and activate mobile mode or open this page on your a mobile device

## Release notes
<describe the release notes>
