### PR TITLE
Issue #3167974: Ensure as CM+ we can also request to join a group

### DIFF
--- a/modules/social_features/social_group/modules/social_group_request/social_group_request.module
+++ b/modules/social_features/social_group/modules/social_group_request/social_group_request.module
@@ -187,8 +187,10 @@ function social_group_request_preprocess_group(&$variables) {
     return;
   }
 
+  $variables['closed_group'] = TRUE;
   $variables['allow_request'] = TRUE;
   $variables['group_operations_url'] = Url::fromRoute('grequest.request_membership', ['group' => $group->id()]);
+  $variables['cta'] = t('Request to join');
 
   $contentTypeConfigId = $group
     ->getGroupType()


### PR DESCRIPTION
## Problem
When a CM or SM or admin visits a group, with the request to join a group setting enabled it gets redirected to a page with a debug message.
This is due to the fact we don't pass along the correct setting to twig which renders the ajax pop-up to request to join a group.

## Solution
Make sure we pass along the correct variables in the preprocess_group so that twig knows what to render.

## Issue tracker
*Paste a link to the drupal.org issue queue item. If any other issue trackers were used, include links to those too.*

## How to test
- [ ] Create a Closed Group with Enable "Request membership" checkbox.
- [ ] As a sitemanager visit the group
- [ ] See that it fails
- [ ] Checkout this branch, do a cache clear to rebuild the hero
- [ ] See that you now also get the nice pop-up.

## Release notes
As a CM+ you can now also request to join a group when that setting is enabled.