### PR TITLE
3114852: CTA for account creation on Event AN Guest sign-up should not always show

### DIFF
--- a/modules/social_features/social_event/modules/social_event_an_enroll/src/Controller/EventAnEnrollController.php
+++ b/modules/social_features/social_event/modules/social_event_an_enroll/src/Controller/EventAnEnrollController.php
@@ -23,30 +23,31 @@ class EventAnEnrollController extends ControllerBase {
   /**
    * The route match.
    *
-   * @var RouteMatchInterface
+   * @var \Drupal\Core\Routing\RouteMatchInterface
    */
   protected $routeMatch;
 
   /**
    * The entity type manager.
    *
-   * @var EntityTypeManagerInterface
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
    */
   protected $entityTypeManager;
 
   /**
-   * @var ConfigFactoryInterface
+   * @var \Drupal\Core\Config\ConfigFactoryInterface
    */
   protected $configFactory;
 
   /**
    * SocialTopicController constructor.
    *
-   * @param RouteMatchInterface $routeMatch
+   * @param \Drupal\Core\Routing\RouteMatchInterface $routeMatch
    *   The route match object.
-   * @param EntityTypeManagerInterface $entityTypeManager
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
    *   The entity type manager.
-   * @param ConfigFactoryInterface $configFactory
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $configFactory
+   *   The config factory.
    */
   public function __construct(RouteMatchInterface $routeMatch,
                               EntityTypeManagerInterface $entityTypeManager,

--- a/modules/social_features/social_event/modules/social_event_an_enroll/src/Controller/EventAnEnrollController.php
+++ b/modules/social_features/social_event/modules/social_event_an_enroll/src/Controller/EventAnEnrollController.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\social_event_an_enroll\Controller;
 
+use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Url;
@@ -22,28 +23,37 @@ class EventAnEnrollController extends ControllerBase {
   /**
    * The route match.
    *
-   * @var \Drupal\Core\Routing\RouteMatchInterface
+   * @var RouteMatchInterface
    */
   protected $routeMatch;
 
   /**
    * The entity type manager.
    *
-   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   * @var EntityTypeManagerInterface
    */
   protected $entityTypeManager;
 
   /**
+   * @var ConfigFactoryInterface
+   */
+  protected $configFactory;
+
+  /**
    * SocialTopicController constructor.
    *
-   * @param \Drupal\Core\Routing\RouteMatchInterface $routeMatch
+   * @param RouteMatchInterface $routeMatch
    *   The route match object.
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
+   * @param EntityTypeManagerInterface $entityTypeManager
    *   The entity type manager.
+   * @param ConfigFactoryInterface $configFactory
    */
-  public function __construct(RouteMatchInterface $routeMatch, EntityTypeManagerInterface $entityTypeManager) {
+  public function __construct(RouteMatchInterface $routeMatch,
+                              EntityTypeManagerInterface $entityTypeManager,
+                              ConfigFactoryInterface $configFactory) {
     $this->routeMatch = $routeMatch;
     $this->entityTypeManager = $entityTypeManager;
+    $this->configFactory = $configFactory;
   }
 
   /**
@@ -52,7 +62,8 @@ class EventAnEnrollController extends ControllerBase {
   public static function create(ContainerInterface $container) {
     return new static(
       $container->get('current_route_match'),
-      $container->get('entity_type.manager')
+      $container->get('entity_type.manager'),
+      $container->get('config.factory')
     );
   }
 
@@ -76,35 +87,40 @@ class EventAnEnrollController extends ControllerBase {
    * Enroll dialog callback.
    */
   public function enrollDialog(NodeInterface $node) {
-    $action_links = [
-      'login' => [
-        'uri' => Url::fromRoute('user.login', [], [
-          'query' => [
-            'destination' => Url::fromRoute('entity.node.canonical', ['node' => $node->id()])
-              ->toString(),
-          ],
-        ])->toString(),
-      ],
-      'register' => [
+
+    // Fetch the user settings.
+    $userSettings = $this->configFactory->get('user.settings');
+
+    $action_links['login'] = [
+      'uri' => Url::fromRoute('user.login', [], [
+        'query' => [
+          'destination' => Url::fromRoute('entity.node.canonical', ['node' => $node->id()])
+            ->toString(),
+        ],
+      ])->toString(),
+    ];
+
+    // Check if users are allowed to register.
+    if ('admin_only' !== $userSettings->get('register')) {
+      $action_links['register'] = [
         'uri' => Url::fromRoute('user.register', [], [
           'query' => [
             'destination' => Url::fromRoute('entity.node.canonical', ['node' => $node->id()])
               ->toString(),
           ],
         ])->toString(),
-      ],
-      'guest' => [
-        'uri' => Url::fromRoute('social_event_an_enroll.enroll_form', ['node' => $node->id()], [])
-          ->toString(),
-      ],
+      ];
+    }
+
+    $action_links['guest'] = [
+      'uri' => Url::fromRoute('social_event_an_enroll.enroll_form', ['node' => $node->id()], [])
+        ->toString(),
     ];
 
-    $output = [
+    return [
       '#theme' => 'event_an_enroll_dialog',
       '#links' => $action_links,
     ];
-
-    return $output;
   }
 
   /**

--- a/modules/social_features/social_event/modules/social_event_an_enroll/src/Controller/EventAnEnrollController.php
+++ b/modules/social_features/social_event/modules/social_event_an_enroll/src/Controller/EventAnEnrollController.php
@@ -74,8 +74,10 @@ class EventAnEnrollController extends ControllerBase {
    * Determines if user has access to enroll form.
    *
    * @param \Drupal\node\NodeInterface $node
+   *   The node.
    *
    * @return \Drupal\Core\Access\AccessResultAllowed|\Drupal\Core\Access\AccessResultForbidden
+   *   Allowed or not allowed.
    */
   public function enrollAccess(NodeInterface $node) {
     $config = $this->config('social_event_an_enroll.settings');

--- a/modules/social_features/social_event/modules/social_event_an_enroll/src/Controller/EventAnEnrollController.php
+++ b/modules/social_features/social_event/modules/social_event_an_enroll/src/Controller/EventAnEnrollController.php
@@ -35,6 +35,8 @@ class EventAnEnrollController extends ControllerBase {
   protected $entityTypeManager;
 
   /**
+   * The config factory.
+   *
    * @var \Drupal\Core\Config\ConfigFactoryInterface
    */
   protected $configFactory;
@@ -70,6 +72,10 @@ class EventAnEnrollController extends ControllerBase {
 
   /**
    * Determines if user has access to enroll form.
+   *
+   * @param \Drupal\node\NodeInterface $node
+   *
+   * @return \Drupal\Core\Access\AccessResultAllowed|\Drupal\Core\Access\AccessResultForbidden
    */
   public function enrollAccess(NodeInterface $node) {
     $config = $this->config('social_event_an_enroll.settings');

--- a/modules/social_features/social_event/modules/social_event_an_enroll/templates/event-an-enroll-dialog.html.twig
+++ b/modules/social_features/social_event/modules/social_event_an_enroll/templates/event-an-enroll-dialog.html.twig
@@ -3,8 +3,13 @@
 <div{{ attributes.addClass('event_an_enroll','row') }}>
   <div class="col-md">
     <h5>{% trans %}Enroll with account{% endtrans %}</h5>
-    <p><a class="btn-lg btn btn-primary" href="{{ links.register.uri }}" title="{% trans %}Create an account{% endtrans %}">{% trans %}Create an account{% endtrans %}</a>
-    <a class="btn-lg btn btn-default" href="{{ links.login.uri }}" title="{% trans %}Login{% endtrans %}">{% trans %}Log in{% endtrans %}</a></p>
+
+    <p>
+      {% if links.register is defined %}
+        <a class="btn-lg btn btn-primary" href="{{ links.register.uri }}" title="{% trans %}Create an account{% endtrans %}">{% trans %}Create an account{% endtrans %}</a>
+      {% endif %}
+      <a class="btn-lg btn btn-default" href="{{ links.login.uri }}" title="{% trans %}Login{% endtrans %}">{% trans %}Log in{% endtrans %}</a>
+    </p>
   </div>
   <div class="col-md">
     <h5>{% trans %}Enroll without account{% endtrans %}</h5>


### PR DESCRIPTION
## Problem
CTA for account creation on Event AN Guest sign-up shows when account creation for anonymous users is disabled.

## Solution
Hide the CTA when account creation is disabled.

## Issue tracker
https://www.drupal.org/project/social/issues/3114852

## How to test
- [ ] Enable the `social_event_an_enroll` module 
- [ ] Allow anonymous enrolment for an event
- [ ] Go to the event as AN
- [ ] Click enrol and notice 3 options (create account, login, anonymous)
- [ ] Login as SM+ and disable creation of user accounts by anyone other than admin
- [ ] Check the event again.
- [ ] Notice only 2 options now (login and anonymous)
- [ ] Merge
- [ ] 🍻 

## Release notes
When a platform admin disabled accounts registration and people try to enrol in an event anonymously, the 'create an account' button is no longer displayed.
