### PR TITLE
Issue #3125226 by agami4: Update info tab layout on the profile and group page

### DIFF
--- a/themes/socialblue/templates/group/group--default--sky.html.twig
+++ b/themes/socialblue/templates/group/group--default--sky.html.twig
@@ -41,7 +41,6 @@
 #}
 {% if content.field_group_description|render %}
   <div{{ attributes.addClass('card') }}>
-    <h2 class="card__title">{% trans %} Introduction {% endtrans %}</h2>
     <div{{ content_attributes.addClass('card__body body-text') }}>
       {{ content.field_group_description }}
     </div>

--- a/themes/socialblue/templates/profile/profile--profile--default--sky.html.twig
+++ b/themes/socialblue/templates/profile/profile--profile--default--sky.html.twig
@@ -76,10 +76,6 @@
       </div>
     {% endif %}
 
-    {% if (content.field_profile_phone_number|render or user_mail or content.field_profile_address|render) %}
-      <h4>{% trans %}Contact information{% endtrans %}</h4>
-    {% endif %}
-
     {% if content.field_profile_phone_number|render %}
       <div class="list-item card--content-merged__list">
           <div class="list-item__label">{% trans %}Phone{% endtrans %}</div>
@@ -138,7 +134,7 @@
 
     {{  content|without('field_profile_phone_number', 'user_mail', 'field_profile_address',
       'field_profile_self_introduction', 'field_profile_interests', 'field_profile_expertise',
-      'field_profile_profile_tag') }}
+      'field_profile_profile_tag', 'field_manager_notes') }}
 
     {% if (content|render is empty and user_mail is empty)%}
         {% trans %}{{ profile_name }} {{ profile_name_extra }} has not shared profile information.{% endtrans %}
@@ -146,3 +142,7 @@
 
   </div>
 </div>
+
+{% if (content.field_manager_notes|render) %}
+  {{ content.field_manager_notes }}
+{% endif %}

--- a/themes/socialblue/templates/profile/profile--profile--default--sky.html.twig
+++ b/themes/socialblue/templates/profile/profile--profile--default--sky.html.twig
@@ -68,6 +68,14 @@
 
 <div class="card">
   <div class="card__body card--content-merged">
+    {% if content.field_profile_self_introduction|render %}
+      <div class="card--content-merged__list">
+        <div class="list-item__text">
+          {{ content.field_profile_self_introduction }}
+        </div>
+      </div>
+    {% endif %}
+
     {% if (content.field_profile_phone_number|render or user_mail or content.field_profile_address|render) %}
       <h4>{% trans %}Contact information{% endtrans %}</h4>
     {% endif %}
@@ -92,15 +100,6 @@
           <div class="list-item__text">
               {{ content.field_profile_address }}
           </div>
-      </div>
-    {% endif %}
-
-    {% if content.field_profile_self_introduction|render %}
-      <div class="card--content-merged__list">
-        <h5>{% trans %}Intro{% endtrans %}</h5>
-        <div class="list-item__text">
-          {{ content.field_profile_self_introduction }}
-        </div>
       </div>
     {% endif %}
 


### PR DESCRIPTION
## Solution
The introduction part full width of the content card, but keep the rest of the fields in the 2 columns layout.

## Issue tracker
https://www.drupal.org/project/social/issues/3125226
https://getopensocial.atlassian.net/browse/YANG-2648

## How to test
- [ ] Go to the profile page and click to the information tab

## Screenshots
![profile_introduction_desktop](https://user-images.githubusercontent.com/16086340/78544796-600e3400-7803-11ea-81e9-a6e5ad483a7f.png)
