### PR TITLE
Issue #3162344 by robertragas: add translationcontext when retrieving…

### DIFF
--- a/modules/social_features/social_tagging/social_tagging.services.yml
+++ b/modules/social_features/social_tagging/social_tagging.services.yml
@@ -1,7 +1,7 @@
 services:
   social_tagging.tag_service:
     class: Drupal\social_tagging\SocialTaggingService
-    arguments: ['@entity_type.manager', '@config.factory']
+    arguments: ['@entity_type.manager', '@config.factory', '@language_manager']
   social_tagging.overrider:
     class: Drupal\social_tagging\SocialTaggingOverrides
     tags:


### PR DESCRIPTION
… labels from the social_tagging taxonomy

## Problem
Open Social offers the possibility to insert content tags as taxonomy, these are then shown altered/shown through code in the social_tagging module.
This module does not take translations into account when getting the labels. As a result it will always show the source language aka english when your site is multilangual.

## Solution
Change the way the labels are getting retrieved in the social_tagging module to take translation context into account.

## Issue tracker
https://www.drupal.org/project/social/issues/3162344

## How to test
- [ ] Enable the Social language modules
- [ ] Enable the Social tagging module
- [ ] Make sure you go to the Open Social -> Tag settings and save the form once
- [ ] Add a second language
- [ ] Make sure you edit the content tags taxonomy category and make it translatable
- [ ] Create some taxonomy terms in this category and translate them
- [ ] Create a topic when switched to the secondary language. See that the content tags are found in the original language
- [ ] Save the content and see the sidebar block also has the original language content tags block. Same goes when trying to use the search content function and want to apply the filter.

## Release notes
We have fixed an issue where content tags taxonomy terms would show in source language when you would have multiple languages. Now it will show the correct translation according to the active language.