### PR TITLE
Issue #3128174 - Ensure filter works for multilingual sites regardless of language detection

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,8 @@
                 "Optimize getCommentedEntity()": "https://www.drupal.org/files/issues/2018-12-28/2580551-72.patch",
                 "#states cannot check/uncheck 'radios' and 'checkboxes' elements": "https://www.drupal.org/files/issues/drupal-994360-74-states-checkboxes-checked.patch",
                 "Multiple usages of FieldPluginBase::getEntity do not check for NULL, leading to WSOD": "https://www.drupal.org/files/issues/2019-11-14/3007424-68.patch",
-                "Default role id causes issues with validation on VBO": "https://www.drupal.org/files/issues/2018-05-24/2974925-default-rid-config-causes-illegal-error.patch"
+                "Default role id causes issues with validation on VBO": "https://www.drupal.org/files/issues/2018-05-24/2974925-default-rid-config-causes-illegal-error.patch",
+                "Ensure views exposed form in a form block keeps contextual arguments": "https://www.drupal.org/files/issues/2020-04-17/views-exposed-form-block-args-2821962-30-8.8-notest.patch"
             },
             "drupal/flag": {
                 "Add relationship to flagged entities when Flagging is base table": "https://www.drupal.org/files/issues/2723703_31.patch"

--- a/drupal-org-core.make
+++ b/drupal-org-core.make
@@ -1,10 +1,11 @@
 api = 2
 core = 8.x
 projects[drupal][type] = core
-projects[drupal][version] = 8.8.4
+projects[drupal][version] = 8.8.5
 projects[drupal][patch][] = "https://www.drupal.org/files/issues/color-optional-html-preview-2844190-2.patch"
 projects[drupal][patch][] = "https://www.drupal.org/files/issues/2018-10-26/2528214-47.patch"
 projects[drupal][patch][] = "https://www.drupal.org/files/issues/2018-12-28/2580551-72.patch"
 projects[drupal][patch][] = "https://www.drupal.org/files/issues/drupal-994360-74-states-checkboxes-checked.patch"
 projects[drupal][patch][] = "https://www.drupal.org/files/issues/2019-11-14/3007424-68.patch"
 projects[drupal][patch][] = "https://www.drupal.org/files/issues/2018-05-24/2974925-default-rid-config-causes-illegal-error.patch"
+projects[drupal][patch][] = "https://www.drupal.org/files/issues/2020-04-17/views-exposed-form-block-args-2821962-30-8.8-notest.patch"

--- a/modules/social_features/social_search/social_search.module
+++ b/modules/social_features/social_search/social_search.module
@@ -10,6 +10,7 @@ use Drupal\Component\Plugin\Exception\PluginNotFoundException;
 use Drupal\Core\Block\BlockPluginInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Url;
 use Drupal\group\Entity\GroupType;
 use Drupal\profile\Entity\Profile;
 use Drupal\search_api\Entity\Index;
@@ -29,27 +30,9 @@ function social_search_form_views_exposed_form_alter(&$form, FormStateInterface 
   ];
 
   if (in_array($form['#id'], $filter_forms, TRUE)) {
-    // Get the current path.
-    $path = \Drupal::service('path.current')->getPath();
-
-    // We need to add the language prefix to the action if a different language
-    // is chosen in a multi language environment.
-    if (\Drupal::languageManager()->isMultilingual()) {
-      $langcode = \Drupal::languageManager()->getCurrentLanguage()->getId();
-      $prefix = \Drupal::config('language.negotiation')->get('url.prefixes');
-
-      // Append the language prefix.
-      if ($prefix[$langcode]) {
-        $path = '/' . $prefix[$langcode] . $path;
-      }
-    }
-
-    // Set current path as form action, in order to keep search input.
-    $form['#action'] = $path;
     // Always enable the reset button.
     $form['actions']['reset']['#access'] = TRUE;
     $form['#attached']['library'][] = 'social_search/search_filters';
-
     switch ($form['#id']) {
       case 'views-exposed-form-search-users-page':
         social_search_alter_users_exposed_filter_block($form, $form_state, $form_id);

--- a/modules/social_features/social_search/social_search.module
+++ b/modules/social_features/social_search/social_search.module
@@ -10,7 +10,6 @@ use Drupal\Component\Plugin\Exception\PluginNotFoundException;
 use Drupal\Core\Block\BlockPluginInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Form\FormStateInterface;
-use Drupal\Core\Url;
 use Drupal\group\Entity\GroupType;
 use Drupal\profile\Entity\Profile;
 use Drupal\search_api\Entity\Index;


### PR DESCRIPTION
## Problem
The problem #1729 tried solve is that when you have a site with more than 1 language, and URL detection available as Language detection and selection option, the redirect doesn't take the current active language in to account and it switches back to back to the main/default language when filtering in Search.

This was due to the fact the path was hardcoded as the current_path which didnt take in to account this language code. 

But this resulted in a 'Page not found' for those multilingual sites that did not have Language detection and selection set to detect form URL because it enforces the form submit to go to the current page with a langcode, but it doesn't mean anything for sites without URL detection on langauges. 
It could also result in issues with installations in a subfolder.

## Solution
When looking at the code the entire form action should not be necessary as ViewsExposedForm should do this already and take into account any arguments passed. This will also ensure the normal Drupal core logic for dealing with language is invoked instead of making this custom. 
I have ensured there is now a Drupal core fix that does that trick so we don't have to do it for all our exposed forms.

## Issue tracker
- https://www.drupal.org/project/social/issues/3128174

## How to test
- [x] Enable social_language, social_tagging
- [x] Add some content tags, some user profile interests
- [x] Enable a new language and set it to default
- [x] See that URL detection is enabled 
- [x] See that you can now filter and will be redirected to the URL with langcode, filters on interest should work, resetting filters should work
- [x] See that the language doesn't switch back to the default
- [ ] Disable URL detection from language detection and selection options through `/admin/config/regional/language/detection`
- [ ] Do a cache clear and refresh the search page, now all the URLs should not be prefixed anymore with the langcode
- [ ] See that you can filter, reset filters etc

- [ ] Side regression is that for social autocomplete searching for users also doesn't work correctly see that this now also works :) 

I have demonstrated these options in the attached video as it's quite the thing to test :) 

## Video
https://www.loom.com/share/72b2a61e73214857ad130dcd7c836e76

## Release notes
In release 8.2 we created some regression for multilingual sites that did not use the URL based detection and selection option. Searching and filtering would cause redirects to URL's including the language code resulting in a Page not found.