### PR TITLE
Issue #3136540 by navneet0693: Added configuration override for sending notification to group manager in flexible & secret groups.

### DIFF
--- a/modules/social_features/social_core/social_core.install
+++ b/modules/social_features/social_core/social_core.install
@@ -1005,7 +1005,7 @@ function social_core_update_8803() {
   activity_creator_set_entity_view_mode('node', 'activity');
 }
 
-  /**
+/**
  * Allow site managers to use contextual links.
  */
 function social_core_update_8804() {

--- a/modules/social_features/social_group/modules/social_group_flexible_group/src/SocialGroupFlexibleGroupConfigOverride.php
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/src/SocialGroupFlexibleGroupConfigOverride.php
@@ -271,6 +271,16 @@ class SocialGroupFlexibleGroupConfigOverride implements ConfigFactoryOverrideInt
         ];
     }
 
+    // Send a notification when a person joins flexible groups.
+    $config_name = 'message.template.join_to_group';
+
+    if (in_array($config_name, $names, FALSE)) {
+      $overrides[$config_name]['third_party_settings']['activity_logger']['activity_bundle_entities'] =
+        [
+          'group_content-flexible_group-group_membership' => 'group_content-flexible_group-group_membership',
+        ];
+    }
+
     $config_name = 'views.view.group_managers';
 
     if (in_array($config_name, $names, FALSE)) {

--- a/modules/social_features/social_group/modules/social_group_secret/src/SocialGroupSecretConfigOverride.php
+++ b/modules/social_features/social_group/modules/social_group_secret/src/SocialGroupSecretConfigOverride.php
@@ -167,6 +167,16 @@ class SocialGroupSecretConfigOverride implements ConfigFactoryOverrideInterface 
         ];
     }
 
+    // Send a notification when a person joins secret groups.
+    $config_name = 'message.template.join_to_group';
+
+    if (in_array($config_name, $names, FALSE)) {
+      $overrides[$config_name]['third_party_settings']['activity_logger']['activity_bundle_entities'] =
+        [
+          'group_content-secret_group-group_membership' => 'group_content-secret_group-group_membership',
+        ];
+    }
+
     $config_name = 'views.view.newest_groups';
 
     $displays = [


### PR DESCRIPTION
## Problem
Group Manager doesn't receive a notification when someone joins the group of type "Flexible groups".

## Solution
Add configuration override to add the flexible group in this configuration https://github.com/goalgorilla/open_social/blob/8.x-9.x/modules/social_features/social_activity/config/install/message.template.join_to_group.yml#L8 for adding flexible groups as well.

Do the same for secret groups too.

## Issue tracker
https://www.drupal.org/project/social/issues/3136540

## How to test
- [ ] Login as User A
- [ ] Create a flexible group
- [ ] Login as User B and join the group created above
- [ ] Run cron
- [ ] User A should receive notification of User B joining the group
- [ ] Repeat for Secret group

## Screenshots
![image](https://user-images.githubusercontent.com/8435994/81944914-af633380-95fd-11ea-9210-19e4643c278e.png)


## Release notes
Flexible and Secret Group Manager will receive a notification when someone joins the group.

## Change Record
N.A

## Translations
N.A
