### PR TITLE
Issue #317156 by navneet0693: Moved logic from activity_creator_update_8802 to hook_post_update_name and refactored.

### DIFF
--- a/modules/custom/activity_creator/activity_creator.install
+++ b/modules/custom/activity_creator/activity_creator.install
@@ -5,9 +5,7 @@
  * Installation code for the activity_creator module.
  */
 
-use Drupal\activity_creator\ActivityInterface;
 use Drupal\Core\Database\Database;
-use Drupal\Core\Site\Settings;
 
 /**
  * Implements hook_schema().
@@ -142,56 +140,9 @@ function activity_creator_update_8801() {
 
 /**
  * Remove activities notification status if related entity not exist.
+ *
+ * @see activity_creator_post_update_8802_remove_activities_with_no_related_entities()
  */
 function activity_creator_update_8802(&$sandbox) {
-  $database = Drupal::database();
-  if (!isset($sandbox['total'])) {
-    $query = $database->select('activity_notification_status', 'ans');
-    $query->addExpression('COUNT(*)');
-    $count = $query->execute()->fetchField();
-    $sandbox['total'] = $count;
-    $sandbox['current'] = 0;
-  }
-
-  // Activities per one batch operation.
-  $activities_per_batch = Settings::get('activity_update_batch_size', 100);
-
-  // Get activity IDs.
-  $aids = $database
-    ->select('activity_notification_status', 'ans')
-    ->fields('ans', ['aid'])
-    ->range($sandbox['current'], $sandbox['current'] + $activities_per_batch)
-    ->execute()
-    ->fetchCol();
-
-  // Get activity storage.
-  $activity_storage = $activity = Drupal::entityTypeManager()
-    ->getStorage('activity');
-
-  foreach ($aids as $aid) {
-    /** @var \Drupal\activity_creator\ActivityInterface $activity */
-    $activity = $activity_storage->load($aid);
-
-    if (!$activity instanceof ActivityInterface) {
-      $aids_for_delete[] = $aid;
-    }
-    elseif (is_null($activity->getRelatedEntity())) {
-      $activity_storage->delete([$activity]);
-      $aids_for_delete[] = $aid;
-    }
-
-    $sandbox['current']++;
-  }
-
-  if (!empty($aids_for_delete)) {
-    Drupal::service('activity_creator.activity_notifications')
-      ->deleteNotificationsbyIds($aids_for_delete);
-  }
-
-  if ($sandbox['total'] == 0) {
-    $sandbox['#finished'] = 1;
-  }
-  else {
-    $sandbox['#finished'] = ($sandbox['current'] / $sandbox['total']);
-  }
+  // Removed in https://www.drupal.org/project/social/issues/3171563.
 }

--- a/modules/custom/activity_creator/activity_creator.post_update.php
+++ b/modules/custom/activity_creator/activity_creator.post_update.php
@@ -117,7 +117,7 @@ function activity_creator_post_update_8802_remove_activities_with_no_related_ent
     // 'activities_per_batch' is a custom amount that we’ll use to limit
     // how many activities we’re processing in each batch.
     // This is a large part of how we limit expensive batch operations.
-    $sandbox['activities_per_batch'] = Settings::get('activity_update_batch_size', 5000);;
+    $sandbox['activities_per_batch'] = Settings::get('activity_update_batch_size', 100);
 
     // 'activities_id' will store the activity IDs from activity notification
     // table that we just queried for above during this initialization phase.

--- a/modules/custom/activity_creator/activity_creator.post_update.php
+++ b/modules/custom/activity_creator/activity_creator.post_update.php
@@ -152,7 +152,6 @@ function activity_creator_post_update_8802_remove_activities_with_no_related_ent
     elseif (is_null($activity->getRelatedEntity())) {
       $entity_ids[] = $activity_id;
       $activities_for_delete[$activity_id] = $activity;
-      $activity_storage->resetCache($entity_ids);
     }
     else {
       // If the database has more than 100K of activities to be processed
@@ -172,7 +171,6 @@ function activity_creator_post_update_8802_remove_activities_with_no_related_ent
   // Delete not required activity entities.
   if (!empty($activities_for_delete)) {
     $activity_storage->delete($activities_for_delete);
-    $activity_storage->resetCache($entity_ids);
   }
 
   // Update the batch variables to track our progress.

--- a/modules/custom/activity_creator/activity_creator.post_update.php
+++ b/modules/custom/activity_creator/activity_creator.post_update.php
@@ -152,7 +152,7 @@ function activity_creator_post_update_8802_remove_activities_with_no_related_ent
     elseif (is_null($activity->getRelatedEntity())) {
       $entity_ids[] = $activity_id;
       $activities_for_delete[$activity_id] = $activity;
-      $activity_storage->resetCache($entity_ids[]);
+      $activity_storage->resetCache($entity_ids);
     }
     else {
       // If the database has more than 100K of activities to be processed
@@ -172,7 +172,7 @@ function activity_creator_post_update_8802_remove_activities_with_no_related_ent
   // Delete not required activity entities.
   if (!empty($activities_for_delete)) {
     $activity_storage->delete($activities_for_delete);
-    $activity_storage->resetCache($entity_ids[]);
+    $activity_storage->resetCache($entity_ids);
   }
 
   // Update the batch variables to track our progress.

--- a/modules/custom/activity_creator/activity_creator.post_update.php
+++ b/modules/custom/activity_creator/activity_creator.post_update.php
@@ -134,6 +134,7 @@ function activity_creator_post_update_8802_remove_activities_with_no_related_ent
       $aids_for_delete[] = $aid;
       $activities_for_delete[$aid] = $activity;
     }
+    $sandbox['current']++;
   }
 
   // Remove notifications.
@@ -145,16 +146,6 @@ function activity_creator_post_update_8802_remove_activities_with_no_related_ent
   // Delete not required activity entities.
   if (!empty($activities_for_delete)) {
     $activity_storage->delete($activities_for_delete);
-  }
-
-  // Increment currently processed entities.
-  // Check if current starting point is less than our range selection.
-  if ($sandbox['total'] - $sandbox['current'] > $activities_per_batch) {
-    $sandbox['current'] += $activities_per_batch;
-  }
-  else {
-    // If we have less number of results to process, we increment by difference.
-    $sandbox['current'] += ($sandbox['total'] - $sandbox['current']);
   }
 
   // The batch will finish when '#finished' will become '1'.

--- a/modules/custom/activity_creator/activity_creator.post_update.php
+++ b/modules/custom/activity_creator/activity_creator.post_update.php
@@ -118,7 +118,7 @@ function activity_creator_post_update_8802_remove_activities_with_no_related_ent
     ->getStorage('activity');
 
   // Choose chunk of array to be processed.
-  $activity_ids = array_slice($sandbox['activities_id'], $sandbox['current'], $activities_per_batch);
+  $activity_ids = array_slice($sandbox['activities_id'], $sandbox['current'], $activities_per_batch, TRUE);
 
   // Prepare the array of ids for deletion.
   foreach ($activity_ids as $aid) {

--- a/modules/custom/activity_creator/activity_creator.post_update.php
+++ b/modules/custom/activity_creator/activity_creator.post_update.php
@@ -112,7 +112,7 @@ function activity_creator_post_update_8802_remove_activities_with_no_related_ent
   }
 
   // Activities per one batch operation.
-  $activities_per_batch = Settings::get('activity_update_batch_size', 10000);
+  $activities_per_batch = Settings::get('activity_update_batch_size', 5000);
   // Get activity storage.
   $activity_storage = $activity = \Drupal::entityTypeManager()
     ->getStorage('activity');

--- a/modules/custom/activity_creator/activity_creator.post_update.php
+++ b/modules/custom/activity_creator/activity_creator.post_update.php
@@ -5,6 +5,9 @@
  * Contains post update hook implementations.
  */
 
+use Drupal\activity_creator\ActivityInterface;
+use Drupal\Core\Site\Settings;
+
 /**
  * Migrate all the activity status information to new table.
  *
@@ -66,4 +69,96 @@ function activity_creator_post_update_8001_one_to_many_activities(&$sandbox) {
   $sandbox['#finished'] = ($sandbox['current'] / $sandbox['total']);
   // Print some progress.
   return t('@count activities data has been migrated to activity_notification_table.', ['@count' => $sandbox['current']]);
+}
+
+/**
+ * Remove activities notification status if related entity not exist.
+ *
+ * @throws \Drupal\Core\Entity\EntityStorageException
+ */
+function activity_creator_post_update_8802_remove_activities_with_no_related_entities(&$sandbox) {
+  // Fetching amount of data we need to process.
+  // Runs only once per update.
+  $database = \Drupal::database();
+  if (!isset($sandbox['total'])) {
+    // Get count of all the necessary fields information from current database.
+    /** @var \Drupal\Core\Database\Query\Select $query */
+    $query = $database->select('activity_notification_status', 'ans');
+    $number_of_activities = $query->countQuery()->execute()->fetchField();
+
+    // Write total of entities need to be processed to $sandbox.
+    $sandbox['total'] = $number_of_activities;
+    // Initiate default value for current processing of element.
+    $sandbox['current'] = 0;
+
+    // Get activity IDs.
+    /** @var \Drupal\Core\Database\Query\Select $query */
+    $activity_ids = $database->select('activity_notification_status', 'ans')
+      ->fields('ans', ['aid'])
+      ->execute()
+      ->fetchCol();
+
+    // We pass all the ids in sandbox to be processed in each batch.
+    // We will choose a chunk of ids from this ids and use $sanbox['current']
+    // as offset. We do this to ensure all the ids are processed because we are
+    // deleting the data from the same table we are choosing from.
+    $sandbox['activities_id'] = $activity_ids;
+  }
+
+  // Do not continue if no entities are found.
+  if (empty($sandbox['total'])) {
+    $sandbox['#finished'] = 1;
+    return t('No activities data to be processed.');
+  }
+
+  // Activities per one batch operation.
+  $activities_per_batch = Settings::get('activity_update_batch_size', 10000);
+  // Get activity storage.
+  $activity_storage = $activity = \Drupal::entityTypeManager()
+    ->getStorage('activity');
+
+  // Choose chunk of array to be processed.
+  $activity_ids = array_slice($sandbox['activities_id'], $sandbox['current'], $activities_per_batch);
+
+  // Prepare the array of ids for deletion.
+  foreach ($activity_ids as $aid) {
+    /** @var \Drupal\activity_creator\ActivityInterface $activity */
+    $activity = $activity_storage->load($aid);
+
+    // Add invalid ids for deletion.
+    if (!$activity instanceof ActivityInterface) {
+      $aids_for_delete[] = $aid;
+    }
+    // Add not required $activity.
+    elseif (is_null($activity->getRelatedEntity())) {
+      $aids_for_delete[] = $aid;
+      $activities_for_delete[$aid] = $activity;
+    }
+  }
+
+  // Remove notifications.
+  if (!empty($aids_for_delete)) {
+    \Drupal::service('activity_creator.activity_notifications')
+      ->deleteNotificationsbyIds($aids_for_delete);
+  }
+
+  // Delete not required activity entities.
+  if (!empty($activities_for_delete)) {
+    $activity_storage->delete($activities_for_delete);
+  }
+
+  // Increment currently processed entities.
+  // Check if current starting point is less than our range selection.
+  if ($sandbox['total'] - $sandbox['current'] > $activities_per_batch) {
+    $sandbox['current'] += $activities_per_batch;
+  }
+  else {
+    // If we have less number of results to process, we increment by difference.
+    $sandbox['current'] += ($sandbox['total'] - $sandbox['current']);
+  }
+
+  // The batch will finish when '#finished' will become '1'.
+  $sandbox['#finished'] = ($sandbox['current'] / $sandbox['total']);
+  // Print some progress.
+  return t('@count activities data has been cleaned up.', ['@count' => $sandbox['current']]);
 }

--- a/modules/custom/activity_creator/activity_creator.post_update.php
+++ b/modules/custom/activity_creator/activity_creator.post_update.php
@@ -127,7 +127,7 @@ function activity_creator_post_update_8802_remove_activities_with_no_related_ent
   // Initialization code done. The following code will always run:
   // both during the first run AND during any subsequent batches.
   // Now let’s remove the  missing activity ids.
-  $activity_storage = $activity = \Drupal::entityTypeManager()->getStorage('activity');
+  $activity_storage = \Drupal::entityTypeManager()->getStorage('activity');
 
   // Calculates current batch range.
   $range_end = $sandbox['progress'] + $sandbox['activities_per_batch'];


### PR DESCRIPTION
## Problem
Originating PR: #1965 

When upgrading OpenSocial from 8.4 to 8.5,  `drush updb` fails due to https://github.com/goalgorilla/open_social/blob/10.0.x/modules/custom/activity_creator/activity_creator.install#L146

The better place for any such entity updates is hook_post_update_name, also as documentation of hook_update_N states:

> Be careful about API functions and especially CRUD operations that you use in your update function. If they invoke hooks or use services, they may not behave as expected, and it may actually not be appropriate to use the normal API functions that invoke all the hooks, use the database schema, and/or use services in an update function -- you may need to switch to using a more direct method (database query, etc.).
> In particular, loading, saving, or performing any other CRUD operation on an entity is never safe to do (they always involve hooks and services).
> Never rebuild the router during an update function.

Also, https://github.com/goalgorilla/open_social/blob/10.0.x/modules/custom/activity_creator/activity_creator.install#L163 is increasing the range of query exponentially.

Definition of range function:

```
/**
   * Restricts a query to a given range in the result set.
   *
   * If this method is called with no parameters, will remove any range
   * directives that have been set.
   *
   * @param $start
   *   The first record from the result set to return. If NULL, removes any
   *   range directives that are set.
   * @param $length
   *   The number of records to return from the result set.
   * @return $this
   *   The called object.
   */
  public function range($start = NULL, $length = NULL);

```
```
1st round: range(0, 100) // 100 entitites (Total = 100)
2nd round: range(100, 100+100) // 200 entities (Total = 300)
3rd round: range(200, 200+100) // 300 entities (Total = 600)
and so on..
```

Also, as @Kingdutch  noted that this update could skip certain ids to be processed as it is reading https://github.com/goalgorilla/open_social/blob/10.0.x/modules/custom/activity_creator/activity_creator.install#L160 and deleting ids https://github.com/goalgorilla/open_social/blob/10.0.x/modules/custom/activity_creator/activity_creator.install#L187 from the same table.

```
Assume, we have notifications [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]
The first query for $sandbox['total'] will count(*) 20 items. Say the $activities_per_batch is 5.
The first cycle will load five with offset 0:
$aids = [1, 2, 3, 4, 5];
// delete
$sandbox['current'] will now be set to 5.
The second cycle will load (assuming you fix the $range argument) another 5, offset 5. However, the dataset in the database is now:
[6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]
So you’ll load 5 offsets 5:
[11, 12, 13, 14, 15]
This means 6 through 10 aren’t processed.

```

## Solution
1. Move function activity_creator_update_8802(&$sandbox) to activity_creator.post_update.php
2. Refactor the function to delete in bulk.
3. Correct the logic of getting and deleting the data.

## Issue tracker
https://www.drupal.org/project/social/issues/3171563

## How to test
- [ ] Using version <8.5 of Open Social.
- [ ] Upgrade to 8.5.
- [ ] Check for no memory outage.

## Screenshots
N.A

## Release notes
Logic from activity_creator_update_8802() moved to activity_creator_post_update_8802_remove_activities_with_no_related_entities()

## Change Record
Resolved a problem of memory outage on upgrade by moving logic from activity_creator_update_8802() moved to activity_creator_post_update_8802_remove_activities_with_no_related_entities()

## Translations
N.A