### PR TITLE
Issue 3130599 by AlanHDev: Fix typos in translatable strings and comm…

### DIFF
--- a/modules/custom/social_tour/src/Form/SocialTourSettings.php
+++ b/modules/custom/social_tour/src/Form/SocialTourSettings.php
@@ -37,7 +37,7 @@ class SocialTourSettings extends ConfigFormBase {
     $form['social_tour_enabled'] = [
       '#type' => 'checkbox',
       '#title' => $this->t('Enable the social tour'),
-      '#description' => $this->t('Set wether the tour is enabled or not.'),
+      '#description' => $this->t('Set whether the tour is enabled or not.'),
       '#default_value' => $config->get('social_tour_enabled'),
     ];
 

--- a/modules/social_features/social_comment_upload/src/Form/SocialCommentUploadSettingsForm.php
+++ b/modules/social_features/social_comment_upload/src/Form/SocialCommentUploadSettingsForm.php
@@ -68,7 +68,7 @@ class SocialCommentUploadSettingsForm extends ConfigFormBase implements Containe
       '#title' => $this->t('Allow file uploads in comments.'),
       '#default_value' => $config->get('allow_upload_comments'),
       '#required' => FALSE,
-      '#description' => $this->t("Determine wether users can upload documents to comments."),
+      '#description' => $this->t("Determine whether users can upload documents to comments."),
     ];
 
     return parent::buildForm($form, $form_state);

--- a/modules/social_features/social_event/modules/social_event_type/src/Form/SocialEventTypeSettings.php
+++ b/modules/social_features/social_event/modules/social_event_type/src/Form/SocialEventTypeSettings.php
@@ -37,7 +37,7 @@ class SocialEventTypeSettings extends ConfigFormBase {
     $form['social_event_type_required'] = [
       '#type' => 'checkbox',
       '#title' => $this->t('Event types required'),
-      '#description' => $this->t('Set wether event types field is required or not.'),
+      '#description' => $this->t('Set whether event types field is required or not.'),
       '#default_value' => $config->get('social_event_type_required'),
     ];
 

--- a/modules/social_features/social_tagging/src/SocialTaggingService.php
+++ b/modules/social_features/social_tagging/src/SocialTaggingService.php
@@ -43,20 +43,20 @@ class SocialTaggingService {
   }
 
   /**
-   * Returns wether the feature is turned on or not.
+   * Returns whether the feature is turned on or not.
    *
    * @return bool
-   *   Wether tagging is turnded on or not.
+   *   Whether tagging is turned on or not.
    */
   public function active() {
     return (bool) $this->configFactory->get('social_tagging.settings')->get('enable_content_tagging');
   }
 
   /**
-   * Returns wether the feature is turned on for groups or not.
+   * Returns whether the feature is turned on for groups or not.
    *
    * @return bool
-   *   Wether tagging is turnded on or not for groups.
+   *   Whether tagging is turned on or not for groups.
    */
   public function groupActive() {
     return (bool) $this->configFactory->get('social_tagging.settings')->get('tag_type_group');
@@ -82,10 +82,10 @@ class SocialTaggingService {
   }
 
   /**
-   * Returns wether splitting of fields is allowed.
+   * Returns whether splitting of fields is allowed.
    *
    * @return bool
-   *   Wether category split on field level is turnded on or not.
+   *   Whether category split on field level is turned on or not.
    */
   public function allowSplit() {
     return (bool) ($this->active() && $this->configFactory->get('social_tagging.settings')->get('allow_category_split'));

--- a/themes/socialbase/components/03-molecules/navigation/nav-book/nav-book.scss
+++ b/themes/socialbase/components/03-molecules/navigation/nav-book/nav-book.scss
@@ -1,6 +1,6 @@
 // Nav book
 //
-// Styles for table of contents as provided bij the social_book module. Menu items have triangle icons indicating wether there are menu items below this item or not.
+// Styles for table of contents as provided bij the social_book module. Menu items have triangle icons indicating whether there are menu items below this item or not.
 // The highlighted path leads to the page title the user is currently viewing.
 //
 // markup: nav-book.twig

--- a/translations.php
+++ b/translations.php
@@ -25,6 +25,11 @@ die('This file should not be run directly.');
 // new TranslatableMarkup('Example');
 // new PluralTranslatableMarkup($count, '1 example', '@count examples');.
 
+// Change in version 8.3.
+new TranslatableMarkup("Set wether event types field is required or not.");
+new TranslatableMarkup("Determine wether users can upload documents to comments.");
+new TranslatableMarkup("Set wether the tour is enabled or not.");
+
 // Changed in version 8.x.
 new TranslatableMarkup("Send mail");
 new TranslatableMarkup("Can not send e-mail for %entity");

--- a/translations/ca_gpi.po
+++ b/translations/ca_gpi.po
@@ -5667,7 +5667,7 @@ msgstr ""
 "etiquetes de contingut."
 
 #: modules/social_features/social_comment_upload/src/Form/SocialCommentUploadSettingsForm.php:71
-msgid "Determine wether users can upload documents to comments."
+msgid "Determine whether users can upload documents to comments."
 msgstr "Determina si els perfil poden pujar documents als comentaris."
 
 #: modules/social_features/social_tagging/src/Form/SocialTaggingSettingsForm.php:79
@@ -10985,11 +10985,11 @@ msgstr ""
 "memòria del compte de visualitzacions d’una pantalla de nodes."
 
 #: modules/social_features/social_event/modules/social_event_type/src/Form/SocialEventTypeSettings.php:40
-msgid "Set wether event types field is required or not."
+msgid "Set whether event types field is required or not."
 msgstr "Estableix si el camp de tipus d'esdeveniment és obligatori o no."
 
 #: modules/custom/social_tour/src/Form/SocialTourSettings.php:40
-msgid "Set wether the tour is enabled or not."
+msgid "Set whether the tour is enabled or not."
 msgstr "Estableix si la guia està habilitada o no."
 
 #: modules/custom/entity_access_by_field/entity_access_by_field.links.menu.yml:0

--- a/translations/de.po
+++ b/translations/de.po
@@ -4290,7 +4290,7 @@ msgstr ""
 "werden."
 
 #: modules/social_features/social_comment_upload/src/Form/SocialCommentUploadSettingsForm.php:71
-msgid "Determine wether users can upload documents to comments."
+msgid "Determine whether users can upload documents to comments."
 msgstr ""
 
 #: modules/social_features/social_tagging/src/Form/SocialTaggingSettingsForm.php:79
@@ -9478,11 +9478,11 @@ msgid ""
 msgstr ""
 
 #: modules/social_features/social_event/modules/social_event_type/src/Form/SocialEventTypeSettings.php:40
-msgid "Set wether event types field is required or not."
+msgid "Set whether event types field is required or not."
 msgstr ""
 
 #: modules/custom/social_tour/src/Form/SocialTourSettings.php:40
-msgid "Set wether the tour is enabled or not."
+msgid "Set whether the tour is enabled or not."
 msgstr ""
 
 #: modules/custom/entity_access_by_field/entity_access_by_field.links.menu.yml:0

--- a/translations/de_CH_gpi.po
+++ b/translations/de_CH_gpi.po
@@ -5648,7 +5648,7 @@ msgstr ""
 "werden."
 
 #: modules/social_features/social_comment_upload/src/Form/SocialCommentUploadSettingsForm.php:71
-msgid "Determine wether users can upload documents to comments."
+msgid "Determine whether users can upload documents to comments."
 msgstr ""
 
 #: modules/social_features/social_tagging/src/Form/SocialTaggingSettingsForm.php:79
@@ -10836,11 +10836,11 @@ msgid ""
 msgstr ""
 
 #: modules/social_features/social_event/modules/social_event_type/src/Form/SocialEventTypeSettings.php:40
-msgid "Set wether event types field is required or not."
+msgid "Set whether event types field is required or not."
 msgstr ""
 
 #: modules/custom/social_tour/src/Form/SocialTourSettings.php:40
-msgid "Set wether the tour is enabled or not."
+msgid "Set whether the tour is enabled or not."
 msgstr ""
 
 #: modules/custom/entity_access_by_field/entity_access_by_field.links.menu.yml:0

--- a/translations/en.pot
+++ b/translations/en.pot
@@ -5351,7 +5351,7 @@ msgid ""
 msgstr ""
 
 #: modules/social_features/social_comment_upload/src/Form/SocialCommentUploadSettingsForm.php:71
-msgid "Determine wether users can upload documents to comments."
+msgid "Determine whether users can upload documents to comments."
 msgstr ""
 
 #: modules/social_features/social_tagging/src/Form/SocialTaggingSettingsForm.php:79
@@ -10435,11 +10435,11 @@ msgid ""
 msgstr ""
 
 #: modules/social_features/social_event/modules/social_event_type/src/Form/SocialEventTypeSettings.php:40
-msgid "Set wether event types field is required or not."
+msgid "Set whether event types field is required or not."
 msgstr ""
 
 #: modules/custom/social_tour/src/Form/SocialTourSettings.php:40
-msgid "Set wether the tour is enabled or not."
+msgid "Set whether the tour is enabled or not."
 msgstr ""
 
 #: modules/custom/entity_access_by_field/entity_access_by_field.links.menu.yml:0

--- a/translations/en_GB.po
+++ b/translations/en_GB.po
@@ -4213,8 +4213,8 @@ msgstr ""
 "tag fields or as a single tag field when using tags on content."
 
 #: modules/social_features/social_comment_upload/src/Form/SocialCommentUploadSettingsForm.php:71
-msgid "Determine wether users can upload documents to comments."
-msgstr "Determine wether users can upload documents to comments."
+msgid "Determine whether users can upload documents to comments."
+msgstr "Determine whether users can upload documents to comments."
 
 #: modules/social_features/social_tagging/src/Form/SocialTaggingSettingsForm.php:79
 msgid ""
@@ -9484,12 +9484,12 @@ msgstr ""
 "display is invalidated."
 
 #: modules/social_features/social_event/modules/social_event_type/src/Form/SocialEventTypeSettings.php:40
-msgid "Set wether event types field is required or not."
-msgstr "Set wether event types field is required or not."
+msgid "Set whether event types field is required or not."
+msgstr "Set whether event types field is required or not."
 
 #: modules/custom/social_tour/src/Form/SocialTourSettings.php:40
-msgid "Set wether the tour is enabled or not."
-msgstr "Set wether the tour is enabled or not."
+msgid "Set whether the tour is enabled or not."
+msgstr "Set whether the tour is enabled or not."
 
 #: modules/custom/entity_access_by_field/entity_access_by_field.links.menu.yml:0
 msgid "Set who can post public items on this platform."

--- a/translations/es.po
+++ b/translations/es.po
@@ -3930,7 +3930,7 @@ msgid ""
 msgstr ""
 
 #: modules/social_features/social_comment_upload/src/Form/SocialCommentUploadSettingsForm.php:71
-msgid "Determine wether users can upload documents to comments."
+msgid "Determine whether users can upload documents to comments."
 msgstr ""
 
 #: modules/social_features/social_tagging/src/Form/SocialTaggingSettingsForm.php:79
@@ -9020,11 +9020,11 @@ msgid ""
 msgstr ""
 
 #: modules/social_features/social_event/modules/social_event_type/src/Form/SocialEventTypeSettings.php:40
-msgid "Set wether event types field is required or not."
+msgid "Set whether event types field is required or not."
 msgstr ""
 
 #: modules/custom/social_tour/src/Form/SocialTourSettings.php:40
-msgid "Set wether the tour is enabled or not."
+msgid "Set whether the tour is enabled or not."
 msgstr ""
 
 #: modules/custom/entity_access_by_field/entity_access_by_field.links.menu.yml:0

--- a/translations/es_MX_gpi.po
+++ b/translations/es_MX_gpi.po
@@ -4391,7 +4391,7 @@ msgstr ""
 "usan etiquetas en el contenido."
 
 #: modules/social_features/social_comment_upload/src/Form/SocialCommentUploadSettingsForm.php:71
-msgid "Determine wether users can upload documents to comments."
+msgid "Determine whether users can upload documents to comments."
 msgstr "Determine si los usuarios pueden subir documentos a los comentarios."
 
 #: modules/social_features/social_tagging/src/Form/SocialTaggingSettingsForm.php:79
@@ -9700,11 +9700,11 @@ msgstr ""
 "memoria caché de recuento de vistas en una pantalla de nodo."
 
 #: modules/social_features/social_event/modules/social_event_type/src/Form/SocialEventTypeSettings.php:40
-msgid "Set wether event types field is required or not."
+msgid "Set whether event types field is required or not."
 msgstr "Establecer si el campo para tipos de evento es obligatorio o no."
 
 #: modules/custom/social_tour/src/Form/SocialTourSettings.php:40
-msgid "Set wether the tour is enabled or not."
+msgid "Set whether the tour is enabled or not."
 msgstr "Establezca si el recorrido está habilitado o no."
 
 #: modules/custom/entity_access_by_field/entity_access_by_field.links.menu.yml:0

--- a/translations/es_gpi.po
+++ b/translations/es_gpi.po
@@ -5592,7 +5592,7 @@ msgid ""
 msgstr ""
 
 #: modules/social_features/social_comment_upload/src/Form/SocialCommentUploadSettingsForm.php:71
-msgid "Determine wether users can upload documents to comments."
+msgid "Determine whether users can upload documents to comments."
 msgstr "Determina si las personas pueden subir documentos a los comentarios."
 
 #: modules/social_features/social_tagging/src/Form/SocialTaggingSettingsForm.php:79
@@ -10851,11 +10851,11 @@ msgid ""
 msgstr ""
 
 #: modules/social_features/social_event/modules/social_event_type/src/Form/SocialEventTypeSettings.php:40
-msgid "Set wether event types field is required or not."
+msgid "Set whether event types field is required or not."
 msgstr "Establecer si el campo de tipos de evento es obligatorio o no."
 
 #: modules/custom/social_tour/src/Form/SocialTourSettings.php:40
-msgid "Set wether the tour is enabled or not."
+msgid "Set whether the tour is enabled or not."
 msgstr ""
 
 #: modules/custom/entity_access_by_field/entity_access_by_field.links.menu.yml:0

--- a/translations/eu_gpi.po
+++ b/translations/eu_gpi.po
@@ -5372,7 +5372,7 @@ msgid ""
 msgstr ""
 
 #: modules/social_features/social_comment_upload/src/Form/SocialCommentUploadSettingsForm.php:71
-msgid "Determine wether users can upload documents to comments."
+msgid "Determine whether users can upload documents to comments."
 msgstr ""
 
 #: modules/social_features/social_tagging/src/Form/SocialTaggingSettingsForm.php:79
@@ -10483,11 +10483,11 @@ msgid ""
 msgstr ""
 
 #: modules/social_features/social_event/modules/social_event_type/src/Form/SocialEventTypeSettings.php:40
-msgid "Set wether event types field is required or not."
+msgid "Set whether event types field is required or not."
 msgstr ""
 
 #: modules/custom/social_tour/src/Form/SocialTourSettings.php:40
-msgid "Set wether the tour is enabled or not."
+msgid "Set whether the tour is enabled or not."
 msgstr ""
 
 #: modules/custom/entity_access_by_field/entity_access_by_field.links.menu.yml:0

--- a/translations/fr.po
+++ b/translations/fr.po
@@ -4130,7 +4130,7 @@ msgid ""
 msgstr ""
 
 #: modules/social_features/social_comment_upload/src/Form/SocialCommentUploadSettingsForm.php:71
-msgid "Determine wether users can upload documents to comments."
+msgid "Determine whether users can upload documents to comments."
 msgstr ""
 
 #: modules/social_features/social_tagging/src/Form/SocialTaggingSettingsForm.php:79
@@ -9252,11 +9252,11 @@ msgid ""
 msgstr ""
 
 #: modules/social_features/social_event/modules/social_event_type/src/Form/SocialEventTypeSettings.php:40
-msgid "Set wether event types field is required or not."
+msgid "Set whether event types field is required or not."
 msgstr ""
 
 #: modules/custom/social_tour/src/Form/SocialTourSettings.php:40
-msgid "Set wether the tour is enabled or not."
+msgid "Set whether the tour is enabled or not."
 msgstr ""
 
 #: modules/custom/entity_access_by_field/entity_access_by_field.links.menu.yml:0

--- a/translations/fr_CH_gpi.po
+++ b/translations/fr_CH_gpi.po
@@ -5481,7 +5481,7 @@ msgid ""
 msgstr ""
 
 #: modules/social_features/social_comment_upload/src/Form/SocialCommentUploadSettingsForm.php:71
-msgid "Determine wether users can upload documents to comments."
+msgid "Determine whether users can upload documents to comments."
 msgstr ""
 
 #: modules/social_features/social_tagging/src/Form/SocialTaggingSettingsForm.php:79
@@ -10602,11 +10602,11 @@ msgid ""
 msgstr ""
 
 #: modules/social_features/social_event/modules/social_event_type/src/Form/SocialEventTypeSettings.php:40
-msgid "Set wether event types field is required or not."
+msgid "Set whether event types field is required or not."
 msgstr ""
 
 #: modules/custom/social_tour/src/Form/SocialTourSettings.php:40
-msgid "Set wether the tour is enabled or not."
+msgid "Set whether the tour is enabled or not."
 msgstr ""
 
 #: modules/custom/entity_access_by_field/entity_access_by_field.links.menu.yml:0

--- a/translations/fr_GPI.po
+++ b/translations/fr_GPI.po
@@ -5471,7 +5471,7 @@ msgid ""
 msgstr ""
 
 #: modules/social_features/social_comment_upload/src/Form/SocialCommentUploadSettingsForm.php:71
-msgid "Determine wether users can upload documents to comments."
+msgid "Determine whether users can upload documents to comments."
 msgstr ""
 
 #: modules/social_features/social_tagging/src/Form/SocialTaggingSettingsForm.php:79
@@ -10592,11 +10592,11 @@ msgid ""
 msgstr ""
 
 #: modules/social_features/social_event/modules/social_event_type/src/Form/SocialEventTypeSettings.php:40
-msgid "Set wether event types field is required or not."
+msgid "Set whether event types field is required or not."
 msgstr ""
 
 #: modules/custom/social_tour/src/Form/SocialTourSettings.php:40
-msgid "Set wether the tour is enabled or not."
+msgid "Set whether the tour is enabled or not."
 msgstr ""
 
 #: modules/custom/entity_access_by_field/entity_access_by_field.links.menu.yml:0

--- a/translations/gl_gpi.po
+++ b/translations/gl_gpi.po
@@ -5431,7 +5431,7 @@ msgid ""
 msgstr ""
 
 #: modules/social_features/social_comment_upload/src/Form/SocialCommentUploadSettingsForm.php:71
-msgid "Determine wether users can upload documents to comments."
+msgid "Determine whether users can upload documents to comments."
 msgstr "Define se @s usuari@s poden subir documentos aos comentarios."
 
 #: modules/social_features/social_tagging/src/Form/SocialTaggingSettingsForm.php:79
@@ -10551,11 +10551,11 @@ msgid ""
 msgstr ""
 
 #: modules/social_features/social_event/modules/social_event_type/src/Form/SocialEventTypeSettings.php:40
-msgid "Set wether event types field is required or not."
+msgid "Set whether event types field is required or not."
 msgstr ""
 
 #: modules/custom/social_tour/src/Form/SocialTourSettings.php:40
-msgid "Set wether the tour is enabled or not."
+msgid "Set whether the tour is enabled or not."
 msgstr ""
 
 #: modules/custom/entity_access_by_field/entity_access_by_field.links.menu.yml:0

--- a/translations/it.po
+++ b/translations/it.po
@@ -4268,7 +4268,7 @@ msgid ""
 msgstr ""
 
 #: modules/social_features/social_comment_upload/src/Form/SocialCommentUploadSettingsForm.php:71
-msgid "Determine wether users can upload documents to comments."
+msgid "Determine whether users can upload documents to comments."
 msgstr ""
 
 #: modules/social_features/social_tagging/src/Form/SocialTaggingSettingsForm.php:79
@@ -9388,11 +9388,11 @@ msgid ""
 msgstr ""
 
 #: modules/social_features/social_event/modules/social_event_type/src/Form/SocialEventTypeSettings.php:40
-msgid "Set wether event types field is required or not."
+msgid "Set whether event types field is required or not."
 msgstr ""
 
 #: modules/custom/social_tour/src/Form/SocialTourSettings.php:40
-msgid "Set wether the tour is enabled or not."
+msgid "Set whether the tour is enabled or not."
 msgstr ""
 
 #: modules/custom/entity_access_by_field/entity_access_by_field.links.menu.yml:0

--- a/translations/it_CH_gpi.po
+++ b/translations/it_CH_gpi.po
@@ -5621,7 +5621,7 @@ msgid ""
 msgstr ""
 
 #: modules/social_features/social_comment_upload/src/Form/SocialCommentUploadSettingsForm.php:71
-msgid "Determine wether users can upload documents to comments."
+msgid "Determine whether users can upload documents to comments."
 msgstr ""
 
 #: modules/social_features/social_tagging/src/Form/SocialTaggingSettingsForm.php:79
@@ -10741,11 +10741,11 @@ msgid ""
 msgstr ""
 
 #: modules/social_features/social_event/modules/social_event_type/src/Form/SocialEventTypeSettings.php:40
-msgid "Set wether event types field is required or not."
+msgid "Set whether event types field is required or not."
 msgstr ""
 
 #: modules/custom/social_tour/src/Form/SocialTourSettings.php:40
-msgid "Set wether the tour is enabled or not."
+msgid "Set whether the tour is enabled or not."
 msgstr ""
 
 #: modules/custom/entity_access_by_field/entity_access_by_field.links.menu.yml:0

--- a/translations/nl.po
+++ b/translations/nl.po
@@ -4274,7 +4274,7 @@ msgstr ""
 "inhoud."
 
 #: modules/social_features/social_comment_upload/src/Form/SocialCommentUploadSettingsForm.php:71
-msgid "Determine wether users can upload documents to comments."
+msgid "Determine whether users can upload documents to comments."
 msgstr "Bepaal of gebruikers documenten kunnen uploaden bij een reactie."
 
 #: modules/social_features/social_tagging/src/Form/SocialTaggingSettingsForm.php:79
@@ -9464,7 +9464,7 @@ msgstr ""
 "paginabezoeken teller wordt geïnvalideerd."
 
 #: modules/social_features/social_event/modules/social_event_type/src/Form/SocialEventTypeSettings.php:40
-msgid "Set wether event types field is required or not."
+msgid "Set whether event types field is required or not."
 msgstr ""
 "Indien ingeschakeld is het verplicht om een evenement type te selecteren bij "
 "aanmaken van een evenement.\n"
@@ -9472,7 +9472,7 @@ msgstr ""
 "Taxonomien'."
 
 #: modules/custom/social_tour/src/Form/SocialTourSettings.php:40
-msgid "Set wether the tour is enabled or not."
+msgid "Set whether the tour is enabled or not."
 msgstr ""
 
 #: modules/custom/entity_access_by_field/entity_access_by_field.links.menu.yml:0

--- a/translations/pt-br.po
+++ b/translations/pt-br.po
@@ -4178,7 +4178,7 @@ msgid ""
 msgstr ""
 
 #: modules/social_features/social_comment_upload/src/Form/SocialCommentUploadSettingsForm.php:71
-msgid "Determine wether users can upload documents to comments."
+msgid "Determine whether users can upload documents to comments."
 msgstr ""
 
 #: modules/social_features/social_tagging/src/Form/SocialTaggingSettingsForm.php:79
@@ -9304,11 +9304,11 @@ msgid ""
 msgstr ""
 
 #: modules/social_features/social_event/modules/social_event_type/src/Form/SocialEventTypeSettings.php:40
-msgid "Set wether event types field is required or not."
+msgid "Set whether event types field is required or not."
 msgstr ""
 
 #: modules/custom/social_tour/src/Form/SocialTourSettings.php:40
-msgid "Set wether the tour is enabled or not."
+msgid "Set whether the tour is enabled or not."
 msgstr ""
 
 #: modules/custom/entity_access_by_field/entity_access_by_field.links.menu.yml:0

--- a/translations/ru.po
+++ b/translations/ru.po
@@ -4105,7 +4105,7 @@ msgid ""
 msgstr ""
 
 #: modules/social_features/social_comment_upload/src/Form/SocialCommentUploadSettingsForm.php:71
-msgid "Determine wether users can upload documents to comments."
+msgid "Determine whether users can upload documents to comments."
 msgstr ""
 
 #: modules/social_features/social_tagging/src/Form/SocialTaggingSettingsForm.php:79
@@ -9221,11 +9221,11 @@ msgid ""
 msgstr ""
 
 #: modules/social_features/social_event/modules/social_event_type/src/Form/SocialEventTypeSettings.php:40
-msgid "Set wether event types field is required or not."
+msgid "Set whether event types field is required or not."
 msgstr "Указать, требуется ли поле типов событий или нет"
 
 #: modules/custom/social_tour/src/Form/SocialTourSettings.php:40
-msgid "Set wether the tour is enabled or not."
+msgid "Set whether the tour is enabled or not."
 msgstr ""
 
 #: modules/custom/entity_access_by_field/entity_access_by_field.links.menu.yml:0


### PR DESCRIPTION
…ents

## Problem
There are a few typos in the codebase where the word "whether" is spelt "wether" and a couple of instances of "turnded".

## Solution
Fix the typos in strings and also in the msgid for any translation

## Issue tracker
https://www.drupal.org/project/social/issues/3130599

## How to test
- [ ] Visit the admin link and check the typo is not present: /admin/config/opensocial/event-type
- [ ] Visit the admin link on a site where the UI is presented in a language that has an existing translation. Check that the translation is still present. Example in release note for Catalan.

## Release notes
Changes msgid for any translation that had an incorrect spelling. This may need intervention to fix any broken translation on an existing installation that uses a translated Admin UI.

**Example:** 
Original Catalan translation:
msgid "Set wether event types field is required or not."
msgstr "Estableix si el camp de tipus d'esdeveniment és obligatori o no."

Updated version:
msgid "Set whether event types field is required or not."
msgstr "Estableix si el camp de tipus d'esdeveniment és obligatori o no."
