### PR TITLE
YANG-2111: Add reset styles for the select widget on the IE11 browser

### DIFF
--- a/themes/socialbase/assets/css/form-controls.css
+++ b/themes/socialbase/assets/css/form-controls.css
@@ -8,7 +8,10 @@
   font-size: inherit;
   line-height: 1.5;
   background-image: none;
+  -webkit-transition: border-color ease-in-out .15s, -webkit-box-shadow ease-in-out .15s;
+  transition: border-color ease-in-out .15s, -webkit-box-shadow ease-in-out .15s;
   transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s;
+  transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s, -webkit-box-shadow ease-in-out .15s;
 }
 
 .form-control::-moz-placeholder {
@@ -39,7 +42,8 @@ textarea.form-control {
 }
 
 input[type="search"] {
-  box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
 }
 
 input[type="radio"],
@@ -111,6 +115,7 @@ input[type="search"] {
   display: inline-block;
   line-height: 21px;
   font-size: 0.875rem;
+  -webkit-transition: .28s ease;
   transition: .28s ease;
   -webkit-user-select: none;
      -moz-user-select: none;
@@ -128,6 +133,7 @@ input[type="search"] {
   width: 16px;
   height: 16px;
   z-index: 0;
+  -webkit-transition: .28s ease;
   transition: .28s ease;
 }
 
@@ -141,7 +147,8 @@ input[type="search"] {
   border-radius: 50%;
   border: 2px solid #555555;
   z-index: -1;
-  transform: scale(0);
+  -webkit-transform: scale(0);
+          transform: scale(0);
 }
 
 [type="radio"]:checked + label:before {
@@ -151,7 +158,8 @@ input[type="search"] {
 [type="radio"]:checked + label:after {
   border-radius: 50%;
   z-index: 0;
-  transform: scale(0.5);
+  -webkit-transform: scale(0.5);
+          transform: scale(0.5);
 }
 
 /* Disabled style */
@@ -189,6 +197,7 @@ input[type="search"] {
   left: 0;
   position: absolute;
   /* .1s delay is for check animation */
+  -webkit-transition: border .25s, background-color .25s, width .20s .1s, height .20s .1s, top .20s .1s, left .20s .1s;
   transition: border .25s, background-color .25s, width .20s .1s, height .20s .1s, top .20s .1s, left .20s .1s;
   z-index: 1;
 }
@@ -199,7 +208,9 @@ input[type="search"] {
   border: 3px solid transparent;
   left: 6px;
   top: 10px;
-  transform: rotateZ(37deg);
+  -webkit-transform: rotateZ(37deg);
+          transform: rotateZ(37deg);
+  -webkit-transform-origin: 20% 40%;
   transform-origin: 100% 100%;
 }
 
@@ -221,10 +232,13 @@ input[type="search"] {
   border-left: 2px solid transparent;
   border-right: 2px solid white;
   border-bottom: 2px solid white;
-  transform: rotateZ(37deg);
+  -webkit-transform: rotateZ(37deg);
+          transform: rotateZ(37deg);
   margin-top: 2px;
+  -webkit-transition: .2s;
   transition: .2s;
-  transform-origin: 100% 100%;
+  -webkit-transform-origin: 100% 100%;
+          transform-origin: 100% 100%;
 }
 
 [type="checkbox"]:checked + label:after {
@@ -281,16 +295,22 @@ input[type="search"] {
 }
 
 .switch {
+  display: -webkit-box;
+  display: -ms-flexbox;
   display: flex;
   width: 100%;
 }
 
 .switch__label {
-  flex: 1 1 auto;
+  -webkit-box-flex: 1;
+      -ms-flex: 1 1 auto;
+          flex: 1 1 auto;
 }
 
 .switch__options {
-  flex: 1 0 150px;
+  -webkit-box-flex: 1;
+      -ms-flex: 1 0 150px;
+          flex: 1 0 150px;
   text-align: right;
 }
 
@@ -313,13 +333,15 @@ input[type="search"] {
   background-color: #777777;
   border-radius: 15px;
   margin-right: 10px;
+  -webkit-transition: background 0.3s ease;
   transition: background 0.3s ease;
   vertical-align: middle;
   margin: 0 16px;
 }
 
 .switch .lever:after {
-  box-shadow: 0 0 1px rgba(0, 0, 0, 0.11), 0 1px 2px rgba(0, 0, 0, 0.22);
+  -webkit-box-shadow: 0 0 1px rgba(0, 0, 0, 0.11), 0 1px 2px rgba(0, 0, 0, 0.22);
+          box-shadow: 0 0 1px rgba(0, 0, 0, 0.11), 0 1px 2px rgba(0, 0, 0, 0.22);
   content: "";
   position: absolute;
   display: inline-block;
@@ -329,11 +351,15 @@ input[type="search"] {
   border-radius: 21px;
   left: -5px;
   top: -3px;
+  -webkit-transition: left 0.3s ease, background .3s ease, -webkit-box-shadow 0.1s ease;
+  transition: left 0.3s ease, background .3s ease, -webkit-box-shadow 0.1s ease;
   transition: left 0.3s ease, background .3s ease, box-shadow 0.1s ease;
+  transition: left 0.3s ease, background .3s ease, box-shadow 0.1s ease, -webkit-box-shadow 0.1s ease;
 }
 
 input[type=checkbox]:not(:disabled) ~ .lever:active:after {
-  box-shadow: 0 1px 3px 1px rgba(0, 0, 0, 0.4), 0 0 0 15px rgba(0, 0, 0, 0.08);
+  -webkit-box-shadow: 0 1px 3px 1px rgba(0, 0, 0, 0.4), 0 0 0 15px rgba(0, 0, 0, 0.08);
+          box-shadow: 0 1px 3px 1px rgba(0, 0, 0, 0.4), 0 0 0 15px rgba(0, 0, 0, 0.08);
 }
 
 .switch input[type=checkbox]:checked + .lever:after {
@@ -430,5 +456,14 @@ input[type=checkbox]:not(:disabled) ~ .lever:active:after {
   input[type="datetime-local"].form-control:focus,
   input[type="month"].form-control:focus {
     background: inherit;
+  }
+}
+
+@media all and (-ms-high-contrast: none) {
+  *::-ms-backdrop, .select-wrapper:after {
+    display: none;
+  }
+  *::-ms-backdrop, .select-wrapper select {
+    padding-right: 12px;
   }
 }

--- a/themes/socialbase/components/02-atoms/form-controls/_select.scss
+++ b/themes/socialbase/components/02-atoms/form-controls/_select.scss
@@ -58,6 +58,12 @@
 
 }
 
+// Reset custom styles of the arrow for the select widget on the IE11.
+@media all and (-ms-high-contrast:none) {
+  *::-ms-backdrop, .select-wrapper:after { display: none }
+  *::-ms-backdrop, .select-wrapper select { padding-right: 12px }
+}
+
 
 .form-disabled .select-wrapper::after {
   color: $btn-link-disabled-color;


### PR DESCRIPTION
## Problem
The custom styles of the select widget do not work on the IE11 browser

## Solution
Add reset styles of the select widget on the IE11 browser

## Issue tracker
https://getopensocial.atlassian.net/browse/YANG-2111

## How to test
- [ ] Open IE11 browser
- [ ] Go to the Group page -> Event tab

## Screenshots
before: ![Screenshot at Feb 03 12-53-00](https://user-images.githubusercontent.com/16086340/73647535-60177980-4684-11ea-8445-d9c5d4148480.png)
after: <img width="415" alt="Screenshot at Feb 03 12-53-50" src="https://user-images.githubusercontent.com/16086340/73647559-6d346880-4684-11ea-8d6d-ed43b71a17ad.png">

## Release notes
<describe the release notes>
