### PR TITLE
Issue #3113150 by navneet0693: Reverted remaining configuration by hook_update_N which was left in 8801.

### DIFF
--- a/modules/social_features/social_private_message/social_private_message.install
+++ b/modules/social_features/social_private_message/social_private_message.install
@@ -237,6 +237,32 @@ function social_private_message_update_8801() {
     'core.entity_view_display.private_message_thread.private_message_thread.default',
   ];
 
+  // Revert the configurations.
+  _social_private_message_features_removal_config_revert_helper($config_files);
+}
+
+/**
+ * Revert remaining social_private_message configs not included in 8801.
+ */
+function social_private_message_update_8802() {
+  $config_files = [
+    'core.entity_view_display.private_message.private_message.inbox',
+    'core.entity_view_display.profile.profile.compact_private_message',
+    'core.entity_view_mode.profile.compact_private_message',
+    'message.template.create_private_message',
+    'views.view.inbox',
+  ];
+  // Revert the configurations.
+  _social_private_message_features_removal_config_revert_helper($config_files);
+}
+
+/**
+ * Helper function to revert configurations.
+ *
+ * @param array $config_files
+ *   Array of configuration file names.
+ */
+function _social_private_message_features_removal_config_revert_helper(array $config_files) {
   foreach ($config_files as $config_file) {
     $config = drupal_get_path('module', 'social_private_message') . '/config/features_removal/' . $config_file . '.yml';
 


### PR DESCRIPTION
## Problem
Follow up for https://github.com/goalgorilla/open_social/pull/1727. We need to revert all the configurations in the features_removal folder. One of the issues which came up is that /user/inbox theme is broken after the upgrade to OS 8.x

## Solution
Revert remaining features.

## Issue tracker
https://www.drupal.org/project/social/issues/3113150

## How to test
- [ ] Try to upgrade an OS 7.x platform to OS 8.x with already installed social_private_messages module.
- [ ] Check that /user/inbox theme is not broken
- [ ] Also, check that creating a message is working

## Screenshots
N.A

## Release notes
N.A

## Change Record
N.A

## Translations
N.A
