### PR TITLE
TB-2922 - Remove the background for input type date fields

### DIFF
--- a/themes/socialbase/assets/css/form-controls.css
+++ b/themes/socialbase/assets/css/form-controls.css
@@ -422,7 +422,6 @@ form:not(.layout-builder-configure-block) .form-disabled .select-wrapper::after 
   form:not(.layout-builder-configure-block) .form-control {
     font-size: 16px;
   }
-  form:not(.layout-builder-configure-block) input[type="date"].form-control,
   form:not(.layout-builder-configure-block) input[type="time"].form-control,
   form:not(.layout-builder-configure-block) input[type="datetime-local"].form-control,
   form:not(.layout-builder-configure-block) input[type="month"].form-control {
@@ -432,10 +431,19 @@ form:not(.layout-builder-configure-block) .form-disabled .select-wrapper::after 
        -moz-appearance: none;
             appearance: none;
   }
-  form:not(.layout-builder-configure-block) input[type="date"].form-control:focus,
   form:not(.layout-builder-configure-block) input[type="time"].form-control:focus,
   form:not(.layout-builder-configure-block) input[type="datetime-local"].form-control:focus,
   form:not(.layout-builder-configure-block) input[type="month"].form-control:focus {
+    background: inherit;
+  }
+  form:not(.layout-builder-configure-block) input[type="date"].form-control {
+    line-height: 24px;
+    background: none;
+    -webkit-appearance: none;
+       -moz-appearance: none;
+            appearance: none;
+  }
+  form:not(.layout-builder-configure-block) input[type="date"].form-control:focus {
     background: inherit;
   }
 }

--- a/themes/socialbase/components/02-atoms/form-controls/_input.scss
+++ b/themes/socialbase/components/02-atoms/form-controls/_input.scss
@@ -83,13 +83,24 @@ input[type="search"] {
 //
 
 @media screen and (-webkit-min-device-pixel-ratio: 0) {
-  input[type="date"],
   input[type="time"],
   input[type="datetime-local"],
   input[type="month"] {
     &.form-control {
       line-height: $line-height-computed;
       background: url(data:image/svg+xml;base64,PHN2ZyBpZD0iTGF5ZXJfMSIgZGF0YS1uYW1lPSJMYXllciAxIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA0Ljk1IDEwIj48ZGVmcz48c3R5bGU+LmNscy0xe2ZpbGw6I2ZmZjt9LmNscy0ye2ZpbGw6IzQ0NDt9PC9zdHlsZT48L2RlZnM+PHRpdGxlPmFycm93czwvdGl0bGU+PHJlY3QgY2xhc3M9ImNscy0xIiB3aWR0aD0iNC45NSIgaGVpZ2h0PSIxMCIvPjxwb2x5Z29uIGNsYXNzPSJjbHMtMiIgcG9pbnRzPSIxLjQxIDQuNjcgMi40OCAzLjE4IDMuNTQgNC42NyAxLjQxIDQuNjciLz48cG9seWdvbiBjbGFzcz0iY2xzLTIiIHBvaW50cz0iMy41NCA1LjMzIDIuNDggNi44MiAxLjQxIDUuMzMgMy41NCA1LjMzIi8+PC9zdmc+) no-repeat 95% 50%;
+      appearance: none;
+
+      &:focus {
+        background: inherit;
+      }
+    }
+  }
+
+  input[type="date"] {
+    &.form-control {
+      line-height: $line-height-computed;
+      background: none;
       appearance: none;
 
       &:focus {


### PR DESCRIPTION
## Problem
When we use a browser-native datepicker for an input of type `date`, we do not want to show a background image. This because it overlaps with the arrow that's placed inside the field by the browser itself (See screenshot).

## Solution
Remove the background from the input with type `date`. At the moment, this is only the case when we want to use our native datepicker referenced in https://github.com/goalgorilla/open_social/pull/1741

## How to test
- [ ] On an environment with the social_birthday module enabled and the birthday field on the registration page, go to `/user/register`
- [ ] See that the dropdown icon is not shown on the birthday field.
- [ ] Open the native date picker. When hovering the field, the browser will show it's own dropdown icon in the field.

## Screenshots
Before:
![Screenshot 2020-03-12 at 10 41 43](https://user-images.githubusercontent.com/19951173/76508078-1e7da980-644e-11ea-841a-db776dc1e013.png)

After without hover:
![Screenshot 2020-03-12 at 10 42 18](https://user-images.githubusercontent.com/19951173/76508127-33f2d380-644e-11ea-8bcd-0c64ca266a10.png)

After with hover:
![Screenshot 2020-03-12 at 10 42 28](https://user-images.githubusercontent.com/19951173/76508140-38b78780-644e-11ea-8258-ec8b28e9a4ab.png)

## Release notes
We improved the way we display a native datepicker on specified fields. The dropdown indicator should only show the native dropdown icon from the browser, not our own background icon.