### PR TITLE
Revert "Issue 3144794: Replace paths with routs to avoid incorrect matches in conditions. (#1915)"

### DIFF
--- a/modules/custom/social_path_manager/social_path_manager.module
+++ b/modules/custom/social_path_manager/social_path_manager.module
@@ -292,15 +292,19 @@ function social_path_manager_preprocess_block(&$variables) {
     if (!empty($variables['elements']['#plugin_id']) &&
       $variables['elements']['#plugin_id'] === 'social_page_title_block' &&
       $variables['elements']['#id'] === 'socialblue_pagetitleblock_content') {
+      $current_url = Url::fromRoute('<current>');
+      $current_path = $current_url->toString();
+
+      $paths_to_exclude = [
+        'edit',
+        'add',
+        'delete',
+      ];
+
+      $in_path = str_replace($paths_to_exclude, '', $current_path) !== $current_path;
 
       // We make sure there are no two heroes shown only page titles.
-      $route_name = \Drupal::routeMatch()->getRouteName();
-      if (in_array($route_name, [
-        'entity.node.edit_form',
-        'entity.node.delete_form',
-        'entity.node.add_form',
-      ])) {
-
+      if ($in_path) {
         $variables['content']['#type'] = 'page_title';
         if (!empty($variables['content']['#hero_node'])) {
           unset($variables['content']['#hero_node']);


### PR DESCRIPTION
## Problem
After merging PR #1915 there are hero duplicates on content pages with aliases including words `add`, `edit`

## Solution
Revert commit d90926e2 and implement a fix for missing her in external modules, see book config override for example.

## Issue tracker
- https://getopensocial.atlassian.net/browse/YANG-3491

## How to test
- [x]  Create a page with a custom alias that containt /add or /delete or /edit as part of the URL.
- [x]  See that the redirect module is also enabled with social_path_manager

