### PR TITLE
Issue 3175191 by makkus183: Added EntityInterface to inherited isVali…

### DIFF
--- a/modules/social_features/social_group/modules/social_group_invite/src/Plugin/ActivityContext/InvitedToGroupActivityContext.php
+++ b/modules/social_features/social_group/modules/social_group_invite/src/Plugin/ActivityContext/InvitedToGroupActivityContext.php
@@ -4,6 +4,7 @@ namespace Drupal\social_group_invite\Plugin\ActivityContext;
 
 use Drupal\activity_creator\Plugin\ActivityContextBase;
 use Drupal\ginvite\Plugin\GroupContentEnabler\GroupInvitation;
+use Drupal\Core\Entity\EntityInterface;
 
 /**
  * Provides a 'InvitedToGroupActivityContext' activity context.
@@ -51,7 +52,7 @@ class InvitedToGroupActivityContext extends ActivityContextBase {
   /**
    * {@inheritdoc}
    */
-  public function isValidEntity($entity) {
+  public function isValidEntity(EntityInterface $entity) {
     /** @var \Drupal\Core\Entity\EntityInterface $entity */
     return $entity->getEntityTypeId() === 'group_content';
   }

--- a/modules/social_features/social_group/modules/social_group_request/src/Plugin/ActivityContext/ApprovedRequestJoinGroupActivityContext.php
+++ b/modules/social_features/social_group/modules/social_group_request/src/Plugin/ActivityContext/ApprovedRequestJoinGroupActivityContext.php
@@ -4,6 +4,7 @@ namespace Drupal\social_group_request\Plugin\ActivityContext;
 
 use Drupal\activity_creator\Plugin\ActivityContextBase;
 use Drupal\grequest\Plugin\GroupContentEnabler\GroupMembershipRequest;
+use Drupal\Core\Entity\EntityInterface;
 
 /**
  * Provides a 'ApprovedRequestJoinGroupActivityContext' activity context.
@@ -49,7 +50,7 @@ class ApprovedRequestJoinGroupActivityContext extends ActivityContextBase {
   /**
    * {@inheritdoc}
    */
-  public function isValidEntity($entity) {
+  public function isValidEntity(EntityInterface $entity) {
     /** @var \Drupal\Core\Entity\EntityInterface $entity */
     return $entity->getEntityTypeId() === 'group_content';
   }


### PR DESCRIPTION
…dEntity() functions

## Problem
Fixes an Fatal Error after upgrading opensocial from `8.4.0 => 9.2.0` on `PHP 7.1`:

`Declaration of Drupal\\social_group_request\\Plugin\\ActivityContext\\ApprovedRequestJoinGroupActivityContext::isValidEntity($entity) must be compatible with Drupal\\activity_creator\\Plugin\\ActivityContextInterface::isValidEntity(Drupal\\Core\\Entity\\EntityInterface $entity) in ../profiles/contrib/social/modules/social_features/social_group/modules/social_group_request/src/Plugin/ActivityContext/ApprovedRequestJoinGroupActivityContext.php`

`Declaration of Drupal\\social_group_invite\\Plugin\\ActivityContext\\InvitedToGroupActivityContext::isValidEntity($entity) must be compatible with Drupal\\activity_creator\\Plugin\\ActivityContextInterface::isValidEntity(Drupal\\Core\\Entity\\EntityInterface $entity) in ../profiles/contrib/social/modules/social_features/social_group/modules/social_group_invite/src/Plugin/ActivityContext/InvitedToGroupActivityContext.php`

## Solution
Added `EntityInterface` to `isValidEntity()` function `$entity` parameter and `use Drupal\Core\Entity\EntityInterface` Statement to both files

## Issue tracker
https://www.drupal.org/project/social/issues/3175191

## How to test

- [ ] update opensocial from `8.4.0 => 9.2.0` on `PHP 7.1` using `composer update`

- [ ] Add post on `social-post-entity-form`

## Screenshots

## Release notes
Added parameter types in method `ApprovedRequestJoinGroupActivityContext` and `ApprovedRequestJoinGroupActivityContext`


