### PR TITLE
#3120797: Change the 'cancel enrollment by event manager' to Declined instead of Invalidd/Expired

### DIFF
--- a/modules/social_features/social_event/modules/social_event_invite/src/Controller/CancelEnrollInviteController.php
+++ b/modules/social_features/social_event/modules/social_event_invite/src/Controller/CancelEnrollInviteController.php
@@ -75,7 +75,7 @@ class CancelEnrollInviteController extends ControllerBase {
     if ($node instanceof Node && !empty($event_enrollment)) {
       // When the event owner/organizer cancelled the invite, update the status
       // and set a message for the executor that it has been done.
-      $event_enrollment->field_request_or_invite_status->value = EventEnrollmentInterface::INVITE_INVALID_OR_EXPIRED;
+      $event_enrollment->field_request_or_invite_status->value = EventEnrollmentInterface::REQUEST_OR_INVITE_DECLINED;
       $this->messenger()->addStatus(t('The event enrollment request has been declined.'));
 
       // In order for the notifications to be sent correctly we're updating the


### PR DESCRIPTION
## Problem
When cancelling an invite as the event organizer I get the confirmation that the invite is declined. However the status message shows it is "Invalid or expired".

<img width="1226" alt="Screenshot 2020-05-25 at 13 26 36" src="https://user-images.githubusercontent.com/7124754/82808990-662ba300-9e8b-11ea-9fc0-13e89f757484.png">

## Solution
Change the status message to "Declined".

<img width="1232" alt="Screenshot 2020-05-25 at 13 26 21" src="https://user-images.githubusercontent.com/7124754/82809011-70e63800-9e8b-11ea-9e93-0d1e5299dd68.png">

## Issue tracker
https://www.drupal.org/project/social/issues/3120797

## How to test
- [ ] Invite someone to your event.
- [ ] Cancel the invite.
- [ ] Observe that the status text is correct.

## Screenshots
N/a

## Release notes
N/a, part of #1782.

## Change Record
N/a

## Translations
N.a