### PR TITLE
YANG-3671: Fix text copy and styles for event date & time fields

### DIFF
--- a/modules/social_features/social_event/assets/css/social-event--admin.css
+++ b/modules/social_features/social_event/assets/css/social-event--admin.css
@@ -13,6 +13,7 @@
   padding-left: 0;
   border: 0;
   font-size: 0.875rem;
+  font-weight: 300;
 }
 .node-event-form .field--name-field-event-date .card__block,
 .node-event-form .field--name-field-event-date-end .card__block,

--- a/modules/social_features/social_event/assets/css/social-event--admin.scss
+++ b/modules/social_features/social_event/assets/css/social-event--admin.scss
@@ -12,6 +12,7 @@
       padding-left: 0;
       border: 0;
       font-size: .875rem;
+      font-weight: 300;
     }
 
     .card__block {

--- a/modules/social_features/social_event/social_event.module
+++ b/modules/social_features/social_event/social_event.module
@@ -631,27 +631,35 @@ function social_event_form_alter(&$form, FormStateInterface $form_state, $form_i
     // Get user timezone.
     $user_timezone = _social_event_user_timezone(date_default_timezone_get());
     $timezone_label = t('Time zone');
-    $markup = '<div class="control-label margin-bottom-s form-wrapper__label">' . $timezone_label . '</div>';
+    $markup = '<div class="control-label margin-bottom-s">' . $timezone_label . '</div>';
     $markup .= '<div class="bg-gray-lightest btn btn-lg">' . $user_timezone . '</div>';
+    // Check if user has access to change his timezone.
+    $date_config = Drupal::config('system.date');
+    if ($date_config->get('timezone.user.configurable')) {
+      $description = t('The event date and time are set based on your timezone. @change_timezone.', [
+        '@change_timezone' => Link::createFromRoute(
+          t('Change your timezone here'),
+          'entity.user.edit_form',
+          ['user' => \Drupal::currentUser()->id()],
+          [
+            'attributes' => [
+              'target' => '_blank',
+            ],
+            'fragment' => 'edit-group-locale-settings',
+          ]
+        )->toString(),
+      ]);
+    }
+    else {
+      $description = t('The event date and time are set based on the site\'s default timezone.');
+    }
     $form['timezone_indication'] = [
       '#type' => 'container',
       '#weight' => 99,
       'content' => [
         '#type' => 'item',
         '#markup' => $markup,
-        '#description' => t('The event date and time are set based on your timezone. @change_timezone.', [
-          '@change_timezone' => Link::createFromRoute(
-            t('Change your timezone here'),
-            'entity.user.edit_form',
-            ['user' => \Drupal::currentUser()->id()],
-            [
-              'attributes' => [
-                'target' => '_blank',
-              ],
-              'fragment' => 'edit-group-locale-settings',
-            ]
-          )->toString(),
-        ]),
+        '#description' => $description,
       ],
     ];
 

--- a/modules/social_features/social_event/social_event.module
+++ b/modules/social_features/social_event/social_event.module
@@ -651,7 +651,7 @@ function social_event_form_alter(&$form, FormStateInterface $form_state, $form_i
       ]);
     }
     else {
-      $description = t('The event date and time are set based on the site\'s default timezone.');
+      $description = t("The event date and time are set based on the site's default timezone.");
     }
     $form['timezone_indication'] = [
       '#type' => 'container',

--- a/modules/social_features/social_event/social_event.module
+++ b/modules/social_features/social_event/social_event.module
@@ -631,15 +631,15 @@ function social_event_form_alter(&$form, FormStateInterface $form_state, $form_i
     // Get user timezone.
     $user_timezone = _social_event_user_timezone(date_default_timezone_get());
     $timezone_label = t('Time zone');
-    $markup = '<div class="control-label margin-bottom-s">' . $timezone_label . '</div>';
-    $markup .= '<div class="bg-gray-lighter btn btn-lg">' . $user_timezone . '</div>';
+    $markup = '<div class="control-label margin-bottom-s form-wrapper__label">' . $timezone_label . '</div>';
+    $markup .= '<div class="bg-gray-lightest btn btn-lg">' . $user_timezone . '</div>';
     $form['timezone_indication'] = [
       '#type' => 'container',
       '#weight' => 99,
       'content' => [
         '#type' => 'item',
         '#markup' => $markup,
-        '#description' => t('The event date and time are set based on tour timezone. @change_timezone', [
+        '#description' => t('The event date and time are set based on your timezone. @change_timezone.', [
           '@change_timezone' => Link::createFromRoute(
             t('Change your timezone here'),
             'entity.user.edit_form',


### PR DESCRIPTION
## Problem
There are some inconsistencies in the event create/edit page that will make the page harder to understand.
Incorrect copy text under timezone.

## Solution
1. Update text
2. Change/add classes for correct styles

## Issue tracker
- https://getopensocial.atlassian.net/browse/YANG-3671
- https://github.com/goalgorilla/open_social/pull/1921

## How to test
- [x] Go to edit/add event page
- [x] You should see changes as on the last screenshot

## Screenshots
**Before:**
![Screenshot 2020-09-08 at 10 47 27](https://user-images.githubusercontent.com/11648677/92575689-5183e700-f291-11ea-80e3-08f64f22744e.png)
![Screenshot 2020-09-08 at 10 49 08](https://user-images.githubusercontent.com/11648677/92575718-5c3e7c00-f291-11ea-9d65-c8f6421a7d15.png)

**After**
![Знімок екрана 2020-09-09 о 11 42 05](https://user-images.githubusercontent.com/11648677/92575978-a1fb4480-f291-11ea-9e2d-883497e5295e.png)


## Release notes
N/A

## Change Record
N/A

## Translations
N/A
