### PR TITLE
Issue #3089112 by royharink: Registration field specific validation error messages

### DIFF
--- a/modules/social_features/social_user/social_user.module
+++ b/modules/social_features/social_user/social_user.module
@@ -236,21 +236,38 @@ function social_user_form_user_register_form_alter(&$form, FormStateInterface $f
  * Validate function for the user register form.
  */
 function social_user_register_validate(&$form, FormStateInterface $form_state) {
-
   // Fetch input.
   $input = $form_state->getValues();
+  // Check if user data with the input can be found.
+  $mail_exists = user_load_by_mail($input['mail']);
+  $name_exists = user_load_by_name($input['name']);
+
 
   // Check if mail or username already exist.
-  if (user_load_by_mail($input['mail']) || user_load_by_name($input['name'])) {
+  if ($mail_exists || $name_exists) {
     // If either the username or mail already exists in the DB, we clear ALL
     // existing messages, making sure nothing about this is being disclosed.
     $form_state->clearErrors();
+
+    // Check if the email address already exist. Set a generic message
+    // regarding the problem.
+    if ($mail_exists) {
+      $form_state->setErrorByName('mail', t('Oops, there is a problem with the email address.'));
+    }
+
+    // Check if the username already exist. Set a generic message regarding
+    // the problem.
+    if ($name_exists) {
+      $form_state->setErrorByName('name', t('Oops, there is a problem with the username.'));
+    }
+
     // Set a new more general error.
     $site_config = \Drupal::config('system.site');
     $site_mail = $site_config->get('mail');
     $show_mail = $site_config->get('show_mail_in_messages');
     $admin_link = ($site_mail && $show_mail) ? Link::fromTextAndUrl(t('site administrator'), Url::fromUri('mailto:' . $site_mail))->toString() : t('site administrator');
-    $form_state->setErrorByName('mail', t("Oops, there was an error with the email address or username you entered. Due to privacy concerns, we can't disclose the existence of already registered email addresses.
+    // Message is set to a generic field so it's not attached to a field.
+    $form_state->setErrorByName('status', t("Oops, there was an error with the email address or username you entered. Due to privacy concerns, we can't disclose the existence of already registered email addresses.
     So, please try again! Contact the @admin_link if there are any problems.", ['@admin_link' => $admin_link]));
   }
 }

--- a/modules/social_features/social_user/social_user.module
+++ b/modules/social_features/social_user/social_user.module
@@ -242,7 +242,6 @@ function social_user_register_validate(&$form, FormStateInterface $form_state) {
   $mail_exists = user_load_by_mail($input['mail']);
   $name_exists = user_load_by_name($input['name']);
 
-
   // Check if mail or username already exist.
   if ($mail_exists || $name_exists) {
     // If either the username or mail already exists in the DB, we clear ALL
@@ -252,23 +251,14 @@ function social_user_register_validate(&$form, FormStateInterface $form_state) {
     // Check if the email address already exist. Set a generic message
     // regarding the problem.
     if ($mail_exists) {
-      $form_state->setErrorByName('mail', t('Oops, there is a problem with the email address.'));
+      $form_state->setErrorByName('mail', t("Due to privacy concerns, we can't disclose the existence of registered email addresses. Please make sure the email address is entered correctly and try again."));
     }
 
     // Check if the username already exist. Set a generic message regarding
     // the problem.
     if ($name_exists) {
-      $form_state->setErrorByName('name', t('Oops, there is a problem with the username.'));
+      $form_state->setErrorByName('name', t('The entered username already exists or has an incorrect format. Please try again.'));
     }
-
-    // Set a new more general error.
-    $site_config = \Drupal::config('system.site');
-    $site_mail = $site_config->get('mail');
-    $show_mail = $site_config->get('show_mail_in_messages');
-    $admin_link = ($site_mail && $show_mail) ? Link::fromTextAndUrl(t('site administrator'), Url::fromUri('mailto:' . $site_mail))->toString() : t('site administrator');
-    // Message is set to a generic field so it's not attached to a field.
-    $form_state->setErrorByName('status', t("Oops, there was an error with the email address or username you entered. Due to privacy concerns, we can't disclose the existence of already registered email addresses.
-    So, please try again! Contact the @admin_link if there are any problems.", ['@admin_link' => $admin_link]));
   }
 }
 
@@ -333,7 +323,7 @@ function _social_user_pass_reset_submit($form, FormStateInterface $form_state) {
   $storage = $form_state->getValues();
   $submitted_user_id = isset($storage['uid']) ? $storage['uid'] : '';
 
-  // Only when there is actual user, and the actual user is changing his own
+  // Only when there is actual user, and the actual user is changing its own
   // account we redirect. When you're editing others you don't want this.
   if (!empty($submitted_user_id) && \Drupal::currentUser()->id() == $submitted_user_id) {
     $first_time_login = $form_state->get('first_time_login');

--- a/translations.php
+++ b/translations.php
@@ -40,6 +40,8 @@ new TranslatableMarkup('Invite-only - users can only enroll for this event if th
 new TranslatableMarkup('Request to join - users can "request to join" this group which group managers approve/decline');
 new TranslatableMarkup('Invite-only - users can only join this group if they are added/invited by group managers');
 new TranslatableMarkup('Open to join - users can join this group without approval');
+new TranslatableMarkup("Due to privacy concerns, we can't disclose the existence of registered email addresses. Please make sure the email address is entered correctly and try again.");
+new TranslatableMarkup('The entered username already exists or has an incorrect format. Please try again.');
 
 // Changed in version 7.2.
 new TranslatableMarkup('Select / unselect all @count results in this view');


### PR DESCRIPTION
## Problem
When a user tries to create an account using an e-mail address and username.
The process returns the wrong error message when the username already exists.
Currently, the message states that there is an error with the e-mail address, while it's actually the username that gives the problem.

## Solution
A better distinction has been made in the field that didn't pass validation. The message is kept generic by (still) removing the original Drupal message, trying not to disclose information about the existence of the user.
The generic message is left in place to inform about the information disclosure but hasn't been assigned to a field but to the form.

## Issue tracker
https://www.drupal.org/project/social/issues/3089112

## How to test
- [ ] To to the registration page
- [ ] Try registering with a non-existing email address and an existing username.
- [ ] See that the username is validated wrong, the message is generic and that the information disclosure error is still appearing.

## Screenshots
![image](https://user-images.githubusercontent.com/8435994/84025990-c858cd80-a98c-11ea-8e5a-ea5ac9db798d.png)

## Release notes
Registration form now have more distinct messages.

## Translations
Updated strings are now added to translation file.
