### PR TITLE
Issue #3170824 by agami4: Update margin-bottom for the "card" class for both themes

### DIFF
--- a/themes/socialbase/assets/css/cards.css
+++ b/themes/socialbase/assets/css/cards.css
@@ -1,11 +1,19 @@
 .card {
-  box-shadow: 0 -1px 0 #e0e0e0, 0 0 2px rgba(0, 0, 0, 0.12), 0 2px 4px rgba(0, 0, 0, 0.24);
+  -webkit-box-shadow: 0 -1px 0 #e0e0e0, 0 0 2px rgba(0, 0, 0, 0.12), 0 2px 4px rgba(0, 0, 0, 0.24);
+          box-shadow: 0 -1px 0 #e0e0e0, 0 0 2px rgba(0, 0, 0, 0.12), 0 2px 4px rgba(0, 0, 0, 0.24);
   position: relative;
+  display: -webkit-box;
+  display: -ms-flexbox;
   display: flex;
-  flex-direction: column;
-  margin-bottom: 0.75rem;
+  -webkit-box-orient: vertical;
+  -webkit-box-direction: normal;
+      -ms-flex-direction: column;
+          flex-direction: column;
+  margin-bottom: 1.25rem;
   background-clip: padding-box;
-  flex-grow: 1;
+  -webkit-box-flex: 1;
+      -ms-flex-positive: 1;
+          flex-grow: 1;
 }
 
 .card__title {
@@ -29,7 +37,9 @@
 
 .card__block {
   position: relative;
-  flex: 1 1 auto;
+  -webkit-box-flex: 1;
+      -ms-flex: 1 1 auto;
+          flex: 1 1 auto;
   padding: 1.25rem;
 }
 
@@ -91,6 +101,7 @@
   font-size: 0.875rem;
   margin-left: 24px;
   float: right;
+  -webkit-transition: color .3s ease;
   transition: color .3s ease;
 }
 

--- a/themes/socialbase/components/02-atoms/cards/cards.scss
+++ b/themes/socialbase/components/02-atoms/cards/cards.scss
@@ -54,7 +54,7 @@
   position: relative;
   display: flex;
   flex-direction: column;
-  margin-bottom: $card-spacer-y;
+  margin-bottom: $card-spacer-x;
   background-clip: padding-box;
 
   // IE Fix: Default flex values for <IE11 is `flex: 0 0 auto` while other

--- a/themes/socialblue/assets/css/stream--sky.css
+++ b/themes/socialblue/assets/css/stream--sky.css
@@ -1,12 +1,12 @@
-.socialblue--sky .card--stream {
-  margin-bottom: 1.5rem;
-}@media (min-width: 600px) {
+@media (min-width: 600px) {
   .socialblue--sky .teaser.teaser--stream {
     height: 180px;
   }
   .socialblue--sky .teaser.teaser--stream .teaser__image {
     height: 180px;
-    flex: 0 0 180px;
+    -webkit-box-flex: 0;
+        -ms-flex: 0 0 180px;
+            flex: 0 0 180px;
   }
 }@media (min-width: 900px) {
   .socialblue--sky .teaser.teaser--stream .teaser__title {

--- a/themes/socialblue/components/04-organisms/stream/stream--sky.scss
+++ b/themes/socialblue/components/04-organisms/stream/stream--sky.scss
@@ -20,8 +20,4 @@
       }
     }
   }
-
-  .card--stream {
-    margin-bottom: 1.5rem;
-  }
 }


### PR DESCRIPTION
## Problem
The spacing in the right column is 12 px, and in the left column is 24 px. They should both be 20 px.

## Solution
Update margin-bottom to 20px for the 'card' class

## Issue tracker
https://www.drupal.org/project/social/issues/3170824

## How to test
*For example*
- [ ] Go to the Home page and check margin-bottom for the 'card' class on the general content and on the sidebar content.
- [ ] You can check it for both themes.

## Screenshots
before:
![card_bug](https://user-images.githubusercontent.com/16086340/93085166-d447e000-f69d-11ea-8cb5-b21b99aa8e48.png)
after:
<img width="1215" alt="card_fix" src="https://user-images.githubusercontent.com/16086340/93085362-1ffa8980-f69e-11ea-8ecf-43df124c7c2b.png">

## Release notes
The margin-bottom was changed from 12px to 20px for both themes

## Change Record

## Translations
