### PR TITLE
Issue #3166533: SKY theme on public content with social sharing enabled the share buttons dont get rendered for AN

### DIFF
--- a/themes/socialbase/src/Plugin/Preprocess/Node.php
+++ b/themes/socialbase/src/Plugin/Preprocess/Node.php
@@ -141,7 +141,7 @@ class Node extends PreprocessBase {
         $variables['visibility_icon'] = 'public';
       }
     }
-    
+
     // Let's see if we can remove comments from the content and render them in a
     // separate content_below array.
     $comment_field_name = '';

--- a/themes/socialbase/src/Plugin/Preprocess/Node.php
+++ b/themes/socialbase/src/Plugin/Preprocess/Node.php
@@ -130,6 +130,18 @@ class Node extends PreprocessBase {
       $variables['status_label'] = t('unpublished');
     }
 
+    // Content visibility for AN can be shown.
+    // This is also used to render the shariff links for example.
+    if ((isset($node->field_content_visibility)) &&
+      ($variables['view_mode'] === 'full' || $variables['view_mode'] === 'hero') &&
+      $currentuser->isAnonymous()) {
+      $node_visibility_value = $node->field_content_visibility->getValue();
+      $content_visibility = reset($node_visibility_value);
+      if ($content_visibility['value'] === 'public') {
+        $variables['visibility_icon'] = 'public';
+      }
+    }
+    
     // Let's see if we can remove comments from the content and render them in a
     // separate content_below array.
     $comment_field_name = '';


### PR DESCRIPTION
## Problem
When enabling social_sharing, with SKY theme enabled the social sharing buttons arent rendered for AN on public content.

`{% if content.shariff_field and visibility_icon == 'public' %}
          <div class="hero-footer__share">
            <span>{% trans %} Share this page {% endtrans %}</span>
            {{ content.shariff_field }}
          </div>
        {% endif %}`

On NON Sky we use the shariff block which is not affected by this.

## Solution
Make sure the twig statement in node--hero--sky gets the correct data. 
The visibility icon was only set for LU+ not for AN, therefor it never came in this statement.
So we need to ensure for AN this is also OK.


## Issue tracker
https://www.drupal.org/project/social/issues/3166533

## How to test
- [ ] Enable social_sharing, and set SKY in the theme settings.
- [ ] As a LU create a public topic / basic page / whatever
- [ ] See that sharing is enabled for you as LU
- [ ] Logout and see that it's still there for AN

## Release notes
When you have enabled SKY and social_sharing you are now able to share a public page again as anonymous user.