### PR TITLE
Issue #3162557: Increase number of activities per one batch operation

### DIFF
--- a/modules/custom/activity_creator/activity_creator.install
+++ b/modules/custom/activity_creator/activity_creator.install
@@ -7,6 +7,7 @@
 
 use Drupal\activity_creator\ActivityInterface;
 use Drupal\Core\Database\Database;
+use Drupal\Core\Site\Settings;
 
 /**
  * Implements hook_schema().
@@ -153,7 +154,7 @@ function activity_creator_update_8802(&$sandbox) {
   }
 
   // Activities per one batch operation.
-  $activities_per_batch = 100;
+  $activities_per_batch = Settings::get('activity_update_batch_size', 100);
 
   // Get activity IDs.
   $aids = $database

--- a/modules/custom/activity_creator/activity_creator.install
+++ b/modules/custom/activity_creator/activity_creator.install
@@ -153,7 +153,7 @@ function activity_creator_update_8802(&$sandbox) {
   }
 
   // Activities per one batch operation.
-  $activities_per_batch = 10;
+  $activities_per_batch = 100;
 
   // Get activity IDs.
   $aids = $database


### PR DESCRIPTION
## Problem
In PR #1956 we introduced batch update of all activity entities in `activity_creator_update_8802()`.
During update to latest 8.x-8.x on one of project with around 30000 activities, I received memory outage during this batch, both locally and on Platform.sh.

## Solution
I propose to increase the number of items from 10 to at least 100 to have this batch finished.
When I tried this locally all was good, but on Platform.sh it was not enough even when I increased to 200, but I am also not sure to what value it's good to increase.

## Issue tracker

- https://github.com/goalgorilla/open_social/pull/1965

## How to test
- [ ] Using latest version 8.x-8.x of Open Social
- [ ] Run update hook
- [ ] You should have activity_creator_update_8802 run without error

## Screenshots
N.A

## Release notes
N.A

## Change Record
N.A

## Translations
N.A
