### PR TITLE
Issue #3171566 by agami4: Make back infobox icon not visible for the accessibility tree and add title to button

### DIFF
--- a/themes/socialbase/templates/private_message/private-message-thread.html.twig
+++ b/themes/socialbase/templates/private_message/private-message-thread.html.twig
@@ -45,8 +45,8 @@
       <div class="media-wrapper">
         <div class="media message__heading">
           <div class="message__back-btn">
-            <a href="{{ content.back_to_inbox }}" class="btn btn-icon-toggle">
-              <svg class="btn-icon icon-gray">
+            <a href="{{ content.back_to_inbox }}" class="btn btn-icon-toggle" title="{{ 'Go back to your inbox'|t }}">
+              <svg class="btn-icon icon-gray" aria-hidden="true">
                 <use xlink:href="#icon-navigate_before"></use>
               </svg>
             </a>


### PR DESCRIPTION
## Problem
When viewing a private message conversation, there's an icon shaped like a "left arrow" in the top left corner. This icon allows you to go back to your inbox. The link does not contain any text indicating where the link goes so screen reader users only hear "link".

## Solution
Add `aria-hidden="true"` to the SVG icon and add title to the `back to infobox` button.

## Issue tracker
https://www.drupal.org/project/social/issues/3171566

## How to test
*For example*
- [ ] Go to the private messages page 
- [ ] Hover `back to infobox` button and check title

## Screenshots
![back-infobox](https://user-images.githubusercontent.com/16086340/95192191-7ad55b80-07da-11eb-961f-47fcf90eb9e5.png)

## Release notes
The `back to infobox` has the `title` attribute and SVG icon has `aria-hidden="true"` attribute.

## Change Record
-

## Translations
-
