### PR TITLE
#3152934 - Follow up for preview add directly functionality

### DIFF
--- a/modules/social_features/social_event/modules/social_event_managers/src/Form/SocialEventManagersAddEnrolleeForm.php
+++ b/modules/social_features/social_event/modules/social_event_managers/src/Form/SocialEventManagersAddEnrolleeForm.php
@@ -57,7 +57,6 @@ class SocialEventManagersAddEnrolleeForm extends FormBase {
    */
   protected $renderer;
 
-
   /**
    * Constructs a new GroupContentController.
    */
@@ -238,7 +237,7 @@ class SocialEventManagersAddEnrolleeForm extends FormBase {
       '#theme' => 'invite_email_preview',
       '#title' => $this->t('Message'),
       '#logo' => $logo,
-      '#subject' =>  t('Notification from %site_name', $variables),
+      '#subject' => $this->t('Notification from %site_name', $variables),
       '#body' => $body,
       '#helper' => $this->token->replace($invite_config->get('invite_helper'), $params),
     ];

--- a/modules/social_features/social_event/modules/social_event_managers/src/Form/SocialEventManagersAddEnrolleeForm.php
+++ b/modules/social_features/social_event/modules/social_event_managers/src/Form/SocialEventManagersAddEnrolleeForm.php
@@ -4,6 +4,10 @@ namespace Drupal\social_event_managers\Form;
 
 use Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\Core\Utility\Token;
+use Drupal\file\Entity\File;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Render\RendererInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -19,6 +23,27 @@ use Drupal\node\NodeInterface;
 class SocialEventManagersAddEnrolleeForm extends FormBase {
 
   /**
+   * The route match.
+   *
+   * @var \Drupal\Core\Routing\RouteMatchInterface
+   */
+  protected $routeMatch;
+
+  /**
+   * The Config factory.
+   *
+   * @var \Drupal\Core\Config\ConfigFactory
+   */
+  protected $configFactory;
+
+  /**
+   * The token service.
+   *
+   * @var \Drupal\Core\Utility\Token
+   */
+  protected $token;
+
+  /**
    * The entity type manager.
    *
    * @var \Drupal\Core\Entity\EntityTypeManagerInterface
@@ -32,12 +57,16 @@ class SocialEventManagersAddEnrolleeForm extends FormBase {
    */
   protected $renderer;
 
+
   /**
    * Constructs a new GroupContentController.
    */
-  public function __construct(EntityTypeManagerInterface $entity_type_manager, RendererInterface $renderer) {
+  public function __construct(RouteMatchInterface $route_match, EntityTypeManagerInterface $entity_type_manager, RendererInterface $renderer, ConfigFactoryInterface $config_factory, Token $token) {
+    $this->routeMatch = $route_match;
     $this->entityTypeManager = $entity_type_manager;
     $this->renderer = $renderer;
+    $this->configFactory = $config_factory;
+    $this->token = $token;
   }
 
   /**
@@ -45,8 +74,11 @@ class SocialEventManagersAddEnrolleeForm extends FormBase {
    */
   public static function create(ContainerInterface $container) {
     return new static(
+      $container->get('current_route_match'),
       $container->get('entity_type.manager'),
-      $container->get('renderer')
+      $container->get('renderer'),
+      $container->get('config.factory'),
+      $container->get('token')
     );
   }
 
@@ -121,7 +153,7 @@ class SocialEventManagersAddEnrolleeForm extends FormBase {
     $form['#attributes']['class'][] = 'card card__block form--default form-wrapper form-group';
 
     if (empty($nid)) {
-      $node = \Drupal::routeMatch()->getParameter('node');
+      $node = $this->routeMatch->getParameter('node');
       if ($node instanceof NodeInterface) {
         // You can get nid and anything else you need from the node object.
         $nid = $node->id();
@@ -164,6 +196,51 @@ class SocialEventManagersAddEnrolleeForm extends FormBase {
       '#type' => 'submit',
       '#value' => $this->t('Save'),
       '#button_type' => 'primary',
+    ];
+
+    // Add the params that the email preview needs.
+    $params = [
+      'user' => $this->currentUser(),
+      'node' => $this->entityTypeManager->getStorage('node')->load($nid),
+    ];
+
+    $variables = [
+      '%site_name' => \Drupal::config('system.site')->get('name'),
+    ];
+
+    // Load event invite configuration.
+    $add_directly_config = $this->configFactory->get('message.template.member_added_by_event_organiser')->getRawData();
+    $invite_config = $this->configFactory->get('social_event_invite.settings');
+
+    // Replace the tokens with similar ones since these rely
+    // on the message object which we don't have in the preview.
+    $add_directly_config['text'][2]['value'] = str_replace('[message:author:display-name]', '[user:display-name]', $add_directly_config['text'][2]['value']);
+    $add_directly_config['text'][2]['value'] = str_replace('[social_event:event_iam_organizing]', '[node:title]', $add_directly_config['text'][2]['value']);
+
+    // Cleanup message body and replace any links on invite preview page.
+    $body = $this->token->replace($add_directly_config['text'][2]['value'], $params);
+    $body = preg_replace('/href="([^"]*)"/', 'href="#"', $body);
+
+    // Get default logo image and replace if it overridden with email settings.
+    $theme_id = $this->configFactory->get('system.theme')->get('default');
+    $logo = $this->getRequest()->getBaseUrl() . theme_get_setting('logo.url', $theme_id);
+    $email_logo = theme_get_setting('email_logo', $theme_id);
+
+    if (is_array($email_logo) && !empty($email_logo)) {
+      $file = File::load(reset($email_logo));
+
+      if ($file instanceof File) {
+        $logo = file_create_url($file->getFileUri());
+      }
+    }
+
+    $form['preview'] = [
+      '#theme' => 'invite_email_preview',
+      '#title' => $this->t('Message'),
+      '#logo' => $logo,
+      '#subject' =>  t('Notification from %site_name', $variables),
+      '#body' => $body,
+      '#helper' => $this->token->replace($invite_config->get('invite_helper'), $params),
     ];
 
     $form['#cache']['contexts'][] = 'user';

--- a/themes/socialbase/assets/css/email-preview.css
+++ b/themes/socialbase/assets/css/email-preview.css
@@ -48,6 +48,11 @@
   margin: 0 auto;
 }
 
+.email-preview .logo {
+  max-height: 80px;
+  max-width: 160px;
+}
+
 .email-preview .footer {
   font-size: 12px;
 }

--- a/themes/socialbase/components/04-organisms/email/email-preview.scss
+++ b/themes/socialbase/components/04-organisms/email/email-preview.scss
@@ -46,6 +46,11 @@
     }
   }
 
+  .logo {
+    max-height: 80px;
+    max-width: 160px;
+  }
+
   .footer {
     font-size: 12px;
   }


### PR DESCRIPTION
## Problem
For the group invite feature we have created a email preview what the recipients will see. We also need this for the event invite for consistency.

## Solution
Add the email preview to the event invite feature.

## Issue tracker
https://www.drupal.org/project/social/issues/3160262

## How to test
- [x] Enable event invite feature
- [x] Create an event and invite people by email
- [x] See that it has the invite preview email

## Release notes
For the group invite feature you could see the preview of the email you are about to send out to invitees. This has also been added to the invite event feature.
