### PR TITLE
Issue #3169448 by agami4: Fix color for the badge label on the group teasers

### DIFF
--- a/themes/socialblue/assets/css/teaser--sky.css
+++ b/themes/socialblue/assets/css/teaser--sky.css
@@ -26,10 +26,6 @@
   transition: .3s ease-out;
 }
 
-.socialblue--sky .teaser .badge__label {
-  color: #4d4d4d;
-}
-
 .socialblue--sky .teaser--tile .teaser__title {
   min-height: auto;
   max-height: none;

--- a/themes/socialblue/assets/css/teaser.css
+++ b/themes/socialblue/assets/css/teaser.css
@@ -20,6 +20,10 @@
   padding-left: 1em;
 }
 
+.teaser .badge__label {
+  color: #4d4d4d;
+}
+
 @media (min-width: 600px) {
   .teaser__image {
     border-top-left-radius: inherit;

--- a/themes/socialblue/components/03-molecules/teaser/teaser--sky.scss
+++ b/themes/socialblue/components/03-molecules/teaser/teaser--sky.scss
@@ -43,12 +43,6 @@
     }
   }
 
-  .teaser {
-    .badge__label {
-      color: $default-color;
-    }
-  }
-
   .teaser--tile {
 
     .teaser__title {

--- a/themes/socialblue/components/03-molecules/teaser/teaser.scss
+++ b/themes/socialblue/components/03-molecules/teaser/teaser.scss
@@ -32,8 +32,8 @@
   }
 }
 
-// Remove 'padding-left' from teaser badge if teaser badge(first-child) does not use 'background-color'.
 .teaser {
+  // Remove 'padding-left' from teaser badge if teaser badge(first-child) does not use 'background-color'.
   .teaser__badge {
     &:first-child {
       padding-left: 0;
@@ -50,5 +50,9 @@
         padding-left: 1em;
       }
     }
+  }
+
+  .badge__label {
+    color: $default-color;
   }
 }


### PR DESCRIPTION
## Problem
At landing pages or group pages, I can no longer see the number of members of the group.

## Solution
Update color number of members of the group teasers

## Issue tracker
https://www.drupal.org/project/social/issues/3169448
https://getopensocial.atlassian.net/browse/YANG-2974

## How to test
- [x] Go to the all-groups/ page

## Screenshots
before:
![group-number](https://user-images.githubusercontent.com/16086340/92375555-ef4caa00-f109-11ea-820d-421dbe1411c0.png)

after:
<img width="806" alt="group-teaser-fix" src="https://user-images.githubusercontent.com/16086340/92375566-f2e03100-f109-11ea-8fe1-48267044aab2.png">


## Release notes
The badge label has a correct color on the teasers

## Change Record
Update color for the badge label on the teasers for blue and sky themes
