### PR TITLE
Issue #3157999 by robertragas: if the results are empty we should not…

### DIFF
--- a/themes/socialbase/templates/views/views-view--activity-stream-notifications--page.html.twig
+++ b/themes/socialbase/templates/views/views-view--activity-stream-notifications--page.html.twig
@@ -45,7 +45,9 @@
     {{ title_prefix }}
     {{ title }}
     {{ title_suffix }}
-    {{ rows }}
+    {% if not empty %}
+        {{ rows }}
+    {% endif %}
 
     {% if empty %}
       <div{{ content_attributes.addClass(error_classes) }}" role="alert">

--- a/themes/socialbase/templates/views/views-view--event-manage-enrollments.html.twig
+++ b/themes/socialbase/templates/views/views-view--event-manage-enrollments.html.twig
@@ -80,7 +80,9 @@
     </div>
   {% endif %}
 
-  {{ rows }}
+  {% if not empty %}
+    {{ rows }}
+  {% endif %}
 
   {% if empty %}
 

--- a/themes/socialbase/templates/views/views-view--event_manage_enrollments.html.twig
+++ b/themes/socialbase/templates/views/views-view--event_manage_enrollments.html.twig
@@ -80,7 +80,9 @@
     </div>
   {% endif %}
 
-  {{ rows }}
+  {% if not empty %}
+    {{ rows }}
+  {% endif %}
 
   {% if empty %}
 

--- a/themes/socialbase/templates/views/views-view--group-manage-members.html.twig
+++ b/themes/socialbase/templates/views/views-view--group-manage-members.html.twig
@@ -80,7 +80,9 @@
     </div>
   {% endif %}
 
-  {{ rows }}
+  {% if not empty %}
+    {{ rows }}
+  {% endif %}
 
   {% if empty %}
 

--- a/themes/socialbase/templates/views/views-view.html.twig
+++ b/themes/socialbase/templates/views/views-view.html.twig
@@ -73,7 +73,9 @@
     </div>
   {% endif %}
 
-  {{ rows }}
+  {% if not empty %}
+    {{ rows }}
+  {% endif %}
 
   {% if empty %}
 


### PR DESCRIPTION
… render the rows, as we already have a seperate empty message defined in the templates

## Problem
We have some views that when empty, show the empty message twice.

## Solution
Change the templates to not show the rows rendering if the result is empty, because we have a different part defined for the empty message.

## Issue tracker
https://www.drupal.org/project/social/issues/3157999

## How to test
- [x] Create a group and remove yourself as a member
- [x] See the double empty text "There are no members yet."
- [x] Enable the social_event_managers module.
- [x] Create an event and go to the manage enrollments tab.
- [x] See the double empty text "No one has enrolled for this event"
- [x] Check out to this branch and check both cases, now it should only show the text within the white block.
- [x] Fill the group and event with people and see they also still show up.

## Screenshots
![Screen Shot 2020-07-09 at 1 58 17 PM](https://user-images.githubusercontent.com/19951171/87038270-c97c5500-c1ed-11ea-8a8e-a78d5a9088f4.png)

## Release notes
In some of the overview there were double headers when there were no results. We removed the faulty header.

