### PR TITLE
Issue #3174889 by tBKoT: Bug with only one selected calendar in settings

### DIFF
--- a/modules/social_features/social_event/modules/social_event_addtocal/social_event_addtocal.links.menu.yml
+++ b/modules/social_features/social_event/modules/social_event_addtocal/social_event_addtocal.links.menu.yml
@@ -1,6 +1,6 @@
 social_event_addtocal.settings:
   title: 'Add to calendar settings'
   route_name: social_event_addtocal.settings
-  description: 'A description for the menu entry'
+  description: 'Settings for the Add to Calendar button'
   parent: social_core.admin.config.social
   weight: 99

--- a/modules/social_features/social_event/modules/social_event_addtocal/social_event_addtocal.module
+++ b/modules/social_features/social_event/modules/social_event_addtocal/social_event_addtocal.module
@@ -51,6 +51,9 @@ function social_event_addtocal_node_view(array &$build, NodeInterface $node, Ent
       '#links' => $links,
     ];
 
+    // Make sure we clear the cache if the settings is submitted.
+    $build['#cache']['tags'][] = 'config:social_event_addtocal.settings';
+
     // Split links if there is more than one.
     if (count($links) > 1) {
       $build['field_event_addtocal']['#attributes']['no-split'] = [

--- a/modules/social_features/social_event/modules/social_event_addtocal/social_event_addtocal.module
+++ b/modules/social_features/social_event/modules/social_event_addtocal/social_event_addtocal.module
@@ -36,19 +36,28 @@ function social_event_addtocal_node_view(array &$build, NodeInterface $node, Ent
 
   // Get 'Add to calendar' configuration.
   $addtocal_config = Drupal::config('social_event_addtocal.settings');
+
+  // Set render array if the 'Add to calendar' feature enabled.
   if ($addtocal_config->get('enable_add_to_calendar')) {
+    // Get calendar links.
+    $links = _social_event_addtocal_get_links($node);
+
     // Update the 'Add to calendar' field rendering.
     $build['field_event_addtocal'] = [
       '#type' => 'dropbutton',
       '#attributes' => [
         'class' => ['add-to-calendar'],
-        'no-split' => [
-          'title' => t('Add to Calendar'),
-          'alignment' => 'right',
-        ],
       ],
-      '#links' => _social_event_addtocal_get_links($node),
+      '#links' => $links,
     ];
+
+    // Split links if there is more than one.
+    if (count($links) > 1) {
+      $build['field_event_addtocal']['#attributes']['no-split'] = [
+        'title' => t('Add to Calendar'),
+        'alignment' => 'right',
+      ];
+    }
   }
 }
 
@@ -88,11 +97,16 @@ function _social_event_addtocal_get_links(NodeInterface $node) {
       }
 
       // Set link for plugin instance.
-      $links[$allowed_calendar] = [
+      $links[] = [
         'title' => $calendar->getName(),
         'url' => $calendar->generateUrl($node),
       ];
     }
+  }
+
+  // Change title if only one calendar enabled.
+  if (count($links) === 1) {
+    $links[0]['title'] = t('Add to Calendar');
   }
 
   return $links;

--- a/modules/social_features/social_event/modules/social_event_addtocal/src/Form/SocialAddToCalendarSettingsForm.php
+++ b/modules/social_features/social_event/modules/social_event_addtocal/src/Form/SocialAddToCalendarSettingsForm.php
@@ -92,7 +92,7 @@ class SocialAddToCalendarSettingsForm extends ConfigFormBase {
           ':input[name="enable_add_to_calendar"]' => ['checked' => TRUE],
         ],
       ],
-      '#default_value' => $config->get('allowed_calendars'),
+      '#default_value' => $config->get('allowed_calendars') ?: [],
     ];
 
     return parent::buildForm($form, $form_state);


### PR DESCRIPTION
## Problem
For the `Add to calendar` feature we have a configuration page. But if we select only one calendar for it the button 'Add to Calendar' on the event page doesn't work.

## Solution
Check the number of links before the render button. If the count of links is 1 don't use the 'no-split' attribute.

## Issue tracker
https://www.drupal.org/project/social/issues/3174889

## How to test
*For example*
- [ ] Go to Configuration -> Open Social Settings -> Add to calendar settings
- [ ] Enable the `Add to calendar` feature
- [ ] Select only one calendar for use.
- [ ] Go to any event page.
- [ ] The `Add to Calendar` button does not respond. 

## Screenshots
N/A

## Release notes
N/A

## Change Record
N/A

## Translations
N/A
