### PR TITLE
Issue #3109206 by agami4: Change color separate line between sections on the sidebar on the profile and groups pages

### DIFF
--- a/themes/socialblue/assets/css/cards--sky.css
+++ b/themes/socialblue/assets/css/cards--sky.css
@@ -57,11 +57,6 @@
   position: relative;
 }
 
-.socialblue--sky .content-merged--sky .region--complementary-top > *:not(.views-exposed-form):after,
-.socialblue--sky .content-merged--sky .region--complementary-bottom > *:not(.views-exposed-form):after {
-  top: 100%;
-}
-
 .socialblue--sky .content-merged--sky .region--complementary-top > *:not(.views-exposed-form):last-child:after,
 .socialblue--sky .content-merged--sky .region--complementary-bottom > *:not(.views-exposed-form):last-child:after {
   display: none;
@@ -73,10 +68,6 @@
 .socialblue--sky .content-merged--sky .region--complementary-bottom > *:not(.views-exposed-form).block-group-add-event-block,
 .socialblue--sky .content-merged--sky .region--complementary-bottom > *:not(.views-exposed-form).block-group-add-discussion-block {
   padding: 20px;
-}
-
-.socialblue--sky .content-merged--sky .region--complementary-top + .region--complementary-bottom > .card:first-child:before {
-  bottom: 100%;
 }
 
 .socialblue--sky .content-merged--sky .block-profile-statistic-block,
@@ -405,8 +396,9 @@
     right: 1.875rem;
     height: 2px;
     margin: 0 auto;
-    background: #fafafa;
+    background: #adadad;
     z-index: 1;
+    top: 100%;
   }
   .socialblue--sky .content-merged--sky .region--complementary-top + .region--complementary-bottom > .card:first-child:before {
     max-width: 280px;
@@ -416,8 +408,24 @@
     right: 1.875rem;
     height: 2px;
     margin: 0 auto;
+    background: #adadad;
+    z-index: 1;
+    bottom: 100%;
+  }
+  .socialblue--sky .block-profile-statistic-block:before,
+  .socialblue--sky .block-group-statistic-block:before {
+    max-width: 280px;
+    content: '';
+    position: absolute;
+    left: 1.875rem;
+    right: 1.875rem;
+    height: 2px;
+    margin: 0 auto;
     background: #fafafa;
     z-index: 1;
+    top: 100%;
+    margin-top: -2px;
+    z-index: 10;
   }
   .socialblue--sky .block-views-blockgroup-managers-block-list-managers .card, .socialblue--sky .block-views-blockgroup-managers-block-list-managers.card,
   .socialblue--sky .view-group-information .card,

--- a/themes/socialblue/components/00-config/mixins/_card--sky.scss
+++ b/themes/socialblue/components/00-config/mixins/_card--sky.scss
@@ -3,7 +3,7 @@
 // Easily pump out default styles, as well as :hover, :focus, :active,
 // and disabled options for all link buttons of the card
 
-@mixin separate-line {
+@mixin separate-line($bg-color) {
   @include for-tablet-landscape-up {
     max-width: 280px;
     content: '';
@@ -12,7 +12,9 @@
     right: 1.875rem;
     height: 2px;
     margin: 0 auto;
-    background: #fafafa;
+    background: $bg-color;
     z-index: 1;
+
+    @content;
   }
 }

--- a/themes/socialblue/components/02-atoms/cards/cards--sky.scss
+++ b/themes/socialblue/components/02-atoms/cards/cards--sky.scss
@@ -113,8 +113,9 @@
         position: relative;
 
         &:after {
-          @include separate-line;
-          top: 100%;
+          @include separate-line(#adadad) {
+            top: 100%;
+          };
         }
 
         &:last-child:after {
@@ -132,8 +133,9 @@
 
     .region--complementary-top + .region--complementary-bottom {
       > .card:first-child:before {
-        @include separate-line;
-        bottom: 100%;
+        @include separate-line(#adadad) {
+          bottom: 100%;
+        };
       }
     }
 
@@ -149,6 +151,14 @@
     position: relative;
     padding: 1rem 1.875rem 0;
     background: #fafafa;
+
+    &:before {
+      @include separate-line(#fafafa) {
+        top: 100%;
+        margin-top: -2px;
+        z-index: 10;
+      }
+    }
 
     @include for-tablet-portrait-up {
       padding: 2.5rem 2.25rem 0;


### PR DESCRIPTION
## Problem
The grey line that separates different sections of the left sidebar on profiles and groups should be clearer. At the moment it is a bit hard to scan.

## Solution
Change the line color into #adadad.

## Issue tracker
https://www.drupal.org/project/social/issues/3109206

## How to test
- [ ] Go to the profile/group pages and check the color of the separate line between sections on the sidebar.

## Release notes
<describe the release notes>
