### PR TITLE
Elaborate in pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,23 +1,29 @@
 ## Problem
-<describe the problem you're trying to solve>
+*Describe the problem you're trying to solve, this should motivate why the changes you're proposing are needed.*
 
 ## Solution
-<describe the solution you're created>
+*Describe the solution you've created, elaborate on any technical choices you've made. Why is this the right solution and is a different solution not the right one?*
 
 ## Issue tracker
-<paste a link to the drupal.org issue queue item, or any other issue tracker if applicable>
+*Paste a link to the drupal.org issue queue item. If any other issue trackers were used, include links to those too.*
 
 ## How to test
-- [ ] <enter multiple how to test steps here>
+*For example*
+- [ ] Using version X.Y.Z of Open Social with the example module enabled
+- [ ] As a sitemanager
+- [ ] Try to enable the option B on screen c/d/e
+- [ ] When saving I expect the result to be F but instead see G.
+- [ ] The expected result F is attained when repeating the steps with this fix applied.
 
 ## Screenshots
-If this Pull Request makes visual changes then please include some screenshots that show what has changed here. 
+*If this Pull Request makes visual changes then please include some screenshots that show what has changed here. A before and after screenshot helps the reviewer determine what changes were made.*
 
 ## Release notes
-<describe the release notes>
+*A short summary of the changes that were made that can be included in release notes.*
 
 ## Change Record
-If this Pull Request changes the way that developers should do things or introduces a new API for developers then a change record to document this is needed. Please provide a draft for a change record or a link to an unpublished change record below. [Existing change records](https://www.drupal.org/list-changes/social) can be consulted as example.
+*If this Pull Request changes the way that developers should do things or introduces a new API for developers then a change record to document this is needed. Please provide a draft for a change record or a link to an unpublished change record below. [Existing change records](https://www.drupal.org/list-changes/social) can be consulted as example.*
 
 ## Translations
+*Translatable strings are always extracted from the latest development branch. To ensure translations remain available for platforms running older versions of Open Social the original string should be added to `translations.php` when it's changed or removed.*
 - [ ] Changed or removed source strings are added to the `translations.php` file.


### PR DESCRIPTION
## Problem
It's not always clear for developers what the intention is of the headings in the pull request template. This causes information that can be useful to reviewers to be missed.

## Solution
Be more elaborate in the pull request template. Prompting the developer for the information that's expected and providing some examples.

A full How to test is included because it's sometimes difficult to determine the level of details required.

The issue link section is clarified to show that a Drupal.org issue is always needed for release management and links to other issue trackers are additions, not substitutions.

The screenshots section shows what a screenshot could be made of.

The release notes described better what they actually are.

The translations section now explains why it's there to guide developers in whether it's necessary or not.

## Issue tracker
GitHub only change not needed for the release notes so Drupal.org issue omitted.

## How to test

- [ ] Ask a developer to make a pull request with the new template
- [ ] I expect it to be a subjective improvement over previous pull requests by that same developer
