### PR TITLE
Add update and install hook to remove follow content button from topic small teassers

### DIFF
--- a/modules/social_features/social_follow_content/config/update/social_follow_content_update_8001.yml
+++ b/modules/social_features/social_follow_content/config/update/social_follow_content_update_8001.yml
@@ -1,0 +1,11 @@
+core.entity_view_display.node.topic.small_teaser:
+  expected_config:
+    content:
+      flag_follow_content: { }
+  update_actions:
+    add:
+      hidden:
+        flag_follow_content: true
+    delete:
+      content:
+        flag_follow_content: { }

--- a/modules/social_features/social_follow_content/social_follow_content.install
+++ b/modules/social_features/social_follow_content/social_follow_content.install
@@ -67,3 +67,29 @@ function _social_follow_content_get_permissions($role) {
   }
   return [];
 }
+
+/**
+ * Implements hook_update_dependencies().
+ */
+function social_follow_content_update_dependencies() {
+  // New config changes should run after the Update Helper module is enabled.
+  $dependencies['social_follow_content'][8801] = [
+    'social_core' => 8805,
+  ];
+
+  return $dependencies;
+}
+
+/**
+ * Remove follow content button from Topic small teasers.
+ */
+function social_follow_content_update_8001() {
+  /** @var \Drupal\update_helper\Updater $updateHelper */
+  $updateHelper = \Drupal::service('update_helper.updater');
+
+  // Execute configuration update definitions with logging of success.
+  $updateHelper->executeUpdate('social_follow_content', 'social_follow_content_update_8001');
+
+  // Output logged messages to related channel of update execution.
+  return $updateHelper->logger()->output();
+}

--- a/modules/social_features/social_follow_content/social_follow_content.module
+++ b/modules/social_features/social_follow_content/social_follow_content.module
@@ -15,6 +15,31 @@ use Drupal\flag\FlagInterface;
 use Drupal\node\NodeInterface;
 
 /**
+ * Implements hook_modules_installed().
+ */
+function social_follow_content_modules_installed($modules) {
+  // Check if the topic, flag or this module is being installed in which case
+  // the follow content field needs to be hidden for topic small teaser view
+  // modes. All these modules are checked because the order is not guaranteed
+  // and it's not quite known when the `flag_follow_content` field is added.
+  if (!empty(array_intersect(['social_topic', 'flag', 'social_follow_content'], $modules))) {
+    /** @var \Drupal\Core\Entity\EntityDisplayRepositoryInterface $entityDisplayRepository */
+    $entityDisplayRepository = \Drupal::service('entity_display.repository');
+    /** @var \Drupal\Core\Entity\Display\EntityViewDisplayInterface $view_mode */
+    $view_mode = $entityDisplayRepository->getViewDisplay('node', 'topic', 'small_teaser');
+    // The getViewDisplay returns a new view mode entity if one didn't already
+    // exist but only existing view modes should be edited.
+    if ($view_mode->isNew()) {
+      return;
+    }
+
+    // When a field gets moved to the hidden region its component just gets
+    // removed.
+    $view_mode->removeComponent('flag_follow_content')->save();
+  }
+}
+
+/**
  * Implements hook_ENTITY_TYPE_insert().
  */
 function social_follow_content_event_enrollment_insert(EntityInterface $entity) {


### PR DESCRIPTION

<h2>Problem</h2>
The follow content button is added after modules have been installed. 
It's also the result of an optional module so it's possible that the 
button doesn't exist. These factors don't allow the view display 
configuration for the field to be set in configuration that is shipped 
with our modules. 

<h2>Solution</h2>
To work around this an modules_installed hook is implemented that makes 
the change for us. An update hook is provided to fix platforms that 
installed a version that had the new templates to render before this fix 
was present.


## Issue tracker
https://www.drupal.org/project/social/issues/3120644

## How to test
- [ ] Install a platform and login to view the default stream page
- [ ] Before: with follow content buttons in recent topic block
- [ ] After: no follow content buttons in recent topic block

## Release notes
A new style for topic teasers caused the "follow content" button to show up in the teaser erroneously. This has been resolved.
