### PR TITLE
Issue #3157175 by navneet0693: Added proper cach tags consistent caching of add members button.

### DIFF
--- a/modules/social_features/social_event/modules/social_event_managers/social_event_managers.links.action.yml
+++ b/modules/social_features/social_event/modules/social_event_managers/social_event_managers.links.action.yml
@@ -3,3 +3,6 @@ social_event_managers.add_member:
   route_name: 'social_event_managers.add_enrollees'
   appears_on:
     - view.event_manage_enrollments.page_manage_enrollments
+  cache_contexts:
+    - 'user.permissions'
+    - 'user.roles'

--- a/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.module
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.module
@@ -143,7 +143,7 @@ function _social_flexible_group_edit_submit(array $form, FormStateInterface $for
   // This will help "Add member" button to appear on "Manage members" tab.
   $original_join_method = $form['field_group_allowed_join_method']['widget']['#default_value'];
   $changed_join_method = $form_state->getValue('field_group_allowed_join_method');
-  if (array_diff($original_join_method, array_column($changed_join_method, 'value'))) {
+  if ($original_join_method !== array_column($changed_join_method, 'value')) {
     Cache::invalidateTags(['group:' . $group->id() . ':join_method']);
   }
 }

--- a/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.module
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.module
@@ -138,14 +138,6 @@ function _social_flexible_group_edit_submit(array $form, FormStateInterface $for
       Cache::invalidateTags([$cache_tag]);
     }
   }
-
-  // If the group join method has been changes, invalidate the cache tag.
-  // This will help "Add member" button to appear on "Manage members" tab.
-  $original_join_method = $form['field_group_allowed_join_method']['widget']['#default_value'];
-  $changed_join_method = $form_state->getValue('field_group_allowed_join_method');
-  if ($original_join_method !== array_column($changed_join_method, 'value')) {
-    Cache::invalidateTags(['group:' . $group->id() . ':join_method']);
-  }
 }
 
 /**

--- a/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.module
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.module
@@ -122,12 +122,13 @@ function _social_flexible_group_edit_submit(array $form, FormStateInterface $for
     }
   }
 
+  // Get the current group.
+  $group = _social_group_get_current_group();
+
   // So there is now a visibility setting we don't support anymore
   // after editing. Make sure we update all the content that has this
   // to the next best optin.
   if (!empty($changed_visibility)) {
-    $group = _social_group_get_current_group();
-
     // Update the default visibility of all the content.
     FlexibleGroupContentVisibilityUpdate::batchUpdateGroupContentVisibility($group, $changed_visibility, $new_visibility);
 

--- a/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.module
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.module
@@ -137,6 +137,14 @@ function _social_flexible_group_edit_submit(array $form, FormStateInterface $for
       Cache::invalidateTags([$cache_tag]);
     }
   }
+
+  // If the group join method has been changes, invalidate the cache tag.
+  // This will help "Add member" button to appear on "Manage members" tab.
+  $original_join_method = $form['field_group_allowed_join_method']['widget']['#default_value'];
+  $changed_join_method = $form_state->getValue('field_group_allowed_join_method');
+  if (array_diff($original_join_method, array_column($changed_join_method, 'value'))) {
+    Cache::invalidateTags(['group:' . $group->id() . ':join_method']);
+  }
 }
 
 /**

--- a/modules/social_features/social_group/social_group.links.action.yml
+++ b/modules/social_features/social_group/social_group.links.action.yml
@@ -9,6 +9,4 @@ social_group.add_member:
   cache_contexts:
     - 'group'
     - 'user.permissions'
-    - 'group.type'
     - 'user.roles'
-  cache_max_age: 0

--- a/modules/social_features/social_group/social_group.links.action.yml
+++ b/modules/social_features/social_group/social_group.links.action.yml
@@ -8,7 +8,6 @@ social_group.add_member:
     - 'view.group_manage_members.page_group_manage_members'
   cache_contexts:
     - 'group'
-    - 'group.type'
     - 'user.permissions'
     - 'user.roles'
     - 'user.group_permissions'

--- a/modules/social_features/social_group/social_group.links.action.yml
+++ b/modules/social_features/social_group/social_group.links.action.yml
@@ -7,6 +7,6 @@ social_group.add_member:
   appears_on:
     - 'view.group_manage_members.page_group_manage_members'
   cache_contexts:
-    - 'group'
+    - 'group.type'
     - 'user.permissions'
     - 'user.roles'

--- a/modules/social_features/social_group/social_group.links.action.yml
+++ b/modules/social_features/social_group/social_group.links.action.yml
@@ -7,6 +7,8 @@ social_group.add_member:
   appears_on:
     - 'view.group_manage_members.page_group_manage_members'
   cache_contexts:
+    - 'group'
     - 'group.type'
     - 'user.permissions'
     - 'user.roles'
+    - 'user.group_permissions'

--- a/modules/social_features/social_group/social_group.module
+++ b/modules/social_features/social_group/social_group.module
@@ -1339,6 +1339,13 @@ function social_group_preprocess_views_view(&$variables) {
     $variables['header']['actions'] = \Drupal::entityTypeManager()
       ->getViewBuilder('block')
       ->view($entity);
+
+    // Add caching tag on group itself.
+    // If the group join method will be changed, we will invalidate this
+    // cache tag. This will help "Add member" button to appear on
+    // "Manage members" tab.
+    $group_id = $view->args[0];
+    $variables['#cache']['tag'][] = "group:$group_id:join_method";
   }
 }
 

--- a/modules/social_features/social_group/social_group.module
+++ b/modules/social_features/social_group/social_group.module
@@ -1339,13 +1339,6 @@ function social_group_preprocess_views_view(&$variables) {
     $variables['header']['actions'] = \Drupal::entityTypeManager()
       ->getViewBuilder('block')
       ->view($entity);
-
-    // Add caching tag on group itself.
-    // If the group join method will be changed, we will invalidate this
-    // cache tag. This will help "Add member" button to appear on
-    // "Manage members" tab.
-    $group_id = $view->args[0];
-    $variables['#cache']['tag'][] = "group:$group_id:join_method";
   }
 }
 


### PR DESCRIPTION
## Problem
Buttons to Add a Member to a Group and to Add an Enrollee to an Event sometime are not visible on the page, this happens for different roles.

## Solution
Add proper caching tags and cache context to button.

## Issue tracker
https://www.drupal.org/project/social/issues/3157175
https://getopensocial.atlassian.net/browse/TB-4365

## How to test
- [x] As an LU, create a flexible group with "Open to Join" method
- [x] Check the "Manage Enrollment" tab.
- [x] You should not be able to see "Add Members" button
- [x] Now, toggle the joining method and save the group.
- [x] Go to the "manage enrollment" tab and you should be able to see the button.
- [x] Create an event.
- [x] Add the current user as Organizer
- [x] You should be able to see "Add an Enrollee" button on the "Enrollment" tab.

## Screenshots
N.A

## Release notes
There was inconsistent caching bug due to which sometimes the group manager or event organizer was not able to see the "Add member" button if they have an LU role. It should be solved now.

## Change Record
N.A

## Translations
N.A