### PR TITLE
Issue #3098031 by Kingdutch, ronaldtebrake: Evaluate which modules sh…

### DIFF
--- a/modules/custom/social_ajax_comments/social_ajax_comments.info.yml
+++ b/modules/custom/social_ajax_comments/social_ajax_comments.info.yml
@@ -2,6 +2,6 @@ name: Social Ajax Comments
 type: module
 description: Integration with Ajax Comments.
 core: 8.x
-package: Social
+package: Social (experimental)
 dependencies:
   - ajax_comments:ajax_comments

--- a/modules/custom/social_queue_storage/social_queue_storage.info.yml
+++ b/modules/custom/social_queue_storage/social_queue_storage.info.yml
@@ -2,6 +2,6 @@ name: 'Social Queue item Storage'
 type: module
 description: 'Storage for queue item data to be used in processes that run in the background with a long duration.'
 core: 8.x
-package: 'Social'
+package: Social (experimental)
 dependencies:
   - social:activity_logger

--- a/modules/custom/social_react/social_react.info.yml
+++ b/modules/custom/social_react/social_react.info.yml
@@ -9,4 +9,4 @@ description: >-
   properly loaded.
 type: module
 core: 8.x
-package: Social (experimental)
+package: Social

--- a/modules/social_features/social_embed/social_embed.info.yml
+++ b/modules/social_features/social_embed/social_embed.info.yml
@@ -2,7 +2,7 @@ name: Social Embed
 type: module
 description: Module for embedding social media links. Currently in an experimental stage. NOTE, This module is a work in progress and has some serious peformance issues still.
 core: '8.x'
-package: Social (experimental)
+package: Social
 dependencies:
   - embed:embed
   - url_embed:url_embed

--- a/modules/social_features/social_group/modules/social_group_welcome_message/social_group_welcome_message.info.yml
+++ b/modules/social_features/social_group/modules/social_group_welcome_message/social_group_welcome_message.info.yml
@@ -5,4 +5,4 @@ core: 8.x
 dependencies:
   - social:social_group
   - social:social_private_message
-package: Social
+package: Social (experimental)

--- a/modules/social_features/social_private_message/social_private_message.info.yml
+++ b/modules/social_features/social_private_message/social_private_message.info.yml
@@ -2,7 +2,7 @@ name: Social Private Message
 type: module
 description: Allow users to send private messages to each other
 core: 8.x
-package: Social (experimental)
+package: Social
 dependencies:
   - private_message:private_message
   - social:social_profile

--- a/modules/social_features/social_profile/modules/social_profile_fields/social_profile_fields.info.yml
+++ b/modules/social_features/social_profile/modules/social_profile_fields/social_profile_fields.info.yml
@@ -2,7 +2,7 @@ name: 'Social Profile Fields'
 description: 'Provides hiding fields on a per profile_type basis'
 type: module
 core: 8.x
-package: Social (experimental)
+package: Social
 configure: social_profile_fields.settings
 dependencies:
   - drupal:user

--- a/modules/social_features/social_profile/modules/social_profile_organization_tag/social_profile_organization_tag.info.yml
+++ b/modules/social_features/social_profile/modules/social_profile_organization_tag/social_profile_organization_tag.info.yml
@@ -2,7 +2,7 @@ name: 'Social Profile Organization Tag'
 description: 'Provides Profile Organization Tag field and vocabulary'
 type: module
 core: 8.x
-package: Social (experimental)
+package: Social
 dependencies:
   - social:social_profile
   - drupal:taxonomy

--- a/modules/social_features/social_profile/modules/social_profile_privacy/social_profile_privacy.info.yml
+++ b/modules/social_features/social_profile/modules/social_profile_privacy/social_profile_privacy.info.yml
@@ -2,7 +2,7 @@ name: 'Social Profile Privacy'
 description: 'Provides ability to set visibility of profile fields'
 type: module
 core: 8.x
-package: Social (experimental)
+package: Social
 configure: social_profile.settings
 dependencies:
   - social:social_profile

--- a/modules/social_features/social_search/modules/social_search_autocomplete/social_search_autocomplete.info.yml
+++ b/modules/social_features/social_search/modules/social_search_autocomplete/social_search_autocomplete.info.yml
@@ -6,4 +6,4 @@ dependencies:
   - drupal:rest
   - social:social_react
   - social:social_search
-package: Social (experimental)
+package: Social


### PR DESCRIPTION
…ould be marked as experimental

## Problem
There are quite a few modules that we ship with Open Social which we've marked as experimental. Some of these have been experimental for quite a few versions and can probably be marked as stable and supported at this point.

Before the 8.x release we should evaluate the list.

## Solution
Mark modules as stable (see release notes)

## Issue tracker
https://www.drupal.org/project/social/issues/3098031

## How to test
- [ ] No functional change

## Release notes
The following modules are no longer considered experimental: Social Embed, Social Private Message, Social Profile Fields, Social Profile Privacy, Social Profile Organization Tag, Social Search Autocomplete.
