### PR TITLE
Issue #3123493 by AlanHDev: Resolve missing/broken view filter on act…

### DIFF
--- a/modules/social_features/social_activity/config/features_removal/views.view.activity_stream.yml
+++ b/modules/social_features/social_activity/config/features_removal/views.view.activity_stream.yml
@@ -162,43 +162,6 @@ display:
             group_items: {  }
           reduce_duplicates: false
           plugin_id: list_field
-        activity_filter_nodes_from_my_groups_filter:
-          id: activity_filter_nodes_from_my_groups_filter
-          table: activity
-          field: activity_filter_nodes_from_my_groups_filter
-          relationship: none
-          group_type: group
-          admin_label: ''
-          operator: '='
-          value: ''
-          group: 1
-          exposed: false
-          expose:
-            operator_id: ''
-            label: ''
-            description: ''
-            use_operator: false
-            operator: ''
-            identifier: ''
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
-          entity_type: activity
-          plugin_id: activity_filter_nodes_from_my_groups
       sorts:
         created:
           id: created

--- a/modules/social_features/social_activity/config/optional/views.view.activity_stream.yml
+++ b/modules/social_features/social_activity/config/optional/views.view.activity_stream.yml
@@ -165,45 +165,6 @@ display:
             group_items: {  }
           reduce_duplicates: false
           plugin_id: list_field
-        activity_filter_nodes_from_my_groups_filter:
-          id: activity_filter_nodes_from_my_groups_filter
-          table: activity
-          field: activity_filter_nodes_from_my_groups_filter
-          relationship: none
-          group_type: group
-          admin_label: ''
-          operator: '='
-          value: ''
-          group: 1
-          exposed: false
-          expose:
-            operator_id: ''
-            label: ''
-            description: ''
-            use_operator: false
-            operator: ''
-            identifier: ''
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-            operator_limit_selection: false
-            operator_list: {  }
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
-          entity_type: activity
-          plugin_id: activity_filter_nodes_from_my_groups
       sorts:
         created:
           id: created

--- a/modules/social_features/social_activity/social_activity.install
+++ b/modules/social_features/social_activity/social_activity.install
@@ -167,3 +167,37 @@ function social_activity_update_8801() {
   $view->set('display', $displays);
   $view->save(TRUE);
 }
+
+/**
+ * Resolve missing filter on Activity Stream view.
+ */
+function social_activity_update_8802() {
+  // Set the key for the filter to remove from all displays.
+  $filter_to_remove = 'activity_filter_nodes_from_my_groups_filter';
+
+  $config_factory = \Drupal::configFactory();
+  // Load the activity stream.
+  $view = $config_factory->getEditable('views.view.activity_stream');
+  // Get the displays.
+  $displays = $view->get('display');
+
+  // Remove the filter from any displays where it is used.
+  $updated = [];
+  foreach ($displays as $display_name => &$display) {
+    // Remove the redundant filter.
+    if (isset($display['display_options']['filters'][$filter_to_remove])) {
+      unset ($display['display_options']['filters'][$filter_to_remove]);
+      $updated[] = $display_name;
+    }
+  }
+
+  // Save and log if we changed a display.
+  if (count($updated)) {
+    $view->set('display', $displays);
+    $view->save(TRUE);
+    // Log the updates.
+    foreach ($updated as $display_name) {
+      \Drupal::logger('system')->info(dt('Filter removed from display: @name', ['@name' => $display_name]));
+    }
+  }
+}

--- a/modules/social_features/social_activity/social_activity.install
+++ b/modules/social_features/social_activity/social_activity.install
@@ -186,7 +186,7 @@ function social_activity_update_8802() {
   foreach ($displays as $display_name => &$display) {
     // Remove the redundant filter.
     if (isset($display['display_options']['filters'][$filter_to_remove])) {
-      unset ($display['display_options']['filters'][$filter_to_remove]);
+      unset($display['display_options']['filters'][$filter_to_remove]);
       $updated[] = $display_name;
     }
   }


### PR DESCRIPTION
…ivity stream

## Problem
The Activity Stream view page for /stream displays an error on the views UI in the Filter Criteria. This is basically a filter that does not have (and never has had) an accompanying plugin. It was introduced here: https://github.com/goalgorilla/open_social/pull/539/files

## Solution
- Remove the filter from the view config files
- Add an update hook to remove from current config.

## Issue tracker
https://www.drupal.org/project/social/issues/3123493

## How to test
- [ ] Visit /admin/structure/views/view/activity_stream and confirm that 'Broken/missing handler' no longer appears in the Filter Criteria section.
