### PR TITLE
Fix compatibility with Mink 1.8.0

### DIFF
--- a/tests/behat/features/bootstrap/FeatureContext.php
+++ b/tests/behat/features/bootstrap/FeatureContext.php
@@ -45,12 +45,21 @@ class FeatureContext extends RawMinkContext implements Context, SnippetAccepting
      * @param \Behat\Behat\Hook\Scope\BeforeScenarioScope $scope
      */
     public function before(BeforeScenarioScope $scope) {
+      // Start a session if not already done.
+      // Needed since https://github.com/minkphp/Mink/pull/705
+      // Otherwise resizeWindow will throw an error.
+      if (!$this->getSession()->isStarted()) {
+        $this->getSession()->start();
+      }
+
       // Let's disable the tour module for all tests by default.
       \Drupal::configFactory()->getEditable('social_tour.settings')->set('social_tour_enabled', 0)->save();
 
       /** @var \Behat\Testwork\Environment\Environment $environment */
       $environment = $scope->getEnvironment();
       $this->minkContext = $environment->getContext(SocialMinkContext::class);
+
+      $this->getSession()->resizeWindow(1280, 2024, 'current');
     }
 
   /**
@@ -474,14 +483,6 @@ class FeatureContext extends RawMinkContext implements Context, SnippetAccepting
         array_search($checkAfter, $items),
         "$textBefore does not proceed $textAfter"
       );
-    }
-
-    /**
-     * @BeforeScenario
-     */
-    public function resizeWindow()
-    {
-      $this->getSession()->resizeWindow(1280, 2024, 'current');
     }
 
     /**

--- a/tests/behat/features/bootstrap/SocialDrupalContext.php
+++ b/tests/behat/features/bootstrap/SocialDrupalContext.php
@@ -27,6 +27,13 @@ class SocialDrupalContext extends DrupalContext {
    * @BeforeScenario
    */
   public function prepareBigPipeNoJsCookie(BeforeScenarioScope $scope) {
+    // Start a session if not already done.
+    // Needed since https://github.com/minkphp/Mink/pull/705
+    // Otherwise executeScript or setCookie will throw an error.
+    if (!$this->getSession()->isStarted()) {
+      $this->getSession()->start();
+    }
+
     try {
       // Check if JavaScript can be executed by Driver.
       $this->getSession()->getDriver()->executeScript('true');


### PR DESCRIPTION
Mink 1.8.0 no longer automatically starts a session when `getSession` is
called. This breaks some `beforeScenario` steps that rely on the
sessions (for example, testing JS support or resizing the window).

This commit simply checks whether the session is started before calling
any methods on the session, starting it if needed. This is only done in
`beforeScenario` calls that actually use the session.

For `FeatureContext` the beforeScenario calls are merged because I'm
unsure whether we can rely on call order.

Change in Mink: https://github.com/minkphp/Mink/pull/705

*Should be backported to all supported branches*

## Issue tracker
No issue, issue in testing.

## How to test
- [ ] Travis should be green again

## Release notes
N/A

## Change Record
N/A