### PR TITLE
Issue #3099608 by robertragas: Add patch to fix time() callback filling up logs for the votingapi module

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -98,7 +98,8 @@
                 "Make sure select all gets fired for socialbase theme": "https://www.drupal.org/files/issues/2019-09-19/3042494-trigger-vbo-action-on-jquery-checkbox-change-5.patch"
             },
             "drupal/votingapi" : {
-                "votingapi_views_data_alter uses incorrect empty check for missing entity error handling": "https://www.drupal.org/files/issues/2020-01-31/votingapi-3110353-2.patch"
+                "votingapi_views_data_alter uses incorrect empty check for missing entity error handling": "https://www.drupal.org/files/issues/2020-01-31/votingapi-3110353-2.patch",
+                "#3048085 - fix time() callback filling up the logs": "https://www.drupal.org/files/issues/2019-05-02/votingapi-timecallback-3048085-1-4.patch"
             }
         }
     },

--- a/drupal-org.make
+++ b/drupal-org.make
@@ -121,6 +121,7 @@ projects[views_infinite_scroll][version] = 1.6
 projects[votingapi][type] = module
 projects[votingapi][version] = 3.0-beta1
 projects[votingapi][patch][] = "https://www.drupal.org/files/issues/2020-01-31/votingapi-3110353-2.patch"
+projects[votingapi][patch][] = "https://www.drupal.org/files/issues/2019-05-02/votingapi-timecallback-3048085-1-4.patch"
 projects[bootstrap][type] = theme
 projects[bootstrap][version] = 3.20
 projects[bootstrap][patch][] = "https://www.drupal.org/files/issues/2018-12-19/dropdown-without-default-button-3021413-2.patch"


### PR DESCRIPTION
## Problem
Logs filling up with the following warning so many times that it can create logs up to 400mb per day.

Warning: time() expects exactly 0 parameters, 2 given in /var/www/drupal/web/core/lib/Drupal/Core/Field/BaseFieldDefinition.php on line 469

## Solution
Apply the patch from the votingagpi module
https://www.drupal.org/project/votingapi/issues/3048085

## Issue tracker
https://www.drupal.org/project/social/issues/3099608

## How to test
- [ ] Just browse through a platform and notice the logs filling up with these warning. 

## Screenshots
If this Pull Request makes visual changes then please include some screenshots that show what has changed here. 

## Release notes
We applied a patch for the votingapi module that will prevent the logs being filled up with warnings.
