### PR TITLE
Issue #3174638 - Make sure links in a post get the correct configured theme color applied

### DIFF
--- a/themes/socialbase/templates/post/post--activity.html.twig
+++ b/themes/socialbase/templates/post/post--activity.html.twig
@@ -33,8 +33,10 @@
 
 <div{{ attributes.addClass(classes) }}>
 
-
-  {{ content|without('links', 'field_post_comments', 'like_and_dislike', 'field_post_image', 'user_id') }}
+  {# body-text is necessary for theme colors to be applied #}
+  <div class="body-text">
+    {{ content|without('links', 'field_post_comments', 'like_and_dislike', 'field_post_image', 'user_id') }}
+  </div>
 
   {% if content.field_post_image|render %}
     <p>{{ content.field_post_image }}</p>

--- a/themes/socialbase/templates/post/post.html.twig
+++ b/themes/socialbase/templates/post/post.html.twig
@@ -65,7 +65,9 @@
     </div>
     <div class="margin-top-s iframe-container">
 
-      {{ content|without('links', 'field_post_comments', 'like_and_dislike', 'field_post_image', 'user_id') }}
+        <div class="body-text">
+            {{ content|without('links', 'field_post_comments', 'like_and_dislike', 'field_post_image', 'user_id') }}
+        </div>
 
       {% if content.field_post_image|render %}
         <p>{{ content.field_post_image }}</p>

--- a/themes/socialblue/color/preview.html
+++ b/themes/socialblue/color/preview.html
@@ -139,7 +139,7 @@
         <li class="stream-item">
           <i class="stream-icon"></i>
           <div class="card card--stream">
-            <div class="card__block">
+            <div class="card__block body-text">
 
               <p>Sed posuere consectetur est at lobortis. Nullam quis risus eget urna mollis ornare vel eu leo. Cum sociis natoque <a href="#">penatibus et magnis</a> dis parturient montes, nascetur ridiculus mus.</p>
 


### PR DESCRIPTION
## Problem
When adding a link to a topic, you see that the color of the link within the body adheres to the color settings configured for the Link color in the theme settings. See the bold text in the previewed html.

<img width="778" alt="Screenshot 2020-10-03 at 11 51 56" src="https://user-images.githubusercontent.com/16667281/94988904-ec11d600-0570-11eb-9728-98f583e4e8da.png">

## Solution
For Post this isnt the case. Let's make sure it does. 

## Issue tracker
https://www.drupal.org/project/social/issues/3174638

## How to test
- [ ] As a sitemanager, add a post with a link
- [ ] See that the link is rendered in bold
- [ ] cache clear after checking out this branch
- [ ] The link color should now apply.

## Screenshots
<img width="819" alt="Screenshot 2020-10-03 at 11 50 41" src="https://user-images.githubusercontent.com/16667281/94988926-27140980-0571-11eb-956b-50d4dbc25bf2.png">
<img width="805" alt="Screenshot 2020-10-03 at 11 51 10" src="https://user-images.githubusercontent.com/16667281/94988929-28453680-0571-11eb-82af-6d37cb8a5d71.png">

## Release notes
Links in a post will now understand that it needs to follow the theme color configuration.
