### PR TITLE
Issue #3174646 - impoved colors gin theme based on social blue

### DIFF
--- a/modules/social_features/social_core/social_core.install
+++ b/modules/social_features/social_core/social_core.install
@@ -1190,7 +1190,7 @@ function social_core_update_8901() {
   }
 }
 
-/*
+/**
  * Update GIN theme settings based on SocialBlue primary secondary.
  */
 function social_core_update_8902() {

--- a/modules/social_features/social_core/social_core.install
+++ b/modules/social_features/social_core/social_core.install
@@ -1189,3 +1189,33 @@ function social_core_update_8901() {
     user_role_grant_permissions($role, $permissions);
   }
 }
+
+/*
+ * Update GIN theme settings based on SocialBlue primary secondary.
+ */
+function social_core_update_8902() {
+  // Only when GIN is the admin theme and SocialBlue is the active theme.
+  if (\Drupal::configFactory()->get('system.theme')->get('admin') === 'gin' &&
+    \Drupal::theme()->getActiveTheme()->getName() === 'socialblue') {
+    // We need to grab the socialblue colors from the config.
+    $socialblue_colors = \Drupal::configFactory()
+      ->getEditable('socialblue.settings')
+      ->getRawData();
+
+    // See if we can update GIN settings with our brand colors.
+    if (isset($socialblue_colors['color_primary'], $socialblue_colors['color_secondary'])) {
+      $config = \Drupal::configFactory()->getEditable('gin.settings');
+      if (!empty($config->getRawData())) {
+        $gin_config = $config->getRawData();
+        // Override preset colors as custom so we can fill in the hex colors.
+        $gin_config['preset_accent_color'] = 'custom';
+        $gin_config['preset_focus_color'] = 'custom';
+        // Update the accent and focus with our branded colors.
+        $gin_config['accent_color'] = $socialblue_colors['color_primary'];
+        $gin_config['focus_color'] = $socialblue_colors['color_secondary'];
+        $config->setData($gin_config);
+        $config->save();
+      }
+    }
+  }
+}

--- a/modules/social_features/social_core/social_core.install
+++ b/modules/social_features/social_core/social_core.install
@@ -1197,13 +1197,23 @@ function social_core_update_8902() {
   // Only when GIN is the admin theme and SocialBlue is the active theme.
   if (\Drupal::configFactory()->get('system.theme')->get('admin') === 'gin' &&
     \Drupal::theme()->getActiveTheme()->getName() === 'socialblue') {
-    // We need to grab the socialblue colors from the config.
-    $socialblue_colors = \Drupal::configFactory()
-      ->getEditable('socialblue.settings')
-      ->getRawData();
+    // Grab the default socialblue colors, these are set if the color settings
+    // aren't overridden yet.
+    $default_colors = \Drupal::configFactory()->getEditable('socialblue.settings')->getRawData();
+    // Unfortunately the color module doesnt add the color details to the
+    // $form_state. So we need to grab it from the config once overridden.
+    // luckily color does set their submit function as first, so we can
+    // safely assume the config uses the updated colors.
+    $socialblue_colors = \Drupal::configFactory()->getEditable('color.theme.socialblue')->getRawData();
+
+    // The brand colors are first of all coming from the overridden color
+    // settings. But if that is not set, we will grab them from the
+    // default Social Blue settings.
+    $brand_primary = !empty($socialblue_colors) ? $socialblue_colors['palette']['brand-primary'] : $default_colors['color_primary'];
+    $brand_secondary = !empty($socialblue_colors) ? $socialblue_colors['palette']['brand-secondary'] : $default_colors['color_secondary'];
 
     // See if we can update GIN settings with our brand colors.
-    if (isset($socialblue_colors['color_primary'], $socialblue_colors['color_secondary'])) {
+    if (isset($brand_primary, $brand_secondary)) {
       $config = \Drupal::configFactory()->getEditable('gin.settings');
       if (!empty($config->getRawData())) {
         $gin_config = $config->getRawData();
@@ -1211,8 +1221,8 @@ function social_core_update_8902() {
         $gin_config['preset_accent_color'] = 'custom';
         $gin_config['preset_focus_color'] = 'custom';
         // Update the accent and focus with our branded colors.
-        $gin_config['accent_color'] = $socialblue_colors['color_primary'];
-        $gin_config['focus_color'] = $socialblue_colors['color_secondary'];
+        $gin_config['accent_color'] = $brand_primary;
+        $gin_config['focus_color'] = $brand_secondary;
         $config->setData($gin_config);
         $config->save();
       }

--- a/themes/socialblue/theme-settings.php
+++ b/themes/socialblue/theme-settings.php
@@ -203,7 +203,6 @@ function socialblue_update_gin_color_settings(array $form, FormStateInterface $f
   }
 }
 
-
 /**
  * Marks the e-mail logo file as permanent.
  *


### PR DESCRIPTION
## Problem
When GIN is the admin theme, and socialblue the default theme we can try and update the brand colors in GIN to match the socialblue ones. This will give a better admin experience.

## Solution
Create an update hook to override the gin settings if we have the socialblue as default and gin as admin.
Also write a custom form submit function which listens to the system_theme form being submitted. 
Both SocialBlue as the color module actually use this form to update the necessary style settings.

## Issue tracker
https://www.drupal.org/project/social/issues/3174646

## How to test
- [ ] Make some custom changes to your theme settings
- [ ] See GIN still uses their defaults
- [ ] Checkout this branch run the update to see GIN automatically updates the colors towards the primary and secondary color as set by the theme settings.
- [ ] When updating the theme settings now, also the GIN theme will be updated but not vice versa, so GIN is only updated by socialblue.

## Release notes
Update the GIN admin theme colors so they actually adhere to your custom branded primary and secondary colors.