### PR TITLE
Issue 3127915 by tstoeckler: Remove default config hashes from shippe…

### DIFF
--- a/config/install/mentions.mentions_type.UserMention.yml
+++ b/config/install/mentions.mentions_type.UserMention.yml
@@ -1,8 +1,6 @@
 langcode: en
 status: true
 dependencies: {  }
-_core:
-  default_config_hash: NB-WRkiPnJMofk3ncSOZzU9fH3bKeypiMghNwymeVuw
 id: UserMention
 name: UserMention
 description: 'User mentions'

--- a/config/install/views.view.content.yml
+++ b/config/install/views.view.content.yml
@@ -4,8 +4,6 @@ dependencies:
   module:
     - node
     - user
-_core:
-  default_config_hash: 0a14mVVCnnJaHe3k6iFyp_GAY3ZSdmKDyL77A1LEpp8
 id: content
 label: Content
 module: node

--- a/modules/social_features/social_activity/config/install/core.entity_view_display.activity.activity.notification.yml
+++ b/modules/social_features/social_activity/config/install/core.entity_view_display.activity.activity.notification.yml
@@ -13,8 +13,6 @@ dependencies:
   module:
     - activity_creator
     - text
-_core:
-  default_config_hash: _PP-WiPTqYhSbjdVpCP7tG1ylK-g8j1kwL5hCCd769A
 id: activity.activity.notification
 targetEntityType: activity
 bundle: activity

--- a/modules/social_features/social_activity/config/install/core.entity_view_display.activity.activity.notification_archive.yml
+++ b/modules/social_features/social_activity/config/install/core.entity_view_display.activity.activity.notification_archive.yml
@@ -13,8 +13,6 @@ dependencies:
   module:
     - activity_creator
     - text
-_core:
-  default_config_hash: tx4bSyJKCIyH-UgPhJ9KMaJQjMQqJEJU1YZpd999QdY
 id: activity.activity.notification_archive
 targetEntityType: activity
 bundle: activity

--- a/modules/social_features/social_activity/config/install/core.entity_view_mode.activity.notification.yml
+++ b/modules/social_features/social_activity/config/install/core.entity_view_mode.activity.notification.yml
@@ -3,8 +3,6 @@ status: true
 dependencies:
   module:
     - activity_creator
-_core:
-  default_config_hash: QmSIdLfe2oRQx49C39LN166ZrWB3SsdDwR1hb0iCFjc
 id: activity.notification
 label: Notification
 targetEntityType: activity

--- a/modules/social_features/social_activity/config/install/core.entity_view_mode.activity.notification_archive.yml
+++ b/modules/social_features/social_activity/config/install/core.entity_view_mode.activity.notification_archive.yml
@@ -3,8 +3,6 @@ status: true
 dependencies:
   module:
     - activity_creator
-_core:
-  default_config_hash: g0xG6W1yMrC3-0MmqSGi4TS3cI962yWsynMHyWz0LC0
 id: activity.notification_archive
 label: 'Notification archive'
 targetEntityType: activity

--- a/modules/social_features/social_activity/config/install/field.field.message.create_comment_author_node_post.field_message_context.yml
+++ b/modules/social_features/social_activity/config/install/field.field.message.create_comment_author_node_post.field_message_context.yml
@@ -6,8 +6,6 @@ dependencies:
     - message.template.create_comment_author_node_post
   module:
     - options
-_core:
-  default_config_hash: 61iiuomlGfSPAnJC0m-YQaMk_u35XgXB33PoXTtFxgA
 id: message.create_comment_author_node_post.field_message_context
 field_name: field_message_context
 entity_type: message

--- a/modules/social_features/social_activity/config/install/field.field.message.create_comment_author_node_post.field_message_destination.yml
+++ b/modules/social_features/social_activity/config/install/field.field.message.create_comment_author_node_post.field_message_destination.yml
@@ -6,8 +6,6 @@ dependencies:
     - message.template.create_comment_author_node_post
   module:
     - options
-_core:
-  default_config_hash: '-4P6HP5rTTmpZoGKBI1lBXTxiCNYa2_4Wl1MiqeLfDI'
 id: message.create_comment_author_node_post.field_message_destination
 field_name: field_message_destination
 entity_type: message

--- a/modules/social_features/social_activity/config/install/field.field.message.create_comment_author_node_post.field_message_related_object.yml
+++ b/modules/social_features/social_activity/config/install/field.field.message.create_comment_author_node_post.field_message_related_object.yml
@@ -8,8 +8,6 @@ dependencies:
     - node.type.topic
   module:
     - dynamic_entity_reference
-_core:
-  default_config_hash: YlcvoTrPzgBHC4uTe2gI7ATG8EyARnEZ0olbN2tlHJE
 id: message.create_comment_author_node_post.field_message_related_object
 field_name: field_message_related_object
 entity_type: message

--- a/modules/social_features/social_activity/config/install/field.field.message.create_comment_community_node.field_message_context.yml
+++ b/modules/social_features/social_activity/config/install/field.field.message.create_comment_community_node.field_message_context.yml
@@ -6,8 +6,6 @@ dependencies:
     - message.template.create_comment_community_node
   module:
     - options
-_core:
-  default_config_hash: 906sWgM0zYozX08boJlmQw_sKk8NM_ajqWndG_TdDsQ
 id: message.create_comment_community_node.field_message_context
 field_name: field_message_context
 entity_type: message

--- a/modules/social_features/social_activity/config/install/field.field.message.create_comment_community_node.field_message_destination.yml
+++ b/modules/social_features/social_activity/config/install/field.field.message.create_comment_community_node.field_message_destination.yml
@@ -6,8 +6,6 @@ dependencies:
     - message.template.create_comment_community_node
   module:
     - options
-_core:
-  default_config_hash: NPpXuuhlOUCVQ62aG8hZ_zoOreetRZrtxlUy7a-Mjq8
 id: message.create_comment_community_node.field_message_destination
 field_name: field_message_destination
 entity_type: message

--- a/modules/social_features/social_activity/config/install/field.field.message.create_comment_community_node.field_message_related_object.yml
+++ b/modules/social_features/social_activity/config/install/field.field.message.create_comment_community_node.field_message_related_object.yml
@@ -8,8 +8,6 @@ dependencies:
     - node.type.topic
   module:
     - dynamic_entity_reference
-_core:
-  default_config_hash: T7evOT83Bw6JseQNCogM5d656d_6Thm4ydeGOLlMc7c
 id: message.create_comment_community_node.field_message_related_object
 field_name: field_message_related_object
 entity_type: message

--- a/modules/social_features/social_activity/config/install/field.field.message.create_comment_community_post.field_message_context.yml
+++ b/modules/social_features/social_activity/config/install/field.field.message.create_comment_community_post.field_message_context.yml
@@ -6,8 +6,6 @@ dependencies:
     - message.template.create_comment_community_post
   module:
     - options
-_core:
-  default_config_hash: 4rdvYMNPdC8fV_TWcQTK_6zOrITiCZFt1EFlLs3fD_w
 id: message.create_comment_community_post.field_message_context
 field_name: field_message_context
 entity_type: message

--- a/modules/social_features/social_activity/config/install/field.field.message.create_comment_community_post.field_message_destination.yml
+++ b/modules/social_features/social_activity/config/install/field.field.message.create_comment_community_post.field_message_destination.yml
@@ -6,8 +6,6 @@ dependencies:
     - message.template.create_comment_community_post
   module:
     - options
-_core:
-  default_config_hash: 81Y0fEN14YHo9YW2hrzQ77vlO8hphyG3e1zde1De9OU
 id: message.create_comment_community_post.field_message_destination
 field_name: field_message_destination
 entity_type: message

--- a/modules/social_features/social_activity/config/install/field.field.message.create_comment_community_post.field_message_related_object.yml
+++ b/modules/social_features/social_activity/config/install/field.field.message.create_comment_community_post.field_message_related_object.yml
@@ -8,8 +8,6 @@ dependencies:
     - node.type.topic
   module:
     - dynamic_entity_reference
-_core:
-  default_config_hash: r7y-KWgazz2ImQGYVK9qUtS4oxCm_i0yqUn1WlPnRNY
 id: message.create_comment_community_post.field_message_related_object
 field_name: field_message_related_object
 entity_type: message

--- a/modules/social_features/social_activity/config/install/field.field.message.create_comment_group_node.field_message_context.yml
+++ b/modules/social_features/social_activity/config/install/field.field.message.create_comment_group_node.field_message_context.yml
@@ -6,8 +6,6 @@ dependencies:
     - message.template.create_comment_group_node
   module:
     - options
-_core:
-  default_config_hash: sUX2_dxeeJimo4x6wVqZHLWYx4h84vzdoVGutY77_lc
 id: message.create_comment_group_node.field_message_context
 field_name: field_message_context
 entity_type: message

--- a/modules/social_features/social_activity/config/install/field.field.message.create_comment_group_node.field_message_destination.yml
+++ b/modules/social_features/social_activity/config/install/field.field.message.create_comment_group_node.field_message_destination.yml
@@ -6,8 +6,6 @@ dependencies:
     - message.template.create_comment_group_node
   module:
     - options
-_core:
-  default_config_hash: CNZ6Vry1Dw5KubbX3JUXRGS8jaUYYZ0SEDnGZwCRBHc
 id: message.create_comment_group_node.field_message_destination
 field_name: field_message_destination
 entity_type: message

--- a/modules/social_features/social_activity/config/install/field.field.message.create_comment_group_node.field_message_related_object.yml
+++ b/modules/social_features/social_activity/config/install/field.field.message.create_comment_group_node.field_message_related_object.yml
@@ -8,8 +8,6 @@ dependencies:
     - node.type.topic
   module:
     - dynamic_entity_reference
-_core:
-  default_config_hash: 201hNynC1bt0_MJaWP-TVLL1SsEgMwnHgGiz9kNtYdI
 id: message.create_comment_group_node.field_message_related_object
 field_name: field_message_related_object
 entity_type: message

--- a/modules/social_features/social_activity/config/install/field.field.message.create_comment_group_post.field_message_context.yml
+++ b/modules/social_features/social_activity/config/install/field.field.message.create_comment_group_post.field_message_context.yml
@@ -6,8 +6,6 @@ dependencies:
     - message.template.create_comment_group_post
   module:
     - options
-_core:
-  default_config_hash: ED6T0P7rteP40RObNXtnNzeWAndgw8LvAWDWyFZVjAA
 id: message.create_comment_group_post.field_message_context
 field_name: field_message_context
 entity_type: message

--- a/modules/social_features/social_activity/config/install/field.field.message.create_comment_group_post.field_message_destination.yml
+++ b/modules/social_features/social_activity/config/install/field.field.message.create_comment_group_post.field_message_destination.yml
@@ -6,8 +6,6 @@ dependencies:
     - message.template.create_comment_group_post
   module:
     - options
-_core:
-  default_config_hash: AjANSHQfqvJnuUQlzyM7emySWvnB1Sh8QYVpDitVjGk
 id: message.create_comment_group_post.field_message_destination
 field_name: field_message_destination
 entity_type: message

--- a/modules/social_features/social_activity/config/install/field.field.message.create_comment_group_post.field_message_related_object.yml
+++ b/modules/social_features/social_activity/config/install/field.field.message.create_comment_group_post.field_message_related_object.yml
@@ -8,8 +8,6 @@ dependencies:
     - node.type.topic
   module:
     - dynamic_entity_reference
-_core:
-  default_config_hash: 9W8nCkR8cG8qoiRxFGR42OAcvXg9zCXQV19gQ0XoqaE
 id: message.create_comment_group_post.field_message_related_object
 field_name: field_message_related_object
 entity_type: message

--- a/modules/social_features/social_activity/config/install/field.field.message.create_comment_post_profile.field_message_context.yml
+++ b/modules/social_features/social_activity/config/install/field.field.message.create_comment_post_profile.field_message_context.yml
@@ -6,8 +6,6 @@ dependencies:
     - message.template.create_comment_post_profile
   module:
     - options
-_core:
-  default_config_hash: 82icKv6Z7qbFSmz0A92NGYqMBlFkNg3wHQc2dwSS2Nw
 id: message.create_comment_post_profile.field_message_context
 field_name: field_message_context
 entity_type: message

--- a/modules/social_features/social_activity/config/install/field.field.message.create_comment_post_profile.field_message_destination.yml
+++ b/modules/social_features/social_activity/config/install/field.field.message.create_comment_post_profile.field_message_destination.yml
@@ -6,8 +6,6 @@ dependencies:
     - message.template.create_comment_post_profile
   module:
     - options
-_core:
-  default_config_hash: I62J1u1wcexWjosRcIpl0pf_6RPrAJ4cWlPMxBUecHA
 id: message.create_comment_post_profile.field_message_destination
 field_name: field_message_destination
 entity_type: message

--- a/modules/social_features/social_activity/config/install/field.field.message.create_comment_post_profile.field_message_related_object.yml
+++ b/modules/social_features/social_activity/config/install/field.field.message.create_comment_post_profile.field_message_related_object.yml
@@ -8,8 +8,6 @@ dependencies:
     - node.type.topic
   module:
     - dynamic_entity_reference
-_core:
-  default_config_hash: apixEhzDvH0hpI-fybNDwg9DETd4U-yRocIYhw3MK3c
 id: message.create_comment_post_profile.field_message_related_object
 field_name: field_message_related_object
 entity_type: message

--- a/modules/social_features/social_activity/config/install/field.field.message.create_comment_reply.field_message_context.yml
+++ b/modules/social_features/social_activity/config/install/field.field.message.create_comment_reply.field_message_context.yml
@@ -6,8 +6,6 @@ dependencies:
     - message.template.create_comment_reply
   module:
     - options
-_core:
-  default_config_hash: 9scupCAlDcXatd2xVP0OCCaU-8Orn2eKQp1RSvlTJfU
 id: message.create_comment_reply.field_message_context
 field_name: field_message_context
 entity_type: message

--- a/modules/social_features/social_activity/config/install/field.field.message.create_comment_reply.field_message_destination.yml
+++ b/modules/social_features/social_activity/config/install/field.field.message.create_comment_reply.field_message_destination.yml
@@ -6,8 +6,6 @@ dependencies:
     - message.template.create_comment_reply
   module:
     - options
-_core:
-  default_config_hash: 22jpDRQwoKsqNSTgmwaLlgLzTE0SxC7jR40-z3Q-NdM
 id: message.create_comment_reply.field_message_destination
 field_name: field_message_destination
 entity_type: message

--- a/modules/social_features/social_activity/config/install/field.field.message.create_comment_reply.field_message_related_object.yml
+++ b/modules/social_features/social_activity/config/install/field.field.message.create_comment_reply.field_message_related_object.yml
@@ -8,8 +8,6 @@ dependencies:
     - node.type.topic
   module:
     - dynamic_entity_reference
-_core:
-  default_config_hash: xJqTWGzk_HFCdL9rRjDZ1CDB5BNkfw684ysE0I70_n4
 id: message.create_comment_reply.field_message_related_object
 field_name: field_message_related_object
 entity_type: message

--- a/modules/social_features/social_activity/config/install/field.field.message.create_event_community.field_message_context.yml
+++ b/modules/social_features/social_activity/config/install/field.field.message.create_event_community.field_message_context.yml
@@ -6,8 +6,6 @@ dependencies:
     - message.template.create_event_community
   module:
     - options
-_core:
-  default_config_hash: 8acckeWT5uuFmnpEuzVmX5CfAJEHee1n9DiSZOOIXPY
 id: message.create_event_community.field_message_context
 field_name: field_message_context
 entity_type: message

--- a/modules/social_features/social_activity/config/install/field.field.message.create_event_community.field_message_destination.yml
+++ b/modules/social_features/social_activity/config/install/field.field.message.create_event_community.field_message_destination.yml
@@ -6,8 +6,6 @@ dependencies:
     - message.template.create_event_community
   module:
     - options
-_core:
-  default_config_hash: zUvmSJ77xup2KcXOGF_2cqlkiIl42X4L8JMjFoY-0SI
 id: message.create_event_community.field_message_destination
 field_name: field_message_destination
 entity_type: message

--- a/modules/social_features/social_activity/config/install/field.field.message.create_event_community.field_message_related_object.yml
+++ b/modules/social_features/social_activity/config/install/field.field.message.create_event_community.field_message_related_object.yml
@@ -8,8 +8,6 @@ dependencies:
     - node.type.topic
   module:
     - dynamic_entity_reference
-_core:
-  default_config_hash: jNsi-9GoeWXNy89h9AhuGSqakWAhtzbhwj4wFc3siKI
 id: message.create_event_community.field_message_related_object
 field_name: field_message_related_object
 entity_type: message

--- a/modules/social_features/social_activity/config/install/field.field.message.create_event_group.field_message_context.yml
+++ b/modules/social_features/social_activity/config/install/field.field.message.create_event_group.field_message_context.yml
@@ -6,8 +6,6 @@ dependencies:
     - message.template.create_event_group
   module:
     - options
-_core:
-  default_config_hash: NUy_O2KmdJDJQKXXWG8ihwtpmp0bPIli7TncVyQwwD0
 id: message.create_event_group.field_message_context
 field_name: field_message_context
 entity_type: message

--- a/modules/social_features/social_activity/config/install/field.field.message.create_event_group.field_message_destination.yml
+++ b/modules/social_features/social_activity/config/install/field.field.message.create_event_group.field_message_destination.yml
@@ -6,8 +6,6 @@ dependencies:
     - message.template.create_event_group
   module:
     - options
-_core:
-  default_config_hash: HPbxsTGiymAdPmjNJ3IUNGB11U0f782BvjnBaszs9_c
 id: message.create_event_group.field_message_destination
 field_name: field_message_destination
 entity_type: message

--- a/modules/social_features/social_activity/config/install/field.field.message.create_event_group.field_message_related_object.yml
+++ b/modules/social_features/social_activity/config/install/field.field.message.create_event_group.field_message_related_object.yml
@@ -8,8 +8,6 @@ dependencies:
     - node.type.topic
   module:
     - dynamic_entity_reference
-_core:
-  default_config_hash: 40uyoe8nYWAK2Rp_Gyvi_gD9lQkvTzf2GKobjJ4yX7A
 id: message.create_event_group.field_message_related_object
 field_name: field_message_related_object
 entity_type: message

--- a/modules/social_features/social_activity/config/install/field.field.message.create_post_community.field_message_context.yml
+++ b/modules/social_features/social_activity/config/install/field.field.message.create_post_community.field_message_context.yml
@@ -6,8 +6,6 @@ dependencies:
     - message.template.create_post_community
   module:
     - options
-_core:
-  default_config_hash: 5KfIuTF_y3KpelJrihbTEQxlbUGWM-371m0NmR43epA
 id: message.create_post_community.field_message_context
 field_name: field_message_context
 entity_type: message

--- a/modules/social_features/social_activity/config/install/field.field.message.create_post_community.field_message_destination.yml
+++ b/modules/social_features/social_activity/config/install/field.field.message.create_post_community.field_message_destination.yml
@@ -6,8 +6,6 @@ dependencies:
     - message.template.create_post_community
   module:
     - options
-_core:
-  default_config_hash: _QtTu2mntihqrHFEAVSb3CJMxtco8UYqdqcU-D2em38
 id: message.create_post_community.field_message_destination
 field_name: field_message_destination
 entity_type: message

--- a/modules/social_features/social_activity/config/install/field.field.message.create_post_community.field_message_related_object.yml
+++ b/modules/social_features/social_activity/config/install/field.field.message.create_post_community.field_message_related_object.yml
@@ -8,8 +8,6 @@ dependencies:
     - node.type.topic
   module:
     - dynamic_entity_reference
-_core:
-  default_config_hash: 46PcRXwr6DttcbqByjwDbZ1UlQ0JnpWy7MiD8PxOrdA
 id: message.create_post_community.field_message_related_object
 field_name: field_message_related_object
 entity_type: message

--- a/modules/social_features/social_activity/config/install/field.field.message.create_post_group.field_message_context.yml
+++ b/modules/social_features/social_activity/config/install/field.field.message.create_post_group.field_message_context.yml
@@ -6,8 +6,6 @@ dependencies:
     - message.template.create_post_group
   module:
     - options
-_core:
-  default_config_hash: EMMftMafkVbQGFljBGHQvZ1xuHqC-SGaUvuYMhU2d_U
 id: message.create_post_group.field_message_context
 field_name: field_message_context
 entity_type: message

--- a/modules/social_features/social_activity/config/install/field.field.message.create_post_group.field_message_destination.yml
+++ b/modules/social_features/social_activity/config/install/field.field.message.create_post_group.field_message_destination.yml
@@ -6,8 +6,6 @@ dependencies:
     - message.template.create_post_group
   module:
     - options
-_core:
-  default_config_hash: Fdn97vInPgVruTxyR_4s3j7eFgKAOpG6Eu-IF-QerqA
 id: message.create_post_group.field_message_destination
 field_name: field_message_destination
 entity_type: message

--- a/modules/social_features/social_activity/config/install/field.field.message.create_post_group.field_message_related_object.yml
+++ b/modules/social_features/social_activity/config/install/field.field.message.create_post_group.field_message_related_object.yml
@@ -8,8 +8,6 @@ dependencies:
     - node.type.topic
   module:
     - dynamic_entity_reference
-_core:
-  default_config_hash: UaNFLIxolVMg2S3_wsAwRq3TWH4iKp-zVLIzJUS9rS0
 id: message.create_post_group.field_message_related_object
 field_name: field_message_related_object
 entity_type: message

--- a/modules/social_features/social_activity/config/install/field.field.message.create_post_profile.field_message_context.yml
+++ b/modules/social_features/social_activity/config/install/field.field.message.create_post_profile.field_message_context.yml
@@ -6,8 +6,6 @@ dependencies:
     - message.template.create_post_profile
   module:
     - options
-_core:
-  default_config_hash: 8UiBRHVfnrKN2KUrJSvlQ-r0rAFfqs0wOdvkHRoP15U
 id: message.create_post_profile.field_message_context
 field_name: field_message_context
 entity_type: message

--- a/modules/social_features/social_activity/config/install/field.field.message.create_post_profile.field_message_destination.yml
+++ b/modules/social_features/social_activity/config/install/field.field.message.create_post_profile.field_message_destination.yml
@@ -6,8 +6,6 @@ dependencies:
     - message.template.create_post_profile
   module:
     - options
-_core:
-  default_config_hash: 7UKoDr-YvfjRgQUuh-5WaPO2jJzLJNJFX3XybSw8NUQ
 id: message.create_post_profile.field_message_destination
 field_name: field_message_destination
 entity_type: message

--- a/modules/social_features/social_activity/config/install/field.field.message.create_post_profile.field_message_related_object.yml
+++ b/modules/social_features/social_activity/config/install/field.field.message.create_post_profile.field_message_related_object.yml
@@ -8,8 +8,6 @@ dependencies:
     - node.type.topic
   module:
     - dynamic_entity_reference
-_core:
-  default_config_hash: gCEJvp5mXPQH3s73iMUNhMc8NisjH9IlB7RfLPYTUiM
 id: message.create_post_profile.field_message_related_object
 field_name: field_message_related_object
 entity_type: message

--- a/modules/social_features/social_activity/config/install/field.field.message.create_topic_community.field_message_context.yml
+++ b/modules/social_features/social_activity/config/install/field.field.message.create_topic_community.field_message_context.yml
@@ -6,8 +6,6 @@ dependencies:
     - message.template.create_topic_community
   module:
     - options
-_core:
-  default_config_hash: gFK0i7C2SswYzoRuil84e1Do_zA0PWUvY0mGUrLSXzc
 id: message.create_topic_community.field_message_context
 field_name: field_message_context
 entity_type: message

--- a/modules/social_features/social_activity/config/install/field.field.message.create_topic_community.field_message_destination.yml
+++ b/modules/social_features/social_activity/config/install/field.field.message.create_topic_community.field_message_destination.yml
@@ -6,8 +6,6 @@ dependencies:
     - message.template.create_topic_community
   module:
     - options
-_core:
-  default_config_hash: ct_0eR-TLfLcn4g96tzah5BKe6sAfXNCG3hVewK92-M
 id: message.create_topic_community.field_message_destination
 field_name: field_message_destination
 entity_type: message

--- a/modules/social_features/social_activity/config/install/field.field.message.create_topic_community.field_message_related_object.yml
+++ b/modules/social_features/social_activity/config/install/field.field.message.create_topic_community.field_message_related_object.yml
@@ -8,8 +8,6 @@ dependencies:
     - node.type.topic
   module:
     - dynamic_entity_reference
-_core:
-  default_config_hash: AnmbH3eNzjkecRD2E3znXCJcrAMWLQ0_tbn4ne898kM
 id: message.create_topic_community.field_message_related_object
 field_name: field_message_related_object
 entity_type: message

--- a/modules/social_features/social_activity/config/install/field.field.message.create_topic_group.field_message_context.yml
+++ b/modules/social_features/social_activity/config/install/field.field.message.create_topic_group.field_message_context.yml
@@ -6,8 +6,6 @@ dependencies:
     - message.template.create_topic_group
   module:
     - options
-_core:
-  default_config_hash: dfQOtuiC6n9CnDahFcJLItpi5RfZqNoO4nYWEYsKFjQ
 id: message.create_topic_group.field_message_context
 field_name: field_message_context
 entity_type: message

--- a/modules/social_features/social_activity/config/install/field.field.message.create_topic_group.field_message_destination.yml
+++ b/modules/social_features/social_activity/config/install/field.field.message.create_topic_group.field_message_destination.yml
@@ -6,8 +6,6 @@ dependencies:
     - message.template.create_topic_group
   module:
     - options
-_core:
-  default_config_hash: 1o6xbwIeI5jYVQc8XcHSwZGuBBopUJbF3Uzu5bEcymg
 id: message.create_topic_group.field_message_destination
 field_name: field_message_destination
 entity_type: message

--- a/modules/social_features/social_activity/config/install/field.field.message.create_topic_group.field_message_related_object.yml
+++ b/modules/social_features/social_activity/config/install/field.field.message.create_topic_group.field_message_related_object.yml
@@ -8,8 +8,6 @@ dependencies:
     - node.type.topic
   module:
     - dynamic_entity_reference
-_core:
-  default_config_hash: Y2SxLG8va09HU6VImzeV8buy78j65vRwnahBKg6rH0E
 id: message.create_topic_group.field_message_related_object
 field_name: field_message_related_object
 entity_type: message

--- a/modules/social_features/social_activity/config/install/field.field.message.moved_content_between_groups.field_message_context.yml
+++ b/modules/social_features/social_activity/config/install/field.field.message.moved_content_between_groups.field_message_context.yml
@@ -6,8 +6,6 @@ dependencies:
     - message.template.moved_content_between_groups
   module:
     - options
-_core:
-  default_config_hash: kzAypjVdDdE1BMaI5V-_I6wdIwOphPSFRvr_zJ3umeg
 id: message.moved_content_between_groups.field_message_context
 field_name: field_message_context
 entity_type: message

--- a/modules/social_features/social_activity/config/install/field.field.message.moved_content_between_groups.field_message_destination.yml
+++ b/modules/social_features/social_activity/config/install/field.field.message.moved_content_between_groups.field_message_destination.yml
@@ -6,8 +6,6 @@ dependencies:
     - message.template.moved_content_between_groups
   module:
     - options
-_core:
-  default_config_hash: m6OaP_pLMQjA4oyTCS0q9bAe7vc2_ply-AMTsxOYjTU
 id: message.moved_content_between_groups.field_message_destination
 field_name: field_message_destination
 entity_type: message

--- a/modules/social_features/social_activity/config/install/field.field.message.moved_content_between_groups.field_message_related_object.yml
+++ b/modules/social_features/social_activity/config/install/field.field.message.moved_content_between_groups.field_message_related_object.yml
@@ -6,8 +6,6 @@ dependencies:
     - message.template.moved_content_between_groups
   module:
     - dynamic_entity_reference
-_core:
-  default_config_hash: iaG_kZr_BA8JPVuTI3oumeBKrJaPet1INbUOQ9xJNko
 id: message.moved_content_between_groups.field_message_related_object
 field_name: field_message_related_object
 entity_type: message

--- a/modules/social_features/social_activity/config/install/message.template.create_comment_author_node_post.yml
+++ b/modules/social_features/social_activity/config/install/message.template.create_comment_author_node_post.yml
@@ -16,8 +16,6 @@ third_party_settings:
     activity_create_direct: false
     activity_aggregate: false
     activity_entity_condition: comment_not_reply
-_core:
-  default_config_hash: qOUMKHmbm98fQ8Ug1NFOM95XpiHI1BTFd-vNQ6-PEI4
 template: create_comment_author_node_post
 label: 'Create comment on authors node or post'
 description: 'A person commented on content created or organised by me'

--- a/modules/social_features/social_activity/config/install/message.template.create_comment_community_node.yml
+++ b/modules/social_features/social_activity/config/install/message.template.create_comment_community_node.yml
@@ -15,8 +15,6 @@ third_party_settings:
     activity_create_direct: 1
     activity_aggregate: 1
     activity_entity_condition: comment_not_reply
-_core:
-  default_config_hash: dL6ebaOTtEEseLIn2aJePZCssDoJ2TF2ws6LhkNEMTc
 template: create_comment_community_node
 label: 'Create comment on node in the community'
 description: 'A user add a comment to content in the community'

--- a/modules/social_features/social_activity/config/install/message.template.create_comment_community_post.yml
+++ b/modules/social_features/social_activity/config/install/message.template.create_comment_community_post.yml
@@ -15,8 +15,6 @@ third_party_settings:
     activity_create_direct: 1
     activity_aggregate: 1
     activity_entity_condition: comment_not_reply
-_core:
-  default_config_hash: Wjl3SIFYw2tL2G6J0AR6L9KtREmAbvjXVg_z_R9FCbM
 template: create_comment_community_post
 label: 'Create comment on post in the community'
 description: 'A user add a comment to post in the community'

--- a/modules/social_features/social_activity/config/install/message.template.create_comment_group_node.yml
+++ b/modules/social_features/social_activity/config/install/message.template.create_comment_group_node.yml
@@ -17,8 +17,6 @@ third_party_settings:
     activity_create_direct: 1
     activity_aggregate: 1
     activity_entity_condition: comment_not_reply
-_core:
-  default_config_hash: Xpiwy9_US7kX5AIDS0E5D9Xt5t4o_RPJtBSBZr9NcQY
 template: create_comment_group_node
 label: 'Create comment on node in the group'
 description: 'A user add a comment to content in the group'

--- a/modules/social_features/social_activity/config/install/message.template.create_comment_group_post.yml
+++ b/modules/social_features/social_activity/config/install/message.template.create_comment_group_post.yml
@@ -15,8 +15,6 @@ third_party_settings:
     activity_create_direct: 1
     activity_aggregate: 1
     activity_entity_condition: comment_not_reply
-_core:
-  default_config_hash: M8MzlG1Oa8UNBJnMxdrjHclBuWwjUEOeMndsgJ3A0as
 template: create_comment_group_post
 label: 'Create comment on post in the group'
 description: 'A user add a comment to post in the group'

--- a/modules/social_features/social_activity/config/install/message.template.create_comment_post_profile.yml
+++ b/modules/social_features/social_activity/config/install/message.template.create_comment_post_profile.yml
@@ -15,8 +15,6 @@ third_party_settings:
     activity_create_direct: false
     activity_aggregate: false
     activity_entity_condition: comment_not_reply
-_core:
-  default_config_hash: aHhTYdCJ_xAeaDCj3ZWbok-JgyBEW1XZC03Ffy9wGj0
 template: create_comment_post_profile
 label: 'Create comment on post on my profile'
 description: 'A person commented on a post on my profile'

--- a/modules/social_features/social_activity/config/install/message.template.create_comment_reply.yml
+++ b/modules/social_features/social_activity/config/install/message.template.create_comment_reply.yml
@@ -15,8 +15,6 @@ third_party_settings:
     activity_create_direct: false
     activity_aggregate: false
     activity_entity_condition: comment_reply
-_core:
-  default_config_hash: x362ycPU3LkbbzQjL1AYFA4vHeyupoa9d5hjmfUjZjA
 template: create_comment_reply
 label: 'Create reply on my comment'
 description: 'A person replied on my comments'

--- a/modules/social_features/social_activity/config/install/message.template.create_content_in_joined_group.yml
+++ b/modules/social_features/social_activity/config/install/message.template.create_content_in_joined_group.yml
@@ -22,8 +22,6 @@ third_party_settings:
     activity_create_direct: 0
     activity_aggregate: 0
     activity_entity_condition: ''
-_core:
-  default_config_hash: HJQPSAtPJVu2yXl_X1EKoBuGoEohBpgyY9B-qH4S_oM
 template: create_content_in_joined_group
 label: 'Create a post, topic or event in a joined group'
 description: 'A person created a post, event or topic in a group I joined'

--- a/modules/social_features/social_activity/config/install/message.template.create_event_community.yml
+++ b/modules/social_features/social_activity/config/install/message.template.create_event_community.yml
@@ -16,8 +16,6 @@ third_party_settings:
     activity_action: create_entitiy_action
     activity_bundle_entities:
       node-event: node-event
-_core:
-  default_config_hash: d_hYLyzo043jYPuyxksHaDanlpT5yoICTkQSdCnSyJA
 template: create_event_community
 label: 'Create event'
 description: 'A user created an event in the community'

--- a/modules/social_features/social_activity/config/install/message.template.create_event_group.yml
+++ b/modules/social_features/social_activity/config/install/message.template.create_event_group.yml
@@ -16,8 +16,6 @@ third_party_settings:
     activity_action: create_entitiy_action
     activity_bundle_entities:
       node-event: node-event
-_core:
-  default_config_hash: d80x8W0Bqnzm4i700qKLolEydxxoxsZZE9ULbgs6ZBY
 template: create_event_group
 label: 'Create event in group'
 description: 'A user created an event in a group'

--- a/modules/social_features/social_activity/config/install/message.template.create_post_community.yml
+++ b/modules/social_features/social_activity/config/install/message.template.create_post_community.yml
@@ -14,8 +14,6 @@ third_party_settings:
     activity_action: create_entitiy_action
     activity_bundle_entities:
       post-post: post-post
-_core:
-  default_config_hash: kKHsUYXAxkTVpHpcsY5TpAthL6g7h74_Xf7CaFXmHJY
 template: create_post_community
 label: 'Create post in the community'
 description: 'A user created a post in the community'

--- a/modules/social_features/social_activity/config/install/message.template.create_post_group.yml
+++ b/modules/social_features/social_activity/config/install/message.template.create_post_group.yml
@@ -15,8 +15,6 @@ third_party_settings:
     activity_action: create_entitiy_action
     activity_bundle_entities:
       post-post: post-post
-_core:
-  default_config_hash: FSiWpXVjHWQe6wjHZyrDbvmAS-QZJh3bkKx9DllyP7E
 template: create_post_group
 label: 'Create post in a group'
 description: 'A user created a post in a group'

--- a/modules/social_features/social_activity/config/install/message.template.create_post_profile.yml
+++ b/modules/social_features/social_activity/config/install/message.template.create_post_profile.yml
@@ -14,8 +14,6 @@ third_party_settings:
       post-post: post-post
     activity_action: create_entitiy_action
     activity_aggregate: 0
-_core:
-  default_config_hash: qSOzrHG_GK56jMNkCbKiGHTZMyBCFK5UTiB01yFY3kI
 template: create_post_profile
 label: 'Create post on profile'
 description: 'A person created a post on my profile'

--- a/modules/social_features/social_activity/config/install/message.template.create_post_profile_stream.yml
+++ b/modules/social_features/social_activity/config/install/message.template.create_post_profile_stream.yml
@@ -13,8 +13,6 @@ third_party_settings:
       post-post: post-post
     activity_action: create_entitiy_action
     activity_aggregate: 0
-_core:
-  default_config_hash: U5d0ddvvE-svRyes1CxU9oJRpxIPS3D6tB8iZGb2FMo
 template: create_post_profile_stream
 label: 'Create post on profile stream output'
 description: 'A person created a post on my profile and I see it on the stream'

--- a/modules/social_features/social_activity/config/install/message.template.create_topic_community.yml
+++ b/modules/social_features/social_activity/config/install/message.template.create_topic_community.yml
@@ -16,8 +16,6 @@ third_party_settings:
     activity_action: create_entitiy_action
     activity_bundle_entities:
       node-topic: node-topic
-_core:
-  default_config_hash: fUIQO9Lm_XhSfzcT-ae10YmFY4YdMea1rMIFMfUjI0M
 template: create_topic_community
 label: 'Create topic'
 description: 'A user created a topic in the community'

--- a/modules/social_features/social_activity/config/install/message.template.create_topic_group.yml
+++ b/modules/social_features/social_activity/config/install/message.template.create_topic_group.yml
@@ -16,8 +16,6 @@ third_party_settings:
     activity_action: create_entitiy_action
     activity_bundle_entities:
       node-topic: node-topic
-_core:
-  default_config_hash: OrkUYYKXIRasMwuzGHiVq927BlFg0vX1kMV6f2NDI0Q
 template: create_topic_group
 label: 'Create topic in group'
 description: 'A user created a topic in a group'

--- a/modules/social_features/social_activity/config/install/message.template.join_to_group.yml
+++ b/modules/social_features/social_activity/config/install/message.template.join_to_group.yml
@@ -17,8 +17,6 @@ third_party_settings:
     activity_create_direct: 0
     activity_aggregate: 0
     activity_entity_condition: ''
-_core:
-  default_config_hash: Ec3_5IyNhcMOlY0h_xEJ5CtGv-XWJoRcdEVpnzgtUU4
 template: join_to_group
 label: 'Join to group'
 description: 'A person joins a group I am managing'

--- a/modules/social_features/social_activity/config/install/message.template.moved_content_between_groups.yml
+++ b/modules/social_features/social_activity/config/install/message.template.moved_content_between_groups.yml
@@ -16,8 +16,6 @@ third_party_settings:
     activity_create_direct: 1
     activity_aggregate: 0
     activity_entity_condition: ''
-_core:
-  default_config_hash: nTBuMEPVeXWQIQe6VCIogGhVbKAaWs_4CN33vCaYkHc
 template: moved_content_between_groups
 label: 'Moved event or topic between groups'
 description: 'A person moved event or topic to other group'

--- a/modules/social_features/social_activity/config/install/views.view.activity_stream_notifications.yml
+++ b/modules/social_features/social_activity/config/install/views.view.activity_stream_notifications.yml
@@ -10,8 +10,6 @@ dependencies:
     - activity_viewer
     - options
     - user
-_core:
-  default_config_hash: ttxaKuxOXNBOVRhBP19lSnXWA1LFxjYkmqqlkNX6mWE
 id: activity_stream_notifications
 label: 'Activity stream notifications'
 module: views

--- a/modules/social_features/social_activity/config/optional/views.view.activity_stream.yml
+++ b/modules/social_features/social_activity/config/optional/views.view.activity_stream.yml
@@ -8,8 +8,6 @@ dependencies:
     - activity_viewer
     - options
     - social_post
-_core:
-  default_config_hash: taJtVLpGOqefYYGQiaA9LUHwIATJB8SmDG6ACxrNGiw
 id: activity_stream
 label: 'Activity Stream'
 module: views

--- a/modules/social_features/social_activity/config/optional/views.view.activity_stream_group.yml
+++ b/modules/social_features/social_activity/config/optional/views.view.activity_stream_group.yml
@@ -8,8 +8,6 @@ dependencies:
     - activity_viewer
     - group
     - options
-_core:
-  default_config_hash: OH0bM8gu2xiYjc8j4aaGuF7KyThAG7tHt0GP2ADt-6w
 id: activity_stream_group
 label: activity_stream_group
 module: views

--- a/modules/social_features/social_activity/config/optional/views.view.activity_stream_profile.yml
+++ b/modules/social_features/social_activity/config/optional/views.view.activity_stream_profile.yml
@@ -9,8 +9,6 @@ dependencies:
     - activity_viewer
     - options
     - user
-_core:
-  default_config_hash: vFW30BSSL9R69dLaBcCqJ25jrWGBw5nKxwEv5AySm00
 id: activity_stream_profile
 label: activity_stream_profile
 module: views

--- a/modules/social_features/social_core/config/install/block_content.type.basic.yml
+++ b/modules/social_features/social_core/config/install/block_content.type.basic.yml
@@ -1,8 +1,6 @@
 langcode: en
 status: true
 dependencies: {  }
-_core:
-  default_config_hash: zglzjmYxi0G0ag9MZ02y0LSJOdpWRwJxyP_OvFojFyo
 id: basic
 label: 'Basic block'
 revision: 0

--- a/modules/social_features/social_core/config/install/block_content.type.hero_call_to_action_block.yml
+++ b/modules/social_features/social_core/config/install/block_content.type.hero_call_to_action_block.yml
@@ -1,8 +1,6 @@
 langcode: en
 status: true
 dependencies: {  }
-_core:
-  default_config_hash: XR_f0lfXIV2PJVpU4QEFgePYCLxpxC6QfoA03cGVYDw
 id: hero_call_to_action_block
 label: 'Hero call to action block'
 revision: 0

--- a/modules/social_features/social_core/config/install/block_content.type.platform_intro.yml
+++ b/modules/social_features/social_core/config/install/block_content.type.platform_intro.yml
@@ -1,8 +1,6 @@
 langcode: en
 status: true
 dependencies: {  }
-_core:
-  default_config_hash: 3WJ5HkGqCxmh7dLzdWXBN-PHDQb1TsYDjkTqmMdIptE
 id: platform_intro
 label: 'Platform introduction'
 revision: 0

--- a/modules/social_features/social_core/config/install/core.date_format.day_month.yml
+++ b/modules/social_features/social_core/config/install/core.date_format.day_month.yml
@@ -1,8 +1,6 @@
 langcode: en
 status: true
 dependencies: {  }
-_core:
-  default_config_hash: 3_efTeruTseDKsX25lEwhNav7kRJcb908WGKYAifNTk
 id: day_month
 label: 'Day Month'
 locked: false

--- a/modules/social_features/social_core/config/install/core.date_format.day_month_time.yml
+++ b/modules/social_features/social_core/config/install/core.date_format.day_month_time.yml
@@ -1,8 +1,6 @@
 langcode: en
 status: true
 dependencies: {  }
-_core:
-  default_config_hash: dl-Ya4SNTwMX8SiI0S2LSGnCFr4Avni9NnjxaFwy0bo
 id: day_month_time
 label: 'Day Month Time'
 locked: false

--- a/modules/social_features/social_core/config/install/core.date_format.social_long_date.yml
+++ b/modules/social_features/social_core/config/install/core.date_format.social_long_date.yml
@@ -1,8 +1,6 @@
 langcode: en
 status: true
 dependencies: {  }
-_core:
-  default_config_hash: yn7hJ7aKHaqAB7NobQ5AvSonDaKip1njklGDp6I6yN4
 id: social_long_date
 label: 'Social long date'
 locked: false

--- a/modules/social_features/social_core/config/install/core.date_format.social_medium_date.yml
+++ b/modules/social_features/social_core/config/install/core.date_format.social_medium_date.yml
@@ -1,8 +1,6 @@
 langcode: en
 status: true
 dependencies: {  }
-_core:
-  default_config_hash: Lh0Rvn87J0sp5EpvRKVE43aoS3XVOWriPuVupW0-_As
 id: social_medium_date
 label: 'Social medium date'
 locked: false

--- a/modules/social_features/social_core/config/install/core.date_format.social_medium_extended_date.yml
+++ b/modules/social_features/social_core/config/install/core.date_format.social_medium_extended_date.yml
@@ -1,8 +1,6 @@
 langcode: en
 status: true
 dependencies: {  }
-_core:
-  default_config_hash: bOLSR3np9VWFHJ5bmOIQVvyJfxKrfRSOle0J97qTQfQ
 id: social_medium_extended_date
 label: 'Social medium extended date'
 locked: false

--- a/modules/social_features/social_core/config/install/core.date_format.social_short_date.yml
+++ b/modules/social_features/social_core/config/install/core.date_format.social_short_date.yml
@@ -1,8 +1,6 @@
 langcode: en
 status: true
 dependencies: {  }
-_core:
-  default_config_hash: 9spt4BeQnJe7BMrbK2twj_p1HZsNVJ4xcixqyPQjkHg
 id: social_short_date
 label: 'Social short date'
 locked: false

--- a/modules/social_features/social_core/config/install/core.date_format.social_time.yml
+++ b/modules/social_features/social_core/config/install/core.date_format.social_time.yml
@@ -1,8 +1,6 @@
 langcode: en
 status: true
 dependencies: {  }
-_core:
-  default_config_hash: oNz650PO1orDMqoiW9r-X59cklOJFD8KjFJoHu3h5PA
 id: social_time
 label: 'Social time'
 locked: false

--- a/modules/social_features/social_core/config/install/core.entity_form_display.block_content.hero_call_to_action_block.default.yml
+++ b/modules/social_features/social_core/config/install/core.entity_form_display.block_content.hero_call_to_action_block.default.yml
@@ -11,8 +11,6 @@ dependencies:
     - image_widget_crop
     - link
     - text
-_core:
-  default_config_hash: KkxvZs-jt05xqKx9mYUXEaFQ0HRs1wr3o8DQNIRN6K0
 id: block_content.hero_call_to_action_block.default
 targetEntityType: block_content
 bundle: hero_call_to_action_block

--- a/modules/social_features/social_core/config/install/core.entity_form_display.block_content.platform_intro.default.yml
+++ b/modules/social_features/social_core/config/install/core.entity_form_display.block_content.platform_intro.default.yml
@@ -21,8 +21,6 @@ third_party_settings:
         classes: ''
         id: ''
         required_fields: true
-_core:
-  default_config_hash: 8TUFmFkJcvfyHRGY8yfnwsKNbxxgLXHZM021Bc1Rs30
 id: block_content.platform_intro.default
 targetEntityType: block_content
 bundle: platform_intro

--- a/modules/social_features/social_core/config/install/core.entity_view_display.block_content.hero_call_to_action_block.default.yml
+++ b/modules/social_features/social_core/config/install/core.entity_view_display.block_content.hero_call_to_action_block.default.yml
@@ -11,8 +11,6 @@ dependencies:
     - image
     - link
     - text
-_core:
-  default_config_hash: xcn78jEvv0PMkBHNBl0s4uKp9MlLHs432utlSRAmDMc
 id: block_content.hero_call_to_action_block.default
 targetEntityType: block_content
 bundle: hero_call_to_action_block

--- a/modules/social_features/social_core/config/install/core.entity_view_display.block_content.platform_intro.default.yml
+++ b/modules/social_features/social_core/config/install/core.entity_view_display.block_content.platform_intro.default.yml
@@ -6,8 +6,6 @@ dependencies:
     - field.field.block_content.platform_intro.field_text_block
   module:
     - text
-_core:
-  default_config_hash: Ec4Lz0EcmBPQ7Jfpj0Swo2As0Q1RtZXUStwPYQIVVbE
 id: block_content.platform_intro.default
 targetEntityType: block_content
 bundle: platform_intro

--- a/modules/social_features/social_core/config/install/core.entity_view_mode.node.activity.yml
+++ b/modules/social_features/social_core/config/install/core.entity_view_mode.node.activity.yml
@@ -3,8 +3,6 @@ status: true
 dependencies:
   module:
     - node
-_core:
-  default_config_hash: LpD_MAUoA0okeonj6aHMAbxxudoAFn-YAxAz_reE5yE
 id: node.activity
 label: Activity
 targetEntityType: node

--- a/modules/social_features/social_core/config/install/core.entity_view_mode.node.activity_comment.yml
+++ b/modules/social_features/social_core/config/install/core.entity_view_mode.node.activity_comment.yml
@@ -3,8 +3,6 @@ status: true
 dependencies:
   module:
     - node
-_core:
-  default_config_hash: epUnKT076SuTjQqSLpgt9KR9cPGPg7_p6koQnrY11lU
 id: node.activity_comment
 label: 'Activity comment'
 targetEntityType: node

--- a/modules/social_features/social_core/config/install/core.entity_view_mode.node.hero.yml
+++ b/modules/social_features/social_core/config/install/core.entity_view_mode.node.hero.yml
@@ -3,8 +3,6 @@ status: true
 dependencies:
   module:
     - node
-_core:
-  default_config_hash: '-fLBsNoKIGtlN0e9v2AcfCs57oib5teICxBu9UgElHY'
 id: node.hero
 label: Hero
 targetEntityType: node

--- a/modules/social_features/social_core/config/install/core.entity_view_mode.node.small_teaser.yml
+++ b/modules/social_features/social_core/config/install/core.entity_view_mode.node.small_teaser.yml
@@ -3,8 +3,6 @@ status: true
 dependencies:
   module:
     - node
-_core:
-  default_config_hash: lulkSzjQ1KNGdYNGZUe1nK8moHQ0vOwtAMxclh7EbnY
 id: node.small_teaser
 label: 'Small teaser'
 targetEntityType: node

--- a/modules/social_features/social_core/config/install/crop.type.hero.yml
+++ b/modules/social_features/social_core/config/install/crop.type.hero.yml
@@ -1,8 +1,6 @@
 langcode: en
 status: true
 dependencies: {  }
-_core:
-  default_config_hash: M7gu0hM5eQSjsQOYu7Dr2RFyItlWKYgKPQIfGbhVo1Q
 label: Large
 id: hero
 description: 'Header image in the hero region'

--- a/modules/social_features/social_core/config/install/crop.type.hero_an.yml
+++ b/modules/social_features/social_core/config/install/crop.type.hero_an.yml
@@ -1,8 +1,6 @@
 langcode: en
 status: true
 dependencies: {  }
-_core:
-  default_config_hash: j5YPnaCyl47xAY39R53lJJnPGilTYlERuPS9ORto4D8
 label: 'Hero AN'
 id: hero_an
 description: 'Header image in the AN hero region'

--- a/modules/social_features/social_core/config/install/crop.type.hero_small.yml
+++ b/modules/social_features/social_core/config/install/crop.type.hero_small.yml
@@ -1,8 +1,6 @@
 langcode: en
 status: true
 dependencies: {  }
-_core:
-  default_config_hash: XhgGhzh4Elr2gujmY6Fr0fsTKh4yCp5IYBIDbGzA8Os
 label: 'Small hero'
 id: hero_small
 description: 'A smaller variant for the hero region'

--- a/modules/social_features/social_core/config/install/crop.type.profile_large.yml
+++ b/modules/social_features/social_core/config/install/crop.type.profile_large.yml
@@ -1,8 +1,6 @@
 langcode: en
 status: true
 dependencies: {  }
-_core:
-  default_config_hash: dSb4z9EX4Ax03cx2nQ8Kwm34h3AqmJBy2-dKLvGp7S4
 label: 'Profile large'
 id: profile_large
 description: 'Large sized profile image'

--- a/modules/social_features/social_core/config/install/crop.type.profile_medium.yml
+++ b/modules/social_features/social_core/config/install/crop.type.profile_medium.yml
@@ -1,8 +1,6 @@
 langcode: en
 status: true
 dependencies: {  }
-_core:
-  default_config_hash: UiiDzWwsv6XOpSmO4iIT1PB8aaXWNq_fdJWki4TlE6I
 label: 'Profile medium'
 id: profile_medium
 description: 'Medium sized profile image'

--- a/modules/social_features/social_core/config/install/crop.type.profile_small.yml
+++ b/modules/social_features/social_core/config/install/crop.type.profile_small.yml
@@ -1,8 +1,6 @@
 langcode: en
 status: true
 dependencies: {  }
-_core:
-  default_config_hash: dlzhxhc9R3WQnyWJ8TkCz2Ekote8VmPbaRRfj2wNtpM
 label: 'Profile small'
 id: profile_small
 description: 'Small sized profile image'

--- a/modules/social_features/social_core/config/install/crop.type.teaser.yml
+++ b/modules/social_features/social_core/config/install/crop.type.teaser.yml
@@ -1,8 +1,6 @@
 langcode: en
 status: true
 dependencies: {  }
-_core:
-  default_config_hash: vyCdkkefvOpkZ7JeB2BoNPPPIT2tyd8DmKJI-Zc0bro
 label: Small
 id: teaser
 description: 'Teaser image in overviews'

--- a/modules/social_features/social_core/config/install/field.field.block_content.hero_call_to_action_block.field_call_to_action_link.yml
+++ b/modules/social_features/social_core/config/install/field.field.block_content.hero_call_to_action_block.field_call_to_action_link.yml
@@ -6,8 +6,6 @@ dependencies:
     - field.storage.block_content.field_call_to_action_link
   module:
     - link
-_core:
-  default_config_hash: 8MVChOjbx-5ZQRA8FHWN7iJuS3y9a3KEbr7M4yQi3IY
 id: block_content.hero_call_to_action_block.field_call_to_action_link
 field_name: field_call_to_action_link
 entity_type: block_content

--- a/modules/social_features/social_core/config/install/field.field.block_content.hero_call_to_action_block.field_hero_image.yml
+++ b/modules/social_features/social_core/config/install/field.field.block_content.hero_call_to_action_block.field_hero_image.yml
@@ -6,8 +6,6 @@ dependencies:
     - field.storage.block_content.field_hero_image
   module:
     - image
-_core:
-  default_config_hash: 9dJ8YW6quwievC6YFiy5yQiRlwnGRWkzcQmG6lG1M3o
 id: block_content.hero_call_to_action_block.field_hero_image
 field_name: field_hero_image
 entity_type: block_content

--- a/modules/social_features/social_core/config/install/field.field.block_content.hero_call_to_action_block.field_text_block.yml
+++ b/modules/social_features/social_core/config/install/field.field.block_content.hero_call_to_action_block.field_text_block.yml
@@ -6,8 +6,6 @@ dependencies:
     - field.storage.block_content.field_text_block
   module:
     - text
-_core:
-  default_config_hash: SCzn6crnz6ZM-1bF9iGPs7wyZute36lDQStl3k3yx90
 id: block_content.hero_call_to_action_block.field_text_block
 field_name: field_text_block
 entity_type: block_content

--- a/modules/social_features/social_core/config/install/field.field.block_content.platform_intro.field_text_block.yml
+++ b/modules/social_features/social_core/config/install/field.field.block_content.platform_intro.field_text_block.yml
@@ -6,8 +6,6 @@ dependencies:
     - field.storage.block_content.field_text_block
   module:
     - text
-_core:
-  default_config_hash: 2M4dO9Gms17T3Nnnum_SDoxy3-PK1rORGcU9yA_AoR8
 id: block_content.platform_intro.field_text_block
 field_name: field_text_block
 entity_type: block_content

--- a/modules/social_features/social_core/config/install/field.storage.block_content.field_hero_image.yml
+++ b/modules/social_features/social_core/config/install/field.storage.block_content.field_hero_image.yml
@@ -5,8 +5,6 @@ dependencies:
     - block_content
     - file
     - image
-_core:
-  default_config_hash: luHEf-HUEp2GWRiQv0baeG3kja-o-UQvnET1eU-fdqs
 id: block_content.field_hero_image
 field_name: field_hero_image
 entity_type: block_content

--- a/modules/social_features/social_core/config/install/field.storage.block_content.field_text_block.yml
+++ b/modules/social_features/social_core/config/install/field.storage.block_content.field_text_block.yml
@@ -4,8 +4,6 @@ dependencies:
   module:
     - block_content
     - text
-_core:
-  default_config_hash: bKn73jUZ6znmFyAFqeHp0ZU7_62ZyLR_inMVBNCboaU
 id: block_content.field_text_block
 field_name: field_text_block
 entity_type: block_content

--- a/modules/social_features/social_core/config/install/image.style.crop_thumbnail.yml
+++ b/modules/social_features/social_core/config/install/image.style.crop_thumbnail.yml
@@ -3,8 +3,6 @@ status: true
 dependencies:
   module:
     - image_effects
-_core:
-  default_config_hash: hwRrbLJEH3rFypPW8XnswA7U-o5V2T4uq7H-O0gW3aM
 name: crop_thumbnail
 label: 'Crop thumbnail'
 effects:

--- a/modules/social_features/social_core/config/install/image.style.social_an_hero.yml
+++ b/modules/social_features/social_core/config/install/image.style.social_an_hero.yml
@@ -6,8 +6,6 @@ dependencies:
   module:
     - crop
     - image_effects
-_core:
-  default_config_hash: x6JAV-s7L13C_dpDjAiZCXcPWzq6W2G8mgnTIFjqDRk
 name: social_an_hero
 label: 'social an hero image (1200 x 490)'
 effects:

--- a/modules/social_features/social_core/config/install/image.style.social_hero_small.yml
+++ b/modules/social_features/social_core/config/install/image.style.social_hero_small.yml
@@ -6,8 +6,6 @@ dependencies:
   module:
     - crop
     - image_effects
-_core:
-  default_config_hash: dMVU_VJ-WM9yHKsH2NGsNClFxlYuIb5idL_DAJbGVdc
 name: social_hero_small
 label: 'social hero small (1200 x 193)'
 effects:

--- a/modules/social_features/social_core/config/install/image.style.social_large.yml
+++ b/modules/social_features/social_core/config/install/image.style.social_large.yml
@@ -6,8 +6,6 @@ dependencies:
   module:
     - crop
     - image_effects
-_core:
-  default_config_hash: by7soStphcJwnSYwoc3Jh100ArXP2AVNcFhDQqrX73E
 name: social_large
 label: 'social large (128 x 128)'
 effects:

--- a/modules/social_features/social_core/config/install/image.style.social_medium.yml
+++ b/modules/social_features/social_core/config/install/image.style.social_medium.yml
@@ -6,8 +6,6 @@ dependencies:
   module:
     - crop
     - image_effects
-_core:
-  default_config_hash: ewGfEO9BnBI6O4B6354tcojbYzNmQTpGJuL1o1wO-AY
 name: social_medium
 label: 'social medium (44 x 44)'
 effects:

--- a/modules/social_features/social_core/config/install/image.style.social_small.yml
+++ b/modules/social_features/social_core/config/install/image.style.social_small.yml
@@ -6,8 +6,6 @@ dependencies:
   module:
     - crop
     - image_effects
-_core:
-  default_config_hash: jQGw92zx4a6kuLl6UifCoNFmTCL2637hvKR8TaiMYCI
 name: social_small
 label: 'social small (24 x 24)'
 effects:

--- a/modules/social_features/social_core/config/install/image.style.social_tiny.yml
+++ b/modules/social_features/social_core/config/install/image.style.social_tiny.yml
@@ -3,8 +3,6 @@ status: true
 dependencies:
   module:
     - image_effects
-_core:
-  default_config_hash: H0KZbkHErovOlL5g4WyfsMaBiGeQoXKJ5xt17zJ9fYc
 name: social_tiny
 label: 'social tiny (16 x 16)'
 effects:

--- a/modules/social_features/social_core/config/install/image.style.social_x_large.yml
+++ b/modules/social_features/social_core/config/install/image.style.social_x_large.yml
@@ -6,8 +6,6 @@ dependencies:
   module:
     - crop
     - image_effects
-_core:
-  default_config_hash: '-5vLOwysLk3MdZDPODbjHHp_ghkxfYchyU5F30h_-FA'
 name: social_x_large
 label: 'social extra large (220 x 220)'
 effects:

--- a/modules/social_features/social_core/config/install/image.style.social_xx_large.yml
+++ b/modules/social_features/social_core/config/install/image.style.social_xx_large.yml
@@ -6,8 +6,6 @@ dependencies:
   module:
     - crop
     - image_effects
-_core:
-  default_config_hash: NbMJeiAWrT8HzPnJR9nELyum0RqLsh-mhj5qMNl7-m0
 name: social_xx_large
 label: 'social extra extra large (1200 x 423)'
 effects:

--- a/modules/social_features/social_event/config/install/core.base_field_override.node.event.promote.yml
+++ b/modules/social_features/social_event/config/install/core.base_field_override.node.event.promote.yml
@@ -3,8 +3,6 @@ status: true
 dependencies:
   config:
     - node.type.event
-_core:
-  default_config_hash: 8ZTn-RglIOozpCCJ_n-bfJBCPeQlWRvaMWPjFpw2nYQ
 id: node.event.promote
 field_name: promote
 entity_type: node

--- a/modules/social_features/social_event/config/install/core.entity_form_display.event_enrollment.event_enrollment.default.yml
+++ b/modules/social_features/social_event/config/install/core.entity_form_display.event_enrollment.event_enrollment.default.yml
@@ -7,8 +7,6 @@ dependencies:
     - field.field.event_enrollment.event_enrollment.field_event
   module:
     - social_event
-_core:
-  default_config_hash: NMbvfZgCd0-cBojlZ5n_KDJOjX69vRHjnCw-i5a_hMc
 id: event_enrollment.event_enrollment.default
 targetEntityType: event_enrollment
 bundle: event_enrollment

--- a/modules/social_features/social_event/config/install/core.entity_form_display.node.event.default.yml
+++ b/modules/social_features/social_event/config/install/core.entity_form_display.node.event.default.yml
@@ -113,8 +113,6 @@ third_party_settings:
         required_fields: true
         id: enrollment
         classes: card
-_core:
-  default_config_hash: qKBzdABwV4xgosxvvpPa9VD-XmjoctFRVihQvmMs2a4
 id: node.event.default
 targetEntityType: node
 bundle: event

--- a/modules/social_features/social_event/config/install/core.entity_view_display.event_enrollment.event_enrollment.default.yml
+++ b/modules/social_features/social_event/config/install/core.entity_view_display.event_enrollment.event_enrollment.default.yml
@@ -9,8 +9,6 @@ dependencies:
     - options
     - social_event
     - user
-_core:
-  default_config_hash: uGHIGQBfJTvsxIXE7F9BxubYqW4oGit-jjHrvOHsTXQ
 id: event_enrollment.event_enrollment.default
 targetEntityType: event_enrollment
 bundle: event_enrollment

--- a/modules/social_features/social_event/config/install/core.entity_view_display.node.event.activity.yml
+++ b/modules/social_features/social_event/config/install/core.entity_view_display.node.event.activity.yml
@@ -21,8 +21,6 @@ dependencies:
     - image
     - social_core
     - user
-_core:
-  default_config_hash: r8pYWAV1CaGVHSd3VwVdYWqJyiBlHK1MqJOAcTwDnQw
 id: node.event.activity
 targetEntityType: node
 bundle: event

--- a/modules/social_features/social_event/config/install/core.entity_view_display.node.event.activity_comment.yml
+++ b/modules/social_features/social_event/config/install/core.entity_view_display.node.event.activity_comment.yml
@@ -20,8 +20,6 @@ dependencies:
     - datetime
     - image
     - user
-_core:
-  default_config_hash: psOy9JYXqH1kjMmGPXNIsB_qmfjt_8eKxTJRH-FiG1s
 id: node.event.activity_comment
 targetEntityType: node
 bundle: event

--- a/modules/social_features/social_event/config/install/core.entity_view_display.node.event.default.yml
+++ b/modules/social_features/social_event/config/install/core.entity_view_display.node.event.default.yml
@@ -20,8 +20,6 @@ dependencies:
     - group_core_comments
     - text
     - user
-_core:
-  default_config_hash: YSzSy3HUo9je_gPC2_J3qhGlXR5m_9do9ByM1pYjWPQ
 id: node.event.default
 targetEntityType: node
 bundle: event

--- a/modules/social_features/social_event/config/install/core.entity_view_display.node.event.hero.yml
+++ b/modules/social_features/social_event/config/install/core.entity_view_display.node.event.hero.yml
@@ -20,8 +20,6 @@ dependencies:
     - datetime
     - image
     - user
-_core:
-  default_config_hash: reagk3KKyc3bb_YShysQtwYrIAlbF_c_iz0iMPBEYyo
 id: node.event.hero
 targetEntityType: node
 bundle: event

--- a/modules/social_features/social_event/config/install/core.entity_view_display.node.event.search_index.yml
+++ b/modules/social_features/social_event/config/install/core.entity_view_display.node.event.search_index.yml
@@ -19,8 +19,6 @@ dependencies:
     - comment
     - text
     - user
-_core:
-  default_config_hash: zi8mN4y6pXncHTKLEAu3I-xeC6BVzHseJz0n0LILUmo
 id: node.event.search_index
 targetEntityType: node
 bundle: event

--- a/modules/social_features/social_event/config/install/core.entity_view_display.node.event.teaser.yml
+++ b/modules/social_features/social_event/config/install/core.entity_view_display.node.event.teaser.yml
@@ -21,8 +21,6 @@ dependencies:
     - image
     - options
     - user
-_core:
-  default_config_hash: xvdrW_Y1J3gkr2lXzQqQZt8ljax50tJ6mwu06zcuTHY
 id: node.event.teaser
 targetEntityType: node
 bundle: event

--- a/modules/social_features/social_event/config/install/field.field.event_enrollment.event_enrollment.field_account.yml
+++ b/modules/social_features/social_event/config/install/field.field.event_enrollment.event_enrollment.field_account.yml
@@ -5,8 +5,6 @@ dependencies:
     - field.storage.event_enrollment.field_account
   module:
     - social_event
-_core:
-  default_config_hash: hT3ch3WHdm7qK_WG9muPJczKnhCHiixAY4bbHxhSf3Y
 id: event_enrollment.event_enrollment.field_account
 field_name: field_account
 entity_type: event_enrollment

--- a/modules/social_features/social_event/config/install/field.field.event_enrollment.event_enrollment.field_enrollment_status.yml
+++ b/modules/social_features/social_event/config/install/field.field.event_enrollment.event_enrollment.field_enrollment_status.yml
@@ -6,8 +6,6 @@ dependencies:
   module:
     - options
     - social_event
-_core:
-  default_config_hash: XgNJ1_CVEwnC4fSbjkxigoa4GcRuO24e62A-fLYcxxc
 id: event_enrollment.event_enrollment.field_enrollment_status
 field_name: field_enrollment_status
 entity_type: event_enrollment

--- a/modules/social_features/social_event/config/install/field.field.event_enrollment.event_enrollment.field_event.yml
+++ b/modules/social_features/social_event/config/install/field.field.event_enrollment.event_enrollment.field_event.yml
@@ -6,8 +6,6 @@ dependencies:
     - node.type.event
   module:
     - social_event
-_core:
-  default_config_hash: WLl7Vwltvns43j0YjLdua-m682y1jsInbmh8RCukF1U
 id: event_enrollment.event_enrollment.field_event
 field_name: field_event
 entity_type: event_enrollment

--- a/modules/social_features/social_event/config/install/field.field.node.event.body.yml
+++ b/modules/social_features/social_event/config/install/field.field.node.event.body.yml
@@ -6,8 +6,6 @@ dependencies:
     - node.type.event
   module:
     - text
-_core:
-  default_config_hash: D5SYDe0gQVqiM9ZlIMfhAP7eRCT4g4ceCnzuAJoVbTs
 id: node.event.body
 field_name: body
 entity_type: node

--- a/modules/social_features/social_event/config/install/field.field.node.event.field_content_visibility.yml
+++ b/modules/social_features/social_event/config/install/field.field.node.event.field_content_visibility.yml
@@ -6,8 +6,6 @@ dependencies:
     - node.type.event
   module:
     - entity_access_by_field
-_core:
-  default_config_hash: 20ligM0K79fbYngfooKMfP12shzEe59yW5MZfVucnKw
 id: node.event.field_content_visibility
 field_name: field_content_visibility
 entity_type: node

--- a/modules/social_features/social_event/config/install/field.field.node.event.field_event_address.yml
+++ b/modules/social_features/social_event/config/install/field.field.node.event.field_event_address.yml
@@ -6,8 +6,6 @@ dependencies:
     - node.type.event
   module:
     - address
-_core:
-  default_config_hash: 9Y_QDOq-feqABZOQc53yifOuN8H7rhHxw0Mwt5ISPMc
 id: node.event.field_event_address
 field_name: field_event_address
 entity_type: node

--- a/modules/social_features/social_event/config/install/field.field.node.event.field_event_comments.yml
+++ b/modules/social_features/social_event/config/install/field.field.node.event.field_event_comments.yml
@@ -6,8 +6,6 @@ dependencies:
     - node.type.event
   module:
     - comment
-_core:
-  default_config_hash: vwf3UG4AfeKtuNSWPqZPy509jLIrUDCvWjyoknc7B08
 id: node.event.field_event_comments
 field_name: field_event_comments
 entity_type: node

--- a/modules/social_features/social_event/config/install/field.field.node.event.field_event_date.yml
+++ b/modules/social_features/social_event/config/install/field.field.node.event.field_event_date.yml
@@ -6,8 +6,6 @@ dependencies:
     - node.type.event
   module:
     - datetime
-_core:
-  default_config_hash: pPHPELeLXbiNq458ZjX_PF5-6oEJjCG6vowOqiVjA4g
 id: node.event.field_event_date
 field_name: field_event_date
 entity_type: node

--- a/modules/social_features/social_event/config/install/field.field.node.event.field_event_date_end.yml
+++ b/modules/social_features/social_event/config/install/field.field.node.event.field_event_date_end.yml
@@ -6,8 +6,6 @@ dependencies:
     - node.type.event
   module:
     - datetime
-_core:
-  default_config_hash: Ne8ZNHPF17tl3ecCJtFonYmWVnrHIvn3yiVJGO604aU
 id: node.event.field_event_date_end
 field_name: field_event_date_end
 entity_type: node

--- a/modules/social_features/social_event/config/install/field.field.node.event.field_event_enroll.yml
+++ b/modules/social_features/social_event/config/install/field.field.node.event.field_event_enroll.yml
@@ -4,8 +4,6 @@ dependencies:
   config:
     - field.storage.node.field_event_enroll
     - node.type.event
-_core:
-  default_config_hash: MhRr0lj2xDxHDvWc3VVz-cZVg8KlV4jERnEae5cHHCk
 id: node.event.field_event_enroll
 field_name: field_event_enroll
 entity_type: node

--- a/modules/social_features/social_event/config/install/field.field.node.event.field_event_image.yml
+++ b/modules/social_features/social_event/config/install/field.field.node.event.field_event_image.yml
@@ -6,8 +6,6 @@ dependencies:
     - node.type.event
   module:
     - image
-_core:
-  default_config_hash: 1voReQy0M0g_Q37FfXnf_P79HHYR3refXZGStPgnE6s
 id: node.event.field_event_image
 field_name: field_event_image
 entity_type: node

--- a/modules/social_features/social_event/config/install/field.field.node.event.field_event_location.yml
+++ b/modules/social_features/social_event/config/install/field.field.node.event.field_event_location.yml
@@ -4,8 +4,6 @@ dependencies:
   config:
     - field.storage.node.field_event_location
     - node.type.event
-_core:
-  default_config_hash: R7kQhajFTZvuITuttlDeba23FJCn-RaUX5SgRSixO_4
 id: node.event.field_event_location
 field_name: field_event_location
 entity_type: node

--- a/modules/social_features/social_event/config/install/field.field.node.event.field_files.yml
+++ b/modules/social_features/social_event/config/install/field.field.node.event.field_files.yml
@@ -6,8 +6,6 @@ dependencies:
     - node.type.event
   module:
     - file
-_core:
-  default_config_hash: GkmWEYyUBQqlE_w4wImeaEUu5TpeOMn0v-iddqCg5I4
 id: node.event.field_files
 field_name: field_files
 entity_type: node

--- a/modules/social_features/social_event/config/install/field.storage.event_enrollment.field_account.yml
+++ b/modules/social_features/social_event/config/install/field.storage.event_enrollment.field_account.yml
@@ -4,8 +4,6 @@ dependencies:
   module:
     - social_event
     - user
-_core:
-  default_config_hash: _aXXBgWq3i2pnCB-pysXTS-g8QpHXnROSx0bhN8nyZw
 id: event_enrollment.field_account
 field_name: field_account
 entity_type: event_enrollment

--- a/modules/social_features/social_event/config/install/field.storage.event_enrollment.field_enrollment_status.yml
+++ b/modules/social_features/social_event/config/install/field.storage.event_enrollment.field_enrollment_status.yml
@@ -4,8 +4,6 @@ dependencies:
   module:
     - options
     - social_event
-_core:
-  default_config_hash: EwwLz17loR8Y3GotHFqIzv6lxIC6LhRtHqGaEGLgfs4
 id: event_enrollment.field_enrollment_status
 field_name: field_enrollment_status
 entity_type: event_enrollment

--- a/modules/social_features/social_event/config/install/field.storage.event_enrollment.field_event.yml
+++ b/modules/social_features/social_event/config/install/field.storage.event_enrollment.field_event.yml
@@ -4,8 +4,6 @@ dependencies:
   module:
     - node
     - social_event
-_core:
-  default_config_hash: W7T1QQuUjEeZCgC_3Vfpeljkf7jc54xyeDDZYKGx8wI
 id: event_enrollment.field_event
 field_name: field_event
 entity_type: event_enrollment

--- a/modules/social_features/social_event/config/install/field.storage.node.field_content_visibility.yml
+++ b/modules/social_features/social_event/config/install/field.storage.node.field_content_visibility.yml
@@ -4,8 +4,6 @@ dependencies:
   module:
     - entity_access_by_field
     - node
-_core:
-  default_config_hash: JzDmy8pQ5QXtw4GI-V3qGD5hGn67xxn2wigWltKkav4
 id: node.field_content_visibility
 field_name: field_content_visibility
 entity_type: node

--- a/modules/social_features/social_event/config/install/field.storage.node.field_event_address.yml
+++ b/modules/social_features/social_event/config/install/field.storage.node.field_event_address.yml
@@ -4,8 +4,6 @@ dependencies:
   module:
     - address
     - node
-_core:
-  default_config_hash: Cw4zMPX5baU9ygQFDu_ym2hMezfWv58GV6wdaAjHUXk
 id: node.field_event_address
 field_name: field_event_address
 entity_type: node

--- a/modules/social_features/social_event/config/install/field.storage.node.field_event_comments.yml
+++ b/modules/social_features/social_event/config/install/field.storage.node.field_event_comments.yml
@@ -4,8 +4,6 @@ dependencies:
   module:
     - comment
     - node
-_core:
-  default_config_hash: q1MFwnpfOimodFTajUv32VLbO41BBTwymyLdROIjoq8
 id: node.field_event_comments
 field_name: field_event_comments
 entity_type: node

--- a/modules/social_features/social_event/config/install/field.storage.node.field_event_date.yml
+++ b/modules/social_features/social_event/config/install/field.storage.node.field_event_date.yml
@@ -4,8 +4,6 @@ dependencies:
   module:
     - datetime
     - node
-_core:
-  default_config_hash: Wy89Y-RqThburQ0cZc-SH08AgwXkjSxEba7sBkw1034
 id: node.field_event_date
 field_name: field_event_date
 entity_type: node

--- a/modules/social_features/social_event/config/install/field.storage.node.field_event_date_end.yml
+++ b/modules/social_features/social_event/config/install/field.storage.node.field_event_date_end.yml
@@ -4,8 +4,6 @@ dependencies:
   module:
     - datetime
     - node
-_core:
-  default_config_hash: 7MJM1J1RJynow3ZTVPB0C9bGkvidD_LBMvwqMCquN2Q
 id: node.field_event_date_end
 field_name: field_event_date_end
 entity_type: node

--- a/modules/social_features/social_event/config/install/field.storage.node.field_event_enroll.yml
+++ b/modules/social_features/social_event/config/install/field.storage.node.field_event_enroll.yml
@@ -3,8 +3,6 @@ status: true
 dependencies:
   module:
     - node
-_core:
-  default_config_hash: q1L5aaKA7giAB3zZyc_ZiihldYteLZkEvut6Pi0jhPQ
 id: node.field_event_enroll
 field_name: field_event_enroll
 entity_type: node

--- a/modules/social_features/social_event/config/install/field.storage.node.field_event_image.yml
+++ b/modules/social_features/social_event/config/install/field.storage.node.field_event_image.yml
@@ -5,8 +5,6 @@ dependencies:
     - file
     - image
     - node
-_core:
-  default_config_hash: n_BOi0DfHp0aPnWWKoLJ_a42dGf-PmH1UM3JyhfWbv8
 id: node.field_event_image
 field_name: field_event_image
 entity_type: node

--- a/modules/social_features/social_event/config/install/field.storage.node.field_event_location.yml
+++ b/modules/social_features/social_event/config/install/field.storage.node.field_event_location.yml
@@ -3,8 +3,6 @@ status: true
 dependencies:
   module:
     - node
-_core:
-  default_config_hash: e1C4rmrO-3L1I0l2J5EP0LneHwi2Ts398GxTX40rLIM
 id: node.field_event_location
 field_name: field_event_location
 entity_type: node

--- a/modules/social_features/social_event/config/install/field.storage.node.field_files.yml
+++ b/modules/social_features/social_event/config/install/field.storage.node.field_files.yml
@@ -4,8 +4,6 @@ dependencies:
   module:
     - file
     - node
-_core:
-  default_config_hash: 0xdqy7Uw_dER7wQBvjVbAdwYyhN6TRjztM4HJNlDN30
 id: node.field_files
 field_name: field_files
 entity_type: node

--- a/modules/social_features/social_event/config/install/node.type.event.yml
+++ b/modules/social_features/social_event/config/install/node.type.event.yml
@@ -7,8 +7,6 @@ third_party_settings:
   menu_ui:
     available_menus: {  }
     parent: ''
-_core:
-  default_config_hash: xAKaUWzbpluOMIPdY2QIzKEqVZffz4vaL3nWFtL884I
 name: Event
 type: event
 description: ''

--- a/modules/social_features/social_event/config/install/views.view.event_enrollments.yml
+++ b/modules/social_features/social_event/config/install/views.view.event_enrollments.yml
@@ -10,8 +10,6 @@ dependencies:
     - profile
     - social_event
     - user
-_core:
-  default_config_hash: oqH52X8EmLo58zmC-MtaJP97dVGIRxxtppFmPV8uyb4
 id: event_enrollments
 label: Enrollments
 module: views

--- a/modules/social_features/social_event/config/install/views.view.events.yml
+++ b/modules/social_features/social_event/config/install/views.view.events.yml
@@ -10,8 +10,6 @@ dependencies:
     - node
     - social_event
     - user
-_core:
-  default_config_hash: S62CjB3X7jHYzK5Hx-bQdr9jh6lwjPe-w4sSSsUpmbE
 id: events
 label: 'Events Profile'
 module: views

--- a/modules/social_features/social_event/config/install/views.view.upcoming_events.yml
+++ b/modules/social_features/social_event/config/install/views.view.upcoming_events.yml
@@ -12,8 +12,6 @@ dependencies:
     - options
     - social_event
     - user
-_core:
-  default_config_hash: jICmCvyBLhkwjQbswDAncFY0kUOuDGtZmMJf26vPvxg
 id: upcoming_events
 label: '(Upcoming) Community events'
 module: views

--- a/modules/social_features/social_follow_content/config/install/field.field.message.create_comment_following_node.field_message_context.yml
+++ b/modules/social_features/social_follow_content/config/install/field.field.message.create_comment_following_node.field_message_context.yml
@@ -6,8 +6,6 @@ dependencies:
     - message.template.create_comment_following_node
   module:
     - options
-_core:
-  default_config_hash: Piuz2n5ougkqE7XjHlgbG-Mp_hpR_uV1i8c7_FaNI88
 id: message.create_comment_following_node.field_message_context
 field_name: field_message_context
 entity_type: message

--- a/modules/social_features/social_follow_content/config/install/field.field.message.create_comment_following_node.field_message_destination.yml
+++ b/modules/social_features/social_follow_content/config/install/field.field.message.create_comment_following_node.field_message_destination.yml
@@ -6,8 +6,6 @@ dependencies:
     - message.template.create_comment_following_node
   module:
     - options
-_core:
-  default_config_hash: YWduKtAu2eaIj4NLryatzOUH3lp0uP919a27fHhKSNc
 id: message.create_comment_following_node.field_message_destination
 field_name: field_message_destination
 entity_type: message

--- a/modules/social_features/social_follow_content/config/install/field.field.message.create_comment_following_node.field_message_related_object.yml
+++ b/modules/social_features/social_follow_content/config/install/field.field.message.create_comment_following_node.field_message_related_object.yml
@@ -8,8 +8,6 @@ dependencies:
     - node.type.topic
   module:
     - dynamic_entity_reference
-_core:
-  default_config_hash: O2QWxLGwDr_RuOBA3e7z2ipY-9dpIY9iC2miLjLwokQ
 id: message.create_comment_following_node.field_message_related_object
 field_name: field_message_related_object
 entity_type: message

--- a/modules/social_features/social_follow_content/config/install/flag.flag.follow_content.yml
+++ b/modules/social_features/social_follow_content/config/install/flag.flag.follow_content.yml
@@ -3,8 +3,6 @@ status: true
 dependencies:
   module:
     - node
-_core:
-  default_config_hash: u7QcIilN6W6ooHahb_7xRJH8vSy0RDp_LDpyqBUk1Dk
 id: follow_content
 label: 'Follow content'
 bundles: {  }

--- a/modules/social_features/social_follow_content/config/install/message.template.create_comment_following_node.yml
+++ b/modules/social_features/social_follow_content/config/install/message.template.create_comment_following_node.yml
@@ -15,8 +15,6 @@ third_party_settings:
     activity_create_direct: false
     activity_aggregate: false
     activity_entity_condition: comment_all
-_core:
-  default_config_hash: eoiFOMPHdOLwaN-IdH5cE9nLcspVTmvjdVjJCSfmwnI
 template: create_comment_following_node
 label: 'Create comment on following node'
 description: 'A person commented on content I am following'

--- a/modules/social_features/social_follow_content/config/install/views.view.following.yml
+++ b/modules/social_features/social_follow_content/config/install/views.view.following.yml
@@ -12,8 +12,6 @@ dependencies:
     - node
     - profile
     - user
-_core:
-  default_config_hash: 2UFxRhD62-Y1YVrzHK9eECIsh1QAWh_JmdzIi3fv030
 id: following
 label: 'Content I follow'
 module: views

--- a/modules/social_features/social_group/config/install/core.entity_form_display.group.closed_group.default.yml
+++ b/modules/social_features/social_group/config/install/core.entity_form_display.group.closed_group.default.yml
@@ -55,8 +55,6 @@ third_party_settings:
         required_fields: true
       label: Settings
       region: content
-_core:
-  default_config_hash: kATstxtWBQIeHU47wQOh8CNoworw7pMiPY6RGgOd2Z4
 id: group.closed_group.default
 targetEntityType: group
 bundle: closed_group

--- a/modules/social_features/social_group/config/install/core.entity_form_display.group.open_group.default.yml
+++ b/modules/social_features/social_group/config/install/core.entity_form_display.group.open_group.default.yml
@@ -55,8 +55,6 @@ third_party_settings:
         required_fields: true
       label: Settings
       region: content
-_core:
-  default_config_hash: Ip_OKGrmJhw6_2IIz5s_KGBETX59Snsxlt3p3hZxIKQ
 id: group.open_group.default
 targetEntityType: group
 bundle: open_group

--- a/modules/social_features/social_group/config/install/core.entity_form_display.group.public_group.default.yml
+++ b/modules/social_features/social_group/config/install/core.entity_form_display.group.public_group.default.yml
@@ -55,8 +55,6 @@ third_party_settings:
         required_fields: true
       label: Settings
       region: content
-_core:
-  default_config_hash: jP1xtfSYzLbG5kwQ53MOz2hWETJCNioarzuiECckYkQ
 id: group.public_group.default
 targetEntityType: group
 bundle: public_group

--- a/modules/social_features/social_group/config/install/core.entity_form_display.group_content.closed_group-group_membership.default.yml
+++ b/modules/social_features/social_group/config/install/core.entity_form_display.group_content.closed_group-group_membership.default.yml
@@ -6,8 +6,6 @@ dependencies:
     - group.content_type.closed_group-group_membership
   module:
     - path
-_core:
-  default_config_hash: pz7emc5Ba6KiEt7OnOPSjSVsaLN0ZIay-4Jdh_ixxeI
 id: group_content.closed_group-group_membership.default
 targetEntityType: group_content
 bundle: closed_group-group_membership

--- a/modules/social_features/social_group/config/install/core.entity_form_display.group_content.open_group-group_membership.default.yml
+++ b/modules/social_features/social_group/config/install/core.entity_form_display.group_content.open_group-group_membership.default.yml
@@ -6,8 +6,6 @@ dependencies:
     - group.content_type.open_group-group_membership
   module:
     - path
-_core:
-  default_config_hash: RumROeaBKTmN8AWc0ewyQZJ9oAILH3bdiNpIkaiNu_Y
 id: group_content.open_group-group_membership.default
 targetEntityType: group_content
 bundle: open_group-group_membership

--- a/modules/social_features/social_group/config/install/core.entity_form_display.group_content.public_group-group_membership.default.yml
+++ b/modules/social_features/social_group/config/install/core.entity_form_display.group_content.public_group-group_membership.default.yml
@@ -6,8 +6,6 @@ dependencies:
     - group.content_type.public_group-group_membership
   module:
     - path
-_core:
-  default_config_hash: varQuDQHL_XXfXpFeRrCSQH-foOy3aP0yC1XFXrfc9s
 id: group_content.public_group-group_membership.default
 targetEntityType: group_content
 bundle: public_group-group_membership

--- a/modules/social_features/social_group/config/install/core.entity_view_display.group.closed_group.default.yml
+++ b/modules/social_features/social_group/config/install/core.entity_view_display.group.closed_group.default.yml
@@ -7,8 +7,6 @@ dependencies:
     - field.field.group.closed_group.field_group_image
     - field.field.group.closed_group.field_group_location
     - group.type.closed_group
-_core:
-  default_config_hash: QINyh7YnF9AP4gx-KHy-mUPDUoov06tQz57VkM1YpPE
 id: group.closed_group.default
 targetEntityType: group
 bundle: closed_group

--- a/modules/social_features/social_group/config/install/core.entity_view_display.group.closed_group.hero.yml
+++ b/modules/social_features/social_group/config/install/core.entity_view_display.group.closed_group.hero.yml
@@ -12,8 +12,6 @@ dependencies:
   module:
     - address
     - image
-_core:
-  default_config_hash: 5awF-p4gmAsVt6eT-8I31agN8iFVXK7UmZSQzwvlz84
 id: group.closed_group.hero
 targetEntityType: group
 bundle: closed_group

--- a/modules/social_features/social_group/config/install/core.entity_view_display.group.closed_group.stream.yml
+++ b/modules/social_features/social_group/config/install/core.entity_view_display.group.closed_group.stream.yml
@@ -8,8 +8,6 @@ dependencies:
     - field.field.group.closed_group.field_group_image
     - field.field.group.closed_group.field_group_location
     - group.type.closed_group
-_core:
-  default_config_hash: IW9GutftuvaGiBVaBcWunM-yPg40z4RS0sK3riTWykc
 id: group.closed_group.stream
 targetEntityType: group
 bundle: closed_group

--- a/modules/social_features/social_group/config/install/core.entity_view_display.group.closed_group.teaser.yml
+++ b/modules/social_features/social_group/config/install/core.entity_view_display.group.closed_group.teaser.yml
@@ -12,8 +12,6 @@ dependencies:
   module:
     - address
     - image
-_core:
-  default_config_hash: zno14GBDQfRxTONPPd-BEf91KcbNba23a1XpOdpIfJQ
 id: group.closed_group.teaser
 targetEntityType: group
 bundle: closed_group

--- a/modules/social_features/social_group/config/install/core.entity_view_display.group.open_group.default.yml
+++ b/modules/social_features/social_group/config/install/core.entity_view_display.group.open_group.default.yml
@@ -7,8 +7,6 @@ dependencies:
     - field.field.group.open_group.field_group_image
     - field.field.group.open_group.field_group_location
     - group.type.open_group
-_core:
-  default_config_hash: clf8xhH6T-dbKfoHVmLHi19n25BDMGz-lWZbBPpCOIA
 id: group.open_group.default
 targetEntityType: group
 bundle: open_group

--- a/modules/social_features/social_group/config/install/core.entity_view_display.group.open_group.hero.yml
+++ b/modules/social_features/social_group/config/install/core.entity_view_display.group.open_group.hero.yml
@@ -12,8 +12,6 @@ dependencies:
   module:
     - address
     - image
-_core:
-  default_config_hash: QG60AYCONRBY3QdKV-fsbFVKh2x_ZjAEfVIZ2euUGys
 id: group.open_group.hero
 targetEntityType: group
 bundle: open_group

--- a/modules/social_features/social_group/config/install/core.entity_view_display.group.open_group.stream.yml
+++ b/modules/social_features/social_group/config/install/core.entity_view_display.group.open_group.stream.yml
@@ -8,8 +8,6 @@ dependencies:
     - field.field.group.open_group.field_group_image
     - field.field.group.open_group.field_group_location
     - group.type.open_group
-_core:
-  default_config_hash: FppTrfCu72F1-39fWIij1pXldzbeLwollIJ3Cayd8Zg
 id: group.open_group.stream
 targetEntityType: group
 bundle: open_group

--- a/modules/social_features/social_group/config/install/core.entity_view_display.group.open_group.teaser.yml
+++ b/modules/social_features/social_group/config/install/core.entity_view_display.group.open_group.teaser.yml
@@ -12,8 +12,6 @@ dependencies:
   module:
     - address
     - image
-_core:
-  default_config_hash: PNgCWEqaC2TCb47rcG5TmkYRANaY61Q-kt3jG4hcJFk
 id: group.open_group.teaser
 targetEntityType: group
 bundle: open_group

--- a/modules/social_features/social_group/config/install/core.entity_view_display.group.public_group.default.yml
+++ b/modules/social_features/social_group/config/install/core.entity_view_display.group.public_group.default.yml
@@ -7,8 +7,6 @@ dependencies:
     - field.field.group.public_group.field_group_image
     - field.field.group.public_group.field_group_location
     - group.type.public_group
-_core:
-  default_config_hash: LUlT3cNG0k8QOivaMahrt4lb_3ea_a3GMKNI73EAhS0
 id: group.public_group.default
 targetEntityType: group
 bundle: public_group

--- a/modules/social_features/social_group/config/install/core.entity_view_display.group.public_group.hero.yml
+++ b/modules/social_features/social_group/config/install/core.entity_view_display.group.public_group.hero.yml
@@ -12,8 +12,6 @@ dependencies:
   module:
     - address
     - image
-_core:
-  default_config_hash: feMrVgB2pgadOnic6CUJoNL4we8xt8K_wMOXe2d3Yy0
 id: group.public_group.hero
 targetEntityType: group
 bundle: public_group

--- a/modules/social_features/social_group/config/install/core.entity_view_display.group.public_group.stream.yml
+++ b/modules/social_features/social_group/config/install/core.entity_view_display.group.public_group.stream.yml
@@ -8,8 +8,6 @@ dependencies:
     - field.field.group.public_group.field_group_image
     - field.field.group.public_group.field_group_location
     - group.type.public_group
-_core:
-  default_config_hash: iYlV-zetLMpBxhcmx7Zhe3qxW9ScJsfJ8KHCHdf93Ew
 id: group.public_group.stream
 targetEntityType: group
 bundle: public_group

--- a/modules/social_features/social_group/config/install/core.entity_view_display.group.public_group.teaser.yml
+++ b/modules/social_features/social_group/config/install/core.entity_view_display.group.public_group.teaser.yml
@@ -12,8 +12,6 @@ dependencies:
   module:
     - address
     - image
-_core:
-  default_config_hash: p9JiSsEAYPkRZhNky8ssHIcyQH9W8TbAb5lsH-SrLeM
 id: group.public_group.teaser
 targetEntityType: group
 bundle: public_group

--- a/modules/social_features/social_group/config/install/core.entity_view_display.group_content.closed_group-group_membership.default.yml
+++ b/modules/social_features/social_group/config/install/core.entity_view_display.group_content.closed_group-group_membership.default.yml
@@ -4,8 +4,6 @@ dependencies:
   config:
     - field.field.group_content.closed_group-group_membership.group_roles
     - group.content_type.closed_group-group_membership
-_core:
-  default_config_hash: JvPWmhPxCZqE_JAaXc1jXANcZtzQOeudVFjv9GFePLk
 id: group_content.closed_group-group_membership.default
 targetEntityType: group_content
 bundle: closed_group-group_membership

--- a/modules/social_features/social_group/config/install/core.entity_view_display.group_content.closed_group-group_node-event.default.yml
+++ b/modules/social_features/social_group/config/install/core.entity_view_display.group_content.closed_group-group_node-event.default.yml
@@ -3,8 +3,6 @@ status: true
 dependencies:
   config:
     - group.content_type.closed_group-group_node-event
-_core:
-  default_config_hash: 7N2nmZjtJWnzknwB0_r7apApsb7HgzBQMwHPQ8sLy3Q
 id: group_content.closed_group-group_node-event.default
 targetEntityType: group_content
 bundle: closed_group-group_node-event

--- a/modules/social_features/social_group/config/install/core.entity_view_display.group_content.closed_group-group_node-event.teaser.yml
+++ b/modules/social_features/social_group/config/install/core.entity_view_display.group_content.closed_group-group_node-event.teaser.yml
@@ -4,8 +4,6 @@ dependencies:
   config:
     - core.entity_view_mode.group_content.teaser
     - group.content_type.closed_group-group_node-event
-_core:
-  default_config_hash: IGnChFYt_HY5ECLnnLgnn4LL8h3X5alAE0wGB_NZf8k
 id: group_content.closed_group-group_node-event.teaser
 targetEntityType: group_content
 bundle: closed_group-group_node-event

--- a/modules/social_features/social_group/config/install/core.entity_view_display.group_content.closed_group-group_node-topic.default.yml
+++ b/modules/social_features/social_group/config/install/core.entity_view_display.group_content.closed_group-group_node-topic.default.yml
@@ -3,8 +3,6 @@ status: true
 dependencies:
   config:
     - group.content_type.closed_group-group_node-topic
-_core:
-  default_config_hash: R9o3Tro06F5Sn837Ok2tgHiIOTIWBINMSM6tf7P1fzQ
 id: group_content.closed_group-group_node-topic.default
 targetEntityType: group_content
 bundle: closed_group-group_node-topic

--- a/modules/social_features/social_group/config/install/core.entity_view_display.group_content.closed_group-group_node-topic.teaser.yml
+++ b/modules/social_features/social_group/config/install/core.entity_view_display.group_content.closed_group-group_node-topic.teaser.yml
@@ -4,8 +4,6 @@ dependencies:
   config:
     - core.entity_view_mode.group_content.teaser
     - group.content_type.closed_group-group_node-topic
-_core:
-  default_config_hash: mLzua4CIQxW1etCFXwxLW_AHJkiJNWFG8C8rCSSq8b0
 id: group_content.closed_group-group_node-topic.teaser
 targetEntityType: group_content
 bundle: closed_group-group_node-topic

--- a/modules/social_features/social_group/config/install/core.entity_view_display.group_content.open_group-group_membership.default.yml
+++ b/modules/social_features/social_group/config/install/core.entity_view_display.group_content.open_group-group_membership.default.yml
@@ -4,8 +4,6 @@ dependencies:
   config:
     - field.field.group_content.open_group-group_membership.group_roles
     - group.content_type.open_group-group_membership
-_core:
-  default_config_hash: Xrf9eC02dbsoGN2k-T5_ALRLEHesY7Biqjo4lQlvFa4
 id: group_content.open_group-group_membership.default
 targetEntityType: group_content
 bundle: open_group-group_membership

--- a/modules/social_features/social_group/config/install/core.entity_view_display.group_content.open_group-group_node-event.default.yml
+++ b/modules/social_features/social_group/config/install/core.entity_view_display.group_content.open_group-group_node-event.default.yml
@@ -3,8 +3,6 @@ status: true
 dependencies:
   config:
     - group.content_type.open_group-group_node-event
-_core:
-  default_config_hash: PZr4DpV1iD_bdhzuU5z-qRJrlrUKfDEkaDgqqxVsw08
 id: group_content.open_group-group_node-event.default
 targetEntityType: group_content
 bundle: open_group-group_node-event

--- a/modules/social_features/social_group/config/install/core.entity_view_display.group_content.open_group-group_node-event.teaser.yml
+++ b/modules/social_features/social_group/config/install/core.entity_view_display.group_content.open_group-group_node-event.teaser.yml
@@ -4,8 +4,6 @@ dependencies:
   config:
     - core.entity_view_mode.group_content.teaser
     - group.content_type.open_group-group_node-event
-_core:
-  default_config_hash: A6YHuZCKCozkmu-liDqpbmzjRCbV7MH_wmRTDkVtCEc
 id: group_content.open_group-group_node-event.teaser
 targetEntityType: group_content
 bundle: open_group-group_node-event

--- a/modules/social_features/social_group/config/install/core.entity_view_display.group_content.open_group-group_node-topic.default.yml
+++ b/modules/social_features/social_group/config/install/core.entity_view_display.group_content.open_group-group_node-topic.default.yml
@@ -3,8 +3,6 @@ status: true
 dependencies:
   config:
     - group.content_type.open_group-group_node-topic
-_core:
-  default_config_hash: TJj4XyxytZvwUyURwj_7A7XCa7LOQadz2yOnTgLVkLs
 id: group_content.open_group-group_node-topic.default
 targetEntityType: group_content
 bundle: open_group-group_node-topic

--- a/modules/social_features/social_group/config/install/core.entity_view_display.group_content.open_group-group_node-topic.teaser.yml
+++ b/modules/social_features/social_group/config/install/core.entity_view_display.group_content.open_group-group_node-topic.teaser.yml
@@ -4,8 +4,6 @@ dependencies:
   config:
     - core.entity_view_mode.group_content.teaser
     - group.content_type.open_group-group_node-topic
-_core:
-  default_config_hash: LMBFIkJLb9vvrt9p-PYj_zfm-tMEQoQCykpHXUsB0LA
 id: group_content.open_group-group_node-topic.teaser
 targetEntityType: group_content
 bundle: open_group-group_node-topic

--- a/modules/social_features/social_group/config/install/core.entity_view_display.group_content.public_group-group_membership.default.yml
+++ b/modules/social_features/social_group/config/install/core.entity_view_display.group_content.public_group-group_membership.default.yml
@@ -4,8 +4,6 @@ dependencies:
   config:
     - field.field.group_content.public_group-group_membership.group_roles
     - group.content_type.public_group-group_membership
-_core:
-  default_config_hash: 1SRYehZYHIkYG64EWzfeRs1GVnwHDorMmE4QYZnZu78
 id: group_content.public_group-group_membership.default
 targetEntityType: group_content
 bundle: public_group-group_membership

--- a/modules/social_features/social_group/config/install/core.entity_view_display.group_content.public_group-group_node-event.default.yml
+++ b/modules/social_features/social_group/config/install/core.entity_view_display.group_content.public_group-group_node-event.default.yml
@@ -3,8 +3,6 @@ status: true
 dependencies:
   config:
     - group.content_type.public_group-group_node-event
-_core:
-  default_config_hash: JAHPSh1UwR9kNFOx3aWZ3_X5q2xZa5M0fDwtl178M2A
 id: group_content.public_group-group_node-event.default
 targetEntityType: group_content
 bundle: public_group-group_node-event

--- a/modules/social_features/social_group/config/install/core.entity_view_display.group_content.public_group-group_node-event.teaser.yml
+++ b/modules/social_features/social_group/config/install/core.entity_view_display.group_content.public_group-group_node-event.teaser.yml
@@ -4,8 +4,6 @@ dependencies:
   config:
     - core.entity_view_mode.group_content.teaser
     - group.content_type.public_group-group_node-event
-_core:
-  default_config_hash: olbMZvLrVuGkpKn2pJbnyRRxbs1NUi1cDQzBQjwmzHM
 id: group_content.public_group-group_node-event.teaser
 targetEntityType: group_content
 bundle: public_group-group_node-event

--- a/modules/social_features/social_group/config/install/core.entity_view_display.group_content.public_group-group_node-topic.default.yml
+++ b/modules/social_features/social_group/config/install/core.entity_view_display.group_content.public_group-group_node-topic.default.yml
@@ -3,8 +3,6 @@ status: true
 dependencies:
   config:
     - group.content_type.public_group-group_node-topic
-_core:
-  default_config_hash: R9IBZWmuO7f-K10CeMq2nOCf91RYGbqW2YEMD8OdSdg
 id: group_content.public_group-group_node-topic.default
 targetEntityType: group_content
 bundle: public_group-group_node-topic

--- a/modules/social_features/social_group/config/install/core.entity_view_display.group_content.public_group-group_node-topic.teaser.yml
+++ b/modules/social_features/social_group/config/install/core.entity_view_display.group_content.public_group-group_node-topic.teaser.yml
@@ -4,8 +4,6 @@ dependencies:
   config:
     - core.entity_view_mode.group_content.teaser
     - group.content_type.public_group-group_node-topic
-_core:
-  default_config_hash: o1c6xUunctYmlr44HJ6SRmJBNDBds90TVFZPANq7je0
 id: group_content.public_group-group_node-topic.teaser
 targetEntityType: group_content
 bundle: public_group-group_node-topic

--- a/modules/social_features/social_group/config/install/core.entity_view_mode.group.hero.yml
+++ b/modules/social_features/social_group/config/install/core.entity_view_mode.group.hero.yml
@@ -3,8 +3,6 @@ status: true
 dependencies:
   module:
     - group
-_core:
-  default_config_hash: MPXuZOzK4bIORWlIavYvxuvIcrB35y7_WPzKKxjvtAg
 id: group.hero
 label: Hero
 targetEntityType: group

--- a/modules/social_features/social_group/config/install/core.entity_view_mode.group.small_teaser.yml
+++ b/modules/social_features/social_group/config/install/core.entity_view_mode.group.small_teaser.yml
@@ -3,8 +3,6 @@ status: true
 dependencies:
   module:
     - group
-_core:
-  default_config_hash: IVSyQ6fjaMOZdEEqizw220YWT0vtcXW_LOgOP6a2Ies
 id: group.small_teaser
 label: 'Small teaser'
 targetEntityType: group

--- a/modules/social_features/social_group/config/install/core.entity_view_mode.group.stream.yml
+++ b/modules/social_features/social_group/config/install/core.entity_view_mode.group.stream.yml
@@ -3,8 +3,6 @@ status: true
 dependencies:
   module:
     - group
-_core:
-  default_config_hash: aSldOvfYlcervH_tNioEypeWBC_zi6o8NgliDe6v7nM
 id: group.stream
 label: Stream
 targetEntityType: group

--- a/modules/social_features/social_group/config/install/core.entity_view_mode.group.teaser.yml
+++ b/modules/social_features/social_group/config/install/core.entity_view_mode.group.teaser.yml
@@ -3,8 +3,6 @@ status: true
 dependencies:
   module:
     - group
-_core:
-  default_config_hash: YXlikPyGTT4Ozc42C7qAGkMEreAc7X4yfCg6B16lH2I
 id: group.teaser
 label: Teaser
 targetEntityType: group

--- a/modules/social_features/social_group/config/install/core.entity_view_mode.group_content.teaser.yml
+++ b/modules/social_features/social_group/config/install/core.entity_view_mode.group_content.teaser.yml
@@ -3,8 +3,6 @@ status: true
 dependencies:
   module:
     - group
-_core:
-  default_config_hash: 4ovumvZuS5UXl_YkuAM0Pu2wB4n5ho7R4amUxJLf2jQ
 id: group_content.teaser
 label: Teaser
 targetEntityType: group_content

--- a/modules/social_features/social_group/config/install/field.field.group.closed_group.field_group_address.yml
+++ b/modules/social_features/social_group/config/install/field.field.group.closed_group.field_group_address.yml
@@ -6,8 +6,6 @@ dependencies:
     - group.type.closed_group
   module:
     - address
-_core:
-  default_config_hash: AkRoGsTNkGpDJka7p7r86NUKGFqImeRykfNwFW5e_p0
 id: group.closed_group.field_group_address
 field_name: field_group_address
 entity_type: group

--- a/modules/social_features/social_group/config/install/field.field.group.closed_group.field_group_description.yml
+++ b/modules/social_features/social_group/config/install/field.field.group.closed_group.field_group_description.yml
@@ -6,8 +6,6 @@ dependencies:
     - group.type.closed_group
   module:
     - text
-_core:
-  default_config_hash: xDNbbtwO2Cx6YOYqQTNvJ62wm1DB2NC8k7u9k2ZMpYU
 id: group.closed_group.field_group_description
 field_name: field_group_description
 entity_type: group

--- a/modules/social_features/social_group/config/install/field.field.group.closed_group.field_group_image.yml
+++ b/modules/social_features/social_group/config/install/field.field.group.closed_group.field_group_image.yml
@@ -6,8 +6,6 @@ dependencies:
     - group.type.closed_group
   module:
     - image
-_core:
-  default_config_hash: 8CHbo8rFHj4m-ss0svicglmjTh90_cGzmoZWCRcDjlI
 id: group.closed_group.field_group_image
 field_name: field_group_image
 entity_type: group

--- a/modules/social_features/social_group/config/install/field.field.group.closed_group.field_group_location.yml
+++ b/modules/social_features/social_group/config/install/field.field.group.closed_group.field_group_location.yml
@@ -4,8 +4,6 @@ dependencies:
   config:
     - field.storage.group.field_group_location
     - group.type.closed_group
-_core:
-  default_config_hash: TH226YOewWLT_cRqouHI3HgxBja_hnGGschVeqfOSHU
 id: group.closed_group.field_group_location
 field_name: field_group_location
 entity_type: group

--- a/modules/social_features/social_group/config/install/field.field.group.open_group.field_group_address.yml
+++ b/modules/social_features/social_group/config/install/field.field.group.open_group.field_group_address.yml
@@ -6,8 +6,6 @@ dependencies:
     - group.type.open_group
   module:
     - address
-_core:
-  default_config_hash: uBSj9unWO8ta4GSwwRAmN2SfDo3o-YXx27y4aNKefUE
 id: group.open_group.field_group_address
 field_name: field_group_address
 entity_type: group

--- a/modules/social_features/social_group/config/install/field.field.group.open_group.field_group_description.yml
+++ b/modules/social_features/social_group/config/install/field.field.group.open_group.field_group_description.yml
@@ -6,8 +6,6 @@ dependencies:
     - group.type.open_group
   module:
     - text
-_core:
-  default_config_hash: SbxMZ_Odyu_9UiGxKl9a-Etr9nnsFr9UONXBgt3dIiI
 id: group.open_group.field_group_description
 field_name: field_group_description
 entity_type: group

--- a/modules/social_features/social_group/config/install/field.field.group.open_group.field_group_image.yml
+++ b/modules/social_features/social_group/config/install/field.field.group.open_group.field_group_image.yml
@@ -6,8 +6,6 @@ dependencies:
     - group.type.open_group
   module:
     - image
-_core:
-  default_config_hash: 9MU0oWlhR0IgFGZnZTCjONVEce9u29uEN1edEZcQAxU
 id: group.open_group.field_group_image
 field_name: field_group_image
 entity_type: group

--- a/modules/social_features/social_group/config/install/field.field.group.open_group.field_group_location.yml
+++ b/modules/social_features/social_group/config/install/field.field.group.open_group.field_group_location.yml
@@ -4,8 +4,6 @@ dependencies:
   config:
     - field.storage.group.field_group_location
     - group.type.open_group
-_core:
-  default_config_hash: J1paJHIS9R08olEYxw0uLNro5bI6KEaj8sheWGHWCW0
 id: group.open_group.field_group_location
 field_name: field_group_location
 entity_type: group

--- a/modules/social_features/social_group/config/install/field.field.group.public_group.field_group_address.yml
+++ b/modules/social_features/social_group/config/install/field.field.group.public_group.field_group_address.yml
@@ -6,8 +6,6 @@ dependencies:
     - group.type.public_group
   module:
     - address
-_core:
-  default_config_hash: lbzxes7SH5SUIf50CoWhOpEQMjHU7kuC2HYf_UyBqeo
 id: group.public_group.field_group_address
 field_name: field_group_address
 entity_type: group

--- a/modules/social_features/social_group/config/install/field.field.group.public_group.field_group_description.yml
+++ b/modules/social_features/social_group/config/install/field.field.group.public_group.field_group_description.yml
@@ -6,8 +6,6 @@ dependencies:
     - group.type.public_group
   module:
     - text
-_core:
-  default_config_hash: iW7FYiG9qjPg8mBWEmrduz2IKONozPCF1rsnGUw52ZE
 id: group.public_group.field_group_description
 field_name: field_group_description
 entity_type: group

--- a/modules/social_features/social_group/config/install/field.field.group.public_group.field_group_image.yml
+++ b/modules/social_features/social_group/config/install/field.field.group.public_group.field_group_image.yml
@@ -6,8 +6,6 @@ dependencies:
     - group.type.public_group
   module:
     - image
-_core:
-  default_config_hash: 8nYM-KRF7ztUhF8jlTySNZtcnN4sABUWGVfH_UlA0kc
 id: group.public_group.field_group_image
 field_name: field_group_image
 entity_type: group

--- a/modules/social_features/social_group/config/install/field.field.group.public_group.field_group_location.yml
+++ b/modules/social_features/social_group/config/install/field.field.group.public_group.field_group_location.yml
@@ -4,8 +4,6 @@ dependencies:
   config:
     - field.storage.group.field_group_location
     - group.type.public_group
-_core:
-  default_config_hash: cBgTQg7_F-v-hpcwm3Yeh_Us6hv8q4MDs1aBcy22iMs
 id: group.public_group.field_group_location
 field_name: field_group_location
 entity_type: group

--- a/modules/social_features/social_group/config/install/field.field.group_content.closed_group-group_membership.group_roles.yml
+++ b/modules/social_features/social_group/config/install/field.field.group_content.closed_group-group_membership.group_roles.yml
@@ -4,8 +4,6 @@ dependencies:
   config:
     - field.storage.group_content.group_roles
     - group.content_type.closed_group-group_membership
-_core:
-  default_config_hash: xAvreYocc2OQaUkxofsyl7YVtsImf6tl93WdRPxzBKM
 id: group_content.closed_group-group_membership.group_roles
 field_name: group_roles
 entity_type: group_content

--- a/modules/social_features/social_group/config/install/field.field.group_content.open_group-group_membership.group_roles.yml
+++ b/modules/social_features/social_group/config/install/field.field.group_content.open_group-group_membership.group_roles.yml
@@ -4,8 +4,6 @@ dependencies:
   config:
     - field.storage.group_content.group_roles
     - group.content_type.open_group-group_membership
-_core:
-  default_config_hash: 3GrROZqOe12b7S_Fl8SlcvjcRHsUSmLO8ewsfmkY3Tg
 id: group_content.open_group-group_membership.group_roles
 field_name: group_roles
 entity_type: group_content

--- a/modules/social_features/social_group/config/install/field.field.group_content.public_group-group_membership.group_roles.yml
+++ b/modules/social_features/social_group/config/install/field.field.group_content.public_group-group_membership.group_roles.yml
@@ -4,8 +4,6 @@ dependencies:
   config:
     - field.storage.group_content.group_roles
     - group.content_type.public_group-group_membership
-_core:
-  default_config_hash: rohsVmlG9rS-yMNboNOkLmPNsPMl8NmWNDFHzEmSCUg
 id: group_content.public_group-group_membership.group_roles
 field_name: group_roles
 entity_type: group_content

--- a/modules/social_features/social_group/config/install/field.storage.group.field_group_address.yml
+++ b/modules/social_features/social_group/config/install/field.storage.group.field_group_address.yml
@@ -4,8 +4,6 @@ dependencies:
   module:
     - address
     - group
-_core:
-  default_config_hash: SThhVdsoT2cGEl1WixzKDeTriPp9zTmXWBNcUrUwIgs
 id: group.field_group_address
 field_name: field_group_address
 entity_type: group

--- a/modules/social_features/social_group/config/install/field.storage.group.field_group_description.yml
+++ b/modules/social_features/social_group/config/install/field.storage.group.field_group_description.yml
@@ -4,8 +4,6 @@ dependencies:
   module:
     - group
     - text
-_core:
-  default_config_hash: X3uqFg12E2rJ3gtTAeDlxLm6xjW8zFqFHKCZkdG-UU8
 id: group.field_group_description
 field_name: field_group_description
 entity_type: group

--- a/modules/social_features/social_group/config/install/field.storage.group.field_group_image.yml
+++ b/modules/social_features/social_group/config/install/field.storage.group.field_group_image.yml
@@ -5,8 +5,6 @@ dependencies:
     - file
     - group
     - image
-_core:
-  default_config_hash: u7wTgG3APVnwXqEqtYhU-FN9kPGC5Rp3ha2eHf7rXas
 id: group.field_group_image
 field_name: field_group_image
 entity_type: group

--- a/modules/social_features/social_group/config/install/field.storage.group.field_group_location.yml
+++ b/modules/social_features/social_group/config/install/field.storage.group.field_group_location.yml
@@ -3,8 +3,6 @@ status: true
 dependencies:
   module:
     - group
-_core:
-  default_config_hash: 9WJe5N1_nHZPgJdC-fvMqXz3RwdpduNqloBc5yteYWw
 id: group.field_group_location
 field_name: field_group_location
 entity_type: group

--- a/modules/social_features/social_group/config/install/group.content_type.closed_group-group_membership.yml
+++ b/modules/social_features/social_group/config/install/group.content_type.closed_group-group_membership.yml
@@ -5,8 +5,6 @@ dependencies:
     - group.type.closed_group
   module:
     - user
-_core:
-  default_config_hash: u8h2r1BrUH6OfI_yTrgSWFmrdtrXHD2Dp82nuImJ8XY
 id: closed_group-group_membership
 label: 'Closed group: Group membership'
 description: 'Adds users to groups as members.'

--- a/modules/social_features/social_group/config/install/group.content_type.closed_group-group_node-event.yml
+++ b/modules/social_features/social_group/config/install/group.content_type.closed_group-group_node-event.yml
@@ -7,8 +7,6 @@ dependencies:
   module:
     - gnode
     - node
-_core:
-  default_config_hash: hZlsNQO2vMpaRKx_BN_ndP2Y7bkGKo7VAGFkdxT77-Y
 id: closed_group-group_node-event
 label: event
 description: 'Adds <em class="placeholder">Event</em> content to groups both publicly and privately.'

--- a/modules/social_features/social_group/config/install/group.content_type.closed_group-group_node-topic.yml
+++ b/modules/social_features/social_group/config/install/group.content_type.closed_group-group_node-topic.yml
@@ -7,8 +7,6 @@ dependencies:
   module:
     - gnode
     - node
-_core:
-  default_config_hash: epw4DZ0eXhrFncFtPdG524rOwJImLLuWSg2Lyh6NOYE
 id: closed_group-group_node-topic
 label: topic
 description: 'Adds <em class="placeholder">Topic</em> content to groups both publicly and privately.'

--- a/modules/social_features/social_group/config/install/group.content_type.open_group-group_membership.yml
+++ b/modules/social_features/social_group/config/install/group.content_type.open_group-group_membership.yml
@@ -5,8 +5,6 @@ dependencies:
     - group.type.open_group
   module:
     - user
-_core:
-  default_config_hash: ANRuEQZLCnuSVkBzT8h_wvvOREIVnH_5-o2zAjoY6Gs
 id: open_group-group_membership
 label: 'Open group: Group membership'
 description: 'Adds users to groups as members.'

--- a/modules/social_features/social_group/config/install/group.content_type.open_group-group_node-event.yml
+++ b/modules/social_features/social_group/config/install/group.content_type.open_group-group_node-event.yml
@@ -7,8 +7,6 @@ dependencies:
   module:
     - gnode
     - node
-_core:
-  default_config_hash: '-XdurIv4oSKYpHpWZxsh2c1Y6RlgYlLl3klv2i4X2c8'
 id: open_group-group_node-event
 label: event
 description: 'Adds <em class="placeholder">Event</em> content to groups both publicly and privately.'

--- a/modules/social_features/social_group/config/install/group.content_type.open_group-group_node-topic.yml
+++ b/modules/social_features/social_group/config/install/group.content_type.open_group-group_node-topic.yml
@@ -7,8 +7,6 @@ dependencies:
   module:
     - gnode
     - node
-_core:
-  default_config_hash: BgBLkxuqqlzVEeCVcDGgjrpjtFMtKa6LCaBt6zjK90M
 id: open_group-group_node-topic
 label: topic
 description: 'Adds <em class="placeholder">Topic</em> content to groups both publicly and privately.'

--- a/modules/social_features/social_group/config/install/group.content_type.public_group-group_membership.yml
+++ b/modules/social_features/social_group/config/install/group.content_type.public_group-group_membership.yml
@@ -5,8 +5,6 @@ dependencies:
     - group.type.public_group
   module:
     - user
-_core:
-  default_config_hash: cPjfyyWZ8lpmzCCdjw5Z3RCENdTbYf-9ITbuweAV7gc
 id: public_group-group_membership
 label: 'Public group: Group membership'
 description: 'Adds users to groups as members.'

--- a/modules/social_features/social_group/config/install/group.content_type.public_group-group_node-event.yml
+++ b/modules/social_features/social_group/config/install/group.content_type.public_group-group_node-event.yml
@@ -7,8 +7,6 @@ dependencies:
   module:
     - gnode
     - node
-_core:
-  default_config_hash: DB32pK5lspppyPygfjvqIGia8rzGF0kI-YxAHcRKMVg
 id: public_group-group_node-event
 label: event
 description: 'Adds <em class="placeholder">Event</em> content to groups both publicly and privately.'

--- a/modules/social_features/social_group/config/install/group.content_type.public_group-group_node-topic.yml
+++ b/modules/social_features/social_group/config/install/group.content_type.public_group-group_node-topic.yml
@@ -7,8 +7,6 @@ dependencies:
   module:
     - gnode
     - node
-_core:
-  default_config_hash: qCLMP-0MXlEosgCTtSObGZfI5-merhzowkllR1Jgyq8
 id: public_group-group_node-topic
 label: topic
 description: 'Adds <em class="placeholder">Topic</em> content to groups both publicly and privately.'

--- a/modules/social_features/social_group/config/install/group.role.closed_group-83776d798.yml
+++ b/modules/social_features/social_group/config/install/group.role.closed_group-83776d798.yml
@@ -6,8 +6,6 @@ dependencies:
   enforced:
     config:
       - user.role.contentmanager
-_core:
-  default_config_hash: ARmhcIpEs-1zCYeHsJUHaZ3YKAj_qwRzVBgmpgUZkP8
 id: closed_group-83776d798
 label: 'Content manager'
 weight: 3

--- a/modules/social_features/social_group/config/install/group.role.closed_group-a416e6833.yml
+++ b/modules/social_features/social_group/config/install/group.role.closed_group-a416e6833.yml
@@ -6,8 +6,6 @@ dependencies:
   enforced:
     config:
       - user.role.administrator
-_core:
-  default_config_hash: RPwoMLing5lOczeeNe2fQvsJo2_iLYF6R1EkXOJBItc
 id: closed_group-a416e6833
 label: Administrator
 weight: 2

--- a/modules/social_features/social_group/config/install/group.role.closed_group-anonymous.yml
+++ b/modules/social_features/social_group/config/install/group.role.closed_group-anonymous.yml
@@ -3,8 +3,6 @@ status: true
 dependencies:
   config:
     - group.type.closed_group
-_core:
-  default_config_hash: bGZzi19d2obpAPvYxvV0bnJ1rXzzgNMLu9i0irH_Mn4
 id: closed_group-anonymous
 label: Anonymous
 weight: -102

--- a/modules/social_features/social_group/config/install/group.role.closed_group-ba5854c29.yml
+++ b/modules/social_features/social_group/config/install/group.role.closed_group-ba5854c29.yml
@@ -6,8 +6,6 @@ dependencies:
   enforced:
     config:
       - user.role.sitemanager
-_core:
-  default_config_hash: 0xDzd7F3UbEGEimFYiU16gYob8Dq-RbDLnBffery69w
 id: closed_group-ba5854c29
 label: 'Site manager'
 weight: 4

--- a/modules/social_features/social_group/config/install/group.role.closed_group-group_admin.yml
+++ b/modules/social_features/social_group/config/install/group.role.closed_group-group_admin.yml
@@ -3,8 +3,6 @@ status: true
 dependencies:
   config:
     - group.type.closed_group
-_core:
-  default_config_hash: hYz9s--hZtPdjfZfp03steLfM3lI3HjTd_qOl5DQYTg
 id: closed_group-group_admin
 label: 'Group Admin'
 weight: 6

--- a/modules/social_features/social_group/config/install/group.role.closed_group-group_manager.yml
+++ b/modules/social_features/social_group/config/install/group.role.closed_group-group_manager.yml
@@ -3,8 +3,6 @@ status: true
 dependencies:
   config:
     - group.type.closed_group
-_core:
-  default_config_hash: SsbFvuhxkbOGZWPOPj7wg2Z-_SBGyW7rVefjyxxQXng
 id: closed_group-group_manager
 label: 'Group Manager'
 weight: -99

--- a/modules/social_features/social_group/config/install/group.role.closed_group-member.yml
+++ b/modules/social_features/social_group/config/install/group.role.closed_group-member.yml
@@ -3,8 +3,6 @@ status: true
 dependencies:
   config:
     - group.type.closed_group
-_core:
-  default_config_hash: NYhZOTXP27ZKkLdCk5Af5GMrgbuqIjeQu1fJuZdhI1s
 id: closed_group-member
 label: Member
 weight: -100

--- a/modules/social_features/social_group/config/install/group.role.closed_group-outsider.yml
+++ b/modules/social_features/social_group/config/install/group.role.closed_group-outsider.yml
@@ -3,8 +3,6 @@ status: true
 dependencies:
   config:
     - group.type.closed_group
-_core:
-  default_config_hash: Ct5fMFE18UrtF_i705sC3QIN0smpgkPdmjfEAT9-2vI
 id: closed_group-outsider
 label: Outsider
 weight: -101

--- a/modules/social_features/social_group/config/install/group.role.open_group-83776d798.yml
+++ b/modules/social_features/social_group/config/install/group.role.open_group-83776d798.yml
@@ -6,8 +6,6 @@ dependencies:
   enforced:
     config:
       - user.role.contentmanager
-_core:
-  default_config_hash: 2SELMYbEio1bFoXgJ_TcBijjj1vIpvbOrCgg9rjAFTs
 id: open_group-83776d798
 label: 'Content manager'
 weight: 3

--- a/modules/social_features/social_group/config/install/group.role.open_group-a416e6833.yml
+++ b/modules/social_features/social_group/config/install/group.role.open_group-a416e6833.yml
@@ -6,8 +6,6 @@ dependencies:
   enforced:
     config:
       - user.role.administrator
-_core:
-  default_config_hash: iV7JOI9aWQVkGk-i-h0fQ4jabPbkckcdnaqa-VqqLqM
 id: open_group-a416e6833
 label: Administrator
 weight: 2

--- a/modules/social_features/social_group/config/install/group.role.open_group-anonymous.yml
+++ b/modules/social_features/social_group/config/install/group.role.open_group-anonymous.yml
@@ -3,8 +3,6 @@ status: true
 dependencies:
   config:
     - group.type.open_group
-_core:
-  default_config_hash: BUh83uMuawEc3R9mSPg6fJfJdlMDVmTVH7vpiJy-tFA
 id: open_group-anonymous
 label: Anonymous
 weight: -102

--- a/modules/social_features/social_group/config/install/group.role.open_group-ba5854c29.yml
+++ b/modules/social_features/social_group/config/install/group.role.open_group-ba5854c29.yml
@@ -6,8 +6,6 @@ dependencies:
   enforced:
     config:
       - user.role.sitemanager
-_core:
-  default_config_hash: GINWC2f9vIHJODzOAHTQ-eN0ZN87uBkOsGTyty21WVw
 id: open_group-ba5854c29
 label: 'Site manager'
 weight: 4

--- a/modules/social_features/social_group/config/install/group.role.open_group-group_admin.yml
+++ b/modules/social_features/social_group/config/install/group.role.open_group-group_admin.yml
@@ -3,8 +3,6 @@ status: true
 dependencies:
   config:
     - group.type.open_group
-_core:
-  default_config_hash: CIgp_eD-zKvSFyyRmx7xQeslDr_3u9GJFpRQ-o-_CJs
 id: open_group-group_admin
 label: 'Group Admin'
 weight: 5

--- a/modules/social_features/social_group/config/install/group.role.open_group-group_manager.yml
+++ b/modules/social_features/social_group/config/install/group.role.open_group-group_manager.yml
@@ -3,8 +3,6 @@ status: true
 dependencies:
   config:
     - group.type.open_group
-_core:
-  default_config_hash: 3dIDvIKQyZdxNW0UYBa2yWt4F5h7QksLn8mce_sx_bY
 id: open_group-group_manager
 label: 'Group Manager'
 weight: -99

--- a/modules/social_features/social_group/config/install/group.role.open_group-member.yml
+++ b/modules/social_features/social_group/config/install/group.role.open_group-member.yml
@@ -3,8 +3,6 @@ status: true
 dependencies:
   config:
     - group.type.open_group
-_core:
-  default_config_hash: R9Ud-0J7aDxsMiaej4BRcZ8QJW2eBMDLqTev5FW-YaE
 id: open_group-member
 label: Member
 weight: -100

--- a/modules/social_features/social_group/config/install/group.role.open_group-outsider.yml
+++ b/modules/social_features/social_group/config/install/group.role.open_group-outsider.yml
@@ -3,8 +3,6 @@ status: true
 dependencies:
   config:
     - group.type.open_group
-_core:
-  default_config_hash: OFLEanEBYiOHBrqlH_muTDb5oInfY2Z-xi10J9vCVIk
 id: open_group-outsider
 label: Outsider
 weight: -101

--- a/modules/social_features/social_group/config/install/group.role.public_group-83776d798.yml
+++ b/modules/social_features/social_group/config/install/group.role.public_group-83776d798.yml
@@ -6,8 +6,6 @@ dependencies:
   enforced:
     config:
       - user.role.contentmanager
-_core:
-  default_config_hash: nQobBD764pcCFfCMs_aZYi-sMRS0mxU-lE90V7Kxe-I
 id: public_group-83776d798
 label: 'Content manager'
 weight: 3

--- a/modules/social_features/social_group/config/install/group.role.public_group-a416e6833.yml
+++ b/modules/social_features/social_group/config/install/group.role.public_group-a416e6833.yml
@@ -6,8 +6,6 @@ dependencies:
   enforced:
     config:
       - user.role.administrator
-_core:
-  default_config_hash: XntV6SfMcMLDo9-ySaAlUtdeWTRuHmWvgr3gUTWqz-s
 id: public_group-a416e6833
 label: Administrator
 weight: 2

--- a/modules/social_features/social_group/config/install/group.role.public_group-anonymous.yml
+++ b/modules/social_features/social_group/config/install/group.role.public_group-anonymous.yml
@@ -3,8 +3,6 @@ status: true
 dependencies:
   config:
     - group.type.public_group
-_core:
-  default_config_hash: KYZC4Itvc_DW3-sTNLwD-vhwzO5pN0u7K14vN9gauSw
 id: public_group-anonymous
 label: Anonymous
 weight: -102

--- a/modules/social_features/social_group/config/install/group.role.public_group-ba5854c29.yml
+++ b/modules/social_features/social_group/config/install/group.role.public_group-ba5854c29.yml
@@ -6,8 +6,6 @@ dependencies:
   enforced:
     config:
       - user.role.sitemanager
-_core:
-  default_config_hash: cSvVmuegleQCQ41OfpV6qNT7_alnno2C0GD2DHMdgxM
 id: public_group-ba5854c29
 label: 'Site manager'
 weight: 4

--- a/modules/social_features/social_group/config/install/group.role.public_group-group_admin.yml
+++ b/modules/social_features/social_group/config/install/group.role.public_group-group_admin.yml
@@ -3,8 +3,6 @@ status: true
 dependencies:
   config:
     - group.type.public_group
-_core:
-  default_config_hash: 2S3YLMrJUx1O3lHyT_MAs6FidhHFEapF8cm1T3yOwhI
 id: public_group-group_admin
 label: 'Group Admin'
 weight: 5

--- a/modules/social_features/social_group/config/install/group.role.public_group-group_manager.yml
+++ b/modules/social_features/social_group/config/install/group.role.public_group-group_manager.yml
@@ -3,8 +3,6 @@ status: true
 dependencies:
   config:
     - group.type.public_group
-_core:
-  default_config_hash: Ad23SnoO_i-2NNPL1zOY1hjD1xGBkjvwa3wRBxbp0KA
 id: public_group-group_manager
 label: 'Group Manager'
 weight: -99

--- a/modules/social_features/social_group/config/install/group.role.public_group-member.yml
+++ b/modules/social_features/social_group/config/install/group.role.public_group-member.yml
@@ -3,8 +3,6 @@ status: true
 dependencies:
   config:
     - group.type.public_group
-_core:
-  default_config_hash: 7SovxMOzfqK536uzQ2Y0QMLu48DHZoGsO-ws2sQhaAw
 id: public_group-member
 label: Member
 weight: -100

--- a/modules/social_features/social_group/config/install/group.role.public_group-outsider.yml
+++ b/modules/social_features/social_group/config/install/group.role.public_group-outsider.yml
@@ -3,8 +3,6 @@ status: true
 dependencies:
   config:
     - group.type.public_group
-_core:
-  default_config_hash: EKNx2oP4Q3v4ILh08JN3oLLv0LaYwGeko0WKDBM1R7U
 id: public_group-outsider
 label: Outsider
 weight: -101

--- a/modules/social_features/social_group/config/install/group.type.closed_group.yml
+++ b/modules/social_features/social_group/config/install/group.type.closed_group.yml
@@ -1,8 +1,6 @@
 langcode: en
 status: true
 dependencies: {  }
-_core:
-  default_config_hash: xroGCpvSEB-Z8oEpr64RsyjOZ2T4BnXvgTpvgo_O5DY
 id: closed_group
 label: 'Closed group'
 description: 'This is a closed group. Users can only join by invitation and the content in the group is hidden from non members.'

--- a/modules/social_features/social_group/config/install/group.type.open_group.yml
+++ b/modules/social_features/social_group/config/install/group.type.open_group.yml
@@ -1,8 +1,6 @@
 langcode: en
 status: true
 dependencies: {  }
-_core:
-  default_config_hash: Uk_6UORiObPWyRN59-gp0zB8x7xIBXd3az6L65RXeGE
 id: open_group
 label: 'Open group'
 description: 'This is an open group. Users may join without approval and all content added in this group will be visible to all community members.'

--- a/modules/social_features/social_group/config/install/group.type.public_group.yml
+++ b/modules/social_features/social_group/config/install/group.type.public_group.yml
@@ -1,8 +1,6 @@
 langcode: en
 status: true
 dependencies: {  }
-_core:
-  default_config_hash: 9RnptqADUkDGf5Gahtu0f6ErAjqvOLUit4TqbEiwg8k
 id: public_group
 label: 'Public group'
 description: 'This is a public group. Users may join without approval and all content added in this group will be visible to all community members and anonymous users.'

--- a/modules/social_features/social_group/config/install/views.view.group_events.yml
+++ b/modules/social_features/social_group/config/install/views.view.group_events.yml
@@ -14,8 +14,6 @@ dependencies:
     - group
     - node
     - social_event
-_core:
-  default_config_hash: U1m7im0n_LIf-xAersIh9IgiJ-tRm2iZ9odxkEOxeBU
 id: group_events
 label: 'Group Events'
 module: views

--- a/modules/social_features/social_group/config/install/views.view.group_information.yml
+++ b/modules/social_features/social_group/config/install/views.view.group_information.yml
@@ -3,8 +3,6 @@ status: true
 dependencies:
   module:
     - group
-_core:
-  default_config_hash: q8BMTefPMCErqS5j7G979LlY7p_6EvQeBHiSR7cooWY
 id: group_information
 label: 'Group Information'
 module: views

--- a/modules/social_features/social_group/config/install/views.view.group_manage_members.yml
+++ b/modules/social_features/social_group/config/install/views.view.group_manage_members.yml
@@ -13,8 +13,6 @@ dependencies:
     - profile
     - social_group
     - user
-_core:
-  default_config_hash: XMkAOCeioLxvZ_MJvF7EhWEcAKSZP07d7Z4Nx-BeutI
 id: group_manage_members
 label: 'Group Manage Members'
 module: views

--- a/modules/social_features/social_group/config/install/views.view.group_managers.yml
+++ b/modules/social_features/social_group/config/install/views.view.group_managers.yml
@@ -8,8 +8,6 @@ dependencies:
     - group
     - profile
     - user
-_core:
-  default_config_hash: nZhqrvviO-n1tVyu1NzRv175wsIviYg_CAgQcaX7Zl4
 id: group_managers
 label: 'Group Managers'
 module: views

--- a/modules/social_features/social_group/config/install/views.view.group_members.yml
+++ b/modules/social_features/social_group/config/install/views.view.group_members.yml
@@ -7,8 +7,6 @@ dependencies:
     - group.content_type.public_group-group_membership
   module:
     - group
-_core:
-  default_config_hash: n75IM66dZTlDKXzx0u9cSjZ46pqlfVvJBhcanEMXsmo
 id: group_members
 label: 'Group Members'
 module: views

--- a/modules/social_features/social_group/config/install/views.view.group_topics.yml
+++ b/modules/social_features/social_group/config/install/views.view.group_topics.yml
@@ -14,8 +14,6 @@ dependencies:
     - group
     - node
     - taxonomy
-_core:
-  default_config_hash: w68Lg24lxOIZS50lCZN4ldYaaotGC6Zf5hvGlTC7uOg
 id: group_topics
 label: 'Group Topics'
 module: views

--- a/modules/social_features/social_group/config/install/views.view.groups.yml
+++ b/modules/social_features/social_group/config/install/views.view.groups.yml
@@ -8,8 +8,6 @@ dependencies:
     - group
     - social_group
     - user
-_core:
-  default_config_hash: j7pIbbkhq33FlY-AoeiglfeTG18bPehQSYti_JGti1E
 id: groups
 label: 'User Groups'
 module: views

--- a/modules/social_features/social_group/config/install/views.view.newest_groups.yml
+++ b/modules/social_features/social_group/config/install/views.view.newest_groups.yml
@@ -7,8 +7,6 @@ dependencies:
   module:
     - group
     - user
-_core:
-  default_config_hash: m59mmgLMtOnt0MSyksk0IBtUNeEDnRLhyjKNf_aUWSU
 id: newest_groups
 label: 'Newest groups'
 module: views

--- a/modules/social_features/social_group/modules/social_group_flexible_group/config/install/core.entity_form_display.group.flexible_group.default.yml
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/config/install/core.entity_form_display.group.flexible_group.default.yml
@@ -61,8 +61,6 @@ third_party_settings:
         required_fields: true
       label: Settings
       region: content
-_core:
-  default_config_hash: jxUlnDLygWdcUhk-I8XiFfSgY9hiJqWYgkx60agyfxc
 id: group.flexible_group.default
 targetEntityType: group
 bundle: flexible_group

--- a/modules/social_features/social_group/modules/social_group_flexible_group/config/install/core.entity_form_display.group_content.flexible_group-group_membership.default.yml
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/config/install/core.entity_form_display.group_content.flexible_group-group_membership.default.yml
@@ -6,8 +6,6 @@ dependencies:
     - group.content_type.flexible_group-group_membership
   module:
     - path
-_core:
-  default_config_hash: alEk64NdiF0HGHAFEtGBu4JLMQh9CQ_saSXMgohJ3Nk
 id: group_content.flexible_group-group_membership.default
 targetEntityType: group_content
 bundle: flexible_group-group_membership

--- a/modules/social_features/social_group/modules/social_group_flexible_group/config/install/core.entity_view_display.group.flexible_group.default.yml
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/config/install/core.entity_view_display.group.flexible_group.default.yml
@@ -11,8 +11,6 @@ dependencies:
     - group.type.flexible_group
   module:
     - options
-_core:
-  default_config_hash: EsUA6_KIKnFzDKnw4ta9Ca3D41YhSNqTY1ZH_U3HRi4
 id: group.flexible_group.default
 targetEntityType: group
 bundle: flexible_group

--- a/modules/social_features/social_group/modules/social_group_flexible_group/config/install/core.entity_view_display.group.flexible_group.hero.yml
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/config/install/core.entity_view_display.group.flexible_group.hero.yml
@@ -14,8 +14,6 @@ dependencies:
   module:
     - address
     - image
-_core:
-  default_config_hash: MTYg82XqRSWv3lA-f728vfIER4AS9xS1Jkvyh1aClck
 id: group.flexible_group.hero
 targetEntityType: group
 bundle: flexible_group

--- a/modules/social_features/social_group/modules/social_group_flexible_group/config/install/core.entity_view_display.group.flexible_group.stream.yml
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/config/install/core.entity_view_display.group.flexible_group.stream.yml
@@ -10,8 +10,6 @@ dependencies:
     - field.field.group.flexible_group.field_group_image
     - field.field.group.flexible_group.field_group_location
     - group.type.flexible_group
-_core:
-  default_config_hash: g_tUlvNiixpkhGaludEae0JrYQR5jgAZS8b9ahlt-_M
 id: group.flexible_group.stream
 targetEntityType: group
 bundle: flexible_group

--- a/modules/social_features/social_group/modules/social_group_flexible_group/config/install/core.entity_view_display.group.flexible_group.teaser.yml
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/config/install/core.entity_view_display.group.flexible_group.teaser.yml
@@ -14,8 +14,6 @@ dependencies:
   module:
     - address
     - image
-_core:
-  default_config_hash: AUQfGkRd_KwhKyGvGAwDYu1LL0m3D-EFxsOXFzKjPQQ
 id: group.flexible_group.teaser
 targetEntityType: group
 bundle: flexible_group

--- a/modules/social_features/social_group/modules/social_group_flexible_group/config/install/core.entity_view_display.group_content.flexible_group-group_membership.default.yml
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/config/install/core.entity_view_display.group_content.flexible_group-group_membership.default.yml
@@ -4,8 +4,6 @@ dependencies:
   config:
     - field.field.group_content.flexible_group-group_membership.group_roles
     - group.content_type.flexible_group-group_membership
-_core:
-  default_config_hash: _att_w7tm8SViQriauACBKmegluSQSyAd_J0i3enmfo
 id: group_content.flexible_group-group_membership.default
 targetEntityType: group_content
 bundle: flexible_group-group_membership

--- a/modules/social_features/social_group/modules/social_group_flexible_group/config/install/core.entity_view_display.group_content.flexible_group-group_node-event.default.yml
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/config/install/core.entity_view_display.group_content.flexible_group-group_node-event.default.yml
@@ -3,8 +3,6 @@ status: true
 dependencies:
   config:
     - group.content_type.flexible_group-group_node-event
-_core:
-  default_config_hash: cJYpTFgnHg5XVJx2KtlXwU2EFunqB4ISJJjyMHFEwHE
 id: group_content.flexible_group-group_node-event.default
 targetEntityType: group_content
 bundle: flexible_group-group_node-event

--- a/modules/social_features/social_group/modules/social_group_flexible_group/config/install/core.entity_view_display.group_content.flexible_group-group_node-event.teaser.yml
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/config/install/core.entity_view_display.group_content.flexible_group-group_node-event.teaser.yml
@@ -4,8 +4,6 @@ dependencies:
   config:
     - core.entity_view_mode.group_content.teaser
     - group.content_type.flexible_group-group_node-event
-_core:
-  default_config_hash: TXAQ3iXef0TdHdRAdYM8LObpadYFrjxU9_8oVttnucI
 id: group_content.flexible_group-group_node-event.teaser
 targetEntityType: group_content
 bundle: flexible_group-group_node-event

--- a/modules/social_features/social_group/modules/social_group_flexible_group/config/install/core.entity_view_display.group_content.flexible_group-group_node-topic.default.yml
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/config/install/core.entity_view_display.group_content.flexible_group-group_node-topic.default.yml
@@ -3,8 +3,6 @@ status: true
 dependencies:
   config:
     - group.content_type.flexible_group-group_node-topic
-_core:
-  default_config_hash: mw8q9aOHJfHGZd-yb6_vUVp7dJbJu27UA0QCvYfCOd0
 id: group_content.flexible_group-group_node-topic.default
 targetEntityType: group_content
 bundle: flexible_group-group_node-topic

--- a/modules/social_features/social_group/modules/social_group_flexible_group/config/install/core.entity_view_display.group_content.flexible_group-group_node-topic.teaser.yml
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/config/install/core.entity_view_display.group_content.flexible_group-group_node-topic.teaser.yml
@@ -4,8 +4,6 @@ dependencies:
   config:
     - core.entity_view_mode.group_content.teaser
     - group.content_type.flexible_group-group_node-topic
-_core:
-  default_config_hash: ntHDr3J7xLCXHRO_ph15VtnlCPQl11LbpwwhXmOZo2k
 id: group_content.flexible_group-group_node-topic.teaser
 targetEntityType: group_content
 bundle: flexible_group-group_node-topic

--- a/modules/social_features/social_group/modules/social_group_flexible_group/config/install/field.field.group.flexible_group.field_group_address.yml
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/config/install/field.field.group.flexible_group.field_group_address.yml
@@ -6,8 +6,6 @@ dependencies:
     - group.type.flexible_group
   module:
     - address
-_core:
-  default_config_hash: TWRQla6NWdRXUYxeS-XOCspe2UcrbQgQUq8NXPqS4Ac
 id: group.flexible_group.field_group_address
 field_name: field_group_address
 entity_type: group

--- a/modules/social_features/social_group/modules/social_group_flexible_group/config/install/field.field.group.flexible_group.field_group_allowed_join_method.yml
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/config/install/field.field.group.flexible_group.field_group_allowed_join_method.yml
@@ -6,8 +6,6 @@ dependencies:
     - group.type.flexible_group
   module:
     - options
-_core:
-  default_config_hash: VtgTXNfjsaADUCJe7ivuTQOsEB0aCpW4VnfHMTWFuyc
 id: group.flexible_group.field_group_allowed_join_method
 field_name: field_group_allowed_join_method
 entity_type: group

--- a/modules/social_features/social_group/modules/social_group_flexible_group/config/install/field.field.group.flexible_group.field_group_allowed_visibility.yml
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/config/install/field.field.group.flexible_group.field_group_allowed_visibility.yml
@@ -6,8 +6,6 @@ dependencies:
     - group.type.flexible_group
   module:
     - options
-_core:
-  default_config_hash: B2skyt2zQ2A8UuREnOPGgBA_Ltld-b-brA03cIVVfPI
 id: group.flexible_group.field_group_allowed_visibility
 field_name: field_group_allowed_visibility
 entity_type: group

--- a/modules/social_features/social_group/modules/social_group_flexible_group/config/install/field.field.group.flexible_group.field_group_description.yml
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/config/install/field.field.group.flexible_group.field_group_description.yml
@@ -6,8 +6,6 @@ dependencies:
     - group.type.flexible_group
   module:
     - text
-_core:
-  default_config_hash: RXon3uXmTihfo7QGrl0WWTWnqVNpYdmRZBJsdBL0dcA
 id: group.flexible_group.field_group_description
 field_name: field_group_description
 entity_type: group

--- a/modules/social_features/social_group/modules/social_group_flexible_group/config/install/field.field.group.flexible_group.field_group_image.yml
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/config/install/field.field.group.flexible_group.field_group_image.yml
@@ -6,8 +6,6 @@ dependencies:
     - group.type.flexible_group
   module:
     - image
-_core:
-  default_config_hash: gfSMDaodVTavNFkx65ZEBci8Na_7paWsq24tyjS72lg
 id: group.flexible_group.field_group_image
 field_name: field_group_image
 entity_type: group

--- a/modules/social_features/social_group/modules/social_group_flexible_group/config/install/field.field.group.flexible_group.field_group_location.yml
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/config/install/field.field.group.flexible_group.field_group_location.yml
@@ -4,8 +4,6 @@ dependencies:
   config:
     - field.storage.group.field_group_location
     - group.type.flexible_group
-_core:
-  default_config_hash: '-0F6somXycYJAQyqlu-gEsgdhEAJSj9ryxRlfF7dX6Y'
 id: group.flexible_group.field_group_location
 field_name: field_group_location
 entity_type: group

--- a/modules/social_features/social_group/modules/social_group_flexible_group/config/install/field.field.group_content.flexible_group-group_membership.group_roles.yml
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/config/install/field.field.group_content.flexible_group-group_membership.group_roles.yml
@@ -4,8 +4,6 @@ dependencies:
   config:
     - field.storage.group_content.group_roles
     - group.content_type.flexible_group-group_membership
-_core:
-  default_config_hash: BtPRixKmpCYlcEX6JRlfI8OKwokcAdGcVEEqljnHM6A
 id: group_content.flexible_group-group_membership.group_roles
 field_name: group_roles
 entity_type: group_content

--- a/modules/social_features/social_group/modules/social_group_flexible_group/config/install/field.storage.group.field_group_allowed_join_method.yml
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/config/install/field.storage.group.field_group_allowed_join_method.yml
@@ -4,8 +4,6 @@ dependencies:
   module:
     - group
     - options
-_core:
-  default_config_hash: X4MpjmJmGgzw_778qhXMP0hSUVb-ppthC_cj_Na4hak
 id: group.field_group_allowed_join_method
 field_name: field_group_allowed_join_method
 entity_type: group

--- a/modules/social_features/social_group/modules/social_group_flexible_group/config/install/field.storage.group.field_group_allowed_visibility.yml
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/config/install/field.storage.group.field_group_allowed_visibility.yml
@@ -4,8 +4,6 @@ dependencies:
   module:
     - group
     - options
-_core:
-  default_config_hash: rcofQoJONrsuzsXK450Frwl_cTiJTlSXux9JDA6UMPM
 id: group.field_group_allowed_visibility
 field_name: field_group_allowed_visibility
 entity_type: group

--- a/modules/social_features/social_group/modules/social_group_flexible_group/config/install/group.content_type.flexible_group-group_membership.yml
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/config/install/group.content_type.flexible_group-group_membership.yml
@@ -6,8 +6,6 @@ dependencies:
   module:
     - social_group_flexible_group
     - user
-_core:
-  default_config_hash: 3KAQc6TXh1EMGrsI8qT0fiM9CFAgzJk7pudOE1Do4qY
 id: flexible_group-group_membership
 label: 'Flexible group: Group membership'
 description: 'Adds users to groups as members.'

--- a/modules/social_features/social_group/modules/social_group_flexible_group/config/install/group.content_type.flexible_group-group_node-event.yml
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/config/install/group.content_type.flexible_group-group_node-event.yml
@@ -8,8 +8,6 @@ dependencies:
     - gnode
     - node
     - social_group_flexible_group
-_core:
-  default_config_hash: PEAHiStUxaYJjmvl6U9LRiQNDJkKIh_KuFzT_r98iHk
 id: flexible_group-group_node-event
 label: event
 description: 'Adds <em class="placeholder">Event</em> content to groups using private content settings.'

--- a/modules/social_features/social_group/modules/social_group_flexible_group/config/install/group.content_type.flexible_group-group_node-topic.yml
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/config/install/group.content_type.flexible_group-group_node-topic.yml
@@ -8,8 +8,6 @@ dependencies:
     - gnode
     - node
     - social_group_flexible_group
-_core:
-  default_config_hash: NdqEQFRAz_vLVQbQZ-bats8yKYlmokAmmoJuhywMeNg
 id: flexible_group-group_node-topic
 label: topic
 description: 'Adds <em class="placeholder">Topic</em> content to groups using private content settings.'

--- a/modules/social_features/social_group/modules/social_group_flexible_group/config/install/group.role.flexible_group-83776d798.yml
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/config/install/group.role.flexible_group-83776d798.yml
@@ -6,8 +6,6 @@ dependencies:
   enforced:
     config:
       - user.role.contentmanager
-_core:
-  default_config_hash: 9YE1aXEOVH9wbFfIckU-p6Tt70Ot6-U6oh2j0-ybvUc
 id: flexible_group-83776d798
 label: 'Content manager'
 weight: 3

--- a/modules/social_features/social_group/modules/social_group_flexible_group/config/install/group.role.flexible_group-a416e6833.yml
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/config/install/group.role.flexible_group-a416e6833.yml
@@ -6,8 +6,6 @@ dependencies:
   enforced:
     config:
       - user.role.administrator
-_core:
-  default_config_hash: DOBgS8wqA_LmQspia221YjpkLNjz_Z2lPyacJ5m5VNQ
 id: flexible_group-a416e6833
 label: Administrator
 weight: 2

--- a/modules/social_features/social_group/modules/social_group_flexible_group/config/install/group.role.flexible_group-anonymous.yml
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/config/install/group.role.flexible_group-anonymous.yml
@@ -3,8 +3,6 @@ status: true
 dependencies:
   config:
     - group.type.flexible_group
-_core:
-  default_config_hash: jy2K7Ecz9KLP0E0a_Wt2dFF5FOR3NQzvpJY4gVQdejQ
 id: flexible_group-anonymous
 label: Anonymous
 weight: -102

--- a/modules/social_features/social_group/modules/social_group_flexible_group/config/install/group.role.flexible_group-ba5854c29.yml
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/config/install/group.role.flexible_group-ba5854c29.yml
@@ -6,8 +6,6 @@ dependencies:
   enforced:
     config:
       - user.role.sitemanager
-_core:
-  default_config_hash: PM0TerfUpGE_tXrc_-xZbFMHuwe5fUi5vqh7QZaF6Gg
 id: flexible_group-ba5854c29
 label: 'Site manager'
 weight: 4

--- a/modules/social_features/social_group/modules/social_group_flexible_group/config/install/group.role.flexible_group-group_admin.yml
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/config/install/group.role.flexible_group-group_admin.yml
@@ -3,8 +3,6 @@ status: true
 dependencies:
   config:
     - group.type.flexible_group
-_core:
-  default_config_hash: DF37GPsKQQvB7A5eoy36cXv9bnEubuCBSrMVzTBNJh0
 id: flexible_group-group_admin
 label: 'Group Admin'
 weight: 6

--- a/modules/social_features/social_group/modules/social_group_flexible_group/config/install/group.role.flexible_group-group_manager.yml
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/config/install/group.role.flexible_group-group_manager.yml
@@ -3,8 +3,6 @@ status: true
 dependencies:
   config:
     - group.type.flexible_group
-_core:
-  default_config_hash: cc1hiO_WzjT6LoKlXd4PRRB8QZuWymgq4jLLEbX1uos
 id: flexible_group-group_manager
 label: 'Group Manager'
 weight: -99

--- a/modules/social_features/social_group/modules/social_group_flexible_group/config/install/group.role.flexible_group-member.yml
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/config/install/group.role.flexible_group-member.yml
@@ -3,8 +3,6 @@ status: true
 dependencies:
   config:
     - group.type.flexible_group
-_core:
-  default_config_hash: RihA44yokK1pd786x0783AOehdyGLZpA9IatPCmmUuM
 id: flexible_group-member
 label: Member
 weight: -100

--- a/modules/social_features/social_group/modules/social_group_flexible_group/config/install/group.role.flexible_group-outsider.yml
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/config/install/group.role.flexible_group-outsider.yml
@@ -3,8 +3,6 @@ status: true
 dependencies:
   config:
     - group.type.flexible_group
-_core:
-  default_config_hash: WY5Lu6JzEenwyHDhshtKAcnjBXz-b9TackCM3NVCWxA
 id: flexible_group-outsider
 label: Outsider
 weight: -101

--- a/modules/social_features/social_group/modules/social_group_flexible_group/config/install/group.type.flexible_group.yml
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/config/install/group.type.flexible_group.yml
@@ -1,8 +1,6 @@
 langcode: en
 status: true
 dependencies: {  }
-_core:
-  default_config_hash: 0UMYgQUpGfoJEzely-IKuaD4FLRkU2Fvw47evh0TVRQ
 id: flexible_group
 label: 'Flexible group'
 description: 'By choosing this option you can customize many group settings to your needs.'

--- a/modules/social_features/social_like/config/install/field.field.message.create_like_node_or_post.field_message_context.yml
+++ b/modules/social_features/social_like/config/install/field.field.message.create_like_node_or_post.field_message_context.yml
@@ -6,8 +6,6 @@ dependencies:
     - message.template.create_like_node_or_post
   module:
     - options
-_core:
-  default_config_hash: 6smwKYTNZbZucdwo00NdeizeXUfsaTqoE9_eqZgIsqE
 id: message.create_like_node_or_post.field_message_context
 field_name: field_message_context
 entity_type: message

--- a/modules/social_features/social_like/config/install/field.field.message.create_like_node_or_post.field_message_destination.yml
+++ b/modules/social_features/social_like/config/install/field.field.message.create_like_node_or_post.field_message_destination.yml
@@ -6,8 +6,6 @@ dependencies:
     - message.template.create_like_node_or_post
   module:
     - options
-_core:
-  default_config_hash: jIwN3hiZCpsEzSqpLawpZg3-tmhMqBxSHERpAKJ_CrU
 id: message.create_like_node_or_post.field_message_destination
 field_name: field_message_destination
 entity_type: message

--- a/modules/social_features/social_like/config/install/field.field.message.create_like_node_or_post.field_message_related_object.yml
+++ b/modules/social_features/social_like/config/install/field.field.message.create_like_node_or_post.field_message_related_object.yml
@@ -6,8 +6,6 @@ dependencies:
     - message.template.create_like_node_or_post
   module:
     - dynamic_entity_reference
-_core:
-  default_config_hash: b_BD1GCbAuAVldgG8AQeUeznxvN0sG_1NZAjy_jYgo8
 id: message.create_like_node_or_post.field_message_related_object
 field_name: field_message_related_object
 entity_type: message

--- a/modules/social_features/social_like/config/install/message.template.create_like_node_or_post.yml
+++ b/modules/social_features/social_like/config/install/message.template.create_like_node_or_post.yml
@@ -15,8 +15,6 @@ third_party_settings:
     activity_create_direct: 0
     activity_aggregate: 0
     activity_entity_condition: ''
-_core:
-  default_config_hash: mhEYhJvbKkGB-A56aWNgx_6_CTv88nIPQ2l2if3JS1s
 template: create_like_node_or_post
 label: 'Create like on node or post'
 description: 'A person likes a post, topic, comment or event created by me'

--- a/modules/social_features/social_like/config/install/views.view.who_liked_this_entity.yml
+++ b/modules/social_features/social_like/config/install/views.view.who_liked_this_entity.yml
@@ -9,8 +9,6 @@ dependencies:
     - user
     - views_infinite_scroll
     - votingapi
-_core:
-  default_config_hash: 7jtDFqTgkAkBnIZ9y5SlE0yRujnCmwUExvLIF_KgoBU
 id: who_liked_this_entity
 label: 'Who liked this entity'
 module: views

--- a/modules/social_features/social_mentions/config/install/core.entity_view_display.profile.profile.autocomplete_item.yml
+++ b/modules/social_features/social_mentions/config/install/core.entity_view_display.profile.profile.autocomplete_item.yml
@@ -20,8 +20,6 @@ dependencies:
     - profile.type.profile
   module:
     - image
-_core:
-  default_config_hash: oNo6GVuWY51XV_kPfrCRA1KeS3kXk962ToYNhRSLY6Y
 id: profile.profile.autocomplete_item
 targetEntityType: profile
 bundle: profile

--- a/modules/social_features/social_mentions/config/install/core.entity_view_mode.profile.autocomplete_item.yml
+++ b/modules/social_features/social_mentions/config/install/core.entity_view_mode.profile.autocomplete_item.yml
@@ -3,8 +3,6 @@ status: true
 dependencies:
   module:
     - profile
-_core:
-  default_config_hash: JH3nv505iN4UqNbGtEugpWqpm3_rIery4SKKuY7m70w
 id: profile.autocomplete_item
 label: 'Autocomplete Item'
 targetEntityType: profile

--- a/modules/social_features/social_mentions/config/install/field.field.message.create_comment_reply_mention.field_message_context.yml
+++ b/modules/social_features/social_mentions/config/install/field.field.message.create_comment_reply_mention.field_message_context.yml
@@ -6,8 +6,6 @@ dependencies:
     - message.template.create_comment_reply_mention
   module:
     - options
-_core:
-  default_config_hash: vAj0ImaTrIUEUE2i8-e7eGiqSphhZccZYnIuUmlnORY
 id: message.create_comment_reply_mention.field_message_context
 field_name: field_message_context
 entity_type: message

--- a/modules/social_features/social_mentions/config/install/field.field.message.create_comment_reply_mention.field_message_destination.yml
+++ b/modules/social_features/social_mentions/config/install/field.field.message.create_comment_reply_mention.field_message_destination.yml
@@ -6,8 +6,6 @@ dependencies:
     - message.template.create_comment_reply_mention
   module:
     - options
-_core:
-  default_config_hash: b7EFM3cKq0mX4og3y1kCUVvI2i_26sV09dX7B-XGnyE
 id: message.create_comment_reply_mention.field_message_destination
 field_name: field_message_destination
 entity_type: message

--- a/modules/social_features/social_mentions/config/install/field.field.message.create_comment_reply_mention.field_message_related_object.yml
+++ b/modules/social_features/social_mentions/config/install/field.field.message.create_comment_reply_mention.field_message_related_object.yml
@@ -6,8 +6,6 @@ dependencies:
     - message.template.create_comment_reply_mention
   module:
     - dynamic_entity_reference
-_core:
-  default_config_hash: ys3XgCGvvOVYCfPvFa56YFUoEB6myTt4XjLUVGfp2B4
 id: message.create_comment_reply_mention.field_message_related_object
 field_name: field_message_related_object
 entity_type: message

--- a/modules/social_features/social_mentions/config/install/field.field.message.create_mention_comment.field_message_context.yml
+++ b/modules/social_features/social_mentions/config/install/field.field.message.create_mention_comment.field_message_context.yml
@@ -6,8 +6,6 @@ dependencies:
     - message.template.create_mention_comment
   module:
     - options
-_core:
-  default_config_hash: KJIXfWZ491j8g5dICEQsgVUrSEj_jZXgRfiy-HXyUho
 id: message.create_mention_comment.field_message_context
 field_name: field_message_context
 entity_type: message

--- a/modules/social_features/social_mentions/config/install/field.field.message.create_mention_comment.field_message_destination.yml
+++ b/modules/social_features/social_mentions/config/install/field.field.message.create_mention_comment.field_message_destination.yml
@@ -6,8 +6,6 @@ dependencies:
     - message.template.create_mention_comment
   module:
     - options
-_core:
-  default_config_hash: 4ZpwlYKwHYWKQp3tYTBrt1Nq-cmvaufPjxX8F6pDkIA
 id: message.create_mention_comment.field_message_destination
 field_name: field_message_destination
 entity_type: message

--- a/modules/social_features/social_mentions/config/install/field.field.message.create_mention_comment.field_message_related_object.yml
+++ b/modules/social_features/social_mentions/config/install/field.field.message.create_mention_comment.field_message_related_object.yml
@@ -6,8 +6,6 @@ dependencies:
     - message.template.create_mention_comment
   module:
     - dynamic_entity_reference
-_core:
-  default_config_hash: 0Ue3FFY6KroMDeHNAjYvktkdoHNzvSx16ST13-Qo13s
 id: message.create_mention_comment.field_message_related_object
 field_name: field_message_related_object
 entity_type: message

--- a/modules/social_features/social_mentions/config/install/field.field.message.create_mention_post.field_message_context.yml
+++ b/modules/social_features/social_mentions/config/install/field.field.message.create_mention_post.field_message_context.yml
@@ -6,8 +6,6 @@ dependencies:
     - message.template.create_mention_post
   module:
     - options
-_core:
-  default_config_hash: vSWd1CGSTJAQBwN-5SvbeWfW3tjXZYtdWtEL9eN4OM0
 id: message.create_mention_post.field_message_context
 field_name: field_message_context
 entity_type: message

--- a/modules/social_features/social_mentions/config/install/field.field.message.create_mention_post.field_message_destination.yml
+++ b/modules/social_features/social_mentions/config/install/field.field.message.create_mention_post.field_message_destination.yml
@@ -6,8 +6,6 @@ dependencies:
     - message.template.create_mention_post
   module:
     - options
-_core:
-  default_config_hash: f1bYL89m8J7ZxxlH2pO2xGv1hbIAKhsLkrYdAmjNC_c
 id: message.create_mention_post.field_message_destination
 field_name: field_message_destination
 entity_type: message

--- a/modules/social_features/social_mentions/config/install/field.field.message.create_mention_post.field_message_related_object.yml
+++ b/modules/social_features/social_mentions/config/install/field.field.message.create_mention_post.field_message_related_object.yml
@@ -6,8 +6,6 @@ dependencies:
     - message.template.create_mention_post
   module:
     - dynamic_entity_reference
-_core:
-  default_config_hash: q9b-dh4M7WionnuHXr0gEldWkzwZ1g2pL7Qkg1gdbaw
 id: message.create_mention_post.field_message_related_object
 field_name: field_message_related_object
 entity_type: message

--- a/modules/social_features/social_mentions/config/install/mentions.mentions_type.ProfileMention.yml
+++ b/modules/social_features/social_mentions/config/install/mentions.mentions_type.ProfileMention.yml
@@ -1,8 +1,6 @@
 langcode: en
 status: true
 dependencies: {  }
-_core:
-  default_config_hash: FK1aIcm7WNB5LxKEQikPArccHbZ_kJKneTr1oXhNar8
 id: ProfileMention
 name: ProfileMention
 description: 'Mention by Profile entity'

--- a/modules/social_features/social_mentions/config/install/message.template.create_comment_reply_mention.yml
+++ b/modules/social_features/social_mentions/config/install/message.template.create_comment_reply_mention.yml
@@ -15,8 +15,6 @@ third_party_settings:
     activity_create_direct: 0
     activity_aggregate: 0
     activity_entity_condition: comment_reply
-_core:
-  default_config_hash: 2o1nYXUEaNMlXq1DNTHGO58kbvC4MY_o4i6i7W_l3ZU
 template: create_comment_reply_mention
 label: 'Create reply on comment with mentions'
 description: 'A person replied to a comment where I am mentioned'

--- a/modules/social_features/social_mentions/config/install/message.template.create_mention_comment.yml
+++ b/modules/social_features/social_mentions/config/install/message.template.create_mention_comment.yml
@@ -15,8 +15,6 @@ third_party_settings:
     activity_create_direct: 0
     activity_aggregate: 0
     activity_entity_condition: mention_comment
-_core:
-  default_config_hash: GZVjDepT25MvYNlyjH_cmxcCo_h0TGx8CF2DYX5TDto
 template: create_mention_comment
 label: 'Create mention in a comment'
 description: 'A person mentioned me in a comment'

--- a/modules/social_features/social_mentions/config/install/message.template.create_mention_comment_stream.yml
+++ b/modules/social_features/social_mentions/config/install/message.template.create_mention_comment_stream.yml
@@ -14,8 +14,6 @@ third_party_settings:
     activity_create_direct: 1
     activity_aggregate: 0
     activity_entity_condition: mention_comment
-_core:
-  default_config_hash: 9hCeIXvZlJrHgwBEsHzlSrMEtrVty8m0xSywwuAOAHI
 template: create_mention_comment_stream
 label: 'Create mention in a comment (stream: profile)'
 description: 'A person mentioned me in a comment (stream: profile)'

--- a/modules/social_features/social_mentions/config/install/message.template.create_mention_post.yml
+++ b/modules/social_features/social_mentions/config/install/message.template.create_mention_post.yml
@@ -15,8 +15,6 @@ third_party_settings:
     activity_create_direct: 0
     activity_aggregate: 0
     activity_entity_condition: mention_post
-_core:
-  default_config_hash: vyKJz0S0x7cwBMtod4MpUvtZeaKe4NaeTPkdc3-yU8o
 template: create_mention_post
 label: 'Create mention in a post'
 description: 'A person mentioned me in a post'

--- a/modules/social_features/social_mentions/config/install/message.template.create_mention_post_stream.yml
+++ b/modules/social_features/social_mentions/config/install/message.template.create_mention_post_stream.yml
@@ -14,8 +14,6 @@ third_party_settings:
     activity_create_direct: 1
     activity_aggregate: 0
     activity_entity_condition: mention_post
-_core:
-  default_config_hash: AiSquT8Sp70tAx-ra3IYzdzT2pRJVWpSt5bRtEZ0qhg
 template: create_mention_post_stream
 label: 'Create mention in a post (stream: profile)'
 description: 'A person mentioned me in a post (stream: profile)'

--- a/modules/social_features/social_page/config/install/core.base_field_override.node.page.promote.yml
+++ b/modules/social_features/social_page/config/install/core.base_field_override.node.page.promote.yml
@@ -3,8 +3,6 @@ status: true
 dependencies:
   config:
     - node.type.page
-_core:
-  default_config_hash: fPUEnm4T5zfZRr3ttDUqq7yCDd2uW3clWD-pvos4tlQ
 id: node.page.promote
 field_name: promote
 entity_type: node

--- a/modules/social_features/social_page/config/install/core.entity_form_display.node.page.default.yml
+++ b/modules/social_features/social_page/config/install/core.entity_form_display.node.page.default.yml
@@ -67,8 +67,6 @@ third_party_settings:
         required_fields: true
         id: visibility
         classes: 'card '
-_core:
-  default_config_hash: 3Z-1RH4Ygf-ZS11i1tHHb08h_tsEQ6BwTPx3gUUH3Wo
 id: node.page.default
 targetEntityType: node
 bundle: page

--- a/modules/social_features/social_page/config/install/core.entity_view_display.node.page.activity.yml
+++ b/modules/social_features/social_page/config/install/core.entity_view_display.node.page.activity.yml
@@ -14,8 +14,6 @@ dependencies:
     - image
     - social_core
     - user
-_core:
-  default_config_hash: MOwMLFoE7s630IIuH3ml6JuouPVGMjqKHVehU3-kK-8
 id: node.page.activity
 targetEntityType: node
 bundle: page

--- a/modules/social_features/social_page/config/install/core.entity_view_display.node.page.activity_comment.yml
+++ b/modules/social_features/social_page/config/install/core.entity_view_display.node.page.activity_comment.yml
@@ -13,8 +13,6 @@ dependencies:
   module:
     - image
     - user
-_core:
-  default_config_hash: vNN88EYaSfziM9dykYGOUaM_EzdH6WlkIWmbxwktnJQ
 id: node.page.activity_comment
 targetEntityType: node
 bundle: page

--- a/modules/social_features/social_page/config/install/core.entity_view_display.node.page.default.yml
+++ b/modules/social_features/social_page/config/install/core.entity_view_display.node.page.default.yml
@@ -14,8 +14,6 @@ dependencies:
     - file
     - text
     - user
-_core:
-  default_config_hash: LPXoB0rY5wFFUpL_vK-Fno0brMV_3CuhDzF5SbgDJXk
 id: node.page.default
 targetEntityType: node
 bundle: page

--- a/modules/social_features/social_page/config/install/core.entity_view_display.node.page.search_index.yml
+++ b/modules/social_features/social_page/config/install/core.entity_view_display.node.page.search_index.yml
@@ -14,8 +14,6 @@ dependencies:
     - comment
     - text
     - user
-_core:
-  default_config_hash: StGKT95jqWJol1ViUCv1sFx2UkiJk9V0ODl5JDkDtsQ
 id: node.page.search_index
 targetEntityType: node
 bundle: page

--- a/modules/social_features/social_page/config/install/core.entity_view_display.node.page.teaser.yml
+++ b/modules/social_features/social_page/config/install/core.entity_view_display.node.page.teaser.yml
@@ -14,8 +14,6 @@ dependencies:
     - image
     - options
     - user
-_core:
-  default_config_hash: 9sTjSemSHaUnHQeBsGy479G03O1t-_i_tHF7IHFPEO0
 id: node.page.teaser
 targetEntityType: node
 bundle: page

--- a/modules/social_features/social_page/config/install/field.field.node.page.body.yml
+++ b/modules/social_features/social_page/config/install/field.field.node.page.body.yml
@@ -6,8 +6,6 @@ dependencies:
     - node.type.page
   module:
     - text
-_core:
-  default_config_hash: YqTLY16HlbKkePuAIBfan9dOaXbB-k2Vw3PdReMyYVc
 id: node.page.body
 field_name: body
 entity_type: node

--- a/modules/social_features/social_page/config/install/field.field.node.page.field_content_visibility.yml
+++ b/modules/social_features/social_page/config/install/field.field.node.page.field_content_visibility.yml
@@ -6,8 +6,6 @@ dependencies:
     - node.type.page
   module:
     - entity_access_by_field
-_core:
-  default_config_hash: Cif_9GrczDSXr3x8VCzzlgOL6ouAZgIT7tiYAkHutto
 id: node.page.field_content_visibility
 field_name: field_content_visibility
 entity_type: node

--- a/modules/social_features/social_page/config/install/field.field.node.page.field_files.yml
+++ b/modules/social_features/social_page/config/install/field.field.node.page.field_files.yml
@@ -6,8 +6,6 @@ dependencies:
     - node.type.page
   module:
     - file
-_core:
-  default_config_hash: X7oF_vls-1z6d5kzBBjQfYuCq-zuJvrZFhZanIIf7RM
 id: node.page.field_files
 field_name: field_files
 entity_type: node

--- a/modules/social_features/social_page/config/install/field.field.node.page.field_page_comments.yml
+++ b/modules/social_features/social_page/config/install/field.field.node.page.field_page_comments.yml
@@ -6,8 +6,6 @@ dependencies:
     - node.type.page
   module:
     - comment
-_core:
-  default_config_hash: 8GnjpCnb7Lf-s2Z5nQTvdN_fJ879XMD3Fj49R8yuABI
 id: node.page.field_page_comments
 field_name: field_page_comments
 entity_type: node

--- a/modules/social_features/social_page/config/install/field.field.node.page.field_page_image.yml
+++ b/modules/social_features/social_page/config/install/field.field.node.page.field_page_image.yml
@@ -6,8 +6,6 @@ dependencies:
     - node.type.page
   module:
     - image
-_core:
-  default_config_hash: U8I1NkTJdcp2XhHbBStFMbuSw94jfetwCVz_GnKEZQQ
 id: node.page.field_page_image
 field_name: field_page_image
 entity_type: node

--- a/modules/social_features/social_page/config/install/field.storage.node.field_page_comments.yml
+++ b/modules/social_features/social_page/config/install/field.storage.node.field_page_comments.yml
@@ -4,8 +4,6 @@ dependencies:
   module:
     - comment
     - node
-_core:
-  default_config_hash: PHoIi90y7iXa0vCCGCCBBPOQB089rXIlr-5DvnXT9P8
 id: node.field_page_comments
 field_name: field_page_comments
 entity_type: node

--- a/modules/social_features/social_page/config/install/field.storage.node.field_page_image.yml
+++ b/modules/social_features/social_page/config/install/field.storage.node.field_page_image.yml
@@ -5,8 +5,6 @@ dependencies:
     - file
     - image
     - node
-_core:
-  default_config_hash: EOkGkoLCL_Dxpfdpq3cVK30o59SJhOWh7CYbaMPCmuk
 id: node.field_page_image
 field_name: field_page_image
 entity_type: node

--- a/modules/social_features/social_page/config/install/node.type.page.yml
+++ b/modules/social_features/social_page/config/install/node.type.page.yml
@@ -9,8 +9,6 @@ third_party_settings:
       - footer
       - main
     parent: 'main:'
-_core:
-  default_config_hash: vo_zw-ZU4gjWynbEmXqJGrwdkbdnVuVUohurx8Iit50
 name: 'Basic page'
 type: page
 description: 'Use basic pages for your static content, such as an ''About us'' page.'

--- a/modules/social_features/social_post/config/features_removal/core.entity_view_display.post.post.default.yml
+++ b/modules/social_features/social_post/config/features_removal/core.entity_view_display.post.post.default.yml
@@ -12,8 +12,6 @@ dependencies:
     - social_post
     - text
     - user
-_core:
-  default_config_hash: 92DypJVTBk9RAojIcXfv18icSfCeu2ruTrrs_4dMYk8
 id: post.post.default
 targetEntityType: post
 bundle: post

--- a/modules/social_features/social_post/config/install/comment.type.post_comment.yml
+++ b/modules/social_features/social_post/config/install/comment.type.post_comment.yml
@@ -1,8 +1,6 @@
 langcode: en
 status: true
 dependencies: {  }
-_core:
-  default_config_hash: hGHnIBzGy-ezfVmmfzoO6FbC-fhM8_KKG_Ysyae9xtk
 id: post_comment
 label: 'Post comment'
 target_entity_type_id: post

--- a/modules/social_features/social_post/config/install/core.entity_form_display.comment.post_comment.default.yml
+++ b/modules/social_features/social_post/config/install/core.entity_form_display.comment.post_comment.default.yml
@@ -4,8 +4,6 @@ dependencies:
   config:
     - comment.type.post_comment
     - field.field.comment.post_comment.field_comment_body
-_core:
-  default_config_hash: nnUo3hAW_J-kEuqqWBEFSm2wzQU48NaKnBCGecPtvK0
 id: comment.post_comment.default
 targetEntityType: comment
 bundle: post_comment

--- a/modules/social_features/social_post/config/install/core.entity_form_display.post.post.default.yml
+++ b/modules/social_features/social_post/config/install/core.entity_form_display.post.post.default.yml
@@ -10,8 +10,6 @@ dependencies:
     - social_post.post_type.post
   module:
     - dropdown
-_core:
-  default_config_hash: DetPMoKU2Q7vOFGCjoO00gpsfVk-MxIHEWexOXNgbkI
 id: post.post.default
 targetEntityType: post
 bundle: post

--- a/modules/social_features/social_post/config/install/core.entity_form_display.post.post.group.yml
+++ b/modules/social_features/social_post/config/install/core.entity_form_display.post.post.group.yml
@@ -11,8 +11,6 @@ dependencies:
     - social_post.post_type.post
   module:
     - dropdown
-_core:
-  default_config_hash: '-5WM09YiGMF21AtZGs16oNQ_LwVhaGQilD-aog7WnpE'
 id: post.post.group
 targetEntityType: post
 bundle: post

--- a/modules/social_features/social_post/config/install/core.entity_form_display.post.post.profile.yml
+++ b/modules/social_features/social_post/config/install/core.entity_form_display.post.post.profile.yml
@@ -11,8 +11,6 @@ dependencies:
     - social_post.post_type.post
   module:
     - dropdown
-_core:
-  default_config_hash: WU5RP0OlbkLrfULjyeVIbzVODVg_PS3g5tpwmtH06X0
 id: post.post.profile
 targetEntityType: post
 bundle: post

--- a/modules/social_features/social_post/config/install/core.entity_form_mode.post.group.yml
+++ b/modules/social_features/social_post/config/install/core.entity_form_mode.post.group.yml
@@ -3,8 +3,6 @@ status: true
 dependencies:
   module:
     - social_post
-_core:
-  default_config_hash: j1ZT5107i2koTB3Ts1Ql6HJBJTRbgLAlMvNpCsVH2ZA
 id: post.group
 label: Group
 targetEntityType: post

--- a/modules/social_features/social_post/config/install/core.entity_form_mode.post.profile.yml
+++ b/modules/social_features/social_post/config/install/core.entity_form_mode.post.profile.yml
@@ -3,8 +3,6 @@ status: true
 dependencies:
   module:
     - social_post
-_core:
-  default_config_hash: XqND3WmnPUGOb_j_NqRg7_of_gaSstrJ4iIJg3wD9TI
 id: post.profile
 label: 'Profile of others'
 targetEntityType: post

--- a/modules/social_features/social_post/config/install/core.entity_view_display.comment.post_comment.default.yml
+++ b/modules/social_features/social_post/config/install/core.entity_view_display.comment.post_comment.default.yml
@@ -4,8 +4,6 @@ dependencies:
   config:
     - comment.type.post_comment
     - field.field.comment.post_comment.field_comment_body
-_core:
-  default_config_hash: FofkEbCSl5bmiwsIkBnLEdy9UzgZh3vsNmwNyOVPshw
 id: comment.post_comment.default
 targetEntityType: comment
 bundle: post_comment

--- a/modules/social_features/social_post/config/install/core.entity_view_display.post.post.activity.yml
+++ b/modules/social_features/social_post/config/install/core.entity_view_display.post.post.activity.yml
@@ -13,8 +13,6 @@ dependencies:
     - social_post
     - text
     - user
-_core:
-  default_config_hash: b44BGhIgbu5CKjG8HZzvz1Ecdls6TA5KaBHBOzRJFso
 id: post.post.activity
 targetEntityType: post
 bundle: post

--- a/modules/social_features/social_post/config/install/core.entity_view_display.post.post.activity_comment.yml
+++ b/modules/social_features/social_post/config/install/core.entity_view_display.post.post.activity_comment.yml
@@ -12,8 +12,6 @@ dependencies:
   module:
     - text
     - user
-_core:
-  default_config_hash: 7BdNcT77pVzRbWjS9ayAQkUnpTURDGrrTF5Jsoj8iTI
 id: post.post.activity_comment
 targetEntityType: post
 bundle: post

--- a/modules/social_features/social_post/config/install/core.entity_view_mode.post.activity.yml
+++ b/modules/social_features/social_post/config/install/core.entity_view_mode.post.activity.yml
@@ -3,8 +3,6 @@ status: true
 dependencies:
   module:
     - social_post
-_core:
-  default_config_hash: C7jN5Ir6IticKf_T5catiIapjlD2RLRF6P-Y13NCqfQ
 id: post.activity
 label: Activity
 targetEntityType: post

--- a/modules/social_features/social_post/config/install/core.entity_view_mode.post.activity_comment.yml
+++ b/modules/social_features/social_post/config/install/core.entity_view_mode.post.activity_comment.yml
@@ -3,8 +3,6 @@ status: true
 dependencies:
   module:
     - social_post
-_core:
-  default_config_hash: cCy_sVSMi5Y7Emunx-Us8Qb9yzlw-GSrnkpW8LRWoD8
 id: post.activity_comment
 label: 'Activity comment'
 targetEntityType: post

--- a/modules/social_features/social_post/config/install/field.field.comment.post_comment.field_comment_body.yml
+++ b/modules/social_features/social_post/config/install/field.field.comment.post_comment.field_comment_body.yml
@@ -6,8 +6,6 @@ dependencies:
     - field.storage.comment.field_comment_body
   module:
     - text
-_core:
-  default_config_hash: GiX8YiQqlzuNVPmuQJwBQwwb4OYBlya8povx8_9MTqY
 id: comment.post_comment.field_comment_body
 field_name: field_comment_body
 entity_type: comment

--- a/modules/social_features/social_post/config/install/field.field.post.post.field_post.yml
+++ b/modules/social_features/social_post/config/install/field.field.post.post.field_post.yml
@@ -6,8 +6,6 @@ dependencies:
     - social_post.post_type.post
   module:
     - text
-_core:
-  default_config_hash: 1fb6Z78K1xvRoc6lIFSEsMZU_nxQY4Qp4e_XM3_WnJw
 id: post.post.field_post
 field_name: field_post
 entity_type: post

--- a/modules/social_features/social_post/config/install/field.field.post.post.field_post_comments.yml
+++ b/modules/social_features/social_post/config/install/field.field.post.post.field_post_comments.yml
@@ -6,8 +6,6 @@ dependencies:
     - social_post.post_type.post
   module:
     - comment
-_core:
-  default_config_hash: AQ9iC2hR5QGEr6dkImYd5RVm0egxSfZEDDaHShMANws
 id: post.post.field_post_comments
 field_name: field_post_comments
 entity_type: post

--- a/modules/social_features/social_post/config/install/field.field.post.post.field_recipient_group.yml
+++ b/modules/social_features/social_post/config/install/field.field.post.post.field_recipient_group.yml
@@ -4,8 +4,6 @@ dependencies:
   config:
     - field.storage.post.field_recipient_group
     - social_post.post_type.post
-_core:
-  default_config_hash: SwwEbemUe_i8ALLpWSLa_4gV2nX_j0PB5p60lyLqBfc
 id: post.post.field_recipient_group
 field_name: field_recipient_group
 entity_type: post

--- a/modules/social_features/social_post/config/install/field.field.post.post.field_recipient_user.yml
+++ b/modules/social_features/social_post/config/install/field.field.post.post.field_recipient_user.yml
@@ -4,8 +4,6 @@ dependencies:
   config:
     - field.storage.post.field_recipient_user
     - social_post.post_type.post
-_core:
-  default_config_hash: lp10ScgbXp069od5iTgXkrk7824GuA4X6QIr4HvjZ7g
 id: post.post.field_recipient_user
 field_name: field_recipient_user
 entity_type: post

--- a/modules/social_features/social_post/config/install/field.field.post.post.field_visibility.yml
+++ b/modules/social_features/social_post/config/install/field.field.post.post.field_visibility.yml
@@ -6,8 +6,6 @@ dependencies:
     - social_post.post_type.post
   module:
     - dropdown
-_core:
-  default_config_hash: f_3E2Rlb8_M1NISovsA7IV5mWI4PbELyomXNVllV05A
 id: post.post.field_visibility
 field_name: field_visibility
 entity_type: post

--- a/modules/social_features/social_post/config/install/field.storage.post.field_post.yml
+++ b/modules/social_features/social_post/config/install/field.storage.post.field_post.yml
@@ -4,8 +4,6 @@ dependencies:
   module:
     - social_post
     - text
-_core:
-  default_config_hash: c54Ovci6FJDLI_-xmGiTv17AFGkTVZt6jutqTQvS8ns
 id: post.field_post
 field_name: field_post
 entity_type: post

--- a/modules/social_features/social_post/config/install/field.storage.post.field_post_comments.yml
+++ b/modules/social_features/social_post/config/install/field.storage.post.field_post_comments.yml
@@ -4,8 +4,6 @@ dependencies:
   module:
     - comment
     - social_post
-_core:
-  default_config_hash: 53vimJ-4WkdX5lHYUperAG-hJK0_g6Y4EPuhj7_Dp_A
 id: post.field_post_comments
 field_name: field_post_comments
 entity_type: post

--- a/modules/social_features/social_post/config/install/field.storage.post.field_recipient_group.yml
+++ b/modules/social_features/social_post/config/install/field.storage.post.field_recipient_group.yml
@@ -4,8 +4,6 @@ dependencies:
   module:
     - group
     - social_post
-_core:
-  default_config_hash: tU_PYT-wu36DVEwlFn0mtZn-2qkQ0S1Xv24V6KHI-K4
 id: post.field_recipient_group
 field_name: field_recipient_group
 entity_type: post

--- a/modules/social_features/social_post/config/install/field.storage.post.field_recipient_user.yml
+++ b/modules/social_features/social_post/config/install/field.storage.post.field_recipient_user.yml
@@ -4,8 +4,6 @@ dependencies:
   module:
     - social_post
     - user
-_core:
-  default_config_hash: 4PGg5JDZA1hH3j20SPuLfzO6U9S0f3_c62gypX_nwvI
 id: post.field_recipient_user
 field_name: field_recipient_user
 entity_type: post

--- a/modules/social_features/social_post/config/install/field.storage.post.field_visibility.yml
+++ b/modules/social_features/social_post/config/install/field.storage.post.field_visibility.yml
@@ -4,8 +4,6 @@ dependencies:
   module:
     - dropdown
     - social_post
-_core:
-  default_config_hash: 9IChKT1xRW3I7-oWdWMhAXoRYjpyJzG7PIVhkHaOlzU
 id: post.field_visibility
 field_name: field_visibility
 entity_type: post

--- a/modules/social_features/social_post/config/install/social_post.post_type.post.yml
+++ b/modules/social_features/social_post/config/install/social_post.post_type.post.yml
@@ -1,7 +1,5 @@
 langcode: en
 status: true
 dependencies: {  }
-_core:
-  default_config_hash: EPY0EVYUwR5X6zk3qxbChGYJqMT6OTe9cvEG3suZOT4
 id: post
 label: Post

--- a/modules/social_features/social_post/config/install/views.view.recipient_group_reference.yml
+++ b/modules/social_features/social_post/config/install/views.view.recipient_group_reference.yml
@@ -3,8 +3,6 @@ status: true
 dependencies:
   module:
     - group
-_core:
-  default_config_hash: XwB1tiTp_9hTMfUH0z-CjJOB-tVgjrvHu_7hRDrOcQw
 id: recipient_group_reference
 label: recipient_group_reference
 module: views

--- a/modules/social_features/social_profile/config/install/core.entity_form_display.profile.profile.default.yml
+++ b/modules/social_features/social_profile/config/install/core.entity_form_display.profile.profile.default.yml
@@ -81,8 +81,6 @@ third_party_settings:
         required_fields: true
         id: contact
         classes: scollspy
-_core:
-  default_config_hash: q5dRMlfrlHczeboqgnggDsIvBp1Z0aun2cMsa4qIDbQ
 id: profile.profile.default
 targetEntityType: profile
 bundle: profile

--- a/modules/social_features/social_profile/config/install/core.entity_view_display.profile.profile.compact.yml
+++ b/modules/social_features/social_profile/config/install/core.entity_view_display.profile.profile.compact.yml
@@ -20,8 +20,6 @@ dependencies:
     - profile.type.profile
   module:
     - image
-_core:
-  default_config_hash: 5JpVMOxBztNKigvSbrpNQLM4Efar6pFjMneGF61lctQ
 id: profile.profile.compact
 targetEntityType: profile
 bundle: profile

--- a/modules/social_features/social_profile/config/install/core.entity_view_display.profile.profile.compact_notification.yml
+++ b/modules/social_features/social_profile/config/install/core.entity_view_display.profile.profile.compact_notification.yml
@@ -20,8 +20,6 @@ dependencies:
     - profile.type.profile
   module:
     - image
-_core:
-  default_config_hash: iVNq3S4Ce_YQ5DPG4GOSyEm-BWVHZrLa0GEBpCbCAU4
 id: profile.profile.compact_notification
 targetEntityType: profile
 bundle: profile

--- a/modules/social_features/social_profile/config/install/core.entity_view_display.profile.profile.compact_teaser.yml
+++ b/modules/social_features/social_profile/config/install/core.entity_view_display.profile.profile.compact_teaser.yml
@@ -20,8 +20,6 @@ dependencies:
     - profile.type.profile
   module:
     - image
-_core:
-  default_config_hash: LhTkc9uKty6op2mF2sRhyHSZbPfxgVcQnv_ai4BYKL4
 id: profile.profile.compact_teaser
 targetEntityType: profile
 bundle: profile

--- a/modules/social_features/social_profile/config/install/core.entity_view_display.profile.profile.default.yml
+++ b/modules/social_features/social_profile/config/install/core.entity_view_display.profile.profile.default.yml
@@ -19,8 +19,6 @@ dependencies:
   module:
     - address
     - text
-_core:
-  default_config_hash: 58km7VIH-fzAz4VoS-3UD6-va3DXkuyuCg7Q5n0jPdQ
 id: profile.profile.default
 targetEntityType: profile
 bundle: profile

--- a/modules/social_features/social_profile/config/install/core.entity_view_display.profile.profile.hero.yml
+++ b/modules/social_features/social_profile/config/install/core.entity_view_display.profile.profile.hero.yml
@@ -20,8 +20,6 @@ dependencies:
     - profile.type.profile
   module:
     - image
-_core:
-  default_config_hash: qqDHRFDvMQktSEGNvGvxXzY-4YeVspZEAwOwADcHMw0
 id: profile.profile.hero
 targetEntityType: profile
 bundle: profile

--- a/modules/social_features/social_profile/config/install/core.entity_view_display.profile.profile.search_index.yml
+++ b/modules/social_features/social_profile/config/install/core.entity_view_display.profile.profile.search_index.yml
@@ -20,8 +20,6 @@ dependencies:
   module:
     - address
     - text
-_core:
-  default_config_hash: deHlSJRd3xCeatWn_C0Uf2ixOT7eyl-DzLcRJs3JhDE
 id: profile.profile.search_index
 targetEntityType: profile
 bundle: profile

--- a/modules/social_features/social_profile/config/install/core.entity_view_display.profile.profile.small.yml
+++ b/modules/social_features/social_profile/config/install/core.entity_view_display.profile.profile.small.yml
@@ -20,8 +20,6 @@ dependencies:
     - profile.type.profile
   module:
     - image
-_core:
-  default_config_hash: A4EdmFec2hpk65XCDSqGBbu7RxUROmvIazio32D47qI
 id: profile.profile.small
 targetEntityType: profile
 bundle: profile

--- a/modules/social_features/social_profile/config/install/core.entity_view_display.profile.profile.small_teaser.yml
+++ b/modules/social_features/social_profile/config/install/core.entity_view_display.profile.profile.small_teaser.yml
@@ -20,8 +20,6 @@ dependencies:
     - profile.type.profile
   module:
     - image
-_core:
-  default_config_hash: cme1dXyejIMZqleCc1lq6guoASVtyxwnTDJ0TZQPdUA
 id: profile.profile.small_teaser
 targetEntityType: profile
 bundle: profile

--- a/modules/social_features/social_profile/config/install/core.entity_view_display.profile.profile.table.yml
+++ b/modules/social_features/social_profile/config/install/core.entity_view_display.profile.profile.table.yml
@@ -20,8 +20,6 @@ dependencies:
     - profile.type.profile
   module:
     - image
-_core:
-  default_config_hash: 4f-ZYQ9uYrTOn0BSa6jh5zXspIBGi5mT1JqTOLJpJ8c
 id: profile.profile.table
 targetEntityType: profile
 bundle: profile

--- a/modules/social_features/social_profile/config/install/core.entity_view_display.profile.profile.teaser.yml
+++ b/modules/social_features/social_profile/config/install/core.entity_view_display.profile.profile.teaser.yml
@@ -20,8 +20,6 @@ dependencies:
     - profile.type.profile
   module:
     - image
-_core:
-  default_config_hash: FcXkiWibWukZQuFR-tl1OjDt2wjIVy111jf3yg7i3B8
 id: profile.profile.teaser
 targetEntityType: profile
 bundle: profile

--- a/modules/social_features/social_profile/config/install/core.entity_view_mode.profile.compact.yml
+++ b/modules/social_features/social_profile/config/install/core.entity_view_mode.profile.compact.yml
@@ -3,8 +3,6 @@ status: true
 dependencies:
   module:
     - profile
-_core:
-  default_config_hash: anz9ltkbslFLYv4Mlzxb0htf6HueGYPqSZUZI7zAdkc
 id: profile.compact
 label: 'Compact Avatar'
 targetEntityType: profile

--- a/modules/social_features/social_profile/config/install/core.entity_view_mode.profile.compact_notification.yml
+++ b/modules/social_features/social_profile/config/install/core.entity_view_mode.profile.compact_notification.yml
@@ -3,8 +3,6 @@ status: true
 dependencies:
   module:
     - profile
-_core:
-  default_config_hash: n12lIObk4emC0lDI24D8lc8yzDP9t1R5IbQ29HHGL-M
 id: profile.compact_notification
 label: 'Compact Notifcation'
 targetEntityType: profile

--- a/modules/social_features/social_profile/config/install/core.entity_view_mode.profile.compact_teaser.yml
+++ b/modules/social_features/social_profile/config/install/core.entity_view_mode.profile.compact_teaser.yml
@@ -3,8 +3,6 @@ status: true
 dependencies:
   module:
     - profile
-_core:
-  default_config_hash: hmyLw8np1Uh1v6B6ByZqIwItE1yXHrT1khezvyTEoOk
 id: profile.compact_teaser
 label: 'Compact Teaser'
 targetEntityType: profile

--- a/modules/social_features/social_profile/config/install/core.entity_view_mode.profile.hero.yml
+++ b/modules/social_features/social_profile/config/install/core.entity_view_mode.profile.hero.yml
@@ -3,8 +3,6 @@ status: true
 dependencies:
   module:
     - profile
-_core:
-  default_config_hash: xdbH1V3Bt9GEL2CC6M60aOSNjKeK1jpRpWoB6_OZl80
 id: profile.hero
 label: Hero
 targetEntityType: profile

--- a/modules/social_features/social_profile/config/install/core.entity_view_mode.profile.search_index.yml
+++ b/modules/social_features/social_profile/config/install/core.entity_view_mode.profile.search_index.yml
@@ -3,8 +3,6 @@ status: true
 dependencies:
   module:
     - profile
-_core:
-  default_config_hash: wmO6xCxLIrGhfwHdZnry41ZEiacB3O0VogCoyxIgWuI
 id: profile.search_index
 label: 'Search Index'
 targetEntityType: profile

--- a/modules/social_features/social_profile/config/install/core.entity_view_mode.profile.small.yml
+++ b/modules/social_features/social_profile/config/install/core.entity_view_mode.profile.small.yml
@@ -3,8 +3,6 @@ status: true
 dependencies:
   module:
     - profile
-_core:
-  default_config_hash: jKBVdYcXFQuNJWKHW8lusoDp-moh7l1VryBlgy1QBq8
 id: profile.small
 label: 'Small Avatar'
 targetEntityType: profile

--- a/modules/social_features/social_profile/config/install/core.entity_view_mode.profile.small_teaser.yml
+++ b/modules/social_features/social_profile/config/install/core.entity_view_mode.profile.small_teaser.yml
@@ -3,8 +3,6 @@ status: true
 dependencies:
   module:
     - profile
-_core:
-  default_config_hash: 1pGJP3tKJXIdHu3fWL9HU-hTPEXcKpqxsWadT9Wdh8s
 id: profile.small_teaser
 label: 'Small Teaser'
 targetEntityType: profile

--- a/modules/social_features/social_profile/config/install/core.entity_view_mode.profile.table.yml
+++ b/modules/social_features/social_profile/config/install/core.entity_view_mode.profile.table.yml
@@ -3,8 +3,6 @@ status: true
 dependencies:
   module:
     - profile
-_core:
-  default_config_hash: YcYEl_VJgKpEnxk1iIM85ybbcVWyZHCzgsxjh_DAtuk
 id: profile.table
 label: Table
 targetEntityType: profile

--- a/modules/social_features/social_profile/config/install/core.entity_view_mode.profile.teaser.yml
+++ b/modules/social_features/social_profile/config/install/core.entity_view_mode.profile.teaser.yml
@@ -3,8 +3,6 @@ status: true
 dependencies:
   module:
     - profile
-_core:
-  default_config_hash: QwHKCTpE1suKE_XELJtpxPdCy6856mg2nrGY2GQI6tw
 id: profile.teaser
 label: Teaser
 targetEntityType: profile

--- a/modules/social_features/social_profile/config/install/field.field.profile.profile.field_profile_address.yml
+++ b/modules/social_features/social_profile/config/install/field.field.profile.profile.field_profile_address.yml
@@ -6,8 +6,6 @@ dependencies:
     - profile.type.profile
   module:
     - address
-_core:
-  default_config_hash: UNKuuXtOlJqkZYLFhGPgvltZZW6z_avDa5uMddCXJ4c
 id: profile.profile.field_profile_address
 field_name: field_profile_address
 entity_type: profile

--- a/modules/social_features/social_profile/config/install/field.field.profile.profile.field_profile_banner_image.yml
+++ b/modules/social_features/social_profile/config/install/field.field.profile.profile.field_profile_banner_image.yml
@@ -6,8 +6,6 @@ dependencies:
     - profile.type.profile
   module:
     - image
-_core:
-  default_config_hash: UawMZhFSdMC2-AAWiIopNZcwbmXdudFfo1gRND_A7Qg
 id: profile.profile.field_profile_banner_image
 field_name: field_profile_banner_image
 entity_type: profile

--- a/modules/social_features/social_profile/config/install/field.field.profile.profile.field_profile_expertise.yml
+++ b/modules/social_features/social_profile/config/install/field.field.profile.profile.field_profile_expertise.yml
@@ -5,8 +5,6 @@ dependencies:
     - field.storage.profile.field_profile_expertise
     - profile.type.profile
     - taxonomy.vocabulary.expertise
-_core:
-  default_config_hash: 6rQZDIIzqv6dn5rfNV1R_uVO1uSISsC5Bb33ZX7WHfg
 id: profile.profile.field_profile_expertise
 field_name: field_profile_expertise
 entity_type: profile

--- a/modules/social_features/social_profile/config/install/field.field.profile.profile.field_profile_first_name.yml
+++ b/modules/social_features/social_profile/config/install/field.field.profile.profile.field_profile_first_name.yml
@@ -4,8 +4,6 @@ dependencies:
   config:
     - field.storage.profile.field_profile_first_name
     - profile.type.profile
-_core:
-  default_config_hash: AJUjf-s01_Y0pXAPGUHoSxHIQop4_nSV4suqed6qRAg
 id: profile.profile.field_profile_first_name
 field_name: field_profile_first_name
 entity_type: profile

--- a/modules/social_features/social_profile/config/install/field.field.profile.profile.field_profile_function.yml
+++ b/modules/social_features/social_profile/config/install/field.field.profile.profile.field_profile_function.yml
@@ -4,8 +4,6 @@ dependencies:
   config:
     - field.storage.profile.field_profile_function
     - profile.type.profile
-_core:
-  default_config_hash: ay3MOEZlPmYKTqkwlwE4jRjEnzNzVED3G28CA2KHNa0
 id: profile.profile.field_profile_function
 field_name: field_profile_function
 entity_type: profile

--- a/modules/social_features/social_profile/config/install/field.field.profile.profile.field_profile_image.yml
+++ b/modules/social_features/social_profile/config/install/field.field.profile.profile.field_profile_image.yml
@@ -6,8 +6,6 @@ dependencies:
     - profile.type.profile
   module:
     - image
-_core:
-  default_config_hash: tSyQuKXSwEWCqPytdKi5gnT04E2SCEUfF6-3AUegANk
 id: profile.profile.field_profile_image
 field_name: field_profile_image
 entity_type: profile

--- a/modules/social_features/social_profile/config/install/field.field.profile.profile.field_profile_interests.yml
+++ b/modules/social_features/social_profile/config/install/field.field.profile.profile.field_profile_interests.yml
@@ -5,8 +5,6 @@ dependencies:
     - field.storage.profile.field_profile_interests
     - profile.type.profile
     - taxonomy.vocabulary.interests
-_core:
-  default_config_hash: 3lITbyDH8RJ0nmopxGSVhcW4u3Nd2WGIqbcj5xyZ2gg
 id: profile.profile.field_profile_interests
 field_name: field_profile_interests
 entity_type: profile

--- a/modules/social_features/social_profile/config/install/field.field.profile.profile.field_profile_last_name.yml
+++ b/modules/social_features/social_profile/config/install/field.field.profile.profile.field_profile_last_name.yml
@@ -4,8 +4,6 @@ dependencies:
   config:
     - field.storage.profile.field_profile_last_name
     - profile.type.profile
-_core:
-  default_config_hash: csNjl3bGScQ3rN5gozhGKMxRo1RKmw0EfFRjEEOEzK4
 id: profile.profile.field_profile_last_name
 field_name: field_profile_last_name
 entity_type: profile

--- a/modules/social_features/social_profile/config/install/field.field.profile.profile.field_profile_organization.yml
+++ b/modules/social_features/social_profile/config/install/field.field.profile.profile.field_profile_organization.yml
@@ -4,8 +4,6 @@ dependencies:
   config:
     - field.storage.profile.field_profile_organization
     - profile.type.profile
-_core:
-  default_config_hash: KIkcp7sAw2x_W8-DLJ9NGnZ9f_rrqyPQD9FKsNwoFD4
 id: profile.profile.field_profile_organization
 field_name: field_profile_organization
 entity_type: profile

--- a/modules/social_features/social_profile/config/install/field.field.profile.profile.field_profile_phone_number.yml
+++ b/modules/social_features/social_profile/config/install/field.field.profile.profile.field_profile_phone_number.yml
@@ -6,8 +6,6 @@ dependencies:
     - profile.type.profile
   module:
     - telephone
-_core:
-  default_config_hash: 7upql6fv9ahKc2JfcLhygR5hetRvCj07z6CUuSP5gPw
 id: profile.profile.field_profile_phone_number
 field_name: field_profile_phone_number
 entity_type: profile

--- a/modules/social_features/social_profile/config/install/field.field.profile.profile.field_profile_profile_tag.yml
+++ b/modules/social_features/social_profile/config/install/field.field.profile.profile.field_profile_profile_tag.yml
@@ -5,8 +5,6 @@ dependencies:
     - field.storage.profile.field_profile_profile_tag
     - profile.type.profile
     - taxonomy.vocabulary.profile_tag
-_core:
-  default_config_hash: 9nuh7_PtQan2tfsC1n-tRhfasDLLygRLrIGk5eB4mhg
 id: profile.profile.field_profile_profile_tag
 field_name: field_profile_profile_tag
 entity_type: profile

--- a/modules/social_features/social_profile/config/install/field.field.profile.profile.field_profile_self_introduction.yml
+++ b/modules/social_features/social_profile/config/install/field.field.profile.profile.field_profile_self_introduction.yml
@@ -6,8 +6,6 @@ dependencies:
     - profile.type.profile
   module:
     - text
-_core:
-  default_config_hash: EtzFYMBWMlgHvlBDKsZJubuEqQtKgMFRdNdTOd9C7Gc
 id: profile.profile.field_profile_self_introduction
 field_name: field_profile_self_introduction
 entity_type: profile

--- a/modules/social_features/social_profile/config/install/field.field.profile.profile.field_profile_show_email.yml
+++ b/modules/social_features/social_profile/config/install/field.field.profile.profile.field_profile_show_email.yml
@@ -4,8 +4,6 @@ dependencies:
   config:
     - field.storage.profile.field_profile_show_email
     - profile.type.profile
-_core:
-  default_config_hash: sUwWTGsv71PxDl7Av0XwlJ72HfrlddIXNJfZ6kcubcs
 id: profile.profile.field_profile_show_email
 field_name: field_profile_show_email
 entity_type: profile

--- a/modules/social_features/social_profile/config/install/field.storage.profile.field_profile_address.yml
+++ b/modules/social_features/social_profile/config/install/field.storage.profile.field_profile_address.yml
@@ -4,8 +4,6 @@ dependencies:
   module:
     - address
     - profile
-_core:
-  default_config_hash: l2okytkJohIWmU2T2NmxRzna88wCBVluBofI9VURZ4k
 id: profile.field_profile_address
 field_name: field_profile_address
 entity_type: profile

--- a/modules/social_features/social_profile/config/install/field.storage.profile.field_profile_banner_image.yml
+++ b/modules/social_features/social_profile/config/install/field.storage.profile.field_profile_banner_image.yml
@@ -5,8 +5,6 @@ dependencies:
     - file
     - image
     - profile
-_core:
-  default_config_hash: 0KW5AMbJi-9HVPSWZWvonnSGb9wM4107yFKKAd0Oxi0
 id: profile.field_profile_banner_image
 field_name: field_profile_banner_image
 entity_type: profile

--- a/modules/social_features/social_profile/config/install/field.storage.profile.field_profile_expertise.yml
+++ b/modules/social_features/social_profile/config/install/field.storage.profile.field_profile_expertise.yml
@@ -4,8 +4,6 @@ dependencies:
   module:
     - profile
     - taxonomy
-_core:
-  default_config_hash: sWcQsnM2xvASI-H6QeowIEMTDMrz3lYcs5_eg6OCp9Q
 id: profile.field_profile_expertise
 field_name: field_profile_expertise
 entity_type: profile

--- a/modules/social_features/social_profile/config/install/field.storage.profile.field_profile_first_name.yml
+++ b/modules/social_features/social_profile/config/install/field.storage.profile.field_profile_first_name.yml
@@ -3,8 +3,6 @@ status: true
 dependencies:
   module:
     - profile
-_core:
-  default_config_hash: _gQ-Dr-WCOHq3QNzgr9gcxURxv8AInzkSwp8T97NkQk
 id: profile.field_profile_first_name
 field_name: field_profile_first_name
 entity_type: profile

--- a/modules/social_features/social_profile/config/install/field.storage.profile.field_profile_function.yml
+++ b/modules/social_features/social_profile/config/install/field.storage.profile.field_profile_function.yml
@@ -3,8 +3,6 @@ status: true
 dependencies:
   module:
     - profile
-_core:
-  default_config_hash: 95hSWaQBnRc3XkOwQi3mtBcxgKDg3KsZuZsB-Dooe8U
 id: profile.field_profile_function
 field_name: field_profile_function
 entity_type: profile

--- a/modules/social_features/social_profile/config/install/field.storage.profile.field_profile_image.yml
+++ b/modules/social_features/social_profile/config/install/field.storage.profile.field_profile_image.yml
@@ -5,8 +5,6 @@ dependencies:
     - file
     - image
     - profile
-_core:
-  default_config_hash: 8OO_sIuv7nQOIZRI03qMSZmDzW0zINwN6nM4j4v4XrM
 id: profile.field_profile_image
 field_name: field_profile_image
 entity_type: profile

--- a/modules/social_features/social_profile/config/install/field.storage.profile.field_profile_interests.yml
+++ b/modules/social_features/social_profile/config/install/field.storage.profile.field_profile_interests.yml
@@ -4,8 +4,6 @@ dependencies:
   module:
     - profile
     - taxonomy
-_core:
-  default_config_hash: _dW0wlwL1YwfblcR4pQeVLiJzix15duG4bBA1P0IW2w
 id: profile.field_profile_interests
 field_name: field_profile_interests
 entity_type: profile

--- a/modules/social_features/social_profile/config/install/field.storage.profile.field_profile_last_name.yml
+++ b/modules/social_features/social_profile/config/install/field.storage.profile.field_profile_last_name.yml
@@ -3,8 +3,6 @@ status: true
 dependencies:
   module:
     - profile
-_core:
-  default_config_hash: bKXsR9oEv2U_V06W-F-Hs8DrqUxH099-nGSKptXziaE
 id: profile.field_profile_last_name
 field_name: field_profile_last_name
 entity_type: profile

--- a/modules/social_features/social_profile/config/install/field.storage.profile.field_profile_organization.yml
+++ b/modules/social_features/social_profile/config/install/field.storage.profile.field_profile_organization.yml
@@ -3,8 +3,6 @@ status: true
 dependencies:
   module:
     - profile
-_core:
-  default_config_hash: D7EZM3YkqZXzO7eZ6aJNbAwQ4ETNy-yMk3N0lo49iPM
 id: profile.field_profile_organization
 field_name: field_profile_organization
 entity_type: profile

--- a/modules/social_features/social_profile/config/install/field.storage.profile.field_profile_phone_number.yml
+++ b/modules/social_features/social_profile/config/install/field.storage.profile.field_profile_phone_number.yml
@@ -4,8 +4,6 @@ dependencies:
   module:
     - profile
     - telephone
-_core:
-  default_config_hash: QWiaI2rMrX0hNgal4fCWX_9RIR14UD--KDQKhInEmtc
 id: profile.field_profile_phone_number
 field_name: field_profile_phone_number
 entity_type: profile

--- a/modules/social_features/social_profile/config/install/field.storage.profile.field_profile_profile_tag.yml
+++ b/modules/social_features/social_profile/config/install/field.storage.profile.field_profile_profile_tag.yml
@@ -4,8 +4,6 @@ dependencies:
   module:
     - profile
     - taxonomy
-_core:
-  default_config_hash: 0wGajjKhaMA7cSwI9XvyWSqeLIeaKB_PjWOo-TIo8lw
 id: profile.field_profile_profile_tag
 field_name: field_profile_profile_tag
 entity_type: profile

--- a/modules/social_features/social_profile/config/install/field.storage.profile.field_profile_self_introduction.yml
+++ b/modules/social_features/social_profile/config/install/field.storage.profile.field_profile_self_introduction.yml
@@ -4,8 +4,6 @@ dependencies:
   module:
     - profile
     - text
-_core:
-  default_config_hash: Pytz4MnaPg-k4HXKcKJqJ6b-5YcGYiEVexJflP6PQXQ
 id: profile.field_profile_self_introduction
 field_name: field_profile_self_introduction
 entity_type: profile

--- a/modules/social_features/social_profile/config/install/field.storage.profile.field_profile_show_email.yml
+++ b/modules/social_features/social_profile/config/install/field.storage.profile.field_profile_show_email.yml
@@ -3,8 +3,6 @@ status: true
 dependencies:
   module:
     - profile
-_core:
-  default_config_hash: vGXUm3bNcLqNfEpuFnaYAV80fyySQCRzAYGKjyuQGYo
 id: profile.field_profile_show_email
 field_name: field_profile_show_email
 entity_type: profile

--- a/modules/social_features/social_profile/config/install/profile.type.profile.yml
+++ b/modules/social_features/social_profile/config/install/profile.type.profile.yml
@@ -1,8 +1,6 @@
 langcode: en
 status: true
 dependencies: {  }
-_core:
-  default_config_hash: XknqMjXmay6Ivp8iiMAhawIM4idlyWLmoGLuNZtPyBA
 id: profile
 label: Profile
 display_label: null

--- a/modules/social_features/social_profile/config/install/taxonomy.vocabulary.expertise.yml
+++ b/modules/social_features/social_profile/config/install/taxonomy.vocabulary.expertise.yml
@@ -1,8 +1,6 @@
 langcode: en
 status: true
 dependencies: {  }
-_core:
-  default_config_hash: epRs57Sw7vhbWAgfsdT8AlIC3DXa3rfauWFlgQKo10I
 name: Expertise
 vid: expertise
 description: 'A users expertises'

--- a/modules/social_features/social_profile/config/install/taxonomy.vocabulary.interests.yml
+++ b/modules/social_features/social_profile/config/install/taxonomy.vocabulary.interests.yml
@@ -1,8 +1,6 @@
 langcode: en
 status: true
 dependencies: {  }
-_core:
-  default_config_hash: 0oDKR41_MvDHVtKzJwxUv877N6E6vHBi5_yCMu7Vo8s
 name: Interests
 vid: interests
 description: 'A users interests for their profile.'

--- a/modules/social_features/social_profile/config/install/taxonomy.vocabulary.profile_tag.yml
+++ b/modules/social_features/social_profile/config/install/taxonomy.vocabulary.profile_tag.yml
@@ -1,8 +1,6 @@
 langcode: en
 status: true
 dependencies: {  }
-_core:
-  default_config_hash: AeOmDRryaH6IVdLehAFSAmYxOuorndgApcHCEapsDjE
 name: 'Profile tag'
 vid: profile_tag
 description: 'CM can tag a user, giving options on filtering / searching users.'

--- a/modules/social_features/social_profile/config/install/views.view.newest_users.yml
+++ b/modules/social_features/social_profile/config/install/views.view.newest_users.yml
@@ -8,8 +8,6 @@ dependencies:
   module:
     - profile
     - user
-_core:
-  default_config_hash: 7buHn5i4wy753bx_Q2g9CtIjfu74pZ1uv7L_9GifXlA
 id: newest_users
 label: 'Newest users'
 module: views

--- a/modules/social_features/social_profile/config/install/views.view.user_information.yml
+++ b/modules/social_features/social_profile/config/install/views.view.user_information.yml
@@ -6,8 +6,6 @@ dependencies:
   module:
     - profile
     - user
-_core:
-  default_config_hash: IcO0jdveNQfm7V73VxfEkOwhoc1Es3Dtd3QJaqxGtAk
 id: user_information
 label: 'User information'
 module: views

--- a/modules/social_features/social_search/config/install/search_api.index.social_all.yml
+++ b/modules/social_features/social_search/config/install/search_api.index.social_all.yml
@@ -20,8 +20,6 @@ dependencies:
     - core.entity_view_mode.group.teaser
     - core.entity_view_mode.node.search_index
     - core.entity_view_mode.profile.search_index
-_core:
-  default_config_hash: 23JByI5ueZJnZX3kInKd9F_KoHrx6fZZyhSc4AtvSrI
 id: social_all
 name: 'Social all'
 description: 'All content index created for the Social distribution.'

--- a/modules/social_features/social_search/config/install/search_api.index.social_content.yml
+++ b/modules/social_features/social_search/config/install/search_api.index.social_content.yml
@@ -9,8 +9,6 @@ dependencies:
     - field.storage.node.field_event_date_end
     - search_api.server.social_database
     - core.entity_view_mode.node.search_index
-_core:
-  default_config_hash: MbX9nCJS7GUDX3vfIkeKB6-6wVbLokpUUXwFaw2oO58
 id: social_content
 name: 'Social Content'
 description: 'Default content index created for the Social distribution.'

--- a/modules/social_features/social_search/config/install/search_api.index.social_groups.yml
+++ b/modules/social_features/social_search/config/install/search_api.index.social_groups.yml
@@ -9,8 +9,6 @@ dependencies:
     - field.storage.group.field_group_description
     - search_api.server.social_database
     - core.entity_view_mode.group.teaser
-_core:
-  default_config_hash: Ed3QodM_5VMVirtscZV64UyLSBVNL0B4_UJSKAMhC00
 id: social_groups
 name: 'Social Groups'
 description: 'Default group index created for the Social distribution.'

--- a/modules/social_features/social_search/config/install/search_api.index.social_users.yml
+++ b/modules/social_features/social_search/config/install/search_api.index.social_users.yml
@@ -14,8 +14,6 @@ dependencies:
     - field.storage.profile.field_profile_profile_tag
     - search_api.server.social_database
     - core.entity_view_mode.profile.search_index
-_core:
-  default_config_hash: DISMSpL3sN3hwLfwzea6p8b8ZCaZnjde0lx5MYXnYhs
 id: social_users
 name: 'Social Users'
 description: 'Default users index created for the Social distribution.'

--- a/modules/social_features/social_search/config/install/search_api.server.social_database.yml
+++ b/modules/social_features/social_search/config/install/search_api.server.social_database.yml
@@ -3,8 +3,6 @@ status: true
 dependencies:
   module:
     - search_api_db
-_core:
-  default_config_hash: ZaXa4IxmouC6d7eyj_koIgnFyAWZdO2_FrqO2bid04A
 id: social_database
 name: 'Social Database'
 description: 'Default database server created for the Social distribution.'

--- a/modules/social_features/social_search/config/install/views.view.search_all.yml
+++ b/modules/social_features/social_search/config/install/views.view.search_all.yml
@@ -5,8 +5,6 @@ dependencies:
     - search_api.index.social_all
   module:
     - search_api
-_core:
-  default_config_hash: M4Tk3dGtX7YSFAk0rzvxZy5zc0sL_8X44RcnCdrn1SA
 id: search_all
 label: 'Search All'
 module: views

--- a/modules/social_features/social_search/config/install/views.view.search_content.yml
+++ b/modules/social_features/social_search/config/install/views.view.search_content.yml
@@ -8,8 +8,6 @@ dependencies:
     - search_api
     - social_search
     - user
-_core:
-  default_config_hash: a19IcAteq_kDlYZTbWZgPHGMlmh_tGlBa_F0086x3bw
 id: search_content
 label: 'Search Content'
 module: views

--- a/modules/social_features/social_search/config/install/views.view.search_groups.yml
+++ b/modules/social_features/social_search/config/install/views.view.search_groups.yml
@@ -6,8 +6,6 @@ dependencies:
   module:
     - search_api
     - user
-_core:
-  default_config_hash: UzqYXdbaXFDPvfUFswTry6Km44lfyuNVMAG2cOgMC6w
 id: search_groups
 label: 'Search Groups'
 module: views

--- a/modules/social_features/social_search/config/install/views.view.search_users.yml
+++ b/modules/social_features/social_search/config/install/views.view.search_users.yml
@@ -10,8 +10,6 @@ dependencies:
     - search_api
     - social_search
     - user
-_core:
-  default_config_hash: 3t4oQs-q-RDi9JCtaFfnkv9PqGB-X0K8kj1U1nELHn0
 id: search_users
 label: 'Search Users'
 module: views

--- a/modules/social_features/social_topic/config/install/core.base_field_override.node.topic.promote.yml
+++ b/modules/social_features/social_topic/config/install/core.base_field_override.node.topic.promote.yml
@@ -3,8 +3,6 @@ status: true
 dependencies:
   config:
     - node.type.topic
-_core:
-  default_config_hash: 7w8fdz8qR86mEWrTpLV1mMI6vhRjAgGCkukABGM73c0
 id: node.topic.promote
 field_name: promote
 entity_type: node

--- a/modules/social_features/social_topic/config/install/core.entity_form_display.node.topic.default.yml
+++ b/modules/social_features/social_topic/config/install/core.entity_form_display.node.topic.default.yml
@@ -70,8 +70,6 @@ third_party_settings:
         required_fields: true
         id: attachments
         classes: 'card '
-_core:
-  default_config_hash: 7gp9MbxXU7HOGmCzXk8LMVCxpLv_WPYpnFy49fW_2os
 id: node.topic.default
 targetEntityType: node
 bundle: topic

--- a/modules/social_features/social_topic/config/install/core.entity_view_display.node.topic.activity.yml
+++ b/modules/social_features/social_topic/config/install/core.entity_view_display.node.topic.activity.yml
@@ -15,8 +15,6 @@ dependencies:
     - image
     - social_core
     - user
-_core:
-  default_config_hash: VFw3HprqHS1qnizX1520vozN98V3WB_YCNc9Wk6HpPI
 id: node.topic.activity
 targetEntityType: node
 bundle: topic

--- a/modules/social_features/social_topic/config/install/core.entity_view_display.node.topic.activity_comment.yml
+++ b/modules/social_features/social_topic/config/install/core.entity_view_display.node.topic.activity_comment.yml
@@ -14,8 +14,6 @@ dependencies:
   module:
     - image
     - user
-_core:
-  default_config_hash: 4AnPBOFQOdlyi6zQcSuNt7j2_IqZQO3V9I5JRFaH94M
 id: node.topic.activity_comment
 targetEntityType: node
 bundle: topic

--- a/modules/social_features/social_topic/config/install/core.entity_view_display.node.topic.default.yml
+++ b/modules/social_features/social_topic/config/install/core.entity_view_display.node.topic.default.yml
@@ -15,8 +15,6 @@ dependencies:
     - group_core_comments
     - text
     - user
-_core:
-  default_config_hash: _rfdDQ708wrytrUXs9o6sYeh1KEqmRUlDcNOEW0NfX0
 id: node.topic.default
 targetEntityType: node
 bundle: topic

--- a/modules/social_features/social_topic/config/install/core.entity_view_display.node.topic.hero.yml
+++ b/modules/social_features/social_topic/config/install/core.entity_view_display.node.topic.hero.yml
@@ -15,8 +15,6 @@ dependencies:
     - image
     - options
     - user
-_core:
-  default_config_hash: a8_rXJA48NC7i-OgqDEExrahbUZOPgbs8WlFbxy77dc
 id: node.topic.hero
 targetEntityType: node
 bundle: topic

--- a/modules/social_features/social_topic/config/install/core.entity_view_display.node.topic.search_index.yml
+++ b/modules/social_features/social_topic/config/install/core.entity_view_display.node.topic.search_index.yml
@@ -15,8 +15,6 @@ dependencies:
     - comment
     - text
     - user
-_core:
-  default_config_hash: tfOj-1S9WNKhzOJ_aN9E-mF8WKj1EmbseJ4KAiEtXYc
 id: node.topic.search_index
 targetEntityType: node
 bundle: topic

--- a/modules/social_features/social_topic/config/install/core.entity_view_display.node.topic.teaser.yml
+++ b/modules/social_features/social_topic/config/install/core.entity_view_display.node.topic.teaser.yml
@@ -15,8 +15,6 @@ dependencies:
     - image
     - options
     - user
-_core:
-  default_config_hash: HdMaBP6yLx8r9k6vWAUjts9P4E-7i2AGstV4nmTf6EY
 id: node.topic.teaser
 targetEntityType: node
 bundle: topic

--- a/modules/social_features/social_topic/config/install/field.field.node.topic.body.yml
+++ b/modules/social_features/social_topic/config/install/field.field.node.topic.body.yml
@@ -6,8 +6,6 @@ dependencies:
     - node.type.topic
   module:
     - text
-_core:
-  default_config_hash: kPhMJEXfAV-2K2emmJ7Bl0kC6HcHbnbTE-LQXFJglBw
 id: node.topic.body
 field_name: body
 entity_type: node

--- a/modules/social_features/social_topic/config/install/field.field.node.topic.field_content_visibility.yml
+++ b/modules/social_features/social_topic/config/install/field.field.node.topic.field_content_visibility.yml
@@ -6,8 +6,6 @@ dependencies:
     - node.type.topic
   module:
     - entity_access_by_field
-_core:
-  default_config_hash: 7rGqucvku02N5sLOXcLRmAWWwMwJP6inibcXQRKYAU4
 id: node.topic.field_content_visibility
 field_name: field_content_visibility
 entity_type: node

--- a/modules/social_features/social_topic/config/install/field.field.node.topic.field_files.yml
+++ b/modules/social_features/social_topic/config/install/field.field.node.topic.field_files.yml
@@ -6,8 +6,6 @@ dependencies:
     - node.type.topic
   module:
     - file
-_core:
-  default_config_hash: gqYN8SEYCh20SklV9WEx7kQt5vlRnNLbDw2Lose7wTY
 id: node.topic.field_files
 field_name: field_files
 entity_type: node

--- a/modules/social_features/social_topic/config/install/field.field.node.topic.field_topic_comments.yml
+++ b/modules/social_features/social_topic/config/install/field.field.node.topic.field_topic_comments.yml
@@ -6,8 +6,6 @@ dependencies:
     - node.type.topic
   module:
     - comment
-_core:
-  default_config_hash: luiSb8lAfZU-ywuqThHmCmoH6P47HKGQRv6F05t_c38
 id: node.topic.field_topic_comments
 field_name: field_topic_comments
 entity_type: node

--- a/modules/social_features/social_topic/config/install/field.field.node.topic.field_topic_image.yml
+++ b/modules/social_features/social_topic/config/install/field.field.node.topic.field_topic_image.yml
@@ -6,8 +6,6 @@ dependencies:
     - node.type.topic
   module:
     - image
-_core:
-  default_config_hash: Tqdqu-VdrzuNBYtEYJ9KOUWISjYETHxgehPkIO4hMQE
 id: node.topic.field_topic_image
 field_name: field_topic_image
 entity_type: node

--- a/modules/social_features/social_topic/config/install/field.field.node.topic.field_topic_type.yml
+++ b/modules/social_features/social_topic/config/install/field.field.node.topic.field_topic_type.yml
@@ -5,8 +5,6 @@ dependencies:
     - field.storage.node.field_topic_type
     - node.type.topic
     - taxonomy.vocabulary.topic_types
-_core:
-  default_config_hash: xhXWNs6CiVtAAoUOXFMH_UeNRXXy470sFEs0oNLeqP4
 id: node.topic.field_topic_type
 field_name: field_topic_type
 entity_type: node

--- a/modules/social_features/social_topic/config/install/field.storage.node.field_topic_comments.yml
+++ b/modules/social_features/social_topic/config/install/field.storage.node.field_topic_comments.yml
@@ -4,8 +4,6 @@ dependencies:
   module:
     - comment
     - node
-_core:
-  default_config_hash: 7h3FwBNPeJAFmp_lY6ctJc0Xt7zRXCwJiPgD56UGyPY
 id: node.field_topic_comments
 field_name: field_topic_comments
 entity_type: node

--- a/modules/social_features/social_topic/config/install/field.storage.node.field_topic_image.yml
+++ b/modules/social_features/social_topic/config/install/field.storage.node.field_topic_image.yml
@@ -5,8 +5,6 @@ dependencies:
     - file
     - image
     - node
-_core:
-  default_config_hash: p-l4-A2XLI2AChXR9bN6T4oZycn-9WMVcbTkwP4PHTo
 id: node.field_topic_image
 field_name: field_topic_image
 entity_type: node

--- a/modules/social_features/social_topic/config/install/field.storage.node.field_topic_type.yml
+++ b/modules/social_features/social_topic/config/install/field.storage.node.field_topic_type.yml
@@ -4,8 +4,6 @@ dependencies:
   module:
     - node
     - taxonomy
-_core:
-  default_config_hash: WJQoLs3aSY75uYW0p28m8m5_yTSDmyIqCm8kBupXCZc
 id: node.field_topic_type
 field_name: field_topic_type
 entity_type: node

--- a/modules/social_features/social_topic/config/install/node.type.topic.yml
+++ b/modules/social_features/social_topic/config/install/node.type.topic.yml
@@ -7,8 +7,6 @@ third_party_settings:
   menu_ui:
     available_menus: {  }
     parent: ''
-_core:
-  default_config_hash: YAfFfoWEwsZ4zhpgJul5q3wxYHutZ-dr0xHiDuvSfX8
 name: Topic
 type: topic
 description: ''

--- a/modules/social_features/social_topic/config/install/taxonomy.vocabulary.topic_types.yml
+++ b/modules/social_features/social_topic/config/install/taxonomy.vocabulary.topic_types.yml
@@ -1,8 +1,6 @@
 langcode: en
 status: true
 dependencies: {  }
-_core:
-  default_config_hash: LlQFf1W77EmhdUzLeOoaMExT1oXPNKa9BhrpW3hMgVs
 name: 'Topic types'
 vid: topic_types
 description: 'Topic types'

--- a/modules/social_features/social_topic/config/install/views.view.latest_topics.yml
+++ b/modules/social_features/social_topic/config/install/views.view.latest_topics.yml
@@ -11,8 +11,6 @@ dependencies:
     - node
     - taxonomy
     - user
-_core:
-  default_config_hash: tL9gepi6J0s7ykJivuWs6lvK0MkeSW1DK6I6A1OC9xs
 id: latest_topics
 label: 'Latest topics'
 module: views

--- a/modules/social_features/social_topic/config/install/views.view.topics.yml
+++ b/modules/social_features/social_topic/config/install/views.view.topics.yml
@@ -10,8 +10,6 @@ dependencies:
     - node
     - taxonomy
     - user
-_core:
-  default_config_hash: r72T2d1Jmx-7Disor6Ip5-xvbhZ_P9MdQw8n0tNKPkI
 id: topics
 label: 'User Topics'
 module: views

--- a/modules/social_features/social_user/config/install/core.entity_form_display.user.user.default.yml
+++ b/modules/social_features/social_user/config/install/core.entity_form_display.user.user.default.yml
@@ -30,8 +30,6 @@ third_party_settings:
         description: ''
         required_fields: true
       label: 'Locale settings'
-_core:
-  default_config_hash: pRQ6ymdA2LS1Ssy6jQIpcFyAkOgrFCOfnW5S1j_knPE
 id: user.user.default
 targetEntityType: user
 bundle: user

--- a/modules/social_features/social_user/config/install/core.entity_form_display.user.user.register.yml
+++ b/modules/social_features/social_user/config/install/core.entity_form_display.user.user.register.yml
@@ -5,8 +5,6 @@ dependencies:
     - core.entity_form_mode.user.register
   module:
     - user
-_core:
-  default_config_hash: 5XmB0TdrQv500vSDploRnCfyrbBrMfB975V9S17CRaQ
 id: user.user.register
 targetEntityType: user
 bundle: user

--- a/modules/social_features/social_user/config/install/core.entity_view_display.user.user.default.yml
+++ b/modules/social_features/social_user/config/install/core.entity_view_display.user.user.default.yml
@@ -3,8 +3,6 @@ status: true
 dependencies:
   module:
     - user
-_core:
-  default_config_hash: m2KUyVd52WOjOKfANphGWnvnM6AzChT6cogYWkk_efo
 id: user.user.default
 targetEntityType: user
 bundle: user

--- a/modules/social_features/social_user/config/install/core.entity_view_display.user.user.full.yml
+++ b/modules/social_features/social_user/config/install/core.entity_view_display.user.user.full.yml
@@ -5,8 +5,6 @@ dependencies:
     - core.entity_view_mode.user.full
   module:
     - user
-_core:
-  default_config_hash: Q0XhfQDJskQ6lK21AWfMJuXpz-8thFdxA2CLj6Yg7ng
 id: user.user.full
 targetEntityType: user
 bundle: user

--- a/modules/social_features/social_user/config/install/social_user.settings.yml
+++ b/modules/social_features/social_user/config/install/social_user.settings.yml
@@ -2,5 +2,3 @@ langcode: en
 signup_help: 'A welcome message with further instructions will be sent to your email address after you successfully enter your email address and a username.'
 login_help: ''
 social_user_profile_landingpage: social_user.stream
-_core:
-  default_config_hash: olu0qGxeLmRSDeYDtBxZveqpc2LNmlKiirZf9300v0A

--- a/modules/social_features/social_user/config/install/views.view.user_admin_people.yml
+++ b/modules/social_features/social_user/config/install/views.view.user_admin_people.yml
@@ -10,8 +10,6 @@ dependencies:
     - social_user
     - user
     - views_bulk_operations
-_core:
-  default_config_hash: l6kPjP6UEcgKd3sAfozWD9fqcKqYhOdNIKFaJ8WmxU8
 id: user_admin_people
 label: People
 module: user


### PR DESCRIPTION
…d configuration

## Problem
A bunch of (most?) configuration in OpenSocial contains the default config hash from the export. This does not make sense and should not be removed. While it generally does not hurt to have a default config hash there it leads to problems when using [Config Overlay](https://www.drupal.org/project/config_overlay) (see [#3127746](https://www.drupal.org/project/config_overlay/issues/3127746)).

## Solution

Remove all the default config hashes.
This was scripted by running
```bash
find . -name '*.yml' | xargs sed --in-place '/_core:/d'
find . -name '*.yml' | xargs sed --in-place '/  default_config_hash: /d'
```
on the repository.

## Issue tracker
https://www.drupal.org/project/social/issues/3127915

## How to test
-

## Screenshots
-

## Release notes
-

## Change Record
-

## Translations
-
