### PR TITLE
Issue #3111591 - Fixed an issue with LU users with group manager roles not being able to download an exported CSV from group members

### DIFF
--- a/modules/social_features/social_event/modules/social_event_enrolments_export/src/Plugin/Action/ExportEnrolments.php
+++ b/modules/social_features/social_event/modules/social_event_enrolments_export/src/Plugin/Action/ExportEnrolments.php
@@ -48,6 +48,11 @@ class ExportEnrolments extends ExportUser {
 
   /**
    * {@inheritdoc}
+   *
+   * To make sure the file can be downloaded, the path must be declared in the
+   * download pattern of the social user export module.
+   *
+   * @see social_user_export_file_download()
    */
   protected function generateFilePath() : string {
     $hash = md5(microtime(TRUE));

--- a/modules/social_features/social_group/modules/social_group_members_export/src/Plugin/Action/ExportMember.php
+++ b/modules/social_features/social_group/modules/social_group_members_export/src/Plugin/Action/ExportMember.php
@@ -47,6 +47,11 @@ class ExportMember extends ExportUser {
 
   /**
    * {@inheritdoc}
+   *
+   * To make sure the file can be downloaded, the path must be declared in the
+   * download pattern of the social user export module.
+   *
+   * @see social_user_export_file_download()
    */
   protected function generateFilePath() : string {
     $hash = md5(microtime(TRUE));

--- a/modules/social_features/social_user_export/social_user_export.module
+++ b/modules/social_features/social_user_export/social_user_export.module
@@ -29,7 +29,10 @@ function social_user_export_file_download($uri) {
     $access = TRUE;
   }
 
-  if ($scheme === 'private' && $access && preg_match('/^csv\/export-(users|enrollments)-([a-f0-9]{12})\.csv$/i', $target)) {
+  // The pattern should match all the declared file patterns from
+  // the `generateFilePath()` methods in export bulk actions plugins.
+  if ($scheme === 'private' && $access
+    && preg_match('/^csv\/export-(users|enrollments|members)-([a-f0-9]{12})\.csv$/i', $target)) {
     return [
       'Content-disposition' => 'attachment; filename="' . basename($target) . '"',
     ];

--- a/modules/social_features/social_user_export/src/Plugin/Action/ExportUser.php
+++ b/modules/social_features/social_user_export/src/Plugin/Action/ExportUser.php
@@ -198,6 +198,11 @@ class ExportUser extends ViewsBulkOperationsActionBase implements ContainerFacto
    * to work on distributed systems where the temporary file path may change
    * in between batch ticks.
    *
+   * To make sure the file can be downloaded, the path must be declared in the
+   * download pattern of the social user export module.
+   *
+   * @see social_user_export_file_download()
+   *
    * @return string
    *   The path to the file.
    */


### PR DESCRIPTION
## Problem
LU with Group Manager role can't download CSV export of group members when performing the export users bulk action via the manage members tab of a group.

**How to reproduce**
_Make sure the social_user_export module is enabled._

- As a regular logged in user (non admin, or site manager etc.) who is a manager of a group.
- Go to a group I manage.
- Go to manage members.
- Select users you want to export, click Action > Export members.
- When completed, see the notification the export has been completed and click on the download link.
- See that the user lands on an access denied page.

## Solution
The logged in user with the role manage members should be able to download the exported CSV file.

## Issue tracker
https://www.drupal.org/project/social/issues/3111591

## How to test
_Make sure the social_user_export module is enabled._

- [x] Log in as a regular user (non admin, or site manager etc.) who is a manager of a group.
- [x] Go to a group the user manages.
- [x] Go to manage members.
- [x] Select users you want to export, click Action > Export members.
- [x] When completed, see the notification the export has been completed and click on the download link.
- [x] See this can be downloaded.
- [x] Repeat this for other roles: Administrator, SM, CM.
