### PR TITLE
#3109067 - @mention doest not work correctly due to attributes being rendered.. twice.

### DIFF
--- a/themes/socialbase/templates/comment/form--comment.html.twig
+++ b/themes/socialbase/templates/comment/form--comment.html.twig
@@ -13,7 +13,7 @@
  */
 #}
 {{ attach_library('socialbase/comment')}}
-<div {{ attributes.addClass('js-comment comment comment-form__wrapper') }}>
+<div class="js-comment comment comment-form__wrapper">
   <div class="comment__avatar">{{ current_user_picture }}</div>
   <div class="comment__content">
     <form{{ attributes }}>


### PR DESCRIPTION
## Problem
The mention doesn't work consistently when Ajax Comments is enabled, although this wasn't the actual issue.
Due to the creation of Ajax Comments we noticed we rendered attributes for the _form--comments_ twice. 

## Solution
I reverted that part and only added my own class to the list.

## Issue tracker
https://www.drupal.org/project/social/issues/3109067 
It was noticed in there, but mentions not working was a side effect.

## How to test
- [ ] Enable social_ajax_comments
- [ ] See that you can mention a user in a reply on a post in the stream and in the post and in the comments and it still looks good (e.g. with a highlighted background color)