### PR TITLE
Issue #3144445 by rolki: Add extra conditions to the AccountHeaderBlock plugin

### DIFF
--- a/modules/social_features/social_user/src/Plugin/Block/AccountHeaderBlock.php
+++ b/modules/social_features/social_user/src/Plugin/Block/AccountHeaderBlock.php
@@ -165,7 +165,7 @@ class AccountHeaderBlock extends BlockBase implements ContainerFactoryPluginInte
       $menu_items['create'] += $create_links;
 
       // If the user can't access any children then we disable the entire menu.
-      if (!$this->hasAccessibleChild($menu_items['create'])) {
+      if (isset($menu_items['create']) && is_array($menu_items['create']) && !$this->hasAccessibleChild($menu_items['create'])) {
         $menu_items['create']['#access'] = FALSE;
       }
 


### PR DESCRIPTION
## Problem
After login under custom role, I receive an error:
`TypeError: Argument 1 passed to Drupal\social_user\Plugin\Block\AccountHeaderBlock::hasAccessibleChild() must be of the type array, null given, called in /var/www/html/profiles/contrib/social/modules/social_features/social_user/src/Plugin/Block/AccountHeaderBlock.php on line 172 in Drupal\social_user\Plugin\Block\AccountHeaderBlock->hasAccessibleChild() (line 307 of /var/www/html/profiles/contrib/social/modules/social_features/social_user/src/Plugin/Block/AccountHeaderBlock.php)`

## Solution
Add extra conditions to the `AccountHeaderBlock` plugin

## Issue tracker
https://www.drupal.org/project/social/issues/3144445
