### PR TITLE
Issue #3175203 by tBKoT: Create an alter hook to modify the list of content type where need to hide the default title block

### DIFF
--- a/modules/social_features/social_core/social_core.api.php
+++ b/modules/social_features/social_core/social_core.api.php
@@ -71,7 +71,7 @@ function hook_social_core_block_visibility_path() {
  */
 
 /**
- * Provide a method to alter array of CT where need to hide default title.
+ * Provide a method to alter array on content types used in open social.
  *
  * @param array $page_to_exclude
  *   Array of content types.

--- a/modules/social_features/social_core/social_core.api.php
+++ b/modules/social_features/social_core/social_core.api.php
@@ -62,3 +62,26 @@ function hook_social_core_block_visibility_path() {
 /**
  * @} End of "denyaccesstoblock hooks".
  */
+
+/**
+ * Hooks to alter excluded CT for default title.
+ *
+ * @hidedefaultitle hooks
+ * @{
+ */
+
+/**
+ * Provide a method to alter array of CT where need to hide default title.
+ *
+ * @param array $page_to_exclude
+ *   Array of content types.
+ *
+ * @ingroup social_core_api
+ */
+function hook_social_content_type_alter(array &$page_to_exclude) {
+  $page_to_exclude[] = 'article';
+}
+
+/**
+ * @} End of "hidedefaultitle hooks".
+ */

--- a/themes/socialbase/src/Plugin/Preprocess/Page.php
+++ b/themes/socialbase/src/Plugin/Preprocess/Page.php
@@ -68,6 +68,9 @@ class Page extends PreprocessBase {
         'book',
       ];
 
+      // Alter list of content types where need to hide the default page title.
+      \Drupal::moduleHandler()->alter('social_content_type', $page_to_exclude);
+
       $paths_to_exclude = [
         'edit',
         'add',


### PR DESCRIPTION
## Problem
Title block duplicates on the discussion pages.

## Solution
Add alter hook to modify the list of content types where need to hide the default title block

## Issue tracker
https://www.drupal.org/project/social/issues/3175203
https://getopensocial.atlassian.net/browse/YANG-3709

## How to test
- [x] Using the `Social Discussion` module
- [x] Go to any discussion page

## Screenshots
![image](https://user-images.githubusercontent.com/11648677/95212436-5dae8600-07f6-11eb-99f3-c0885337e191.png)

## Release notes
Create a new hook (`hook_social_content_type_alter`) that allow modifying the list of content types where need to hide the default title block

## Change Record
N/A

## Translations
N/A
