### PR TITLE
TB-4416 - Add directly page access

### DIFF
--- a/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.module
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.module
@@ -147,7 +147,9 @@ function social_group_flexible_group_can_join_directly(Group $group) {
 function social_group_flexible_group_can_be_added(Group $group) {
   $join_methods = $group->get('field_group_allowed_join_method')->getValue();
 
-  if (!in_array('added', array_column($join_methods, 'value'), FALSE)) {
+  $allowed_methods = ['added', 'drect'];
+
+  if (count(array_intersect($allowed_methods, array_column($join_methods, 'value'))) === 0) {
     return FALSE;
   }
 

--- a/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.module
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.module
@@ -147,9 +147,7 @@ function social_group_flexible_group_can_join_directly(Group $group) {
 function social_group_flexible_group_can_be_added(Group $group) {
   $join_methods = $group->get('field_group_allowed_join_method')->getValue();
 
-  $allowed_methods = ['added', 'drect'];
-
-  if (count(array_intersect($allowed_methods, array_column($join_methods, 'value'))) === 0) {
+  if (!in_array('added', array_column($join_methods, 'value'), FALSE)) {
     return FALSE;
   }
 

--- a/modules/social_features/social_group/modules/social_group_flexible_group/src/Access/FlexibleGroupJoinPermissionAccessCheck.php
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/src/Access/FlexibleGroupJoinPermissionAccessCheck.php
@@ -69,6 +69,11 @@ class FlexibleGroupJoinPermissionAccessCheck implements AccessInterface {
       return AccessResult::allowedIf($condition1 || $condition2)->addCacheableDependency($group);
     }
 
+    // GM is allowed to go to Add Directly page, adding new members directly.
+    if ($permission === 'join added' && $group->hasPermission('administer members', $account)) {
+      return AccessResult::allowed()->addCacheableDependency($group);
+    }
+
     // A user with this access can definitely do everything.
     if ($account->hasPermission('manage all groups')) {
       return AccessResult::allowed()->addCacheableDependency($group);


### PR DESCRIPTION
## Problem
A user with sufficient access has no access to add people to a group directly; he / she will be refused access because of access checks.

## Solution
When a user has sufficient rights to a group and wants to add people directly to the group, we will now grant this person access.

## How to test
*For example*
- [x] Login as a GM and go to your group
- [x] Go to `group/{{GROUP ID}}/content/add/group_membership`
- [x] See that you are able to access this page and that you can add people to your group.

## Release notes
*A group manager is now able to add people to his/her flexible group directly.*