### PR TITLE
Issue #3130548 by rolki: Remove OR conditions for node comments and likes to fix performance issues with "Last interacted sorting"

### DIFF
--- a/modules/social_features/social_content_block/src/ContentBuilder.php
+++ b/modules/social_features/social_content_block/src/ContentBuilder.php
@@ -361,8 +361,8 @@ class ContentBuilder implements ContentBuilderInterface {
           $query->leftJoin('group_content_field_data', 'gfd', "base_table.${entity_id_key} = gfd.gid");
           $query->leftjoin('post__field_recipient_group', 'pst', "base_table.${entity_id_key} = pst.field_recipient_group_target_id");
           $query->leftjoin('post_field_data', 'pfd', 'pst.entity_id = pfd.id');
-          $query->leftjoin('comment_field_data', 'cfd', "(gfd.entity_id = cfd.entity_id AND cfd.entity_type = 'node') OR (pfd.id = cfd.entity_id AND cfd.entity_type = 'post')");
-          $query->leftJoin('votingapi_vote', 'vv', "(gfd.entity_id = vv.entity_id AND vv.entity_type = 'node') OR (pfd.id = vv.entity_id AND vv.entity_type = 'post') OR (cfd.cid = vv.entity_id AND vv.entity_type = 'comment')");
+          $query->leftjoin('comment_field_data', 'cfd', "pfd.id = cfd.entity_id AND cfd.entity_type = 'post'");
+          $query->leftJoin('votingapi_vote', 'vv', "pfd.id = vv.entity_id AND vv.entity_type = 'post'");
           $query->leftjoin('node_field_data', 'nfd', 'gfd.entity_id = nfd.nid');
 
           $query->addExpression('GREATEST(COALESCE(MAX(gfd.changed), 0),


### PR DESCRIPTION
## Problem
The page loads endlessly or breaks the site

## Solution
Remove OR conditions to includes related nodes for comments and likes

## Issue tracker
https://www.drupal.org/project/social/issues/3130548 

## How to test
Create a new custom content block and choose the group type and last interacted sorting then go to the page with this block
