### PR TITLE
add [social_user:recepient] token

### DIFF
--- a/modules/social_features/social_user/social_user.tokens.inc
+++ b/modules/social_features/social_user/social_user.tokens.inc
@@ -16,7 +16,7 @@ function social_user_token_info() {
     'description' => t('Tokens from the social user module.'),
   ];
 
-  $social_user['recepient'] = [
+  $social_user['recipient'] = [
     'name' => t('The display name of the Receiver of the email.'),
     'description' => t('The individual display name of a user, when receiving an email.'),
   ];
@@ -42,7 +42,7 @@ function social_user_tokens($type, $tokens, array $data, array $options, Bubblea
     foreach ($tokens as $name => $original) {
       switch ($name) {
 
-        case 'recepient':
+        case 'recipient':
 
           if (isset($data['display_name'])) {
             $replacements[$original] = $data['display_name'];

--- a/modules/social_features/social_user/social_user.tokens.inc
+++ b/modules/social_features/social_user/social_user.tokens.inc
@@ -11,7 +11,6 @@ use Drupal\Core\Render\BubbleableMetadata;
  * Implements hook_token_info().
  */
 function social_user_token_info() {
-
   $type = [
     'name' => t('Social User'),
     'description' => t('Tokens from the social user module.'),

--- a/modules/social_features/social_user/social_user.tokens.inc
+++ b/modules/social_features/social_user/social_user.tokens.inc
@@ -6,7 +6,6 @@
  */
 
 use Drupal\Core\Render\BubbleableMetadata;
-use Drupal\Core\Render\Markup;
 
 /**
  * Implements hook_token_info().

--- a/modules/social_features/social_user/social_user.tokens.inc
+++ b/modules/social_features/social_user/social_user.tokens.inc
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * @file
+ * Builds placeholder replacement tokens for Social Group module.
+ */
+
+use Drupal\Core\Render\BubbleableMetadata;
+use Drupal\Core\Render\Markup;
+
+/**
+ * Implements hook_token_info().
+ */
+function social_user_token_info() {
+
+  $type = [
+    'name' => t('Social User'),
+    'description' => t('Tokens from the social user module.'),
+  ];
+
+  $social_user['recepient'] = [
+    'name' => t('The display name of the Receiver of the email.'),
+    'description' => t('The individual display name of a user, when receiving an email.'),
+  ];
+
+  return [
+    'types' => ['social_user' => $type],
+    'tokens' => [
+      'social_user' => $social_user,
+    ],
+  ];
+}
+
+/**
+ * Implements hook_tokens().
+ */
+function social_user_tokens($type, $tokens, array $data, array $options, BubbleableMetadata $bubbleable_metadata) {
+  $replacements = [];
+
+  if ($type == 'social_user' && !empty($data['message'])) {
+    /** @var \Drupal\message\Entity\Message $message */
+    $message = $data['message'];
+
+    foreach ($tokens as $name => $original) {
+      switch ($name) {
+
+        case 'recepient':
+
+          if (isset($data['display_name'])) {
+            $replacements[$original] = $data['display_name'];
+          }
+          break;
+      }
+    }
+  }
+
+  return $replacements;
+}

--- a/modules/social_features/social_user/src/Plugin/Action/SocialSendEmail.php
+++ b/modules/social_features/social_user/src/Plugin/Action/SocialSendEmail.php
@@ -237,7 +237,7 @@ class SocialSendEmail extends ViewsBulkOperationsActionBase implements Container
       '#default_value' => $form_state->getValue('message'),
       '#cols' => '80',
       '#rows' => '20',
-      '#description' => $this->t("You can use the token [social_user:recepient] for a personalized salutation, to add the users name in your email"),
+      '#description' => $this->t("You can use the token [social_user:recipient] for a personalized salutation, to add the users name in your email"),
     ];
 
     if ($this->allowTextFormat) {

--- a/modules/social_features/social_user/src/Plugin/Action/SocialSendEmail.php
+++ b/modules/social_features/social_user/src/Plugin/Action/SocialSendEmail.php
@@ -237,7 +237,7 @@ class SocialSendEmail extends ViewsBulkOperationsActionBase implements Container
       '#default_value' => $form_state->getValue('message'),
       '#cols' => '80',
       '#rows' => '20',
-      '#description' => $this->t("You can use the token [social_user:recepient] for a personalized salutation, to print the users name in your email"),
+      '#description' => $this->t("You can use the token [social_user:recepient] for a personalized salutation, to add the users name in your email"),
     ];
 
     if ($this->allowTextFormat) {

--- a/modules/social_features/social_user/src/Plugin/Action/SocialSendEmail.php
+++ b/modules/social_features/social_user/src/Plugin/Action/SocialSendEmail.php
@@ -237,6 +237,7 @@ class SocialSendEmail extends ViewsBulkOperationsActionBase implements Container
       '#default_value' => $form_state->getValue('message'),
       '#cols' => '80',
       '#rows' => '20',
+      '#description' => $this->t("You can use the token [social_user:recepient] for a personalized salutation, to print the users name in your email"),
     ];
 
     if ($this->allowTextFormat) {

--- a/modules/social_features/social_user/src/Plugin/QueueWorker/UserMailQueueProcessor.php
+++ b/modules/social_features/social_user/src/Plugin/QueueWorker/UserMailQueueProcessor.php
@@ -115,7 +115,7 @@ class UserMailQueueProcessor extends QueueWorkerBase implements ContainerFactory
           foreach ($users as $user) {
             // Attempt sending mail.
             if ($user->getEmail()) {
-              $this->sendMail($user->getEmail(), $user->language()->getId(), $queue_storage);
+              $this->sendMail($user->getEmail(), $user->language()->getId(), $queue_storage, $user->getDisplayName());
             }
           }
         }


### PR DESCRIPTION
## Problem
When using "Send email to group members" you are not abel to personalize the salutation.

You can't say:

"Hello [username],
please enjoy the new discussion here"

you can only have a common salutation:

"Hello all,
please enjoy the new discussion here"

## Solution
Idea, spend social_user module a recepient token which enable group managers / admins to send emails with a personalized salutation.

## Issue tracker
https://www.drupal.org/project/social/issues/3119823

## How to test
- [ ] Install the patch
- [ ] go to manage group members page for a group of your choice
- [ ] Write a mail and use the token [social_user:recipient] in the message body
- [ ] Check, that you receive an email with your display name, that replaced the token

## Screenshots
![Screen Shot 2021-01-07 at 2 41 15 PM](https://user-images.githubusercontent.com/8435994/103874438-1e464d00-50f7-11eb-99a6-25288b700889.png)

<img width="1677" alt="Screen Shot 2021-01-07 at 2 42 50 PM" src="https://user-images.githubusercontent.com/8435994/103874672-7aa96c80-50f7-11eb-8039-d4e4e1969d9e.png">

## Release notes
A group manager will now be able to send now emails to group members with a personalized salutation using the tokens in message body.

## Change Record
There is a new token declared in social_user module called [social_user:recipient] which will enabled user to add the display name of user in message body.

## Translations
- [ ] N.A
