### PR TITLE
Issue 3132823 by AlanHDev: Update social features field group config

### DIFF
--- a/modules/social_features/social_book/config/features_removal/core.entity_form_display.node.book.default.yml
+++ b/modules/social_features/social_book/config/features_removal/core.entity_form_display.node.book.default.yml
@@ -30,6 +30,7 @@ third_party_settings:
         required_fields: true
         id: visibility
         classes: 'card'
+      region: content
     group_description:
       children:
         - body
@@ -42,6 +43,7 @@ third_party_settings:
         classes: ''
         id: ''
         required_fields: true
+      region: content
     group_title:
       children:
         - title
@@ -55,6 +57,7 @@ third_party_settings:
         classes: ''
         id: ''
         required_fields: true
+      region: content
     group_attachments:
       children:
         - field_files
@@ -67,6 +70,7 @@ third_party_settings:
         classes: ''
         id: ''
         required_fields: true
+      region: content
 id: node.book.default
 targetEntityType: node
 bundle: book

--- a/modules/social_features/social_core/config/features_removal/core.entity_form_display.block_content.platform_intro.default.yml
+++ b/modules/social_features/social_core/config/features_removal/core.entity_form_display.block_content.platform_intro.default.yml
@@ -21,6 +21,7 @@ third_party_settings:
         classes: ''
         id: ''
         required_fields: true
+      region: content
 id: block_content.platform_intro.default
 targetEntityType: block_content
 bundle: platform_intro

--- a/modules/social_features/social_core/config/install/core.entity_form_display.block_content.platform_intro.default.yml
+++ b/modules/social_features/social_core/config/install/core.entity_form_display.block_content.platform_intro.default.yml
@@ -21,6 +21,7 @@ third_party_settings:
         classes: ''
         id: ''
         required_fields: true
+      region: content
 _core:
   default_config_hash: 8TUFmFkJcvfyHRGY8yfnwsKNbxxgLXHZM021Bc1Rs30
 id: block_content.platform_intro.default

--- a/modules/social_features/social_event/config/features_removal/core.entity_form_display.node.event.default.yml
+++ b/modules/social_features/social_event/config/features_removal/core.entity_form_display.node.event.default.yml
@@ -38,6 +38,7 @@ third_party_settings:
         classes: ''
         id: ''
         required_fields: true
+      region: content
     group_date_time:
       children:
         - field_event_date
@@ -51,6 +52,7 @@ third_party_settings:
         classes: ''
         id: ''
         required_fields: true
+      region: content
     group_location:
       children:
         - field_event_location
@@ -64,6 +66,7 @@ third_party_settings:
         classes: ''
         id: ''
         required_fields: true
+      region: content
     group_description:
       children:
         - body
@@ -76,6 +79,7 @@ third_party_settings:
         classes: ''
         id: ''
         required_fields: true
+      region: content
     group_event_visibility:
       children:
         - groups
@@ -89,6 +93,7 @@ third_party_settings:
         required_fields: true
         id: visibility
         classes: 'card '
+      region: content
     group_attachments:
       children:
         - field_files
@@ -101,6 +106,7 @@ third_party_settings:
         required_fields: true
         id: attachments
         classes: card
+      region: content
     group_enrollment:
       children:
         - field_event_enroll
@@ -113,6 +119,7 @@ third_party_settings:
         required_fields: true
         id: enrollment
         classes: card
+      region: content
 id: node.event.default
 targetEntityType: node
 bundle: event

--- a/modules/social_features/social_event/config/install/core.entity_form_display.node.event.default.yml
+++ b/modules/social_features/social_event/config/install/core.entity_form_display.node.event.default.yml
@@ -38,6 +38,7 @@ third_party_settings:
         classes: ''
         id: ''
         required_fields: true
+      region: content
     group_date_time:
       children:
         - field_event_date
@@ -51,6 +52,7 @@ third_party_settings:
         classes: ''
         id: ''
         required_fields: true
+      region: content
     group_location:
       children:
         - field_event_location
@@ -64,6 +66,7 @@ third_party_settings:
         classes: ''
         id: ''
         required_fields: true
+      region: content
     group_description:
       children:
         - body
@@ -76,6 +79,7 @@ third_party_settings:
         classes: ''
         id: ''
         required_fields: true
+      region: content
     group_event_visibility:
       children:
         - groups
@@ -89,6 +93,7 @@ third_party_settings:
         required_fields: true
         id: visibility
         classes: 'card '
+      region: content
     group_attachments:
       children:
         - field_files
@@ -101,6 +106,7 @@ third_party_settings:
         required_fields: true
         id: attachments
         classes: card
+      region: content
     group_enrollment:
       children:
         - field_event_enroll
@@ -113,6 +119,7 @@ third_party_settings:
         required_fields: true
         id: enrollment
         classes: card
+      region: content
 _core:
   default_config_hash: qKBzdABwV4xgosxvvpPa9VD-XmjoctFRVihQvmMs2a4
 id: node.event.default

--- a/modules/social_features/social_group/config/features_removal/core.entity_form_display.group.closed_group.default.yml
+++ b/modules/social_features/social_group/config/features_removal/core.entity_form_display.group.closed_group.default.yml
@@ -30,6 +30,7 @@ third_party_settings:
         classes: ''
         id: ''
         required_fields: true
+      region: content
     group_location:
       children:
         - field_group_location
@@ -43,6 +44,7 @@ third_party_settings:
         classes: ''
         id: ''
         required_fields: true
+      region: content
     group_settings:
       children: {  }
       parent_name: ''

--- a/modules/social_features/social_group/config/features_removal/core.entity_form_display.group.open_group.default.yml
+++ b/modules/social_features/social_group/config/features_removal/core.entity_form_display.group.open_group.default.yml
@@ -30,6 +30,7 @@ third_party_settings:
         classes: ''
         id: ''
         required_fields: true
+      region: content
     group_location:
       children:
         - field_group_location
@@ -43,6 +44,7 @@ third_party_settings:
         classes: ''
         id: ''
         required_fields: true
+      region: content
     group_settings:
       children: {  }
       parent_name: ''

--- a/modules/social_features/social_group/config/features_removal/core.entity_form_display.group.public_group.default.yml
+++ b/modules/social_features/social_group/config/features_removal/core.entity_form_display.group.public_group.default.yml
@@ -30,6 +30,7 @@ third_party_settings:
         classes: ''
         id: ''
         required_fields: true
+      region: content
     group_location:
       children:
         - field_group_location
@@ -43,6 +44,7 @@ third_party_settings:
         classes: ''
         id: ''
         required_fields: true
+      region: content
     group_settings:
       children: {  }
       parent_name: ''

--- a/modules/social_features/social_group/config/install/core.entity_form_display.group.closed_group.default.yml
+++ b/modules/social_features/social_group/config/install/core.entity_form_display.group.closed_group.default.yml
@@ -30,6 +30,7 @@ third_party_settings:
         classes: ''
         id: ''
         required_fields: true
+      region: content
     group_location:
       children:
         - field_group_location
@@ -43,6 +44,7 @@ third_party_settings:
         classes: ''
         id: ''
         required_fields: true
+      region: content
     group_settings:
       children: {  }
       parent_name: ''

--- a/modules/social_features/social_group/config/install/core.entity_form_display.group.open_group.default.yml
+++ b/modules/social_features/social_group/config/install/core.entity_form_display.group.open_group.default.yml
@@ -30,6 +30,7 @@ third_party_settings:
         classes: ''
         id: ''
         required_fields: true
+      region: content
     group_location:
       children:
         - field_group_location
@@ -43,6 +44,7 @@ third_party_settings:
         classes: ''
         id: ''
         required_fields: true
+      region: content
     group_settings:
       children: {  }
       parent_name: ''

--- a/modules/social_features/social_group/config/install/core.entity_form_display.group.public_group.default.yml
+++ b/modules/social_features/social_group/config/install/core.entity_form_display.group.public_group.default.yml
@@ -30,6 +30,7 @@ third_party_settings:
         classes: ''
         id: ''
         required_fields: true
+      region: content
     group_location:
       children:
         - field_group_location
@@ -43,6 +44,7 @@ third_party_settings:
         classes: ''
         id: ''
         required_fields: true
+      region: content
     group_settings:
       children: {  }
       parent_name: ''

--- a/modules/social_features/social_group/modules/social_group_secret/config/features_removal/core.entity_form_display.group.secret_group.default.yml
+++ b/modules/social_features/social_group/modules/social_group_secret/config/features_removal/core.entity_form_display.group.secret_group.default.yml
@@ -31,6 +31,7 @@ third_party_settings:
         classes: ''
         id: ''
         required_fields: true
+      region: content
     group_location:
       children:
         - field_group_location
@@ -44,6 +45,7 @@ third_party_settings:
         classes: ''
         id: ''
         required_fields: true
+      region: content
     group_settings:
       children: {  }
       parent_name: ''

--- a/modules/social_features/social_group/modules/social_group_secret/config/install/core.entity_form_display.group.secret_group.default.yml
+++ b/modules/social_features/social_group/modules/social_group_secret/config/install/core.entity_form_display.group.secret_group.default.yml
@@ -31,6 +31,7 @@ third_party_settings:
         classes: ''
         id: ''
         required_fields: true
+      region: content
     group_location:
       children:
         - field_group_location
@@ -44,6 +45,7 @@ third_party_settings:
         classes: ''
         id: ''
         required_fields: true
+      region: content
     group_settings:
       children: {  }
       parent_name: ''

--- a/modules/social_features/social_landing_page/config/features_removal/core.entity_form_display.node.landing_page.default.yml
+++ b/modules/social_features/social_landing_page/config/features_removal/core.entity_form_display.node.landing_page.default.yml
@@ -25,6 +25,7 @@ third_party_settings:
         id: title
         classes: card
       label: Title
+      region: content
     group_sections:
       children:
         - field_landing_page_section
@@ -38,6 +39,7 @@ third_party_settings:
         id: sections
         classes: card
       label: Sections
+      region: content
 id: node.landing_page.default
 targetEntityType: node
 bundle: landing_page

--- a/modules/social_features/social_landing_page/config/install/core.entity_form_display.node.landing_page.default.yml
+++ b/modules/social_features/social_landing_page/config/install/core.entity_form_display.node.landing_page.default.yml
@@ -25,6 +25,7 @@ third_party_settings:
         id: title
         classes: card
       label: Title
+      region: content
     group_sections:
       children:
         - field_landing_page_section
@@ -38,6 +39,7 @@ third_party_settings:
         id: sections
         classes: card
       label: Sections
+      region: content
 id: node.landing_page.default
 targetEntityType: node
 bundle: landing_page

--- a/modules/social_features/social_page/config/features_removal/core.entity_form_display.node.page.default.yml
+++ b/modules/social_features/social_page/config/features_removal/core.entity_form_display.node.page.default.yml
@@ -31,6 +31,7 @@ third_party_settings:
         required_fields: true
         id: content
         classes: 'card '
+      region: content
     group_page_description:
       children:
         - body
@@ -43,6 +44,7 @@ third_party_settings:
         required_fields: true
         id: description
         classes: 'card '
+      region: content
     group_attachments:
       children:
         - field_files
@@ -55,6 +57,7 @@ third_party_settings:
         required_fields: true
         id: attachments
         classes: 'card '
+      region: content
     group_page_visibility:
       children:
         - field_content_visibility
@@ -67,6 +70,7 @@ third_party_settings:
         required_fields: true
         id: visibility
         classes: 'card '
+      region: content
 id: node.page.default
 targetEntityType: node
 bundle: page

--- a/modules/social_features/social_page/config/install/core.entity_form_display.node.page.default.yml
+++ b/modules/social_features/social_page/config/install/core.entity_form_display.node.page.default.yml
@@ -31,6 +31,7 @@ third_party_settings:
         required_fields: true
         id: content
         classes: 'card '
+      region: content
     group_page_description:
       children:
         - body
@@ -43,6 +44,7 @@ third_party_settings:
         required_fields: true
         id: description
         classes: 'card '
+      region: content
     group_attachments:
       children:
         - field_files
@@ -55,6 +57,7 @@ third_party_settings:
         required_fields: true
         id: attachments
         classes: 'card '
+      region: content
     group_page_visibility:
       children:
         - field_content_visibility
@@ -67,6 +70,7 @@ third_party_settings:
         required_fields: true
         id: visibility
         classes: 'card '
+      region: content
 _core:
   default_config_hash: 3Z-1RH4Ygf-ZS11i1tHHb08h_tsEQ6BwTPx3gUUH3Wo
 id: node.page.default

--- a/modules/social_features/social_profile/config/features_removal/core.entity_form_display.profile.profile.default.yml
+++ b/modules/social_features/social_profile/config/features_removal/core.entity_form_display.profile.profile.default.yml
@@ -40,6 +40,7 @@ third_party_settings:
         required_fields: true
         id: name
         classes: scrollspy
+      region: content
     group_profile_funct_organization:
       children:
         - field_profile_function
@@ -53,6 +54,7 @@ third_party_settings:
         required_fields: true
         id: work
         classes: scollspy
+      region: content
     group_profile_self_intro:
       children:
         - field_profile_self_introduction
@@ -68,6 +70,7 @@ third_party_settings:
         required_fields: true
         id: details
         classes: scrollspy
+      region: content
     group_profile_contact_info:
       children:
         - field_profile_phone_number
@@ -81,6 +84,7 @@ third_party_settings:
         required_fields: true
         id: contact
         classes: scollspy
+      region: content
 id: profile.profile.default
 targetEntityType: profile
 bundle: profile

--- a/modules/social_features/social_profile/config/install/core.entity_form_display.profile.profile.default.yml
+++ b/modules/social_features/social_profile/config/install/core.entity_form_display.profile.profile.default.yml
@@ -40,6 +40,7 @@ third_party_settings:
         required_fields: true
         id: name
         classes: scrollspy
+      region: content
     group_profile_funct_organization:
       children:
         - field_profile_function
@@ -53,6 +54,7 @@ third_party_settings:
         required_fields: true
         id: work
         classes: scollspy
+      region: content
     group_profile_self_intro:
       children:
         - field_profile_self_introduction
@@ -68,6 +70,7 @@ third_party_settings:
         required_fields: true
         id: details
         classes: scrollspy
+      region: content
     group_profile_contact_info:
       children:
         - field_profile_phone_number
@@ -81,6 +84,7 @@ third_party_settings:
         required_fields: true
         id: contact
         classes: scollspy
+      region: content
 _core:
   default_config_hash: q5dRMlfrlHczeboqgnggDsIvBp1Z0aun2cMsa4qIDbQ
 id: profile.profile.default

--- a/modules/social_features/social_topic/config/features_removal/core.entity_form_display.node.topic.default.yml
+++ b/modules/social_features/social_topic/config/features_removal/core.entity_form_display.node.topic.default.yml
@@ -33,6 +33,7 @@ third_party_settings:
         required_fields: true
         id: content
         classes: 'card '
+      region: content
     group_topic_description:
       children:
         - body
@@ -45,6 +46,7 @@ third_party_settings:
         required_fields: true
         id: description
         classes: 'card '
+      region: content
     group_topic_visibility:
       children:
         - groups
@@ -58,6 +60,7 @@ third_party_settings:
         required_fields: true
         id: visibility
         classes: 'card '
+      region: content
     group_attachments:
       children:
         - field_files
@@ -70,6 +73,7 @@ third_party_settings:
         required_fields: true
         id: attachments
         classes: 'card '
+      region: content
 id: node.topic.default
 targetEntityType: node
 bundle: topic

--- a/modules/social_features/social_topic/config/install/core.entity_form_display.node.topic.default.yml
+++ b/modules/social_features/social_topic/config/install/core.entity_form_display.node.topic.default.yml
@@ -33,6 +33,7 @@ third_party_settings:
         required_fields: true
         id: content
         classes: 'card '
+      region: content
     group_topic_description:
       children:
         - body
@@ -45,6 +46,7 @@ third_party_settings:
         required_fields: true
         id: description
         classes: 'card '
+      region: content
     group_topic_visibility:
       children:
         - groups
@@ -58,6 +60,7 @@ third_party_settings:
         required_fields: true
         id: visibility
         classes: 'card '
+      region: content
     group_attachments:
       children:
         - field_files
@@ -70,6 +73,7 @@ third_party_settings:
         required_fields: true
         id: attachments
         classes: 'card '
+      region: content
 _core:
   default_config_hash: 7gp9MbxXU7HOGmCzXk8LMVCxpLv_WPYpnFy49fW_2os
 id: node.topic.default

--- a/modules/social_features/social_user/config/features_removal/core.entity_form_display.user.user.default.yml
+++ b/modules/social_features/social_user/config/features_removal/core.entity_form_display.user.user.default.yml
@@ -18,6 +18,7 @@ third_party_settings:
         required_fields: true
         id: ''
         classes: ''
+      region: content
     group_locale_settings:
       children:
         - timezone
@@ -30,6 +31,7 @@ third_party_settings:
         description: ''
         required_fields: true
       label: 'Locale settings'
+      region: content
 id: user.user.default
 targetEntityType: user
 bundle: user

--- a/modules/social_features/social_user/config/install/core.entity_form_display.user.user.default.yml
+++ b/modules/social_features/social_user/config/install/core.entity_form_display.user.user.default.yml
@@ -18,6 +18,7 @@ third_party_settings:
         required_fields: true
         id: ''
         classes: ''
+      region: content
     group_locale_settings:
       children:
         - timezone
@@ -30,6 +31,7 @@ third_party_settings:
         description: ''
         required_fields: true
       label: 'Locale settings'
+      region: content
 _core:
   default_config_hash: pRQ6ymdA2LS1Ssy6jQIpcFyAkOgrFCOfnW5S1j_knPE
 id: user.user.default


### PR DESCRIPTION
## Problem
Field group 3.0 requires that region is specified in the config for the group. There is a post-update hook provided by the Field Group contrib module that adds the required config to existing form display config on the site. 

Having updated to Open Social that includes Field Group 3.0, enabling a module such as social_landing_page or another module that provides install config for entity_form_display containing field group settings causes issues. The install config does not contain the required 'region: content' and, as the field group update has already run, the config is incomplete.

## Solution
The resolution is to add region: content to any config provided by open social modules that contain entity_form_display config with field group settings.

If an affected module has already been installed, this won't fix it. In that case, you'd need to ensure that the config is updated manually and then re-import.

## Issue tracker
https://www.drupal.org/project/social/issues/3132823

## How to test
- [ ] Enable social_landing_page on a site where it has not been previously enabled
- [ ] Attempt to create a new landing page
- [ ] Observe a notice: Undefined property: stdClass::$region in field_group_form_process()
- [ ] Enable Field UI
- [ ] Visit Manage form display for the landing page content type
- [ ] Observe the field groups and field order is broken in the UI and a notice is present
- [ ] Roll back the database and repeat tests having applied the changes
- [ ] No notices present
- [ ] Field drag drop UI is as expected  
