### PR TITLE
Issue #3123861 by Kingdutch: Image label is visible on basic page tea…

### DIFF
--- a/config/optional/core.entity_view_display.node.book.teaser.yml
+++ b/config/optional/core.entity_view_display.node.book.teaser.yml
@@ -23,7 +23,7 @@ content:
   field_book_image:
     type: image
     weight: 0
-    label: hide
+    label: hidden
     settings:
       image_style: social_x_large
       image_link: content

--- a/config/optional/core.entity_view_display.node.book.teaser.yml
+++ b/config/optional/core.entity_view_display.node.book.teaser.yml
@@ -23,7 +23,7 @@ content:
   field_book_image:
     type: image
     weight: 0
-    label: above
+    label: hide
     settings:
       image_style: social_x_large
       image_link: content

--- a/modules/social_features/social_book/config/update/social_book_update_8802.yml
+++ b/modules/social_features/social_book/config/update/social_book_update_8802.yml
@@ -1,0 +1,20 @@
+core.entity_view_display.node.book.teaser:
+  expected_config:
+    content:
+      field_book_image:
+        label: above
+  update_actions:
+    change:
+      content:
+        field_book_image:
+          label: hidden
+core.entity_view_display.node.book.hero:
+  expected_config:
+    content:
+      field_book_image:
+        label: above
+  update_actions:
+    change:
+      content:
+        field_book_image:
+          label: hidden

--- a/modules/social_features/social_book/social_book.install
+++ b/modules/social_features/social_book/social_book.install
@@ -28,6 +28,12 @@ function social_book_update_dependencies() {
     'social_core' => 8802,
   ];
 
+  // Ensure update helper dependant hooks run after update helper
+  // is enabled.
+  $dependencies['social_book'][8802] = [
+    'social_core' => 8805,
+  ];
+
   return $dependencies;
 }
 

--- a/modules/social_features/social_book/social_book.install
+++ b/modules/social_features/social_book/social_book.install
@@ -147,3 +147,17 @@ function social_book_update_8801() {
     }
   }
 }
+
+/**
+ * Hide image label in teasers.
+ */
+function social_book_update_8802() {
+  /** @var \Drupal\update_helper\Updater $updateHelper */
+  $updateHelper = \Drupal::service('update_helper.updater');
+
+  // Execute configuration update definitions with logging of success.
+  $updateHelper->executeUpdate('social_book', 'social_book_update_8802');
+
+  // Output logged messages to related channel of update execution.
+  return $updateHelper->logger()->output();
+}

--- a/modules/social_features/social_page/config/install/core.entity_view_display.node.page.teaser.yml
+++ b/modules/social_features/social_page/config/install/core.entity_view_display.node.page.teaser.yml
@@ -14,8 +14,6 @@ dependencies:
     - image
     - options
     - user
-_core:
-  default_config_hash: 9sTjSemSHaUnHQeBsGy479G03O1t-_i_tHF7IHFPEO0
 id: node.page.teaser
 targetEntityType: node
 bundle: page
@@ -31,7 +29,7 @@ content:
   field_page_image:
     type: image
     weight: 0
-    label: above
+    label: hidden
     settings:
       image_style: social_x_large
       image_link: content

--- a/modules/social_features/social_page/config/update/social_page_update_8002.yml
+++ b/modules/social_features/social_page/config/update/social_page_update_8002.yml
@@ -1,0 +1,10 @@
+core.entity_view_display.node.page.teaser:
+  expected_config:
+    content:
+      field_page_image:
+        label: above
+  update_actions:
+    change:
+      content:
+        field_page_image:
+          label: hidden

--- a/modules/social_features/social_page/social_page.install
+++ b/modules/social_features/social_page/social_page.install
@@ -103,3 +103,17 @@ function social_page_update_8001() {
   // Output logged messages to related channel of update execution.
   return $updateHelper->logger()->output();
 }
+
+/**
+ * Hide image label in teasers.
+ */
+function social_page_update_8002() {
+  /** @var \Drupal\update_helper\Updater $updateHelper */
+  $updateHelper = \Drupal::service('update_helper.updater');
+
+  // Execute configuration update definitions with logging of success.
+  $updateHelper->executeUpdate('social_page', 'social_page_update_8002');
+
+  // Output logged messages to related channel of update execution.
+  return $updateHelper->logger()->output();
+}


### PR DESCRIPTION
…sers
<h2>Problem</h2>
The view configuration shows the label for the image of basic pages and book pages in teasers and heros.

<h2>Solution</h2>
Update the view configuration

## Issue tracker
https://www.drupal.org/project/social/issues/3123861

## How to test
- [ ] View a basic page in the search results
- [ ] Create (with hero image) and view the detail page of a book page.

## Screenshots
If this Pull Request makes visual changes then please include some screenshots that show what has changed here. 

## Release notes
The label for the image field is no longer visible in teasers for basic pages.
