### PR TITLE
#3120797: Make sure Max Enroll plays nicely with the Request to Event feature

### DIFF
--- a/modules/social_features/social_event/modules/social_event_invite/social_event_invite.module
+++ b/modules/social_features/social_event/modules/social_event_invite/social_event_invite.module
@@ -250,7 +250,7 @@ function social_event_invite_entity_operation_alter(array &$operations, EntityIn
   // correct view. Otherwise it would update all actions across the platform.
   if ($entity->getEntityTypeId() === 'event_enrollment') {
     // Save the delete operation for later.
-    $delete_operation = $operations['delete'];
+    $delete_operation = $operations['delete'] ?? [];
     // Build operations for the event invites overview for the owner/manager.
     if (social_event_owner_or_organizer() && $route_name === 'view.event_manage_enrollment_invites.page_manage_enrollment_invites') {
       // Empty the current operations.

--- a/modules/social_features/social_event/modules/social_event_max_enroll/social_event_max_enroll.module
+++ b/modules/social_features/social_event/modules/social_event_max_enroll/social_event_max_enroll.module
@@ -84,6 +84,7 @@ function social_event_max_enroll_form_alter(&$form, FormStateInterface $form_sta
     // Alter the Event Enrollments forms.
     case 'enroll_action_form':
     case 'event_an_enroll_action_form':
+    case 'event_invite_enroll_action_form':
       // We can't use dependency injection, because service is optional.
       $event_max_enroll_service = \Drupal::service('social_event_max_enroll.service');
       $node = \Drupal::routeMatch()->getParameter('node');
@@ -99,7 +100,7 @@ function social_event_max_enroll_form_alter(&$form, FormStateInterface $form_sta
             $enrollments = \Drupal::entityTypeManager()->getStorage('event_enrollment')
               ->loadByProperties([
                 'field_event' => $node->id(),
-                'user_id' => \Drupal::currentUser()->id(),
+                'field_account' => \Drupal::currentUser()->id(),
                 'field_enrollment_status' => 1,
               ]);
           }
@@ -114,7 +115,7 @@ function social_event_max_enroll_form_alter(&$form, FormStateInterface $form_sta
           // If this user or visitor is not enrolled to the event, show that
           // there are no more spots left.
           if (!$enrollments && !$an_enrollments) {
-            if ($form_id === 'enroll_action_form') {
+            if ($form_id === 'enroll_action_form' || $form_id === 'event_invite_enroll_action_form') {
               $form['enroll_for_this_event']['#type'] = 'submit';
               $form['enroll_for_this_event']['#value'] = t('No spots left');
               $form['enroll_for_this_event']['#disabled'] = TRUE;

--- a/modules/social_features/social_event/modules/social_event_max_enroll/src/Service/EventMaxEnrollService.php
+++ b/modules/social_features/social_event/modules/social_event_max_enroll/src/Service/EventMaxEnrollService.php
@@ -44,6 +44,9 @@ class EventMaxEnrollService implements EventMaxEnrollServiceInterface {
    *   Injection of the configFactory.
    * @param \Drupal\social_event\Service\SocialEventEnrollServiceInterface $social_event_enroll
    *   The social event enroll.
+   *
+   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
+   * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
    */
   public function __construct(
     EntityTypeManagerInterface $entity_type_manager,


### PR DESCRIPTION
## Problem
The Max Enroll feature no longer works due to changes in the Request to Event and Invite to Event features.

## Solution
Added the new enroll action form to the list of forms the Max Enroll feature is checking. Also fixed an issue with the active enrollment check for the current user.

And fixed two minor coding improvements, preventing a possible notice.

## Issue tracker
*Paste a link to the drupal.org issue queue item. If any other issue trackers were used, include links to those too.*

## How to test
- [ ] Enable the Max Enroll feature, as well as the Event Invite feature
- [ ] Create an event with "open for all" and max enroll set to **1**
- [ ] Join the event, it's now full
- [ ] Observe you can still cancel your enrollment
- [ ] As a different user go to the event, observe that you cannot join
- [ ] Change the Max Enroll to **2**
- [ ] As the different user, observe you can now enroll
- [ ] Change the join method to "request to enroll"
- [ ] As the different user you can see that you can Request to Enroll
- [ ] Do it, observe that you can cancel your request
- [ ] Change the Max Enroll back to **1**
- [ ] Observe for the different user that they cannot cancel their request, it just says the event is closed

**Play around with all the options**, try to invite people, add people, etc.

## Screenshots
N/a

## Release notes
N/a, part of #1782.

## Change Record
N/a

## Translations
N/a