### PR TITLE
Issue #3164984 by rolki: Add an extra condition to cacheTags method for GroupStatisticBlock

### DIFF
--- a/modules/social_features/social_group/src/Plugin/Block/GroupStatisticBlock.php
+++ b/modules/social_features/social_group/src/Plugin/Block/GroupStatisticBlock.php
@@ -8,6 +8,7 @@ use Drupal\Core\Cache\Cache;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\Session\AccountInterface;
+use Drupal\group\Entity\GroupInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 
@@ -110,6 +111,10 @@ class GroupStatisticBlock extends BlockBase implements ContainerFactoryPluginInt
    */
   public function getCacheTags() {
     $group = _social_group_get_current_group();
+
+    if (!($group instanceof GroupInterface)) {
+      return parent::getCacheContexts();
+    }
 
     return Cache::mergeTags(parent::getCacheTags(), [
       'group_content_list:entity:' . \Drupal::currentUser()->id(),


### PR DESCRIPTION
## Problem
I get an error when going to the group members page

## Solution
Add an extra condition to the getcacheTags for GroupStatisticBlock

## Issue tracker
* https://www.drupal.org/project/social/issues/3164984
* https://getopensocial.atlassian.net/browse/YANG-3526

## How to test
- Login as member
- Go to some basic course
- Go to the members tab manually

## Screenshots
![Снимок экрана 2020-08-13 в 12 10 48](https://user-images.githubusercontent.com/50984627/90117146-2f18af80-dd5f-11ea-8d8a-0fba367c2347.png)
