### PR TITLE
Issue #3089852 by robertragas: featured item link markup to make the whole button clickable

### DIFF
--- a/modules/social_features/social_core/src/Plugin/Field/FieldFormatter/LinkClassFormatter.php
+++ b/modules/social_features/social_core/src/Plugin/Field/FieldFormatter/LinkClassFormatter.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Drupal\social_core\Plugin\Field\FieldFormatter;
+
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\link\LinkItemInterface;
+use Drupal\link\Plugin\Field\FieldFormatter\LinkFormatter;
+
+/**
+ * Plugin implementation of the 'link' formatter.
+ *
+ * @FieldFormatter(
+ *   id = "link_with_class",
+ *   label = @Translation("Link with Custom Class"),
+ *   field_types = {
+ *     "link"
+ *   }
+ * )
+ */
+class LinkClassFormatter extends LinkFormatter {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function defaultSettings() {
+    return parent::defaultSettings() +
+      ['class' => ''];
+
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function settingsForm(array $form, FormStateInterface $form_state) {
+    $elements = parent::settingsForm($form, $form_state);
+
+    $elements['class'] = [
+      '#type' => 'textfield',
+      '#title' => t('Class on Link'),
+      '#default_value' => $this->getSetting('class'),
+    ];
+
+    return $elements;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function settingsSummary() {
+
+    $summary = parent::settingsSummary();
+
+    $settings = $this->getSettings();
+
+    if (!empty($settings['class'])) {
+      $summary[] = t('Class(es) on button = "@classes"', ['@classes' => $settings['class']]);
+    }
+
+    return $summary;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function buildUrl(LinkItemInterface $item) {
+    $url = parent::buildUrl($item);
+
+    $settings = $this->getSettings();
+
+    if (!empty($settings['class'])) {
+      $options = $url->getOptions();
+      $options['attributes']['class'] = $settings['class'];
+      $url->setOptions($options);
+    }
+
+    return $url;
+  }
+
+}

--- a/modules/social_features/social_featured_items/config/install/core.entity_view_display.paragraph.featured_item.default.yml
+++ b/modules/social_features/social_featured_items/config/install/core.entity_view_display.paragraph.featured_item.default.yml
@@ -10,7 +10,7 @@ dependencies:
     - paragraphs.paragraphs_type.featured_item
   module:
     - image
-    - link
+    - social_core
     - text
 id: paragraph.featured_item.default
 targetEntityType: paragraph
@@ -37,13 +37,14 @@ content:
     weight: 1
     label: hidden
     settings:
-      trim_length: 80
+      trim_length: '80'
+      class: 'card__link btn btn-default'
       url_only: false
       url_plain: false
-      rel: ''
-      target: ''
+      rel: 0
+      target: 0
     third_party_settings: {  }
-    type: link
+    type: link_with_class
     region: content
   field_featured_item_title:
     weight: 0

--- a/modules/social_features/social_featured_items/config/update/social_featured_items_update_8001.yml
+++ b/modules/social_features/social_featured_items/config/update/social_featured_items_update_8001.yml
@@ -1,0 +1,12 @@
+core.entity_view_display.paragraph.featured_item.default:
+  expected_config: { }
+  update_actions:
+    change:
+      content:
+        field_featured_item_link:
+          settings:
+            class: 'card__link btn btn-default'
+            rel: 0
+            target: 0
+            trim_length: '80'
+          type: link_with_class

--- a/modules/social_features/social_featured_items/social_featured_items.install
+++ b/modules/social_features/social_featured_items/social_featured_items.install
@@ -8,7 +8,7 @@
 /**
  * Set the new class for the featured content items on the link itself.
  */
-function social_featured_content_update_8001() {
+function social_featured_items_update_8001() {
   /** @var \Drupal\update_helper\Updater $updateHelper */
   $updateHelper = \Drupal::service('update_helper.updater');
 

--- a/modules/social_features/social_featured_items/social_featured_items.install
+++ b/modules/social_features/social_featured_items/social_featured_items.install
@@ -1,6 +1,11 @@
 <?php
 
 /**
+ * @file
+ * Install, update and uninstall functions for the social_featured_items module.
+ */
+
+/**
  * Set the new class for the featured content items on the link itself.
  */
 function social_featured_content_update_8001() {

--- a/modules/social_features/social_featured_items/social_featured_items.install
+++ b/modules/social_features/social_featured_items/social_featured_items.install
@@ -1,0 +1,15 @@
+<?php
+
+/**
+ * Set the new class for the featured content items on the link itself.
+ */
+function social_featured_content_update_8001() {
+  /** @var \Drupal\update_helper\Updater $updateHelper */
+  $updateHelper = \Drupal::service('update_helper.updater');
+
+  // Execute configuration update definitions with logging of success.
+  $updateHelper->executeUpdate('social_featured_items', 'social_featured_items_update_8001');
+
+  // Output logged messages to related channel of update execution.
+  return $updateHelper->logger()->output();
+}

--- a/modules/social_features/social_featured_items/templates/paragraph--featured-item--default.html.twig
+++ b/modules/social_features/social_featured_items/templates/paragraph--featured-item--default.html.twig
@@ -41,7 +41,7 @@
 
       {% if (content.field_featured_item_link|render is not empty) %}
         <footer class="card__actionbar">
-          <div class="card__link btn btn-default">
+          <div>
             {{ content.field_featured_item_link }}
           </div>
         </footer>


### PR DESCRIPTION
## Problem
When you create a featured item on a landing page, you can define an url with a "read more". Only the text within this button is clickable while the whole button should work.

## Solution
Move the classes around so the button itself is styled on the link and not the surrounding div.

## Issue tracker
https://www.drupal.org/project/social/issues/3089852

## How to test
- [x]  Enable the social_landing_page module or run drush updb.
- [x]  Create a landing page
- [x]  Add a section item
- [x]  Add a featured item
- [x]  Add URL and a text
- [x]  See that the whole button is clickable now.

## Release notes
When creating a featured item for a landing page, only the link text was clickable. This has been fixed and now the complete button can be clicked.