### PR TITLE
Issue #3118044 by rolki: As a CM I want to sort content for the custom content block according to my specific use case

### DIFF
--- a/modules/social_features/social_content_block/config/install/field.storage.block_content.field_sorting.yml
+++ b/modules/social_features/social_content_block/config/install/field.storage.block_content.field_sorting.yml
@@ -16,6 +16,12 @@ settings:
     -
       value: changed
       label: 'Last updated'
+    -
+      value: most_commented
+      label: 'Most commented'
+    -
+      value: most_liked
+      label: 'Most liked'
   allowed_values_function: ''
 module: options
 locked: false

--- a/modules/social_features/social_content_block/config/install/field.storage.block_content.field_sorting.yml
+++ b/modules/social_features/social_content_block/config/install/field.storage.block_content.field_sorting.yml
@@ -22,6 +22,9 @@ settings:
     -
       value: most_liked
       label: 'Most liked'
+    -
+      value: last_interacted
+      label: 'Last interacted'
   allowed_values_function: ''
 module: options
 locked: false

--- a/modules/social_features/social_content_block/social_content_block.install
+++ b/modules/social_features/social_content_block/social_content_block.install
@@ -357,21 +357,6 @@ function social_content_block_update_8004() {
     'value' => 'most_liked',
     'label' => 'Most liked',
   ];
-
-  $config_data['settings']['allowed_values'] = $allowed_values;
-  $config->setData($config_data)->save();
-  \Drupal::service('entity_field.manager')->clearCachedFieldDefinitions();
-}
-
-/**
- * Add a last interacted as an extra allowed value to the sorting field.
- */
-function social_content_block_update_8005() {
-  $config_name = 'field.storage.block_content.field_sorting';
-  $config = \Drupal::configFactory()->getEditable($config_name);
-  $config_data = $config->getRawData();
-  $allowed_values = $config_data['settings']['allowed_values'];
-
   $allowed_values[] = [
     'value' => 'last_interacted',
     'label' => 'Last interacted',

--- a/modules/social_features/social_content_block/social_content_block.install
+++ b/modules/social_features/social_content_block/social_content_block.install
@@ -325,3 +325,26 @@ function social_content_block_update_8002(&$sandbox) {
 
   $sandbox['#finished'] = $sandbox['processed'] / $sandbox['total'];
 }
+
+/**
+ * Add an extra allowed values to the sorting field.
+ */
+function social_content_block_update_8003() {
+  $config_name = 'field.storage.block_content.field_sorting';
+  $config =  Drupal::configFactory()->getEditable($config_name);
+  $config_data = $config->getRawData();
+  $allowed_values = $config_data['settings']['allowed_values'];
+
+  $allowed_values[] = [
+    'value' => 'most_commented',
+    'label' => 'Most commented',
+  ];
+  $allowed_values[] = [
+    'value' => 'most_liked',
+    'label' => 'Most liked',
+  ];
+
+  $config_data['settings']['allowed_values'] = $allowed_values;
+  $config->setData($config_data)->save();
+  Drupal::service('entity_field.manager')->clearCachedFieldDefinitions();
+}

--- a/modules/social_features/social_content_block/social_content_block.install
+++ b/modules/social_features/social_content_block/social_content_block.install
@@ -348,3 +348,22 @@ function social_content_block_update_8003() {
   $config->setData($config_data)->save();
   Drupal::service('entity_field.manager')->clearCachedFieldDefinitions();
 }
+
+/**
+ * Add a last interacted as an extra allowed value to the sorting field.
+ */
+function social_content_block_update_8004() {
+  $config_name = 'field.storage.block_content.field_sorting';
+  $config =  Drupal::configFactory()->getEditable($config_name);
+  $config_data = $config->getRawData();
+  $allowed_values = $config_data['settings']['allowed_values'];
+
+  $allowed_values[] = [
+    'value' => 'last_interacted',
+    'label' => 'Last interacted',
+  ];
+
+  $config_data['settings']['allowed_values'] = $allowed_values;
+  $config->setData($config_data)->save();
+  Drupal::service('entity_field.manager')->clearCachedFieldDefinitions();
+}

--- a/modules/social_features/social_content_block/social_content_block.install
+++ b/modules/social_features/social_content_block/social_content_block.install
@@ -331,7 +331,7 @@ function social_content_block_update_8002(&$sandbox) {
  */
 function social_content_block_update_8003() {
   $config_name = 'field.storage.block_content.field_sorting';
-  $config =  Drupal::configFactory()->getEditable($config_name);
+  $config =  \Drupal::configFactory()->getEditable($config_name);
   $config_data = $config->getRawData();
   $allowed_values = $config_data['settings']['allowed_values'];
 
@@ -346,7 +346,7 @@ function social_content_block_update_8003() {
 
   $config_data['settings']['allowed_values'] = $allowed_values;
   $config->setData($config_data)->save();
-  Drupal::service('entity_field.manager')->clearCachedFieldDefinitions();
+  \Drupal::service('entity_field.manager')->clearCachedFieldDefinitions();
 }
 
 /**
@@ -354,7 +354,7 @@ function social_content_block_update_8003() {
  */
 function social_content_block_update_8004() {
   $config_name = 'field.storage.block_content.field_sorting';
-  $config =  Drupal::configFactory()->getEditable($config_name);
+  $config =  \Drupal::configFactory()->getEditable($config_name);
   $config_data = $config->getRawData();
   $allowed_values = $config_data['settings']['allowed_values'];
 
@@ -365,5 +365,5 @@ function social_content_block_update_8004() {
 
   $config_data['settings']['allowed_values'] = $allowed_values;
   $config->setData($config_data)->save();
-  Drupal::service('entity_field.manager')->clearCachedFieldDefinitions();
+  \Drupal::service('entity_field.manager')->clearCachedFieldDefinitions();
 }

--- a/modules/social_features/social_content_block/social_content_block.install
+++ b/modules/social_features/social_content_block/social_content_block.install
@@ -345,7 +345,7 @@ function social_content_block_update_8003() {
  */
 function social_content_block_update_8004() {
   $config_name = 'field.storage.block_content.field_sorting';
-  $config =  \Drupal::configFactory()->getEditable($config_name);
+  $config = \Drupal::configFactory()->getEditable($config_name);
   $config_data = $config->getRawData();
   $allowed_values = $config_data['settings']['allowed_values'];
 
@@ -368,7 +368,7 @@ function social_content_block_update_8004() {
  */
 function social_content_block_update_8005() {
   $config_name = 'field.storage.block_content.field_sorting';
-  $config =  \Drupal::configFactory()->getEditable($config_name);
+  $config = \Drupal::configFactory()->getEditable($config_name);
   $config_data = $config->getRawData();
   $allowed_values = $config_data['settings']['allowed_values'];
 

--- a/modules/social_features/social_content_block/src/ContentBuilder.php
+++ b/modules/social_features/social_content_block/src/ContentBuilder.php
@@ -268,9 +268,13 @@ class ContentBuilder implements ContentBuilderInterface {
           $query = $this->connection->select('comment_field_data', 'cfd');
           $query->condition('cfd.entity_id', $entities, 'IN');
           $query->condition('cfd.created', $start_time, '>');
-          $query->addField('cfd', 'entity_id');
+          $query->condition('cfd.status', 1, '=');
+          // Only nodes, without posts or other entities.
+          $query->innerJoin('node_field_data', 'nfd', 'nfd.nid = cfd.entity_id');
+
+          $query->addField('nfd', 'nid');
           $query->addExpression('COUNT(cfd.entity_id)', 'count');
-          $query->groupBy('cfd.entity_id');
+          $query->groupBy('nfd.nid');
         }
         $query->orderBy('count','DESC');
         break;
@@ -295,9 +299,12 @@ class ContentBuilder implements ContentBuilderInterface {
           $query->condition('vv.entity_id', $entities, 'IN');
           $query->condition('vv.entity_type', $entity_type, '=');
           $query->condition('vv.timestamp', $start_time, '>');
-          $query->addField('vv', 'entity_id');
+          // Only nodes, without posts or other entities.
+          $query->innerJoin('node_field_data', 'nfd', 'nfd.nid = vv.entity_id');
+
+          $query->addField('nfd', 'nid');
           $query->addExpression('COUNT(vv.entity_id)', 'count');
-          $query->groupBy('vv.entity_id');
+          $query->groupBy('nfd.nid');
         }
         $query->orderBy('count','DESC');
         break;
@@ -339,6 +346,7 @@ class ContentBuilder implements ContentBuilderInterface {
           // Last interacted for all the time.
           $query = $this->connection->select('node_field_data', 'nfd');
           $query->condition('nfd.nid', $entities, 'IN');
+          $query->condition('nfd.status', 1, '=');
           // Comment entity.
           $query->leftjoin('comment_field_data', 'cfd', 'nfd.nid = cfd.entity_id');
           // Like node.

--- a/modules/social_features/social_content_block/src/ContentBuilder.php
+++ b/modules/social_features/social_content_block/src/ContentBuilder.php
@@ -285,9 +285,9 @@ class ContentBuilder implements ContentBuilderInterface {
           $query = $this->connection->select('group_content_field_data', 'gfd');
           $query->condition('gfd.gid', $entities, 'IN');
 
-          $query->leftJoin('votingapi_vote', 'vv', 'gfd.entity_id = %alias.entity_id');
-          $query->leftjoin('comment_field_data', 'cfd', 'gfd.entity_id = %alias.entity_id');
-          $query->leftjoin('node_field_data', 'nfd', 'gfd.entity_id = %alias.nid');
+          $query->leftJoin('votingapi_vote', 'vv', 'gfd.entity_id = vv.entity_id');
+          $query->leftjoin('comment_field_data', 'cfd', 'gfd.entity_id = cfd.entity_id');
+          $query->leftjoin('node_field_data', 'nfd', 'gfd.entity_id = nfd.nid');
 
           // Create or update post.
           $query->leftjoin('post__field_recipient_group', 'pst', 'gfd.gid = pst.field_recipient_group_target_id');
@@ -317,11 +317,11 @@ class ContentBuilder implements ContentBuilderInterface {
           $query = $this->connection->select('node_field_data', 'nfd');
           $query->condition('nfd.nid', $entities, 'IN');
           // Comment entity.
-          $cfd_alias = $query->leftjoin('comment_field_data', 'cfd', 'nfd.nid = %alias.entity_id');
+          $query->leftjoin('comment_field_data', 'cfd', 'nfd.nid = cfd.entity_id');
           // Like node.
-          $query->leftjoin('votingapi_vote', 'vv', 'nfd.nid = %alias.entity_id');
+          $query->leftjoin('votingapi_vote', 'vv', 'nfd.nid = vv.entity_id');
           // Like comment related to node.
-          $query->leftjoin('votingapi_vote', 'vvn', "{$cfd_alias}.cid = %alias.entity_id");
+          $query->leftjoin('votingapi_vote', 'vvn', 'cfd.cid = vvn.entity_id');
 
           $query->addField('nfd', 'nid');
           $query->addExpression('GREATEST(COALESCE(MAX(vv.timestamp), 0),

--- a/modules/social_features/social_content_block/src/ContentBuilder.php
+++ b/modules/social_features/social_content_block/src/ContentBuilder.php
@@ -4,6 +4,7 @@ namespace Drupal\social_content_block;
 
 use Drupal\block_content\BlockContentInterface;
 use Drupal\Core\Database\Connection;
+use Drupal\Core\Database\Query\SelectInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Form\FormStateInterface;
@@ -289,8 +290,9 @@ class ContentBuilder implements ContentBuilderInterface {
    *   The entity type.
    *
    * @return array
+   *   The entity IDs list.
    */
-  private function sortAndRange($block_content, $query, $entity_type) {
+  private function sortAndRange(BlockContentInterface $block_content, SelectInterface $query, $entity_type) {
     $entities = $query->execute()->fetchAllKeyed(0, 0);
     $start_time = strtotime('-90 days');
 
@@ -323,12 +325,13 @@ class ContentBuilder implements ContentBuilderInterface {
           $query->addExpression('COUNT(cfd.entity_id)', 'count');
           $query->groupBy('nfd.nid');
         }
-        $query->orderBy('count','DESC');
+        $query->orderBy('count', 'DESC');
         break;
 
       case 'most_liked':
         if ($entity_type === 'group') {
-          // This query does not include likes for post comments and likes for entity comments.
+          // This query does not include likes for post comments and likes for
+          // entity comments.
           $entities = implode(',', $entities);
           $query = $this->connection->select('votingapi_vote', 'vv');
           $query->condition('vv.timestamp', $start_time, '>');
@@ -353,7 +356,7 @@ class ContentBuilder implements ContentBuilderInterface {
           $query->addExpression('COUNT(vv.entity_id)', 'count');
           $query->groupBy('nfd.nid');
         }
-        $query->orderBy('count','DESC');
+        $query->orderBy('count', 'DESC');
         break;
 
       case 'last_interacted':
@@ -408,7 +411,7 @@ class ContentBuilder implements ContentBuilderInterface {
           COALESCE(MAX(nfd.changed), 0))', 'newest_timestamp');
 
           $query->groupBy('nfd.nid');
-          $query->orderBy('newest_timestamp','DESC');
+          $query->orderBy('newest_timestamp', 'DESC');
         }
         break;
 

--- a/modules/social_features/social_content_block/src/ContentBuilder.php
+++ b/modules/social_features/social_content_block/src/ContentBuilder.php
@@ -356,7 +356,7 @@ class ContentBuilder implements ContentBuilderInterface {
       // that as sort value.
       case 'last_interacted':
         if ($entity_type_id === 'group') {
-          $query->leftJoin('group_content_field_data', 'gfd',"base_table.${entity_id_key} = gfd.gid");
+          $query->leftJoin('group_content_field_data', 'gfd', "base_table.${entity_id_key} = gfd.gid");
           $query->leftjoin('post__field_recipient_group', 'pst', "base_table.${entity_id_key} = pst.field_recipient_group_target_id");
           $query->leftjoin('post_field_data', 'pfd', 'pst.entity_id = pfd.id');
           $query->leftjoin('comment_field_data', 'cfd', "(gfd.entity_id = cfd.entity_id AND cfd.entity_type = 'node') OR (pfd.id = cfd.entity_id AND cfd.entity_type = 'post')");

--- a/modules/social_features/social_content_block/src/ContentBuilder.php
+++ b/modules/social_features/social_content_block/src/ContentBuilder.php
@@ -313,11 +313,10 @@ class ContentBuilder implements ContentBuilderInterface {
           $query->orderBy('newest_timestamp', 'DESC');
         }
         else {
-          // Last interacted for last 90 days.
+          // Last interacted for all the time.
           $query = $this->connection->select('votingapi_vote', 'vv');
           $query->condition('vv.entity_id', $entities, 'IN');
           $query->condition('vv.entity_type', $entity_type, '=');
-          $query->condition('vv.timestamp', $start_time, '>');
 
           $query->leftjoin('comment_field_data', 'cfd', 'vv.entity_id = %alias.entity_id');
           $query->leftjoin('node_field_data', 'nfd', 'vv.entity_id = %alias.nid');

--- a/modules/social_features/social_content_block/src/ContentBuilder.php
+++ b/modules/social_features/social_content_block/src/ContentBuilder.php
@@ -4,14 +4,12 @@ namespace Drupal\social_content_block;
 
 use Drupal\block_content\BlockContentInterface;
 use Drupal\Core\Database\Connection;
-use Drupal\Core\Datetime\DrupalDateTime;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Link;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Core\StringTranslation\TranslationInterface;
 use Drupal\Core\Url;
-use Drupal\group\Entity\Group;
 
 /**
  * Class ContentBuilder.

--- a/modules/social_features/social_content_block/src/ContentBuilder.php
+++ b/modules/social_features/social_content_block/src/ContentBuilder.php
@@ -296,6 +296,12 @@ class ContentBuilder implements ContentBuilderInterface {
     $entities = $query->execute()->fetchAllKeyed(0, 0);
     $start_time = strtotime('-90 days');
 
+    if (empty($entities)) {
+      $query->orderBy('base_table.' . $block_content->field_sorting->value);
+      $query->range(0, $block_content->field_item_amount->value);
+      return $query->execute()->fetchAllKeyed(0, 0);
+    }
+
     switch ($block_content->field_sorting->value) {
       case 'most_commented':
         if ($entity_type === 'group') {


### PR DESCRIPTION
## Problem
As a CM I want to sort content for the custom content block according to my specific use case

## Solution
- Add sorting by most commented
- Add sorting by most liked

## Issue tracker
- https://www.drupal.org/project/social/issues/3118044
- https://getopensocial.atlassian.net/browse/YANG-2000

## How to test
- When you open Add Custom content list block custom block page (/block/add/custom_content_list) then you should see that these page doesn't use an administrative theme
- You should see two extra sorting options (most commented and most liked)
- Use a new specific sorting
- Paste this block to the Complementary top region

## Screenshots
![image](https://user-images.githubusercontent.com/50984627/76079404-403de300-5fad-11ea-9055-b80ff5f89c13.png)
![image](https://user-images.githubusercontent.com/50984627/76079465-5f3c7500-5fad-11ea-8fe8-28058f53384d.png)