### PR TITLE
Issue #3157175 - Add member button

### DIFF
--- a/modules/social_features/social_event/modules/social_event_managers/social_event_managers.links.action.yml
+++ b/modules/social_features/social_event/modules/social_event_managers/social_event_managers.links.action.yml
@@ -3,3 +3,6 @@ social_event_managers.add_member:
   route_name: 'social_event_managers.add_enrollees'
   appears_on:
     - view.event_manage_enrollments.page_manage_enrollments
+  cache_contexts:
+    - 'user.permissions'
+    - 'user.roles'

--- a/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.module
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.module
@@ -262,6 +262,7 @@ function social_group_flexible_group_menu_local_actions_alter(&$local_actions) {
     && $group->getGroupType()->id() === 'flexible_group'
     && !social_group_flexible_group_can_be_added($group)
     && !$user->hasPermission('manage all groups')
+    && !$group->hasPermission('administer members', $user)
   ) {
     unset($local_actions['social_group.add_member']);
   }

--- a/tests/behat/features/capabilities/group/group-edit-join-method-flexible.feature
+++ b/tests/behat/features/capabilities/group/group-edit-join-method-flexible.feature
@@ -15,14 +15,15 @@ Feature: Edit my group as a group manager
     And I press "Continue"
     And I wait for AJAX to finish
     When I fill in "Title" with "Test flexible group"
+    Then I click radio button "Open to join - users can join this group without approval" with the id "edit-field-group-allowed-join-method-direct"
     And I fill in the "edit-field-group-description-0-value" WYSIWYG editor with "Description text"
     And I press "Save"
     And I should see "Test flexible group" in the "Main content"
     And I should see "1 member"
-
-  # TB-4365 - As a Group Manager I want to change group join-method
     And I click "Manage members"
     Then I should see the link "Add members"
+
+  # TB-4365 - As a Group Manager I want to change group join-method
     When I click "Edit group"
     And I wait for AJAX to finish
     Then I click radio button "Invite-only - users can only join this group if they are added/invited by group managers" with the id "edit-field-group-allowed-join-method-added"

--- a/tests/behat/features/capabilities/group/group-edit-join-method-flexible.feature
+++ b/tests/behat/features/capabilities/group/group-edit-join-method-flexible.feature
@@ -1,0 +1,31 @@
+@api @group @stability @stability-2 @TB-4365 @group-edit-join-method-flexible
+Feature: Edit my group as a group manager
+  Benefit: Have control over adding members as Group Manager regardless of join method
+  Role: As a GM
+  Goal/desire: I want to change join method of my flexible group and still be able to add members
+
+  Scenario: Successfully change join method of my group as a group manager and still be able to add members
+    Given users:
+      | name              | mail             | field_profile_organization | status |
+      | Group Manager     | gm_1@example.com | GoalGorilla                | 1      |
+
+    And I am logged in as "Group Manager"
+    And I am on "group/add"
+    Then I click radio button "Flexible group By choosing this option you can customize many group settings to your needs." with the id "edit-group-type-flexible-group"
+    And I press "Continue"
+    And I wait for AJAX to finish
+    When I fill in "Title" with "Test flexible group"
+    And I fill in the "edit-field-group-description-0-value" WYSIWYG editor with "Description text"
+    And I press "Save"
+    And I should see "Test flexible group" in the "Main content"
+    And I should see "1 member"
+
+  # TB-4365 - As a Group Manager I want to change group join-method
+    And I click "Manage members"
+    Then I should see the link "Add members"
+    When I click "Edit group"
+    And I wait for AJAX to finish
+    Then I click radio button "Invite-only - users can only join this group if they are added/invited by group managers" with the id "edit-field-group-allowed-join-method-added"
+    And I press "Save"
+    When I click "Manage members"
+    Then I should see the link "Add members"


### PR DESCRIPTION
## Problem
Buttons to Add a Member to a Group and to Add an Enrollee to an Event sometime are not visible on the page, this happens for different roles.

## Solution
Add proper cache context to button for event and add group manager's check in social_group_flexible_group_menu_local_actions_alter.

## Issue tracker
https://www.drupal.org/project/social/issues/3157175
https://getopensocial.atlassian.net/browse/TB-4365

## How to test
- [ ] As an LU, create a flexible group with "Open to Join" method
- [ ] Check the "Manage Enrollment" tab.
- [ ] You should not be able to see the "Add Members" button
- [ ] Now, toggle the joining method and save the group.
- [ ] Go to the "manage enrollment" tab and you should be able to see the button.
- [ ] Create an event.
- [ ] Add the current user as Organizer
- [ ] You should be able to see the "Add an Enrollee" button on the "Enrollment" tab.

## Screenshots
N.A

## Release notes
There was an inconsistent caching bug due to which sometimes the group manager or event organizer was not able to see the "Add member" button if they have an LU role. It should be solved now.

## Change Record
N.A

## Translations
N.A