### PR TITLE
#3111961: Make sure the post, comment and node entities have the correct view mode in the stream after the update to 8.x

### DIFF
--- a/modules/social_features/social_comment/social_comment.install
+++ b/modules/social_features/social_comment/social_comment.install
@@ -75,6 +75,18 @@ function _social_comment_get_permissions($role) {
 }
 
 /**
+ * Implements hook_update_dependencies().
+ */
+function social_comment_update_dependencies() {
+  // Run the activities view mode update after the final features removal ran.
+  $dependencies['social_comment'][8801] = [
+    'social_core' => 8802,
+  ];
+
+  return $dependencies;
+}
+
+/**
  * Enable 'administer own comments' permission for authenticated users.
  */
 function social_comment_update_8001(&$sandbox) {
@@ -100,4 +112,11 @@ function social_comment_update_8002() {
   // hook was not added at that point so this must be rectified now.
   user_role_grant_permissions('contentmanager', ['administer comments']);
   user_role_grant_permissions('sitemanager', ['administer comments']);
+}
+
+/**
+ * Set the view mode to use when shown in activities.
+ */
+function social_comment_update_8801() {
+  activity_creator_set_entity_view_mode('comment', 'activity');
 }

--- a/modules/social_features/social_core/social_core.install
+++ b/modules/social_features/social_core/social_core.install
@@ -993,3 +993,10 @@ function social_core_update_8802() {
 
   // TODO: Output which config has been imported/updated?
 }
+
+/**
+ * Set the view mode for nodes to use when shown in activities.
+ */
+function social_core_update_8803() {
+  activity_creator_set_entity_view_mode('node', 'activity');
+}

--- a/modules/social_features/social_node/social_node.install
+++ b/modules/social_features/social_node/social_node.install
@@ -12,3 +12,22 @@ function social_node_install() {
   // Set the view mode to use when shown in activities.
   activity_creator_set_entity_view_mode('node', 'activity');
 }
+
+/**
+ * Implements hook_update_dependencies().
+ */
+function social_node_update_dependencies() {
+  // Run the activities view mode update after the final features removal ran.
+  $dependencies['social_node'][8801] = [
+    'social_core' => 8802,
+  ];
+
+  return $dependencies;
+}
+
+/**
+ * Set the view mode to use when shown in activities.
+ */
+function social_node_update_8801() {
+  activity_creator_set_entity_view_mode('node', 'activity');
+}

--- a/modules/social_features/social_node/social_node.install
+++ b/modules/social_features/social_node/social_node.install
@@ -12,22 +12,3 @@ function social_node_install() {
   // Set the view mode to use when shown in activities.
   activity_creator_set_entity_view_mode('node', 'activity');
 }
-
-/**
- * Implements hook_update_dependencies().
- */
-function social_node_update_dependencies() {
-  // Run the activities view mode update after the final features removal ran.
-  $dependencies['social_node'][8801] = [
-    'social_core' => 8802,
-  ];
-
-  return $dependencies;
-}
-
-/**
- * Set the view mode to use when shown in activities.
- */
-function social_node_update_8801() {
-  activity_creator_set_entity_view_mode('node', 'activity');
-}

--- a/modules/social_features/social_post/social_post.install
+++ b/modules/social_features/social_post/social_post.install
@@ -89,3 +89,22 @@ function _social_post_get_permissions($role) {
   }
   return [];
 }
+
+/**
+ * Implements hook_update_dependencies().
+ */
+function social_post_update_dependencies() {
+  // Run the activities view mode update after the final features removal ran.
+  $dependencies['social_post'][8801] = [
+    'social_core' => 8802,
+  ];
+
+  return $dependencies;
+}
+
+/**
+ * Set the view mode to use when shown in activities.
+ */
+function social_post_update_8801() {
+  activity_creator_set_entity_view_mode('post', 'activity');
+}


### PR DESCRIPTION
## Problem
![Screenshot 2020-02-07 at 12 25 02](https://user-images.githubusercontent.com/7124754/74043125-1e126e80-49c9-11ea-9525-8d8165dbdadd.png)

## Solution
Update hook to set the correct view mode for post, comments and nodes in the stream.

## Issue tracker
https://www.drupal.org/project/social/issues/3111961

## How to test
- [ ] Install Open Social 8.x-7.x (or earlier)
- [ ] Update to 8.x-8.x
- [ ] Observe that the activities in the stream (post, comments and nodes) are displayed as expected.

## Release notes
n/a