### PR TITLE
Issue #2995501: Group filters show values that a user does not need access to

### DIFF
--- a/modules/social_features/social_group/social_group.module
+++ b/modules/social_features/social_group/social_group.module
@@ -1895,14 +1895,14 @@ function social_group_can_view_groups_of_type(string $type, AccountInterface $ac
   // Authenticated is a locked Role,
   // So first we check outsiders also easier on the performance :)
   $outsider = $group_type->getOutsiderRole();
-  if (NULL !== $outsider && $outsider->hasPermission('view group'))  {
+  if (NULL !== $outsider && $outsider->hasPermission('view group')) {
     return TRUE;
   }
 
   // If members can see it, we also need to show group types because
   // we are not calculation memberships.
   $member = $group_type->getMemberRole();
-  if (NULL !== $member && $member->hasPermission('view group'))  {
+  if (NULL !== $member && $member->hasPermission('view group')) {
     return TRUE;
   }
 

--- a/modules/social_features/social_group/social_group.module
+++ b/modules/social_features/social_group/social_group.module
@@ -1396,7 +1396,7 @@ function social_group_block_access(Block $block, $operation, AccountInterface $a
  * @return int
  *   The amount of group_types
  */
-function _social_group_get_current_group_types($account) {
+function _social_group_get_current_group_types(AccountInterface $account) {
   $group_types = 0;
 
   /** @var \Drupal\group\Entity\GroupTypeInterface $group_type */
@@ -1406,7 +1406,6 @@ function _social_group_get_current_group_types($account) {
 
   return $group_types;
 }
-
 
 /**
  * Delete the group and all of its content.

--- a/modules/social_features/social_group/social_group.module
+++ b/modules/social_features/social_group/social_group.module
@@ -745,6 +745,7 @@ function social_group_form_alter(&$form, FormStateInterface $form_state, $form_i
   if ($form['#id'] === 'views-exposed-form-newest-groups-page-all-groups' ||
   $form['#id'] === 'views-exposed-form-search-groups-page-no-value' ||
   $form['#id'] === 'views-exposed-form-search-groups-page') {
+    $account = \Drupal::currentUser();
     if (!empty($form['type']['#options'])) {
       foreach ($form['type']['#options'] as $type => $label) {
         // All / Any we can skip they are optional translatable options
@@ -752,7 +753,7 @@ function social_group_form_alter(&$form, FormStateInterface $form_state, $form_i
         if ($label instanceof TranslatableMarkup) {
           continue;
         }
-        if (!social_group_can_view_groups_of_type($type, \Drupal::currentUser())) {
+        if (!social_group_can_view_groups_of_type($type, $account)) {
           unset($form['type']['#options'][$type]);
         }
       }
@@ -1341,14 +1342,9 @@ function social_group_block_access(Block $block, $operation, AccountInterface $a
   // Check access for AN and LU, if only one group type is available
   // we can remove the filter block.
   if ($block->getPluginId() == 'views_exposed_filter_block:newest_groups-page_all_groups' && $operation == 'view') {
-    $group_types = 0;
+    $user_grouptypes = _social_group_get_current_group_types($account);
 
-    /** @var \Drupal\group\Entity\GroupTypeInterface $group_type */
-    foreach (GroupType::loadMultiple() as $group_type) {
-      $group_types += (int) social_group_can_view_groups_of_type($group_type->id(), $account);
-    }
-
-    if ($group_types < 2) {
+    if ($user_grouptypes < 2) {
       return AccessResult::forbidden();
     }
   }
@@ -1390,6 +1386,27 @@ function social_group_block_access(Block $block, $operation, AccountInterface $a
 
   return AccessResult::neutral();
 }
+
+/**
+ * Determine the amount of group_types a user can see.
+ *
+ * @param \Drupal\Core\Session\AccountInterface $account
+ *   The user to check for.
+ *
+ * @return int
+ *   The amount of group_types
+ */
+function _social_group_get_current_group_types($account) {
+  $group_types = 0;
+
+  /** @var \Drupal\group\Entity\GroupTypeInterface $group_type */
+  foreach (GroupType::loadMultiple() as $group_type) {
+    $group_types += (int) social_group_can_view_groups_of_type($group_type->id(), $account);
+  }
+
+  return $group_types;
+}
+
 
 /**
  * Delete the group and all of its content.

--- a/modules/social_features/social_group/social_group.module
+++ b/modules/social_features/social_group/social_group.module
@@ -1339,16 +1339,6 @@ function social_group_block_access(Block $block, $operation, AccountInterface $a
     return AccessResult::neutral();
   }
 
-  // Check access for AN and LU, if only one group type is available
-  // we can remove the filter block.
-  if ($block->getPluginId() == 'views_exposed_filter_block:newest_groups-page_all_groups' && $operation == 'view') {
-    $user_grouptypes = _social_group_get_current_group_types($account);
-
-    if ($user_grouptypes < 2) {
-      return AccessResult::forbidden();
-    }
-  }
-
   $group = _social_group_get_current_group();
   $user = Drupal::currentUser();
   // Check if there is a group set and if its an closed group.

--- a/modules/social_features/social_group/social_group.module
+++ b/modules/social_features/social_group/social_group.module
@@ -740,6 +740,24 @@ function social_group_form_alter(&$form, FormStateInterface $form_state, $form_i
     $form['field_group_allowed_join_method']['widget']['#type'] = 'radios';
     $form['field_group_allowed_join_method']['widget']['#default_value'] = $join_method_default_value;
   }
+
+  // Exposed Filter block on the all-groups overview.
+  if ($form['#id'] === 'views-exposed-form-newest-groups-page-all-groups' ||
+  $form['#id'] === 'views-exposed-form-search-groups-page-no-value' ||
+  $form['#id'] === 'views-exposed-form-search-groups-page') {
+    if (!empty($form['type']['#options'])) {
+      foreach ($form['type']['#options'] as $type => $label) {
+        // All / Any we can skip they are optional translatable options
+        // and not group types.
+        if ($label instanceof TranslatableMarkup) {
+          continue;
+        }
+        if (!social_group_can_view_groups_of_type($type, \Drupal::currentUser())) {
+          unset($form['type']['#options'][$type]);
+        }
+      }
+    }
+  }
 }
 
 /**
@@ -1243,6 +1261,20 @@ function social_group_block_view_local_tasks_block_alter(array &$build, BlockPlu
 }
 
 /**
+ * Implements hook_block_build_alter().
+ */
+function social_group_block_build_alter(array &$build, BlockPluginInterface $block) {
+  if (!empty($block->getPluginId()) &&
+    ($block->getPluginId() === 'views_exposed_filter_block:newest_groups-page_all_groups' ||
+    $block->getPluginId() === 'views_exposed_filter_block:search_groups-page')) {
+    // The Group Type filter has to listen to changes in
+    // group type role permissions. Using the role list ensures
+    // it's cleared correctly.
+    $build['#cache']['tags'][] = 'config:group_role_list';
+  }
+}
+
+/**
  * Implements hook_preprocess_HOOK().
  */
 function social_group_preprocess_profile(&$variables) {
@@ -1306,12 +1338,14 @@ function social_group_block_access(Block $block, $operation, AccountInterface $a
     return AccessResult::neutral();
   }
 
-  if ($block->getPluginId() == 'views_exposed_filter_block:newest_groups-page_all_groups' && $operation == 'view' && $account->isAnonymous()) {
+  // Check access for AN and LU, if only one group type is available
+  // we can remove the filter block.
+  if ($block->getPluginId() == 'views_exposed_filter_block:newest_groups-page_all_groups' && $operation == 'view') {
     $group_types = 0;
 
     /** @var \Drupal\group\Entity\GroupTypeInterface $group_type */
     foreach (GroupType::loadMultiple() as $group_type) {
-      $group_types += (int) $group_type->getAnonymousRole()->hasPermission('view group');
+      $group_types += (int) social_group_can_view_groups_of_type($group_type->id(), $account);
     }
 
     if ($group_types < 2) {
@@ -1839,7 +1873,7 @@ function social_group_can_view_groups_of_type(string $type, AccountInterface $ac
   $group_type = GroupType::load($type);
 
   // If the group type doesn't exist then the user can't see the group type.
-  if ($group_type === FALSE) {
+  if ($group_type === FALSE || $group_type === NULL) {
     return FALSE;
   }
 
@@ -1858,8 +1892,23 @@ function social_group_can_view_groups_of_type(string $type, AccountInterface $ac
 
   $user_roles = $account->getRoles(TRUE);
 
+  // Authenticated is a locked Role,
+  // So first we check outsiders also easier on the performance :)
+  $outsider = $group_type->getOutsiderRole();
+  if (NULL !== $outsider && $outsider->hasPermission('view group'))  {
+    return TRUE;
+  }
+
+  // If members can see it, we also need to show group types because
+  // we are not calculation memberships.
+  $member = $group_type->getMemberRole();
+  if (NULL !== $member && $member->hasPermission('view group'))  {
+    return TRUE;
+  }
+
   // Check each role this user has whether its group counterpart has the correct
-  // permission.
+  // permission. This counts for the advanced group permissions.
+  // Admin, SM, CM.
   foreach ($user_roles as $role) {
     $group_role = $group_role_synchroniser->getGroupRoleId($type, $role);
     if ($group_roles[$group_role]->hasPermission('view group')) {


### PR DESCRIPTION
## Problem
On the all groups page if a user has access to two different types of groups then the user can filter on all group types. Even if he/she does not have access to a certain group type.

## Solution
We need to ensure we check the current user roles, and see if any of those roles have acces to the 'view group' permission of a certain group type if that its the case we can show the filter option.

The way it's done is the following.

1. If AN can see the groups of a group type - We show the filter
2. If group type has a outsider role and that role can see the groups of a group type  - We show the filter
3. If group type has a member role and that role can see the groups of a group type  - We show the filter (This is necessary so we don't need to invalidate caches or calculate which group a user belongs to every time he joins / leaves a group. Once a member can see it and a user can potentially become a member it's good enough for us to show the filter option)
4. For all the group type advanced outsider roles matching any of the user roles, and that role can see the groups of a group type we show the filter.
For example the Administrator, CM, SM roles can have view group permissions while the rest doesn't. We show the filter option as well.

## Issue tracker
https://www.drupal.org/project/social/issues/2995501

## How to test
- [x] See that for AN users on the Group search and the All Groups overview the filter block only shows the group types Anonymous users have "view group" permissions for. You can play around with this by going to for example
`/admin/group/types/manage/closed_group/permissions`
Enable the General " View group " permission for anonymous to see the filter option becomes available. 
- [x] See for secret groups nothing breaks so access checks are still in place
- [x] See that for SM / CM you can change the advanced outsider permissions and they work
- [x] See that if there is only one group type you can filter, the block is removed. One option doesn't make sense.

## Release notes
On the search groups and all groups page we now ensure you can only filter on group types of groups you are able to see. 

