### PR TITLE
Issue 3144794: Hero block display based on path is too fragile

### DIFF
--- a/modules/custom/social_path_manager/social_path_manager.module
+++ b/modules/custom/social_path_manager/social_path_manager.module
@@ -292,19 +292,15 @@ function social_path_manager_preprocess_block(&$variables) {
     if (!empty($variables['elements']['#plugin_id']) &&
       $variables['elements']['#plugin_id'] === 'social_page_title_block' &&
       $variables['elements']['#id'] === 'socialblue_pagetitleblock_content') {
-      $current_url = Url::fromRoute('<current>');
-      $current_path = $current_url->toString();
-
-      $paths_to_exclude = [
-        'edit',
-        'add',
-        'delete',
-      ];
-
-      $in_path = str_replace($paths_to_exclude, '', $current_path) !== $current_path;
 
       // We make sure there are no two heroes shown only page titles.
-      if ($in_path) {
+      $route_name = \Drupal::routeMatch()->getRouteName();
+      if (in_array($route_name, [
+        'entity.node.edit_form',
+        'entity.node.delete_form',
+        'entity.node.add_form',
+      ])) {
+
         $variables['content']['#type'] = 'page_title';
         if (!empty($variables['content']['#hero_node'])) {
           unset($variables['content']['#hero_node']);


### PR DESCRIPTION
## Problem
*Hero image is missing on the discussion page with ailas /digitalhealthrights/discussion/digital-health-technologies-respecting-rights-**add**ressing because Hero block display based on path*

## Solution
*Replace paths with routes to avoid incorrect matches in conditions*

## Issue tracker
*https://www.drupal.org/project/social/issues/3144794*
*https://getopensocial.atlassian.net/browse/YANG-3422*

## How to test
- [x] Create discussion node as a sitemanager
     - fill all fields
     - add alias like: /digitalhealthrights/discussion/digital-health-technologies-respecting-rights-**add**ressing 
- [x] After saving I expect the that hereo back displays on the view page 
- [x] The expected result is attained when repeating the steps with this fix applied.

## Release notes
*Resolve an issue when "Hero block" is not displays on the node page.*

