### PR TITLE
Issue #3150451 by rolki: Add the ability to hide/show flexible group members tab and newest members block for outsiders

### DIFF
--- a/modules/social_features/social_group/modules/social_group_flexible_group/config/update/social_group_flexible_group_update_8802.yml
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/config/update/social_group_flexible_group_update_8802.yml
@@ -1,0 +1,66 @@
+core.entity_form_display.group.flexible_group.default:
+  expected_config:
+    content:
+      path:
+        weight: 3
+    third_party_settings:
+      field_group:
+        group_content:
+          weight: 1
+        group_location:
+          weight: 2
+  update_actions:
+    add:
+      content:
+        field_members_tab_visibility:
+          region: content
+          settings:
+            display_label: true
+          third_party_settings: {  }
+          type: boolean_checkbox
+          weight: 11
+        field_newest_members_visibility:
+          region: content
+          settings:
+            display_label: true
+          third_party_settings: {  }
+          type: boolean_checkbox
+          weight: 12
+      third_party_settings:
+        field_group:
+          group_content:
+            group_outsider_settings:
+              children:
+                - field_members_tab_visibility
+                - field_newest_members_visibility
+              format_settings:
+                classes: ''
+                description: ''
+                id: ''
+                required_fields: true
+              format_type: fieldset
+              label: 'Outsider settings'
+              parent_name: ''
+              region: content
+              weight: 2
+    change:
+      third_party_settings:
+        field_group:
+          group_content:
+            weight: 4
+          group_location:
+            weight: 5
+          group_outsider_settings:
+            children:
+              - field_members_tab_visibility
+              - field_newest_members_visibility
+            format_settings:
+              classes: ''
+              description: ''
+              id: ''
+              required_fields: true
+            format_type: fieldset
+            label: 'Outsider settings'
+            parent_name: ''
+            region: content
+            weight: 2

--- a/modules/social_features/social_group/modules/social_group_flexible_group/config/update/social_group_flexible_group_update_8802.yml
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/config/update/social_group_flexible_group_update_8802.yml
@@ -12,34 +12,26 @@ core.entity_form_display.group.flexible_group.default:
   update_actions:
     add:
       content:
-        field_members_tab_visibility:
+        field_members_visibility:
           region: content
           settings:
             display_label: true
           third_party_settings: {  }
           type: boolean_checkbox
           weight: 11
-        field_newest_members_visibility:
-          region: content
-          settings:
-            display_label: true
-          third_party_settings: {  }
-          type: boolean_checkbox
-          weight: 12
       third_party_settings:
         field_group:
           group_content:
             group_outsider_settings:
               children:
-                - field_members_tab_visibility
-                - field_newest_members_visibility
+                - field_members_visibility
               format_settings:
                 classes: ''
                 description: ''
                 id: ''
                 required_fields: true
               format_type: fieldset
-              label: 'Outsider settings'
+              label: 'Non-member settings'
               parent_name: ''
               region: content
               weight: 2
@@ -52,15 +44,14 @@ core.entity_form_display.group.flexible_group.default:
             weight: 5
           group_outsider_settings:
             children:
-              - field_members_tab_visibility
-              - field_newest_members_visibility
+              - field_members_visibility
             format_settings:
               classes: ''
               description: ''
               id: ''
               required_fields: true
             format_type: fieldset
-            label: 'Outsider settings'
+            label: 'Non-member settings'
             parent_name: ''
             region: content
             weight: 2

--- a/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.install
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.install
@@ -98,3 +98,139 @@ function social_group_flexible_group_update_8802() {
     $index->reindex();
   }
 }
+
+/**
+ * Create field_members_tab_visibility and
+ * field_newest_members_visibility fields.
+ */
+function social_group_flexible_group_update_8803() {
+  $configs = [
+    'field_storage_config' => [
+      [
+        'langcode' => 'en',
+        'status' => TRUE,
+        'dependencies' => [
+          'module' => [
+            'group',
+          ],
+        ],
+        'id' => 'group.field_members_tab_visibility',
+        'field_name' => 'field_members_tab_visibility',
+        'entity_type' => 'group',
+        'type' => 'boolean',
+        'settings' => [],
+        'module' => 'core',
+        'locked' => FALSE,
+        'cardinality' => 1,
+        'translatable' => TRUE,
+        'indexes' => [],
+        'persist_with_no_fields' => FALSE,
+        'custom_storage' => FALSE,
+      ],
+      [
+        'langcode' => 'en',
+        'status' => TRUE,
+        'dependencies' => [
+          'module' => [
+            0 => 'group',
+          ],
+        ],
+        'id' => 'group.field_newest_members_visibility',
+        'field_name' => 'field_newest_members_visibility',
+        'entity_type' => 'group',
+        'type' => 'boolean',
+        'settings' => [],
+        'module' => 'core',
+        'locked' => FALSE,
+        'cardinality' => 1,
+        'translatable' => TRUE,
+        'indexes' => [],
+        'persist_with_no_fields' => FALSE,
+        'custom_storage' => FALSE,
+      ],
+    ],
+    'field_config' => [
+      [
+        'langcode' => 'en',
+        'status' => TRUE,
+        'dependencies' => [
+          'config' => [
+            'field.storage.group.field_members_tab_visibility',
+            'group.type.flexible_group',
+          ],
+        ],
+        'id' => 'group.flexible_group.field_members_tab_visibility',
+        'field_name' => 'field_members_tab_visibility',
+        'entity_type' => 'group',
+        'bundle' => 'flexible_group',
+        'label' => 'Show group members tab',
+        'description' => 'If this box is unchecked then the "Members" tab for the group will be hidden for the outsiders. This condition will be ignored for "Public" and "Community" visibilities.',
+        'required' => FALSE,
+        'translatable' => FALSE,
+        'default_value' => [
+          [
+            'value' => 1,
+          ],
+        ],
+        'default_value_callback' => '',
+        'settings' => [
+          'on_label' => 'On',
+          'off_label' => 'Off',
+        ],
+        'field_type' => 'boolean',
+      ],
+      [
+        'langcode' => 'en',
+        'status' => TRUE,
+        'dependencies' => [
+          'config' => [
+            'field.storage.group.field_newest_members_visibility',
+            'group.type.flexible_group',
+          ],
+        ],
+        'id' => 'group.flexible_group.field_newest_members_visibility',
+        'field_name' => 'field_newest_members_visibility',
+        'entity_type' => 'group',
+        'bundle' => 'flexible_group',
+        'label' => 'Show newest members block',
+        'description' => 'If this box is unchecked then the "Newest members" block for the group will be hidden for the outsiders. This condition will be ignored for "Public" and "Community" visibilities.',
+        'required' => FALSE,
+        'translatable' => FALSE,
+        'default_value' => [
+          [
+            'value' => 1,
+          ],
+        ],
+        'default_value_callback' => '',
+        'settings' => [
+          'on_label' => 'On',
+          'off_label' => 'Off',
+        ],
+        'field_type' => 'boolean',
+      ],
+    ],
+  ];
+
+  foreach ($configs as $entity_type_id => $data) {
+    /** @var \Drupal\Core\Config\Entity\ConfigEntityStorageInterface $storage */
+    $storage = \Drupal::entityTypeManager()->getStorage($entity_type_id);
+
+    foreach ($data as $datum) {
+      $storage->createFromStorageRecord($datum)->save();
+    }
+  }
+}
+
+/**
+ * Create "Outsider settings" group settings block.
+ */
+function social_group_flexible_group_update_8804() {
+  /** @var \Drupal\update_helper\Updater $updateHelper */
+  $updateHelper = \Drupal::service('update_helper.updater');
+
+  // Execute configuration update definitions with logging of success.
+  $updateHelper->executeUpdate('social_group_flexible_group', 'social_group_flexible_group_update_8802');
+
+  // Output logged messages to related channel of update execution.
+  return $updateHelper->logger()->output();
+}

--- a/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.install
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.install
@@ -100,123 +100,66 @@ function social_group_flexible_group_update_8802() {
 }
 
 /**
- * Create members_tab_visibility and newest_members_visibility fields.
+ * Create the members_visibility field.
  */
 function social_group_flexible_group_update_8803() {
   $configs = [
     'field_storage_config' => [
-      [
-        'langcode' => 'en',
-        'status' => TRUE,
-        'dependencies' => [
-          'module' => [
-            'group',
-          ],
+      'langcode' => 'en',
+      'status' => TRUE,
+      'dependencies' => [
+        'module' => [
+          'group',
         ],
-        'id' => 'group.field_members_tab_visibility',
-        'field_name' => 'field_members_tab_visibility',
-        'entity_type' => 'group',
-        'type' => 'boolean',
-        'settings' => [],
-        'module' => 'core',
-        'locked' => FALSE,
-        'cardinality' => 1,
-        'translatable' => TRUE,
-        'indexes' => [],
-        'persist_with_no_fields' => FALSE,
-        'custom_storage' => FALSE,
       ],
-      [
-        'langcode' => 'en',
-        'status' => TRUE,
-        'dependencies' => [
-          'module' => [
-            0 => 'group',
-          ],
-        ],
-        'id' => 'group.field_newest_members_visibility',
-        'field_name' => 'field_newest_members_visibility',
-        'entity_type' => 'group',
-        'type' => 'boolean',
-        'settings' => [],
-        'module' => 'core',
-        'locked' => FALSE,
-        'cardinality' => 1,
-        'translatable' => TRUE,
-        'indexes' => [],
-        'persist_with_no_fields' => FALSE,
-        'custom_storage' => FALSE,
-      ],
+      'id' => 'group.field_members_visibility',
+      'field_name' => 'field_members_visibility',
+      'entity_type' => 'group',
+      'type' => 'boolean',
+      'settings' => [],
+      'module' => 'core',
+      'locked' => FALSE,
+      'cardinality' => 1,
+      'translatable' => TRUE,
+      'indexes' => [],
+      'persist_with_no_fields' => FALSE,
+      'custom_storage' => FALSE,
     ],
     'field_config' => [
-      [
-        'langcode' => 'en',
-        'status' => TRUE,
-        'dependencies' => [
-          'config' => [
-            'field.storage.group.field_members_tab_visibility',
-            'group.type.flexible_group',
-          ],
+      'langcode' => 'en',
+      'status' => TRUE,
+      'dependencies' => [
+        'config' => [
+          'field.storage.group.field_members_visibility',
+          'group.type.flexible_group',
         ],
-        'id' => 'group.flexible_group.field_members_tab_visibility',
-        'field_name' => 'field_members_tab_visibility',
-        'entity_type' => 'group',
-        'bundle' => 'flexible_group',
-        'label' => 'Show group members tab',
-        'description' => 'If this box is unchecked then the "Members" tab for the group will be hidden for the outsiders. This condition will be ignored for "Public" and "Community" visibilities.',
-        'required' => FALSE,
-        'translatable' => FALSE,
-        'default_value' => [
-          [
-            'value' => 1,
-          ],
-        ],
-        'default_value_callback' => '',
-        'settings' => [
-          'on_label' => 'On',
-          'off_label' => 'Off',
-        ],
-        'field_type' => 'boolean',
       ],
-      [
-        'langcode' => 'en',
-        'status' => TRUE,
-        'dependencies' => [
-          'config' => [
-            'field.storage.group.field_newest_members_visibility',
-            'group.type.flexible_group',
-          ],
+      'id' => 'group.flexible_group.field_members_visibility',
+      'field_name' => 'field_members_visibility',
+      'entity_type' => 'group',
+      'bundle' => 'flexible_group',
+      'label' => 'Show group members tab',
+      'description' => 'If this box is unchecked then the "Members" tab for the group will be hidden for the outsiders. This condition will be ignored for "Public" and "Community" visibilities.',
+      'required' => FALSE,
+      'translatable' => FALSE,
+      'default_value' => [
+        [
+          'value' => 1,
         ],
-        'id' => 'group.flexible_group.field_newest_members_visibility',
-        'field_name' => 'field_newest_members_visibility',
-        'entity_type' => 'group',
-        'bundle' => 'flexible_group',
-        'label' => 'Show newest members block',
-        'description' => 'If this box is unchecked then the "Newest members" block for the group will be hidden for the outsiders. This condition will be ignored for "Public" and "Community" visibilities.',
-        'required' => FALSE,
-        'translatable' => FALSE,
-        'default_value' => [
-          [
-            'value' => 1,
-          ],
-        ],
-        'default_value_callback' => '',
-        'settings' => [
-          'on_label' => 'On',
-          'off_label' => 'Off',
-        ],
-        'field_type' => 'boolean',
       ],
+      'default_value_callback' => '',
+      'settings' => [
+        'on_label' => 'On',
+        'off_label' => 'Off',
+      ],
+      'field_type' => 'boolean',
     ],
   ];
 
   foreach ($configs as $entity_type_id => $data) {
     /** @var \Drupal\Core\Config\Entity\ConfigEntityStorageInterface $storage */
     $storage = \Drupal::entityTypeManager()->getStorage($entity_type_id);
-
-    foreach ($data as $datum) {
-      $storage->createFromStorageRecord($datum)->save();
-    }
+    $storage->createFromStorageRecord($data)->save();
   }
 }
 

--- a/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.install
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.install
@@ -100,8 +100,7 @@ function social_group_flexible_group_update_8802() {
 }
 
 /**
- * Create field_members_tab_visibility and
- * field_newest_members_visibility fields.
+ * Create members_tab_visibility and newest_members_visibility fields.
  */
 function social_group_flexible_group_update_8803() {
   $configs = [

--- a/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.install
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.install
@@ -138,8 +138,8 @@ function social_group_flexible_group_update_8803() {
       'field_name' => 'field_members_visibility',
       'entity_type' => 'group',
       'bundle' => 'flexible_group',
-      'label' => 'Show group members tab',
-      'description' => 'If this box is unchecked then the "Members" tab for the group will be hidden for the outsiders. This condition will be ignored for "Public" and "Community" visibilities.',
+      'label' => 'Show members to non-members',
+      'description' => 'When this option is selected, the newest members block and the members tab will become visible to non-members.',
       'required' => FALSE,
       'translatable' => FALSE,
       'default_value' => [

--- a/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.install
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.install
@@ -176,3 +176,25 @@ function social_group_flexible_group_update_8804() {
   // Output logged messages to related channel of update execution.
   return $updateHelper->logger()->output();
 }
+
+/**
+ * Set default values for the field_members_visibility in flexible groups.
+ */
+function social_group_flexible_group_update_8805() {
+  $query = \Drupal::entityTypeManager()->getStorage('group')->getQuery();
+  $flexible_group_ids = $query->condition('type', 'flexible_group')->execute();
+
+  if (!empty($flexible_group_ids)) {
+    foreach ($flexible_group_ids as $group_id) {
+      \Drupal::database()->insert('group__field_members_visibility')->fields([
+        'bundle' => 'flexible_group',
+        'deleted' => 0,
+        'entity_id' => $group_id,
+        'revision_id' => $group_id,
+        'langcode' => \Drupal::service('language_manager')->getCurrentLanguage()->getId(),
+        'delta' => 0,
+        'field_members_visibility_value' => 1,
+      ])->execute();
+    }
+  }
+}

--- a/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.module
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.module
@@ -403,20 +403,22 @@ function social_group_flexible_group_block_access(Block $block, $operation, Acco
     'views_block:upcoming_events-upcoming_events_group',
     'views_block:latest_topics-group_topics_block',
     'views_block:group_managers-block_list_managers',
+    'views_block:group_members-block_newest_members',
   ];
   // We don't care for other blocks.
   if (!in_array($block_id, $managed_blocks, FALSE)) {
     return AccessResult::neutral();
   }
 
+  /** @var \Drupal\group\Entity\GroupInterface $current_group */
   $group = _social_group_get_current_group();
   // We don't care about other group types in here.
-  if ($group && $group->getGroupType()->id() === 'flexible_group') {
+  if ($group instanceof GroupInterface  && $group->getGroupType()->id() === 'flexible_group') {
     // Only when users cant join directly, add the managers block
     // so they know who to contact.
     if ($operation === 'view' &&
       social_group_flexible_group_can_join_directly($group) &&
-      $block->getPluginId() === 'views_block:group_managers-block_list_managers') {
+      $block_id === 'views_block:group_managers-block_list_managers') {
       return AccessResult::forbidden();
     }
 
@@ -436,7 +438,22 @@ function social_group_flexible_group_block_access(Block $block, $operation, Acco
         'views_block:latest_topics-group_topics_block',
       ];
       foreach ($forbidden_blocks as $forbidden_block) {
-        if ($operation === 'view' && $block->getPluginId() === $forbidden_block) {
+        if ($operation === 'view' && $block_id === $forbidden_block) {
+          return AccessResult::forbidden();
+        }
+      }
+    }
+
+    if ($operation == 'view' && $block_id === 'views_block:group_members-block_newest_members') {
+      if ($group->hasField('field_group_allowed_visibility') && $group->hasField('field_newest_members_visibility') && $group->field_newest_members_visibility->value === '0') {
+        $current_visibilities = array_column($group->field_group_allowed_visibility->getValue(), 'value');
+        $skip_visibilities = [
+          'public',
+          'community',
+        ];
+
+        $is_member = $group->getMember($account);
+        if (!array_intersect($current_visibilities, $skip_visibilities) && !$is_member) {
           return AccessResult::forbidden();
         }
       }

--- a/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.module
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.module
@@ -116,7 +116,7 @@ function _social_flexible_group_edit_submit(array $form, FormStateInterface $for
   // If there was a visibility that we don't have anymore after editting
   // all the content that was inside the group with this visibility
   // will get the lowest visibility that is still checked.
-  foreach ($default_visibility as $key => $option) {
+  foreach ($default_visibility as $option) {
     if (array_search($option, array_column($new_visibility, 'value')) === FALSE) {
       $changed_visibility[] = $option;
     }
@@ -284,7 +284,7 @@ function social_group_flexible_group_can_view_flexible_groups(Group $group, Acco
     return TRUE;
   }
 
-  // If User is a member he can see it.
+  // If the user is a member then can see it.
   if ($group->getMember($account) !== FALSE) {
     return TRUE;
   }

--- a/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.module
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.module
@@ -445,7 +445,7 @@ function social_group_flexible_group_block_access(Block $block, $operation, Acco
     }
 
     if ($operation == 'view' && $block_id === 'views_block:group_members-block_newest_members') {
-      if ($group->hasField('field_group_allowed_visibility') && $group->hasField('field_newest_members_visibility') && $group->field_newest_members_visibility->value === '0') {
+      if ($group->hasField('field_group_allowed_visibility') && $group->hasField('field_members_visibility') && $group->field_members_visibility->value === '0') {
         $current_visibilities = array_column($group->field_group_allowed_visibility->getValue(), 'value');
         $skip_visibilities = [
           'public',

--- a/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.services.yml
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.services.yml
@@ -21,5 +21,6 @@ services:
 
   social_group_flexible_group.redirect_subscriber:
     class: Drupal\social_group_flexible_group\EventSubscriber\RedirectSubscriber
+    arguments: ['@current_route_match', '@current_user']
     tags:
       - { name: event_subscriber }

--- a/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.services.yml
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.services.yml
@@ -10,6 +10,7 @@ services:
 
   social_group_flexible_group_access.route_subscriber:
     class: Drupal\social_group_flexible_group\Subscriber\Route
+    arguments: ['@module_handler']
     tags:
       - { name: event_subscriber }
 

--- a/modules/social_features/social_group/modules/social_group_flexible_group/src/Access/FlexibleGroupContentAccessCheck.php
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/src/Access/FlexibleGroupContentAccessCheck.php
@@ -30,7 +30,6 @@ class FlexibleGroupContentAccessCheck implements AccessInterface {
    */
   public function access(Route $route, RouteMatchInterface $route_match, AccountInterface $account) {
     $permission = $route->getRequirement('_flexible_group_content_visibility');
-    $group_permission = $route->getRequirement('_group_permission');
 
     // Don't interfere if no permission was specified.
     if ($permission === NULL) {

--- a/modules/social_features/social_group/modules/social_group_flexible_group/src/Access/FlexibleGroupContentAccessCheck.php
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/src/Access/FlexibleGroupContentAccessCheck.php
@@ -75,7 +75,7 @@ class FlexibleGroupContentAccessCheck implements AccessInterface {
       && $route_match->getRouteName() !== 'view.group_information.page_group_about'
       && $route_match->getRouteName() !== 'entity.group.canonical') {
 
-      if ($group->hasField('field_members_tab_visibility') && $group->field_members_tab_visibility->value !== '0' && $route_match->getRouteName() === 'view.group_members.page_group_members') {
+      if ($group->hasField('field_members_visibility') && $group->field_members_visibility->value !== '0' && $route_match->getRouteName() === 'view.group_members.page_group_members') {
         return AccessResult::allowed()->addCacheableDependency($group);
       }
       else {

--- a/modules/social_features/social_group/modules/social_group_flexible_group/src/Access/FlexibleGroupContentAccessCheck.php
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/src/Access/FlexibleGroupContentAccessCheck.php
@@ -74,9 +74,15 @@ class FlexibleGroupContentAccessCheck implements AccessInterface {
     // No access for you only for the about page.
     if ($account->isAuthenticated() && !social_group_flexible_group_community_enabled($group)
       && $route_match->getRouteName() !== 'view.group_information.page_group_about'
-      && $route_match->getRouteName() !== 'entity.group.canonical'
-      && $route_match->getRouteName() !== 'view.group_members.page_group_members') {
-      return AccessResult::forbidden()->addCacheableDependency($group);
+      && $route_match->getRouteName() !== 'entity.group.canonical') {
+
+      if ($group->hasField('field_members_tab_visibility') && $group->field_members_tab_visibility->value !== '0' && $route_match->getRouteName() === 'view.group_members.page_group_members') {
+        return AccessResult::allowed()->addCacheableDependency($group);
+      }
+      else {
+        return AccessResult::forbidden()->addCacheableDependency($group);
+      }
+
     }
 
     // We allow it but lets add the group as dependency to the cache

--- a/modules/social_features/social_group/modules/social_group_flexible_group/src/Access/FlexibleGroupJoinPermissionAccessCheck.php
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/src/Access/FlexibleGroupJoinPermissionAccessCheck.php
@@ -124,8 +124,8 @@ class FlexibleGroupJoinPermissionAccessCheck implements AccessInterface {
       return TRUE;
     }
 
-    // LU Can only see members tabs for joining directly
-    // or when he is a GM/GA.
+    // LU can only see members tabs for joining directly
+    // or when LU is a GM/GA.
     if (!$direct_option &&
       $route_match->getRouteName() === 'view.group_manage_members.page_group_manage_members' &&
       $account->isAuthenticated() &&

--- a/modules/social_features/social_group/modules/social_group_flexible_group/src/EventSubscriber/RedirectSubscriber.php
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/src/EventSubscriber/RedirectSubscriber.php
@@ -82,10 +82,13 @@ class RedirectSubscriber implements EventSubscriberInterface {
       if ($this->currentUser->hasPermission('manage all groups')) {
         return;
       }
-      // If the user is not an member of this group.
-      elseif (!$group->getMember($this->currentUser) && in_array($routeMatch, $routes, FALSE)
-        && !social_group_flexible_group_community_enabled($group)
-        && !social_group_flexible_group_public_enabled($group)) {
+      // If the user is not a member and if "Allowed join method" is not set to
+      // "Join directly" in this group.
+      elseif (
+        !$group->getMember($this->currentUser) &&
+        in_array($routeMatch, $routes, FALSE) &&
+        !social_group_flexible_group_can_join_directly($group)
+      ) {
         $event->setResponse(new RedirectResponse(Url::fromRoute('view.group_information.page_group_about', ['group' => $group->id()])
           ->toString()));
       }

--- a/modules/social_features/social_group/modules/social_group_flexible_group/src/EventSubscriber/RedirectSubscriber.php
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/src/EventSubscriber/RedirectSubscriber.php
@@ -2,7 +2,10 @@
 
 namespace Drupal\social_group_flexible_group\EventSubscriber;
 
+use Drupal\Core\Routing\CurrentRouteMatch;
+use Drupal\Core\Session\AccountProxy;
 use Drupal\Core\Url;
+use Drupal\group\Entity\GroupInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
@@ -14,6 +17,34 @@ use Symfony\Component\HttpKernel\KernelEvents;
  * @package Drupal\social_group_flexible_group\EventSubscriber
  */
 class RedirectSubscriber implements EventSubscriberInterface {
+
+  /**
+   * The current route.
+   *
+   * @var \Drupal\Core\Routing\CurrentRouteMatch
+   */
+  protected $currentRoute;
+
+  /**
+   * The current user.
+   *
+   * @var \Drupal\Core\Session\AccountProxy
+   */
+  protected $currentUser;
+
+
+  /**
+   * Redirectsubscriber construct.
+   *
+   * @param \Drupal\Core\Routing\CurrentRouteMatch $route_match
+   *   The current route.
+   * @param \Drupal\Core\Session\AccountProxy $current_user
+   *   The current user.
+   */
+  public function __construct(CurrentRouteMatch $route_match, AccountProxy $current_user) {
+    $this->currentRoute = $route_match;
+    $this->currentUser = $current_user;
+  }
 
   /**
    * Get the request events.
@@ -34,11 +65,10 @@ class RedirectSubscriber implements EventSubscriberInterface {
    */
   public function checkForRedirection(GetResponseEvent $event) {
     // Check if there is a group object on the current route.
+    /** @var \Drupal\group\Entity\GroupInterface $group */
     $group = _social_group_get_current_group();
     // Get the current route name for the checks being performed below.
-    $routeMatch = \Drupal::routeMatch()->getRouteName();
-    // Get the current user.
-    $user = \Drupal::currentUser();
+    $routeMatch = $this->currentRoute->getRouteName();
     // The array of forbidden routes.
     $routes = [
       'entity.group.canonical',
@@ -49,12 +79,12 @@ class RedirectSubscriber implements EventSubscriberInterface {
     ];
 
     // If a group is set, and the type is flexible_group.
-    if ($group && $group->getGroupType()->id() === 'flexible_group') {
-      if ($user->hasPermission('manage all groups')) {
+    if ($group instanceof GroupInterface && $group->getGroupType()->id() === 'flexible_group') {
+      if ($this->currentUser->hasPermission('manage all groups')) {
         return;
       }
       // If the user is not an member of this group.
-      elseif (!$group->getMember($user) && in_array($routeMatch, $routes, FALSE)
+      elseif (!$group->getMember($this->currentUser) && in_array($routeMatch, $routes, FALSE)
         && !social_group_flexible_group_community_enabled($group)
         && !social_group_flexible_group_public_enabled($group)) {
         $event->setResponse(new RedirectResponse(Url::fromRoute('view.group_information.page_group_about', ['group' => $group->id()])

--- a/modules/social_features/social_group/modules/social_group_flexible_group/src/EventSubscriber/RedirectSubscriber.php
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/src/EventSubscriber/RedirectSubscriber.php
@@ -32,7 +32,6 @@ class RedirectSubscriber implements EventSubscriberInterface {
    */
   protected $currentUser;
 
-
   /**
    * Redirectsubscriber construct.
    *

--- a/modules/social_features/social_group/modules/social_group_flexible_group/src/FlexibleGroupContentVisibilityUpdate.php
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/src/FlexibleGroupContentVisibilityUpdate.php
@@ -69,7 +69,7 @@ class FlexibleGroupContentVisibilityUpdate {
 
     // Add posts to the entities we need to update based on visibility.
     if (!empty($posts)) {
-      foreach ($posts as $pid => $post) {
+      foreach ($posts as $post) {
         if (in_array($post->getVisibility(), $changed_visibility, FALSE)) {
           $entities[] = $post;
         }
@@ -136,7 +136,7 @@ class FlexibleGroupContentVisibilityUpdate {
     $context['results'][] = $entity;
 
     // Optional message displayed under the progressbar.
-    $context['message'] = t('Updating group content (@id)', ['@id' => $entity->id()]);
+    $context['message'] = $this->t('Updating group content (@id)', ['@id' => $entity->id()]);
   }
 
   /**

--- a/modules/social_features/social_group/modules/social_group_flexible_group/src/Subscriber/Route.php
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/src/Subscriber/Route.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\social_group_flexible_group\Subscriber;
 
+use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Routing\RouteSubscriberBase;
 use Symfony\Component\Routing\RouteCollection;
 
@@ -11,6 +12,23 @@ use Symfony\Component\Routing\RouteCollection;
  * @package Drupal\social_group_flexible_group\Subscriber
  */
 class Route extends RouteSubscriberBase {
+
+  /**
+   * The module handler.
+   *
+   * @var \Drupal\Core\Extension\ModuleHandlerInterface
+   */
+  protected $moduleHandler;
+
+  /**
+   * Constructs a Route object.
+   *
+   * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
+   *   The module handler.
+   */
+  public function __construct(ModuleHandlerInterface $module_handler) {
+    $this->moduleHandler = $module_handler;
+  }
 
   /**
    * {@inheritdoc}
@@ -45,8 +63,7 @@ class Route extends RouteSubscriberBase {
     // Invoke implementations of
     // hook_social_group_flexible_group_content_routes_alter().
     // This to ensure extensions can also add their content tabs.
-    \Drupal::moduleHandler()
-      ->alter('social_group_flexible_group_content_routes', $content_routes);
+    $this->moduleHandler->alter('social_group_flexible_group_content_routes', $content_routes);
 
     foreach ($content_routes as $name) {
       if ($route = $collection->get($name)) {


### PR DESCRIPTION
## Problem
Outsiders shouldn't be able to see members of a flexible group and newest members block

## Solution
- Make it configurable on group edit page
- Block with newest members and members tab should be shown / hidden depending on settings

## Issue tracker
* https://www.drupal.org/project/social/issues/3150451
* https://getopensocial.atlassian.net/browse/YANG-3022
