### PR TITLE
Issue #3105138: Event enrolment notification all says "Anonymous has enrolled..."

### DIFF
--- a/modules/social_features/social_event/social_event.tokens.inc
+++ b/modules/social_features/social_event/social_event.tokens.inc
@@ -146,7 +146,7 @@ function get_name_from_enrollment($id) {
   // User is AN by default.
   $enrollment_name = \Drupal::configFactory()->get('user.settings')->get('anonymous');
 
-  if (!$enrollment instanceof EventEnrollmentInterface) {
+  if ($enrollment instanceof EventEnrollmentInterface) {
     // If there is a Uid. Lets load the user and return his display name.
     if ($enrollment !== NULL &&
       $enrollment->hasField('field_account') &&


### PR DESCRIPTION
## Problem
Event enrolment notification all says "Anonymous has enrolled..."
See: 
<img width="740" alt="Screen Shot 2020-03-01 at 14 01 48" src="https://user-images.githubusercontent.com/16667281/75658339-6fc8b480-5c68-11ea-8bba-e4f0c827897a.png">

## Solution
The `social_event:enrolled_user` token had a negate on checking the instance of a variable. In this case that meant the user was cast as a AN at the start. 
Even if a EventEnrollment was found, it skipped the part where it was getting the displayname.

## Issue tracker
https://www.drupal.org/node/3105138
https://getopensocial.atlassian.net/browse/DS-7103

## How to test
- [x] Run a re-install and see demo content now shows correct names
- [x] See AN enrollment still works

## Screenshots
![Screen Shot 2020-03-02 at 09 33 20](https://user-images.githubusercontent.com/16667281/75658591-e49bee80-5c68-11ea-9d85-9f2b9d3b976d.png)

## Release notes
Event enrolment notifications all said "Anonymous has enrolled..." even if there was an existing user who enrolled. We made sure the users display name is shown again.
