### PR TITLE
Issue #3136540 by navneet0693: Added a defensive of user authentication in user mail queue processor.

### DIFF
--- a/modules/social_features/social_user/src/Plugin/QueueWorker/UserMailQueueProcessor.php
+++ b/modules/social_features/social_user/src/Plugin/QueueWorker/UserMailQueueProcessor.php
@@ -114,7 +114,9 @@ class UserMailQueueProcessor extends QueueWorkerBase implements ContainerFactory
           /** @var \Drupal\user\UserInterface $user */
           foreach ($users as $user) {
             // Attempt sending mail.
-            $this->sendMail($user->getEmail(), $user->language()->getId(), $queue_storage);
+            if ($user->isAuthenticated() || $user->getEmail()) {
+              $this->sendMail($user->getEmail(), $user->language()->getId(), $queue_storage);
+            }
           }
         }
 

--- a/modules/social_features/social_user/src/Plugin/QueueWorker/UserMailQueueProcessor.php
+++ b/modules/social_features/social_user/src/Plugin/QueueWorker/UserMailQueueProcessor.php
@@ -114,7 +114,7 @@ class UserMailQueueProcessor extends QueueWorkerBase implements ContainerFactory
           /** @var \Drupal\user\UserInterface $user */
           foreach ($users as $user) {
             // Attempt sending mail.
-            if ($user->isAuthenticated() || $user->getEmail()) {
+            if ($user->getEmail()) {
               $this->sendMail($user->getEmail(), $user->language()->getId(), $queue_storage);
             }
           }


### PR DESCRIPTION
## Problem
User accounts can anonymous or cannot email ID sometimes, or contain UID 0, which leads to failure of queues on cron run and then cron is stuck forever.

## Solution
Add defensive checks to check for either user authentication or no empty emails.

## Issue tracker
https://www.drupal.org/project/social/issues/3145643
https://getopensocial.atlassian.net/browse/TB-4528

## How to test
N.A

## Screenshots
N.A

## Release notes
User Emails queue processor now have defensive checks to not crash the queue when user doesn't have an email or anonymous.

## Change Record
N.A

## Translations
N.A