### PR TITLE
Issue #3133763 by rolki: Add an extra condition before invalidating cache tags

### DIFF
--- a/modules/social_features/social_group/social_group.module
+++ b/modules/social_features/social_group/social_group.module
@@ -780,10 +780,12 @@ function _social_group_type_edit_submit($form, FormStateInterface $form_state) {
     }
   }
 
-  // Make sure we clear cache tags accordingly.
-  $cache_tags = _social_group_cache_tags($group);
-  foreach ($cache_tags as $cache_tag) {
-    Cache::invalidateTags([$cache_tag]);
+  if ($group instanceof GroupInterface) {
+    // Make sure we clear cache tags accordingly.
+    $cache_tags = _social_group_cache_tags($group);
+    foreach ($cache_tags as $cache_tag) {
+      Cache::invalidateTags([$cache_tag]);
+    }
   }
 }
 


### PR DESCRIPTION
## Problem
After creating a new group type and adding visibility field to this group then I use _social_flexible_group_edit_submit callback to change visibility options for all content related to this group, but I faced with the error:
`TypeError: Argument 1 passed to _social_group_cache_tags() must implement interface Drupal\group\Entity\GroupInterface, null given, called in /var/www/html/profiles/contrib/social/modules/social_features/social_group/social_group.module on line 769 in _social_group_cache_tags() (line 1197 of /var/www/html/profiles/contrib/social/modules/social_features/social_group/social_group.module`

## Solution
Add an extra condition before invalidating cache tags.

## Issue tracker
https://www.drupal.org/project/social/issues/3133763
