### PR TITLE
Issue #3111945 by frankgraave: fix dependency of role delegation modu…

### DIFF
--- a/modules/social_features/social_core/social_core.install
+++ b/modules/social_features/social_core/social_core.install
@@ -1208,3 +1208,10 @@ function social_core_update_8809() {
   // Output logged messages to related channel of update execution.
   return $updateHelper->logger()->output();
 }
+
+/**
+ * Install the role delegation module.
+ */
+function social_core_update_8810() {
+  \Drupal::service('module_installer')->install(['role_delegation']);
+}

--- a/modules/social_features/social_user/social_user.info.yml
+++ b/modules/social_features/social_user/social_user.info.yml
@@ -11,6 +11,6 @@ dependencies:
   - profile:profile
   - social:social_editor
   - social:social_profile
-  - drupal:role_delegation
+  - role_delegation:role_delegation
   - views_bulk_operations:views_bulk_operations
 package: Social


### PR DESCRIPTION
…le in social_user.info.yml and add update hook to enable the role delegation module

## Problem
There was a wrong dependency declaration in social_user.info.yml.

## Solution
Fixed the dependency and also added an update hook to enable the module for existing platforms.

## Issue tracker
https://www.drupal.org/project/social/issues/3111945

## How to test
- [ ] See that it's not breaking anymore
- [ ] Run the drush updb and see that the module is enabled on an existing site
