### PR TITLE
Issue #3128589 by SV: Comments created with a WYSIWYG editor can not be edited

### DIFF
--- a/modules/social_features/social_mentions/js/jquery.mentions.ckeditor.js
+++ b/modules/social_features/social_mentions/js/jquery.mentions.ckeditor.js
@@ -380,7 +380,8 @@
       MentionsCKEditor.prototype.createHiddenField = function() {
         this.hidden = $("<input />", {
           type: "hidden",
-          name: this.element.attr("name")
+          name: this.element.attr("name"),
+          value: this.element.text()
         });
         return this.element.after(this.hidden).removeAttr("name");
       };


### PR DESCRIPTION
## Problem
When a user goes to edit mode of a comment (with WYSIWYG editor) he is not able just to change status without updating content

## Solution
Adjust & fix the bug in related extension (jquery.mentions.ckeditor.js)

## Issue tracker

- https://www.drupal.org/project/social/issues/3128589
- https://getopensocial.atlassian.net/browse/YANG-2735

## How to test
- [ ] Create a comment on a discussion node (with WYSIWYG editor).
- [ ] Go to edit the comment
- [ ] Don't change the text
- [ ] Click submit 

## Release notes
Comments created with a WYSIWYG editor now can be edited without text lost.