### PR TITLE
Issue #3123458 by Agami4: Fix position for the close button on the message block when using layout builder

### DIFF
--- a/themes/socialbase/assets/css/alert.css
+++ b/themes/socialbase/assets/css/alert.css
@@ -20,8 +20,8 @@
 
 .alert-dismissible .close {
   position: relative;
-  top: -0.75rem;
-  right: -1.25rem;
+  margin-top: -0.75rem;
+  margin-right: -1.25rem;
   padding: 0.75rem 1.25rem;
   color: inherit;
 }

--- a/themes/socialbase/assets/css/alert.css
+++ b/themes/socialbase/assets/css/alert.css
@@ -19,7 +19,6 @@
 }
 
 .alert-dismissible .close {
-  position: relative;
   margin-top: -0.75rem;
   margin-right: -1.25rem;
   padding: 0.75rem 1.25rem;

--- a/themes/socialbase/components/02-atoms/alert/alert.scss
+++ b/themes/socialbase/components/02-atoms/alert/alert.scss
@@ -55,7 +55,6 @@
 
   // Adjust close link position
   .close {
-    position: relative;
     margin-top: -$alert-padding-y;
     margin-right: -$alert-padding-x;
     padding: $alert-padding-y $alert-padding-x;

--- a/themes/socialbase/components/02-atoms/alert/alert.scss
+++ b/themes/socialbase/components/02-atoms/alert/alert.scss
@@ -56,8 +56,8 @@
   // Adjust close link position
   .close {
     position: relative;
-    top: -$alert-padding-y;
-    right: -$alert-padding-x;
+    margin-top: -$alert-padding-y;
+    margin-right: -$alert-padding-x;
     padding: $alert-padding-y $alert-padding-x;
     color: inherit;
   }


### PR DESCRIPTION
## Problem
The layout two columns(layout-builder module) has the wrong styles if you have a message block

## Solution
Update position for the close button on the message block

## Issue tracker
https://getopensocial.atlassian.net/browse/ECI-1020
https://www.drupal.org/project/social/issues/3123458

## How to test
- [x] Go to the Dashboard
- [x] Crear caches and you can have a message block

## Screenshots
Before:
![image-20200319-144842](https://user-images.githubusercontent.com/16086340/77314425-456d9280-6d0e-11ea-95ad-645e532df78c.png)

After:
<img width="1317" alt="Screenshot at Mar 23 13-57-23" src="https://user-images.githubusercontent.com/16086340/77314435-4acadd00-6d0e-11ea-92f6-d55b4eb26a02.png">
