### PR TITLE
YANG-2121: Fix height of edit button on the profile page on the ipad

### DIFF
--- a/themes/socialblue/assets/css/cards--sky.css
+++ b/themes/socialblue/assets/css/cards--sky.css
@@ -97,6 +97,7 @@
   position: static;
   padding: 0 0 1.25rem;
   margin: 0;
+  display: block;
 }
 
 .socialblue--sky .block-profile-statistic-block .hero-footer__cta > *,
@@ -340,9 +341,9 @@
   }
   .socialblue--sky .block-profile-statistic-block .hero-footer__cta,
   .socialblue--sky .block-group-statistic-block .hero-footer__cta {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 100%;
-            flex: 0 0 100%;
+    -webkit-box-flex: 1;
+        -ms-flex: 1;
+            flex: 1;
     max-width: 100%;
     -webkit-box-pack: center;
         -ms-flex-pack: center;

--- a/themes/socialblue/components/02-atoms/cards/cards--sky.scss
+++ b/themes/socialblue/components/02-atoms/cards/cards--sky.scss
@@ -161,12 +161,13 @@
     }
 
     .hero-footer__cta {
+      display: block;
       position: static;
       padding: 0 0 1.25rem;
       margin: 0;
 
       @include for-tablet-portrait-up {
-        flex: 0 0 100%;
+        flex: 1;
         max-width: 100%;
         justify-content: center;
       }


### PR DESCRIPTION
## Problem
There is an issue with the <Edit profile> button, it has a wrong high and a label almost invisible.

## Solution
Fix height of the <Edit profile> button

## Issue tracker
https://getopensocial.atlassian.net/browse/YANG-2121

## How to test
- [ ] Go to the Profile page on the iPad

## Release notes
<describe the release notes>
