### PR TITLE
#3119327: Make the confirmation join text more meaningful for users accepting an invite to a group

### DIFF
--- a/modules/social_features/social_group/social_group.module
+++ b/modules/social_features/social_group/social_group.module
@@ -611,9 +611,17 @@ function social_group_form_alter(&$form, FormStateInterface $form_state, $form_i
 
   // Set some helpful text on the group join form now it's there.
   if (in_array($form_id, $join_forms)) {
+    $markup = t('By submitting this form you will become a member of the group. Please fill out any available fields to complete your membership information.');
+
+    // When the user is accepting an invite, change the text to something more
+    // meaningful.
+    if (\Drupal::routeMatch()->getRouteName() === 'ginvite.invitation.accept') {
+      $markup = t('Are you sure to accept the invitation and join this group? You can leave this group at any time.');
+    }
+
     $form['help'] = [
       '#type' => 'item',
-      '#markup' => t('By submitting this form you will become a member of the group. Please fill out any available fields to complete your membership information.'),
+      '#markup' => $markup,
     ];
     $form['path']['#type'] = 'hidden';
   }


### PR DESCRIPTION
## Problem
![Screenshot 2020-05-22 at 13 39 26](https://user-images.githubusercontent.com/7124754/82664661-79900180-9c32-11ea-90ed-6973bcedc46d.png)
The above text does not refer to the user accepting an invite.

## Solution
By altering the text when someone accepts an invite it is clearer for the user what is about to happen.

![Screenshot 2020-05-22 at 13 35 59](https://user-images.githubusercontent.com/7124754/82664811-d55a8a80-9c32-11ea-81d4-b71c0f738091.png)

## Issue tracker
https://www.drupal.org/project/social/issues/3119327

## How to test
- [ ] Enable the `social_group_invite`
- [ ] Create a group where users can join directly
- [ ] Join the group as a normal user, observe that you see the original text
- [ ] Invite a different user as the group manager
- [ ] Observe that when the invitee accepts to join the group the text is more meaningful

## Screenshots
N/a

## Release notes
N/a, should be part of the Group Invite feature.

## Translations
N/a
