### PR TITLE
Issue #3159764 by agami4: Add "break-word" style to the text of comment block

### DIFF
--- a/themes/socialbase/assets/css/comment.css
+++ b/themes/socialbase/assets/css/comment.css
@@ -9,6 +9,8 @@ a[id^="comment-"] {
   position: relative;
   margin-top: 1em;
   line-height: 1.2;
+  display: -webkit-box;
+  display: -ms-flexbox;
   display: flex;
   width: 100%;
 }
@@ -25,11 +27,14 @@ a[id^="comment-"] {
   margin-right: 8px;
   width: 38px;
   height: 38px;
-  flex-shrink: 0;
+  -ms-flex-negative: 0;
+      flex-shrink: 0;
 }
 
 .comment__content {
-  flex: 1;
+  -webkit-box-flex: 1;
+      -ms-flex: 1;
+          flex: 1;
 }
 
 .comment__author {
@@ -53,12 +58,15 @@ a[id^="comment-"] {
   line-height: 1.3;
 }
 
-.comment__text p {
-  word-break: break-word;
-}
-
 .comment__text p:last-of-type {
   margin-bottom: 0;
+}
+
+.comment__text p,
+.comment__text ul,
+.comment__text ul li,
+.comment__text a {
+  word-break: break-word;
 }
 
 .comment__text .badge {
@@ -117,7 +125,9 @@ a[id^="comment-"] {
  */
 
 .comment-attachments {
-  flex: 1 0 100%;
+  -webkit-box-flex: 1;
+      -ms-flex: 1 0 100%;
+          flex: 1 0 100%;
 }
 
 .comment-attachments .btn {

--- a/themes/socialbase/components/04-organisms/comment/comment.scss
+++ b/themes/socialbase/components/04-organisms/comment/comment.scss
@@ -63,12 +63,15 @@ a[id^="comment-"] {
   margin: .25em 0 .5em;
   line-height: 1.3;
 
-  p {
-    word-break: break-word;
+  p:last-of-type {
+    margin-bottom: 0;
+  }
 
-    &:last-of-type {
-      margin-bottom: 0;
-    }
+  p,
+  ul,
+  ul li,
+  a {
+    word-break: break-word;
   }
 
   // like badge


### PR DESCRIPTION
## Problem
The text is not moved to a new line.

## Solution
Add to the text `word-break: break-word;` style.

## Issue tracker
- https://www.drupal.org/project/social/issues/3159764
- https://getopensocial.atlassian.net/browse/YANG-3354

## How to test
*For example*
- [x] Go to the `Discussion` page
- [x] Add a long word to the comment

## Screenshots
Before:
![bug_text](https://user-images.githubusercontent.com/16086340/87758730-ad903900-c815-11ea-9cae-58eeb86c2e43.png)

After:
<img width="840" alt="text-fix" src="https://user-images.githubusercontent.com/16086340/87758745-b5e87400-c815-11ea-9879-0899104d0971.png">

## Release notes
If the word is very long, it will be moved to a new line on the comment block. 
