### PR TITLE
Issue #3156374 by navneet0693: Added cache context for user anonymous…

### DIFF
--- a/modules/social_features/social_event/modules/social_event_an_enroll/social_event_an_enroll.module
+++ b/modules/social_features/social_event/modules/social_event_an_enroll/social_event_an_enroll.module
@@ -118,7 +118,9 @@ function social_event_an_enroll_preprocess_node(array &$variables) {
       }
 
       // Add caching context to anonymous users.
-      $variables['#cache']['contexts'][] = 'user.roles:anonymous';
+      // This is custom context. We added it in order to vary page cache
+      // of routes given in $an_enroll_routes.
+      $variables['#cache']['contexts'][] = 'event_an_enroll_route';
     }
   }
 }

--- a/modules/social_features/social_event/modules/social_event_an_enroll/social_event_an_enroll.module
+++ b/modules/social_features/social_event/modules/social_event_an_enroll/social_event_an_enroll.module
@@ -116,6 +116,9 @@ function social_event_an_enroll_preprocess_node(array &$variables) {
       if (in_array(\Drupal::routeMatch()->getRouteName(), $an_enroll_routes)) {
         unset($variables['event_enrollment']);
       }
+
+      // Add caching context to anonymous users.
+      $variables['#cache']['contexts'][] = 'user.roles:anonymous';
     }
   }
 }

--- a/modules/social_features/social_event/modules/social_event_an_enroll/social_event_an_enroll.routing.yml
+++ b/modules/social_features/social_event/modules/social_event_an_enroll/social_event_an_enroll.routing.yml
@@ -15,6 +15,7 @@ social_event_an_enroll.enroll_dialog:
     parameters:
       node:
         type: entity:node
+    _event_an_enroll_route: TRUE
   requirements:
     _user_is_logged_in: 'FALSE'
     _custom_access: '\Drupal\social_event_an_enroll\Controller\EventAnEnrollController::enrollAccess'
@@ -31,3 +32,4 @@ social_event_an_enroll.enroll_form:
     parameters:
       node:
         type: entity:node
+    _event_an_enroll_route: TRUE

--- a/modules/social_features/social_event/modules/social_event_an_enroll/social_event_an_enroll.services.yml
+++ b/modules/social_features/social_event/modules/social_event_an_enroll/social_event_an_enroll.services.yml
@@ -11,3 +11,11 @@ services:
       - '@current_user'
       - '@current_route_match'
       - '@database'
+
+  # We added a custom context in order to manage cache of enrollment button.
+  # This is specially for AN enrollment routes.
+  cache_context.event_an_enroll_route:
+    class: Drupal\social_event_an_enroll\EventAnEnrollCacheContext
+    arguments: ['@current_route_match']
+    tags:
+      - { name: cache.context }

--- a/modules/social_features/social_event/modules/social_event_an_enroll/src/EventAnEnrollCacheContext.php
+++ b/modules/social_features/social_event/modules/social_event_an_enroll/src/EventAnEnrollCacheContext.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Drupal\social_event_an_enroll;
+
+use Drupal\Core\Cache\CacheableMetadata;
+use Drupal\Core\Cache\Context\CacheContextInterface;
+use Drupal\Core\Routing\RouteMatchInterface;
+
+/**
+ * Defines a class for a anonymous event enrollment route context.
+ */
+class EventAnEnrollCacheContext implements CacheContextInterface {
+
+  /**
+   * Route match.
+   *
+   * @var \Drupal\Core\Routing\RouteMatchInterface
+   */
+  protected $routeMatch;
+
+  /**
+   * Constructs a new PreviewLinkCacheContext.
+   *
+   * @param \Drupal\Core\Routing\RouteMatchInterface $routeMatch
+   *   Route match.
+   */
+  public function __construct(RouteMatchInterface $routeMatch) {
+    $this->routeMatch = $routeMatch;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getLabel() {
+    return 'Is AN enrollment route';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getContext() {
+    return ($route = $this->routeMatch->getRouteObject()) && $route->getOption('_event_an_enroll_route') ?: FALSE;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCacheableMetadata() {
+    return (new CacheableMetadata())->addCacheTags(['routes']);
+  }
+
+}


### PR DESCRIPTION
… role.

## Problem
Enroll button goes missing for anonymous users.

## Solution
Add cache context of user role in social_event_an_enroll_preprocess_node.

## Issue tracker
https://www.drupal.org/project/social/issues/3156374
https://getopensocial.atlassian.net/browse/TB-4270

## How to test
- [x] Enable social_event_an_enroll module.
- [x] Create an event that allows anonymous user enrollment.
- [x] Visit the page as AN user.
- [x] Enrollment button should be present.

## Screenshots
N.A

## Release notes
Fixed caching problem for the enrollment button for anonymous users.

## Change Record
N.A

## Translations
N.A