### PR TITLE
Fix backport of improvements on statistics block tags and caching to 8.x

### DIFF
--- a/modules/social_features/social_group/src/Plugin/Block/GroupStatisticBlock.php
+++ b/modules/social_features/social_group/src/Plugin/Block/GroupStatisticBlock.php
@@ -4,6 +4,7 @@ namespace Drupal\social_group\Plugin\Block;
 
 use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Block\BlockBase;
+use Drupal\Core\Cache\Cache;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\Session\AccountInterface;
@@ -90,9 +91,6 @@ class GroupStatisticBlock extends BlockBase implements ContainerFactoryPluginInt
       $build['#cache']['tags'][] = 'group_block:' . $group->id();
     }
     // Cache contexts.
-    $build['#cache']['contexts'][] = 'url.path';
-    $build['#cache']['max-age'] = 0;
-
     return $build;
   }
 


### PR DESCRIPTION
## Problem
After update to latest 8.x-8.x, there is an error with Group Statistic block:
`Error: Class 'Drupal\social_group\Plugin\Block\Cache' not found in Drupal\social_group\Plugin\Block\GroupStatisticBlock->getCacheTags() (line 121 of profiles/contrib/social/modules/social_features/social_group/src/Plugin/Block/GroupStatisticBlock.php).`

## Solution
Make sure this file is the same as in 9.x and 10.x
See: https://github.com/goalgorilla/open_social/commit/fd1289a2b518c19625bcbeca3e4dc99bfa75fc61


## How to test
*For example*
- [ ] Using version 8.x-8.x of Open Social with the sky theme enabled
- [ ] As a user go to the group page
- [ ] You should not see fatal errors, and see a correct statistic block

## Screenshots
*If this Pull Request makes visual changes then please include some screenshots that show what has changed here. A before and after screenshot helps the reviewer determine what changes were made.*
