### PR TITLE
Issue #3171502 by agami4: Make post remove image button not visible for the accessibility tree

### DIFF
--- a/modules/social_features/social_post/modules/social_post_photo/js/post-widget.js
+++ b/modules/social_features/social_post/modules/social_post_photo/js/post-widget.js
@@ -11,20 +11,20 @@
     attach: function (context, settings) {
 
       $(document, context).once('field-post-image-add').on('click', '#post-photo-add', function(e) {
-        $('input[data-drupal-selector="edit-field-post-image-0-upload"]').trigger('click');
+        $('input[data-drupal-selector^="edit-field-post-image-0-upload"]', context).trigger('click');
         e.preventDefault();
       });
 
       $(document, context).once('field-post-image-remove').on('click', '#post-photo-remove', function(e) {
-        $('button[data-drupal-selector="edit-field-post-image-0-remove-button"]').trigger('mousedown');
+        $('button[data-drupal-selector^="edit-field-post-image-0-remove-button"]', context).trigger('mousedown');
         e.preventDefault();
       });
 
       // Change placeholder text when someone adds a photo.
-      $('[data-drupal-selector="edit-field-post-image-0-upload"]').change(function(e) {
-        $('#edit-field-post-0-value').attr("placeholder", Drupal.t('Say something about this photo'));
-        $('[data-drupal-selector="edit-field-post-image-wrapper"] .spinner').remove();
-        $('[data-drupal-selector="edit-field-post-image-wrapper"] .form-group .form-group').prepend('<div class="spinner"><div class="bounce1"></div><div class="bounce2"></div><div class="bounce3"></div></div>');
+      $('[data-drupal-selector^="edit-field-post-image-0-upload"]').change(function(e) {
+        $('#edit-field-post-0-value', context).attr("placeholder", Drupal.t('Say something about this photo'));
+        $('[data-drupal-selector^="edit-field-post-image-wrapper"] .spinner', context).remove();
+        $('[data-drupal-selector^="edit-field-post-image-wrapper"] .form-group .form-group', context).prepend('<div class="spinner"><div class="bounce1"></div><div class="bounce2"></div><div class="bounce3"></div></div>');
       });
 
     }

--- a/themes/socialbase/assets/css/image-widget.css
+++ b/themes/socialbase/assets/css/image-widget.css
@@ -22,6 +22,7 @@
   background: rgba(0, 0, 0, 0.2);
   border: 0;
   padding: 0;
+  -webkit-transition: 0.3s background-color;
   transition: 0.3s background-color;
 }
 
@@ -30,27 +31,40 @@
 }
 
 .btn--post-remove-image:hover .btn-icon {
-  transform: rotate(90deg);
+  -webkit-transform: rotate(90deg);
+          transform: rotate(90deg);
+}
+
+.btn--post-remove-image:focus {
+  outline: none;
 }
 
 .btn--post-remove-image .btn-icon {
   fill: white;
   height: 32px;
   width: 32px;
+  -webkit-transition: 0.3s -webkit-transform;
+  transition: 0.3s -webkit-transform;
   transition: 0.3s transform;
+  transition: 0.3s transform, 0.3s -webkit-transform;
 }
 
 @media (min-width: 600px) {
   .form-type-managed-file .image-widget {
+    display: -webkit-box;
+    display: -ms-flexbox;
     display: flex;
   }
   .form-type-managed-file .image-widget .preview {
-    flex: 0 0 auto;
+    -webkit-box-flex: 0;
+        -ms-flex: 0 0 auto;
+            flex: 0 0 auto;
   }
   .form-type-managed-file .image-widget .file--image {
     margin-bottom: 0.5rem;
   }
   .form--post-create .field--name-field-post-image.container-post-image {
-    flex-basis: 100%;
+    -ms-flex-preferred-size: 100%;
+        flex-basis: 100%;
   }
 }

--- a/themes/socialbase/assets/css/image-widget.css
+++ b/themes/socialbase/assets/css/image-widget.css
@@ -22,7 +22,6 @@
   background: rgba(0, 0, 0, 0.2);
   border: 0;
   padding: 0;
-  -webkit-transition: 0.3s background-color;
   transition: 0.3s background-color;
 }
 
@@ -31,8 +30,7 @@
 }
 
 .btn--post-remove-image:hover .btn-icon {
-  -webkit-transform: rotate(90deg);
-          transform: rotate(90deg);
+  transform: rotate(90deg);
 }
 
 .btn--post-remove-image:focus {
@@ -43,28 +41,17 @@
   fill: white;
   height: 32px;
   width: 32px;
-  -webkit-transition: 0.3s -webkit-transform;
-  transition: 0.3s -webkit-transform;
   transition: 0.3s transform;
-  transition: 0.3s transform, 0.3s -webkit-transform;
 }
 
 @media (min-width: 600px) {
   .form-type-managed-file .image-widget {
-    display: -webkit-box;
-    display: -ms-flexbox;
     display: flex;
   }
   .form-type-managed-file .image-widget .preview {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 auto;
-            flex: 0 0 auto;
+    flex: 0 0 auto;
   }
   .form-type-managed-file .image-widget .file--image {
     margin-bottom: 0.5rem;
-  }
-  .form--post-create .field--name-field-post-image.container-post-image {
-    -ms-flex-preferred-size: 100%;
-        flex-basis: 100%;
   }
 }

--- a/themes/socialbase/components/03-molecules/form-elements/image-widget/image-widget.scss
+++ b/themes/socialbase/components/03-molecules/form-elements/image-widget/image-widget.scss
@@ -58,6 +58,10 @@
     }
   }
 
+  &:focus {
+    outline: none;
+  }
+
   .btn-icon {
     fill: white;
     height: 32px;

--- a/themes/socialbase/components/03-molecules/form-elements/image-widget/image-widget.scss
+++ b/themes/socialbase/components/03-molecules/form-elements/image-widget/image-widget.scss
@@ -31,16 +31,6 @@
   margin-top: -0.875rem
 }
 
-
-// This is kind of a hack. The upload field op on the post needs to display inline, but the image should not. Since this library is only loaded when the preview is there, the following line overrides the style from form-post-create.
-.form--post-create .field--name-field-post-image.container-post-image {
-
-  @include for-tablet-portrait-up {
-    flex-basis: 100%;
-  }
-
-}
-
 .btn--post-remove-image {
   position: absolute;
   top: -1px;

--- a/themes/socialbase/templates/file/image-widget.html.twig
+++ b/themes/socialbase/templates/file/image-widget.html.twig
@@ -43,11 +43,9 @@
     <div class="hidden">{{ data.remove_button }}</div>
     <button type="button" id="post-photo-remove" class="btn--post-remove-image">
       <svg class="btn-icon">
+        <title>{% trans %}Remove image{% endtrans %}</title>
         <use id="btnicon" xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-close"></use>
       </svg>
-      <span class="sr-only">
-        {% trans %}Remove image{% endtrans %}
-      </span>
     </button>
 
   {% else %}

--- a/themes/socialbase/templates/file/image-widget.html.twig
+++ b/themes/socialbase/templates/file/image-widget.html.twig
@@ -13,14 +13,11 @@
  */
 #}
 
-{% if data.upload['#id'] starts with "edit-field-post-image-0-upload" %}
-  {% set in_post = true %}
-{% else %}
-  {% set in_post = false %}
-{% endif %}
+{{ attach_library('socialbase/image-widget') }}
+{{ attach_library('image_widget_crop/cropper') }}
+{% set in_post = data.upload['#id'] starts with "edit-field-post-image-0-upload" %}
 
 {% if data.preview %}
-  {{ attach_library('socialbase/image-widget') }}
   <div{{ attributes.addClass('image-widget').removeClass('clearfix') }}>
     <div class="preview">
       {{ data.preview }}
@@ -50,7 +47,6 @@
 
   {% else %}
 
-    {{ attach_library('image_widget_crop/cropper') }}
     {{ data.image_crop }}
 
   {% endif %}
@@ -64,7 +60,7 @@
       {{ data }}
     </div>
     <button type="button" id="post-photo-add" class="btn btn-default">
-      <svg class="btn-icon">
+      <svg class="btn-icon" aria-hidden="true">
         <use id="btnicon" xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-plus"></use>
       </svg>
       <span>


### PR DESCRIPTION
## Problem
When adding an image to a post, the image will show up and be overlaid with a button containing a cross that allows the removal of the image. This button correctly has a text for screenreaders but it does not mark the SVG cross image as being decorative.

## Solution
Remove focus styles and add `aria-hidden="true"` for the `post remove image` button.

## Issue tracker
- https://www.drupal.org/project/social/issues/3171502
- https://www.drupal.org/project/social/issues/3134488

## How to test
*For example*
- [ ] Login to an Open Social community
- [ ] On the main stream page add an image to a new post
- [ ] You should now see the image preview in the post form with `post remove image` button

## Screenshots
![post-remove-image-button](https://user-images.githubusercontent.com/16086340/95180372-8e78c600-07ca-11eb-9dc4-7920db1402bf.png)

## Release notes
The `post remove image` button has not focus styles and has `aria-hidden="true"`

## Change Record
-

## Translations
-
