### PR TITLE
Issue #3171792 by agami4: Update styles for the show/hide search popup

### DIFF
--- a/themes/socialbase/assets/css/navbar.css
+++ b/themes/socialbase/assets/css/navbar.css
@@ -346,6 +346,7 @@
     display: none;
   }
   .search-take-over {
+    display: none;
     height: 50px;
     position: fixed;
     top: 20%;
@@ -353,7 +354,6 @@
     width: 100%;
     z-index: 1050;
     pointer-events: none;
-    opacity: 0;
     -webkit-transition: all 0.3s ease-in-out;
     transition: all 0.3s ease-in-out;
   }
@@ -438,7 +438,7 @@
     overflow: hidden;
   }
   .mode-search .search-take-over {
-    opacity: 1;
+    display: block;
     pointer-events: all;
   }
   .mode-search .navbar__open-search-block {

--- a/themes/socialbase/assets/css/navbar.css
+++ b/themes/socialbase/assets/css/navbar.css
@@ -438,7 +438,7 @@
     overflow: hidden;
   }
   .mode-search .search-take-over {
-    display: block;
+    display: initial;
     pointer-events: all;
   }
   .mode-search .navbar__open-search-block {

--- a/themes/socialbase/components/03-molecules/navigation/navbar/navbar.scss
+++ b/themes/socialbase/components/03-molecules/navigation/navbar/navbar.scss
@@ -636,7 +636,7 @@
     overflow: hidden;
 
     .search-take-over {
-      display: block;
+      display: initial;
       pointer-events: all;
     }
 

--- a/themes/socialbase/components/03-molecules/navigation/navbar/navbar.scss
+++ b/themes/socialbase/components/03-molecules/navigation/navbar/navbar.scss
@@ -551,6 +551,7 @@
 @include for-tablet-landscape-up {
 
   .search-take-over {
+    display: none;
     height: 50px;
     position: fixed;
     top: 20%;
@@ -558,7 +559,6 @@
     width: 100%;
     z-index: $zindex-modal;
     pointer-events: none;
-    opacity: 0;
     transition: all 0.3s ease-in-out;
 
     .form-group {
@@ -636,7 +636,7 @@
     overflow: hidden;
 
     .search-take-over {
-      opacity: 1;
+      display: block;
       pointer-events: all;
     }
 


### PR DESCRIPTION
## Problem
The form with ID search-content-form is used to show the search overlay. However, even when this overlay is not visible the form still captures focus.

## Solution
Adjust the `search-take-over` class to use `display:none` and add `display: initial` to the `.mode-search .search-take-over ` selector. The search icon itself should be keyboard and screenreader accessible to make the search overlay visible.

## Issue tracker
https://www.drupal.org/project/social/issues/3171792

## How to test
*For example*
- [ ] Open a landing page with the stream.
- [ ] Tab through the page.

## Screenshots
<img width="1575" alt="search-form-popup" src="https://user-images.githubusercontent.com/16086340/93882528-07672080-fce9-11ea-8701-ae5bdf2f004e.png">

## Release notes
The search form is no longer in the tab order when it's not visible. No visual changes.