### PR TITLE
Issue #3120797 by bramtenhove: Fix typo in the invite confirmation dialog

### DIFF
--- a/modules/social_features/social_event/modules/social_event_invite/src/Form/EnrollInviteConfirmForm.php
+++ b/modules/social_features/social_event/modules/social_event_invite/src/Form/EnrollInviteConfirmForm.php
@@ -174,7 +174,7 @@ class EnrollInviteConfirmForm extends FormBase {
     $form['question'] = [
       '#type' => 'html_tag',
       '#tag' => 'p',
-      '#value' => $this->t('Are you sure you want to send a invitation to all @questionType listed bellow?', ['@questionType' => $questionType]),
+      '#value' => $this->t('Are you sure you want to send an invitation to all @questionType listed below?', ['@questionType' => $questionType]),
       '#weight' => 1,
       '#prefix' => '<div class="card"><div class="card__block">',
       '#suffix' => '</div></div>',


### PR DESCRIPTION
## Problem
There are 2 typo's in the confirmation dialog screen when inviting users to an event.

## Solution
Fixed the typo's.

## Issue tracker
https://www.drupal.org/project/social/issues/3120797

## How to test
- [ ] Invite a user to your event
- [ ] Observe that in the confirmation dialog the text is grammatically correct

## Release notes
N/a, part of #1782.

## Change Record
N/a

## Translations
N/a