### PR TITLE
Issue #3120797 by bramtenhove: Allow event owners to add users directly

### DIFF
--- a/modules/social_features/social_event/modules/social_event_managers/src/SocialEventManagersAccessHelper.php
+++ b/modules/social_features/social_event/modules/social_event_managers/src/SocialEventManagersAccessHelper.php
@@ -21,6 +21,11 @@ class SocialEventManagersAccessHelper {
       if ($node->getType() === 'event') {
         // Only continue if the user has access to view the event.
         if ($node->access('view', $account)) {
+          // The owner has access.
+          if ($account->id() === $node->getOwnerId()) {
+            return 2;
+          }
+
           $event_managers = $node->get('field_event_managers')->getValue();
 
           foreach ($event_managers as $event_manager) {


### PR DESCRIPTION
##  Problem
The event owner was not able to add user directly to his event.

The access checks were written only for event managers. Not all event managers are also the owner.

## Solution
Allow event owner access to the "add directly" page.

## Issue tracker
https://www.drupal.org/project/social/issues/3120797

## How to test
- [ ] As the event owner (not being an event manager) go to the "add directly" page
- [ ] You should see the page you are expecting

## Screenshots
N/a

## Release notes
N/a, part of #1782 

## Change Record
N/a

## Translations
N/a