### PR TITLE
Issue #3144847: Groups about page shows entity label/title

### DIFF
--- a/themes/socialbase/templates/group/group--default.html.twig
+++ b/themes/socialbase/templates/group/group--default.html.twig
@@ -42,19 +42,7 @@
 {% if content.field_group_description|render %}
   <div{{ attributes.addClass('card') }}>
 
-
     <div{{ content_attributes.addClass('card__body body-text') }}>
-      {% if not label_hidden %}
-        {%
-          set title_classes = [
-          'field--label',
-          label_display == 'visually_hidden' ? 'sr-only',
-        ]
-        %}
-
-        <div{{ title_attributes.addClass(title_classes) }}>{{ label }}</div>
-      {% endif %}
-
       {{ content.field_group_description }}
     </div>
   </div>


### PR DESCRIPTION
## Problem
In https://www.drupal.org/project/social/issues/3071081: Make field label visible by respecting field UI settings the group--default.html.twig template was updated to be able to show the field label.

Some issues with field labels were fixed in https://www.drupal.org/project/social/issues/3108296: Field labels are now shown for multiple display modes of multiple entities but the display configuration for groups is still set to show the label eventhough we only render the group description.

## Solution
We have reverted the changes, so we only render the description field, if necessary this field can have it's label rendered using the manage display settings. So we are not causing the former to not work anymore. It feels like this was added without knowing we are not showing the field label, we are showing the entity label.

## Issue tracker
https://www.drupal.org/project/social/issues/3144847

## How to test
*For example*
- [ ] Visit a group
- [ ] See that on the about page we only render the description, not the group title before that.

## Screenshots
Before
![Screenshot 2020-08-18 at 12 22 48](https://user-images.githubusercontent.com/16667281/90502077-982c6880-e14d-11ea-840a-d85803e51e68.png)


After:
![Screenshot 2020-08-18 at 12 22 37](https://user-images.githubusercontent.com/16667281/90502093-9cf11c80-e14d-11ea-9c42-2c42ce75bb84.png)


## Release notes
We are now rendering only the group description on the about page, instead of also showing the title in the description.
