### PR TITLE
Issue #3171577 by Kingdutch: Landing pages contain empty links in fea…

### DIFF
--- a/modules/social_features/social_featured_content/templates/group--featured.html.twig
+++ b/modules/social_features/social_featured_content/templates/group--featured.html.twig
@@ -27,19 +27,21 @@
 {% endblock %}
 
 {% block card_title %}
-  {{ title_prefix }}
 
+  {{ title_prefix }}
   <h4{{ title_attributes }} class="teaser__title">
     {% if closed_group_lock %}
-      <svg class="icon-gray icon-small">
+      <svg class="icon-gray icon-small" aria-hidden="true">
         <use xlink:href="#icon-lock"></use>
       </svg>
     {% elseif secret_group_shield %}
-      <svg class="icon-gray icon-small">
+      <svg class="icon-gray icon-small" aria-hidden="true">
         <use xlink:href="#icon-shield"></use>
       </svg>
     {% endif %}
-    <a href="{{ url }}" rel="bookmark">{{ label }}</a>
+    <a href="{{ url }}" rel="bookmark">
+      <span class="sr-only">{% trans%}Group{% endtrans %}: </span>{{ label }}
+    </a>
   </h4>
 
   {{ title_suffix }}
@@ -96,8 +98,9 @@
   {% endif %}
 
   {% if not hide_card_link %}
-    <a href="{{ url }}" class="card__link" title="{{ label }}">
-      {% trans %}Read more{% endtrans %}
+    <a href="{{ url }}" class="card__link" rel="bookmark">
+      {{ 'Read more'|t }}
+      <span class="visually-hidden">{% trans %}about {{ label }}{% endtrans %} </span>
     </a>
   {% endif %}
 {% endblock %}

--- a/modules/social_features/social_featured_content/templates/node--featured.html.twig
+++ b/modules/social_features/social_featured_content/templates/node--featured.html.twig
@@ -75,7 +75,7 @@
 <div{{ attributes.addClass(classes) }}>
 
   {% block card_image %}
-    <div class="teaser__image">
+    <div class="teaser__image" aria-hidden="true">
 
       {% block card_hero_image %}
 
@@ -108,7 +108,10 @@
       {% block card_title %}
         {{ title_prefix }}
         <h4{{ title_attributes }} class="teaser__title">
-          <a href="{{ url }}" rel="bookmark">{{ label }}</a>
+          <a href="{{ url }}" rel="bookmark">
+            <span class="sr-only">{{ node.type.0.entity.label() -}}: </span>
+            {{ label }}
+          </a>
         </h4>
         {{ title_suffix }}
       {% endblock %}
@@ -157,11 +160,10 @@
 
       {% block card_link %}
         {% if not hide_card_link %}
-          <div class="card__link">
-            <a href="{{ url }}" rel="bookmark">{{ 'Read more'|t }}
-              <span class="visually-hidden">{% trans %}about {{ label }}{% endtrans %} </span>
-            </a>
-          </div>
+          <a href="{{ url }}" class="card__link" rel="bookmark">
+            {{ 'Read more'|t }}
+            <span class="visually-hidden">{% trans %}about {{ label }}{% endtrans %} </span>
+          </a>
         {% endif %}
       {% endblock %}
 

--- a/modules/social_features/social_featured_content/templates/profile--featured.html.twig
+++ b/modules/social_features/social_featured_content/templates/profile--featured.html.twig
@@ -3,11 +3,13 @@
 {% set attributes = attributes.addClass('teaser-profile') %}
 
 {% block card_image %}
+  <div
   {% if profile_hero_styled_image_url %}
-    <div style="background-image: url('{{ profile_hero_styled_image_url }}')" class="teaser__image">
-  {% else %}
-    <div class="teaser__image">
+    style="background-image: url('{{ profile_hero_styled_image_url }}')"
   {% endif %}
+    class="teaser__image"
+    aria-hidden="true"
+    >
       {% block card_hero_image %}
         <div class="img_wrapper">
           <a href="{{ profile_home }}">
@@ -31,6 +33,7 @@
 {% block card_title %}
   <h4 class="teaser__title">
     <a href="{{ profile_home }}">
+      <span class="sr-only">{% trans%}User{% endtrans %}: </span>
       {{ profile_name }} {{ profile_name_extra }}
     </a>
   </h4>
@@ -49,10 +52,9 @@
 
 {% block card_link %}
   {% if not hide_card_link %}
-    <div class="card__link">
-      <a href="{{ profile_stream_url }}" rel="bookmark">{{ 'Read more'|t }}
-        <span class="visually-hidden">{% trans %}about {{ label }}{% endtrans %} </span>
-      </a>
-    </div>
+    <a href="{{ profile_stream_url }}" class="card__link" rel="bookmark">
+      {{ 'Read more'|t }}
+      <span class="visually-hidden">{% trans %}about {{ profile_name }} {{ profile_name_extra }}{% endtrans %} </span>
+    </a>
   {% endif %}
 {% endblock %}


### PR DESCRIPTION
…tured content teasers when viewed with screen readers

<h3 id="summary-problem-motivation">Problem/Motivation</h3>
The teaser image as well as the type icon of featured content on a landing page are separate links. However, the teaser image is decorative and contains no alt text. This makes the link empty.

Additionally, the type of the content that's being linked to is only available as icon but contains no assistive text.

<h4 id="summary-steps-reproduce">Steps to reproduce</h4>
Created a landing page with at least one featured content item.

<h3 id="summary-proposed-resolution">Proposed resolution</h3>
Hide the teaser image link (and its contents) from assistive technology altogether. The link in the title already provides a clear navigation target for assistive technology.

The information of the type icon is now included in the heading as text available to the screenreader. This has been done on landing pages for the node, profile and group templates.

## Issue tracker
https://www.drupal.org/project/social/issues/3171577

## How to test
*For example*
- [ ] Create a landing page with at least three pieces of featured content: a node, a group, and a user
- [ ] Using a screenreader (e.g. Voice Over on Mac or NVDA on Windows)
- [ ] Visit the created landing page
- [ ] Navigate to the featured content
- [ ] Verify that the image and its associated link is no longer read by the screenreader
- [ ] Verify that it's clear for a screen reader user what type of content they've selected (e.g. Topic, Discussion, User, Group)
- [ ] Perform the above steps in both the default theme and sky

## Screenshots
No visual changes

## Release notes
Featured content on landing pages should now be easier to navigate using a screenreader. Links around decorative images have been hidden and the type of content shown in the teaser has been clarified. 

## Change Record
N.a. 

## Translations
N.a.
