### PR TITLE
Issue #3171577 by agami4: Add area-hidden: true for the links on the teaser [Don't merge]

### DIFF
--- a/modules/social_features/social_featured_content/templates/node--featured.html.twig
+++ b/modules/social_features/social_featured_content/templates/node--featured.html.twig
@@ -90,7 +90,7 @@
       {% endblock %}
 
       {% block card_teaser_type %}
-        <a href="{{ url }}">
+        <a href="{{ url }}" aria-hidden="true">
           <div class="teaser__teaser-type">
             <svg class="teaser__teaser-type-icon">
               <use xlink:href="#icon-{{- node.bundle|clean_class -}}"></use>
@@ -108,7 +108,7 @@
       {% block card_title %}
         {{ title_prefix }}
         <h4{{ title_attributes }} class="teaser__title">
-          <a href="{{ url }}" rel="bookmark">{{ label }}</a>
+          <a href="{{ url }}" rel="bookmark" title="{{ label }}">{{ label }}</a>
         </h4>
         {{ title_suffix }}
       {% endblock %}
@@ -158,7 +158,7 @@
       {% block card_link %}
         {% if not hide_card_link %}
           <div class="card__link">
-            <a href="{{ url }}" rel="bookmark">{{ 'Read more'|t }}
+            <a href="{{ url }}" rel="bookmark" aria-hidden="true">{{ 'Read more'|t }}
               <span class="visually-hidden">{% trans %}about {{ label }}{% endtrans %} </span>
             </a>
           </div>


### PR DESCRIPTION
## Problem
*Describe the problem you're trying to solve, this should motivate why the changes you're proposing are needed.*

## Solution
*Describe the solution you've created, elaborate on any technical choices you've made. Why is this the right solution and is a different solution not the right one?*

## Issue tracker
*Paste a link to the drupal.org issue queue item. If any other issue trackers were used, include links to those too.*

## How to test
*For example*
- [ ] Using version X.Y.Z of Open Social with the example module enabled
- [ ] As a sitemanager
- [ ] Try to enable the option B on screen c/d/e
- [ ] When saving I expect the result to be F but instead see G.
- [ ] The expected result F is attained when repeating the steps with this fix applied.

## Screenshots
*If this Pull Request makes visual changes then please include some screenshots that show what has changed here. A before and after screenshot helps the reviewer determine what changes were made.*

## Release notes
*A short summary of the changes that were made that can be included in release notes.*

## Change Record
*If this Pull Request changes the way that developers should do things or introduces a new API for developers then a change record to document this is needed. Please provide a draft for a change record or a link to an unpublished change record below. [Existing change records](https://www.drupal.org/list-changes/social) can be consulted as example.*

## Translations
*Translatable strings are always extracted from the latest development branch. To ensure translations remain available for platforms running older versions of Open Social the original string should be added to `translations.php` when it's changed or removed.*
- [ ] Changed or removed source strings are added to the `translations.php` file.
