### PR TITLE
YANG-1008: Update styles for the table on the mobile

### DIFF
--- a/themes/socialbase/assets/css/base.css
+++ b/themes/socialbase/assets/css/base.css
@@ -45,7 +45,8 @@ textarea {
   color: inherit;
   font: inherit;
   margin: 0;
-  box-shadow: none;
+  -webkit-box-shadow: none;
+          box-shadow: none;
   line-height: inherit;
 }
 
@@ -83,7 +84,8 @@ input {
 
 input[type="checkbox"],
 input[type="radio"] {
-  box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
   padding: 0;
 }
 
@@ -94,7 +96,8 @@ input[type="number"]::-webkit-outer-spin-button {
 
 input[type="search"] {
   -webkit-appearance: textfield;
-  box-sizing: content-box;
+  -webkit-box-sizing: content-box;
+          box-sizing: content-box;
 }
 
 input[type="search"]::-webkit-search-cancel-button,
@@ -122,7 +125,8 @@ optgroup {
 }
 
 *, *:before, *:after {
-  box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
 }
 
 html {
@@ -143,6 +147,7 @@ body {
 
 .fade {
   opacity: 0;
+  -webkit-transition: opacity .15s linear;
   transition: opacity .15s linear;
 }
 
@@ -162,9 +167,12 @@ body {
   position: relative;
   height: 0;
   overflow: hidden;
+  -webkit-transition-property: height, visibility;
   transition-property: height, visibility;
-  transition-duration: 0.35s;
-  transition-timing-function: ease;
+  -webkit-transition-duration: 0.35s;
+          transition-duration: 0.35s;
+  -webkit-transition-timing-function: ease;
+          transition-timing-function: ease;
 }
 
 code,
@@ -183,7 +191,8 @@ kbd kbd {
   padding: 0;
   font-size: 100%;
   font-weight: bold;
-  box-shadow: none;
+  -webkit-box-shadow: none;
+          box-shadow: none;
 }
 
 pre {
@@ -206,23 +215,28 @@ pre code {
 }
 
 .z-depth-0 {
-  box-shadow: none;
+  -webkit-box-shadow: none;
+          box-shadow: none;
 }
 
 .z-depth-1 {
-  box-shadow: 0 0 1px rgba(0, 0, 0, 0.11), 0 1px 2px rgba(0, 0, 0, 0.22);
+  -webkit-box-shadow: 0 0 1px rgba(0, 0, 0, 0.11), 0 1px 2px rgba(0, 0, 0, 0.22);
+          box-shadow: 0 0 1px rgba(0, 0, 0, 0.11), 0 1px 2px rgba(0, 0, 0, 0.22);
 }
 
 .z-depth-2 {
-  box-shadow: 0 -1px 0 #e0e0e0, 0 0 2px rgba(0, 0, 0, 0.12), 0 2px 4px rgba(0, 0, 0, 0.24);
+  -webkit-box-shadow: 0 -1px 0 #e0e0e0, 0 0 2px rgba(0, 0, 0, 0.12), 0 2px 4px rgba(0, 0, 0, 0.24);
+          box-shadow: 0 -1px 0 #e0e0e0, 0 0 2px rgba(0, 0, 0, 0.12), 0 2px 4px rgba(0, 0, 0, 0.24);
 }
 
 .z-depth-3 {
-  box-shadow: 0 0 4px rgba(0, 0, 0, 0.14), 0 4px 8px rgba(0, 0, 0, 0.28);
+  -webkit-box-shadow: 0 0 4px rgba(0, 0, 0, 0.14), 0 4px 8px rgba(0, 0, 0, 0.28);
+          box-shadow: 0 0 4px rgba(0, 0, 0, 0.14), 0 4px 8px rgba(0, 0, 0, 0.28);
 }
 
 .z-depth-4 {
-  box-shadow: 0 0 6px rgba(0, 0, 0, 0.16), 0 6px 12px rgba(0, 0, 0, 0.32);
+  -webkit-box-shadow: 0 0 6px rgba(0, 0, 0, 0.16), 0 6px 12px rgba(0, 0, 0, 0.32);
+          box-shadow: 0 0 6px rgba(0, 0, 0, 0.16), 0 6px 12px rgba(0, 0, 0, 0.32);
 }
 
 h1, h2, h3, h4, h5, h6,
@@ -231,6 +245,7 @@ h1, h2, h3, h4, h5, h6,
   font-weight: 500;
   line-height: 1.1;
   margin: 1rem 0 0.5rem;
+  -webkit-transition: 0.3s;
   transition: 0.3s;
 }
 
@@ -638,7 +653,9 @@ form:not(.layout-builder-add-block) .tabledrag-handle ~ .form-managed-file {
 }
 
 .vbo-table .btn-group--operations {
-  justify-content: left;
+  -webkit-box-pack: left;
+      -ms-flex-pack: left;
+          justify-content: left;
 }
 
 .vbo-table .form-no-label.checkbox label {
@@ -655,6 +672,7 @@ form:not(.layout-builder-add-block) .tabledrag-handle ~ .form-managed-file {
   font-weight: normal;
   text-align: center;
   vertical-align: middle;
+  -ms-touch-action: manipulation;
   touch-action: manipulation;
   cursor: pointer;
   background-image: none;
@@ -667,6 +685,7 @@ form:not(.layout-builder-add-block) .tabledrag-handle ~ .form-managed-file {
   -ms-user-select: none;
   user-select: none;
   text-transform: uppercase;
+  -webkit-transition: .3s ease-out;
   transition: .3s ease-out;
   outline: 0;
 }
@@ -1005,7 +1024,8 @@ sub {
 }
 
 .align-center {
-  align-self: center;
+  -ms-flex-item-align: center;
+      align-self: center;
 }
 
 .block {
@@ -1036,7 +1056,8 @@ sub {
 
 .img-elevated {
   display: inline-block;
-  box-shadow: 0 0 4px rgba(0, 0, 0, 0.14), 0 4px 8px rgba(0, 0, 0, 0.28);
+  -webkit-box-shadow: 0 0 4px rgba(0, 0, 0, 0.14), 0 4px 8px rgba(0, 0, 0, 0.28);
+          box-shadow: 0 0 4px rgba(0, 0, 0, 0.14), 0 4px 8px rgba(0, 0, 0, 0.28);
 }
 
 p + p .img-elevated {
@@ -1076,8 +1097,11 @@ img.align-center {
 }
 
 .img-grid {
+  display: -webkit-box;
+  display: -ms-flexbox;
   display: flex;
-  flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+      flex-wrap: wrap;
   padding-bottom: 10px;
 }
 
@@ -1370,6 +1394,9 @@ button.close {
     -ms-overflow-style: -ms-autohiding-scrollbar;
     padding-bottom: 100px;
     margin-bottom: -100px;
+  }
+  .table-responsive.card__block--table {
+    margin-bottom: 0;
   }
   .right-auto {
     margin-left: 0.5rem;

--- a/themes/socialbase/components/01-base/tables/_tables.scss
+++ b/themes/socialbase/components/01-base/tables/_tables.scss
@@ -175,6 +175,10 @@ form:not(.layout-builder-add-block) {
     -ms-overflow-style: -ms-autohiding-scrollbar;
     padding-bottom: 100px;
     margin-bottom: -100px;
+
+    &.card__block--table {
+      margin-bottom: 0;
+    }
   }
 
   // Prevent double border on horizontal scroll due to use of `display: block;`


### PR DESCRIPTION
## Problem
The table has the wrong styles on the mobile

## Solution
Add reset `margin-top` for the table on mobile if this table has `card__block--table` class

## Issue tracker
https://getopensocial.atlassian.net/browse/ECI-1008
https://www.drupal.org/project/social/issues/3116652

## How to test
- [ ] Go to the /following page
- [ ] Activated mobile mode on your browser

## Screenshots
before:
![image-2020-02-27-17-23-14-742](https://user-images.githubusercontent.com/16086340/75520436-35fc7180-5a0e-11ea-8fb3-3bdd57b9b6c3.png)

after:
<img width="621" alt="Screenshot at Feb 28 09-39-00" src="https://user-images.githubusercontent.com/16086340/75520448-3e54ac80-5a0e-11ea-9399-6450be74a504.png">

## Release notes
Fixed wrong styles for the table if the table has `card__block--table` class
