### PR TITLE
YANG-3478: Allow to use social activity token in other content types, like Discussion

### DIFF
--- a/modules/social_features/social_activity/social_activity.tokens.inc
+++ b/modules/social_features/social_activity/social_activity.tokens.inc
@@ -8,6 +8,7 @@
 use Drupal\Core\Render\BubbleableMetadata;
 use Drupal\Core\Url;
 use Drupal\group\Entity\GroupContentInterface;
+use Drupal\node\NodeInterface;
 
 /**
  * Implements hook_token_info().
@@ -88,7 +89,7 @@ function social_activity_tokens($type, $tokens, array $data, array $options, Bub
                 /* @var \Drupal\node\NodeInterface $node */
                 $node = $entity->getEntity();
 
-                if (in_array($node->getType(), ['topic', 'event'])) {
+                if ($node instanceof NodeInterface) {
                   $link = Url::fromRoute('entity.node.canonical',
                     ['node' => $node->id()],
                     ['absolute' => TRUE]

--- a/modules/social_features/social_comment/social_comment.tokens.inc
+++ b/modules/social_features/social_comment/social_comment.tokens.inc
@@ -259,7 +259,7 @@ function social_comment_tokens($type, $tokens, array $data, array $options, Bubb
  *   The processed text.
  */
 function _social_comment_get_summary($text) {
-  $summary = strip_tags($text);
+  $summary = html_entity_decode(strip_tags($text));
   $max_length = 280;
 
   if (mb_strlen($summary) > $max_length) {


### PR DESCRIPTION
## Problem
The e-mail notification for a reply to a comment on a discussion is not working properly. It doesn't contain a snippet of the text/comment.

## Solution
Remove hardcoded limitation only for topics and events. We don't need it here.

## Issue tracker

- https://getopensocial.atlassian.net/browse/YANG-3478
- https://github.com/goalgorilla/open_social/pull/1304


## How to test
- [ ]  Create few comments and replies on discussions
- [ ] Email notification should contain a snippet of the text/comment, the same as Topics or Events
