### PR TITLE
Issue #2899705 by rolki: Remove header duplicates after click on "Load more" in table views with Views Infinite Scroll

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -105,6 +105,9 @@
             "drupal/votingapi" : {
                 "votingapi_views_data_alter uses incorrect empty check for missing entity error handling": "https://www.drupal.org/files/issues/2020-01-31/votingapi-3110353-2.patch",
                 "#3048085 - fix time() callback filling up the logs": "https://www.drupal.org/files/issues/2019-05-02/votingapi-timecallback-3048085-1-4.patch"
+            },
+            "drupal/views_infinite_scroll" : {
+                "Headers in table format repeat on load more instead of adding rows": "https://www.drupal.org/files/issues/2019-08-15/table_tbody_append-2899705-26.patch"
             }
         }
     },

--- a/drupal-org.make
+++ b/drupal-org.make
@@ -123,6 +123,7 @@ projects[views_bulk_operations][version] = 3.4
 projects[views_bulk_operations][patch][] = "https://www.drupal.org/files/issues/2019-09-19/3042494-trigger-vbo-action-on-jquery-checkbox-change-5.patch"
 projects[views_infinite_scroll][type] = module
 projects[views_infinite_scroll][version] = 1.6
+projects[views_infinite_scroll][patch][] = "https://www.drupal.org/files/issues/2019-08-15/table_tbody_append-2899705-26.patch"
 projects[votingapi][type] = module
 projects[votingapi][version] = 3.0-beta1
 projects[votingapi][patch][] = "https://www.drupal.org/files/issues/2020-01-31/votingapi-3110353-2.patch"


### PR DESCRIPTION
## Problem
"Load More" button duplicates header on "Manage members" page if using "Infinite Scroll"

## Solution
Add patch to distro to fix this issue. See:
* https://www.drupal.org/project/views_infinite_scroll/issues/2899705
* https://www.drupal.org/project/views_infinite_scroll/issues/2945524

## Issue tracker
https://getopensocial.atlassian.net/browse/YANG-3296

## How to test
*For example*
- [x] Use "Infinite scroll" for people page `/admin/structure/views/view/user_admin_people` don't forget to enable ajax
- [x] Go to this page `/admin/structure/views/view/user_admin_people`
- [x] Click "Load more" button at the end of the page
- [x] You should not see duplicate header with VBO

## Screenshots
![image](https://user-images.githubusercontent.com/50984627/86609341-82574f80-bfb4-11ea-88c1-4b8cf2482e81.png)
