### PR TITLE
Issue #3144424 by ribel: Re-arrange the order of the group statistics block

### DIFF
--- a/modules/social_features/social_group/social_group.module
+++ b/modules/social_features/social_group/social_group.module
@@ -335,6 +335,9 @@ function social_group_preprocess_group(array &$variables) {
 
   // Prepare variables for statistic block.
   if ($variables['view_mode'] === 'statistic') {
+    // Add context, since we render join / invite only etc links in the block.
+    $variables['#cache']['context'][] = 'group';
+    $variables['#cache']['context'][] = 'user';
     if ($group->getGroupType()->hasContentPlugin('group_node:event')) {
       $variables['group_events'] = $group_statistics->getGroupNodeCount($group, 'event');
       $variables['group_events_label'] = \Drupal::translation()->formatPlural($variables['group_events'],

--- a/modules/social_features/social_group/social_group.module
+++ b/modules/social_features/social_group/social_group.module
@@ -335,14 +335,19 @@ function social_group_preprocess_group(array &$variables) {
 
   // Prepare variables for statistic block.
   if ($variables['view_mode'] === 'statistic') {
-    // Add context, since we render join / invite only etc links in the block.
-    $variables['#cache']['context'][] = 'group';
-    $variables['#cache']['context'][] = 'user';
     if ($group->getGroupType()->hasContentPlugin('group_node:event')) {
       $variables['group_events'] = $group_statistics->getGroupNodeCount($group, 'event');
+      $variables['group_events_label'] = \Drupal::translation()->formatPlural($variables['group_events'],
+        'event',
+        'events'
+      );
     }
     if ($group->getGroupType()->hasContentPlugin('group_node:topic')) {
       $variables['group_topics'] = $group_statistics->getGroupNodeCount($group, 'topic');
+      $variables['group_topics_label'] = \Drupal::translation()->formatPlural($variables['group_topics'],
+        'topic',
+        'topics'
+      );
     }
   }
 }

--- a/themes/socialblue/templates/group/group--statistic.html.twig
+++ b/themes/socialblue/templates/group/group--statistic.html.twig
@@ -1,16 +1,16 @@
 <div class="card__counter">
   <ul>
     <li>
+      <span class="card__counter-quantity">{{ group_members }}</span>
+      <span class="card__counter-text">{% trans %}member{% plural group_members %}members{% endtrans %}</span>
+    </li>
+    <li>
       <span class="card__counter-quantity">{{ group_events }}</span>
-      <span class="card__counter-text">{% trans %}event{% plural group_events %}events{% endtrans %}</span>
+      <span class="card__counter-text">{{ group_events_label }}</span>
     </li>
     <li>
       <span class="card__counter-quantity">{{ group_topics }}</span>
-      <span class="card__counter-text">{% trans %}topic{% plural group_topics %}topics{% endtrans %}</span>
-    </li>
-    <li>
-      <span class="card__counter-quantity">{{ group_members }}</span>
-      <span class="card__counter-text">{% trans %}member{% plural group_members %}members{% endtrans %}</span>
+      <span class="card__counter-text">{{ group_topics_label }}</span>
     </li>
   </ul>
 </div>


### PR DESCRIPTION
## Problem
The current representation of numbers related to a group goes in the following order from left to right:

1. Events
2. Topic
3. Members

Typically, members are a bit number while topics and events are smaller.

## Solution
Re-arrange the order to:

1. Members
2. Events
3. Topics

## Issue tracker

- https://www.drupal.org/project/social/issues/3144424
- https://getopensocial.atlassian.net/browse/YANG-3080
- https://getopensocial.atlassian.net/browse/YANG-2843

## How to test
- [ ] Using version 8.x of Open Social with the SKY theme enabled
- [ ] As a LU go to any default group
- [ ] You should see Members counter first in Group Statistic block

