### PR TITLE
Issue #3134100 by navneet0693: Add Group block on user profile's group doesn't takes "create group" permissions in context

### DIFF
--- a/modules/social_features/social_group/social_group.module
+++ b/modules/social_features/social_group/social_group.module
@@ -729,9 +729,16 @@ function social_group_form_alter(&$form, FormStateInterface $form_state, $form_i
       array_unshift($form['actions']['submit']['#submit'], '_social_group_delete_group');
     }
   }
-
   if (in_array($form_id, ['group_flexible_group_edit_form', 'group_flexible_group_add_form'])) {
     $join_method_default_value = 'added';
+    // Ensure we have a better descriptive label.
+    if (array_key_exists('added', $form['field_group_allowed_join_method']['widget']['#options'])) {
+      $form['field_group_allowed_join_method']['widget']['#options']['added'] = t('Be added only - users can only be added by group managers');
+    }
+    if (array_key_exists('direct', $form['field_group_allowed_join_method']['widget']['#options'])) {
+      $form['field_group_allowed_join_method']['widget']['#options']['direct'] = t('Join directly - users can join this group without approval');
+    }
+    // If directly exists it's becoming the default.
     if (in_array('direct', $form['field_group_allowed_join_method']['widget']['#default_value'])) {
       $join_method_default_value = 'direct';
     }
@@ -780,12 +787,10 @@ function _social_group_type_edit_submit($form, FormStateInterface $form_state) {
     }
   }
 
-  if ($group instanceof GroupInterface) {
-    // Make sure we clear cache tags accordingly.
-    $cache_tags = _social_group_cache_tags($group);
-    foreach ($cache_tags as $cache_tag) {
-      Cache::invalidateTags([$cache_tag]);
-    }
+  // Make sure we clear cache tags accordingly.
+  $cache_tags = _social_group_cache_tags($group);
+  foreach ($cache_tags as $cache_tag) {
+    Cache::invalidateTags([$cache_tag]);
   }
 }
 
@@ -1554,10 +1559,8 @@ function social_group_save_group_from_node(array $form, FormStateInterface $form
   foreach ($form_state->getValue('groups') as $new_group_key => $new_group) {
     $groups_to_add[$new_group['target_id']] = $new_group['target_id'];
   }
-  // The node already exist so lets also change the logic accordingly,
-  // only if there is already a group that needs to be removed.
-  if (!empty($form['groups']['widget']['#default_value']) &&
-    $form['#form_id'] === 'node_' . $node->bundle() . '_edit_form') {
+  // The node already exist so lets also change the logic accordingly.
+  if ($form['#form_id'] === 'node_' . $node->bundle() . '_edit_form') {
     $original_groups = $form['groups']['widget']['#default_value'];
     foreach ($original_groups as $original_group_key => $original_group) {
       if (!in_array($original_group, $groups_to_add)) {
@@ -1752,30 +1755,8 @@ function social_group_social_user_account_header_create_links($context) {
   if (!empty($context['user'])) {
     /** @var \Drupal\Core\Session\AccountInterface $user */
     $account = $context['user'];
-    $user_can_create_groups = [];
-    // Get all available group types.
-    foreach (GroupType::loadMultiple() as $group_type) {
-      // When the user has permission to create a group of the current type, add
-      // this to the create group array.
-      if ($account->hasPermission('create ' . $group_type->id() . ' group')) {
-        $user_can_create_groups[$group_type->id()] = $group_type;
-      }
-
-      if (count($user_can_create_groups) > 1) {
-        break;
-      }
-    }
-
-    // There's just one group this user can create.
-    if (count($user_can_create_groups) === 1) {
-      // When there is only one group allowed, add create the url to create a
-      // group of this type.
-      /** @var \Drupal\group\Entity\Group $allowed_group_type */
-      $allowed_group_type = reset($user_can_create_groups);
-      $route_add_group = Url::fromRoute('entity.group.add_form', [
-        'group_type' => $allowed_group_type->id(),
-      ]);
-    }
+    $route_add_group = \Drupal::service('social_group.helper_service')
+      ->getGroupsToAddUrl($account) ?? $route_add_group;
   }
 
   return [

--- a/modules/social_features/social_group/social_group.module
+++ b/modules/social_features/social_group/social_group.module
@@ -731,14 +731,6 @@ function social_group_form_alter(&$form, FormStateInterface $form_state, $form_i
   }
   if (in_array($form_id, ['group_flexible_group_edit_form', 'group_flexible_group_add_form'])) {
     $join_method_default_value = 'added';
-    // Ensure we have a better descriptive label.
-    if (array_key_exists('added', $form['field_group_allowed_join_method']['widget']['#options'])) {
-      $form['field_group_allowed_join_method']['widget']['#options']['added'] = t('Be added only - users can only be added by group managers');
-    }
-    if (array_key_exists('direct', $form['field_group_allowed_join_method']['widget']['#options'])) {
-      $form['field_group_allowed_join_method']['widget']['#options']['direct'] = t('Join directly - users can join this group without approval');
-    }
-    // If directly exists it's becoming the default.
     if (in_array('direct', $form['field_group_allowed_join_method']['widget']['#default_value'])) {
       $join_method_default_value = 'direct';
     }
@@ -787,9 +779,12 @@ function _social_group_type_edit_submit($form, FormStateInterface $form_state) {
     }
   }
 
-  // Make sure we clear cache tags accordingly.
-  $cache_tags = _social_group_cache_tags($group);
-  foreach ($cache_tags as $cache_tag) {
+  if ($group instanceof GroupInterface) {
+    // Make sure we clear cache tags accordingly.
+    $cache_tags = _social_group_cache_tags($group);
+    foreach ($cache_tags as $cache_tag) {
+      Cache::invalidateTags([$cache_tag]);
+    }
     Cache::invalidateTags([$cache_tag]);
   }
 }
@@ -1559,8 +1554,10 @@ function social_group_save_group_from_node(array $form, FormStateInterface $form
   foreach ($form_state->getValue('groups') as $new_group_key => $new_group) {
     $groups_to_add[$new_group['target_id']] = $new_group['target_id'];
   }
-  // The node already exist so lets also change the logic accordingly.
-  if ($form['#form_id'] === 'node_' . $node->bundle() . '_edit_form') {
+  // The node already exist so lets also change the logic accordingly,
+  // only if there is already a group that needs to be removed.
+  if (!empty($form['groups']['widget']['#default_value']) &&
+    $form['#form_id'] === 'node_' . $node->bundle() . '_edit_form') {
     $original_groups = $form['groups']['widget']['#default_value'];
     foreach ($original_groups as $original_group_key => $original_group) {
       if (!in_array($original_group, $groups_to_add)) {

--- a/modules/social_features/social_group/src/Plugin/Block/GroupAddBlock.php
+++ b/modules/social_features/social_group/src/Plugin/Block/GroupAddBlock.php
@@ -3,11 +3,18 @@
 namespace Drupal\social_group\Plugin\Block;
 
 use Drupal\Core\Block\BlockBase;
+use Drupal\Core\Block\BlockPluginInterface;
+use Drupal\Core\Cache\Cache;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\Core\Session\AccountProxyInterface;
 use Drupal\Core\Url;
 use Drupal\Core\Link;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\Access\AccessResult;
 use Drupal\group\Entity\GroupType;
+use Drupal\social_group\SocialGroupHelperService;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Provides a 'GroupAddBlock' block.
@@ -17,7 +24,72 @@ use Drupal\group\Entity\GroupType;
  *  admin_label = @Translation("Group add block"),
  * )
  */
-class GroupAddBlock extends BlockBase {
+class GroupAddBlock extends BlockBase implements BlockPluginInterface, ContainerFactoryPluginInterface {
+
+  /**
+   * The currently active route match object.
+   *
+   * @var \Drupal\Core\Routing\RouteMatchInterface
+   */
+  protected $routeMatch;
+
+  /**
+   * The current user.
+   *
+   * @var \Drupal\Core\Session\AccountProxyInterface
+   */
+  protected $currentUser;
+
+  /**
+   * The social group helper service.
+   *
+   * @var \Drupal\social_group\SocialGroupHelperService
+   */
+  protected $socialGroupHelper;
+
+  /**
+   * Constructs a GroupAddBlock object.
+   *
+   * @param array $configuration
+   *   The block configuration.
+   * @param string $plugin_id
+   *   The ID of the plugin.
+   * @param mixed $plugin_definition
+   *   The plugin definition.
+   * @param \Drupal\Core\Session\AccountProxyInterface $current_user
+   *   The current user.
+   * @param \Drupal\social_group\SocialGroupHelperService $social_group_helper
+   *   The social group helper service.
+   * @param \Drupal\Core\Routing\RouteMatchInterface $route_match
+   *   The currently active route match object.
+   */
+  public function __construct(
+    array $configuration,
+    $plugin_id,
+    $plugin_definition,
+    AccountProxyInterface $current_user,
+    SocialGroupHelperService $social_group_helper,
+    RouteMatchInterface $route_match) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+
+    $this->currentUser = $current_user;
+    $this->socialGroupHelper = $social_group_helper;
+    $this->routeMatch = $route_match;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('current_user'),
+      $container->get('social_group.helper_service'),
+      $container->get('current_route_match')
+    );
+  }
 
   /**
    * {@inheritdoc}
@@ -25,8 +97,7 @@ class GroupAddBlock extends BlockBase {
    * Custom access logic to display the block.
    */
   public function blockAccess(AccountInterface $account) {
-    $current_user = \Drupal::currentUser();
-    $route_user_id = \Drupal::routeMatch()->getParameter('user');
+    $route_user_id = $this->routeMatch->getParameter('user');
 
     // Show this block only on current user Groups page.
     $can_create_groups = FALSE;
@@ -37,7 +108,7 @@ class GroupAddBlock extends BlockBase {
         break;
       }
     }
-    if ($current_user->id() == $route_user_id && $can_create_groups) {
+    if ($account->id() == $route_user_id && $can_create_groups) {
       return AccessResult::allowed();
     }
 
@@ -50,9 +121,8 @@ class GroupAddBlock extends BlockBase {
    */
   public function build() {
     $build = [];
-
     // TODO: Add caching when closed groups will be added.
-    $url = Url::fromRoute('entity.group.add_page');
+    $url = $this->socialGroupHelper->getGroupsToAddUrl($this->currentUser) ?? Url::fromRoute('entity.group.add_page');
     $link_options = [
       'attributes' => [
         'class' => [
@@ -70,6 +140,21 @@ class GroupAddBlock extends BlockBase {
       ->toRenderable();
 
     return $build;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCacheContexts() {
+    // Vary caching of this block per user.
+    return Cache::mergeContexts(parent::getCacheContexts(), ['user']);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCacheTags() {
+    return Cache::mergeTags(parent::getCacheTags(), ['social_group_add_block:uid:' . $this->currentUser->id()]);
   }
 
 }


### PR DESCRIPTION
## Problem
"Add Group" block on /user/{uid}/groups on the current user project doesn't take the context of permissions which enables the user to add groups in the system. If the user has permission to create only one group, the + icon in the header takes directly to that group but Add block doesn't, it will take you to /group/add.

## Solution
Use the same logic to create the link as used here: https://github.com/goalgorilla/open_social/blob/8.x-9.x/modules/social_features/social_group/social_group.module#L1745

## Issue tracker
https://www.drupal.org/project/social/issues/3134100

## How to test
- [ ] Login as an authenticated user with permission to create 1 group.
- [ ] Go to "My groups" on your profile page
- [ ] Click on "Add block"
- [ ] You should be directed to /group/add/{group_type}
- [ ] Add more permissions to create another group
- [ ] Check "Add block" button URL
- [ ] You should be redirected to /group/add

## Screenshots
N.A

## Release notes
The Add Group block on the user profile page will now have a computed URL as per permission to create a group of the current user. It will have either of the two URLs
1. If user have permission to create only 1 group, URL will be /group/add/{group_type}
2. If the user has permissions to create more than 1 group, URL will be /group/add

## Change Record
The SocialGroupHelperService service will have a new function called getGroupsToAddUrl()  to return the group creation URL for a given account.

## Translations
N.A
