### PR TITLE
Issue TB-4384 by frankgraave: put original route and behaviour back f…

### DIFF
--- a/modules/social_features/social_event/modules/social_event_invite/src/Plugin/Block/SocialEventInviteLocalActionsBlock.php
+++ b/modules/social_features/social_event/modules/social_event_invite/src/Plugin/Block/SocialEventInviteLocalActionsBlock.php
@@ -119,7 +119,7 @@ class SocialEventInviteLocalActionsBlock extends BlockBase implements ContainerF
         '#links' => [
           'add_directly' => [
             'title' => $this->t('Add directly'),
-            'url' => Url::fromRoute('social_event_invite.invite_user', ['node' => $event->id()]),
+            'url' => Url::fromRoute('social_event_managers.add_enrollees', ['node' => $event->id()]),
           ],
           'invite_by_mail' => [
             'title' => $this->t('Invite by email'),


### PR DESCRIPTION
## Problem
The add directly button from the local actions block on manage enrollments was sending out invites instead of adding users directly, as the button implies.

## Solution
Put back the original route.

## Issue tracker
-

## How to test
- [ ] Create an event and make yourself organiser (also make sure social_event_invite is enabled)
- [ ] Go to the manage enrollments tab and use the "Add directly" from the dropdown
- [ ] See that the old behaviour is back in place again.

## Screenshots
-

## Release notes
-

## Change Record
-

## Translations
-
