### PR TITLE
Issue #3165299 by navneet0693: Upgrade the url_embed module version.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -88,7 +88,7 @@
                 "WSOD if wrong url or network unavailable": "https://www.drupal.org/files/issues/url_embed_WSOD_convert_url_to_embed-2871744-5.patch",
                 "Translate dialog title": "https://www.drupal.org/files/issues/2018-03-16/url_embed_translate_dialog_title-2953591-2.patch",
                 "Improve performance for embeds": "https://www.drupal.org/files/issues/2020-04-08/url_embed-n2867668-23.patch",
-                "Improve how the module deals with non-embeddable URLs #2761187 (See: https://www.drupal.org/project/social/issues/2930457#comment-13790581)": "https://www.drupal.org/files/issues/2020-08-17/urlembed-non-embeddable-urls-2761187-opensocial-combined.patch"
+                "Improve how the module deals with non-embeddable URLs #2761187 (See: https://www.drupal.org/project/social/issues/2930457#comment-13790581)": "https://www.drupal.org/files/issues/2020-08-18/urlembed-non-embeddable-urls-2761187-opensocial-combined-3.patch"
             },
             "drupal/bootstrap": {
                 "Dropdown toggle variable ignored when using links__dropbutton": "https://www.drupal.org/files/issues/2018-12-19/dropdown-without-default-button-3021413-2.patch"

--- a/composer.json
+++ b/composer.json
@@ -86,9 +86,9 @@
             },
             "drupal/url_embed": {
                 "WSOD if wrong url or network unavailable": "https://www.drupal.org/files/issues/url_embed_WSOD_convert_url_to_embed-2871744-5.patch",
-                "Improve performance for embeds": "https://www.drupal.org/files/issues/2020-04-08/url_embed-n2867668-23.patch",
                 "Translate dialog title": "https://www.drupal.org/files/issues/2018-03-16/url_embed_translate_dialog_title-2953591-2.patch",
-                "Improve how the module deals with non-embeddable URLs": "https://www.drupal.org/files/issues/2020-08-17/urlembed-non-embeddable-urls-2761187-9-d8.patch"
+                "Improve performance for embeds": "https://www.drupal.org/files/issues/2020-04-08/url_embed-n2867668-23.patch",
+                "Improve how the module deals with non-embeddable URLs #2761187 (See: https://www.drupal.org/project/social/issues/2930457#comment-13790581)": "https://www.drupal.org/files/issues/2020-08-17/urlembed-non-embeddable-urls-2761187-opensocial-combined.patch"
             },
             "drupal/bootstrap": {
                 "Dropdown toggle variable ignored when using links__dropbutton": "https://www.drupal.org/files/issues/2018-12-19/dropdown-without-default-button-3021413-2.patch"

--- a/composer.json
+++ b/composer.json
@@ -87,7 +87,8 @@
             "drupal/url_embed": {
                 "WSOD if wrong url or network unavailable": "https://www.drupal.org/files/issues/url_embed_WSOD_convert_url_to_embed-2871744-5.patch",
                 "Improve performance for embeds": "https://www.drupal.org/files/issues/2020-04-08/url_embed-n2867668-23.patch",
-                "Translate dialog title": "https://www.drupal.org/files/issues/2018-03-16/url_embed_translate_dialog_title-2953591-2.patch"
+                "Translate dialog title": "https://www.drupal.org/files/issues/2018-03-16/url_embed_translate_dialog_title-2953591-2.patch",
+                "Improve how the module deals with non-embeddable URLs": "https://www.drupal.org/files/issues/2020-08-17/urlembed-non-embeddable-urls-2761187-9-d8.patch"
             },
             "drupal/bootstrap": {
                 "Dropdown toggle variable ignored when using links__dropbutton": "https://www.drupal.org/files/issues/2018-12-19/dropdown-without-default-button-3021413-2.patch"

--- a/composer.json
+++ b/composer.json
@@ -88,7 +88,7 @@
                 "WSOD if wrong url or network unavailable": "https://www.drupal.org/files/issues/url_embed_WSOD_convert_url_to_embed-2871744-5.patch",
                 "Translate dialog title": "https://www.drupal.org/files/issues/2018-03-16/url_embed_translate_dialog_title-2953591-2.patch",
                 "Improve performance for embeds": "https://www.drupal.org/files/issues/2020-04-08/url_embed-n2867668-23.patch",
-                "Improve how the module deals with non-embeddable URLs #2761187 (See: https://www.drupal.org/project/social/issues/2930457#comment-13790581)": "https://www.drupal.org/files/issues/2020-08-18/urlembed-non-embeddable-urls-2761187-opensocial-combined-3.patch"
+                "Improve how the module deals with non-embeddable URLs (See: https://www.drupal.org/project/social/issues/2930457#comment-13790581)": "https://www.drupal.org/files/issues/2020-08-26/urlembed-non-embeddable-urls-2761187-opensocial-combined-15.patch"
             },
             "drupal/bootstrap": {
                 "Dropdown toggle variable ignored when using links__dropbutton": "https://www.drupal.org/files/issues/2018-12-19/dropdown-without-default-button-3021413-2.patch"

--- a/composer.json
+++ b/composer.json
@@ -86,7 +86,7 @@
             },
             "drupal/url_embed": {
                 "WSOD if wrong url or network unavailable": "https://www.drupal.org/files/issues/url_embed_WSOD_convert_url_to_embed-2871744-5.patch",
-                "Improve performance for embeds": "https://www.drupal.org/files/issues/2018-03-16/url_embed-caching-layer-2867668-17.patch",
+                "Improve performance for embeds": "https://www.drupal.org/files/issues/2020-04-08/url_embed-n2867668-23.patch",
                 "Translate dialog title": "https://www.drupal.org/files/issues/2018-03-16/url_embed_translate_dialog_title-2953591-2.patch"
             },
             "drupal/bootstrap": {
@@ -131,7 +131,6 @@
         "drupal/data_policy": "^1.0-beta6",
         "drupal/devel": "2.1",
         "drupal/dynamic_entity_reference": "1.7",
-        "drupal/embed": "1.0",
         "drupal/entity": "1.0-rc3",
         "drupal/entity_reference_revisions": "1.6",
         "drupal/exif_orientation": "^1.0",
@@ -163,7 +162,7 @@
         "drupal/select2": "1.8",
         "drupal/token": "1.5",
         "drupal/update_helper": "1.3",
-        "drupal/url_embed": "1.0-alpha1",
+        "drupal/url_embed": "1.0-beta1",
         "drupal/views_bulk_operations": "3.4",
         "drupal/views_infinite_scroll": "1.6",
         "drupal/votingapi": "3.0-beta1",
@@ -191,7 +190,6 @@
         "bower-asset/blazy": "~1.8.2",
         "bower-asset/d3": "v3.5.17",
         "bower-asset/highlight": "~9.15.6",
-        "embed/embed": "v2.7.8",
         "npm-asset/jquery.caret": "^0.3.1",
         "npm-asset/diff": "^3.5",
         "npm-asset/photoswipe": "^4.1.2",


### PR DESCRIPTION
## Problem
URL Embed module has done a new release version.
This version contains one of the major improvements in embed library as mention here: https://www.drupal.org/project/url_embed/releases/8.x-1.0-beta1

This will also solve the problem of support of Instagram mentioned here: https://www.drupal.org/project/url_embed/issues/3150213

## Solution
1. Update module version
2. Remove dependencies lock in favor of https://git.drupalcode.org/project/url_embed/-/blob/8.x-1.0-beta1/composer.json

## Issue tracker
https://www.drupal.org/project/social/issues/3165299
https://www.drupal.org/project/social/issues/2930457

## How to test
- [ ] Enabled social_embed module.
- [ ] Create content with embeddable media especially Instagram.
- [ ] See if they are rendered correctly.
- [ ] Create content with a non-embeddable URL.
- [ ] See if the link remains unchanged.

## Setup guide
- [ ] Do a composer require `goalgorilla/opensocial:"dev-issue/3165299-upgrade-url-embed-module"`
- [ ] Make sure the module is upgraded and patches are applied
- [ ] If this fails to add changes, continue to further steps
- [ ] Add the following to root's composer.json:

in composer.json - patches:
```
"drupal/url_embed" : {
                "Improve performance for embeds": "https://www.drupal.org/files/issues/2020-04-08/url_embed-n2867668-23.patch",
                "Improve how the module deals with non-embeddable URLs": "https://www.drupal.org/files/issues/2020-08-17/urlembed-non-embeddable-urls-2761187-9-d8.patch"
            }
```

```
"patches-ignore": {
            "goalgorilla/open_social": {
                "drupal/url_embed": {
                    "Improve performance for embeds": "https://www.drupal.org/files/issues/2018-03-16/url_embed-caching-layer-2867668-17.patch"
                }
            }
        }

```

- [ ] Do `composer require "drupal/embed":"1.4 as 1.0" "drupal/url_embed":"1.0-beta1 as 1.0-alpha1"  "embed/embed":"3.4 as 2.7.8"`
- [ ] Clear the cache and you should be good to go.

## Screenshots
**Before**
![image](https://user-images.githubusercontent.com/8435994/90290965-7789b780-de9c-11ea-9ba5-532c5b04bb2c.png)


**After**
![image](https://user-images.githubusercontent.com/8435994/90290975-7a84a800-de9c-11ea-9022-061261354c31.png)


## Release notes
We have upgraded the URL Embed module to the Beta version. It will now support more embeddable 

## Change Record
URL Embed module and it's dependencies are upgraded.

## Translations
N.A