### PR TITLE
Issue #3123549 by ribel: Hide tabs from /user/x/profile page

### DIFF
--- a/modules/social_features/social_core/config/optional/block.block.socialbase_local_tasks.yml
+++ b/modules/social_features/social_core/config/optional/block.block.socialbase_local_tasks.yml
@@ -30,6 +30,6 @@ visibility:
       user: '@user.current_user_context:current_user'
   request_path:
     id: request_path
-    pages: "post/*/edit\r\npost/*/delete\r\n/post/*/edit\r\n/post/*/delete"
+    pages: "/post/*/edit\r\n/post/*/delete\r\n/user/*/edit\r\n/user/*/profile\r\n/group/*/edit"
     negate: true
     context_mapping: {  }

--- a/modules/social_features/social_core/config/optional/block.block.socialblue_local_tasks.yml
+++ b/modules/social_features/social_core/config/optional/block.block.socialblue_local_tasks.yml
@@ -30,6 +30,6 @@ visibility:
       user: '@user.current_user_context:current_user'
   request_path:
     id: request_path
-    pages: "post/*/edit\r\npost/*/delete\r\n/post/*/edit\r\n/post/*/delete\r\n/user/*/edit\r\n/group/*/edit"
+    pages: "/post/*/edit\r\n/post/*/delete\r\n/user/*/edit\r\n/user/*/profile\r\n/group/*/edit"
     negate: true
     context_mapping: {  }

--- a/modules/social_features/social_core/config/update/social_core_update_8808.yml
+++ b/modules/social_features/social_core/config/update/social_core_update_8808.yml
@@ -8,7 +8,7 @@ block.block.socialbase_local_tasks:
       visibility:
         request_path:
           pages: "/post/*/edit\r\n/post/*/delete\r\n/user/*/edit\r\n/user/*/profile\r\n/group/*/edit"
-block.block.block.block.socialblue_local_tasks:
+block.block.socialblue_local_tasks:
   expected_config:
     visibility:
       request_path:

--- a/modules/social_features/social_core/config/update/social_core_update_8808.yml
+++ b/modules/social_features/social_core/config/update/social_core_update_8808.yml
@@ -1,0 +1,20 @@
+block.block.socialbase_local_tasks:
+  expected_config:
+    visibility:
+      request_path:
+        pages: "post/*/edit\r\npost/*/delete\r\n/post/*/edit\r\n/post/*/delete"
+  update_actions:
+    change:
+      visibility:
+        request_path:
+          pages: "/post/*/edit\r\n/post/*/delete\r\n/user/*/edit\r\n/user/*/profile\r\n/group/*/edit"
+block.block.block.block.socialblue_local_tasks:
+  expected_config:
+    visibility:
+      request_path:
+        pages: "post/*/edit\r\npost/*/delete\r\n/post/*/edit\r\n/post/*/delete\r\n/user/*/edit\r\n/group/*/edit"
+  update_actions:
+    change:
+      visibility:
+        request_path:
+          pages: "/post/*/edit\r\n/post/*/delete\r\n/user/*/edit\r\n/user/*/profile\r\n/group/*/edit"

--- a/modules/social_features/social_core/social_core.install
+++ b/modules/social_features/social_core/social_core.install
@@ -1180,3 +1180,17 @@ function social_core_update_8807() {
   // Output logged messages to related channel of update execution.
   return $updateHelper->logger()->output();
 }
+
+/**
+ * Hide tabs from /user/x/profile page.
+ */
+function social_core_update_8808() {
+  /** @var \Drupal\update_helper\Updater $updateHelper */
+  $updateHelper = \Drupal::service('update_helper.updater');
+
+  // Execute configuration update definitions with logging of success.
+  $updateHelper->executeUpdate('social_core', 'social_core_update_8808');
+
+  // Output logged messages to related channel of update execution.
+  return $updateHelper->logger()->output();
+}


### PR DESCRIPTION
## Problem
On /user/x/profile the tabs are shown (in SKY style).

## Solution
Update block configs ad hide tabs on this page.

## Issue tracker
- https://www.drupal.org/project/social/issues/3123549

## How to test
- [ ] Switch to the SKY style
- [ ] Go to /user/x/profile page
- [ ] You should not see Tabs near the page title

## Screenshots
![image](https://user-images.githubusercontent.com/2241917/77934715-27c59d80-72b9-11ea-8e0d-592350c2d803.png)
