### PR TITLE
Issue #3171785 by agami4: Make help text search button not visible for the accessibility tree

### DIFF
--- a/themes/socialbase/templates/block/block--system-menu-block--main.html.twig
+++ b/themes/socialbase/templates/block/block--system-menu-block--main.html.twig
@@ -49,8 +49,8 @@
   {% if content.links.search_block is defined %}
     <div class="navbar__open-search-control">
       <a href="{{ '/search/all' }}" class="navbar__open-search-block" rel="search" title="{{ 'Click to open search box'|t }}">
-        <span class = "sr-only">{{ 'Search'|t }}</span>
         <svg class="navbar-nav__icon navbar-nav__icon--search">
+          <title>{{ 'Search'|t }}</title>
           <use xlink:href="#icon-search"></use>
         </svg>
       </a>

--- a/themes/socialbase/templates/block/block--system-menu-block--main.html.twig
+++ b/themes/socialbase/templates/block/block--system-menu-block--main.html.twig
@@ -49,7 +49,7 @@
   {% if content.links.search_block is defined %}
     <div class="navbar__open-search-control">
       <a href="{{ '/search/all' }}" class="navbar__open-search-block" rel="search" title="{{ 'Click to open search box'|t }}">
-        <span class = "sr-only" aria-hidden="true">{{ 'Search'|t }}</span>
+        <span class = "sr-only">{{ 'Search'|t }}</span>
         <svg class="navbar-nav__icon navbar-nav__icon--search">
           <use xlink:href="#icon-search"></use>
         </svg>

--- a/themes/socialbase/templates/block/block--system-menu-block--main.html.twig
+++ b/themes/socialbase/templates/block/block--system-menu-block--main.html.twig
@@ -49,7 +49,7 @@
   {% if content.links.search_block is defined %}
     <div class="navbar__open-search-control">
       <a href="{{ '/search/all' }}" class="navbar__open-search-block" rel="search" title="{{ 'Click to open search box'|t }}">
-        <span class="invisible">{{ 'Search'|t }}</span>
+        <span class = "sr-only" aria-hidden="true">{{ 'Search'|t }}</span>
         <svg class="navbar-nav__icon navbar-nav__icon--search">
           <use xlink:href="#icon-search"></use>
         </svg>


### PR DESCRIPTION
## Problem
The search icon in the menu bar contains a help text. However, this help text isn't actually visible for screen readers.

## Solution
Replace <span class="invisible">Search</span> with <span class="sr-only"Search</span> and add `aria-hidden="true"`

## Issue tracker
https://www.drupal.org/project/social/issues/3171785

## How to test
*For example*
- [ ] Open inspector element and check new help text search button

## Screenshots
![search-button-help-text](https://user-images.githubusercontent.com/16086340/95182318-1f50a100-07cd-11eb-922f-c69a30d7f5dd.png)

## Release notes
The help text search button not visible for the accessibility tree.

## Change Record
-

## Translations
-
