### PR TITLE
Issue #3127758 by sjoerdvandervis: Make search filters applicable on mobile

### DIFF
--- a/themes/socialbase/assets/css/offcanvas.css
+++ b/themes/socialbase/assets/css/offcanvas.css
@@ -28,7 +28,7 @@
 
 .offcanvas-body {
   margin-top: 30px;
-  padding-margin: 90px;
+  padding-bottom: 90px;
 }
 
 @media (min-width: 900px) {

--- a/themes/socialbase/assets/css/offcanvas.css
+++ b/themes/socialbase/assets/css/offcanvas.css
@@ -28,6 +28,7 @@
 
 .offcanvas-body {
   margin-top: 30px;
+  padding-margin: 90px;
 }
 
 @media (min-width: 900px) {

--- a/themes/socialbase/components/04-organisms/offcanvas/offcanvas.scss
+++ b/themes/socialbase/components/04-organisms/offcanvas/offcanvas.scss
@@ -93,7 +93,7 @@
 
 .offcanvas-body {
 	margin-top: 30px;
-  padding-margin: 90px;
+  padding-bottom: 90px;
 
   @include for-tablet-landscape-up {
     margin-top: 0;

--- a/themes/socialbase/components/04-organisms/offcanvas/offcanvas.scss
+++ b/themes/socialbase/components/04-organisms/offcanvas/offcanvas.scss
@@ -93,6 +93,7 @@
 
 .offcanvas-body {
 	margin-top: 30px;
+  padding-margin: 90px;
 
   @include for-tablet-landscape-up {
     margin-top: 0;


### PR DESCRIPTION
## Problem
When there are a lot of filters available on mobile, the canvas can't be scrolled to the filter button. Because of this, filters are not applicable (see screenshot).
![Screenshot 2020-04-10 at 15 33 06](https://user-images.githubusercontent.com/19951173/79312660-83219d80-7eff-11ea-9b0a-8006abc4ad19.png)


## Solution
Add some bottom padding to the filter section on mobile, to make sure the filter button is usable.
![Screenshot 2020-04-10 at 15 35 40](https://user-images.githubusercontent.com/19951173/79312697-92085000-7eff-11ea-8333-13b277ff8bb8.png)


## Issue tracker
https://www.drupal.org/project/social/issues/3127758

## How to test
- [x] As a LU, go to search and search for users using your mobile phone.
- [x] Add a filter and see you can use the filters by clicking the filter button at the bottom of the filter section.