### PR TITLE
Issue #3161705 by tBKoT: Set DESC sorting as default for the 'Custom …

### DIFF
--- a/modules/social_features/social_content_block/src/ContentBuilder.php
+++ b/modules/social_features/social_content_block/src/ContentBuilder.php
@@ -485,7 +485,7 @@ class ContentBuilder implements ContentBuilderInterface {
 
       // Fall back by assuming the sorting option is a field.
       default:
-        $query->orderBy("base_table.${sort_by}");
+        $query->orderBy("base_table.${sort_by}", 'DESC');
     }
 
   }


### PR DESCRIPTION
## Problem
When for the custom content list block used the 'Creation date' sorting, firstly displays the older items

## Solution
Set default sorting as descending in content builder

## Issue tracker
- https://www.drupal.org/project/social/issues/3161705
