### PR TITLE
Feature invite emails language and flow

### DIFF
--- a/modules/social_features/social_event/modules/social_event_invite/config/update/social_event_invite_update_8004.yml
+++ b/modules/social_features/social_event/modules/social_event_invite/config/update/social_event_invite_update_8004.yml
@@ -1,0 +1,5 @@
+social_event_invite.settings:
+  expected_config: {  }
+  update_actions:
+    change:
+      invite_message: "<p>Hi</p>\r\n<p>I would like to invite you to join my event <strong>[node:title]</strong> on <strong>[site:name]</strong>.</p>\r\n<p>Kind regards,<br/>[user:display-name]</p>\r\n<table class=\"btn-wrap\">\r\n<tbody>\r\n<tr>\r\n<td class=\"align-center\">\r\n<a class=\"btn-link btn-link-bg btn-link-one\" href=\"[social_event_invite:register_link]\">View event</a>\r\n</td>\r\n<td class=\"align-center\">\r\n<a class=\"btn-link btn-link-bg btn-link-one\" href=\"[site:url]\">About [site:name]</a>\r\n</td>\r\n</tr>\r\n</tbody>\r\n</table>"

--- a/modules/social_features/social_event/modules/social_event_invite/social_event_invite.install
+++ b/modules/social_features/social_event/modules/social_event_invite/social_event_invite.install
@@ -100,7 +100,7 @@ function social_event_invite_update_8004() {
 }
 
 /**
- * Update invite message in the message template
+ * Update invite message in the message template.
  */
 function social_event_invite_update_8005() {
   $config = \Drupal::configFactory()->getEditable('message.template.invite_event_enrollment');
@@ -116,7 +116,7 @@ function social_event_invite_update_8005() {
     ],
     2 => [
       'format' => 'full_html',
-      'value' => '<p>Hi,</p> ' . "\r\n\r\n" . '<p>I would like to invite you to join my event [social_event:event_iam_organizing] on [site:name].</p>' . "\r\n\r\n" . '<p>Kind regards,</p>'. "\r\n\r\n" . '<p>[message:author:display-name]</p>' . "\r\n\r\n" . '<table class="btn-wrap">' . "\r\n\t" . '<tbody>' . "\r\n\t\t" . '<tr>' . "\r\n\t\t\t" . '<td class="align-center"><a class="btn-link btn-link-bg btn-link-one" href="[social_event_invite:user_login_event_invites_overview]">View event</a></td>' . "\r\n\t\t\t" . '<td class="align-center"><a class="btn-link btn-link-bg btn-link-one" href="[site:url]">About [site:name]</a></td>' . "\r\n\t\t" . '</tr>' . "\r\n\t" . '</tbody>' . "\r\n" . '</table>' . "\r\n",
+      'value' => '<p>Hi,</p> ' . "\r\n\r\n" . '<p>I would like to invite you to join my event [social_event:event_iam_organizing] on [site:name].</p>' . "\r\n\r\n" . '<p>Kind regards,</p>' . "\r\n\r\n" . '<p>[message:author:display-name]</p>' . "\r\n\r\n" . '<table class="btn-wrap">' . "\r\n\t" . '<tbody>' . "\r\n\t\t" . '<tr>' . "\r\n\t\t\t" . '<td class="align-center"><a class="btn-link btn-link-bg btn-link-one" href="[social_event_invite:user_login_event_invites_overview]">View event</a></td>' . "\r\n\t\t\t" . '<td class="align-center"><a class="btn-link btn-link-bg btn-link-one" href="[site:url]">About [site:name]</a></td>' . "\r\n\t\t" . '</tr>' . "\r\n\t" . '</tbody>' . "\r\n" . '</table>' . "\r\n",
     ],
   ];
 

--- a/modules/social_features/social_event/modules/social_event_invite/social_event_invite.install
+++ b/modules/social_features/social_event/modules/social_event_invite/social_event_invite.install
@@ -108,15 +108,15 @@ function social_event_invite_update_8005() {
   $new_text = [
     0 => [
       'format' => 'full_html',
-      'value' => '<p>You have been invited for the event [social_event:event_iam_organizing] by [message:author:display-name]</p>' . "\r\n",
+      'value' => '<p>You have been invited to join the event [social_event:event_iam_organizing] by [message:author:display-name]</p>' . "\r\n",
     ],
     1 => [
       'format' => 'full_html',
-      'value' => '<p>You have been invited for the event [social_event:event_iam_organizing] by [message:author:display-name]</p>' . "\r\n",
+      'value' => '<p>You have been invited to join the event [social_event:event_iam_organizing] by [message:author:display-name]</p>' . "\r\n",
     ],
     2 => [
       'format' => 'full_html',
-      'value' => '<p>Hi,</p> ' . "\r\n\r\n" . '<p>I would like to invite you to join my event [social_event:event_iam_organizing] on [site:name].</p>' . "\r\n\r\n" . '<p>Kind regards,</p>'. "\r\n\r\n" . '<p>[message:author:display-name]</p>' . "\r\n\r\n" . '<table class=\"btn-wrap\">' . "\r\n\t" . '<tbody>' . "\r\n\t\t" . '<tr>' . "\r\n\t\t\t" . '<td class=\"align-center\"><a class=\"btn-link btn-link-bg btn-link-one\" href=\"[social_event_invite:user_login_event_invites_overview]\">View event</a></td>' . "\r\n\t\t\t" . '<td class=\"align-center\"><a class=\"btn-link btn-link-bg btn-link-one\" href=\"[site:url]\">About [site:name]</a></td>' . "\r\n\t\t" . '</tr>' . "\r\n\t" . '</tbody>' . "\r\n" . '</table>' . "\r\n'",
+      'value' => '<p>Hi,</p> ' . "\r\n\r\n" . '<p>I would like to invite you to join my event [social_event:event_iam_organizing] on [site:name].</p>' . "\r\n\r\n" . '<p>Kind regards,</p>'. "\r\n\r\n" . '<p>[message:author:display-name]</p>' . "\r\n\r\n" . '<table class="btn-wrap">' . "\r\n\t" . '<tbody>' . "\r\n\t\t" . '<tr>' . "\r\n\t\t\t" . '<td class="align-center"><a class="btn-link btn-link-bg btn-link-one" href="[social_event_invite:user_login_event_invites_overview]">View event</a></td>' . "\r\n\t\t\t" . '<td class="align-center"><a class="btn-link btn-link-bg btn-link-one" href="[site:url]">About [site:name]</a></td>' . "\r\n\t\t" . '</tr>' . "\r\n\t" . '</tbody>' . "\r\n" . '</table>' . "\r\n",
     ],
   ];
 

--- a/modules/social_features/social_event/modules/social_event_invite/social_event_invite.install
+++ b/modules/social_features/social_event/modules/social_event_invite/social_event_invite.install
@@ -84,3 +84,42 @@ function social_event_invite_update_8003() {
   // Output logged messages to related channel of update execution.
   return $updateHelper->logger()->output();
 }
+
+/**
+ * Update invite message in event invite settings.
+ */
+function social_event_invite_update_8004() {
+  /** @var \Drupal\update_helper\Updater $updateHelper */
+  $updateHelper = \Drupal::service('update_helper.updater');
+
+  // Execute configuration update definitions with logging of success.
+  $updateHelper->executeUpdate('social_event_invite', 'social_event_invite_update_8004');
+
+  // Output logged messages to related channel of update execution.
+  return $updateHelper->logger()->output();
+}
+
+/**
+ * Update invite message in the message template
+ */
+function social_event_invite_update_8005() {
+  $config = \Drupal::configFactory()->getEditable('message.template.invite_event_enrollment');
+
+  $new_text = [
+    0 => [
+      'format' => 'full_html',
+      'value' => '<p>You have been invited for the event [social_event:event_iam_organizing] by [message:author:display-name]</p>' . "\r\n",
+    ],
+    1 => [
+      'format' => 'full_html',
+      'value' => '<p>You have been invited for the event [social_event:event_iam_organizing] by [message:author:display-name]</p>' . "\r\n",
+    ],
+    2 => [
+      'format' => 'full_html',
+      'value' => '<p>Hi,</p> ' . "\r\n\r\n" . '<p>I would like to invite you to join my event [social_event:event_iam_organizing] on [site:name].</p>' . "\r\n\r\n" . '<p>Kind regards,</p>'. "\r\n\r\n" . '<p>[message:author:display-name]</p>' . "\r\n\r\n" . '<table class=\"btn-wrap\">' . "\r\n\t" . '<tbody>' . "\r\n\t\t" . '<tr>' . "\r\n\t\t\t" . '<td class=\"align-center\"><a class=\"btn-link btn-link-bg btn-link-one\" href=\"[social_event_invite:user_login_event_invites_overview]\">View event</a></td>' . "\r\n\t\t\t" . '<td class=\"align-center\"><a class=\"btn-link btn-link-bg btn-link-one\" href=\"[site:url]\">About [site:name]</a></td>' . "\r\n\t\t" . '</tr>' . "\r\n\t" . '</tbody>' . "\r\n" . '</table>' . "\r\n'",
+    ],
+  ];
+
+  $config->set('text', $new_text);
+  $config->save();
+}

--- a/modules/social_features/social_event/modules/social_event_invite/social_event_invite.tokens.inc
+++ b/modules/social_features/social_event/modules/social_event_invite/social_event_invite.tokens.inc
@@ -7,6 +7,7 @@
 
 use Drupal\Core\Render\BubbleableMetadata;
 use Drupal\Core\Url;
+use Drupal\user\Entity\User;
 
 /**
  * Implements hook_token_info().
@@ -23,6 +24,11 @@ function social_event_invite_token_info() {
   ];
 
   $social_event_invite['user_login_event_destination'] = [
+    'name' => t('Event link with login page'),
+    'description' => t('Url to the login page with event as destination.'),
+  ];
+
+  $social_event_invite['user_login_event_invites_overview'] = [
     'name' => t('Event link with login page'),
     'description' => t('Url to the login page with event as destination.'),
   ];
@@ -74,6 +80,21 @@ function social_event_invite_tokens($type, $tokens, array $data, array $options,
           $login_link = Url::fromRoute('user.login', ['destination' => $destination], ['absolute' => TRUE])
             ->toString();
           $replacements[$original] = $login_link;
+        }
+      }
+      if ($name == 'user_login_event_invites_overview') {
+        /** @var \Drupal\message\Entity\Message $message */
+        $message = $data['message'];
+
+        // Load the current Event enrollments so we can check duplicates.
+        $storage = \Drupal::entityTypeManager()->getStorage('event_enrollment');
+        /** @var \Drupal\social_event\EventEnrollmentInterface $event_enrollment */
+        $event_enrollment = $storage->load($message->field_message_related_object->target_id);
+
+        if ($event_enrollment) {
+          $user = User::load($event_enrollment->get('field_account')->getString());
+          $my_invitations_link = Url::fromRoute('view.user_event_invites.page_user_event_invites', ['user' => $user->id()], ['absolute' => TRUE])->toString();
+          $replacements[$original] = $my_invitations_link;
         }
       }
     }

--- a/modules/social_features/social_group/modules/social_group_invite/social_group_invite.install
+++ b/modules/social_features/social_group/modules/social_group_invite/social_group_invite.install
@@ -30,3 +30,53 @@ function social_group_invite_update_8001() {
   $config->set('invite_helper', "<p>The message above is edited by the community managers. Please contact them for questions and ideas</p>");
   $config->save();
 }
+
+/**
+ * Update invite message in the message template.
+ */
+function social_group_invite_update_8002() {
+  $config = \Drupal::configFactory()->getEditable('message.template.invited_to_join_group');
+
+  $new_text = [
+    0 => [
+      'format' => 'full_html',
+      'value' => '<p>You have been invited to join the group <a href="[message:gurl]">[message:gtitle]</a></p>' . "\r\n",
+    ],
+    1 => [
+      'format' => 'full_html',
+      'value' => '<p>You have been invited to join the group <a href="[message:gurl]">[message:gtitle]</a></p>' . "\r\n",
+    ],
+    2 => [
+      'format' => 'full_html',
+      'value' => '<p>Hi,</p>' . "\r\n\r\n" . '<p>I would like to invite you to my group [message:gtitle] on [site:name].</p>' . "\r\n\r\n" . '<p>Kind regards,<br />' . "\r\n" . '[message:author:display-name]</p>' . "\r\n\r\n" . '<table class="btn-wrap">' . "\r\n\t" . '<tbody>' . "\r\n\t\t" . '<tr>' . "\r\n\t\t\t" . '<td class="align-center"><a class="btn-link btn-link-bg btn-link-one" href="[message:gurl]">View group</a></td>' . "\r\n\t\t\t" . '<td class="align-center"><a class="btn-link btn-link-bg btn-link-one" href="[site:url]">About [site:name]</a></td>' . "\r\n\t\t" . '</tr>' . "\r\n\t" . '</tbody>' . "\r\n" . '</table>' . "\r\n",
+    ],
+  ];
+
+  $config->set('text', $new_text);
+  $config->save();
+}
+
+/**
+ * Update invite message in group types.
+ */
+function social_group_invite_update_8005() {
+  $configs = [
+    'group.content_type.closed_group-group_invitation',
+    'group.content_type.flexible_group-group_invitation',
+    'group.content_type.open_group-group_invitation',
+    'group.content_type.public_group-group_invitation',
+    'group.content_type.secret_group-group_invitation',
+  ];
+
+  foreach ($configs as $config) {
+    $group_config = \Drupal::configFactory()->getEditable($config);
+
+    $invitation_body = 'Hi,<br/><br/> I would like to invite you to join my group [group:title] on [site:name].<br/><br/>Kind regards,<br/>[current-user:display-name]<br/><br/><table class="btn-wrapp">' . "\r\n\t" . '<tbody>' . "\r\n\t\t" . '<tr>' . "\r\n\t\t\t" . '<td class="align-center"><a class="btn-link btn-link-bg btn-link-one" href="[group_content:register_link]">View group</a></td>' . "\r\n\t\t\t" . '<td class="align-center"><a class="btn-link btn-link-bg btn-link-one" href="[site:url]">About [site:name]</a></td>' . "\r\n\t\t" . '</tr>' . "\r\n\t" . '</tbody>' . "\r\n" . '</table>';
+    $existing_user_invitation_body = 'Hi,<br/><br/>I would like to invite you to join my group [group:title] on [site:name].<br/><br/>Kind regards,<br/>[current-user:display-name]<br/><br/><table class="btn-wrapp">' . "\r\n\t" . '<tbody>' . "\r\n\t\t" . '<tr>' . "\r\n\t\t\t" . '<td class="align-center"><a class="btn-link btn-link-bg btn-link-one" href="[group_content:my_invitations_link]">View group</a></td>' . "\r\n\t\t\t" . '<td class="align-center"><a class="btn-link btn-link-bg btn-link-one" href="[site:url]">About [site:name]</a></td>' . "\r\n\t\t" . '</tr>' . "\r\n\t" . '</tbody>' . "\r\n" . '</table>';
+
+    $group_config->set('plugin_config.invitation_body', $invitation_body);
+    $group_config->set('plugin_config.existing_user_invitation_body', $existing_user_invitation_body);
+    $group_config->save();
+  }
+}
+

--- a/modules/social_features/social_group/modules/social_group_invite/social_group_invite.install
+++ b/modules/social_features/social_group/modules/social_group_invite/social_group_invite.install
@@ -79,4 +79,3 @@ function social_group_invite_update_8005() {
     $group_config->save();
   }
 }
-


### PR DESCRIPTION
## Problem
There are some inconsistencies in the emails that get send out for the invite feature. We have invite for groups and for events, but text is different, and also the flow is different, where as groups lands on the group invites overview page, and the event lands on the event detail page.

## Solution
 Make the language context the same, and also let the event follow the flow of the group.

## Issue tracker
https://www.drupal.org/project/social/issues/3160248

## How to test
- [ ] Enable group and event invite.
- [ ] Start sending out invites for groups and events as various users (logged in vs anonymous).
- [ ] Notice that the group and event emails should be similar (apart from context group vs event)
- [ ] Also check out the flows of the buttons and note that they end up in the same flow.

## Release notes
We made the invite flow for events and groups similar for consistency.