### PR TITLE
Issue #3162222 by tBKoT: Change timezone label from the city name to the timezone's abbreviation

### DIFF
--- a/modules/social_features/social_event/social_event.module
+++ b/modules/social_features/social_event/social_event.module
@@ -442,6 +442,9 @@ function _social_event_format_date($event, $view_mode) {
   // or defaults back to the sites timezone if the user didn't select any.
   $timezone = date_default_timezone_get();
   $user_timezone = date('T');
+  if (in_array($user_timezone[0], ['+', '-'])) {
+    $user_timezone = 'UTC' . $user_timezone;
+  }
   // Timezone that dates should be stored in.
   $utc_timezone = DateTimeItemInterface::STORAGE_TIMEZONE;
 

--- a/modules/social_features/social_event/social_event.module
+++ b/modules/social_features/social_event/social_event.module
@@ -441,7 +441,7 @@ function _social_event_format_date($event, $view_mode) {
   // This will get the users timezone, which is either set by the user
   // or defaults back to the sites timezone if the user didn't select any.
   $timezone = date_default_timezone_get();
-  $user_timezone = _social_event_user_timezone($timezone);
+  $user_timezone = date('T');
   // Timezone that dates should be stored in.
   $utc_timezone = DateTimeItemInterface::STORAGE_TIMEZONE;
 


### PR DESCRIPTION
## Problem
Needs to change the timezone label for the event from the city name to the timezone's abbreviation

## Solution
Use date format `T` instead of timezone from core

## Issue tracker
https://getopensocial.atlassian.net/browse/YANG-2960
https://getopensocial.atlassian.net/browse/YANG-3728

## How to test
- [ ] Set your own timezone to `Amsterdam`
- [ ] Near the event's time you should see CEST

## Screenshots
**Before:**
![image](https://user-images.githubusercontent.com/11648677/93481007-c3e66e00-f906-11ea-9415-f31cef5373c0.png)

**After:**
![image](https://user-images.githubusercontent.com/11648677/93481081-d9f42e80-f906-11ea-983f-6f3d4714255f.png)


## Release notes
Now user see timezone abbreviation instead of the city name

## Change Record
N/A

## Translations
N/A
