### PR TITLE
#3155032: Fix a caching issue with the group join button

### DIFF
--- a/modules/social_features/social_group/social_group.module
+++ b/modules/social_features/social_group/social_group.module
@@ -335,6 +335,9 @@ function social_group_preprocess_group(array &$variables) {
 
   // Prepare variables for statistic block.
   if ($variables['view_mode'] === 'statistic') {
+    $variables['#cache']['contexts'][] = 'group';
+    $variables['#cache']['contexts'][] = 'user';
+
     if ($group->getGroupType()->hasContentPlugin('group_node:event')) {
       $variables['group_events'] = $group_statistics->getGroupNodeCount($group, 'event');
       $variables['group_events_label'] = \Drupal::translation()->formatPlural($variables['group_events'],
@@ -734,7 +737,7 @@ function social_group_form_alter(&$form, FormStateInterface $form_state, $form_i
       array_unshift($form['actions']['submit']['#submit'], '_social_group_delete_group');
     }
   }
-  
+
   if (in_array($form_id, ['group_flexible_group_edit_form', 'group_flexible_group_add_form'])) {
     $join_method_default_value = 'added';
     if (in_array('direct', $form['field_group_allowed_join_method']['widget']['#default_value'])) {


### PR DESCRIPTION
## Problem
There's a caching issue with the join CTA buttons for groups when the Sky theme is enabled.

When a user joins the group, the next user will see that he already joined the group because it's already cached.

## Solution
Apply the same fix as #1890 to `8.x-8.x`. This is a custom backport of that of that issue.

## Issue tracker
https://www.drupal.org/project/social/issues/3155032

## How to test
- [x] Create a group
- [x] As user x join the group
- [x] Log in as a user y, and go to the group
- [x] Observe that the button does not say that you joined the group, but that you can join the group

## Screenshots
N/a

## Release notes
The caching for the group join button, in combination with the Sky theme, was incorrect. The caching contexts are now applied correctly.

## Change Record
N/a

## Translations
N/a
