### PR TITLE
Issue #2995501 group type filters and or block hidden specificaly

### DIFF
--- a/modules/social_features/social_group/social_group.module
+++ b/modules/social_features/social_group/social_group.module
@@ -747,6 +747,12 @@ function social_group_form_alter(&$form, FormStateInterface $form_state, $form_i
   $form['#id'] === 'views-exposed-form-search-groups-page') {
     $account = \Drupal::currentUser();
     if (!empty($form['type']['#options'])) {
+      // We dont need to show the filter option if there is
+      // only 1 option. All / Any is also in the form
+      // therefor we cant check the form options itself.
+      if (_social_group_get_current_group_types($account) < 2) {
+        $form['type']['#type'] = 'hidden';
+      }
       foreach ($form['type']['#options'] as $type => $label) {
         // All / Any we can skip they are optional translatable options
         // and not group types.

--- a/modules/social_features/social_group/social_group.module
+++ b/modules/social_features/social_group/social_group.module
@@ -1895,14 +1895,14 @@ function social_group_can_view_groups_of_type(string $type, AccountInterface $ac
   // Authenticated is a locked Role,
   // So first we check outsiders also easier on the performance :)
   $outsider = $group_type->getOutsiderRole();
-  if (NULL !== $outsider && $outsider->hasPermission('view group'))  {
+  if (NULL !== $outsider && $outsider->hasPermission('view group')) {
     return TRUE;
   }
 
   // If members can see it, we also need to show group types because
   // we are not calculation memberships.
   $member = $group_type->getMemberRole();
-  if (NULL !== $member && $member->hasPermission('view group'))  {
+  if (NULL !== $member && $member->hasPermission('view group')) {
     return TRUE;
   }
 

--- a/modules/social_features/social_group/social_group.module
+++ b/modules/social_features/social_group/social_group.module
@@ -745,6 +745,7 @@ function social_group_form_alter(&$form, FormStateInterface $form_state, $form_i
   if ($form['#id'] === 'views-exposed-form-newest-groups-page-all-groups' ||
   $form['#id'] === 'views-exposed-form-search-groups-page-no-value' ||
   $form['#id'] === 'views-exposed-form-search-groups-page') {
+    $account = \Drupal::currentUser();
     if (!empty($form['type']['#options'])) {
       foreach ($form['type']['#options'] as $type => $label) {
         // All / Any we can skip they are optional translatable options
@@ -752,7 +753,7 @@ function social_group_form_alter(&$form, FormStateInterface $form_state, $form_i
         if ($label instanceof TranslatableMarkup) {
           continue;
         }
-        if (!social_group_can_view_groups_of_type($type, \Drupal::currentUser())) {
+        if (!social_group_can_view_groups_of_type($type, $account)) {
           unset($form['type']['#options'][$type]);
         }
       }
@@ -1341,14 +1342,9 @@ function social_group_block_access(Block $block, $operation, AccountInterface $a
   // Check access for AN and LU, if only one group type is available
   // we can remove the filter block.
   if ($block->getPluginId() == 'views_exposed_filter_block:newest_groups-page_all_groups' && $operation == 'view') {
-    $group_types = 0;
+    $user_grouptypes = _social_group_get_current_group_types($account);
 
-    /** @var \Drupal\group\Entity\GroupTypeInterface $group_type */
-    foreach (GroupType::loadMultiple() as $group_type) {
-      $group_types += (int) social_group_can_view_groups_of_type($group_type->id(), $account);
-    }
-
-    if ($group_types < 2) {
+    if ($user_grouptypes < 2) {
       return AccessResult::forbidden();
     }
   }
@@ -1390,6 +1386,27 @@ function social_group_block_access(Block $block, $operation, AccountInterface $a
 
   return AccessResult::neutral();
 }
+
+/**
+ * Determine the amount of group_types a user can see.
+ *
+ * @param \Drupal\Core\Session\AccountInterface $account
+ *   The user to check for.
+ *
+ * @return int
+ *   The amount of group_types
+ */
+function _social_group_get_current_group_types($account) {
+  $group_types = 0;
+
+  /** @var \Drupal\group\Entity\GroupTypeInterface $group_type */
+  foreach (GroupType::loadMultiple() as $group_type) {
+    $group_types += (int) social_group_can_view_groups_of_type($group_type->id(), $account);
+  }
+
+  return $group_types;
+}
+
 
 /**
  * Delete the group and all of its content.

--- a/modules/social_features/social_group/social_group.module
+++ b/modules/social_features/social_group/social_group.module
@@ -740,6 +740,24 @@ function social_group_form_alter(&$form, FormStateInterface $form_state, $form_i
     $form['field_group_allowed_join_method']['widget']['#type'] = 'radios';
     $form['field_group_allowed_join_method']['widget']['#default_value'] = $join_method_default_value;
   }
+
+  // Exposed Filter block on the all-groups overview.
+  if ($form['#id'] === 'views-exposed-form-newest-groups-page-all-groups' ||
+  $form['#id'] === 'views-exposed-form-search-groups-page-no-value' ||
+  $form['#id'] === 'views-exposed-form-search-groups-page') {
+    if (!empty($form['type']['#options'])) {
+      foreach ($form['type']['#options'] as $type => $label) {
+        // All / Any we can skip they are optional translatable options
+        // and not group types.
+        if ($label instanceof TranslatableMarkup) {
+          continue;
+        }
+        if (!social_group_can_view_groups_of_type($type, \Drupal::currentUser())) {
+          unset($form['type']['#options'][$type]);
+        }
+      }
+    }
+  }
 }
 
 /**
@@ -1243,6 +1261,20 @@ function social_group_block_view_local_tasks_block_alter(array &$build, BlockPlu
 }
 
 /**
+ * Implements hook_block_build_alter().
+ */
+function social_group_block_build_alter(array &$build, BlockPluginInterface $block) {
+  if (!empty($block->getPluginId()) &&
+    ($block->getPluginId() === 'views_exposed_filter_block:newest_groups-page_all_groups' ||
+    $block->getPluginId() === 'views_exposed_filter_block:search_groups-page')) {
+    // The Group Type filter has to listen to changes in
+    // group type role permissions. Using the role list ensures
+    // it's cleared correctly.
+    $build['#cache']['tags'][] = 'config:group_role_list';
+  }
+}
+
+/**
  * Implements hook_preprocess_HOOK().
  */
 function social_group_preprocess_profile(&$variables) {
@@ -1306,12 +1338,14 @@ function social_group_block_access(Block $block, $operation, AccountInterface $a
     return AccessResult::neutral();
   }
 
-  if ($block->getPluginId() == 'views_exposed_filter_block:newest_groups-page_all_groups' && $operation == 'view' && $account->isAnonymous()) {
+  // Check access for AN and LU, if only one group type is available
+  // we can remove the filter block.
+  if ($block->getPluginId() == 'views_exposed_filter_block:newest_groups-page_all_groups' && $operation == 'view') {
     $group_types = 0;
 
     /** @var \Drupal\group\Entity\GroupTypeInterface $group_type */
     foreach (GroupType::loadMultiple() as $group_type) {
-      $group_types += (int) $group_type->getAnonymousRole()->hasPermission('view group');
+      $group_types += (int) social_group_can_view_groups_of_type($group_type->id(), $account);
     }
 
     if ($group_types < 2) {
@@ -1839,7 +1873,7 @@ function social_group_can_view_groups_of_type(string $type, AccountInterface $ac
   $group_type = GroupType::load($type);
 
   // If the group type doesn't exist then the user can't see the group type.
-  if ($group_type === FALSE) {
+  if ($group_type === FALSE || $group_type === NULL) {
     return FALSE;
   }
 
@@ -1858,8 +1892,23 @@ function social_group_can_view_groups_of_type(string $type, AccountInterface $ac
 
   $user_roles = $account->getRoles(TRUE);
 
+  // Authenticated is a locked Role,
+  // So first we check outsiders also easier on the performance :)
+  $outsider = $group_type->getOutsiderRole();
+  if (NULL !== $outsider && $outsider->hasPermission('view group'))  {
+    return TRUE;
+  }
+
+  // If members can see it, we also need to show group types because
+  // we are not calculation memberships.
+  $member = $group_type->getMemberRole();
+  if (NULL !== $member && $member->hasPermission('view group'))  {
+    return TRUE;
+  }
+
   // Check each role this user has whether its group counterpart has the correct
-  // permission.
+  // permission. This counts for the advanced group permissions.
+  // Admin, SM, CM.
   foreach ($user_roles as $role) {
     $group_role = $group_role_synchroniser->getGroupRoleId($type, $role);
     if ($group_roles[$group_role]->hasPermission('view group')) {


### PR DESCRIPTION
## Problem
There are some issue with the filters in the search block for the group filters. Once there is only one group type available for a user the filter doesn't make sense.
So we hide the filter options. However we also want to hide the filter block if that is the only filter available.
This is difficult to determine correctly right now, due to the amount of extensions that are written and might optionally be enabled. Like geolocation, content tagging.
This filter discussion on group types also becomes obsolete once we migrate to one group type. When there is only one group type Open Social doesn't need this filter anymore.

## Solution
We create this patch to ensure the group type filter is hidden, for the Distro this doesn't make sense we rather just remove it from configuration or wait until we can migrate to flexible groups.
That is why I will close it, we can still keep using the patch. But it won't be released.