### PR TITLE
Issue #3171814 by agami4: Replace id with class and update js behavior

### DIFF
--- a/modules/social_features/social_post/js/visibility-settings.js
+++ b/modules/social_features/social_post/js/visibility-settings.js
@@ -12,19 +12,15 @@
         var dropDown = '#post-visibility';
 
         $(dropDown + ' + .dropdown-menu > .list-item').click(function() {
-          var setting = $('label > span', this).text();
+          var label = $('label > span', this).first().text();
+          var icon = $('svg use', this).first().attr('xlink:href');
 
-          $('.text', dropDown).text(setting);
-
-          if (setting == 'Community') {
-            $('#btnicon', dropDown).attr('xlink:href', '#icon-community');
-          }
-          if (setting == 'Public') {
-            $('#btnicon', dropDown).attr('xlink:href', '#icon-public');
-          }
+          // Show the currently selected text and icon on the button.
+          $('.text', dropDown).text(label);
+          $('.btnicon', dropDown).attr('xlink:href', icon);
 
           // Find all the inputs and uncheck them.
-          $(dropDown).find('input').prop("checked", false);
+          $('input', dropDown).prop("checked", false);
           // Just check the input below the list item we clicked.
           $(this).find('input').prop("checked", true);
 

--- a/themes/socialbase/templates/file/image-widget.html.twig
+++ b/themes/socialbase/templates/file/image-widget.html.twig
@@ -41,7 +41,7 @@
     <button type="button" id="post-photo-remove" class="btn--post-remove-image">
       <svg class="btn-icon">
         <title>{% trans %}Remove image{% endtrans %}</title>
-        <use id="btnicon" xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-close"></use>
+        <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-close"></use>
       </svg>
     </button>
 
@@ -61,7 +61,7 @@
     </div>
     <button type="button" id="post-photo-add" class="btn btn-default">
       <svg class="btn-icon" aria-hidden="true">
-        <use id="btnicon" xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-plus"></use>
+        <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-plus"></use>
       </svg>
       <span>
         {% trans %}Add image{% endtrans %}

--- a/themes/socialbase/templates/form/dropdown.html.twig
+++ b/themes/socialbase/templates/form/dropdown.html.twig
@@ -14,7 +14,7 @@
     {# See PostForm.php we set edit_mode to true so people can't actually change the dropdown button for edit mode. #}
         <button id="post-visibility" type="button" {% if edit_mode %}disabled{% endif %} data-toggle="dropdown" aria-expanded="false" aria-haspopup="true" class="btn btn-default dropdown-toggle">
           <svg class="icon-small">
-            <use id="btnicon" xlink:href="#icon-{{ selected_icon }}"></use>
+            <use class="btnicon" xlink:href="#icon-{{ selected_icon }}"></use>
           </svg>
           <span class="text">{{ selected }} </span>
           {% if not edit_mode %}<span class="caret"></span>{% endif %}
@@ -23,7 +23,8 @@
     <ul role="menu" aria-labelledby="post-visibility" class="dropdown-menu dropdown-menu--visibility">
       <li class="dropdown-header">{{ label }}</li>
       {% for key, child in items %}
-        <li class="list-item list-item--visibility {% if key == active %}list-item--active{% endif %}">            {{ child }}
+        <li class="list-item list-item--visibility {% if key == active %}list-item--active{% endif %}">
+          {{ child }}
         </li>
       {% endfor %}
     </ul>


### PR DESCRIPTION
## Problem
The ID `btnicon` is used in image-widget.html.twig as well as dropdown.html.twig. This usage causes it to show up multiple times on the same page. Having an ID duplicated on a page is invalid.
This ID seems to be used in the visibility-settings.js file.

## Solution
Replace id with class and update js behavior

## Issue tracker
https://www.drupal.org/project/social/issues/3171814

## How to test
*For example*
- [ ] Open web inspector and check current buttons

## Screenshots
-

## Release notes
Replaced `btnicon` id with class and updated js behavior

## Change Record
-

## Translations
-
