### PR TITLE
Issue #3175438 by agami4: Update max-height for the teaser title

### DIFF
--- a/themes/socialbase/assets/css/teaser.css
+++ b/themes/socialbase/assets/css/teaser.css
@@ -53,7 +53,7 @@
 .teaser__title {
   margin-top: 0;
   margin-bottom: 20px;
-  max-height: 2.3em;
+  max-height: 2.2em;
   overflow: hidden;
 }
 

--- a/themes/socialbase/assets/css/teaser.css
+++ b/themes/socialbase/assets/css/teaser.css
@@ -53,7 +53,8 @@
 .teaser__title {
   margin-top: 0;
   margin-bottom: 20px;
-  max-height: 2.2em;
+  max-height: 2.4em;
+  line-height: 1.2;
   overflow: hidden;
 }
 

--- a/themes/socialbase/components/03-molecules/teaser/teaser.scss
+++ b/themes/socialbase/components/03-molecules/teaser/teaser.scss
@@ -103,7 +103,7 @@
 .teaser__title {
   margin-top: 0;
   margin-bottom: 20px;
-  max-height: 2.3em;
+  max-height: 2.2em;
   overflow: hidden;
 }
 

--- a/themes/socialbase/components/03-molecules/teaser/teaser.scss
+++ b/themes/socialbase/components/03-molecules/teaser/teaser.scss
@@ -103,7 +103,8 @@
 .teaser__title {
   margin-top: 0;
   margin-bottom: 20px;
-  max-height: 2.2em;
+  max-height: 2.4em;
+  line-height: 1.2;
   overflow: hidden;
 }
 


### PR DESCRIPTION
## Problem
The 3rd line of the teaser title is cut off on Safari.

## Solution
Update max-height for the teaser title.

## Issue tracker
- https://www.drupal.org/project/social/issues/3175438
- https://getopensocial.atlassian.net/browse/YANG-3871

## How to test
*For example*
- [x] Open OS on the Safari browser
- [x] Login as site_manager
- [x] Go to the challenges page and check all titles on the teasers or add to the teaser more symbols of title for one teaser

## Screenshots
before:
<img width="391" alt="teaser-title-safari" src="https://user-images.githubusercontent.com/16086340/95315278-f696dd00-089a-11eb-8175-e907b374f98e.png">

after:
<img width="417" alt="teaser-title-fix" src="https://user-images.githubusercontent.com/16086340/95315298-fc8cbe00-089a-11eb-9720-11b2ba128f11.png">

## Release notes
The title has a maximum of two lines on the teaser

## Change Record
-

## Translations
-
