### PR TITLE
YANG-2120: Fix position "Filter" button on the group page on the mobile/tablet modes

### DIFF
--- a/themes/socialblue/assets/css/offcanvas--sky.css
+++ b/themes/socialblue/assets/css/offcanvas--sky.css
@@ -1,0 +1,5 @@
+@media (max-width: 899px) {
+  .socialblue--sky.path-node .views-exposed-form {
+    top: -3rem;
+  }
+}

--- a/themes/socialblue/components/04-organisms/offcanvas/offcanvas--sky.scss
+++ b/themes/socialblue/components/04-organisms/offcanvas/offcanvas--sky.scss
@@ -1,0 +1,11 @@
+@import "settings";
+
+.socialblue--sky {
+  &.path-node {
+    .views-exposed-form {
+      @include for-tablet-landscape-down {
+        top: -3rem;
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Problem
The <Filter> button is overlapping a phase number on a mobile screen

## Solution
Change position for the 'Filter' button on the group pages on the mobile/tablet modes

## Issue tracker
https://getopensocial.atlassian.net/browse/YANG-2120

## How to test
- [ ] Go to the group/challenge pages
- [ ] Go to the Idea/Event/Topic tabs
- [ ] Enable mobile/tablet mode

## Release notes
<describe the release notes>