### PR TITLE
Issue #3137445 by mdeny: Make sure postalcode can also be hidden

### DIFF
--- a/modules/social_features/social_profile/modules/social_profile_fields/config/install/social_profile_fields.settings.yml
+++ b/modules/social_features/social_profile/modules/social_profile_fields/config/install/social_profile_fields.settings.yml
@@ -15,4 +15,5 @@ profile_profile_field_profile_self_introduction: true
 profile_profile_field_profile_show_email: null
 profile_address_field_city: true
 profile_address_field_address: true
+profile_address_field_postalcode: true
 nickname_unique_validation: false

--- a/modules/social_features/social_profile/modules/social_profile_fields/social_profile_fields.module
+++ b/modules/social_features/social_profile/modules/social_profile_fields/social_profile_fields.module
@@ -215,6 +215,7 @@ function social_profile_fields_social_user_export_plugin_info_alter(array &$plug
     if (!empty($filtered) || array_key_exists('profile_profile_field_profile_address', $profile_fields)) {
       $profile_fields[] = ['id' => 'profile_address_field_city'];
       $profile_fields[] = ['id' => 'profile_address_field_address'];
+      $profile_fields[] = ['id' => 'profile_address_field_postalcode'];
     }
 
     foreach ($profile_fields as $field) {
@@ -254,6 +255,7 @@ function social_profile_fields_entity_bundle_field_info_alter(&$fields, EntityTy
       if ($setting = $field_profile_address->getSetting('fields')) {
         $setting['locality'] = !$config->get('profile_address_field_city') ? '0' : 'locality';
         $setting['addressLine1'] = !$config->get('profile_address_field_address') ? '0' : 'addressLine1';
+        $setting['postalCode'] = !$config->get('profile_address_field_postalcode') ? '0' : 'postalCode';
 
         // Update the settings of address field.
         $fields['field_profile_address']->setSetting('fields', $setting);
@@ -271,6 +273,13 @@ function social_profile_fields_entity_bundle_field_info_alter(&$fields, EntityTy
         }
         else {
           unset($setting['addressLine1']);
+        }
+
+        if (!$config->get('profile_address_field_postalcode')) {
+          $setting['postalCode'] = ['override' => 'hidden'];
+        }
+        else {
+          unset($setting['postalCode']);
         }
 
         // Update the settings of address field.
@@ -297,6 +306,9 @@ function social_profile_fields_preprocess_field(&$variables) {
           if (isset($variables['items'][0]['content']['#address_line1']) && !$config->get('profile_address_field_address')) {
             $variables['items'][0]['content']['#address_line1'] = NULL;
           }
+          if (isset($variables['items'][0]['content']['#postal_code']) && !$config->get('profile_address_field_postalcode')) {
+            $variables['items'][0]['content']['#postal_code'] = NULL;
+          }
           break;
 
         case 'address_default':
@@ -305,6 +317,9 @@ function social_profile_fields_preprocess_field(&$variables) {
           }
           if (isset($variables['items'][0]['content']['address_line1']['#value']) && !$config->get('profile_address_field_address')) {
             $variables['items'][0]['content']['address_line1']['#value'] = '';
+          }
+          if (isset($variables['items'][0]['content']['postal_code']['#value']) && !$config->get('profile_address_field_postalcode')) {
+            $variables['items'][0]['content']['postal_code']['#value'] = '';
           }
           break;
       }

--- a/modules/social_features/social_profile/modules/social_profile_fields/src/Form/SocialProfileFieldsFlushForm.php
+++ b/modules/social_features/social_profile/modules/social_profile_fields/src/Form/SocialProfileFieldsFlushForm.php
@@ -165,6 +165,11 @@ class SocialProfileFieldsFlushForm extends ConfirmFormBase {
         if (isset($address_val) && $address_val == FALSE) {
           $empty[] = 'addressLine1';
         }
+
+        $postalcode_val = $settings->get('profile_address_field_postalcode');
+        if (isset($postalcode_val) && $postalcode_val == FALSE) {
+          $empty[] = 'postalCode';
+        }
       }
     }
     return $empty;

--- a/modules/social_features/social_profile/modules/social_profile_fields/src/Form/SocialProfileFieldsSettingsForm.php
+++ b/modules/social_features/social_profile/modules/social_profile_fields/src/Form/SocialProfileFieldsSettingsForm.php
@@ -209,6 +209,11 @@ class SocialProfileFieldsSettingsForm extends ConfigFormBase implements Containe
             '#title' => $this->t('Address'),
             '#default_value' => is_null($config->get('profile_address_field_address')) ? TRUE : $config->get('profile_address_field_address'),
           ];
+          $form[$type]['profile_profile_field_profile_address_wrapper']['address_settings']['profile_address_field_postalcode'] = [
+            '#type' => 'checkbox',
+            '#title' => $this->t('Postal code'),
+            '#default_value' => is_null($config->get('profile_address_field_postalcode')) ? TRUE : $config->get('profile_address_field_postalcode'),
+          ];
         }
       }
     }
@@ -250,6 +255,7 @@ class SocialProfileFieldsSettingsForm extends ConfigFormBase implements Containe
     $main_address_value = $form_state->getValue('profile_profile_field_profile_address');
     $config->set('profile_address_field_city', $main_address_value ? $form_state->getValue('profile_address_field_city') : FALSE);
     $config->set('profile_address_field_address', $main_address_value ? $form_state->getValue('profile_address_field_address') : FALSE);
+    $config->set('profile_address_field_postalcode', $main_address_value ? $form_state->getValue('profile_address_field_postalcode') : FALSE);
 
     $config->set('nickname_unique_validation', $form_state->getValue('nickname_unique_validation'));
     $config->save();

--- a/modules/social_features/social_profile/modules/social_profile_fields/src/Form/SocialProfileFieldsSettingsForm.php
+++ b/modules/social_features/social_profile/modules/social_profile_fields/src/Form/SocialProfileFieldsSettingsForm.php
@@ -183,7 +183,7 @@ class SocialProfileFieldsSettingsForm extends ConfigFormBase implements Containe
 
           $form[$type]['profile_profile_field_profile_address_wrapper']['address_settings'] = [
             '#type' => 'details',
-            '#title' => $this->t('Address field settings'),
+            '#title' => $this->t('Individual address field settings'),
             '#open' => TRUE,
             '#states' => [
               'visible' => [
@@ -193,11 +193,10 @@ class SocialProfileFieldsSettingsForm extends ConfigFormBase implements Containe
           ];
 
           $form[$type]['profile_profile_field_profile_address_wrapper']['address_settings']['profile_address_field_country'] = [
-            '#type' => 'checkbox',
-            '#title' => $this->t('Country'),
-            '#description' => $this->t('To disable Country you need disable all Address field above'),
-            '#default_value' => TRUE,
-            '#disabled' => TRUE,
+            '#type' => 'html_tag',
+            '#tag' => 'p',
+            '#value' => $this->t('You can hide individual address fields, with the exception of the country field. <br/>
+            Disable the country field by disabling the whole address, using the checkbox <em>field_profile_address</em>.'),
           ];
           $form[$type]['profile_profile_field_profile_address_wrapper']['address_settings']['profile_address_field_city'] = [
             '#type' => 'checkbox',

--- a/modules/social_features/social_profile/modules/social_profile_fields/src/SocialProfileFieldsBatch.php
+++ b/modules/social_features/social_profile/modules/social_profile_fields/src/SocialProfileFieldsBatch.php
@@ -45,6 +45,9 @@ class SocialProfileFieldsBatch {
         elseif ($field_name === 'addressLine1') {
           $profile->field_profile_address->address_line1 = '';
         }
+        elseif ($field_name === 'postalCode') {
+          $profile->field_profile_address->postal_code = '';
+        }
       }
       // Save the profile.
       $results[] = $profile->save();

--- a/modules/social_features/social_profile/modules/social_profile_fields/src/SocialProfileFieldsHelper.php
+++ b/modules/social_features/social_profile/modules/social_profile_fields/src/SocialProfileFieldsHelper.php
@@ -87,7 +87,7 @@ class SocialProfileFieldsHelper {
       'user_address_country_code' => 'profile_profile_field_profile_address',
       'user_address_administrative' => 'profile_profile_field_profile_address',
       'user_address_locality' => 'profile_address_field_city',
-      'user_address_postal_code' => 'profile_profile_field_profile_address',
+      'user_address_postal_code' => 'profile_address_field_postalcode',
       'user_address_line1' => 'profile_address_field_address',
       'user_address_line2' => 'profile_profile_field_profile_address',
       'user_phone_number' => 'profile_profile_field_profile_phone_number',


### PR DESCRIPTION
## Problem
Make sure postalcode can also be hidden

## Solution
Implement possibility to enable/disable postalcode address's profile field 

## Issue tracker
https://www.drupal.org/project/social/issues/3137445
https://getopensocial.atlassian.net/browse/YANG-3511

## How to test
- [ ] Go to Social profile fields settings form (/admin/config/opensocial/profile-fields)
- [ ] Disable postalcode settings option
- [ ] Go to profile edit form
- [ ] The postalcode field shouldn't be displayed
- [ ] Go back to the Social profile fields settings form
- [ ] Click Flush profile data button
- [ ] Run removing data
- [ ] The postalcode field values should be removed from all user profiles

## Release notes
Implement possibility to enable/disable Postal code address's profile field.