### PR TITLE
Issue #3169519 by tBKoT: Remove the 'Ongoing' label on main event page

### DIFF
--- a/themes/socialbase/templates/node/event/node--event--full.html.twig
+++ b/themes/socialbase/templates/node/event/node--event--full.html.twig
@@ -58,6 +58,6 @@
 
 {% block nodefull_body %}
 
-  {{ content|without('field_event_address','field_event_location', 'field_event_type', 'book_navigation', 'flag_follow_content', 'field_event_an_enroll', 'field_enrollment_status', 'enrolled', 'enrollments_count', 'links') }}
+  {{ content|without('field_event_address','field_event_location', 'field_event_type', 'book_navigation', 'flag_follow_content', 'field_event_an_enroll', 'field_enrollment_status', 'enrolled', 'enrollments_count', 'links', 'ongoing') }}
 
 {% endblock %}

--- a/themes/socialblue/templates/node/node--full--sky.html.twig
+++ b/themes/socialblue/templates/node/node--full--sky.html.twig
@@ -89,7 +89,7 @@
     {% endif %}
 
     {% block nodefull_body %}
-      {{ content|without('field_event_address', 'like_and_dislike', 'field_event_location', 'field_event_type', 'book_navigation', 'flag_follow_content', 'field_event_an_enroll', 'field_enrollment_status', 'enrolled', 'enrollments_count', 'links') }}
+      {{ content|without('field_event_address', 'like_and_dislike', 'field_event_location', 'field_event_type', 'book_navigation', 'flag_follow_content', 'field_event_an_enroll', 'field_enrollment_status', 'enrolled', 'enrollments_count', 'links', 'ongoing') }}
     {% endblock %}
 
   </div>


### PR DESCRIPTION
## Problem
The 'Ongoing' label is shown in the main content of the event.

## Solution
Update the node event template.

## Issue tracker
https://www.drupal.org/project/social/issues/3169519
https://getopensocial.atlassian.net/browse/YANG-3667
