### PR TITLE
#3120797: Prevent double notifications

### DIFF
--- a/modules/custom/activity_basics/src/Plugin/ActivityAction/CreateActivityAction.php
+++ b/modules/custom/activity_basics/src/Plugin/ActivityAction/CreateActivityAction.php
@@ -3,10 +3,10 @@
 namespace Drupal\activity_basics\Plugin\ActivityAction;
 
 use Drupal\activity_creator\Plugin\ActivityActionBase;
-use Drupal\node\Entity\Node;
+use Drupal\node\NodeInterface;
 
 /**
- * Provides a 'CreateActivityAction' acitivy action.
+ * Provides a 'CreateActivityAction' activity action.
  *
  * @ActivityAction(
  *  id = "create_entitiy_action",
@@ -24,7 +24,7 @@ class CreateActivityAction extends ActivityActionBase {
 
       // For nodes we make an exception, since they are potentially placed in
       // groups, which we cannot know here yet.
-      if ($entity instanceof Node) {
+      if ($entity instanceof NodeInterface) {
         $data['entity_id'] = $entity->id();
         $queue = \Drupal::queue('activity_logger_message');
         $queue->createItem($data);

--- a/modules/custom/activity_basics/src/Plugin/ActivityContext/EventRequestActivityContext.php
+++ b/modules/custom/activity_basics/src/Plugin/ActivityContext/EventRequestActivityContext.php
@@ -88,7 +88,7 @@ class EventRequestActivityContext extends ActivityContextBase {
         $event_enrollment = $this->entityTypeManager->getStorage('event_enrollment')
           ->load($enrollment_id);
 
-        if (!empty($event_enrollment)) {
+        if ($event_enrollment instanceof EventEnrollmentInterface) {
           // Send out the notification if the user is pending.
           if (!$event_enrollment->get('field_enrollment_status')->isEmpty()
             && $event_enrollment->get('field_enrollment_status')->value === '0'

--- a/modules/custom/activity_basics/src/Plugin/ActivityContext/OwnerActivityContext.php
+++ b/modules/custom/activity_basics/src/Plugin/ActivityContext/OwnerActivityContext.php
@@ -83,6 +83,13 @@ class OwnerActivityContext extends ActivityContextBase {
       $storage = $this->entityTypeManager->getStorage($original_related_object['target_type']);
       $original_related_entity = $storage->load($original_related_object['target_id']);
 
+      // In the case where a user is added by an event manager we'll need to
+      // check on the enrollment status. If the user is not really enrolled we
+      // should skip sending the notification.
+      if ($original_related_entity->get('field_enrollment_status')->value === '0') {
+        return $recipients;
+      }
+
       if (!empty($original_related_entity) && $original_related_entity->getAccount() !== NULL) {
         $recipients[] = [
           'target_type' => 'user',

--- a/modules/custom/activity_creator/src/ActivityFactory.php
+++ b/modules/custom/activity_creator/src/ActivityFactory.php
@@ -9,6 +9,7 @@ use Drupal\Core\Render\BubbleableMetadata;
 use Drupal\language\ConfigurableLanguageManagerInterface;
 use Drupal\message\Entity\Message;
 use Drupal\activity_creator\Plugin\ActivityDestinationManager;
+use Drupal\social_event\EventEnrollmentInterface;
 
 /**
  * Class ActivityFactory to create Activity items based on ActivityLogs.
@@ -316,7 +317,7 @@ class ActivityFactory extends ControllerBase {
         ->getStorage($related_object['target_type']);
       $entity = $entity_storage->load($related_object['target_id']);
 
-      if (!empty($entity)) {
+      if ($entity instanceof EventEnrollmentInterface) {
         /** @var \Drupal\social_event\Entity\EventEnrollment $entity */
         $event_id = $entity->getFieldValue('field_event', 'target_id');
         if (!empty($event_id)) {

--- a/modules/social_features/social_event/modules/social_event_managers/src/Element/SocialEnrollmentAutocomplete.php
+++ b/modules/social_features/social_event/modules/social_event_managers/src/Element/SocialEnrollmentAutocomplete.php
@@ -28,15 +28,13 @@ class SocialEnrollmentAutocomplete extends EntityAutocomplete {
     // Load the current Event enrollments so we can check duplicates.
     $storage = \Drupal::entityTypeManager()->getStorage('event_enrollment');
 
-    if (empty($nid)) {
-      $node = \Drupal::routeMatch()->getParameter('node');
-      if ($node instanceof NodeInterface) {
-        // You can get nid and anything else you need from the node object.
-        $nid = $node->id();
-      }
-      elseif (!is_object($node)) {
-        $nid = $node;
-      }
+    $node = \Drupal::routeMatch()->getParameter('node');
+    if ($node instanceof NodeInterface) {
+      // You can get nid and anything else you need from the node object.
+      $nid = $node->id();
+    }
+    elseif (!is_object($node)) {
+      $nid = $node;
     }
 
     // Grab all the input values so we can get the ID's out of them.

--- a/modules/social_features/social_event/modules/social_event_managers/src/Form/SocialEventManagersAddEnrolleeForm.php
+++ b/modules/social_features/social_event/modules/social_event_managers/src/Form/SocialEventManagersAddEnrolleeForm.php
@@ -82,7 +82,6 @@ class SocialEventManagersAddEnrolleeForm extends FormBase {
           'field_event' => $event,
           'field_enrollment_status' => '1',
           'field_account' => $uid,
-          'field_request_or_invite_status' => EventEnrollmentInterface::REQUEST_APPROVED,
         ]);
         $enrollment->save();
 

--- a/modules/social_features/social_event/modules/social_event_managers/src/Form/SocialEventManagersAddEnrolleeForm.php
+++ b/modules/social_features/social_event/modules/social_event_managers/src/Form/SocialEventManagersAddEnrolleeForm.php
@@ -6,7 +6,6 @@ use Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Render\RendererInterface;
-use Drupal\social_event\EventEnrollmentInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Drupal\Core\Url;
 use Drupal\social_event\Entity\EventEnrollment;


### PR DESCRIPTION
## Problem
When a user is invited they also receive a notification that they're added to an event.
This is not entirely correct as they, so far, only have been invited.

And when a user is added directly to an event by, for example, an event manager, there was also a notification send to the user being added that his request to join was approved. But he never requested anything, so that notification was confusing and useless.

## Solution
Made sure that when a user is invited he gets only one, relevant, notification.

And the same for when a user is added directly, they won't receive another notification about their request being approved.

## Issue tracker
https://www.drupal.org/project/social/issues/3120797

## How to test
- [ ] As an event manager invite a user
- [ ] Check the notifications/email for that user, you should see only one notification/email about the invitation
- [ ] As an event manager add a user directly
- [ ] Check the notifications/email for that user, you should see only one notification/email about being added to the event

## Screenshots
N/a

## Release notes
N/a, part of #1782.

## Change Record
N/a

## Translations
N/a