### PR TITLE
TB-4383: Added cache context of current node to social invite action block

### DIFF
--- a/modules/social_features/social_event/modules/social_event_invite/config/optional/block.block.socialeventinviteblock.yml
+++ b/modules/social_features/social_event/modules/social_event_invite/config/optional/block.block.socialeventinviteblock.yml
@@ -17,6 +17,8 @@ settings:
   label: 'Social Event Invite block'
   provider: social_event_invite
   label_display: '0'
+  context_mapping:
+    node: '@node.node_route_context:node'
 visibility:
   request_path:
     id: request_path

--- a/modules/social_features/social_event/modules/social_event_invite/config/update/social_event_invite_update_8001.yml
+++ b/modules/social_features/social_event/modules/social_event_invite/config/update/social_event_invite_update_8001.yml
@@ -1,0 +1,7 @@
+block.block.socialeventinviteblock:
+  expected_config: {  }
+  update_actions:
+    add:
+      settings:
+        context_mapping:
+          node: '@node.node_route_context:node'

--- a/modules/social_features/social_event/modules/social_event_invite/social_event_invite.install
+++ b/modules/social_features/social_event/modules/social_event_invite/social_event_invite.install
@@ -44,3 +44,17 @@ function social_event_invite_uninstall() {
     }
   }
 }
+
+/**
+ * Added node context to the social invite block to vary results.
+ */
+function social_event_invite_update_8001() {
+  /** @var \Drupal\update_helper\Updater $updateHelper */
+  $updateHelper = \Drupal::service('update_helper.updater');
+
+  // Execute configuration update definitions with logging of success.
+  $updateHelper->executeUpdate('social_event_invite', 'social_event_invite_update_8001');
+
+  // Output logged messages to related channel of update execution.
+  return $updateHelper->logger()->output();
+}

--- a/modules/social_features/social_event/modules/social_event_invite/social_event_invite.module
+++ b/modules/social_features/social_event/modules/social_event_invite/social_event_invite.module
@@ -11,6 +11,7 @@ use Drupal\Core\Cache\RefinableCacheableDependencyInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Url;
+use Drupal\node\Entity\Node;
 use Drupal\social_event\EventEnrollmentInterface;
 use Drupal\user\UserInterface;
 
@@ -152,13 +153,14 @@ function social_event_invite_preprocess_views_view(&$variables) {
     $access = $access->eventFeatureAccess();
 
     if (!$access instanceof AccessResultForbidden) {
-      $entity = \Drupal::entityTypeManager()->getStorage('block')
-        ->load('socialeventinviteblock');
+      // Add the roster-link block to the build-array.
+      /** @var \Drupal\social_event_invite\Plugin\Block\SocialEventInviteLocalActionsBlock $block */
+      $block = \Drupal::service('plugin.manager.block')
+        ->createInstance('social_event_invite_block');
 
-      if (NULL !== $entity) {
-        $block_content = \Drupal::entityTypeManager()
-          ->getViewBuilder('block')
-          ->view($entity);
+      if (NULL !== $block) {
+        $block->setContextValue('node', Node::load(\Drupal::routeMatch()->getParameter('node')));
+        $block_content = $block->build();
 
         if (!empty($block_content)) {
           $variables['header']['actions'] = $block_content;

--- a/modules/social_features/social_event/modules/social_event_invite/src/Plugin/Block/SocialEventInviteLocalActionsBlock.php
+++ b/modules/social_features/social_event/modules/social_event_invite/src/Plugin/Block/SocialEventInviteLocalActionsBlock.php
@@ -13,7 +13,6 @@ use Drupal\Core\Url;
 use Drupal\node\NodeInterface;
 use Drupal\social_event_invite\SocialEventInviteAccessHelper;
 use Symfony\Component\DependencyInjection\ContainerInterface;
-use Drupal\node\Entity\Node;
 
 /**
  * Provides a 'SocialEventInviteLocalActionsBlock' block.
@@ -21,6 +20,9 @@ use Drupal\node\Entity\Node;
  * @Block(
  *  id = "social_event_invite_block",
  *  admin_label = @Translation("Social Event Invite block"),
+ *   context = {
+ *     "node" = @ContextDefinition("entity:node", label = @Translation("Node"), required = FALSE)
+ *   }
  * )
  */
 class SocialEventInviteLocalActionsBlock extends BlockBase implements ContainerFactoryPluginInterface {
@@ -90,23 +92,11 @@ class SocialEventInviteLocalActionsBlock extends BlockBase implements ContainerF
   /**
    * {@inheritdoc}
    */
-  public function getCacheContexts() {
-    $cache_contexts = parent::getCacheContexts();
-    $cache_contexts[] = 'user';
-    return $cache_contexts;
-  }
-
-  /**
-   * {@inheritdoc}
-   */
   public function build() {
     $build = [];
 
-    // Get current group so we can build correct links.
-    $event = $this->routeMatch->getParameter('node');
-    $event = Node::load($event);
-
-    // Todo:: not needed because we get parameter from node anyway?
+    // Get current node so we can build correct links.
+    $event = $this->getContextValue('node');
     if ($event instanceof NodeInterface) {
       $links = [
         '#type' => 'dropbutton',
@@ -133,8 +123,11 @@ class SocialEventInviteLocalActionsBlock extends BlockBase implements ContainerF
       ];
 
       $build['content'] = $links;
+      $build['#cache'] = [
+        'keys' => ['social_event_invite_block', 'node', $event->id()],
+        'contexts' => ['user'],
+      ];
     }
-
     return $build;
   }
 


### PR DESCRIPTION
## Problem
Blalla event invite this that

## Solution
Add cache context of current node to block.

## Issue tracker
https://github.com/goalgorilla/open_social/pull/1782