### PR TITLE
Issue #2947668 by agami4: Check and add updates to focus links [Accessibility]

### DIFF
--- a/themes/socialbase/assets/css/base.css
+++ b/themes/socialbase/assets/css/base.css
@@ -459,8 +459,14 @@ a:active, a:hover {
 }
 
 a:focus {
-  outline: 5px auto -webkit-focus-ring-color;
-  outline-offset: -2px;
+  -webkit-box-shadow: 0 0 1px 3px rgba(59, 153, 252, 0.7);
+          box-shadow: 0 0 1px 3px rgba(59, 153, 252, 0.7);
+  -webkit-box-shadow: 0 0 0 3px activeborder;
+          box-shadow: 0 0 0 3px activeborder;
+  /* Blink, Chrome */
+  box-shadow: 0 0 0 3px -moz-mac-focusring;
+  /* Firefox */
+  outline: auto 1px -webkit-focus-ring-color;
 }
 
 a:active:not(.btn) {

--- a/themes/socialbase/assets/css/like.css
+++ b/themes/socialbase/assets/css/like.css
@@ -8,8 +8,12 @@
 }
 
 .vote__wrapper {
+  display: -webkit-box;
+  display: -ms-flexbox;
   display: flex;
-  align-items: center;
+  -webkit-box-align: center;
+      -ms-flex-align: center;
+          align-items: center;
 }
 
 .vote-like {
@@ -25,6 +29,7 @@
   fill: transparent;
   stroke: #4d4d4d;
   stroke-width: 15px;
+  -webkit-transition: 0.3s;
   transition: 0.3s;
   vertical-align: text-top;
 }
@@ -35,10 +40,6 @@ svg[class^="icon-vote"] {
 
 .vote__count {
   font-size: 14px;
-}
-
-.vote__count .use-ajax {
-  outline: 0;
 }
 
 .vote-widget a.disable-status {
@@ -66,9 +67,14 @@ svg[class^="icon-vote"] {
 }
 
 .view--who-liked .row {
-  flex-wrap: nowrap;
-  justify-content: flex-start;
-  align-items: center;
+  -ms-flex-wrap: nowrap;
+      flex-wrap: nowrap;
+  -webkit-box-pack: start;
+      -ms-flex-pack: start;
+          justify-content: flex-start;
+  -webkit-box-align: center;
+      -ms-flex-align: center;
+          align-items: center;
   border-bottom: 1px solid #e6e6e6;
   padding: 0.5rem 0;
 }
@@ -78,7 +84,9 @@ svg[class^="icon-vote"] {
 }
 
 .view--who-liked .views-field-rendered-entity-1 {
-  flex: 0 0 54px;
+  -webkit-box-flex: 0;
+      -ms-flex: 0 0 54px;
+          flex: 0 0 54px;
 }
 
 .view--who-liked .views-field-rendered-entity-1 a:focus {
@@ -86,7 +94,9 @@ svg[class^="icon-vote"] {
 }
 
 .view--who-liked .views-field-name {
-  flex: 2 1 auto;
+  -webkit-box-flex: 2;
+      -ms-flex: 2 1 auto;
+          flex: 2 1 auto;
   min-width: 0;
 }
 
@@ -109,14 +119,17 @@ svg[class^="icon-vote"] {
   .vote-like a:hover .icon-vote {
     stroke: black;
     fill: transparent;
-    transform: scale(1.3);
+    -webkit-transform: scale(1.3);
+            transform: scale(1.3);
+    -webkit-transition: 0.3s;
     transition: 0.3s;
   }
   .vote-like a:hover.voted-like .icon-vote,
   .vote-like a:hover.disable-status .icon-vote {
     fill: #4d4d4d;
     stroke: #4d4d4d;
-    transform: none;
+    -webkit-transform: none;
+            transform: none;
   }
 }
 
@@ -134,7 +147,8 @@ svg[class^="icon-vote"] {
     font-weight: normal;
     text-align: center;
     vertical-align: middle;
-    touch-action: manipulation;
+    -ms-touch-action: manipulation;
+        touch-action: manipulation;
     cursor: pointer;
     background-image: none;
     border: 1px solid transparent;
@@ -146,6 +160,7 @@ svg[class^="icon-vote"] {
        -moz-user-select: none;
         -ms-user-select: none;
             user-select: none;
+    -webkit-transition: .3s ease-out;
     transition: .3s ease-out;
     outline: 0;
   }
@@ -156,7 +171,9 @@ svg[class^="icon-vote"] {
     width: 100%;
   }
   .vote__wrapper {
-    justify-content: space-between;
+    -webkit-box-pack: justify;
+        -ms-flex-pack: justify;
+            justify-content: space-between;
   }
   .vote-like {
     margin-right: 10px;

--- a/themes/socialbase/components/01-base/links/_links.scss
+++ b/themes/socialbase/components/01-base/links/_links.scss
@@ -39,8 +39,10 @@ a {
   }
 
   &:focus {
-    outline: 5px auto -webkit-focus-ring-color;
-    outline-offset: -2px;
+    box-shadow: 0 0 1px 3px rgba(59, 153, 252, .7);
+    box-shadow: 0 0 0 3px activeborder; /* Blink, Chrome */
+    box-shadow: 0 0 0 3px -moz-mac-focusring; /* Firefox */
+    outline: auto 1px -webkit-focus-ring-color;
   }
 
   &:active:not(.btn) {

--- a/themes/socialbase/components/03-molecules/like/like.scss
+++ b/themes/socialbase/components/03-molecules/like/like.scss
@@ -58,10 +58,6 @@ svg[class^="icon-vote"] {
 
 .vote__count {
   font-size: $font-size-small;
-
-  .use-ajax {
-    outline: 0;
-  }
 }
 
 


### PR DESCRIPTION
## Problem
The focus of elements don't work in Firefox and possibly also in other browsers
## Solution
Update styles for the focus of the elements

## Issue tracker
https://www.drupal.org/project/social/issues/2947668

## How to test
*For example*
- [ ] Go to the page and use the "Tab" keyboard button for navigation
- [ ] You will see focus style on the elements

## Screenshots
<img width="811" alt="focus-elem" src="https://user-images.githubusercontent.com/16086340/93868813-ab45d180-fcd3-11ea-9426-bbe05fe6d71f.png">

## Release notes
Added style updates for the focus of the elements.