### PR TITLE
Issue #3109219 by bramtenhove: Prevent a welcome message being sent to the owner of the group

### DIFF
--- a/modules/social_features/social_group/modules/social_group_welcome_message/social_group_welcome_message.module
+++ b/modules/social_features/social_group/modules/social_group_welcome_message/social_group_welcome_message.module
@@ -93,6 +93,15 @@ function social_group_welcome_message_group_content_insert(GroupContentInterface
   ) {
     $g_type_id = $group->getGroupType()->id();
 
+    // Load the account of the user who just joined.
+    $account = $group_content->getEntity();
+
+    // Skip sending notifications to the owner of the group. They probably know
+    // they created the group a second ago.
+    if ($group->getOwnerId() === $account->id()) {
+      return;
+    }
+
     // Get group admins entities.
     $g_admins = $group->getMembers($g_type_id . '-group_admin');
     $g_admins_users = [];
@@ -123,11 +132,8 @@ function social_group_welcome_message_group_content_insert(GroupContentInterface
     // Merge all managers of the group to recipients array.
     $recipients = array_merge($g_admins_users, $g_managers_users, [$group->getOwner()]);
 
-    // Load joined user.
-    $user = $group_content->getEntity();
-
     // Add the joined user to the already existing recipients array.
-    $recipients[] = $user;
+    $recipients[] = $account;
 
     /** @var \Drupal\private_message\Service\PrivateMessageServiceInterface $private_message_service */
     $private_message_service = \Drupal::service('private_message.service');


### PR DESCRIPTION
# Problem
When you create a group and set a welcome message you will receive the welcome message as well.

## Solution
Check if the welcome message is about to be send to the group owner. If so, don't bother sending it as the group owner probably knows that they created the group.

## Issue tracker
https://www.drupal.org/project/social/issues/3109219

## How to test
- [x] Create a group and set the welcome message
- [ ] Check your PM inbox, you shouldn't have received the welcome message
- [ ] Join the group as someone other than the group owner
- [ ] Check your PM inbox, you should have received the welcome message

## Release notes
N/a, is fixing a bug in #1673.