### PR TITLE
Issue #3049619 by kokrull: Unable to delete comments from comments overview page using bulk operation

### DIFF
--- a/modules/social_features/social_comment/src/Form/SocialCommentAdminOverview.php
+++ b/modules/social_features/social_comment/src/Form/SocialCommentAdminOverview.php
@@ -286,8 +286,8 @@ class SocialCommentAdminOverview extends FormBase {
         $info[$comment->id()][$langcode] = $langcode;
       }
       $this->tempStoreFactory
-        ->get('comment_multiple_delete_confirm')
-        ->set($this->currentUser()->id(), $info);
+        ->get('entity_delete_multiple_confirm')
+        ->set($this->currentUser()->id() . ':comment', $info);
       $form_state->setRedirect('comment.multiple_delete_confirm');
     }
   }


### PR DESCRIPTION
## Problem

Comments can't be bulk deleted from the Comment Overview admin page. This is due core adding a more generic multiple entity delete action, while we're still using the comment-specific one.

Relevant core commit: https://git.drupalcode.org/project/drupal/commit/3d5592257d80324792c86caa25401a3e5f6a122a

## Solution

Update the `SocialCommentAdminOverview` form submit handler to use the correct temp store collection and key names.

## Issue tracker

https://www.drupal.org/project/social/issues/3049619

## How to test
- [ ] Navigate to `/admin/content/comment`
- [ ] Select a few comments using the bulk operations checkboxes
- [ ] Select "Delete the selected comments" from the Update Options dropdown and click "Update"
- [ ] You should see multiple entity delete confirm form

Without this fix, you will likely receive an Access Denied page no matter which user you are logged in as since `EntityDeleteMultipleAccessCheck` won't find any items in the temp store to delete.
