### PR TITLE
Issue #3145315 Add filter to the explore events page for enrollment method

### DIFF
--- a/modules/social_features/social_event/config/install/views.view.upcoming_events.yml
+++ b/modules/social_features/social_event/config/install/views.view.upcoming_events.yml
@@ -12,8 +12,6 @@ dependencies:
     - options
     - social_event
     - user
-_core:
-  default_config_hash: jICmCvyBLhkwjQbswDAncFY0kUOuDGtZmMJf26vPvxg
 id: upcoming_events
 label: '(Upcoming) Community events'
 module: views
@@ -690,6 +688,50 @@ display:
             default_group_multiple: {  }
             group_items: {  }
           plugin_id: node_access
+        field_enroll_method_value:
+          id: field_enroll_method_value
+          table: node__field_enroll_method
+          field: field_enroll_method_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: or
+          value: {  }
+          group: 1
+          exposed: true
+          expose:
+            operator_id: field_enroll_method_value_op
+            label: 'Enroll Method'
+            description: ''
+            use_operator: false
+            operator: field_enroll_method_value_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: field_enroll_method_value
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+              contentmanager: '0'
+              sitemanager: '0'
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          plugin_id: list_field
       defaults:
         filters: false
         filter_groups: false

--- a/modules/social_features/social_event/config/update/social_event_update_8810.yml
+++ b/modules/social_features/social_event/config/update/social_event_update_8810.yml
@@ -1,0 +1,52 @@
+views.view.upcoming_events:
+  expected_config: {  }
+  update_actions:
+    add:
+      display:
+        page_community_events:
+          display_options:
+            filters:
+              field_enroll_method_value:
+                admin_label: ''
+                expose:
+                  description: ''
+                  identifier: field_enroll_method_value
+                  label: 'Enroll Method'
+                  multiple: false
+                  operator: field_enroll_method_value_op
+                  operator_id: field_enroll_method_value_op
+                  operator_limit_selection: false
+                  operator_list: {  }
+                  reduce: false
+                  remember: false
+                  remember_roles:
+                    administrator: '0'
+                    anonymous: '0'
+                    authenticated: authenticated
+                    contentmanager: '0'
+                    sitemanager: '0'
+                  required: false
+                  use_operator: false
+                exposed: true
+                field: field_enroll_method_value
+                group: 1
+                group_info:
+                  default_group: All
+                  default_group_multiple: {  }
+                  description: ''
+                  group_items: {  }
+                  identifier: ''
+                  label: ''
+                  multiple: false
+                  optional: true
+                  remember: false
+                  widget: select
+                group_type: group
+                id: field_enroll_method_value
+                is_grouped: false
+                operator: or
+                plugin_id: list_field
+                reduce_duplicates: false
+                relationship: none
+                table: node__field_enroll_method
+                value: {  }

--- a/modules/social_features/social_event/social_event.install
+++ b/modules/social_features/social_event/social_event.install
@@ -1541,3 +1541,17 @@ function social_event_update_8809() {
     }
   }
 }
+
+/**
+ * Configuration update.
+ */
+function social_event_update_8810() {
+  /** @var \Drupal\update_helper\Updater $updateHelper */
+  $updateHelper = \Drupal::service('update_helper.updater');
+
+  // Execute configuration update definitions with logging of success.
+  $updateHelper->executeUpdate('social_event', 'social_event_update_8810');
+
+  // Output logged messages to related channel of update execution.
+  return $updateHelper->logger()->output();
+}

--- a/modules/social_features/social_event/social_event.install
+++ b/modules/social_features/social_event/social_event.install
@@ -1543,7 +1543,7 @@ function social_event_update_8809() {
 }
 
 /**
- * Configuration update.
+ * Adds the enrollment method field as filter on the community events page.
  */
 function social_event_update_8810() {
   /** @var \Drupal\update_helper\Updater $updateHelper */

--- a/modules/social_features/social_event/social_event.module
+++ b/modules/social_features/social_event/social_event.module
@@ -68,6 +68,21 @@ function social_event_form_views_exposed_form_alter(&$form, FormStateInterface $
     // Make sure we redirect to the current group page.
     $form['#action'] = '/group/' . $group_id . '/events';
   }
+  // Only on the community or explore events overview.
+  if ($form['#id'] === 'views-exposed-form-upcoming-events-page-community-events') {
+    // Update the filter values with better labels.
+    if (!empty($form['field_enroll_method_value']) && !empty($form['field_enroll_method_value']['#options'])) {
+      if (array_key_exists(1, $form['field_enroll_method_value']['#options'])) {
+        $form['field_enroll_method_value']['#options'][1] = t('Open to enroll');
+      }
+      if (array_key_exists(2, $form['field_enroll_method_value']['#options'])) {
+        $form['field_enroll_method_value']['#options'][2] = t('Request to enroll');
+      }
+      if (array_key_exists(3, $form['field_enroll_method_value']['#options'])) {
+        $form['field_enroll_method_value']['#options'][3] = t('Invite-only');
+      }
+    }
+  }
 }
 
 /**


### PR DESCRIPTION
## Problem
As a User it would be helpfull to filter events on the events overview based on their enrollment method.

## Solution
Adds a filter by default to the community or explore events overview.

## Issue tracker
https://www.drupal.org/node/3145315

## How to test
- [x] Enable the social event invite module
- [x] Create several events (at least 6) one for every enrollment method (Open / Request / Invite)
- [x] And one in the future and one in the past
- [x] Go to Explore -> Events
- [x] See that you can now filter on the enrollment method
- [x] See that the upcoming / passed events filter also still works

## Screenshots
https://www.loom.com/share/8d8698956e0d4475a0484830228b2f1a

## Release notes
Adds a new filter for the enrollment method on the explore events overview. So users can quickly identify which events they can easily enroll for.