### PR TITLE
DS-7199 Make module installable from installer

### DIFF
--- a/modules/custom/social_gdpr/social_gdpr.installer_options.yml
+++ b/modules/custom/social_gdpr/social_gdpr.installer_options.yml
@@ -1,0 +1,2 @@
+name: Policies Management
+description: Provides site managers the ability to create policies (e.g. GPDR or Terms & Agreements) that users may/should agree to during registration.

--- a/modules/custom/social_path_manager/social_path_manager.installer_options.yml
+++ b/modules/custom/social_path_manager/social_path_manager.installer_options.yml
@@ -1,0 +1,2 @@
+name: Path Manager
+description: Allows Site Managers to define patterns to automatically assign pretty URLs to content.

--- a/modules/social_features/social_comment_upload/social_comment_upload.installer_options.yml
+++ b/modules/social_features/social_comment_upload/social_comment_upload.installer_options.yml
@@ -1,0 +1,2 @@
+name: Comment Attachment
+description: Allows users to attach files to comments they place.

--- a/modules/social_features/social_content_block/social_content_block.installer_options.yml
+++ b/modules/social_features/social_content_block/social_content_block.installer_options.yml
@@ -1,0 +1,2 @@
+name: Content List Blocks
+description: Allows the creation of custom lists of content on dashboards and landing pages.

--- a/modules/social_features/social_content_report/social_content_report.installer_options.yml
+++ b/modules/social_features/social_content_report/social_content_report.installer_options.yml
@@ -1,0 +1,2 @@
+name: Content Abuse Reporting
+description: Gives users the option to report content to site managers that doesn't fit the community guidelines.

--- a/modules/social_features/social_embed/social_embed.installer_options.yml
+++ b/modules/social_features/social_embed/social_embed.installer_options.yml
@@ -1,0 +1,2 @@
+name: Embed Media in Content
+description: Will automatically render previews of links to content on popular websites such as YouTube, Twitter, Vimeo, etc.

--- a/modules/social_features/social_event/modules/social_event_an_enroll/social_event_an_enroll.installer_options.yml
+++ b/modules/social_features/social_event/modules/social_event_an_enroll/social_event_an_enroll.installer_options.yml
@@ -1,0 +1,2 @@
+name: Anonymous Event Enrolments
+description: Allows users to enroll in events without creating an account in the community.

--- a/modules/social_features/social_event/modules/social_event_enrolments_export/social_event_enrolments_export.installer_options.yml
+++ b/modules/social_features/social_event/modules/social_event_enrolments_export/social_event_enrolments_export.installer_options.yml
@@ -1,0 +1,2 @@
+name: Event Enrolments Export
+description: Allows users to export event enrollees for their events as comma separated value (csv) files.

--- a/modules/social_features/social_event/modules/social_event_managers/social_event_managers.installer_options.yml
+++ b/modules/social_features/social_event/modules/social_event_managers/social_event_managers.installer_options.yml
@@ -1,0 +1,2 @@
+name: Event Organisers
+description: Allows users to add organisers to events besides the creator of the event itself.

--- a/modules/social_features/social_event/modules/social_event_max_enroll/social_event_max_enroll.installer_options.yml
+++ b/modules/social_features/social_event/modules/social_event_max_enroll/social_event_max_enroll.installer_options.yml
@@ -1,0 +1,2 @@
+name: Event Enroll Limit
+description: Allows event creators to set limits to the number of people that can enroll.

--- a/modules/social_features/social_group/modules/social_group_default_route/social_group_default_route.installer_options.yml
+++ b/modules/social_features/social_group/modules/social_group_default_route/social_group_default_route.installer_options.yml
@@ -1,0 +1,2 @@
+name: Group Default Routes
+description: Allows group managers to set the default pages on a group for member and non-members

--- a/modules/social_features/social_landing_page/social_landing_page.installer_options.yml
+++ b/modules/social_features/social_landing_page/social_landing_page.installer_options.yml
@@ -1,0 +1,2 @@
+name: Landing Pages
+description: Provides content managers the ability to create landing pages. Landing pages can be used for external users or as guides for authenticated users.

--- a/modules/social_features/social_private_message/social_private_message.installer_options.yml
+++ b/modules/social_features/social_private_message/social_private_message.installer_options.yml
@@ -1,0 +1,2 @@
+name: Private Messages
+description: Allows users to send eachother private messages.

--- a/modules/social_features/social_profile/modules/social_profile_fields/social_profile_fields.installer_options.yml
+++ b/modules/social_features/social_profile/modules/social_profile_fields/social_profile_fields.installer_options.yml
@@ -1,0 +1,2 @@
+name: Profile Fields Settings
+description: Allows a Site Manager to control what fields are available on a profile.

--- a/modules/social_features/social_profile/modules/social_profile_organization_tag/social_profile_organization_tag.installer_options.yml
+++ b/modules/social_features/social_profile/modules/social_profile_organization_tag/social_profile_organization_tag.installer_options.yml
@@ -1,0 +1,2 @@
+name: Profile Organization Tag
+description: Allows Site Managers to add a special tag to the user that will indicate that this is a trusted user to other users.

--- a/modules/social_features/social_profile/modules/social_profile_privacy/social_profile_privacy.installer_options.yml
+++ b/modules/social_features/social_profile/modules/social_profile_privacy/social_profile_privacy.installer_options.yml
@@ -1,0 +1,2 @@
+name: Profile Privacy Settings
+description: Allows a Site Manager to control the visibility of profile fields.

--- a/modules/social_features/social_tagging/social_tagging.installer_options.yml
+++ b/modules/social_features/social_tagging/social_tagging.installer_options.yml
@@ -1,0 +1,2 @@
+name: Content Tagging
+description: Allows adding tags to content. Tags can be used in search, content overviews and dashboards.

--- a/modules/social_features/social_user_export/social_user_export.installer_options.yml
+++ b/modules/social_features/social_user_export/social_user_export.installer_options.yml
@@ -1,0 +1,2 @@
+name: User Export
+description: Provides the ability to export user data as comma separated values (CSV) files.


### PR DESCRIPTION


## Problem
Open Social includes a lot of optional modules but they may not be easily discovered. Additionally automation applications want to be able to enable these modules during site install.

## Solution
This commit adds `installer_options.yml` to a lot of modules that we
currently install on platforms using _core modules.

Adding these files to these modules will make them available both to
`drush site-install` as well as through the installer UI. This increases
discoverability of these modules for distribution users and eases the
live of our own SaaS hosting :)

## Issue tracker
https://www.drupal.org/project/social/issues/3163317

## How to test
*For example*
- [ ] Install all optional modules with our internal project management tool.

## Screenshots
n.a.

## Release notes
The following modules can now also be chosen during initial site installation: social_gdpr, social_path_manager, social_comment_upload, social_content_block, social_content_report, social_embed, social_event_an_enroll, social_event_enrolments_export, social_event_managers, social_event_max_enroll, social_landing_page, social_group_default_route, social_private_message, social_profile_fields, social_profile_organization_tag, social_profile_privacy, social_tagging, social_user_export
