### PR TITLE
Access denied on group manage members

### DIFF
--- a/modules/social_features/social_group/modules/social_group_flexible_group/src/Access/FlexibleGroupJoinPermissionAccessCheck.php
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/src/Access/FlexibleGroupJoinPermissionAccessCheck.php
@@ -48,7 +48,7 @@ class FlexibleGroupJoinPermissionAccessCheck implements AccessInterface {
     // Don't interfere if the group isn't a real group.
     $group = $parameters->get('group');
     if (!$group instanceof GroupInterface) {
-      $group = Group:load($group);
+      $group = Group::load($group);
       if (!$group instanceof GroupInterface) {
         return AccessResult::neutral();
       }

--- a/modules/social_features/social_group/modules/social_group_flexible_group/src/Access/FlexibleGroupJoinPermissionAccessCheck.php
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/src/Access/FlexibleGroupJoinPermissionAccessCheck.php
@@ -48,7 +48,7 @@ class FlexibleGroupJoinPermissionAccessCheck implements AccessInterface {
     // Don't interfere if the group isn't a real group.
     $group = $parameters->get('group');
     if (!$group instanceof GroupInterface) {
-      $group = _social_group_get_current_group();
+      $group = Group:load($group);
       if (!$group instanceof GroupInterface) {
         return AccessResult::neutral();
       }

--- a/modules/social_features/social_group/social_group.module
+++ b/modules/social_features/social_group/social_group.module
@@ -1294,7 +1294,7 @@ function _social_group_get_current_group($node = NULL) {
   // If we have a cache key we store the value.
   if (!is_null($nid)) {
     // Translate NULL to FALSE so that isset works.
-    $cache[$nid] = isset($group) ? $group : FALSE;
+    $cache[$nid] = isset($group) ? $group : NULL;
   }
 
   return $group;

--- a/modules/social_features/social_group/social_group.module
+++ b/modules/social_features/social_group/social_group.module
@@ -1294,7 +1294,7 @@ function _social_group_get_current_group($node = NULL) {
   // If we have a cache key we store the value.
   if (!is_null($nid)) {
     // Translate NULL to FALSE so that isset works.
-    $cache[$nid] = isset($group) ? $group : NULL;
+    $cache[$nid] = isset($group) ? $group : FALSE;
   }
 
   return $group;


### PR DESCRIPTION
## Problem
Just figured out, that I can not access the group manage members tab, after one of the last upgrades. fe. /group/34/membership
Even with user 1 I receive a "You are not authorized to access this page."

## Solution
This seems to be a "multilayer issue" on most installs I got rid of the behaviour by rebuilding node access permission.
But on one install I still got "You are not authorized to access this page." after rebuilding the permission.

See issue https://www.drupal.org/project/social/issues/3173334

## Issue tracker
https://www.drupal.org/project/social/issues/3173334

## How to test
*For example*
- [ ] Using version X.Y.Z of Open Social with the example module enabled
- [ ] As a sitemanager
- [ ] Try to enable the option B on screen c/d/e
- [ ] When saving I expect the result to be F but instead see G.
- [ ] The expected result F is attained when repeating the steps with this fix applied.

## Screenshots
*If this Pull Request makes visual changes then please include some screenshots that show what has changed here. A before and after screenshot helps the reviewer determine what changes were made.*

## Release notes
*A short summary of the changes that were made that can be included in release notes.*

## Change Record
*If this Pull Request changes the way that developers should do things or introduces a new API for developers then a change record to document this is needed. Please provide a draft for a change record or a link to an unpublished change record below. [Existing change records](https://www.drupal.org/list-changes/social) can be consulted as example.*

## Translations
*Translatable strings are always extracted from the latest development branch. To ensure translations remain available for platforms running older versions of Open Social the original string should be added to `translations.php` when it's changed or removed.*
- [ ] Changed or removed source strings are added to the `translations.php` file.
