### PR TITLE
Issue/3164294 group type

### DIFF
--- a/modules/social_features/social_group/social_group.module
+++ b/modules/social_features/social_group/social_group.module
@@ -81,40 +81,6 @@ function template_preprocess_group_settings_help(array &$variables) {
 }
 
 /**
- * Implements hook_form_FORM_ID_alter().
- */
-function social_group_form_group_public_group_edit_form_alter(&$form, FormStateInterface $form_state, $form_id) {
-  $group = $form_state->getFormObject()->getEntity();
-  $form['group_type'] = SocialGroupAddForm::create(\Drupal::getContainer())->getGroupTypeElement();
-  $form['group_type']['#default_value'] = $group->bundle();
-
-  // If user doesn't have permission to change group types disable it.
-  // Or if group types can't be edited due to visibility issues.
-  if (!social_group_group_type_permission_check()) {
-    $form['group_type']['#disabled'] = TRUE;
-  }
-  else {
-    $form['group_type']['#prefix'] = '<div id="group-type-result"></div>';
-    $group_type_element['#ajax'] = [
-      'callback' => '_social_group_inform_group_type_selection',
-      'effect' => 'fade',
-      'event' => 'change',
-    ];
-  }
-
-  // Disable all group types that can't be edited. Because they don't have
-  // a visibility.
-  foreach ($form['group_type']['#options'] as $type => $label) {
-    if (\Drupal::service('social_group.helper_service')->getDefaultGroupVisibility($type) === NULL) {
-      $form['group_type'][$type] = [
-        '#disabled' => TRUE,
-      ];
-    }
-  }
-  $form['#group_children']['group_type'] = 'group_content';
-}
-
-/**
  * Check if a User is able to edit a Group's GroupType.
  *
  * @return bool

--- a/modules/social_features/social_group/social_group.module
+++ b/modules/social_features/social_group/social_group.module
@@ -133,7 +133,7 @@ function social_group_group_type_permission_check() {
   }
 
   // Otherwise return true when we are able to edit the current group type.
-  return TRUE;
+  return ($group instanceof GroupInterface && $user->hasPermission('edit group types'));;
 }
 
 /**

--- a/modules/social_features/social_group/social_group.module
+++ b/modules/social_features/social_group/social_group.module
@@ -713,8 +713,14 @@ function social_group_form_alter(&$form, FormStateInterface $form_state, $form_i
         ];
       }
 
+      // Add form element group type to include our element in form.
       $form['group_type'] = $group_type_element;
+      // Tell Drupal that it is under fieldset group settings.
+      $form['group_settings']['group_type'] = $form['group_type'];
+      // We also inform Drupal that group type is children of group_settings.
       $form['#group_children']['group_type'] = 'group_settings';
+      // Finally, add the group_type as fieldgroup children,
+      $form['#fieldgroups']['group_settings']->children[] = 'group_type';
 
       // Disable all group types that can't be edited. Because they don't have
       // a visibility.


### PR DESCRIPTION
## Problem
Group type configuration appears when edit group information and it should not

## Solution
1. Revert: https://github.com/goalgorilla/open_social/pull/1093/files#diff-fee9280a28d1f7909b94241fdb6e6754R92
2. Add the logic of rendering form element correctly to ensure group type is added to correct fieldset "Group Settings"

## Issue tracker
https://www.drupal.org/project/social/issues/3164294
https://getopensocial.atlassian.net/browse/DS-7318

## How to test
- [ ] As an LU, add a group and save it
- [ ] Edit the group
- [ ] You shouldn't be able to change the group type of group.
- [ ] As an SM/CM+, you should be able to change the group type of the same group.
- [ ] Group Type options should appear in the "Settings" tab.

## Screenshots
**Before:**
![image](https://user-images.githubusercontent.com/8435994/89761729-b02c3880-db0c-11ea-8274-c2eeaa13fa03.png)

**After:**
![image](https://user-images.githubusercontent.com/8435994/89761742-b4f0ec80-db0c-11ea-9575-3011c9b42fdd.png)

## Release notes
N.A

## Change Record
N.A

## Translations
N.A