### PR TITLE
Issue 3151179 by frankgraave - Fix flexible group with only public content visibility

### DIFF
--- a/modules/social_features/social_group/modules/social_group_flexible_group/src/Access/FlexibleGroupContentAccessCheck.php
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/src/Access/FlexibleGroupContentAccessCheck.php
@@ -73,6 +73,7 @@ class FlexibleGroupContentAccessCheck implements AccessInterface {
     // It's a non member but Community isn't enabled.
     // No access for you only for the about page.
     if ($account->isAuthenticated() && !social_group_flexible_group_community_enabled($group)
+      && social_group_flexible_group_public_enabled($group)
       && $route_match->getRouteName() !== 'view.group_information.page_group_about'
       && $route_match->getRouteName() !== 'entity.group.canonical'
       && $route_match->getRouteName() !== 'view.group_members.page_group_members') {

--- a/modules/social_features/social_group/modules/social_group_flexible_group/src/Access/FlexibleGroupContentAccessCheck.php
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/src/Access/FlexibleGroupContentAccessCheck.php
@@ -73,7 +73,7 @@ class FlexibleGroupContentAccessCheck implements AccessInterface {
     // It's a non member but Community isn't enabled.
     // No access for you only for the about page.
     if ($account->isAuthenticated() && !social_group_flexible_group_community_enabled($group)
-      && social_group_flexible_group_public_enabled($group)
+      && !social_group_flexible_group_public_enabled($group)
       && $route_match->getRouteName() !== 'view.group_information.page_group_about'
       && $route_match->getRouteName() !== 'entity.group.canonical'
       && $route_match->getRouteName() !== 'view.group_members.page_group_members') {

--- a/tests/behat/features/capabilities/group/group-create-flexible.feature
+++ b/tests/behat/features/capabilities/group/group-create-flexible.feature
@@ -169,3 +169,37 @@ Feature: Create flexible Group
     When I fill in "search_input" with "Test group"
     Then I should see "Test group public topic" in the "Main content"
     And I should not see "Test group private topic" in the "Main content"
+
+    # Test flexible group with only public content visibility for LU.
+    Given I am logged in as "GivenUserOne"
+    And I am on "group/add"
+    Then I click radio button "Flexible group By choosing this option you can customize many group settings to your needs." with the id "edit-group-type-flexible-group"
+    And I press "Continue"
+    When I show hidden checkboxes
+    Then I uncheck the box "field_group_allowed_visibility[community]"
+    Then I uncheck the box "field_group_allowed_visibility[group]"
+    When I fill in "Title" with "Cheesy test of flexible group"
+    And I fill in the "edit-field-group-description-0-value" WYSIWYG editor with "Cheesy description text"
+    And I fill in "Location name" with "Cheese St"
+    And I select "US" from "Country"
+    Then I wait for AJAX to finish
+    And I press "Save"
+    # Check this group as an anonymous user.
+    And I logout
+    Then I am on "all-groups"
+    And I should see "Cheesy test of flexible group"
+    When I click "Cheesy test of flexible group"
+    Then I should see the link "Stream"
+    And I should see the link "About"
+    And I should see the link "Events"
+    And I should see the link "Topics"
+    And I should see the link "Members"
+    # Check this as an user with SM permissions.
+    Given I am logged in as an "authenticated user"
+    When I am on "all-groups"
+    And I click "Cheesy test of flexible group"
+    Then I should see the link "Stream"
+    And I should see the link "About"
+    And I should see the link "Events"
+    And I should see the link "Topics"
+    And I should see the link "Members"


### PR DESCRIPTION
## Problem
When creating a flexible group with only public content visibility, the group page does not show certain links such as the stream to the LU any longer. They are also not accessible by logged in users.

## Solution
Inside the `FlexibleGroupContentAccessCheck.php` class, there is the following if statement :

```
    // It's a non member but Community isn't enabled.
    // No access for you only for the about page.
    if ($account->isAuthenticated() && !social_group_flexible_group_community_enabled($group)
      && $route_match->getRouteName() !== 'view.group_information.page_group_about'
      && $route_match->getRouteName() !== 'entity.group.canonical'
      && $route_match->getRouteName() !== 'view.group_members.page_group_members') {
      return AccessResult::forbidden()->addCacheableDependency($group);
    }
```

This if statement should include `&& social_group_flexible_group_public_enabled($group)` to ensure the correct access results. We also should include this check in the tests, which I have done with the first commit. To show that it's actually breaking for LU and not for AN.

## Issue tracker
https://www.drupal.org/project/social/issues/3151179

## How to test
- [ ] Do not check out to this branch yet
- [ ] Create a flexible group with only public content visibility
- [ ] Visit the group as AN user
- [ ] See that you can see the Stream, About, Events, Topics and Members tabs
- [ ] Log in as LU and visit the group
- [ ] See that you only have About and Members
- [ ] Check out to this branch, repeat the above checks and see it works now

## Screenshots
N.A.

## Release notes
Bug fixed where flexible groups with public visibility only restricted authenticated users to view the group properly.

## Change Record
N.A.

## Translations
N.A.
