### PR TITLE
Issue #3111353 - Ensure we run test against all optional modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ matrix:
   - env: TEST_SUITE=install_stability_3
   - env: TEST_SUITE=install_stability_4
   - env: TEST_SUITE=install_update
+  - env: TEST_SUITE=install_without_optional
   - env: TEST_SUITE=drush_make
 #  - env: TEST_SUITE=accessibility
 
@@ -65,7 +66,8 @@ before_install:
   - docker-compose -f docker-compose-ci.yml up -d
 
 install:
-  - if [ "$TEST_SUITE" = "install_stability_1" ] || [ "$TEST_SUITE" = "install_stability_2" ] || [ "$TEST_SUITE" = "install_stability_3" ] || [ "$TEST_SUITE" = "install_stability_4" ]; then docker exec -i social_ci_web bash /var/www/scripts/social/install/install_script.sh; fi
+  - if [ "$TEST_SUITE" = "install_stability_1" ] || [ "$TEST_SUITE" = "install_stability_2" ] || [ "$TEST_SUITE" = "install_stability_3" ] || [ "$TEST_SUITE" = "install_stability_4" ]; then docker exec -i social_ci_web bash /var/www/scripts/social/install/install_script.sh --with-optional; fi
+  - if [ "$TEST_SUITE" = "install_without_optional" ]; then docker exec -i social_ci_web bash /var/www/scripts/social/install/install_script.sh; fi
   - if [ "$TEST_SUITE" = "install_update" ]; then bash scripts/social/ci/build-install-update.sh $PR $BRANCH $COMMIT; fi
   - if [ "$TEST_SUITE" = "drush_make" ]; then bash scripts/social/ci/build-social-make.sh; fi
 
@@ -73,13 +75,13 @@ script:
   - set -e
   - if [ "$TEST_SUITE" = "install_stability_1" ]; then docker exec -i social_ci_web bash /var/www/scripts/social/check-coding-standards.sh full; fi
   - if [ "$TEST_SUITE" = "install_stability_1" ]; then docker exec -i social_ci_web_scripts sh /var/www/scripts/social/unit-tests.sh; fi
-  - if [ "$TEST_SUITE" = "install_stability_1" ] ; then docker exec -i social_ci_web bash /var/www/scripts/social/check-feature-state.sh social; fi
   - if [ "$TEST_SUITE" = "install_stability_1" ]; then docker exec -it social_ci_behat sh /var/www/scripts/social/behatstability.sh "stability-1 --stop-on-failure --strict"; fi
   - if [ "$TEST_SUITE" = "install_stability_2" ]; then docker exec -it social_ci_behat sh /var/www/scripts/social/behatstability.sh "notifications --stop-on-failure --strict"; fi
   - if [ "$TEST_SUITE" = "install_stability_2" ]; then docker exec -it social_ci_behat sh /var/www/scripts/social/behatstability.sh "stability-2 --stop-on-failure --strict"; fi
   - if [ "$TEST_SUITE" = "install_stability_3" ]; then docker exec -it social_ci_behat sh /var/www/scripts/social/behatstability.sh "stability-3 --stop-on-failure --strict"; fi
   - if [ "$TEST_SUITE" = "install_stability_4" ]; then docker exec -it social_ci_behat sh /var/www/scripts/social/behatstability.sh "stability-4 --stop-on-failure --strict"; fi
   - if [ "$TEST_SUITE" = "install_update" ]; then docker exec -it social_ci_behat sh /var/www/scripts/social/behatstability.sh "stability-1&&~DS-1136&&~DS-3605 --stop-on-failure --strict"; fi
+  - if [ "$TEST_SUITE" = "install_without_optional" ]; then docker exec -it social_ci_behat sh /var/www/scripts/social/behatstability.sh "stability-1&&~DS-1136&&~DS-3605 --stop-on-failure --strict"; fi
   - if [ "$TEST_SUITE" = "accessibility" ]; then docker exec -it social_ci_web bash /var/www/scripts/social/check-accessibility.sh install; fi
 
 after_success:


### PR DESCRIPTION
Merge after: https://github.com/goalgorilla/open_social_scripts/pull/30/files

# Problem 
We want to run tests using all the optional modules by default, to ensure we encounter issues in our stability tests with everything enabled, but also ensure we test at least stability-1 using no optional modules. To test scenario's that might have misplaced config etc.

## Solution
1. Updated the scripts in https://github.com/goalgorilla/open_social_scripts/pull/30/files
That will give us the flag --with-optional
2. This is now used for all the stability tests
3. Added a new test suite, this one will run the normal install_script without the flag to ensure we run the same tests as install_update

## Issue tracker
https://www.drupal.org/project/social/issues/3111353

## How to test
- [ ] Make sure travis runs!

## Release notes
We now also test all optional modules that have a `module.installer_options.yml`
