### PR TITLE
Issue 3171630 by agami4: Update styles for the teaser__body

### DIFF
--- a/themes/socialbase/assets/css/teaser.css
+++ b/themes/socialbase/assets/css/teaser.css
@@ -1,7 +1,13 @@
 .teaser {
+  display: -webkit-box;
+  display: -ms-flexbox;
   display: flex;
-  flex-wrap: wrap;
-  flex-direction: row;
+  -ms-flex-wrap: wrap;
+      flex-wrap: wrap;
+  -webkit-box-orient: horizontal;
+  -webkit-box-direction: normal;
+      -ms-flex-direction: row;
+          flex-direction: row;
 }
 
 .teaser__image {
@@ -23,8 +29,12 @@
   background: none;
   width: 100%;
   height: 100%;
+  display: -webkit-box;
+  display: -ms-flexbox;
   display: flex;
-  align-items: center;
+  -webkit-box-align: center;
+      -ms-flex-align: center;
+          align-items: center;
 }
 
 .teaser__teaser-type-icon {
@@ -48,19 +58,30 @@
 }
 
 .teaser__body {
-  flex: 1;
+  -webkit-box-flex: 1;
+      -ms-flex: 1;
+          flex: 1;
+  display: -webkit-box;
+  display: -ms-flexbox;
   display: flex;
   overflow: hidden;
-  flex-direction: column;
+  -webkit-box-orient: vertical;
+  -webkit-box-direction: normal;
+      -ms-flex-direction: column;
+          flex-direction: column;
 }
 
 .teaser__content {
-  flex: 1;
+  -webkit-box-flex: 1;
+      -ms-flex: 1;
+          flex: 1;
   padding: 20px;
   position: relative;
 }
 
 .teaser__content-line {
+  display: -webkit-box;
+  display: -ms-flexbox;
   display: flex;
   max-width: 100%;
   font-size: 0.875rem;
@@ -69,7 +90,9 @@
 .teaser__content-type-icon {
   width: 14px;
   height: 14px;
-  flex: 0 0 14px;
+  -webkit-box-flex: 0;
+      -ms-flex: 0 0 14px;
+          flex: 0 0 14px;
   line-height: 21px;
   margin-top: 3px;
   fill: #555555;
@@ -78,26 +101,33 @@
 
 .teaser__content-text {
   line-height: 21px;
-  flex-grow: 1;
+  -webkit-box-flex: 1;
+      -ms-flex-positive: 1;
+          flex-grow: 1;
   text-overflow: ellipsis;
   overflow-x: hidden;
   white-space: nowrap;
 }
 
 .teaser__published {
+  display: -webkit-box;
+  display: -ms-flexbox;
   display: flex;
   min-width: 0;
 }
 
 .teaser__published-author {
-  flex-grow: 1;
+  -webkit-box-flex: 1;
+      -ms-flex-positive: 1;
+          flex-grow: 1;
   text-overflow: ellipsis;
   overflow: hidden;
   white-space: nowrap;
 }
 
 .teaser__published-date {
-  flex-shrink: 0;
+  -ms-flex-negative: 0;
+      flex-shrink: 0;
   margin-right: 4px;
 }
 
@@ -117,7 +147,9 @@
 }
 
 .teaser--tile.teaser-profile .teaser__image {
-  flex: 0 0 100px;
+  -webkit-box-flex: 0;
+      -ms-flex: 0 0 100px;
+          flex: 0 0 100px;
   height: 100px;
   margin-bottom: 70px;
   border-radius: 0;
@@ -144,12 +176,16 @@
 }
 
 .teaser--small {
+  display: -webkit-box;
+  display: -ms-flexbox;
   display: flex;
   padding: 1.5rem 1.25rem 0;
 }
 
 .teaser--small .teaser--small__media {
-  flex: none;
+  -webkit-box-flex: 0;
+      -ms-flex: none;
+          flex: none;
 }
 
 .teaser--small .teaser--small__media img {
@@ -170,8 +206,13 @@
 }
 
 .teaser--small .teaser--small__details {
+  display: -webkit-box;
+  display: -ms-flexbox;
   display: flex;
-  flex-direction: column;
+  -webkit-box-orient: vertical;
+  -webkit-box-direction: normal;
+      -ms-flex-direction: column;
+          flex-direction: column;
   margin-left: 1rem;
 }
 
@@ -197,13 +238,16 @@
 
 @media (min-width: 600px) {
   .teaser {
-    flex-wrap: nowrap;
+    -ms-flex-wrap: nowrap;
+        flex-wrap: nowrap;
     height: 220px;
   }
   .teaser__image {
     display: block;
     height: 220px;
-    flex: 0 0 220px;
+    -webkit-box-flex: 0;
+        -ms-flex: 0 0 220px;
+            flex: 0 0 220px;
     position: relative;
     overflow: hidden;
     width: auto;
@@ -234,6 +278,7 @@
     display: block;
     position: absolute;
     content: '';
+    background-image: -webkit-gradient(linear, left top, left bottom, color-stop(40%, rgba(0, 0, 0, 0)), color-stop(70%, rgba(0, 0, 0, 0.1)), to(rgba(34, 34, 34, 0.5)));
     background-image: linear-gradient(rgba(0, 0, 0, 0) 40%, rgba(0, 0, 0, 0.1) 70%, rgba(34, 34, 34, 0.5) 100%);
     height: 100%;
     width: 100%;
@@ -245,5 +290,14 @@
   }
   .teaser--unpublished .teaser__title {
     padding-right: 130px;
+  }
+}
+
+@media (max-width: 599px) {
+  .teaser__body {
+    -webkit-box-flex: 0;
+        -ms-flex: 0 0 100%;
+            flex: 0 0 100%;
+    max-width: 100%;
   }
 }

--- a/themes/socialbase/components/03-molecules/teaser/teaser.scss
+++ b/themes/socialbase/components/03-molecules/teaser/teaser.scss
@@ -113,6 +113,11 @@
   display: flex;
   overflow: hidden; // makes sure content doesn't continue outside of teaser
   flex-direction: column;
+
+  @include for-phone-only {
+    flex: 0 0 100%;
+    max-width: 100%;
+  }
 }
 
 // Content of the teaser


### PR DESCRIPTION
## Problem
At a screen width of 320px, the content of a featured content item teaser will overflow. The author text is properly truncated for teasers on a desktop (1200px) but this doesn't seem to work on mobile devices.

## Solution
Update with styles for the `teaser__body` on the mobile.

## Issue tracker
https://www.drupal.org/project/social/issues/3171630

## How to test
*For example*
- [ ] Go/Create `Landing page` and add `Featured content` block
- [ ] Increase the `author name`.

## Screenshots
<img width="1178" alt="teaser-name-desktop" src="https://user-images.githubusercontent.com/16086340/93878774-498d6380-fce3-11ea-8f5c-f17e22406541.png">
<img width="382" alt="teaser-name-mobile" src="https://user-images.githubusercontent.com/16086340/93878781-4c885400-fce3-11ea-9f3c-961794467467.png">
<img width="771" alt="teaser-name-tablet" src="https://user-images.githubusercontent.com/16086340/93878783-4d20ea80-fce3-11ea-8dbd-2d9c2e2275ee.png">

## Release notes
On small devices (320px) the features content items on a landing page no longer overflow