### PR TITLE
YANG-2107: Update "Edit profile" button on the IE11

### DIFF
--- a/themes/socialblue/assets/css/cards--sky.css
+++ b/themes/socialblue/assets/css/cards--sky.css
@@ -100,10 +100,10 @@
 
 .socialblue--sky .block-profile-statistic-block .hero-footer__cta,
 .socialblue--sky .block-group-statistic-block .hero-footer__cta {
+  display: block;
   position: static;
   padding: 0 0 1.25rem;
   margin: 0;
-  display: block;
 }
 
 .socialblue--sky .block-profile-statistic-block .hero-footer__cta > *,
@@ -357,9 +357,6 @@
   }
   .socialblue--sky .block-profile-statistic-block .hero-footer__cta,
   .socialblue--sky .block-group-statistic-block .hero-footer__cta {
-    -webkit-box-flex: 1;
-        -ms-flex: 1;
-            flex: 1;
     max-width: 100%;
     -webkit-box-pack: center;
         -ms-flex-pack: center;

--- a/themes/socialblue/assets/css/cards--sky.css
+++ b/themes/socialblue/assets/css/cards--sky.css
@@ -357,6 +357,9 @@
   }
   .socialblue--sky .block-profile-statistic-block .hero-footer__cta,
   .socialblue--sky .block-group-statistic-block .hero-footer__cta {
+    -webkit-box-flex: 0;
+        -ms-flex: none;
+            flex: none;
     max-width: 100%;
     -webkit-box-pack: center;
         -ms-flex-pack: center;

--- a/themes/socialblue/components/02-atoms/cards/cards--sky.scss
+++ b/themes/socialblue/components/02-atoms/cards/cards--sky.scss
@@ -191,7 +191,6 @@
       margin: 0;
 
       @include for-tablet-portrait-up {
-        flex: 1;
         max-width: 100%;
         justify-content: center;
       }

--- a/themes/socialblue/components/02-atoms/cards/cards--sky.scss
+++ b/themes/socialblue/components/02-atoms/cards/cards--sky.scss
@@ -191,6 +191,7 @@
       margin: 0;
 
       @include for-tablet-portrait-up {
+        flex: none;
         max-width: 100%;
         justify-content: center;
       }


### PR DESCRIPTION
## Problem
The 'Edit Profile' button has the wrong styles on the IE11 browser

## Solution
Update styles for the  'Edit Profile' button on the IE11 browser

## Issue tracker
https://getopensocial.atlassian.net/browse/YANG-2107

## How to test
- [ ] Open the IE11 browser
- [ ] Go to the Profile page

## Screenshots:
- before: ![Image_00115291580131109](https://user-images.githubusercontent.com/16086340/73838039-70ae2800-481b-11ea-84fc-2321917356a8.png)
- after: ![Image_00115481580131188](https://user-images.githubusercontent.com/16086340/73838060-7dcb1700-481b-11ea-9ebe-88a97eef74de.png)

## Release notes
<describe the release notes>
