### PR TITLE
Issue #3115796 by Kingdutch, ronaldtebrake: Create update hook after …

### DIFF
--- a/modules/social_features/social_search/modules/social_search_autocomplete/config/install/views.view.search_all_autocomplete.yml
+++ b/modules/social_features/social_search/modules/social_search_autocomplete/config/install/views.view.search_all_autocomplete.yml
@@ -11,8 +11,6 @@ dependencies:
     - search_api
     - serialization
     - user
-_core:
-  default_config_hash: OqzYowGv0kur_1XWmN81Ha5sf6JuKniFTDMmEyUsUi0
 id: search_all_autocomplete
 label: 'Search All autocomplete'
 module: views
@@ -20,7 +18,6 @@ description: 'Provides a REST endpoint for the Search API to be used for autocom
 tag: ''
 base_table: search_api_index_social_all
 base_field: search_api_id
-core: 8.x
 display:
   default:
     display_plugin: default

--- a/modules/social_features/social_search/modules/social_search_autocomplete/config/update/social_search_autocomplete_update_8001.yml
+++ b/modules/social_features/social_search/modules/social_search_autocomplete/config/update/social_search_autocomplete_update_8001.yml
@@ -1,0 +1,51 @@
+views.view.search_all_autocomplete:
+  expected_config:
+    core: 8.x
+    display:
+      default:
+        display_options:
+          fields:
+            id:
+              alter:
+                alter_text: false
+                text: ''
+              fallback_options:
+                prefix: group/
+            nid:
+              alter:
+                alter_text: false
+                text: ''
+              fallback_options:
+                prefix: node/
+            uid:
+              alter:
+                alter_text: false
+                text: ''
+              fallback_options:
+                prefix: user/
+  update_actions:
+    change:
+      display:
+        default:
+          display_options:
+            fields:
+              id:
+                alter:
+                  alter_text: true
+                  text: 'group/{{ id }}'
+                fallback_options:
+                  prefix: ''
+              nid:
+                alter:
+                  alter_text: true
+                  text: 'node/{{ nid }}'
+                fallback_options:
+                  prefix: ''
+              uid:
+                alter:
+                  alter_text: true
+                  text: 'user/{{ uid }}'
+                fallback_options:
+                  prefix: ''
+    delete:
+      core: 8.x

--- a/modules/social_features/social_search/modules/social_search_autocomplete/config/update/social_search_autocomplete_update_8001.yml
+++ b/modules/social_features/social_search/modules/social_search_autocomplete/config/update/social_search_autocomplete_update_8001.yml
@@ -1,6 +1,5 @@
 views.view.search_all_autocomplete:
   expected_config:
-    core: 8.x
     display:
       default:
         display_options:
@@ -47,5 +46,3 @@ views.view.search_all_autocomplete:
                   text: 'user/{{ uid }}'
                 fallback_options:
                   prefix: ''
-    delete:
-      core: 8.x

--- a/modules/social_features/social_search/modules/social_search_autocomplete/social_search_autocomplete.install
+++ b/modules/social_features/social_search/modules/social_search_autocomplete/social_search_autocomplete.install
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * @file
+ * Install, update and uninstall functions for the search autocomplete module.
+ */
+
+/**
+ * Implements hook_update_dependencies().
+ */
+function social_search_autocomplete_update_dependencies() {
+  // New config changes should run after the update helper module is enabled.
+  $dependencies['social_search_autocomplete'][8801] = [
+    'social_core' => 8805,
+  ];
+
+  return $dependencies;
+}
+
+/**
+ * Fix search suggestion endpoint URLs on translated websites.
+ */
+function social_search_autocomplete_update_8001() {
+  /** @var \Drupal\update_helper\Updater $updateHelper */
+  $updateHelper = \Drupal::service('update_helper.updater');
+
+  // Execute configuration update definitions with logging of success.
+  $updateHelper->executeUpdate('social_search_autocomplete', 'social_search_autocomplete_update_8001');
+
+  // Output logged messages to related channel of update execution.
+  return $updateHelper->logger()->output();
+}


### PR DESCRIPTION
…replacing SocialLanguageMetadataBubblingUrlGenerator by Entity::toUrl implementations

<h3 id="summary-problem-motivation">Problem/Motivation</h3>
[#3098046] In this issue we replaced the SocialLanguageMetadataBubblingUrlGenerator by proper Entity::toUrl implementations.
one of the issues tackled in there was to alter the social autocomplete search view. This was never covered in an update hook.
https://github.com/goalgorilla/open_social/pull/1626/files#diff-9e6738ee851907d213dcf26d545c3eeb

This resulted in weird autocomplete URL's where there was still a prefix for groups / users so url's for search result lead to a page not found.

<h3 id="summary-proposed-resolution">Proposed resolution</h3>
Ensure the update hook is written so people have the correct changes in their configuration.


## Issue tracker
https://www.drupal.org/project/social/issues/3115796

## How to test
- [ ] Set site language to be non-english and ensure strings like "user" and "group" are  translated
- [ ] Confirm that Search Autocomplete fails (requires install from before 8.0)
- [ ] Run updates
- [ ] Confirm that Search Autocomplete works

## Release notes
The search suggestions now work properly for non-English sites after updating. This was previously only fixed for new installations and not for existing platforms.
