### PR TITLE
Issue #3172705 by agami4: Remove bootstrap attributes from second level menu if this level has children elements

### DIFF
--- a/themes/socialbase/assets/js/navbar-main-menu.min.js
+++ b/themes/socialbase/assets/js/navbar-main-menu.min.js
@@ -1,0 +1,1 @@
+!function(n){Drupal.behaviors.navbarMainMenu={attach:function(a,e){n(".menu-main > .main > .expanded > .dropdown-menu > .expanded > a").removeAttr("data-toggle").removeClass("dropdown-toggle")}}}(jQuery);

--- a/themes/socialbase/components/03-molecules/navigation/navbar/navbar-main-menu.js
+++ b/themes/socialbase/components/03-molecules/navigation/navbar/navbar-main-menu.js
@@ -1,0 +1,11 @@
+(function ($) {
+
+  Drupal.behaviors.navbarMainMenu = {
+    attach: function (context, settings) {
+      $('.menu-main > .main > .expanded > .dropdown-menu > .expanded > a').removeAttr('data-toggle')
+        .removeClass('dropdown-toggle');
+    }
+
+  };
+
+})(jQuery);

--- a/themes/socialbase/socialbase.libraries.yml
+++ b/themes/socialbase/socialbase.libraries.yml
@@ -201,6 +201,7 @@ navbar:
     assets/js/navbar-collapse.min.js: { minified: true }
     assets/js/navbar-resize.min.js: { minified: true }
     assets/js/navbar-search.min.js: { minified: true }
+    assets/js/navbar-main-menu.min.js: { minified: true }
 
 pagination:
   css:


### PR DESCRIPTION
## Problem
When you click on the second level(if this level has children elements) menu I can not move to the page.

## Solution
Remove bootstrap attributes from the second-level menu(if this level has children elements).

## Issue tracker
https://www.drupal.org/project/social/issues/3172705

## How to test
- [ ] Click on the second level(if this level has children elements).

## Screenshots
N.A

## Release notes
When you click on the second level(if this level has children elements) menu I can move to the page.