### PR TITLE
Issues #3108504: Added empty check on profile picture and display name to prevent ambiguous variables assignment.

### DIFF
--- a/modules/social_features/social_private_message/social_private_message.module
+++ b/modules/social_features/social_private_message/social_private_message.module
@@ -324,7 +324,7 @@ function social_private_message_entity_view_alter(array &$build, EntityInterface
         $build['membernames']['#suffix'] = '</strong>';
       }
 
-      else {
+      else if (!empty($profile_picture && $display_name)) {
         $build['members'] = $profile_picture;
         // Add members name.
         $build['membernames'] = $display_name;

--- a/modules/social_features/social_private_message/social_private_message.module
+++ b/modules/social_features/social_private_message/social_private_message.module
@@ -324,7 +324,7 @@ function social_private_message_entity_view_alter(array &$build, EntityInterface
         $build['membernames']['#suffix'] = '</strong>';
       }
 
-      else if (!empty($profile_picture && $display_name)) {
+      elseif (!empty($profile_picture && $display_name)) {
         $build['members'] = $profile_picture;
         // Add members name.
         $build['membernames'] = $display_name;


### PR DESCRIPTION
## Problem
After enabling social_group_welcome_message. 

1. Create an open group and also enable the welcome message.
2. Leave the group
3. Re-join the group
4. Visit your inbox.

## Solution
Add a check on profile picture and display_name variables to avoid the errors and unlawful assignment of values.

## Issue tracker
https://www.drupal.org/project/social/issues/3108504

## How to test
- [ ] Create an open group and also enable the welcome message.
- [ ] Leave the group
- [ ] Re-join the group
- [ ] Visit /user/inbox

## Screenshots
N.A

## Release notes
N.A

## Change Record
N.A

## Translations
N.A
