### PR TITLE
Issues #3109076: Added cache context to node edit url link.

### DIFF
--- a/modules/social_features/social_core/social_core.module
+++ b/modules/social_features/social_core/social_core.module
@@ -40,7 +40,7 @@ function social_core_theme() {
  * Implements hook_preprocess_HOOK().
  */
 function social_core_preprocess_node(&$variables) {
-  /** @var \Drupal\node\Entity\NodeInterface $node */
+  /** @var \Drupal\node\NodeInterface $node */
   $node = $variables['node'];
   // Add common variable for teaser images.
   $image_field = "field_{$node->getType()}_image";
@@ -68,6 +68,8 @@ function social_core_preprocess_node(&$variables) {
       $account = \Drupal::currentUser();
       if ($node->access('update', $account)) {
         $variables['node_edit_url'] = $node->toUrl('edit-form')->toString();
+        // Ensure the cache varies correctly depending upon access of the user.
+        $variables['#cache']['contexts'][] = 'user.node_grants';
       }
     }
 


### PR DESCRIPTION
## Problem
The contextual edit icon was appearing to the users even if it didn't have access to edit the node.

## Solution
Added a cache context depending upon permission/access of the user to the node.

## Issue tracker
https://www.drupal.org/project/social/issues/3109076

## How to test
- [ ] Log in as two different users.
- [ ] Create a topic by user A.
- [ ] Try to view it from user B.
- [ ] User B should not be able to access contextual edit icon (quick edit pencil icon).

## Screenshots
![image](https://user-images.githubusercontent.com/8435994/73665671-cbbc0f80-46a1-11ea-8481-780f1d1657e4.png)


## Release notes
N.A

## Change Record
N.A

## Translations
N.A
