### PR TITLE
Issue #3114278: Default social_event.settings.enroll is not an array

### DIFF
--- a/modules/social_features/social_event/config/features_removal/social_event.settings.yml
+++ b/modules/social_features/social_event/config/features_removal/social_event.settings.yml
@@ -1,1 +1,1 @@
-enroll:
+enroll: []

--- a/modules/social_features/social_event/config/install/social_event.settings.yml
+++ b/modules/social_features/social_event/config/install/social_event.settings.yml
@@ -1,1 +1,1 @@
-enroll:
+enroll: []

--- a/modules/social_features/social_event/social_event.install
+++ b/modules/social_features/social_event/social_event.install
@@ -152,3 +152,18 @@ function social_event_update_8003() {
     }
   }
 }
+
+/**
+ * Fix empty value in enroll setting.
+ */
+function social_event_update_8801() {
+  // This does not need to run before 8802 necessarily because the
+  // features_removal/ folder has also been updated so a revert works too.
+  // This update mostly exists for people who've already updated to 8.0.
+  $settings = \Drupal::configFactory()->getEditable('social_event.settings');
+  $enroll = $settings->get('enroll');
+  // Only change it if no value was set yet.
+  if (empty($enroll)) {
+    $settings->set('enroll', [])->save();
+  }
+}


### PR DESCRIPTION
<h2>Problem</h2>

The default for the <code>enroll</code> item in <code>social_event.settings</code> is an empty value. However this value is used in <code>EnrollActionForm</code> as an array directly. This causes warnings.

This has been made more apparent by the feature revert in Open Social 8.0.

<h2>Solution</h2>
Make sure the default value is an empty array instead of an empty value. Include an update hook for existing sites.

## Issue tracker
https://www.drupal.org/project/social/issues/3114280

## How to test
- [ ] Go to an event before updating and see an error
- [ ] Go to the event after updating and see no error

## Release notes
Fixed the default value for the <code>social_event.settings</code> <code>event</code> key that was incorrect and could lead to errors.
