### PR TITLE
Feature/tb 3755 update linkedin api

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -165,7 +165,7 @@
         "php-http/curl-client": "^1.7",
         "guzzlehttp/psr7": "^1.3",
         "php-http/message": "^1.7",
-        "happyr/linkedin-api-client": "^1.0",
+        "zoonman/linkedin-api-php-client": "dev-master#d06531c48d5efc8aaf7dc074a5320f5ba3f906c9",
         "abraham/twitteroauth": "^0.7.4",
         "swiftmailer/swiftmailer" : "v5.4.12",
         "bower-asset/waves": "0.7.6",

--- a/modules/custom/social_auth_linkedin/composer.json
+++ b/modules/custom/social_auth_linkedin/composer.json
@@ -6,6 +6,6 @@
     "php-http/curl-client": "^1.6",
     "guzzlehttp/psr7": "^1.3",
     "php-http/message": "^1.4",
-    "happyr/linkedin-api-client": "^1.0"
+    "zoonman/linkedin-api-php-client": "dev-master#d06531c48d5efc8aaf7dc074a5320f5ba3f906c9"
   }
 }

--- a/modules/custom/social_auth_linkedin/social_auth_linkedin.install
+++ b/modules/custom/social_auth_linkedin/social_auth_linkedin.install
@@ -12,7 +12,7 @@ function social_auth_linkedin_requirements($phase) {
   $requirements = [];
 
   if ($phase == 'install') {
-    if (!class_exists('\Happyr\LinkedIn\LinkedIn', TRUE)) {
+    if (!class_exists('\LinkedIn\Client', TRUE)) {
       $requirements['social_auth_linkedin'] = [
         'description' => t('Social Auth LinkedIn requires LinkedIn PHP Library. Make sure the library is installed via Composer.'),
         'severity' => REQUIREMENT_ERROR,

--- a/modules/custom/social_auth_linkedin/src/Controller/LinkedInAuthController.php
+++ b/modules/custom/social_auth_linkedin/src/Controller/LinkedInAuthController.php
@@ -177,8 +177,8 @@ class LinkedInAuthController extends ControllerBase {
     // form.
     $data_handler = $this->networkManager->createInstance('social_auth_linkedin')->getDataHandler();
     $data_handler->set('access_token', $this->accessToken);
-    $data_handler->set('mail', $profile['emailAddress']);
-    $data_handler->set('name', $profile['formattedName']);
+    $data_handler->set('mail', $this->authManager->getEmailAddress());
+    $data_handler->set('name', $this->authManager->getFirstName() . ' ' . $this->authManager->getLastName());
 
     drupal_set_message($this->t('You are now connected with @network, please continue registration', [
       '@network' => $this->t('LinkedIn'),

--- a/modules/custom/social_auth_linkedin/src/LinkedInAuthManager.php
+++ b/modules/custom/social_auth_linkedin/src/LinkedInAuthManager.php
@@ -4,8 +4,8 @@ namespace Drupal\social_auth_linkedin;
 
 use Drupal\social_auth_extra\AuthManager;
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
-use Happyr\LinkedIn\LinkedIn;
-use Happyr\LinkedIn\Exception\LinkedInException;
+use LinkedIn\Client;
+use LinkedIn\Scope;
 use Drupal\social_auth_linkedin\Settings\LinkedInAuthSettings;
 
 /**
@@ -26,8 +26,8 @@ class LinkedInAuthManager extends AuthManager {
    * {@inheritdoc}
    */
   public function setSdk($sdk) {
-    if (!$sdk instanceof LinkedIn) {
-      throw new InvalidArgumentException('SDK object should be instance of \Happyr\LinkedIn\LinkedIn class');
+    if (!$sdk instanceof Client) {
+      throw new InvalidArgumentException('SDK object should be instance of \LinkedIn\Client class');
     }
 
     $this->sdk = $sdk;
@@ -36,9 +36,8 @@ class LinkedInAuthManager extends AuthManager {
   /**
    * {@inheritdoc}
    */
-  public function getAuthenticationUrl($type, array $scope = ['r_basicprofile', 'r_emailaddress']) {
+  public function getAuthenticationUrl($type, array $scope = [Scope::READ_LITE_PROFILE, Scope::READ_EMAIL_ADDRESS]) {
     return $this->sdk->getLoginUrl([
-      'redirect_uri' => $this->getRedirectUrl($type),
       'scope' => implode(',', $scope),
     ]);
   }
@@ -67,7 +66,7 @@ class LinkedInAuthManager extends AuthManager {
 
     $this->loggerFactory
       ->get('social_auth_linkedin')
-      ->error('Could not get LinkedIn access token. User cancelled the dialog in Facebook or return URL was not valid.');
+      ->error('Could not get LinkedIn access token. User cancelled the dialog in LinkedIn or return URL was not valid.');
 
     return NULL;
   }
@@ -76,6 +75,7 @@ class LinkedInAuthManager extends AuthManager {
    * {@inheritdoc}
    */
   public function getProfile() {
+    $x =1;
     if (!$this->profile) {
       if (($profile = $this->sdk->get('v1/people/~:(id,firstName,lastName,email-address,formattedName,pictureUrls::(original))')) && !isset($profile['errorCode'])) {
         $this->profile = $profile;

--- a/modules/custom/social_auth_linkedin/src/LinkedInAuthManager.php
+++ b/modules/custom/social_auth_linkedin/src/LinkedInAuthManager.php
@@ -37,6 +37,11 @@ class LinkedInAuthManager extends AuthManager {
    * {@inheritdoc}
    */
   public function getAuthenticationUrl($type, array $scope = [Scope::READ_LITE_PROFILE, Scope::READ_EMAIL_ADDRESS]) {
+    $redirect_url = $this->getRedirectUrl($type);
+
+    // Set the redirect for the third party with our own.
+    $this->sdk->setRedirectUrl($redirect_url);
+
     return $this->sdk->getLoginUrl([
       'scope' => implode(',', $scope),
     ]);
@@ -47,7 +52,11 @@ class LinkedInAuthManager extends AuthManager {
    */
   public function getAccessToken($type = '') {
     try {
-      $access_token = $this->sdk->getAccessToken();
+      // set the RedirectUrl before retrieving the access token.
+      $redirect_url = $this->getRedirectUrl($type);
+      $this->sdk->setRedirectUrl($redirect_url);
+
+      $access_token = $this->sdk->getAccessToken($_GET['code']);
       return $access_token;
     }
     catch (LinkedInException $e) {
@@ -75,10 +84,18 @@ class LinkedInAuthManager extends AuthManager {
    * {@inheritdoc}
    */
   public function getProfile() {
-    $x =1;
     if (!$this->profile) {
-      if (($profile = $this->sdk->get('v1/people/~:(id,firstName,lastName,email-address,formattedName,pictureUrls::(original))')) && !isset($profile['errorCode'])) {
-        $this->profile = $profile;
+      // Add basic profile information.
+      if (($profile = $this->sdk->get('me', ['fields' => 'id,firstName,lastName'])) && !isset($profile['errorCode'])) {
+        $this->profile['id'] = $profile['id'];
+        $this->profile['basic_information'] = $profile;
+      }
+      if (($profile = $this->sdk->get('me', ['projection' => '(id,profilePicture(displayImage~:playableStreams))'])) && !isset($profile['errorCode'])) {
+        $this->profile['profile_picture'] = $profile;
+      }
+
+      if (($profile = $this->sdk->get('emailAddress', ['q' => 'members', 'projection' => '(elements*(handle~))'])) && !isset($profile['errorCode'])) {
+        $this->profile['email_information'] = $profile;
       }
     }
 
@@ -89,8 +106,9 @@ class LinkedInAuthManager extends AuthManager {
    * {@inheritdoc}
    */
   public function getProfilePicture() {
-    if (!empty($this->profile['pictureUrls']['_total'])) {
-      return end($this->profile['pictureUrls']['values']);
+    if (!empty($this->profile['profile_picture']['profilePicture']['displayImage~']['elements'])) {
+      $profile_picture = end($this->profile['profile_picture']['profilePicture']['displayImage~']['elements']);
+      return $profile_picture['identifiers'][0]['identifier'];
     }
   }
 
@@ -112,14 +130,27 @@ class LinkedInAuthManager extends AuthManager {
    * {@inheritdoc}
    */
   public function getFirstName() {
-    return isset($this->profile['firstName']) ? $this->profile['firstName'] : NULL;
+    if (!empty($this->profile['basic_information']['firstName'])) {
+      return array_values($this->profile['basic_information']['firstName']['localized'])[0];
+    }
   }
 
   /**
    * {@inheritdoc}
    */
   public function getLastName() {
-    return isset($this->profile['lastName']) ? $this->profile['lastName'] : NULL;
+    if (!empty($this->profile['basic_information']['lastName'])) {
+      return array_values($this->profile['basic_information']['lastName']['localized'])[0];
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getEmailAddress() {
+    if (!empty($this->profile['email_information']['elements'])) {
+      return $this->profile['email_information']['elements'][0]['handle~']['emailAddress'];
+    }
   }
 
 }

--- a/modules/custom/social_auth_linkedin/src/LinkedInAuthManager.php
+++ b/modules/custom/social_auth_linkedin/src/LinkedInAuthManager.php
@@ -52,7 +52,7 @@ class LinkedInAuthManager extends AuthManager {
    */
   public function getAccessToken($type = '') {
     try {
-      // set the RedirectUrl before retrieving the access token.
+      // Set the RedirectUrl before retrieving the access token.
       $redirect_url = $this->getRedirectUrl($type);
       $this->sdk->setRedirectUrl($redirect_url);
 

--- a/modules/custom/social_auth_linkedin/src/Plugin/Network/LinkedInAuth.php
+++ b/modules/custom/social_auth_linkedin/src/Plugin/Network/LinkedInAuth.php
@@ -63,7 +63,7 @@ class LinkedInAuth extends SocialAuthNetwork {
    * @throws \Drupal\social_api\SocialApiException
    */
   public function initSdk() {
-    $class_name = '\Happyr\LinkedIn\LinkedIn';
+    $class_name = '\LinkedIn\Client';
 
     if (!class_exists($class_name)) {
       throw new SocialApiException(sprintf('The PHP SDK for LinkedIn could not be found. Class: %s.', $class_name));

--- a/social.profile
+++ b/social.profile
@@ -105,7 +105,7 @@ function social_verify_custom_requirements(array &$install_state) {
     ];
   }
 
-  if (!class_exists('\Happyr\LinkedIn\LinkedIn')) {
+  if (!class_exists('\LinkedIn\Client')) {
     $requirements['social_auth_linkedin'] = [
       'title' => t('Social Auth LinkedIn module requirements'),
       'value' => t('Not installed'),


### PR DESCRIPTION
## Problem
Linkedin API v1 is deprecated so we are not able to use the SSO anymore for this provider.

## Solution
Since the Happyr does not got updated to support the V2, move to another third party library called https://github.com/zoonman/linkedin-api-php-client

## Issue tracker
https://www.drupal.org/project/social/issues/3133350

## How to test
- [ ] Enable the social_sso and social_auth_linked module and clear the cache
- [ ] Go to Linkedin Developers on https://www.linkedin.com/developers and create an app.
- [ ] In the auth tab, the default permissions are correct, but you need to add the following **callback urls**
http://social.local/social-api/link/linkedin/callback
http://social.local/user/register/linkedin/callback
http://social.local/user/login/linkedin/callback
- [ ] Copy the clientid and secret and fill it on your social installation settings for Linkedin on http://social.local/admin/config/social-api/social-auth/linkedin and check to activate the module
- [ ] Logout and try to sign up using the linkedin link, it should prefill the email adress and username in step 1.
- [ ] In step 2 you should also see a prefilled first name, last name and profile picture.
- [ ] Also try logging in with linkedin
- [ ] Also try unlinking and linking the provider in the account settings page.

Make sure you run a Proxy locally so you have a dedicated url you can use in your callback urls.

## Release notes
Authorization with the social network LinkedIn for Open Social was broken due to deprecation of the V1 API.
We have changed the library to support the V2 API, which means you can use the LinkedIn provider again to log in to Open Social.