### PR TITLE
Issue #3168287 by robertragas: replace addmember query with mention v…

### DIFF
--- a/modules/social_features/social_profile/src/Plugin/EntityReferenceSelection/UserSelection.php
+++ b/modules/social_features/social_profile/src/Plugin/EntityReferenceSelection/UserSelection.php
@@ -33,39 +33,11 @@ class UserSelection extends UserSelectionBase {
    * {@inheritdoc}
    */
   protected function buildEntityQuery($match = NULL, $match_operator = 'CONTAINS') {
-    $query = $this->connection->select('profile', 'p')
-      ->fields('p', ['uid']);
-
-    $addNickName = $this->moduleHandler->moduleExists('social_profile_fields');
-
-    // Give the query a tag to identify it for altering.
-    $query->addTag('social_entityreference');
-
-    $query->leftJoin('profile__field_profile_first_name', 'fn', 'fn.entity_id = p.profile_id');
-    $query->leftJoin('profile__field_profile_last_name', 'ln', 'ln.entity_id = p.profile_id');
-    $query->join('users_field_data', 'ufd', 'ufd.uid = p.uid');
-
-    if ($addNickName === TRUE) {
-      $query->leftJoin('profile__field_profile_nick_name', 'nn', 'nn.entity_id = p.profile_id');
-    }
-
-    $name = $this->connection->escapeLike($match);
-
-    $or = $query->orConditionGroup();
-    $or->condition('ufd.name', '%' . $name . '%', 'LIKE');
-    $or->condition('fn.field_profile_first_name_value', '%' . $name . '%', 'LIKE');
-    $or->condition('ln.field_profile_last_name_value', '%' . $name . '%', 'LIKE');
-
-    if ($addNickName === TRUE) {
-      $or->condition('nn.field_profile_nick_name_value', '%' . $name . '%', 'LIKE');
-    }
-
-    // Only allow searching when user has permission to view.
-    if ($this->currentUser->hasPermission('view profile email')) {
-      $or->condition('ufd.mail', '%' . $name . '%', 'LIKE');
-    }
-
-    $ids = $query->condition($or)->execute()->fetchCol();
+    $config_factory = \Drupal::service('config.factory');
+    $config = $config_factory->get('mentions.settings');
+    $suggestion_format = $config->get('suggestions_format');
+    $suggestion_amount = $config->get('suggestions_amount');
+    $ids = $this->getUserIdsFromName($match, $suggestion_amount, $suggestion_format);
 
     if (empty($ids)) {
       return parent::buildEntityQuery($match, $match_operator);

--- a/tests/behat/features/bootstrap/SocialMinkContext.php
+++ b/tests/behat/features/bootstrap/SocialMinkContext.php
@@ -90,7 +90,7 @@ class SocialMinkContext extends MinkContext {
       throw new \Exception('No field found');
     }
 
-    $this->getSession()->wait(1000);
+    $this->getSession()->wait(2000);
 
     $choice = $inputField->getParent()->find('css', '.select2-selection');
     if (!$choice) {
@@ -104,7 +104,7 @@ class SocialMinkContext extends MinkContext {
     }
     $select2Input->setValue($value);
 
-    $this->getSession()->wait(1000);
+    $this->getSession()->wait(2000);
 
     $chosenResults = $page->findAll('css', '.select2-results li');
     foreach ($chosenResults as $result) {

--- a/tests/behat/features/bootstrap/SocialMinkContext.php
+++ b/tests/behat/features/bootstrap/SocialMinkContext.php
@@ -90,7 +90,7 @@ class SocialMinkContext extends MinkContext {
       throw new \Exception('No field found');
     }
 
-    $this->getSession()->wait(2000);
+    $this->getSession()->wait(1000);
 
     $choice = $inputField->getParent()->find('css', '.select2-selection');
     if (!$choice) {
@@ -104,7 +104,7 @@ class SocialMinkContext extends MinkContext {
     }
     $select2Input->setValue($value);
 
-    $this->getSession()->wait(2000);
+    $this->getSession()->wait(1000);
 
     $chosenResults = $page->findAll('css', '.select2-results li');
     foreach ($chosenResults as $result) {


### PR DESCRIPTION
…ersion to keep consistent

## Problem
When trying to find members on their full name to add them to the group or events it will find no results.

## Solution
The query of finding members does not take the full name into account, while the mention query does. To keep code simple and clean, the adding members query should use the same one as the mentioning. So integrate that query, so we can remove double and obsolete code.

## Issue tracker
https://www.drupal.org/project/social/issues/3168287

## How to test
- [x] Add a new member and name him "John Doe" (first and lastname)
- [x] Create a group or event and try to add members
- [x] Search for "John" you will get results
- [x] Search for "Doe" you will get results
- [x] Search for "Jonh Doe", no results
- [x] Check out to the branch and check again

## Release notes
When adding members in groups or events we fixed a problem where a member could not be found when searching for the full name. This was already possible for mentions, but not adding members. This has been equalized.
