### PR TITLE
Issue #3158812 by tBKoT: Disable access to the blocked users pages

### DIFF
--- a/modules/social_features/social_group/src/Controller/SocialGroupController.php
+++ b/modules/social_features/social_group/src/Controller/SocialGroupController.php
@@ -179,6 +179,10 @@ class SocialGroupController extends ControllerBase {
       }
     }
 
+    if ($user->isBlocked()) {
+      return AccessResult::allowedIfHasPermission($account, 'view blocked user');
+    }
+
     // Own profile?
     if ($user->id() === $account->id()) {
       return AccessResult::allowedIfHasPermission($account, 'view groups on my profile');

--- a/modules/social_features/social_user/social_user.install
+++ b/modules/social_features/social_user/social_user.install
@@ -195,3 +195,13 @@ function social_user_update_8809() {
   // The administrator should be able to assign all roles.
   user_role_grant_permissions('administrator', ['assign all roles']);
 }
+
+/**
+ * Update permissions for the sitemanager role.
+ */
+function social_user_update_8810() {
+  // Grant the sitemanagers new permissions.
+  user_role_grant_permissions('sitemanager', [
+    'view blocked user',
+  ]);
+}

--- a/modules/social_features/social_user/social_user.install
+++ b/modules/social_features/social_user/social_user.install
@@ -175,6 +175,7 @@ function _social_user_get_permissions($role) {
     'administer social_user settings',
     'assign contentmanager role',
     'assign sitemanager role',
+    'view blocked user',
   ]);
 
   if (isset($permissions[$role])) {

--- a/modules/social_features/social_user/social_user.permissions.yml
+++ b/modules/social_features/social_user/social_user.permissions.yml
@@ -8,6 +8,11 @@ block users:
   description: 'Allow to access the administration form to block some users.'
   restrict access: true
 
+view blocked user:
+  title: 'View blocked user'
+  description: 'Allow to access blocked users pages'
+  restrict access: true
+
 administer navigation settings:
   title: 'Administer Navigation Settings'
 

--- a/modules/social_features/social_user/social_user.routing.yml
+++ b/modules/social_features/social_user/social_user.routing.yml
@@ -38,6 +38,7 @@ social_user.user_home:
     _entity_view: 'user.stream'
   requirements:
     _user_is_logged_in: 'TRUE'
+    _custom_access: '\Drupal\social_user\Controller\SocialUserController::accessUsersPages'
 
 social_user.stream:
   path: '/user/{user}/stream'
@@ -45,3 +46,4 @@ social_user.stream:
     _entity_view: 'user.stream'
   requirements:
     _user_is_logged_in: 'TRUE'
+    _custom_access: '\Drupal\social_user\Controller\SocialUserController::accessUsersPages'

--- a/modules/social_features/social_user/src/Controller/SocialUserController.php
+++ b/modules/social_features/social_user/src/Controller/SocialUserController.php
@@ -2,10 +2,13 @@
 
 namespace Drupal\social_user\Controller;
 
-use Drupal\Core\Controller\ControllerBase;
-use Drupal\user\UserInterface;
 use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Routing\RouteMatch;
 use Drupal\Core\Session\AccountInterface;
+use Drupal\user\UserInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Class SocialUserController.
@@ -13,6 +16,32 @@ use Drupal\Core\Session\AccountInterface;
  * @package Drupal\social_user\Controller
  */
 class SocialUserController extends ControllerBase {
+
+  /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * SocialUserController constructor.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager.
+   */
+  public function __construct(EntityTypeManagerInterface $entity_type_manager) {
+    $this->entityTypeManager = $entity_type_manager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('entity_type.manager')
+    );
+  }
 
   /**
    * OtherUserPage.
@@ -46,7 +75,43 @@ class SocialUserController extends ControllerBase {
    *   Check standard and custom permissions.
    */
   public function access(AccountInterface $account) {
-    return AccessResult::allowedIfHasPermissions($account, ['administer users', 'view users'], 'OR');
+    return AccessResult::allowedIfHasPermissions($account, [
+      'administer users',
+      'view users',
+    ], 'OR');
+  }
+
+  /**
+   * Checks access for user page.
+   *
+   * @param \Drupal\Core\Session\AccountInterface $account
+   *   The current user.
+   * @param \Drupal\Core\Routing\RouteMatch $routeMatch
+   *   The matched route.
+   *
+   * @return \Drupal\Core\Access\AccessResultInterface
+   *   The access result.
+   */
+  public function accessUsersPages(AccountInterface $account, RouteMatch $routeMatch) {
+    /** @var \Drupal\user\UserInterface $user */
+    $user = $routeMatch->getParameter('user');
+    if (isset($user)) {
+      if (!$user instanceof UserInterface) {
+        $user = $this->entityTypeManager->getStorage('user')
+          ->load($user);
+      }
+    }
+    else {
+      return AccessResult::neutral();
+    }
+
+    if ($user->isBlocked()) {
+      if ($account->hasPermission('view blocked user')) {
+        return AccessResult::allowed();
+      }
+      return AccessResult::forbidden();
+    }
+    return AccessResult::allowed();
   }
 
 }

--- a/modules/social_features/social_user/src/Routing/RouteSubscriber.php
+++ b/modules/social_features/social_user/src/Routing/RouteSubscriber.php
@@ -45,6 +45,21 @@ class RouteSubscriber extends RouteSubscriberBase {
       $route->setOption('_admin_route', FALSE);
     }
 
+    // Routes for which needs to disable access if the user is blocked.
+    $disable_access_for = [
+      'view.groups.page_user_groups',
+      'view.user_information.user_information',
+      'view.user_discussion.page_user_discussions',
+      'view.events.events_overview',
+      'view.topics.page_profile',
+    ];
+
+    // Add custom access to routes.
+    foreach ($disable_access_for as $route_name) {
+      if ($route = $collection->get($route_name)) {
+        $route->setRequirement('_custom_access', '\Drupal\social_user\Controller\SocialUserController::accessUsersPages');
+      }
+    }
   }
 
 }

--- a/modules/social_features/social_user/src/Routing/RouteSubscriber.php
+++ b/modules/social_features/social_user/src/Routing/RouteSubscriber.php
@@ -47,9 +47,7 @@ class RouteSubscriber extends RouteSubscriberBase {
 
     // Routes for which needs to disable access if the user is blocked.
     $disable_access_for = [
-      'view.groups.page_user_groups',
       'view.user_information.user_information',
-      'view.user_discussion.page_user_discussions',
       'view.events.events_overview',
       'view.topics.page_profile',
     ];


### PR DESCRIPTION
## Problem
Disable access to blocked users' pages through the direct link

## Solution
Add custom permission to allow view blocked users' pages and add it to routes

## Issue tracker
- https://www.drupal.org/project/social/issues/3158812
- https://getopensocial.atlassian.net/browse/YANG-3225

## How to test
- [x] Log in as LU (not as SM)
- [x] Go to the `user/{user_id}/information` page
- [x] You should get the `403` page
