### PR TITLE
YANG-1004: Add condition for the group and profile pages

### DIFF
--- a/themes/socialblue/src/Plugin/Preprocess/Page.php
+++ b/themes/socialblue/src/Plugin/Preprocess/Page.php
@@ -25,7 +25,6 @@ class Page extends PageBase {
       $route_match = \Drupal::routeMatch();
       if ($route_match->getParameter('user') && $route_match->getRouteName() !== 'entity.profile.type.user_profile_form') {
         $variables['content_attributes']->addClass('sidebar-left', 'content-merged--sky');
-//        dump($variables);
 
         // If page has title.
         if ($variables['page']['title']) {

--- a/themes/socialblue/src/Plugin/Preprocess/Page.php
+++ b/themes/socialblue/src/Plugin/Preprocess/Page.php
@@ -25,11 +25,22 @@ class Page extends PageBase {
       $route_match = \Drupal::routeMatch();
       if ($route_match->getParameter('user') && $route_match->getRouteName() !== 'entity.profile.type.user_profile_form') {
         $variables['content_attributes']->addClass('sidebar-left', 'content-merged--sky');
+//        dump($variables);
+
+        // If page has title.
+        if ($variables['page']['title']) {
+          $variables['display_page_title'] = FALSE;
+        }
       }
 
       // Display merged sidebar on the left side of group pages, except edit.
       if ($route_match->getParameter('group') && $route_match->getRouteName() !== 'entity.group.edit_form') {
         $variables['content_attributes']->addClass('sidebar-left', 'content-merged--sky');
+
+        // If page has title.
+        if ($variables['page']['title']) {
+          $variables['display_page_title'] = FALSE;
+        }
       }
 
       // Add extra class if we have blocks in both complementary regions.

--- a/themes/socialblue/src/Plugin/Preprocess/Page.php
+++ b/themes/socialblue/src/Plugin/Preprocess/Page.php
@@ -26,20 +26,16 @@ class Page extends PageBase {
       if ($route_match->getParameter('user') && $route_match->getRouteName() !== 'entity.profile.type.user_profile_form') {
         $variables['content_attributes']->addClass('sidebar-left', 'content-merged--sky');
 
-        // If page has title.
-        if ($variables['page']['title']) {
-          $variables['display_page_title'] = FALSE;
-        }
+        // The title is not needed on this page.
+        $variables['display_page_title'] = FALSE;
       }
 
       // Display merged sidebar on the left side of group pages, except edit.
       if ($route_match->getParameter('group') && $route_match->getRouteName() !== 'entity.group.edit_form') {
         $variables['content_attributes']->addClass('sidebar-left', 'content-merged--sky');
 
-        // If page has title.
-        if ($variables['page']['title']) {
-          $variables['display_page_title'] = FALSE;
-        }
+        // The title is not needed on this page.
+        $variables['display_page_title'] = FALSE;
       }
 
       // Add extra class if we have blocks in both complementary regions.


### PR DESCRIPTION
## Problem
The page title is present on the group and profile pages on the sky theme

## Solution
Add condition for the hide page title on the group and profile pages on the sky theme

## Issue tracker
https://getopensocial.atlassian.net/browse/ECI-1004
https://www.drupal.org/project/social/issues/3116659

## How to test
- [ ] Go to the profile or group page

## Screenshots
before(red border)/after(green border):
![image-20200225-144902](https://user-images.githubusercontent.com/16086340/75538736-c98b6d80-5a21-11ea-8aa5-63d16e4795a3.png)

## Release notes
The page title does not preset on the profile and group pages on the sky theme
