### PR TITLE
Issue #3112823 by Kingdutch, navneet0693: Typo in service restore of …

### DIFF
--- a/modules/social_features/social_core/social_core.install
+++ b/modules/social_features/social_core/social_core.install
@@ -988,7 +988,7 @@ function social_core_update_8802() {
   $updated_config = \Drupal::service('features.manager')->import($removed_features, TRUE);
 
   // Restore the services in case other things in the request use them.
-  $container->set('features.maanger', $original_fm);
+  $container->set('features.manager', $original_fm);
   $container->set('features.extension_storage', $original_fis);
 
   // TODO: Output which config has been imported/updated?


### PR DESCRIPTION
…social_core_update_8802

<h2>Problem</h2>

For the features revert update hook <code>social_core_update_8802</code> we overwrite the features manager module so we can alter the file system access. At the end of the update hook we restore the features manager service to what it was before to ensure any other code gets the service they expect.

In the restore of the service there's a small typo which causes the <code>features.manager</code> service to remain overwritten. This can cause issues when other code tries to access the features manager service <strong>in the same request or drush command</strong>.

It does <strong>not</strong> cause issues in the following cases because in each case the container is rebuilt between the execution of the update hook and the calling of the features manager service.
<ul>
  <li>Updates run through <code>update.php</code></li>
  <li>Running <code>drush fra</code> after <code>drush updb</code></li>
  <li>Executing new update hooks with <code>drush updb</code> separately from the <code>drush updb</code> that executes <code>social_core_update_8802</code></li>
</ul>

<h2>Solution</h2>
Fix the typo

## Issue tracker
https://www.drupal.org/project/social/issues/3112823

## How to test
- [ ] 

## Release notes
When creating update hooks that relied on the features.manager service and that ran in the same update request as social_core_update_8802 the created update hook would use an overwritten service. This has now been fixed.
