### PR TITLE
Issue #3125249 by ribel: Fix complementary region moving page content to the side

### DIFF
--- a/modules/social_features/social_core/config/optional/block.block.socialblue_local_actions.yml
+++ b/modules/social_features/social_core/config/optional/block.block.socialblue_local_actions.yml
@@ -19,6 +19,6 @@ settings:
 visibility:
   request_path:
     id: request_path
-    pages: "/admin/reports/*\r\n/group/*/membership\r\n/node/*/all-enrollments"
+    pages: "/admin/reports/*\r\n/group/*/membership\r\n/group/*/join\r\n/group/*/leave\r\n/group/*/delete\r\n/node/*/all-enrollments\r\n/node/*/delete\r\n/user/*/edit"
     negate: true
     context_mapping: {  }

--- a/modules/social_features/social_core/config/optional/block.block.socialblue_local_actions.yml
+++ b/modules/social_features/social_core/config/optional/block.block.socialblue_local_actions.yml
@@ -19,6 +19,6 @@ settings:
 visibility:
   request_path:
     id: request_path
-    pages: "/admin/reports/*\r\n/group/*/membership\r\n/group/*/join\r\n/group/*/leave\r\n/group/*/delete\r\n/node/*/all-enrollments\r\n/node/*/delete\r\n/user/*/edit"
+    pages: "/admin/reports/*\r\n/group/*/membership\r\n/group/*/join\r\n/group/*/leave\r\n/group/*/delete\r\n/group/*/content/*\r\n/node/*/all-enrollments\r\n/node/*/delete\r\n/user/*/edit"
     negate: true
     context_mapping: {  }

--- a/modules/social_features/social_core/config/update/social_core_update_8809.yml
+++ b/modules/social_features/social_core/config/update/social_core_update_8809.yml
@@ -1,0 +1,10 @@
+block.block.socialblue_local_actions:
+  expected_config:
+    visibility:
+      request_path:
+        pages: "/admin/reports/*\r\n/group/*/membership\r\n/node/*/all-enrollments"
+  update_actions:
+    change:
+      visibility:
+        request_path:
+          pages: "/admin/reports/*\r\n/group/*/membership\r\n/group/*/join\r\n/group/*/leave\r\n/group/*/delete\r\n/node/*/all-enrollments\r\n/node/*/delete\r\n/user/*/edit"

--- a/modules/social_features/social_core/config/update/social_core_update_8809.yml
+++ b/modules/social_features/social_core/config/update/social_core_update_8809.yml
@@ -7,4 +7,4 @@ block.block.socialblue_local_actions:
     change:
       visibility:
         request_path:
-          pages: "/admin/reports/*\r\n/group/*/membership\r\n/group/*/join\r\n/group/*/leave\r\n/group/*/delete\r\n/node/*/all-enrollments\r\n/node/*/delete\r\n/user/*/edit"
+          pages: "/admin/reports/*\r\n/group/*/membership\r\n/group/*/join\r\n/group/*/leave\r\n/group/*/delete\r\n/group/*/content/*\r\n/node/*/all-enrollments\r\n/node/*/delete\r\n/user/*/edit"

--- a/modules/social_features/social_core/social_core.install
+++ b/modules/social_features/social_core/social_core.install
@@ -1194,3 +1194,17 @@ function social_core_update_8808() {
   // Output logged messages to related channel of update execution.
   return $updateHelper->logger()->output();
 }
+
+/**
+ * Hide primary admin actions from /user/x/edit and some other pages.
+ */
+function social_core_update_8809() {
+  /** @var \Drupal\update_helper\Updater $updateHelper */
+  $updateHelper = \Drupal::service('update_helper.updater');
+
+  // Execute configuration update definitions with logging of success.
+  $updateHelper->executeUpdate('social_core', 'social_core_update_8809');
+
+  // Output logged messages to related channel of update execution.
+  return $updateHelper->logger()->output();
+}

--- a/themes/socialblue/templates/layout/page--sky.html.twig
+++ b/themes/socialblue/templates/layout/page--sky.html.twig
@@ -59,7 +59,7 @@
         {{ page.secondary_navigation }}
       {% endif %}
 
-      {% if page.complementary_top|render|striptags|trim or page.complementary_bottom|render|striptags|trim %}
+      {% if page.complementary_top or page.complementary_bottom %}
         <aside class="region--complementary" role="complementary">
           <div class="content-merged--sky--complementary card">
             {% if page.complementary_top %}


### PR DESCRIPTION
## Problem
The socialblue_local_actions is rendered lazily, this can cause the simple `if` check to be false. This is not a problem in the normal layout because the content is limited to 67% width and this region just fills the remaining 1/3rd of the page.

However, in Sky, this is problematic because the region is moved to the left which causes the other content to be shifted to the right even if there appears to be no actual content.

## Solution
Hide socialblue_local_actions on those pages where we don't have any blocks in the sidebar.

## Issue tracker
- https://www.drupal.org/project/social/issues/3125249

## How to test
- [ ] Run hook update
- [ ] Go to /user/*/edit page
- [ ] You should not see layout issue like on the screenshot below

## Screenshots
![image](https://user-images.githubusercontent.com/2241917/78547975-9b5f3180-7808-11ea-8c20-bf394d824a03.png)

## Release notes
Fix complementary region moving page content to the side
