### PR TITLE
fix multiple issues with event invite

### DIFF
--- a/modules/social_features/social_event/modules/social_event_invite/src/Form/EventInviteEnrollActionForm.php
+++ b/modules/social_features/social_event/modules/social_event_invite/src/Form/EventInviteEnrollActionForm.php
@@ -30,7 +30,6 @@ class EventInviteEnrollActionForm extends EnrollActionForm {
     $nid = $this->routeMatch->getRawParameter('node');
     $current_user = $this->currentUser;
     $uid = $current_user->id();
-    $isNodeOwner = ($node->getOwnerId() === $uid);
 
     if (!$current_user->isAnonymous()) {
       $conditions = [
@@ -43,8 +42,7 @@ class EventInviteEnrollActionForm extends EnrollActionForm {
       // Unless you are the node owner or organizer.
       if (empty($enrollments)) {
         if ((int) $node->field_enroll_method->value === EventEnrollmentInterface::ENROLL_METHOD_INVITE
-          && !$isNodeOwner
-          && social_event_manager_or_organizer() === FALSE) {
+          && social_event_owner_or_organizer() === FALSE) {
           return [];
         }
       }

--- a/modules/social_features/social_event/modules/social_event_max_enroll/social_event_max_enroll.module
+++ b/modules/social_features/social_event/modules/social_event_max_enroll/social_event_max_enroll.module
@@ -113,8 +113,8 @@ function social_event_max_enroll_form_alter(&$form, FormStateInterface $form_sta
           }
 
           // If this user or visitor is not enrolled to the event, show that
-          // there are no more spots left.
-          if (!$enrollments && !$an_enrollments) {
+          // there are no more spots left, exception for the owner or organizer.
+          if (!$enrollments && !$an_enrollments && social_event_owner_or_organizer() === FALSE) {
             if ($form_id === 'enroll_action_form' || $form_id === 'event_invite_enroll_action_form') {
               $form['enroll_for_this_event']['#type'] = 'submit';
               $form['enroll_for_this_event']['#value'] = t('No spots left');

--- a/modules/social_features/social_event/social_event.module
+++ b/modules/social_features/social_event/social_event.module
@@ -841,7 +841,9 @@ function social_event_node_update(EntityInterface $entity) {
       $enrollments = \Drupal::service('social_event.status_helper');
 
       foreach ($enrollments->getAllEventEnrollments($entity->id(), TRUE) as $enrollment) {
-        if ((int) $enrollment->get('field_request_or_invite_status')->getString() === EventEnrollmentInterface::REQUEST_PENDING) {
+        // Check if the field is not empty before getting the value,
+        // Since (int) will otherwise return 0 and give false positives.
+        if (!$enrollment->get('field_request_or_invite_status')->isEmpty() && (int) $enrollment->get('field_request_or_invite_status')->getString() === EventEnrollmentInterface::REQUEST_PENDING) {
           $enrollment->delete();
         }
       }

--- a/modules/social_features/social_event/src/Form/EnrollActionForm.php
+++ b/modules/social_features/social_event/src/Form/EnrollActionForm.php
@@ -157,7 +157,9 @@ class EnrollActionForm extends FormBase implements ContainerInjectionInterface {
       $enrollments = $this->entityStorage->loadByProperties($conditions);
 
       // Check if groups are not empty, or that the outsiders are able to join.
-      if (!empty($groups) && $node->field_event_enroll_outside_group->value !== '1' && empty($enrollments)) {
+      if (!empty($groups) && $node->field_event_enroll_outside_group->value !== '1'
+        && empty($enrollments)
+        && social_event_manager_or_organizer() === FALSE) {
 
         $group_type_ids = $this->configFactory->getEditable('social_event.settings')
           ->get('enroll');
@@ -177,10 +179,6 @@ class EnrollActionForm extends FormBase implements ContainerInjectionInterface {
             return [];
           }
         }
-      }
-      // If the event is invite only, always return.
-      if ((int) $node->field_enroll_method->value === EventEnrollmentInterface::ENROLL_METHOD_INVITE) {
-        return [];
       }
     }
 

--- a/modules/social_features/social_event/src/Form/EnrollActionForm.php
+++ b/modules/social_features/social_event/src/Form/EnrollActionForm.php
@@ -436,6 +436,11 @@ class EnrollActionForm extends FormBase implements ContainerInjectionInterface {
           && (int) $enrollment->field_request_or_invite_status->value === EventEnrollmentInterface::INVITE_ACCEPTED_AND_JOINED) {
           // Mark this user his enrollment as declined.
           $enrollment->field_request_or_invite_status->value = EventEnrollmentInterface::REQUEST_OR_INVITE_DECLINED;
+          // If the user is cancelling, un-enroll.
+          $current_enrollment_status = $enrollment->field_enrollment_status->value;
+          if ($current_enrollment_status === '1') {
+            $enrollment->field_enrollment_status->value = '0';
+          }
           $enrollment->save();
         }
         // Else, the user simply wants to cancel his enrollment, so at

--- a/modules/social_features/social_event/src/Form/EnrollActionForm.php
+++ b/modules/social_features/social_event/src/Form/EnrollActionForm.php
@@ -159,7 +159,7 @@ class EnrollActionForm extends FormBase implements ContainerInjectionInterface {
       // Check if groups are not empty, or that the outsiders are able to join.
       if (!empty($groups) && $node->field_event_enroll_outside_group->value !== '1'
         && empty($enrollments)
-        && social_event_manager_or_organizer() === FALSE) {
+        && social_event_owner_or_organizer() === FALSE) {
 
         $group_type_ids = $this->configFactory->getEditable('social_event.settings')
           ->get('enroll');

--- a/modules/social_features/social_event/src/Service/SocialEventEnrollService.php
+++ b/modules/social_features/social_event/src/Service/SocialEventEnrollService.php
@@ -3,6 +3,7 @@
 namespace Drupal\social_event\Service;
 
 use Drupal\node\NodeInterface;
+use Drupal\social_event\EventEnrollmentInterface;
 
 /**
  * Class SocialEventEnrollService.
@@ -18,6 +19,12 @@ class SocialEventEnrollService implements SocialEventEnrollServiceInterface {
     if ($node->bundle() === 'event' && $node->hasField('field_event_enroll')) {
       $was_not_changed = $node->field_event_enroll->isEmpty();
       $is_enabled = $node->field_event_enroll->value;
+
+      // Make an exception for the invite enroll method.
+      // This doesn't allow people to enroll themselves, but get invited.
+      if ((int) $node->get('field_enroll_method')->value === EventEnrollmentInterface::ENROLL_METHOD_INVITE) {
+        $is_enabled = TRUE;
+      }
 
       return $was_not_changed || $is_enabled;
     }

--- a/tests/behat/features/capabilities/group/group-create-open.feature
+++ b/tests/behat/features/capabilities/group/group-create-open.feature
@@ -9,7 +9,7 @@ Feature: Create Open Group
       | name           | mail                     | status |
       | Group User One | group_user_1@example.com | 1      |
       | Group User Two | group_user_2@example.com | 1      |
-      | Outsider       | outsider@example.com | 1      |
+      | Outsider       | outsider@example.com     | 1      |
     And I am logged in as "Group User One"
     And I am on "group/add"
     Then I click radio button "Open group This is an open group. Users may join without approval and all content added in this group will be visible to all community members." with the id "edit-group-type-open-group"

--- a/tests/behat/features/capabilities/group/group-create-open.feature
+++ b/tests/behat/features/capabilities/group/group-create-open.feature
@@ -9,6 +9,7 @@ Feature: Create Open Group
       | name           | mail                     | status |
       | Group User One | group_user_1@example.com | 1      |
       | Group User Two | group_user_2@example.com | 1      |
+      | Outsider       | outsider@example.com | 1      |
     And I am logged in as "Group User One"
     And I am on "group/add"
     Then I click radio button "Open group This is an open group. Users may join without approval and all content added in this group will be visible to all community members." with the id "edit-group-type-open-group"
@@ -155,9 +156,11 @@ Feature: Create Open Group
     And I should see "Group User Two"
     And I should see "Groups"
     And I should not see "Test open group"
+    And I logout
 
   # DS-722 As an outsider I am not allowed to enrol to an event in group
-    When I click "Events"
+    Given I am logged in as "Outsider"
+    When I am on "/community-events"
     And I click "Test group event"
     And I should not see "Enroll" in the "Hero buttons"
 

--- a/tests/behat/features/capabilities/group/group-create-public.feature
+++ b/tests/behat/features/capabilities/group/group-create-public.feature
@@ -9,6 +9,7 @@ Feature: Create Public Group
       | name         | mail                     | status |
       | GivenUserOne | group_user_1@example.com | 1      |
       | GivenUserTwo | group_user_2@example.com | 1      |
+      | Outsider     | outsider@example.com     | 1      |
     Given "event_types" terms:
       | name     |
       | Webinar  |
@@ -127,7 +128,9 @@ Feature: Create Public Group
     And I should see "Groups"
     And I should not see "Test public group"
 
-    When I click "Events"
+    # DS-722 As an outsider I am not allowed to enrol to an event in group
+    Given I am logged in as "Outsider"
+    When I am on "/community-events"
     And I click "Test group event"
     And I should not see "Enroll" in the "Hero buttons"
 


### PR DESCRIPTION
## Problem
We encountered multiple problems with the event invite feature
1. When you are the event owner or organizer you should always be able to enroll via the hero, even when it's invite only
2. When you create an event with "request to join" and have multiple people joined, you can convert it to "invite only" but then all enrollments will be lost that got accepted.
3. When you are invited for an event and accepted, you are not able to un-enroll anymore as the button is gone.
4. When I want to un-enroll to an invite only invite, I need to press the button twice before it actually un-enrolls me.
5. When changing an event from "request to join" to "invite only" the enrollments block on the detail pages is gone.

## Solution
1. Create exceptions for enrolling when you are the event owner or organizer
2. Add extra check in checking values for enrollment status so it does not delete the wrong enrollments.
3. Make sure it checks on enrollments before unsetting the button for invite only
4. When un-enrolling for invite only add an additional check to get the current enrollment status and change it accordingly.
5. In the blockaccess add an additional check to see if the invite only is enabled and make an exception for that.

## Issue tracker
https://www.drupal.org/project/social/issues/3149795

## How to test
1.
- [x] Create an event with enroll method "invite only"
- [x] See that you can still enroll as owner
- [x] Create an event with enroll method "invite only" as assign another person as organizer
- [x] Login as this organizer and see you can still enroll

2. 
- [x] Create an event with enroll method "request to join"
- [x] Enroll as owner, but also request with other people and accept some, other leave them pending.
- [x] Convert the event to "invite only". See that everyone who was enrolled is still enrolled.

3.
- [x] Create an event with enroll method "invite only"
- [x] Invite someone and accept as that person
- [x] See you are still able to un-enroll after accepting

4. 
- [x] Create an event with enroll method "invite only"
- [x] Invite someone and accept as that person
- [x] Un-enroll for the event and see it only takes 1 click.

5.
- [x] Create an event with enroll method "invite only"
- [x] Invite someone and accept as that person
- [x] Go to the detail page of the event and you will still see the enrollment block on the right

## Release notes
We have solved multiple issues concerning the event invite feature, such as 
- properly converting invite statuses when changing the event enroll method
- Enrollment access controls to the event

