### PR TITLE
by robertragas: after executing the bulk operation invite to event, r…

### DIFF
--- a/modules/social_features/social_event/modules/social_event_invite/src/SocialEventInviteBulkHelper.php
+++ b/modules/social_features/social_event/modules/social_event_invite/src/SocialEventInviteBulkHelper.php
@@ -162,7 +162,7 @@ class SocialEventInviteBulkHelper {
       drupal_set_message(t('There was an unexpected error.'), 'error');
     }
 
-    return new RedirectResponse(Url::fromRoute('social_event_invite.invite_user', ['node' => $nid])->toString());
+    return new RedirectResponse(Url::fromRoute('view.event_manage_enrollment_invites.page_manage_enrollment_invites', ['node' => $nid])->toString());
   }
 
   /**
@@ -182,7 +182,7 @@ class SocialEventInviteBulkHelper {
       drupal_set_message(t('There was an unexpected error.'), 'error');
     }
 
-    return new RedirectResponse(Url::fromRoute('social_event_invite.invite_email', ['node' => $nid])->toString());
+    return new RedirectResponse(Url::fromRoute('view.event_manage_enrollment_invites.page_manage_enrollment_invites', ['node' => $nid])->toString());
   }
 
 }


### PR DESCRIPTION
…edirect to the invite overview

## Problem
When we invite people to an event, after the bulk finishes, it ends up at the invite form again which is confusing.

## Solution
Redirect to the the invite overview page, so people can see directly that their action has added the new people to the list.

## Issue tracker
https://www.drupal.org/project/social/issues/3158006

## How to test
- [x] Enable the event invite feature
- [x] Go to the manage enrollments and go to invite by email
- [x] Invite people and confirm so the bulk starts
- [x] See that after it's finished you end up at the same form again.
- [x] Check out to this branch and see you now end up at the invite overview page.

## Release notes
When inviting people after the bulk operation finishes it would redirect back to the invite form. This has been changed to the invite overview page so you can see the results of your action.
