### PR TITLE
Issue #3136189 by rolki: Changing visibility of content items for group doesn't work correctly with social_role_visibility because of hard-coded visibility options

### DIFF
--- a/modules/social_features/social_group/modules/social_group_flexible_group/src/FlexibleGroupContentVisibilityUpdate.php
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/src/FlexibleGroupContentVisibilityUpdate.php
@@ -9,6 +9,7 @@ use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Cache\Cache;
 use Drupal\social_post\Entity\Post;
 use Drupal\node\Entity\Node;
+use Drupal\user\RoleInterface;
 
 /**
  * Class FlexibleGroupContentVisibilityUpdate.
@@ -213,29 +214,36 @@ class FlexibleGroupContentVisibilityUpdate {
   public static function calculateVisibility($current_visibility, array $new_options) {
     // If there is only one option just return that one.
     if (count($new_options) === 1) {
-      return $new_options[0]['value'];
+      return reset($new_options)['value'];
+    }
+
+    /** @var \Drupal\user\RoleInterface $role */
+    $role = \Drupal::entityTypeManager()->getStorage('user_role')->load($current_visibility);
+    if ($role instanceof RoleInterface) {
+      return reset($new_options)['value'];
     }
 
     $visibility = '';
+    $option_values = array_column($new_options, 'value');
     // Calculate new options based on what it was before editting.
     switch ($current_visibility) {
       case 'community':
         $visibility = 'public';
-        if (array_search('group', array_column($new_options, 'value')) !== FALSE) {
+        if (in_array('group', $option_values)) {
           $visibility = 'group';
         }
         break;
 
       case 'public':
         $visibility = 'group';
-        if (array_search('community', array_column($new_options, 'value')) !== FALSE) {
+        if (in_array('community', $option_values)) {
           $visibility = 'community';
         }
         break;
 
       case 'group':
         $visibility = 'public';
-        if (array_search('community', array_column($new_options, 'value')) !== FALSE) {
+        if (in_array('community', $option_values)) {
           $visibility = 'community';
         }
         break;

--- a/modules/social_features/social_post/src/Entity/Post.php
+++ b/modules/social_features/social_post/src/Entity/Post.php
@@ -182,7 +182,8 @@ class Post extends ContentEntityBase implements PostInterface {
               ->execute();
             $role_id = reset($roles);
             // If role_id is empty it means we have an uninspected visibility
-            // option, because this option does not default and not from the role.
+            // option, because this option does not default and not from
+            // the role.
             if (!empty($role_id)) {
               $visibility = $role_id;
             }


### PR DESCRIPTION
## Problem
After installing the social_role_visibility module, adding a new role as visibility option, then go to flexible group and for example choose a role as visibility option and uncheck all other options, and this case visibility options for group content should be changed automatically to role visibility, but it's doesn't work because of hard-coded options in the distro.

## Solution
Add role visibility support to the distro.

## Issue tracker
https://www.drupal.org/project/social/issues/3136189

## How to test
Create a new role and choose this role as visibility option, then go to some flexible group and check the role as visibility option and uncheck all other options, and this case visibility options for group content should be changed automatically to role visibility.
