### PR TITLE
Issue #3161709 by SV: User can change Text Format for body field

### DIFF
--- a/modules/social_features/social_core/social_core.module
+++ b/modules/social_features/social_core/social_core.module
@@ -494,6 +494,13 @@ function social_core_filter_process_format($element) {
     'edit-field-group-description-0',
   ];
 
+  $element_id = $element['#id'];
+
+  // Check if there is generated sub-id and cleanup it.
+  if (($sub_id = strpos($element_id, '--')) !== FALSE) {
+    $element_id = substr($element_id, 0, $sub_id);
+  }
+
   $full_html = FilterFormat::load('full_html');
   $permission_name = $full_html->getPermissionName();
   $account = \Drupal::currentUser();
@@ -511,7 +518,11 @@ function social_core_filter_process_format($element) {
       unset($element['value']['#pre_render'][$key]);
     }
   }
-  elseif ($element['#type'] == 'text_format' && $account->hasPermission($permission_name) && in_array($element['#id'], $full_html_field_ids)) {
+  elseif (
+    $element['#type'] === 'text_format' &&
+    $account->hasPermission($permission_name) &&
+    in_array($element_id, $full_html_field_ids)
+  ) {
     $element['#format'] = 'full_html';
     $element['format']['format']['#access'] = FALSE;
     $element['format']['format']['#value'] = 'full_html';


### PR DESCRIPTION
## Problem
User can change Text Format for body field when enabled quickedit module.

In source code we have the following:

> // Only fields listed here will have text format settings disabled.
  $full_html_field_ids = [
    'edit-body-0',
    'edit-field-profile-self-introduction-0',
    'edit-field-group-description-0',
  ];
...
elseif (
    $element['#type'] == 'text_format' &&
    $account->hasPermission($permission_name) &&
    in_array($element['#id'], $full_html_field_ids)
  ) {
    $element['#format'] = 'full_html';
    $element['format']['format']['#access'] = FALSE;

but when we have enabled quickedit module element id includes additional unique sub-id, like edit-body-0--CN3RzsrtGkE which causes that user can change "disabled" option.
## Solution
Cleanup element id and remove part after "--"

## Issue tracker
- https://www.drupal.org/project/social/issues/3161709
- https://getopensocial.atlassian.net/browse/YANG-3011

## How to test
- [ ] Using the latest version of Open Social with the quickedit module enabled
- [ ] Open view page of existing idea or create new one
- [ ] Click on quickedit in contextual links and select a body field
- [ ] When edit popup is loaded I expect to see only text area, without text format selector 
- [ ] The expected result is attained when repeating the steps with this fix applied.

## Release notes
Hide Text Format for body field when enabled quickedit module.
