### PR TITLE
Issue #3136973 by agami4: Decrease min-height of teaser title

### DIFF
--- a/themes/socialbase/assets/css/teaser.css
+++ b/themes/socialbase/assets/css/teaser.css
@@ -53,7 +53,7 @@
 .teaser__title {
   margin-top: 0;
   margin-bottom: 20px;
-  max-height: 2.5em;
+  max-height: 2.3em;
   overflow: hidden;
 }
 

--- a/themes/socialbase/components/03-molecules/teaser/teaser.scss
+++ b/themes/socialbase/components/03-molecules/teaser/teaser.scss
@@ -103,7 +103,7 @@
 .teaser__title {
   margin-top: 0;
   margin-bottom: 20px;
-  max-height: 2.5em;
+  max-height: 2.3em;
   overflow: hidden;
 }
 


### PR DESCRIPTION
## Problem
Titles for discussions and groups get cut on the third line

## Solution
Decrease min-height of the title

## Issue tracker
https://getopensocial.atlassian.net/browse/YANG-2937
https://www.drupal.org/project/social/issues/3136973

## How to test
- [ ] Go to /all-groups page

## Screenshots
before:
<img width="866" alt="Screenshot at May 15 15-17-27" src="https://user-images.githubusercontent.com/16086340/82054445-a2ab1200-96c7-11ea-9c2d-d84e2c77f76d.png">

after:
<img width="856" alt="Screenshot at May 15 16-17-38" src="https://user-images.githubusercontent.com/16086340/82054453-a5a60280-96c7-11ea-9dd2-50fd8afccbfb.png">

## Release notes
Decrease min-height of the title
