### PR TITLE
TB-4603 - "All my upcoming events" is not translatable correctly

### DIFF
--- a/modules/social_features/social_core/social_core.module
+++ b/modules/social_features/social_core/social_core.module
@@ -293,9 +293,8 @@ function social_core_preprocess_block(&$variables) {
       $variables['view_all_path'] = Url::fromRoute('view.events.events_overview', [
         'user' => \Drupal::currentUser()->id(),
       ]);
-      $variables['button_text'] = t('All @label', [
-        '@label' => $variables['label']['#markup'],
-      ]);
+      $variables['button_text'] = $more_link;
+      $link->setOption('use_more', FALSE);
       break;
 
     case 'upcoming_events-block_community_events':


### PR DESCRIPTION
## Problem
In the block "All my upcoming events" we use the translatable `All @label` where `@label` is the translation for `My upcoming events". This does work correctly in English but not in other languages, as the word `All` can have different translations based on the text that follows. For instance, in Dutch this would translate to "Al mijn aankomende evenementen" while `All upcoming events in the community` would translate to `Alle aankomende evenementen in de community`. You see that All has a different translation based on what follows it.

## Solution
Use the full translation that is being used in views for the More label.

## Issue tracker
https://getopensocial.atlassian.net/browse/TB-4603

## How to test
- [ ] Use a translation of for instance Dutch of French
- [ ] See that the block now has the correct translation on the See More button.

## Release notes
*We changed the way the translatable is loaded for the All My upcoming events block, so that we use the full translation instead of `All @label`.*

## Translations
We now use `All my upcoming events` for this block instead of `All @label`
