### PR TITLE
#3109192 - Better redirecting on View group in group core comments link

### DIFF
--- a/modules/custom/group_core_comments/src/Plugin/Field/FieldFormatter/CommentGroupContentFormatter.php
+++ b/modules/custom/group_core_comments/src/Plugin/Field/FieldFormatter/CommentGroupContentFormatter.php
@@ -58,6 +58,11 @@ class CommentGroupContentFormatter extends CommentDefaultFormatter {
           $join_directly_bool = TRUE;
         }
 
+        // If a user can't join directly, about page makes more sense.
+        if (!$join_directly_bool) {
+          $group_url = Url::fromRoute('view.group_information.page_group_about', ['group' => $group->id()]);
+        }
+
         if ($join_directly_bool) {
           $action = [
             'type' => 'join_directly',


### PR DESCRIPTION
## Problem
When a user can't directly join a group (e.g. Closed groups, or flexible groups without the "join directly" setting enabled) it doesn't make sense to redirect them to the canonical url of the group, which in our case is the stream.

## Solution
For that case, we can just do what the teaser does, so for consistency we will redirect to the about page which is reachable for Closed groups and flexible groups for outsiders :) 

## Issue tracker
https://www.drupal.org/project/social/issues/3109192

## How to test
- [x] Create a flexible group without Join directly, but with community and group content visibility
- [x] Create a topic in that group that has the community visibility
- [x] Login as outsider, go to that topic and see that to interact you need to join the Group
- [x] See that it redirects you to the about page, which has more information.
