### PR TITLE
Issue #3125680 by navneet0693: Removed title property of field_profile_image.

### DIFF
--- a/modules/social_features/social_profile/config/install/field.field.profile.profile.field_profile_image.yml
+++ b/modules/social_features/social_profile/config/install/field.field.profile.profile.field_profile_image.yml
@@ -6,8 +6,6 @@ dependencies:
     - profile.type.profile
   module:
     - image
-_core:
-  default_config_hash: tSyQuKXSwEWCqPytdKi5gnT04E2SCEUfF6-3AUegANk
 id: profile.profile.field_profile_image
 field_name: field_profile_image
 entity_type: profile
@@ -31,7 +29,7 @@ settings:
   default_image:
     uuid: 4eb1d927-28f4-402a-8c87-017e637f434a
     alt: 'Default profile image'
-    title: 'Default profile image'
+    title: ''
     width: 200
     height: 200
   handler: 'default:file'

--- a/modules/social_features/social_profile/config/update/social_profile_update_8008.yml
+++ b/modules/social_features/social_profile/config/update/social_profile_update_8008.yml
@@ -1,0 +1,7 @@
+field.field.profile.profile.field_profile_image:
+  expected_config: {  }
+  update_actions:
+    change:
+      settings:
+        default_image:
+          title: ''

--- a/modules/social_features/social_profile/social_profile.install
+++ b/modules/social_features/social_profile/social_profile.install
@@ -310,3 +310,29 @@ function social_profile_update_8007(&$sandbox) {
     user_role_grant_permissions($role, $permissions);
   }
 }
+
+/**
+ * Remove title property from field_profile_image.
+ */
+function social_profile_update_8008() {
+  /** @var \Drupal\update_helper\Updater $updateHelper */
+  $updateHelper = \Drupal::service('update_helper.updater');
+
+  // Execute configuration update definitions with logging of success.
+  $updateHelper->executeUpdate('social_profile', 'social_profile_update_8008');
+
+  // Output logged messages to related channel of update execution.
+  return $updateHelper->logger()->output();
+}
+
+/**
+ * Implements hook_update_dependencies().
+ */
+function social_profile_update_dependencies() {
+  // Run the config update after the update_helper module is enabled.
+  $dependencies['social_profile'][8808] = [
+    'social_core' => 8805,
+  ];
+
+  return $dependencies;
+}


### PR DESCRIPTION
## Problem
Currently, when a user doesn't have a profile picture and if you hover over the user's picture, you will see "Default profile image" text. 
This is because browsers are picking up the 'title' property of a user's profile which set <code><img></code> tag in https://github.com/goalgorilla/open_social/blob/8.x-9.x/themes/socialbase/templates/profile/profile--compact.html.twig#L26

## Solution
Remove title's value in https://github.com/goalgorilla/open_social/blob/8.x-9.x/modules/social_features/social_profile/config/install/field.field.profile.profile.field_profile_image.yml#L34

## Issue tracker
https://www.drupal.org/project/social/issues/3125680

## How to test
- [ ] Run drush updb
- [ ] Create a user without any profile picture
- [ ] Login with new user and Enroll in an event
- [ ] Hover over the profile picture of the user where enrollees are shown in an event.
- [ ] You should be able to see username of the user.

## Screenshots
**Before**: 
![image](https://user-images.githubusercontent.com/8435994/78688366-7b596c00-78f5-11ea-8b6a-c36c953fb75c.png)

**After**:
![image](https://user-images.githubusercontent.com/8435994/78690824-3d117c00-78f8-11ea-93b4-53fabead79af.png)

## Release notes
Profile Image field will not have a default title by the installation.

## Change Record
The default image title property in the profile image field (field.field.profile.profile.field_profile_image) is removed.

## Translations
N.A
