### PR TITLE
Issue #3108296 by Kingdutch, robertragas, ronaldtebrake: Field labels…

### DIFF
--- a/themes/socialbase/templates/field/field.html.twig
+++ b/themes/socialbase/templates/field/field.html.twig
@@ -40,8 +40,10 @@
 {# Fields in the event teaser need to render without a div, because it is a child element of a tag that cannot have a div such as an anchor or paragraph #}
 
 {% if bare %}
-  {% for item in items %}
+  {% if not label_hidden %}
     <div{{ title_attributes.addClass(title_classes) }}>{{ label }}</div>
+  {% endif %}
+  {% for item in items %}
     {% if entity_type == "node" and field_name == "body" and part_of_teaser %}
       {{ item.content|render|striptags }}
     {% else %}


### PR DESCRIPTION
… are now shown for multiple display modes of multiple entities

<h3 id="summary-problem-motivation">Problem/Motivation</h3>
During development of https://www.drupal.org/project/social/issues/3071081 
Where we noticed, even if configured, field labels wouldn't be rendered correctly. 
We saw some of the field lables are actually configured to be shown, while we don't want them.

## Solution
The label_hidden property wasn't checked when the field was shown bare,
this caused more labels to show up than needed.

## Issue tracker
https://www.drupal.org/project/social/issues/3108296

## How to test
- [ ] Browse the site and check the label

## Release notes
N/a for unreleased bug
