### PR TITLE
Issue #3157762 by ribel: Fix GET parameters in read more links of the custom content list blocks

### DIFF
--- a/modules/social_features/social_content_block/src/ContentBuilder.php
+++ b/modules/social_features/social_content_block/src/ContentBuilder.php
@@ -203,15 +203,8 @@ class ContentBuilder implements ContentBuilderInterface {
 
     if (!$field->isEmpty()) {
       $url = Url::fromUri($field->uri);
-      $link_options = [
-        'attributes' => [
-          'class' => [
-            'btn',
-            'btn-flat',
-          ],
-        ],
-      ];
-      $url->setOptions($link_options);
+      $attributes = ['class' => ['btn', 'btn-flat']];
+      $url->setOption('attributes', $attributes);
 
       return Link::fromTextAndUrl($field->title, $url)->toRenderable();
     }


### PR DESCRIPTION
## Problem
When I try to add a specific link with GET parameters to a custom content list block, those parameters are trimmed.
For example: `/search/resources?f%5B0%5D=topic_type%3A36547` becomes just `/search/resources`

## Solution
Fix overwriting URL options in getLink() method of ContentBuilder.

## Issue tracker
- https://www.drupal.org/project/social/issues/3157762
- https://getopensocial.atlassian.net/browse/YANG-3358

## How to test
- [ ] Using version 8.x of Open Social with the social_content_block module enabled
- [ ] As a content manager 
- [ ] Try to add read more link with GET parameters in custom content list block
- [ ] When saving the block I expect to see read more URL with all parameters

## Release notes
Allow GET parameters in read more links of the custom content list blocks.

