### PR TITLE
Issue #3125295 by Kingdutch: There is space beneath teaser images in …

### DIFF
--- a/themes/socialbase/assets/css/stream.css
+++ b/themes/socialbase/assets/css/stream.css
@@ -90,7 +90,7 @@
   flex-shrink: 0;
 }
 
-.teaser--stream {
+.teaser.teaser--stream {
   margin-top: 0.625rem;
   margin-right: -1.25rem;
   margin-bottom: 0.625rem;
@@ -98,7 +98,7 @@
   background: #e6e6e6;
 }
 
-.teaser--stream:last-child {
+.teaser.teaser--stream:last-child {
   margin-bottom: -1.25rem;
 }
 
@@ -145,10 +145,10 @@
   .card--stream .comment__avatar {
     margin-right: 12px;
   }
-  .teaser--stream {
+  .teaser.teaser--stream {
     height: 200px;
   }
-  .teaser--stream .teaser__image {
+  .teaser.teaser--stream .teaser__image {
     height: 200px;
     flex: 0 0 200px;
   }

--- a/themes/socialbase/components/04-organisms/stream/stream.scss
+++ b/themes/socialbase/components/04-organisms/stream/stream.scss
@@ -132,7 +132,7 @@
 }
 
 
-.teaser--stream {
+.teaser.teaser--stream {
   margin-top: ($card-spacer-x/2);
   margin-right: -$card-spacer-x;
   margin-bottom: ($card-spacer-x/2);

--- a/themes/socialblue/assets/css/stream--sky.css
+++ b/themes/socialblue/assets/css/stream--sky.css
@@ -1,15 +1,15 @@
 .socialblue--sky .card--stream {
   margin-bottom: 1.5rem;
 }@media (min-width: 600px) {
-  .socialblue--sky .teaser--stream {
+  .socialblue--sky .teaser.teaser--stream {
     height: 180px;
   }
-  .socialblue--sky .teaser--stream .teaser__image {
+  .socialblue--sky .teaser.teaser--stream .teaser__image {
     height: 180px;
     flex: 0 0 180px;
   }
 }@media (min-width: 900px) {
-  .socialblue--sky .teaser--stream .teaser__title {
+  .socialblue--sky .teaser.teaser--stream .teaser__title {
     font-size: 1.125rem;
     margin-bottom: 10px;
   }

--- a/themes/socialblue/components/04-organisms/stream/stream--sky.scss
+++ b/themes/socialblue/components/04-organisms/stream/stream--sky.scss
@@ -1,7 +1,7 @@
 @import "settings";
 
 .socialblue--sky {
-  .teaser--stream {
+  .teaser.teaser--stream {
     @include for-tablet-portrait-up {
       height: 180px;
     }


### PR DESCRIPTION
…some situations

<h2>Problem</h2>

The <code>.teaser--stream</code> selector is not more specific than the <code>.teaser</code> selector. In some situations this causes the styles for <code>.teaser</code> to be applied last. This can break the height for stream teasers causing visual issues with images.

<h2>Solution</h2>
Change the selector to <code>.teaser.teaser--stream</code> so that it's more specific and styles are properly applied.

This should happen for both the default style as well as the sky flavour.

## Issue tracker
https://www.drupal.org/project/social/issues/3125295

## How to test
- [ ] Unsure how to reproduce, check our customer's sites

## Screenshots
Can only reproduce on non-public site, screenshot omitted.

## Release notes
In some cases the height of teasers in the stream was not set correctly. The teasers have been told to get in line.
