### PR TITLE
by robertragas: add defensive check for mentions in social tokens

### DIFF
--- a/modules/social_features/social_mentions/social_mentions.tokens.inc
+++ b/modules/social_features/social_mentions/social_mentions.tokens.inc
@@ -7,6 +7,7 @@
 
 use Drupal\Component\Utility\Unicode;
 use Drupal\Core\Render\BubbleableMetadata;
+use Drupal\mentions\Entity\Mentions;
 use Drupal\user\Entity\User;
 use Drupal\Core\Render\Markup;
 
@@ -112,7 +113,7 @@ function social_mentions_tokens($type, $tokens, array $data, array $options, Bub
               ->getStorage($target_type)
               ->load($target_id);
 
-            if ($mentioned_entity = $mention->getMentionedEntity()) {
+            if ($mention instanceof Mentions && $mentioned_entity = $mention->getMentionedEntity()) {
               if ($mentioned_entity->getEntityTypeId() === 'comment') {
                 $entity = $mentioned_entity->getCommentedEntity();
               }


### PR DESCRIPTION
## Problem
When we send out notifications, it can be that in cases a mention is made to a person. These tokens reside in social_features/social_mentions/social_mentions.tokens.inc

The problem is that when these are run through the cron it can be that the mentioned user is already deleted. In this case the cron will crash and stop. 

## Solution
Add defensive checks when converting mention tokens.

## Issue tracker
https://www.drupal.org/project/social/issues/3150253

## How to test
- [ ] Disable cron, and mention someone in a post.
- [ ] After the activity creator has made the notification to send out with the email worker, delete the user you mentioned.
- [ ] Run the cron and see it crashes
- [ ] Try again with this patch and see it will continue.

## Release notes
We have added defensive checks to the cron when sending out notifications with mentions in it.