### PR TITLE
Issue #310855 by sjoerdvandervis: Quickpost with ctrl/cmd + enter

### DIFF
--- a/modules/social_features/social_post/js/keycode-submit.js
+++ b/modules/social_features/social_post/js/keycode-submit.js
@@ -24,7 +24,7 @@
           // post forms this has some side effects that are required for a
           // successful submission.
           if ($submit.length) {
-            $submit.click();
+            $submit.mousedown();
           }
           // If a submit button isn't found we fall back to submitting the form
           // outright.

--- a/modules/social_features/social_post/js/keycode-submit.js
+++ b/modules/social_features/social_post/js/keycode-submit.js
@@ -24,7 +24,16 @@
           // post forms this has some side effects that are required for a
           // successful submission.
           if ($submit.length) {
-            $submit.mousedown();
+            // If it's a submit button, used by Ajax comments
+            // the click event is canceled by ajax_comments, see
+            // e.preventDefault() in ajax_comments.js.
+            // So we use the mousedown event in that specific case.
+            if ($textarea.parents('.ajax-comments-form-add').length) {
+              $submit.mousedown();
+            }
+            else {
+              $submit.click();
+            }
           }
           // If a submit button isn't found we fall back to submitting the form
           // outright.


### PR DESCRIPTION
## Problem
Since the introduction of Ajax comments, the quickpost functionality was not working anymore (Cmd / Ctrl + Enter).

## Solution
The `click()` function is not possible to be used as it seems, as it triggers an ajax call. When using a `mousedown()` function, it does trigger the quickpost action.

## Issue tracker
https://www.drupal.org/project/social/issues/3108558

## How to test
- [ ] Make sure you have `social_ajax_comments` enabled;
- [ ] Respond with a comment to a post in your stream. See that the Ajax post is triggered now.
- [ ] Create a new post, use cmd/ctrl + enter and see this still works
- [ ] Mention a user in a comment on a post to see that still works
- [ ] Add a comment to a topic or event to see that it still works
- [ ] Disable `social_ajax_comments` and repeat the previous to see you didnt cause regression
