### PR TITLE
Issue #3126265 by ribel: Fix behat test for group access roles when Contextual Links are enabled

### DIFF
--- a/tests/behat/features/capabilities/group/group-access-roles.feature
+++ b/tests/behat/features/capabilities/group/group-access-roles.feature
@@ -63,8 +63,7 @@ Feature: Group access roles
     And I should see "Join group Test closed group 3"
     And I should see the button "Cancel"
     And I press "Join group"
-    And I click the xth "0" element with the css ".navbar-nav .profile"
-    And I click "My groups"
+    And I am on "/my-groups"
     Then I click "Test closed group 3"
     And I should see the button "Joined"
 


### PR DESCRIPTION
## Problem
The test fails on step:
`And I click "My groups"`
_Element is not currently visible and so may not be interacted with_

## Solution
Rewrite step by using `And I am on "/my-groups"`

## Issue tracker
- https://www.drupal.org/project/social/issues/3126265

## How to test
- [ ] Enable Social Dashboard module
- [ ] Behat test should pass with this fix

## Screenshots
![image](https://user-images.githubusercontent.com/2241917/78885328-14f35b80-7a65-11ea-87e1-45719da077fa.png)

## Release notes
Fix behat test for group access roles when Contextual Links are enabled
