### PR TITLE
Issue #3159810 by SV: Replace static classes with attributes variable for the body field of node

### DIFF
--- a/themes/socialbase/templates/node/field--node--body.html.twig
+++ b/themes/socialbase/templates/node/field--node--body.html.twig
@@ -15,7 +15,14 @@
     %}
     <div{{ title_attributes.addClass(title_classes) }}>{{ label }}</div>
   {% endif %}
-  <div class="body-text clearfix">
+
+  {%
+    set body_classes = [
+    'body-text',
+    'clearfix',
+  ]
+  %}
+  <div {{ attributes.addClass(body_classes) }}>
     {% for item in items %}
       {{ item.content }}
     {% endfor %}


### PR DESCRIPTION
## Problem
*Using static classes for the body field of node prevents adding dynamic attributes by other modules (like quickedit) which could cause issues.*

## Solution
*Use the "attributes" variable.*

## Issue tracker

- https://www.drupal.org/project/social/issues/3159810
- https://getopensocial.atlassian.net/browse/YANG-3361
