### PR TITLE
Featured view mode for flexible group and social_book

### DIFF
--- a/modules/social_features/social_landing_page/social_landing_page.install
+++ b/modules/social_features/social_landing_page/social_landing_page.install
@@ -639,3 +639,27 @@ function social_landing_page_update_8807() {
   $update_helper->executeUpdate('social_landing_page', 'social_landing_page_update_8807');
   return $update_helper->logger()->output();
 }
+
+/**
+ * Enable helper modules if flexible group and / or social_book are enabled.
+ */
+function social_landing_page_update_8808() {
+  // If we have flexible groups enabled, we want to enable the helper module
+  // social_flexible_group_featured which provides a featured view mode to be
+  // used on landing pages.
+  if (\Drupal::moduleHandler()->moduleExists('social_group_flexible_group')) {
+    $modules = [
+      'social_flexible_group_featured'
+    ];
+    \Drupal::service('module_installer')->install($modules);
+  }
+
+  // If social_book is enabled, we enable the helper module social_book_featured
+  // which provides a featured view mode to be used on landing pages.
+  if (\Drupal::moduleHandler()->moduleExists('social_book')) {
+    $modules = [
+      'social_book_featured'
+    ];
+    \Drupal::service('module_installer')->install($modules);
+  }
+}

--- a/modules/social_features/social_landing_page/social_landing_page.install
+++ b/modules/social_features/social_landing_page/social_landing_page.install
@@ -648,18 +648,12 @@ function social_landing_page_update_8808() {
   // social_flexible_group_featured which provides a featured view mode to be
   // used on landing pages.
   if (\Drupal::moduleHandler()->moduleExists('social_group_flexible_group')) {
-    $modules = [
-      'social_flexible_group_featured'
-    ];
-    \Drupal::service('module_installer')->install($modules);
+    \Drupal::service('module_installer')->install(['social_flexible_group_featured']);
   }
 
   // If social_book is enabled, we enable the helper module social_book_featured
   // which provides a featured view mode to be used on landing pages.
   if (\Drupal::moduleHandler()->moduleExists('social_book')) {
-    $modules = [
-      'social_book_featured'
-    ];
-    \Drupal::service('module_installer')->install($modules);
+    \Drupal::service('module_installer')->install(['social_book_featured']);
   }
 }


### PR DESCRIPTION
Enable helper modules when flexible group and / or social_book are enabled.

When social_group_flexible_group is enabled, we would like to enable the helper module social_flexible_group_featured, which is responsible for providing a featured view mode which is used when a flexible group is added as featured content on landingpages. The same goes for social_book, for which we enable the submodule social_book_featured.

## Problem
When placing flexible groups and / or book pages on a landingpage as featured content, there is no view mode for this so we fall back to a blank placeholder, which doesn't have the image that should be used for this type of content.

## Solution
Enable the two submodules for these modules if they are installed. The submodules provide the configuration for the featured view modes of these types of content.

## Issue tracker
https://www.drupal.org/project/social/issues/3142573

## How to test
- [ ] Add a landing page
- [ ] Add flexible group and a book page as featured content
- [ ] See that the correct view mode is showing up and that you see the image provided by the group / book page.

## Release notes
"We made sure that when placing flexible groups and / or book pages as featured content on a landingpage, the display of these content items shows up correctly."