### PR TITLE
Issue #2947667 by ok_lyndsey, Kingdutch: Style skip to content so it …

### DIFF
--- a/themes/socialbase/assets/css/base.css
+++ b/themes/socialbase/assets/css/base.css
@@ -145,6 +145,23 @@ body {
   -webkit-font-smoothing: antialiased;
 }
 
+#skip-link {
+  text-align: center;
+  position: absolute;
+  left: 0;
+  right: 0;
+  z-index: 15000;
+}
+
+#skip-link a {
+  background: #222222;
+  box-shadow: 0 0 4px rgba(0, 0, 0, 0.14), 0 4px 8px rgba(0, 0, 0, 0.28);
+  color: #f3f3f3;
+  padding: 3px 20px 8px;
+  text-decoration: none;
+  border-radius: 0 0 10px 10px;
+}
+
 .fade {
   opacity: 0;
   -webkit-transition: opacity .15s linear;

--- a/themes/socialbase/assets/css/ckeditor.css
+++ b/themes/socialbase/assets/css/ckeditor.css
@@ -56,6 +56,23 @@ body {
   -webkit-font-smoothing: antialiased;
 }
 
+#skip-link {
+  text-align: center;
+  position: absolute;
+  left: 0;
+  right: 0;
+  z-index: 15000;
+}
+
+#skip-link a {
+  background: #222222;
+  box-shadow: 0 0 4px rgba(0, 0, 0, 0.14), 0 4px 8px rgba(0, 0, 0, 0.28);
+  color: #f3f3f3;
+  padding: 3px 20px 8px;
+  text-decoration: none;
+  border-radius: 0 0 10px 10px;
+}
+
 h1, h2, h3, h4, h5, h6,
 .h1, .h2, .h3, .h4, .h5, .h6 {
   font-family: inherit;

--- a/themes/socialbase/components/01-base/root/_root.scss
+++ b/themes/socialbase/components/01-base/root/_root.scss
@@ -41,3 +41,22 @@ body {
   }
 
 }
+
+// Provide accessible positioning for skip links.
+// The visibility will be handled by the links themselves.
+#skip-link {
+  text-align: center;
+  position: absolute;
+  left: 0;
+  right: 0;
+  z-index: 15000;
+
+  a {
+    background: $gray-darker;
+    @include z-depth-3;
+    color: $gray-lightest;
+    padding: 3px 20px 8px;
+    text-decoration: none;
+    border-radius: 0 0 10px 10px;
+  }
+}

--- a/themes/socialbase/templates/system/html--node--preview.html.twig
+++ b/themes/socialbase/templates/system/html--node--preview.html.twig
@@ -11,9 +11,11 @@
     <js-placeholder token="{{ placeholder_token|raw }}">
   </head>
   <body{{ attributes.addClass('page-preview') }}>
-    <a href="#main-content" class="sr-only sr-only-focusable">
-      {{ 'Skip to main content'|t }}
-    </a>
+    <div id="skip-link">
+      <a href="#main-content" class="sr-only-focusable">
+        {{ 'Skip to main content'|t }}
+      </a>
+    </div>
     {{ page_top }}
     {{ page }}
     {{ page_bottom }}

--- a/themes/socialbase/templates/system/html.html.twig
+++ b/themes/socialbase/templates/system/html.html.twig
@@ -46,9 +46,11 @@
     {% block custom_css %} {% endblock %}
   </head>
   <body{{ attributes.addClass(body_classes) }}>
-    <a href="#main-content" class="sr-only sr-only-focusable">
-      {{ 'Skip to main content'|t }}
-    </a>
+    <div id="skip-link">
+      <a href="#main-content" class="sr-only-focusable">
+        {{ 'Skip to main content'|t }}
+      </a>
+    </div>
     {% if is_front %}
       <h1 class="visually-hidden">{{ head_title|safe_join(' | ') }}</h1>
     {% endif %}

--- a/themes/socialblue/assets/css/brand.css
+++ b/themes/socialblue/assets/css/brand.css
@@ -218,8 +218,12 @@ blockquote {
 
 .input-group .form-control:focus ~ .input-group-addon {
   border-color: #29abe2;
-  -webkit-box-shadow: 0 2px 0 0 #29abe2;
-          box-shadow: 0 2px 0 0 #29abe2;
+  box-shadow: 0 2px 0 0 #29abe2;
+}
+
+#skip-link a {
+  background-color: #1f1f1f;
+  color: #f3f3f3;
 }
 
 .navbar-secondary {

--- a/themes/socialblue/assets/css/preview.css
+++ b/themes/socialblue/assets/css/preview.css
@@ -1624,6 +1624,11 @@ blockquote {
   box-shadow: 0 2px 0 0 #29abe2;
 }
 
+#skip-link a {
+  background-color: #1f1f1f;
+  color: #f3f3f3;
+}
+
 .navbar-secondary {
   color: #f9f9f9;
   background-color: #1f7ea7;

--- a/themes/socialblue/components/brand.scss
+++ b/themes/socialblue/components/brand.scss
@@ -229,6 +229,11 @@ blockquote {
   box-shadow: 0 2px 0 0 $brand-primary;
 }
 
+#skip-link a {
+  background-color: $navbar-default-link-active-bg;
+  color: $navbar-default-link-active-color;
+}
+
 .navbar-secondary {
   color: #f9f9f9;
   background-color: #1f7ea7;

--- a/themes/socialblue/os-builder/index.twig
+++ b/themes/socialblue/os-builder/index.twig
@@ -27,7 +27,11 @@
   {#})(window,document,'script','dataLayer','GTM-5BGZV3');#}
 {#</script>#}
 <!-- End Google Tag Manager-->
-  <a href="#main-content" class="sr-only sr-only-focusable"> Skip to main content </a>
+  <div id="skip-link">
+    <a href="#main-content" class="sr-only-focusable">
+      {{ 'Skip to main content'|t }}
+    </a>
+  </div>
 
 
   <nav class="navbar navbar-default navbar-fixed-top" id="top" role="banner">


### PR DESCRIPTION
…is easily visible on each page


## Problem
There is a skip to content link for people using a keyboard (or screen reader) to skip the menu structure (which can have lots of selectable elements). However, this element doesn't become visible when it receives focus.

## Solution
The style is borrowed from Drupal.org. For the colors we've chosen to
use the navigation active link color as it's usually different from the
navbar color itself. Additionally it has a matching text color that
should be configured by platform users to something accessible. This has
the highest chance of resulting in a skip link that is styled to the
platform styles while being accessible.

## Issue tracker
https://www.drupal.org/project/social/issues/2947667

## How to test
*For example*
- [ ] In a browser that supports tab navigation to links
- [ ] Open the homepage
- [ ] Use the tab button to select the first link on the page
- [ ] This should be the skip link that is now visible on top of the navigation bar.

## Screenshots
The default styling on desktop
![Screenshot 2020-10-02 at 15 24 09](https://user-images.githubusercontent.com/327697/94929207-127a3780-04c5-11eb-8c7b-398956749cbb.png)

The default styling on mobile
![Screenshot 2020-10-02 at 15 24 23](https://user-images.githubusercontent.com/327697/94929233-19a14580-04c5-11eb-8c68-c01735bf9dbc.png)

The link follows the color configuration of the socialblue theme.
![Screenshot 2020-10-02 at 15 22 39](https://user-images.githubusercontent.com/327697/94929255-20c85380-04c5-11eb-8f48-ab041852dd6e.png)

## Release notes
The link that is available to skip the navigation for users navigating the page with a keyboard will now show up when it receives focus.

## Change Record
Not needed

## Translations
None affected