### PR TITLE
#3155032: Group join method CTA buttons caching issue

### DIFF
--- a/modules/custom/social_node_statistics/social_node_statistics.module
+++ b/modules/custom/social_node_statistics/social_node_statistics.module
@@ -44,7 +44,7 @@ function social_node_statistics_preprocess_node(&$variables) {
     $variables['views_count'] = $views_count;
     $variables['views_label'] = \Drupal::translation()->formatPlural($views_count, 'view', 'views');
     $variables['#cache']['tags'][] = 'node:' . $variables['node']->id() . ':views_count';
-    $variables['#cache']['context'][] = 'url.path';
+    $variables['#cache']['contexts'][] = 'url.path';
   }
 }
 

--- a/modules/social_features/social_group/modules/social_group_invite/social_group_invite.module
+++ b/modules/social_features/social_group/modules/social_group_invite/social_group_invite.module
@@ -452,8 +452,8 @@ function social_group_invite_preprocess_group(&$variables) {
         $variables['group_invite_decline_operations_url'] = Url::fromRoute('ginvite.invitation.decline', ['group_content' => $group_content->id()]);
         $variables['#cache']['tags'][] = 'group_content_list:entity:' . $account->id();
         $variables['#cache']['tags'][] = 'group_content_list:plugin:group_invitation:entity:' . $account->id();
-        $variables['#cache']['context'][] = 'group';
-        $variables['#cache']['context'][] = 'user';
+        $variables['#cache']['contexts'][] = 'group';
+        $variables['#cache']['contexts'][] = 'user';
       }
     }
   }

--- a/modules/social_features/social_group/social_group.module
+++ b/modules/social_features/social_group/social_group.module
@@ -336,8 +336,8 @@ function social_group_preprocess_group(array &$variables) {
   // Prepare variables for statistic block.
   if ($variables['view_mode'] === 'statistic') {
     // Add context, since we render join / invite only etc links in the block.
-    $variables['#cache']['context'][] = 'group';
-    $variables['#cache']['context'][] = 'user';
+    $variables['#cache']['contexts'][] = 'group';
+    $variables['#cache']['contexts'][] = 'user';
     if ($group->getGroupType()->hasContentPlugin('group_node:event')) {
       $variables['group_events'] = $group_statistics->getGroupNodeCount($group, 'event');
       $variables['group_events_label'] = \Drupal::translation()->formatPlural($variables['group_events'],


### PR DESCRIPTION
## Problem
There's a caching issue with the join CTA buttons for groups when the Sky theme is enabled.

When a user joins the group, the next user will see that he already joined the group because it's already cached.

## Solution
Fixed the typo in the `cache contexts`. It's now cached correctly and as intended.

_Bonus fix, same typo occurred with the Node Statistics module._

## Issue tracker
https://www.drupal.org/project/social/issues/3155032

## How to test
- [ ] Create a group
- [ ] As user `x` join the group
- [ ] Log in as a user `y`, and go to the group
- [ ] Observe that the button does not say that you joined the group, but that you can join the group
- [ ] Also test this with request to join and the invite functionality

## Screenshots
N/a

## Release notes
N/a, kind of part of the Group Request to Join and Invite to join feature.

## Change Record
N/a

## Translations
N/a