### PR TITLE
Issue 3154067 by frankgraave: use the display name instead of usernam…

### DIFF
--- a/modules/social_features/social_event/modules/social_event_invite/config/install/social_event_invite.settings.yml
+++ b/modules/social_features/social_event/modules/social_event_invite/config/install/social_event_invite.settings.yml
@@ -1,3 +1,3 @@
 invite_enroll: true
-invite_subject: '[user:name] has invited you to the event [node:title] on [site:name]'
+invite_subject: '[current-user:display-name] has invited you to the event [node:title] on [site:name]'
 invite_message: "<p>Hi,</p>\r\n<p>I would like to invite you to my event <strong>[node:title]</strong> on <strong>[site:name]</strong>.</p>\r\n<p>Kind regards, [user:display-name]</p>\r\n<p><a class=\"btn-link btn-link-bg btn-link-two\" href=\"[social_event_invite:register_link]\">View event </a><a class=\"btn-link btn-link-bg btn-link-two\" href=\"[site:url]\">About [site:name]</a></p>"

--- a/modules/social_features/social_event/modules/social_event_invite/social_event_invite.install
+++ b/modules/social_features/social_event/modules/social_event_invite/social_event_invite.install
@@ -58,3 +58,15 @@ function social_event_invite_update_8001() {
   // Output logged messages to related channel of update execution.
   return $updateHelper->logger()->output();
 }
+
+/**
+ * Use display name instead of username for the event invite email.
+ */
+function social_event_invite_update_8002() {
+  // Get the config.
+  $config = \Drupal::configFactory()->getEditable('social_event_invite.settings');
+
+  // Change the value of the invite_subject.
+  $config->set('invite_subject', '[current-user:display-name] has invited you to the event [node:title] on [site:name]');
+  $config->save();
+}


### PR DESCRIPTION
…e for the event invite email template

## Problem
Group invitation uses `[current-user:display-name]` while event invitation uses `[user:name]`. This should be the same for consistency.

## Solution
Use the [current_user:display-name] for the event invite email template.

## Issue tracker
- https://www.drupal.org/project/social/issues/3154067
- https://getopensocial.atlassian.net/browse/TB-4760

## How to test
- [ ] Don't checkout to this branch yet.
- [ ] Invite any email to your event.
- [ ] Check the mailcatcher and see the subject uses the username.
- [ ] Checkout to this branch
- [ ] Repeat the steps above and see that the subject now displays the display-name.

## Screenshots
_(Note: this screenshot is not a visual change, but only shows the change of this fix)_
<img width="353" alt="CleanShot 2020-06-23 at 08 07 26@2x" src="https://user-images.githubusercontent.com/9481723/85367000-b2b8db80-b528-11ea-8381-c10052c997bb.png">

## Release notes
The event invite email subject has been changed for consistency reasons to be aligned with the group invitation email where it uses the display name instead of the username.

## Change Record
N.A.

## Translations
N.A.