### PR TITLE
Issue #3124378 by rolki: Add an extra condition for commented entity

### DIFF
--- a/modules/custom/group_core_comments/src/GroupCommentAccessControlHandler.php
+++ b/modules/custom/group_core_comments/src/GroupCommentAccessControlHandler.php
@@ -4,6 +4,7 @@ namespace Drupal\group_core_comments;
 
 use Drupal\Core\Access\AccessResult;
 use Drupal\comment\CommentAccessControlHandler;
+use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\group\Entity\GroupContent;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Session\AccountInterface;
@@ -26,6 +27,9 @@ class GroupCommentAccessControlHandler extends CommentAccessControlHandler {
     $parent_access = parent::checkAccess($entity, $operation, $account);
 
     $commented_entity = $entity->getCommentedEntity();
+    if (!($commented_entity instanceof ContentEntityInterface)) {
+      return AccessResult::neutral();
+    }
     $group_contents = GroupContent::loadByEntity($commented_entity);
 
     // Check for 'delete all comments' permission in case content is not from


### PR DESCRIPTION
## Problem
During comment migration by Migrate API faced an error:
`TypeError: Argument 1 Passed to Drupal\group\Entity\GroupContent::loadByEntity0 must implement interface ContentEntityInterface`

## Solution
Add an extra condition for commented entity

## Issue tracker
https://www.drupal.org/project/social/issues/3124378

## How to test
Try to run any migration for comments

## Release notes
Add an extra check for the commented entity in `group_core_comments/src/GroupCommentAccessControlHandler.php` to prevent errors with migrate API.

## Screenshots
![image](https://user-images.githubusercontent.com/50984627/78231147-0b08b000-74db-11ea-848e-3fc5641d72a9.png)

