### PR TITLE
Issue #3112434 Behat test for GDPR inform block fails

### DIFF
--- a/tests/behat/features/capabilities/gdpr/inform-block.feature
+++ b/tests/behat/features/capabilities/gdpr/inform-block.feature
@@ -22,7 +22,7 @@ Feature: Inform about personal data collection
     Then I should see "Data Policy Inform" in the ".form-item-settings-admin-label" element
     # Press "Save block" button
     When I select "Complementary top" from "Region"
-    And I click the xth "0" element with the css ".ui-button.form-submit"
+    And I click the xth "0" element with the css ".button.form-submit"
     Then I should see "The block configuration has been saved."
 
     When I am on "admin/config/system/inform-consent"

--- a/tests/behat/features/capabilities/gdpr/inform-block.feature
+++ b/tests/behat/features/capabilities/gdpr/inform-block.feature
@@ -18,15 +18,12 @@ Feature: Inform about personal data collection
     And I uncheck the box "Enforce consent"
     Then I press "Save configuration"
 
-    When I am on "admin/structure/block"
-    And I click "Place block"
-    And I wait for AJAX to finish
-    And I click the xth "4" element with the css ".block-add-table a"
-    And I wait for AJAX to finish
-    And I should see "Data Policy Inform" in the ".form-item-settings-admin-label" element
+    When I am on "admin/structure/block/add/data_policy_inform_block/"
+    Then I should see "Data Policy Inform" in the ".form-item-settings-admin-label" element
     # Press "Save block" button
-    Then I select "Complementary top" from "Region"
+    When I select "Complementary top" from "Region"
     And I click the xth "0" element with the css ".ui-button.form-submit"
+    Then I should see "The block configuration has been saved."
 
     When I am on "admin/config/system/inform-consent"
     And I click "Add page"


### PR DESCRIPTION
## Problem
On our 8.x and 9.x branches the behat test for /gdpr/inform-block.feature fails, due to the fact we have enabled optional modules the order of blocks has changed.

## Solution
Ensure we directly place the block from the machine name link which doesnt change, the order can change due to more or less blocks being available.

## Issue tracker
https://www.drupal.org/project/social/issues/3112434

## How to test
- [ ] Travis behat stability step 4 should now work.

## Release notes
We have ensured our travis test are running for 8 and 9.
