### PR TITLE
Issue #3166522: Sky theme - Render blocks on user edit and profile edit on the right side.

### DIFF
--- a/themes/socialblue/src/Plugin/Preprocess/Html.php
+++ b/themes/socialblue/src/Plugin/Preprocess/Html.php
@@ -40,8 +40,8 @@ class Html extends HtmlBase {
       $variables['attributes']['class'][] = 'socialblue--' . $style;
       $route_match = \Drupal::routeMatch();
       // For SKY when we are on edit user or edit profile
-      // we want to distinct the root_path with a better class name.
-      // this is used in html.html.twig
+      // we want to distinct the root_path with a better class name
+      // this is used in html.html.twig.
       if ($route_match->getParameter('user') &&
         $route_match->getRouteName() === 'profile.user_page.single' ||
         $route_match->getRouteName() === 'entity.user.edit_form') {

--- a/themes/socialblue/src/Plugin/Preprocess/Html.php
+++ b/themes/socialblue/src/Plugin/Preprocess/Html.php
@@ -37,14 +37,7 @@ class Html extends HtmlBase {
     // Add style class to html body.
     $style = theme_get_setting('style');
     if (!empty($style)) {
-      $route_match = \Drupal::routeMatch();
-      // For edit user and edit profile page
-      // we need to remove the socialblue--sky class,
-      // because we render it the old way. See #3166522.
-      if ($route_match->getRouteName() !== 'profile.user_page.single' &&
-        $route_match->getRouteName() !== 'entity.user.edit_form') {
-        $variables['attributes']['class'][] = 'socialblue--' . $style;
-      }
+      $variables['attributes']['class'][] = 'socialblue--' . $style;
     }
 
     parent::preprocessVariables($variables);

--- a/themes/socialblue/src/Plugin/Preprocess/Html.php
+++ b/themes/socialblue/src/Plugin/Preprocess/Html.php
@@ -38,6 +38,15 @@ class Html extends HtmlBase {
     $style = theme_get_setting('style');
     if (!empty($style)) {
       $variables['attributes']['class'][] = 'socialblue--' . $style;
+      $route_match = \Drupal::routeMatch();
+      // For SKY when we are on edit user or edit profile
+      // we want to distinct the root_path with a better class name.
+      // this is used in html.html.twig
+      if ($route_match->getParameter('user') &&
+        $route_match->getRouteName() === 'profile.user_page.single' ||
+        $route_match->getRouteName() === 'entity.user.edit_form') {
+        $variables['root_path'] = 'user-edit';
+      }
     }
 
     parent::preprocessVariables($variables);

--- a/themes/socialblue/src/Plugin/Preprocess/Html.php
+++ b/themes/socialblue/src/Plugin/Preprocess/Html.php
@@ -37,7 +37,14 @@ class Html extends HtmlBase {
     // Add style class to html body.
     $style = theme_get_setting('style');
     if (!empty($style)) {
-      $variables['attributes']['class'][] = 'socialblue--' . $style;
+      $route_match = \Drupal::routeMatch();
+      // For edit user and edit profile page
+      // we need to remove the socialblue--sky class,
+      // because we render it the old way. See #3166522.
+      if ($route_match->getRouteName() !== 'profile.user_page.single' &&
+        $route_match->getRouteName() !== 'entity.user.edit_form') {
+        $variables['attributes']['class'][] = 'socialblue--' . $style;
+      }
     }
 
     parent::preprocessVariables($variables);

--- a/themes/socialblue/src/Plugin/Preprocess/Page.php
+++ b/themes/socialblue/src/Plugin/Preprocess/Page.php
@@ -23,7 +23,9 @@ class Page extends PageBase {
 
       // Display merged sidebar on the left side of profile pages, except edit.
       $route_match = \Drupal::routeMatch();
-      if ($route_match->getParameter('user') && $route_match->getRouteName() !== 'profile.user_page.single') {
+      if ($route_match->getParameter('user') &&
+        $route_match->getRouteName() !== 'profile.user_page.single' &&
+        $route_match->getRouteName() !== 'entity.user.edit_form') {
         $variables['content_attributes']->addClass('sidebar-left', 'content-merged--sky');
       }
 

--- a/themes/socialblue/templates/layout/page--user--edit--sky.html.twig
+++ b/themes/socialblue/templates/layout/page--user--edit--sky.html.twig
@@ -1,0 +1,105 @@
+{#
+/**
+ * @file
+ * Socialbase's theme implementation to display a page.
+ *
+ * The doctype, html, head and body tags are not in this template. Instead they
+ * can be found in the html.html.twig template normally located in the
+ * core/modules/system directory.
+ *
+ * Available variables:
+ *
+ * General utility variables:
+ * - base_path: The base URL path of the Drupal installation. Will usually be
+ *   "/" unless you have installed Drupal in a sub-directory.
+ * - is_front: A flag indicating if the current page is the front page.
+ * - logged_in: A flag indicating if the user is registered and signed in.
+ * - is_admin: A flag indicating if the user has permission to access
+ *   administration pages.
+ *
+ * Site identity:
+ * - front_page: The URL of the front page. Use this instead of base_path when
+ *   linking to the front page. This includes the language domain or prefix.
+ *
+ * Page content (in order of occurrence in the default page.html.twig):
+ * - node: Fully loaded node, if there is an automatically-loaded node
+ *   associated with the page and the node ID is the second argument in the
+ *   page's path (e.g. node/12345 and node/12345/revisions, but not
+ *   comment/reply/12345).
+ *
+ *
+ * @see template_preprocess_page()
+ * @see html.html.twig
+ */
+#}
+
+{% if page.header %}
+  {{ page.header }}
+{% endif %}
+
+<main id="content" class="main-container" role="main">
+
+  {% if page.hero %}
+    {{ page.hero }}
+  {% endif %}
+
+  {% if page.content_top %}
+    {{ page.content_top }}
+  {% endif %}
+
+  {# Content attributes, see Style guide Templates for documentation #}
+  {% block section %}
+    <section{{ content_attributes }}>
+
+      {% if page.title and display_page_title %}
+        {{ page.title }}
+      {% endif %}
+
+      {% if page.secondary_navigation %}
+        {{ page.secondary_navigation }}
+      {% endif %}
+
+      {% if page.complementary_top or page.complementary_bottom %}
+        <aside class="region--complementary" role="complementary">
+          <div class="region--complementary-top">
+            {% if page.complementary_top %}
+              {{ page.complementary_top }}
+            {% endif %}
+            {% if page.complementary_bottom %}
+              {{ page.complementary_bottom }}
+            {% endif %}
+          </div>
+        </aside>
+      {% endif %}
+
+      {% block content %}
+        <a id="main-content" tabindex="-1"></a>
+        {{ page.content }}
+      {% endblock %}
+
+      {# an extra check for complementary regions to be empty #}
+      {% if page.sidebar_first and not page.complementary_top and not page.complementary_bottom %}
+        {% block sidebar_first %}
+          {{ page.sidebar_first }}
+        {% endblock %}
+      {% endif %}
+
+      {# an extra check for complementary regions to be empty #}
+      {% if page.sidebar_second and not page.complementary_top and not page.complementary_bottom %}
+        {% block sidebar_second %}
+          {{ page.sidebar_second }}
+        {% endblock %}
+      {% endif %}
+
+    </section>
+  {% endblock %}
+
+  {% if page.content_bottom %}
+    {{ page.content_bottom }}
+  {% endif %}
+
+</main>
+
+{% if page.footer %}
+  {{ page.footer }}
+{% endif %}

--- a/themes/socialblue/templates/layout/page--user--profile--sky.html.twig
+++ b/themes/socialblue/templates/layout/page--user--profile--sky.html.twig
@@ -1,0 +1,105 @@
+{#
+/**
+ * @file
+ * Socialbase's theme implementation to display a page.
+ *
+ * The doctype, html, head and body tags are not in this template. Instead they
+ * can be found in the html.html.twig template normally located in the
+ * core/modules/system directory.
+ *
+ * Available variables:
+ *
+ * General utility variables:
+ * - base_path: The base URL path of the Drupal installation. Will usually be
+ *   "/" unless you have installed Drupal in a sub-directory.
+ * - is_front: A flag indicating if the current page is the front page.
+ * - logged_in: A flag indicating if the user is registered and signed in.
+ * - is_admin: A flag indicating if the user has permission to access
+ *   administration pages.
+ *
+ * Site identity:
+ * - front_page: The URL of the front page. Use this instead of base_path when
+ *   linking to the front page. This includes the language domain or prefix.
+ *
+ * Page content (in order of occurrence in the default page.html.twig):
+ * - node: Fully loaded node, if there is an automatically-loaded node
+ *   associated with the page and the node ID is the second argument in the
+ *   page's path (e.g. node/12345 and node/12345/revisions, but not
+ *   comment/reply/12345).
+ *
+ *
+ * @see template_preprocess_page()
+ * @see html.html.twig
+ */
+#}
+
+{% if page.header %}
+  {{ page.header }}
+{% endif %}
+
+<main id="content" class="main-container" role="main">
+
+  {% if page.hero %}
+    {{ page.hero }}
+  {% endif %}
+
+  {% if page.content_top %}
+    {{ page.content_top }}
+  {% endif %}
+
+  {# Content attributes, see Style guide Templates for documentation #}
+  {% block section %}
+    <section{{ content_attributes }}>
+
+      {% if page.title and display_page_title %}
+        {{ page.title }}
+      {% endif %}
+
+      {% if page.secondary_navigation %}
+        {{ page.secondary_navigation }}
+      {% endif %}
+
+      {% if page.complementary_top or page.complementary_bottom %}
+        <aside class="region--complementary" role="complementary">
+          <div class="region--complementary-top">
+            {% if page.complementary_top %}
+              {{ page.complementary_top }}
+            {% endif %}
+            {% if page.complementary_bottom %}
+              {{ page.complementary_bottom }}
+            {% endif %}
+          </div>
+        </aside>
+      {% endif %}
+
+      {% block content %}
+        <a id="main-content" tabindex="-1"></a>
+        {{ page.content }}
+      {% endblock %}
+
+      {# an extra check for complementary regions to be empty #}
+      {% if page.sidebar_first and not page.complementary_top and not page.complementary_bottom %}
+        {% block sidebar_first %}
+          {{ page.sidebar_first }}
+        {% endblock %}
+      {% endif %}
+
+      {# an extra check for complementary regions to be empty #}
+      {% if page.sidebar_second and not page.complementary_top and not page.complementary_bottom %}
+        {% block sidebar_second %}
+          {{ page.sidebar_second }}
+        {% endblock %}
+      {% endif %}
+
+    </section>
+  {% endblock %}
+
+  {% if page.content_bottom %}
+    {{ page.content_bottom }}
+  {% endif %}
+
+</main>
+
+{% if page.footer %}
+  {{ page.footer }}
+{% endif %}


### PR DESCRIPTION
## Problem
When SKY is enabled and a user visits the edit profile or edit user page, any blocks (like the data policy from social_gdpr) are rendered incorrect. Either on the left side of the main content, or on the right side without margin for the page title.

## Solution
Make sure we render the blocks on the above pages correctly on the right side, with necessary margin.

## Issue tracker
https://www.drupal.org/project/social/issues/3166522

## How to test
- [ ] Enable SKY in socialblue, enable social_gdpr and add data policy blocks to user/*/edit/ and user/*/profile
- [ ] As a user, login and visit user/*/edit
- [ ] See that the blocks are rendered better

## Screenshots
Before:
![Screenshot 2020-08-21 at 11 39 31](https://user-images.githubusercontent.com/16667281/90877387-42053280-e3a4-11ea-8bd9-ea8637add404.png)
![Screenshot 2020-08-21 at 11 39 54](https://user-images.githubusercontent.com/16667281/90877397-4598b980-e3a4-11ea-9aeb-7d1f0aae1425.png)

After
![Screenshot 2020-08-21 at 11 52 15](https://user-images.githubusercontent.com/16667281/90877755-e25b5700-e3a4-11ea-97aa-3b56baf5f348.png)
![Screenshot 2020-08-21 at 11 52 52](https://user-images.githubusercontent.com/16667281/90877760-e4251a80-e3a4-11ea-8f0a-83bb666568c6.png)

## Release notes
When choosing the SKY style in our theme, on the user edit and edit profile page we now render any blocks correctly in the sidebar on the right.