### PR TITLE
Issue #3171778 by agami4: Add url to the notification center button(icon ring bell)

### DIFF
--- a/modules/social_features/social_activity/social_activity.module
+++ b/modules/social_features/social_activity/social_activity.module
@@ -39,7 +39,7 @@ function social_activity_social_user_account_header_items(array $context) {
       '#wrapper_attributes' => [
         'class' => ['desktop', 'notification-bell'],
       ],
-      '#title' => new TranslatableMarkup('Notification Center'),
+      '#title' => new TranslatableMarkup('Notification Centre'),
       '#icon' => $num_notifications > 0 ? 'notifications' : 'notifications_none',
       '#label' => new TranslatableMarkup('Notifications'),
       '#url' => Url::fromRoute('view.activity_stream_notifications.page_1'),
@@ -47,7 +47,7 @@ function social_activity_social_user_account_header_items(array $context) {
       '#weight' => 800,
       'header' => [
         '#wrapper_attributes' => ['class' => 'dropdown-header'],
-        '#markup' => new TranslatableMarkup('Notification Center'),
+        '#markup' => new TranslatableMarkup('Notification Centre'),
       ],
       'header-divider' => [
         '#wrapper_attributes' => ['class' => 'divider'],

--- a/modules/social_features/social_activity/social_activity.module
+++ b/modules/social_features/social_activity/social_activity.module
@@ -39,14 +39,15 @@ function social_activity_social_user_account_header_items(array $context) {
       '#wrapper_attributes' => [
         'class' => ['desktop', 'notification-bell'],
       ],
-      '#title' => new TranslatableMarkup('Notification Centre'),
+      '#title' => new TranslatableMarkup('Notification Center'),
       '#icon' => $num_notifications > 0 ? 'notifications' : 'notifications_none',
       '#label' => new TranslatableMarkup('Notifications'),
+      '#url' => Url::fromRoute('view.activity_stream_notifications.page_1'),
       '#notification_count' => $num_notifications,
       '#weight' => 800,
       'header' => [
         '#wrapper_attributes' => ['class' => 'dropdown-header'],
-        '#markup' => new TranslatableMarkup('Notification Centre'),
+        '#markup' => new TranslatableMarkup('Notification Center'),
       ],
       'header-divider' => [
         '#wrapper_attributes' => ['class' => 'divider'],


### PR DESCRIPTION
## Problem
The link that pops open the notification center in the header doesn't contain a path to link to. This reduces accessibility for users of screen readers and also makes the notification center inaccessible when not using JavaScript.

## Solution
Make sure the link links to the notification center. The current JavaScript implementation already prevents the default behavior and opens the pop-up as desired.

## Issue tracker
https://www.drupal.org/project/social/issues/3171778

## How to test
*For example*
- [ ] Hover cursor to the notification center button(ring bell icon) and you can see the link to the notifications page.

## Screenshots
![notification-center-button](https://user-images.githubusercontent.com/16086340/95082445-afd2a700-0723-11eb-9045-969b2860792a.png)

## Release notes
The 'notification center' button now links to the notification page. This was previously an anchor tag without a valid href which is invalid.

## Change Record
-

## Translations
-
