### PR TITLE
YANG-2102: Fix position form-item-select-all block on the manage enrollments tab of the event page

### DIFF
--- a/modules/social_features/social_event/modules/social_event_managers/css/vbo_form.css.map
+++ b/modules/social_features/social_event/modules/social_event_managers/css/vbo_form.css.map
@@ -1,0 +1,1 @@
+{"version":3,"sourceRoot":"","sources":["vbo_form.scss"],"names":[],"mappings":"AAAA;EACE;;;AAGF;EACE","file":"vbo_form.css"}

--- a/modules/social_features/social_event/modules/social_event_managers/css/vbo_form.scss
+++ b/modules/social_features/social_event/modules/social_event_managers/css/vbo_form.scss
@@ -5,5 +5,3 @@
 #edit-multipage .btn {
   margin-bottom: 10px !important;
 }
-
-/*# sourceMappingURL=vbo_form.css.map */


### PR DESCRIPTION
## Problem
UI issue with text overlapping on the Event page, Manage enrollments tab

## Solution
Fix position form-item-select-all block on the manage enrollments tab of the event page

## Issue tracker
https://getopensocial.atlassian.net/browse/YANG-2102

## How to test
- [ ] Go to the event page.
- [ ] Go to the Manage enrollments tab.
- [ ] You can see form block.

## Release notes
<describe the release notes>
