### PR TITLE
Issue #3159259: Book pages need to be available in the search all and search autocomplete

### DIFF
--- a/modules/social_features/social_book/social_book.install
+++ b/modules/social_features/social_book/social_book.install
@@ -5,6 +5,8 @@
  * Install, update and uninstall functions for the social_book module.
  */
 
+use Drupal\Core\Entity\EntityStorageException;
+use Drupal\search_api\Entity\Index;
 use Drupal\user\Entity\Role;
 use Symfony\Component\Yaml\Yaml;
 
@@ -166,4 +168,23 @@ function social_book_update_8802() {
 
   // Output logged messages to related channel of update execution.
   return $updateHelper->logger()->output();
+}
+
+/**
+ * Update search all with book pages.
+ */
+function social_book_update_8803() {
+  // If the search module is enabled trigger updating of the indexes affected
+  // by the book update in config override.
+  try {
+    $index = Index::load('social_all');
+    if ($index !== NULL && $index->status()) {
+      $index->save();
+      $index->clear();
+      $index->reindex();
+    }
+  }
+  catch (EntityStorageException $e) {
+    \Drupal::logger('social_book')->info($e->getMessage());
+  }
 }

--- a/modules/social_features/social_book/src/SocialBookConfigOverride.php
+++ b/modules/social_features/social_book/src/SocialBookConfigOverride.php
@@ -32,6 +32,18 @@ class SocialBookConfigOverride implements ConfigFactoryOverrideInterface {
         $overrides[$config_name] = ['visibility' => ['node_type' => ['bundles' => $bundles]]];
       }
     }
+
+    // Ensure book pages are added to social_all so search all
+    // and search autocomplete index and show book results correctly.
+    $config_names = [
+      'search_api.index.social_all',
+    ];
+    foreach ($config_names as $config_name) {
+      if (in_array($config_name, $names)) {
+        $overrides[$config_name]['datasource_settings']['entity:node']['bundles']['selected']['book'] = 'book';
+      }
+    }
+
     return $overrides;
   }
 


### PR DESCRIPTION
## Problem
When enabling social book, when you search for a book you will see the result in the Content tab but not in the All tab although that also shows all other pieces of content.
The search autocomplete through the magnifying glass also doesn't show this in that case.

## Solution
Ensure we also index and show book as search results for the All index. This will make sure it works for both.
Also ensure we trigger a re-index and save so the new config is added.

## Issue tracker
https://www.drupal.org/project/social/issues/3159259
https://getopensocial.atlassian.net/browse/OS-303

## How to test
- [x] Login as LU and create a book page
- [x] Try to find it in the search all tab or using the autocomplete, it's not there
- [ ] See that it is there on the Content tab
- [ ] Checkout this branch, run updates
- [ ] The expected result is the same book page is now available in search all and search autocomplete

## Screenshots
<img width="701" alt="Screen Shot 2020-07-15 at 11 08 31" src="https://user-images.githubusercontent.com/16667281/87526807-91609080-c68b-11ea-93e6-2ed26fe5d092.png">
<img width="941" alt="Screen Shot 2020-07-15 at 11 08 21" src="https://user-images.githubusercontent.com/16667281/87526813-9291bd80-c68b-11ea-9177-5723303307d4.png">

## Release notes
Book pages can now also be found using the search autocomplete using the magnifying glass, or on the search all tab of the search itself.