### PR TITLE
Don't invoke a separate shell to run unit-tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,7 +71,7 @@ install:
 script:
   - set -e
   - if [ "$TEST_SUITE" = "install_stability_1" ]; then docker exec -i social_ci_web bash /var/www/scripts/social/check-coding-standards.sh full; fi
-  - if [ "$TEST_SUITE" = "install_stability_1" ]; then docker exec -i social_ci_web_scripts sh /var/www/scripts/social/unit-tests.sh; fi
+  - if [ "$TEST_SUITE" = "install_stability_1" ]; then docker exec -i social_ci_web_scripts /var/www/scripts/social/unit-tests.sh; fi
   - if [ "$TEST_SUITE" = "install_stability_1" ]; then docker exec -it social_ci_behat sh /var/www/scripts/social/behatstability.sh "stability-1 --stop-on-failure --strict"; fi
   - if [ "$TEST_SUITE" = "install_stability_2" ]; then docker exec -it social_ci_behat sh /var/www/scripts/social/behatstability.sh "notifications --stop-on-failure --strict"; fi
   - if [ "$TEST_SUITE" = "install_stability_2" ]; then docker exec -it social_ci_behat sh /var/www/scripts/social/behatstability.sh "stability-2 --stop-on-failure --strict"; fi


### PR DESCRIPTION


## Problem
The script already provides an interpreter in the script
file itself using the SHEBANG. This allows the script to
execute using `bash` providing all the features it needs.

The `sh` shell does not provide the features needed.

We should consider doing this for the other scripts too.
However, we will need to make sure the scripts are executable
in the script repository.

## Solution
Remove the shell invocation. The `run-tests.sh` and `unit-tests.sh` scripts have been given executable status (`chmod +x`) in the scripts repository.

## Issue tracker
No issue, internal CI hotfix.

## How to test
Travis should pass again.

## Screenshots
Not applicable

## Release notes
Not applicable

## Change Record
Not applicable

## Translations
Not applicable
