### PR TITLE
Issue #3118746 - Profile update changed routes

### DIFF
--- a/modules/custom/social_auth_extra/social_auth_extra.module
+++ b/modules/custom/social_auth_extra/social_auth_extra.module
@@ -202,7 +202,7 @@ function social_auth_extra_form_user_register_form_submit($form, FormStateInterf
 
             // Redirect to profile.
             $form_state->setRedirect(
-              'entity.profile.type.user_profile_form', [
+              'profile.user_page.single', [
                 'user' => $account->id(),
                 'profile_type' => 'profile',
                 [],

--- a/modules/custom/social_tour/config/install/tour.tour.social_user.yml
+++ b/modules/custom/social_tour/config/install/tour.tour.social_user.yml
@@ -9,7 +9,7 @@ label: 'Social profile'
 module: social_tour
 routes:
   -
-    route_name: entity.profile.type.user_profile_form
+    route_name: profile.user_page.single
 tips:
   welcome_message:
     id: welcome_message

--- a/modules/social_features/social_private_message/social_private_message.install
+++ b/modules/social_features/social_private_message/social_private_message.install
@@ -230,7 +230,7 @@ function social_private_message_update_8002() {
  * The feature removal script did not succeed for social_private_message.
  * Import the configs in an update hook.
  */
-function social_private_message_update_8803() {
+function social_private_message_update_8801() {
   $config_files = [
     'core.entity_form_display.private_message_thread.private_message_thread.default',
     'core.entity_view_display.private_message.private_message.default',
@@ -244,7 +244,7 @@ function social_private_message_update_8803() {
 /**
  * Revert remaining social_private_message configs not included in 8801.
  */
-function social_private_message_update_8804() {
+function social_private_message_update_8802() {
   $config_files = [
     'core.entity_view_display.private_message.private_message.inbox',
     'core.entity_view_display.profile.profile.compact_private_message',

--- a/modules/social_features/social_private_message/social_private_message.install
+++ b/modules/social_features/social_private_message/social_private_message.install
@@ -230,7 +230,7 @@ function social_private_message_update_8002() {
  * The feature removal script did not succeed for social_private_message.
  * Import the configs in an update hook.
  */
-function social_private_message_update_8801() {
+function social_private_message_update_8803() {
   $config_files = [
     'core.entity_form_display.private_message_thread.private_message_thread.default',
     'core.entity_view_display.private_message.private_message.default',
@@ -244,7 +244,7 @@ function social_private_message_update_8801() {
 /**
  * Revert remaining social_private_message configs not included in 8801.
  */
-function social_private_message_update_8802() {
+function social_private_message_update_8804() {
   $config_files = [
     'core.entity_view_display.private_message.private_message.inbox',
     'core.entity_view_display.profile.profile.compact_private_message',

--- a/modules/social_features/social_profile/social_profile.module
+++ b/modules/social_features/social_profile/social_profile.module
@@ -369,7 +369,7 @@ function social_profile_preprocess_profile(array &$variables) {
   // Get the current route name to check if the user is on the edit or delete
   // page.
   $route = \Drupal::routeMatch()->getRouteName();
-  if ($route !== 'entity.profile.type.user_profile_form' && $profile->access('update', $current_user)) {
+  if ($route !== 'profile.user_page.single' && $profile->access('update', $current_user)) {
     $variables['profile_edit_url'] = Url::fromUserInput('/user/' . $profile->getOwnerId() . '/profile');
     $variables['#cache']['contexts'][] = 'route.name';
   }

--- a/modules/social_features/social_user/social_user.module
+++ b/modules/social_features/social_user/social_user.module
@@ -312,7 +312,7 @@ function _social_user_pass_reset_submit($form, FormStateInterface $form_state) {
     // the user save form before. Which means we can redirect to user profile.
     if ($first_time_login) {
       $form_state->setRedirect(
-        'entity.profile.type.user_profile_form',
+        'profile.user_page.single',
         [
           'user' => $submitted_user_id,
           'profile_type' => 'profile',

--- a/themes/socialbase/src/Plugin/Preprocess/PageTitle.php
+++ b/themes/socialbase/src/Plugin/Preprocess/PageTitle.php
@@ -26,7 +26,7 @@ class PageTitle extends PreprocessBase {
     $current_path = $current_url->toString();
     $route_name = \Drupal::routeMatch()->getRouteName();
 
-    if ($route_name === 'entity.profile.type.user_profile_form') {
+    if ($route_name === 'profile.user_page.single') {
       if ($variables['title'] instanceof TranslatableMarkup) {
         $profile_type = $variables['title']->getArguments();
       }

--- a/themes/socialblue/src/Plugin/Preprocess/Page.php
+++ b/themes/socialblue/src/Plugin/Preprocess/Page.php
@@ -23,7 +23,7 @@ class Page extends PageBase {
 
       // Display merged sidebar on the left side of profile pages, except edit.
       $route_match = \Drupal::routeMatch();
-      if ($route_match->getParameter('user') && $route_match->getRouteName() !== 'entity.profile.type.user_profile_form') {
+      if ($route_match->getParameter('user') && $route_match->getRouteName() !== 'profile.user_page.single') {
         $variables['content_attributes']->addClass('sidebar-left', 'content-merged--sky');
       }
 


### PR DESCRIPTION
## Problem
See: https://www.drupal.org/node/3090422
The entity.profile.type.user_profile_form and entity.profile.type.user_profile_form.add routes have been replaced by profile.user_page.single, profile.user_page.multiple and profile.user_page.add_form.

Urls generated for the previous routes will need to be updated; the functionality is similar but the old route names will no longer resolve.

## Solution
Change all the in code related routes and match them with the new ones.

## Issue tracker
https://www.drupal.org/node/3118746

## How to test
- [ ] See tests should pass
- [ ] See you can create a profile
- [ ] See after registering you get redirected to a new empty profile

## Release notes
The update of Profile has caused some issues with changed routes in the contrib module not being reflected in Open Social. 