### PR TITLE
Issue #3164021 by ribel: Fix layout misalignment in group invite form

### DIFF
--- a/modules/social_features/social_core/config/optional/block.block.socialblue_local_actions.yml
+++ b/modules/social_features/social_core/config/optional/block.block.socialblue_local_actions.yml
@@ -19,6 +19,6 @@ settings:
 visibility:
   request_path:
     id: request_path
-    pages: "/admin/reports/*\r\n/group/*/membership\r\n/group/*/join\r\n/group/*/leave\r\n/group/*/delete\r\n/group/*/content/*\r\n/node/*/all-enrollments\r\n/node/*/all-enrollment-requests\r\n/node/*/delete\r\n/user/*/edit"
+    pages: "/admin/reports/*\r\n/group/*/membership\r\n/group/*/join\r\n/group/*/leave\r\n/group/*/delete\r\n/group/*/content/*\r\n/group/*/invite-members\r\n/node/*/all-enrollments\r\n/node/*/all-enrollment-requests\r\n/node/*/delete\r\n/user/*/edit"
     negate: true
     context_mapping: {  }

--- a/modules/social_features/social_core/config/update/social_core_update_8813.yml
+++ b/modules/social_features/social_core/config/update/social_core_update_8813.yml
@@ -1,0 +1,10 @@
+block.block.socialblue_local_actions:
+  expected_config:
+    visibility:
+      request_path:
+        pages: "/admin/reports/*\r\n/group/*/membership\r\n/group/*/join\r\n/group/*/leave\r\n/group/*/delete\r\n/group/*/content/*\r\n/node/*/all-enrollments\r\n/node/*/all-enrollment-requests\r\n/node/*/delete\r\n/user/*/edit"
+  update_actions:
+    change:
+      visibility:
+        request_path:
+          pages: "/admin/reports/*\r\n/group/*/membership\r\n/group/*/join\r\n/group/*/leave\r\n/group/*/delete\r\n/group/*/content/*\r\n/group/*/invite-members\r\n/node/*/all-enrollments\r\n/node/*/all-enrollment-requests\r\n/node/*/delete\r\n/user/*/edit"

--- a/modules/social_features/social_core/social_core.install
+++ b/modules/social_features/social_core/social_core.install
@@ -1158,3 +1158,17 @@ function social_core_update_8812(&$sandbox) {
   // Install Gin Toolbar module.
   \Drupal::service('module_installer')->install(['gin_toolbar']);
 }
+
+/**
+ * Block changes for the social_group_request feature.
+ */
+function social_core_update_8813() {
+  /** @var \Drupal\update_helper\Updater $updateHelper */
+  $updateHelper = \Drupal::service('update_helper.updater');
+
+  // Execute configuration update definitions with logging of success.
+  $updateHelper->executeUpdate('social_core', 'social_core_update_8813');
+
+  // Output logged messages to related channel of update execution.
+  return $updateHelper->logger()->output();
+}


### PR DESCRIPTION
## Problem
There is layout misalignment in group invite form in Sky style.

## Solution
Add `group/*/invite-members` to the `socialblue_local_actions` block.

## Issue tracker
- https://www.drupal.org/project/social/issues/3164021

## How to test
- [ ] Using version 9.x of Open Social with the social_group_request module enabled
- [ ] As a site manager
- [ ] Go to group/*/invite-members
- [ ] You should not see empty space on the left sidebar

## Screenshots
Before:
![image](https://user-images.githubusercontent.com/2241917/89664913-8262ac00-d8e0-11ea-826f-8c7b488b3145.png)

After:
![image](https://user-images.githubusercontent.com/2241917/89664999-a6be8880-d8e0-11ea-85e1-de2f19c2f581.png)
