### PR TITLE
#3160305: Change the comment box title when there are no comments

### DIFF
--- a/themes/socialbase/src/Plugin/Preprocess/Node.php
+++ b/themes/socialbase/src/Plugin/Preprocess/Node.php
@@ -158,8 +158,12 @@ class Node extends PreprocessBase {
       // comment count, and add the comment count to the node.
       if ($node->$comment_field_name->status != CommentItemInterface::HIDDEN) {
         $comment_count = _socialbase_node_get_comment_count($node, $comment_field_name);
-        $t_args = [':num_comments' => $comment_count];
-        $variables['below_content'][$comment_field_name]['#title'] = t('Comments (:num_comments)', $t_args);
+        if ($comment_count === 0) {
+          $variables['below_content'][$comment_field_name]['#title'] = t('Be the first one to comment');
+        }
+        else {
+          $variables['below_content'][$comment_field_name]['#title'] = t('Comments (:num_comments)', [':num_comments' => $comment_count]);
+        }
 
         // If it's closed, we only show the comment section when there are
         // comments placed. Closed means we show comments but you are not able

--- a/themes/socialbase/src/Plugin/Preprocess/Node.php
+++ b/themes/socialbase/src/Plugin/Preprocess/Node.php
@@ -158,12 +158,7 @@ class Node extends PreprocessBase {
       // comment count, and add the comment count to the node.
       if ($node->$comment_field_name->status != CommentItemInterface::HIDDEN) {
         $comment_count = _socialbase_node_get_comment_count($node, $comment_field_name);
-        if ($comment_count === 0) {
-          $variables['below_content'][$comment_field_name]['#title'] = t('Be the first one to comment');
-        }
-        else {
-          $variables['below_content'][$comment_field_name]['#title'] = t('Comments (:num_comments)', [':num_comments' => $comment_count]);
-        }
+        $variables['below_content'][$comment_field_name]['#title'] = $comment_count === 0 ? t('Be the first one to comment') : t('Comments (:num_comments)', [':num_comments' => $comment_count]);
 
         // If it's closed, we only show the comment section when there are
         // comments placed. Closed means we show comments but you are not able


### PR DESCRIPTION
## Problem
We can make the comment box title sound more engaging.

## Solution
Change the text for the comment box title.

## Issue tracker
https://www.drupal.org/project/social/issues/3160305

## How to test
- [ ] Go to a node with comments enabled
- [ ] Observe that you see "Be the first one to comment"
- [ ] Place a comment
- [ ] Observe that you see "Comments (1)"

## Screenshots
**Before**
<img width="817" alt="Screenshot 2020-07-20 at 15 42 17" src="https://user-images.githubusercontent.com/7124754/87945215-b9436000-caa0-11ea-8840-9cfa793f429b.png">

**After**
<img width="824" alt="Screenshot 2020-07-20 at 15 45 42" src="https://user-images.githubusercontent.com/7124754/87945227-bcd6e700-caa0-11ea-88d1-2ee560a19c62.png">

## Release notes
The comment box title at nodes now says "Be the first one to comment" instead of a disappointing "Comments (0)".

## Change Record
N/a

## Translations
N/a