### PR TITLE
Issue #3110778 by rolki: Fixed an issue that not set the type for the Post entity

### DIFF
--- a/modules/social_features/social_post/src/Entity/Post.php
+++ b/modules/social_features/social_post/src/Entity/Post.php
@@ -144,7 +144,7 @@ class Post extends ContentEntityBase implements PostInterface {
    * {@inheritdoc}
    */
   public function setType($type) {
-    $this->set('type', $this->bundle());
+    $this->set('type', $type);
     return $this;
   }
 


### PR DESCRIPTION
## Problem
The `setType` method doesn't work correctly for the Post entity. Try to set a new Post type to some entity and you will get the previous type

## Solution
In the method setType set type from parameter instead of current bundle

## Issue tracker
https://www.drupal.org/project/social/issues/3110778

## How to test
Try to set a new Post type to some entity and you should get the new type
