### PR TITLE
Issue #3170776 by sjoerdvandervis: Do not set template variable to TRUE when Gin admin menu is handled

### DIFF
--- a/themes/socialbase/src/Plugin/Preprocess/Container.php
+++ b/themes/socialbase/src/Plugin/Preprocess/Container.php
@@ -56,6 +56,13 @@ class Container extends PreprocessBase {
       $variables['exposed_form'] = TRUE;
     }
 
+    // When we are dealing with the administration toolbar, we should not
+    // set bare to TRUE because it will remove necessary classes from the admin
+    // toolbar.
+    if (isset($variables['element']['administration_menu'])) {
+      $variables['bare'] = FALSE;
+    }
+
   }
 
 }


### PR DESCRIPTION
## Problem
When logged in as a site manager, if you are on a search page when caches haven't been build yet, you'll end up with a broken Gin admin toolbar as shown in the screenshot:

![Screenshot 2020-09-14 at 10 30 22](https://user-images.githubusercontent.com/19951173/93063385-705df100-f676-11ea-8f3e-53d1aba6a21b.png)

## Solution
In `themes/socialbase/src/Plugin/Preprocess/Container.php`, we check whether we are on a search path and set the variable `bare` to TRUE. This should stay in place because it will otherwise break search pages in a different manner. We will add a specific case to the Preprocess class which will set `bare` to be `FALSE` when we are dealing with the element `administration_menu`

## Issue tracker
https://www.drupal.org/project/social/issues/3170776

## How to test
- [ ] On version > 9, Log in as an admin;
- [ ] Go to `/search/all`;
- [ ] Flush caches using the admin toolbar;
- [ ] See that the page is broken as above;
- [ ] Now checkout this branch and do the same;
- [ ] See that the page is rendered correctly.

## Screenshots
The before situation is shown above.

After:
![Screenshot 2020-09-14 at 10 34 27](https://user-images.githubusercontent.com/19951173/93063612-cd59a700-f676-11ea-871f-bba43d83e365.png)

## Release notes
- We squashed a bug where the administration toolbar would not load correctly when cache was not build up yet on certain search pages.