### PR TITLE
Issue #3110952 by robertragas: add extra step to get the translated l…

### DIFF
--- a/themes/socialbase/src/Plugin/Preprocess/LanguageLinks.php
+++ b/themes/socialbase/src/Plugin/Preprocess/LanguageLinks.php
@@ -19,7 +19,9 @@ class LanguageLinks extends PreprocessBase {
    */
   public function preprocessVariables(Variables $variables) {
     $variables['attributes']['class'][] = 'dropdown-menu';
-    $variables['heading']['text'] = \Drupal::languageManager()->getCurrentLanguage()->getName();
+    $langcode = \Drupal::languageManager()->getCurrentLanguage()->getId();
+    $language = \Drupal::languageManager()->getLanguage($langcode);
+    $variables['heading']['text'] = $language->getName();
   }
 
 }


### PR DESCRIPTION
…abel of the active language in the social language switcher

## Problem
The language switcher block in the header has an active state to show on which language the user is browsing. When translated it gets the active language in the default source language. So if you would have Dutch and French as languages where French is the default source, it would show the active Dutch language as "Néerlandais" when "Nederlands" would be expected.

## Solution
Add the extra step getLanguage so it gets the correct translated label when using the getName.

## Issue tracker
https://www.drupal.org/project/social/issues/3110952

## How to test
- [ ] Enable the social translations module
- [ ] Add the Drupal core language switcher to the header
- [ ] Add 2 languages and translate them
- [ ] Now use the language switcher to switch languages and see the active language gets the incorrect language when it's not the default source.
- [ ] Check out to this branch and check again, it works.

## Release notes
We fixed a bug in the language switcher where it would show the incorrect translation for the active language.
