### PR TITLE
Issue #3108605 by royharink: Comments on a Post are collapsed after posting a comment

### DIFF
--- a/modules/social_features/social_post/src/Plugin/Field/FieldFormatter/CommentPostActivityFormatter.php
+++ b/modules/social_features/social_post/src/Plugin/Field/FieldFormatter/CommentPostActivityFormatter.php
@@ -4,6 +4,7 @@ namespace Drupal\social_post\Plugin\Field\FieldFormatter;
 
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\comment\CommentInterface;
+use Drupal\Core\Field\FieldItemListInterface;
 
 /**
  * Provides a post comment activity formatter.
@@ -21,6 +22,18 @@ use Drupal\comment\CommentInterface;
  * )
  */
 class CommentPostActivityFormatter extends CommentPostFormatter {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function viewElements(FieldItemListInterface $items, $langcode) {
+    // Set number of comments to 0 which equals ALL. But only do this for the
+    // AJAX comments which apparently use _custom view mode.
+    if ($this->viewMode === '_custom') {
+      $this->setSetting('num_comments', 0);
+    }
+    return parent::viewElements($items, $langcode);
+  }
 
   /**
    * {@inheritdoc}


### PR DESCRIPTION
## Problem
When viewing all comments on a Post via it's overview page, the comments are normally expanded so the user can see all comments. With Social Ajax Comments enabled this expanded list is collapsed after adding a new comment.

**How to reproduce**
_Make sure Social Ajax Comments is enabled._

1. Either find a post with a lot or comments, or create it.
2. Click on "Show all x comments" to go to the overview page.
3. See that all the comments are visible and not collapsed like they are on the stream.
4. Post a comment.
5. Notice that all the comments apart form the last two are collapsed and the message "Show all x comments" is visible.
6. Also notice that you can expand the list to view them all, but after posting another comment it happens again.

## Solution
With an override of the num_comments setting that controls how many comments are visible. All the comments should remain visible after adding a comment on the comments overview for Posts.
An exception has been added to this, so the comments on a post that is visible on the stream aren't collapsed. 

## Issue tracker
https://www.drupal.org/project/social/issues/3108605

## How to test
- [ ] Go to the stream and see that posts with more than 2 comments are still in the collapsed view.
- [ ] Go to a post with a comment thread, see that it's expanded by default.
- [ ] Post a comment, see that the thread isn't collapsed.

