### PR TITLE
Issue #3171498 by agami4: Add title to edit content svg icon on the all pages

### DIFF
--- a/themes/socialbase/templates/group/group--hero.html.twig
+++ b/themes/socialbase/templates/group/group--hero.html.twig
@@ -38,6 +38,7 @@
     <div class="hero-action-button">
       <a href="{{ group_edit_url }}"  title="{% trans %}Edit group{% endtrans %}" class="btn btn-default btn-floating">
         <svg class="icon-gray icon-medium">
+          <title>{% trans %}Edit group{% endtrans %}</title>
           <use xlink:href="#icon-edit"></use>
         </svg>
       </a>

--- a/themes/socialbase/templates/node/node--hero.html.twig
+++ b/themes/socialbase/templates/node/node--hero.html.twig
@@ -82,6 +82,7 @@
       <a href="{{ node_edit_url }}" title="{% trans %}Edit content{% endtrans %}"
          class="btn btn-raised btn-default btn-floating">
         <svg class="icon-gray icon-medium">
+          <title>{% trans %}Edit content{% endtrans %}</title>
           <use xlink:href="#icon-edit"></use>
         </svg>
       </a>

--- a/themes/socialbase/templates/profile/profile--profile--hero.html.twig
+++ b/themes/socialbase/templates/profile/profile--profile--hero.html.twig
@@ -31,6 +31,7 @@
   <div class="hero-action-button">
     <a href="{{ profile_edit_url }}" title="{% trans %}Edit profile information{% endtrans %}" class="btn btn-raised btn-default btn-floating">
       <svg class="icon-medium">
+        <title>{% trans %}Edit profile information{% endtrans %}</title>
         <use xlink:href="#icon-edit"></use>
       </svg>
     </a>

--- a/themes/socialblue/templates/group/group--hero--sky.html.twig
+++ b/themes/socialblue/templates/group/group--hero--sky.html.twig
@@ -11,6 +11,7 @@
     <div class="hero-action-button">
       <a href="{{ group_edit_url }}" title="{% trans %}Edit group{% endtrans %}" class="btn btn-default btn-floating">
         <svg class="icon-gray icon-medium">
+          <title>{% trans %}Edit group{% endtrans %}</title>
           <use xlink:href="#icon-edit"></use>
         </svg>
       </a>

--- a/themes/socialblue/templates/node/node--hero--sky.html.twig
+++ b/themes/socialblue/templates/node/node--hero--sky.html.twig
@@ -91,6 +91,7 @@
           <a href="{{ node_edit_url }}" title="{% trans %}Edit content{% endtrans %}"
              class="btn btn-raised btn-default btn-floating">
             <svg class="icon-gray icon-medium">
+              <title>{% trans %}Edit content{% endtrans %}</title>
               <use xlink:href="#icon-edit"></use>
             </svg>
           </a>

--- a/themes/socialblue/templates/profile/profile--profile--hero--sky.html.twig
+++ b/themes/socialblue/templates/profile/profile--profile--hero--sky.html.twig
@@ -11,6 +11,7 @@
         <a href="{{ profile_edit_url }}" title="{% trans %}Edit profile information{% endtrans %}"
            class="btn btn-raised btn-default btn-floating">
           <svg class="icon-medium">
+            <title>{% trans %}Edit profile information{% endtrans %}</title>
             <use xlink:href="#icon-edit"></use>
           </svg>
         </a>


### PR DESCRIPTION
## Problem
The pencil edit button that's displayed in the hero contains an SVG element that does not contain an alternative text or title element, this means the edit button is not accessible for screen readers.

## Solution
Add the required alternative or title text to the SVG.

## Issue tracker
https://www.drupal.org/project/social/issues/3171498

## How to test
- [ ] Open the inspector element and check if this SVG icon has a title attribute

## Screenshots
-

## Release notes
The pencil icon to edit the current page now has a title attribute, improving accessibility.

## Change Record
-

## Translations
-
