### PR TITLE
Issue #3143273 - Add filter with group join methods for flexible groups

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -75,6 +75,9 @@
             "drupal/r4032login": {
               "r4032login should perform access check for /user/login as anonymous user": "https://www.drupal.org/files/issues/2018-11-01/3010747-3-perform-access-check-as-an-user.patch"
             },
+            "drupal/search_api": {
+                "Ensure field definition allowed values callbacks are used for field filter callbacks": "https://www.drupal.org/files/issues/2020-06-03/2949022-12--views_filter_options_callback.patch"
+            },
             "drupal/swiftmailer": {
                 "Fix missing filter_format after update to beta2": "https://www.drupal.org/files/issues/2018-03-26/2948607-fix-filter-format-1.patch"
             },

--- a/drupal-org.make
+++ b/drupal-org.make
@@ -99,6 +99,7 @@ projects[role_delegation][type] = module
 projects[role_delegation][version] = 1.1
 projects[search_api][type] = module
 projects[search_api][version] = 1.15
+projects[search_api][patch][] = "https://www.drupal.org/files/issues/2020-06-03/2949022-12--views_filter_options_callback.patch"
 projects[social_api][type] = module
 projects[social_api][version] = 1.1
 projects[social_auth][type] = module

--- a/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.install
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.install
@@ -5,6 +5,8 @@
  * Install and update functions for the social_group_flexible_group module.
  */
 
+use Drupal\search_api\Entity\Index;
+
 /**
  * Implements hook_install().
  */
@@ -83,4 +85,15 @@ function social_group_flexible_group_update_8801() {
 
   // Output logged messages to related channel of update execution.
   return $updateHelper->logger()->output();
+}
+
+/**
+ * Trigger a search_api re-index.
+ */
+function social_group_flexible_group_update_8802() {
+  $index = Index::load('social_groups');
+  if ($index->status()) {
+    $index->clear();
+    $index->reindex();
+  }
 }

--- a/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.install
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.install
@@ -93,6 +93,7 @@ function social_group_flexible_group_update_8801() {
 function social_group_flexible_group_update_8802() {
   $index = Index::load('social_groups');
   if ($index->status()) {
+    $index->save();
     $index->clear();
     $index->reindex();
   }

--- a/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.module
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.module
@@ -61,6 +61,30 @@ function social_group_flexible_group_form_group_flexible_group_edit_form_alter(&
 }
 
 /**
+ * Implements hook_form_alter().
+ */
+function social_group_flexible_group_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+  // Exposed Filter block on the all-groups overview and search.
+  if ($form['#id'] === 'views-exposed-form-newest-groups-page-all-groups' ||
+    $form['#id'] === 'views-exposed-form-search-groups-page-no-value' ||
+    $form['#id'] === 'views-exposed-form-search-groups-page') {
+
+    // Add states so this is only available when flexible groups is checked.
+    // Could be hidden when only flexible groups is enabled, so check that.
+    // @TODO remove this once everything is migrated to flexible groups.
+    if (!empty($form['field_group_allowed_join_method']) &&
+      !empty($form['type']['#options']) &&
+      $form['type']['#type'] !== 'hidden') {
+      $form['field_group_allowed_join_method']['#states'] = [
+        'visible' =>  [
+          ':input[name="type"]' => ['value' => 'flexible_group'],
+        ],
+      ];
+    }
+  }
+}
+
+/**
  * Custom form submit handler for editing a flexible group.
  *
  * @param array $form

--- a/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.module
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.module
@@ -69,6 +69,19 @@ function social_group_flexible_group_form_alter(&$form, FormStateInterface $form
     $form['#id'] === 'views-exposed-form-search-groups-page-no-value' ||
     $form['#id'] === 'views-exposed-form-search-groups-page') {
 
+    // Update filter values so it matches the join methods in the popover.
+    if (!empty($form['field_group_allowed_join_method'])) {
+      if (array_key_exists('added', $form['field_group_allowed_join_method']['#options'])) {
+        $form['field_group_allowed_join_method']['#options']['added'] = t('Invite only');
+      }
+      if (array_key_exists('direct', $form['field_group_allowed_join_method']['#options'])) {
+        $form['field_group_allowed_join_method']['#options']['direct'] = t('Open to join');
+      }
+      if (array_key_exists('request', $form['field_group_allowed_join_method']['#options'])) {
+        $form['field_group_allowed_join_method']['#options']['request'] = t('Request to join');
+      }
+    }
+
     // Add states so this is only available when flexible groups is checked.
     // Could be hidden when only flexible groups is enabled, so check that.
     // @TODO remove this once everything is migrated to flexible groups.

--- a/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.module
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.module
@@ -89,7 +89,7 @@ function social_group_flexible_group_form_alter(&$form, FormStateInterface $form
       !empty($form['type']['#options']) &&
       $form['type']['#type'] !== 'hidden') {
       $form['field_group_allowed_join_method']['#states'] = [
-        'visible' =>  [
+        'visible' => [
           ':input[name="type"]' => ['value' => 'flexible_group'],
         ],
       ];

--- a/modules/social_features/social_group/modules/social_group_flexible_group/src/SocialGroupFlexibleGroupConfigOverride.php
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/src/SocialGroupFlexibleGroupConfigOverride.php
@@ -448,7 +448,7 @@ class SocialGroupFlexibleGroupConfigOverride implements ConfigFactoryOverrideInt
             'label' => 'Allowed join method',
             'datasource_id' => 'entity:group',
             'property_path' => 'field_group_allowed_join_method',
-            'type' => 'text',
+            'type' => 'string',
             'dependencies' => [
               'config' => [
                 'field.storage.group.field_group_allowed_join_method' => 'field.storage.group.field_group_allowed_join_method',

--- a/modules/social_features/social_group/modules/social_group_flexible_group/src/SocialGroupFlexibleGroupConfigOverride.php
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/src/SocialGroupFlexibleGroupConfigOverride.php
@@ -378,27 +378,8 @@ class SocialGroupFlexibleGroupConfigOverride implements ConfigFactoryOverrideInt
       ];
     }
 
-    // Add join methods as option to search api groups.
-    if (in_array('search_api.index.social_groups', $names)) {
-      $overrides[$config_name] = [
-        'field_settings' => [
-          'field_group_allowed_join_method' => [
-            'label' => 'Allowed join method',
-            'datasource_id' => 'entity:group',
-            'property_path' => 'field_group_allowed_join_method',
-            'type' => 'string',
-            'dependencies' => [
-              'config' => [
-                'field.storage.group.field_group_allowed_join_method' => 'field.storage.group.field_group_allowed_join_method',
-              ],
-            ],
-          ],
-        ],
-      ];
-    }
-
     // Add join options to the all-groups and search groups views.
-    $filter_join_methods = [
+    $filter_overview_join_methods = [
       'id' => 'field_group_allowed_join_method_value',
       'table' => 'group__field_group_allowed_join_method',
       'field' => 'field_group_allowed_join_method_value',
@@ -415,7 +396,7 @@ class SocialGroupFlexibleGroupConfigOverride implements ConfigFactoryOverrideInt
         'description' => '',
         'use_operator' => FALSE,
         'operator' => 'field_group_allowed_join_method_value_op',
-        'identifier' => 'field_group_allowed_join_method_value',
+        'identifier' => 'field_group_allowed_join_method',
         'required' => FALSE,
         'remember' => FALSE,
         'multiple' => FALSE,
@@ -427,7 +408,7 @@ class SocialGroupFlexibleGroupConfigOverride implements ConfigFactoryOverrideInt
       'group_info' => [
         'label' => '',
         'description' => '',
-        'identifier' => 'field_group_allowed_join_method_value',
+        'identifier' => 'field_group_allowed_join_method',
         'optional' => TRUE,
         'widget' => 'select',
         'multiple' => FALSE,
@@ -444,17 +425,83 @@ class SocialGroupFlexibleGroupConfigOverride implements ConfigFactoryOverrideInt
         'default',
         'page_all_groups',
       ],
-      'views.view.search_groups' => [
-        'default',
-      ],
     ];
 
     foreach ($config_names_groups as $config_name_groups => $displays_groups) {
       if (in_array($config_name_groups, $names)) {
         foreach ($displays_groups as $display_group) {
-          $overrides[$config_name_groups]['display'][$display_group]['display_options']['filters']['field_group_allowed_join_method_value'] = $filter_join_methods;
+          $overrides[$config_name_groups]['display'][$display_group]['display_options']['filters']['field_group_allowed_join_method_value'] = $filter_overview_join_methods;
         }
       }
+    }
+
+    // Add join methods as option to search api groups.
+    if (in_array('search_api.index.social_groups', $names)) {
+      $overrides['search_api.index.social_groups'] = [
+        'dependencies' => [
+          'config' => [
+            'field.storage.group.field_group_allowed_join_method' => 'field.storage.group.field_group_allowed_join_method',
+          ],
+        ],
+        'field_settings' => [
+          'field_group_allowed_join_method' => [
+            'label' => 'Allowed join method',
+            'datasource_id' => 'entity:group',
+            'property_path' => 'field_group_allowed_join_method',
+            'type' => 'text',
+            'dependencies' => [
+              'config' => [
+                'field.storage.group.field_group_allowed_join_method' => 'field.storage.group.field_group_allowed_join_method',
+              ],
+            ],
+          ],
+        ],
+      ];
+    }
+
+    // Add search api specific filter for join method.
+    $filter_sapi_join_methods = [
+      'id' => 'field_group_allowed_join_method',
+      'table' => 'search_api_index_social_groups',
+      'field' => 'field_group_allowed_join_method',
+      'relationship' => 'none',
+      'group_type' => 'group',
+      'admin_label' => '',
+      'operator' => 'or',
+      'value' => [],
+      'group' => 1,
+      'exposed' => TRUE,
+      'expose' => [
+        'operator_id' => 'field_group_allowed_join_method_op',
+        'label' => 'Join method',
+        'description' => '',
+        'use_operator' => FALSE,
+        'operator' => 'field_group_allowed_join_method_op',
+        'identifier' => 'field_group_allowed_join_method',
+        'required' => FALSE,
+        'remember' => FALSE,
+        'multiple' => FALSE,
+        'remember_roles' => [
+          'authenticated' => 'authenticated',
+        ],
+      ],
+      'is_grouped' => FALSE,
+      'group_info' => [
+        'label' => '',
+        'description' => '',
+        'optional' => TRUE,
+        'widget' => 'select',
+        'multiple' => FALSE,
+        'remember' => FALSE,
+        'default_group' => 'All',
+        'default_group_multiple' => [],
+        'group_items' => [],
+      ],
+      'plugin_id' => 'search_api_options',
+    ];
+
+    if (in_array('views.view.search_groups', $names)) {
+      $overrides['views.view.search_groups']['display']['default']['display_options']['filters']['field_group_allowed_join_method'] = $filter_sapi_join_methods;
     }
 
     return $overrides;

--- a/modules/social_features/social_group/modules/social_group_flexible_group/src/SocialGroupFlexibleGroupConfigOverride.php
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/src/SocialGroupFlexibleGroupConfigOverride.php
@@ -378,6 +378,85 @@ class SocialGroupFlexibleGroupConfigOverride implements ConfigFactoryOverrideInt
       ];
     }
 
+    // Add join methods as option to search api groups.
+    if (in_array('search_api.index.social_groups', $names)) {
+      $overrides[$config_name] = [
+        'field_settings' => [
+          'field_group_allowed_join_method' => [
+            'label' => 'Allowed join method',
+            'datasource_id' => 'entity:group',
+            'property_path' => 'field_group_allowed_join_method',
+            'type' => 'string',
+            'dependencies' => [
+              'config' => [
+                'field.storage.group.field_group_allowed_join_method' => 'field.storage.group.field_group_allowed_join_method',
+              ],
+            ],
+          ],
+        ],
+      ];
+    }
+
+    // Add join options to the all-groups and search groups views.
+    $filter_join_methods = [
+      'id' => 'field_group_allowed_join_method_value',
+      'table' => 'group__field_group_allowed_join_method',
+      'field' => 'field_group_allowed_join_method_value',
+      'relationship' => 'none',
+      'group_type' => 'group',
+      'admin_label' => '',
+      'operator' => 'or',
+      'value' => [],
+      'group' => 1,
+      'exposed' => TRUE,
+      'expose' => [
+        'operator_id' => 'field_group_allowed_join_method_value_op',
+        'label' => 'Join method',
+        'description' => '',
+        'use_operator' => FALSE,
+        'operator' => 'field_group_allowed_join_method_value_op',
+        'identifier' => 'field_group_allowed_join_method_value',
+        'required' => FALSE,
+        'remember' => FALSE,
+        'multiple' => FALSE,
+        'remember_roles' => [
+          'authenticated' => 'authenticated',
+        ],
+      ],
+      'is_grouped' => FALSE,
+      'group_info' => [
+        'label' => '',
+        'description' => '',
+        'identifier' => 'field_group_allowed_join_method_value',
+        'optional' => TRUE,
+        'widget' => 'select',
+        'multiple' => FALSE,
+        'remember' => FALSE,
+        'default_group' => 'All',
+        'default_group_multiple' => [],
+        'group_items' => [],
+      ],
+      'plugin_id' => 'list_field',
+    ];
+
+    $config_names_groups = [
+      'views.view.newest_groups' => [
+        'default',
+        'page_all_groups',
+      ],
+      'views.view.search_groups' => [
+        'default',
+      ],
+    ];
+
+    foreach ($config_names_groups as $config_name_groups => $displays_groups) {
+      if (in_array($config_name_groups, $names)) {
+        foreach ($displays_groups as $display_group) {
+          $overrides[$config_name_groups]['display'][$display_group]['display_options']['filters']['field_group_allowed_join_method_value'] = $filter_join_methods;
+        }
+      }
+    }
+
     return $overrides;
   }
 


### PR DESCRIPTION
## Problem
Whenever a user selects flexible groups from the Group type filter, we want the user to be able to filter on join methods. Especially now with the request to join it makes a lot of sense. In the future all platforms will migrate to flexible groups only. So we can remove some of the additional alter logic that we need to take in to account now.

## Solution
Add a filter for the allowed join method for flexible groups. On the group overview and search page.

## Issue tracker
https://www.drupal.org/node/3143273

## How to test
- [x] Ensure you checkout this branch
- [x] Add 2 flexible groups one with Join directly one with Be added
- [x] See that on the explore groups and search groups you can now filter on join method once flexible group is selected as group types
- [x] Try to enable social group request
- [x] Add a new flexible group with this join method
- [x] See that you can also filter on this new join method

## Screenshots
https://www.loom.com/share/8242b0f475da47ffb2a589fd32000b6f

## Release notes
We now have the group join method available as filter on the explore group and search group pages whenever you filter on flexible groups.