### PR TITLE
Issue #3120580 by Kingdutch: Label of hero image in Sky flavour is vi…

### DIFF
--- a/modules/social_features/social_page/config/install/core.entity_view_display.node.page.hero.yml
+++ b/modules/social_features/social_page/config/install/core.entity_view_display.node.page.hero.yml
@@ -29,7 +29,7 @@ content:
   field_page_image:
     type: image
     weight: 0
-    label: above
+    label: hidden
     settings:
       image_style: social_xx_large
       image_link: ''
@@ -40,9 +40,9 @@ content:
     region: content
   links:
     weight: 1
+    region: content
     settings: {  }
     third_party_settings: {  }
-    region: content
   shariff_field:
     weight: 4
     region: content

--- a/modules/social_features/social_page/config/update/social_page_update_8001.yml
+++ b/modules/social_features/social_page/config/update/social_page_update_8001.yml
@@ -1,0 +1,10 @@
+core.entity_view_display.node.page.hero:
+  expected_config:
+    content:
+      field_page_image:
+        label: above
+  update_actions:
+    change:
+      content:
+        field_page_image:
+          label: hidden

--- a/modules/social_features/social_page/social_page.install
+++ b/modules/social_features/social_page/social_page.install
@@ -77,3 +77,29 @@ function _social_page_get_permissions($role) {
   }
   return [];
 }
+
+/**
+ * Implements hook_update_dependencies().
+ */
+function social_page_update_dependencies() {
+  // New config changes should run after the update helper module is enabled.
+  $dependencies['social_page'][8801] = [
+    'social_core' => 8805,
+  ];
+
+  return $dependencies;
+}
+
+/**
+ * Ensure the hero image field label is not visible.
+ */
+function social_page_update_8001() {
+  /** @var \Drupal\update_helper\Updater $updateHelper */
+  $updateHelper = \Drupal::service('update_helper.updater');
+
+  // Execute configuration update definitions with logging of success.
+  $updateHelper->executeUpdate('social_page', 'social_page_update_8001');
+
+  // Output logged messages to related channel of update execution.
+  return $updateHelper->logger()->output();
+}


### PR DESCRIPTION
…sible

<h2>Problem</h2>

The templates added for the Sky theme were improved in that they more closely render what is configured in the Drupal display layer. However, because this was previously not the case, some configurations are set to display field labels where this shouldn't happen.

<h2>Solution</h2>
Configure the hero view mode for basic pages so that it doesn't show the label for the image field.

## Issue tracker
https://www.drupal.org/project/social/issues/3120580

## How to test
- [ ] Create and view a basic page in the sky flavour

## Release notes
The label of the image field in the hero when using the Sky theme is now properly hidden.
