### PR TITLE
Issue #3171512 by agami4: Add title to SVG elements for all type of the teasers

### DIFF
--- a/modules/social_features/social_featured_content/templates/group--featured.html.twig
+++ b/modules/social_features/social_featured_content/templates/group--featured.html.twig
@@ -51,11 +51,11 @@
   <small class="text-muted">
 
     <div class="teaser__content-line">
-      <svg class="teaser__content-type-icon" aria-hidden="true">
+      <svg class="teaser__content-type-icon" aria-hidden="true" title="{% trans %}Group type{% endtrans %}">
         <use xlink:href="#icon-label"></use>
       </svg>
       <span class="teaser__content-text">
-        <span class="sr-only">{% trans %}The group type{% endtrans %}</span>
+        <span class="sr-only">{% trans %}The group type is{% endtrans %} </span>
         {{ group_type }}
         {{ group_settings_help }}
       </span>
@@ -63,13 +63,16 @@
 
     {% if content.field_group_location|render or content.field_group_address|render %}
       <div class="teaser__content-line">
-        <svg class="teaser__content-type-icon" aria-hidden="true">
+        <svg class="teaser__content-type-icon" aria-hidden="true" title="{% trans %}Event location{% endtrans %}">
           <use xlink:href="#icon-location"></use>
         </svg>
         <span class="teaser__content-text">
-          <span class="sr-only">{% trans %}The group will take place at the{% endtrans %}</span>
+          <span class="sr-only">{% trans %}located at: {% endtrans %} </span>
           {{ content.field_group_location }}
-            {% if content.field_group_location|render is not empty and content.field_group_address|render is not empty %} &bullet;{% endif %}
+          {% if content.field_group_location|render is not empty and content.field_group_address|render is not empty %}
+            <span class="sr-only">, </span>
+            <span aria-hidden="true"> &bullet; </span>
+          {% endif %}
           {{ content.field_group_address }}
         </span>
       </div>
@@ -81,14 +84,14 @@
 {% block card_actionbar %}
 
   {% if group_members is not empty %}
-    <div class="badge teaser__badge" title="{% trans %}Total amount of group members{% endtrans %}">
+    <div class="badge teaser__badge">
       <span class="badge__container">
-        <svg class="badge__icon" aria-hidden="true">
+        <svg class="badge__icon" aria-hidden="true" title="{% trans %}Number of group members{% endtrans %}">
           <use xlink:href="#icon-group"></use>
         </svg>
         <span class="badge__label">
-          <span class="sr-only">{% trans %}The group has{% endtrans %}</span>
           {{ group_members }}
+          <span class="sr-only"> {% trans %}group members{% endtrans %} </span>
         </span>
       </span>
     </div>

--- a/modules/social_features/social_featured_content/templates/group--featured.html.twig
+++ b/modules/social_features/social_featured_content/templates/group--featured.html.twig
@@ -19,7 +19,7 @@
 {% block card_teaser_type %}
   <a href="{{ url }}">
     <div class="teaser__teaser-type">
-      <svg class="teaser__teaser-type-icon">s
+      <svg class="teaser__teaser-type-icon">
         <use xlink:href="#icon-group-white"></use>
       </svg>
     </div>

--- a/modules/social_features/social_featured_content/templates/group--featured.html.twig
+++ b/modules/social_features/social_featured_content/templates/group--featured.html.twig
@@ -20,6 +20,7 @@
   <a href="{{ url }}">
     <div class="teaser__teaser-type">
       <svg class="teaser__teaser-type-icon">
+        <title>{{ label }}</title>
         <use xlink:href="#icon-group-white"></use>
       </svg>
     </div>

--- a/modules/social_features/social_featured_content/templates/group--featured.html.twig
+++ b/modules/social_features/social_featured_content/templates/group--featured.html.twig
@@ -51,10 +51,11 @@
   <small class="text-muted">
 
     <div class="teaser__content-line">
-      <svg class="teaser__content-type-icon">
+      <svg class="teaser__content-type-icon" aria-hidden="true">
         <use xlink:href="#icon-label"></use>
       </svg>
       <span class="teaser__content-text">
+        <span class="sr-only">{% trans %}The group type{% endtrans %}</span>
         {{ group_type }}
         {{ group_settings_help }}
       </span>
@@ -62,10 +63,11 @@
 
     {% if content.field_group_location|render or content.field_group_address|render %}
       <div class="teaser__content-line">
-        <svg class="teaser__content-type-icon">
+        <svg class="teaser__content-type-icon" aria-hidden="true">
           <use xlink:href="#icon-location"></use>
         </svg>
         <span class="teaser__content-text">
+          <span class="sr-only">{% trans %}The group will take place at the{% endtrans %}</span>
           {{ content.field_group_location }}
             {% if content.field_group_location|render is not empty and content.field_group_address|render is not empty %} &bullet;{% endif %}
           {{ content.field_group_address }}
@@ -81,10 +83,11 @@
   {% if group_members is not empty %}
     <div class="badge teaser__badge" title="{% trans %}Total amount of group members{% endtrans %}">
       <span class="badge__container">
-        <svg class="badge__icon">
+        <svg class="badge__icon" aria-hidden="true">
           <use xlink:href="#icon-group"></use>
         </svg>
         <span class="badge__label">
+          <span class="sr-only">{% trans %}The group has{% endtrans %}</span>
           {{ group_members }}
         </span>
       </span>

--- a/modules/social_features/social_featured_content/templates/group--featured.html.twig
+++ b/modules/social_features/social_featured_content/templates/group--featured.html.twig
@@ -19,8 +19,7 @@
 {% block card_teaser_type %}
   <a href="{{ url }}">
     <div class="teaser__teaser-type">
-      <svg class="teaser__teaser-type-icon">
-        <title>{{ label }}</title>
+      <svg class="teaser__teaser-type-icon">s
         <use xlink:href="#icon-group-white"></use>
       </svg>
     </div>

--- a/modules/social_features/social_featured_content/templates/node--event--featured.html.twig
+++ b/modules/social_features/social_featured_content/templates/node--event--featured.html.twig
@@ -4,11 +4,17 @@
     <small class="text-muted">
       {% embed "node--teaser__field.html.twig" %}
         {%- block field_icon -%} event {%- endblock -%}
-        {%- block field_value %} {{ event_date }} {%- endblock -%}
+        {%- block field_value %}
+          <span class="sr-only">{% trans %}Event date{% endtrans %}</span>
+          {{ event_date }}
+        {%- endblock -%}
       {% endembed %}
       {% embed "node--teaser__field.html.twig" %}
         {%- block field_icon -%} location {%- endblock -%}
-        {%- block field_value -%} {{ content.field_event_location }} {%- endblock -%}
+        {%- block field_value -%}
+          <span class="sr-only">{% trans %}The event will take place at the{% endtrans %}</span>
+          {{ content.field_event_location }}
+        {%- endblock -%}
       {% endembed %}
       {% if content.ongoing %}
         <span class="badge badge-primary teaser__badge">

--- a/modules/social_features/social_featured_content/templates/node--event--featured.html.twig
+++ b/modules/social_features/social_featured_content/templates/node--event--featured.html.twig
@@ -5,14 +5,14 @@
       {% embed "node--teaser__field.html.twig" %}
         {%- block field_icon -%} event {%- endblock -%}
         {%- block field_value %}
-          <span class="sr-only">{% trans %}Event date{% endtrans %}</span>
+          <span class="sr-only">{% trans %}Event date{% endtrans %} </span>
           {{ event_date }}
         {%- endblock -%}
       {% endembed %}
       {% embed "node--teaser__field.html.twig" %}
         {%- block field_icon -%} location {%- endblock -%}
         {%- block field_value -%}
-          <span class="sr-only">{% trans %}The event will take place at the{% endtrans %}</span>
+          <span class="sr-only">{% trans %}The event will take place at the{% endtrans %} </span>
           {{ content.field_event_location }}
         {%- endblock -%}
       {% endembed %}

--- a/modules/social_features/social_featured_content/templates/node--featured.html.twig
+++ b/modules/social_features/social_featured_content/templates/node--featured.html.twig
@@ -93,6 +93,7 @@
         <a href="{{ url }}">
           <div class="teaser__teaser-type">
             <svg class="teaser__teaser-type-icon">
+              <title>{{ label }}</title>
               <use xlink:href="#icon-{{- node.bundle|clean_class -}}"></use>
             </svg>
           </div>

--- a/modules/social_features/social_featured_content/templates/node--featured.html.twig
+++ b/modules/social_features/social_featured_content/templates/node--featured.html.twig
@@ -93,7 +93,6 @@
         <a href="{{ url }}">
           <div class="teaser__teaser-type">
             <svg class="teaser__teaser-type-icon">
-              <title>{{ label }}</title>
               <use xlink:href="#icon-{{- node.bundle|clean_class -}}"></use>
             </svg>
           </div>
@@ -125,7 +124,9 @@
               {%- block field_icon -%} account_circle {%- endblock -%}
               {%- block field_value %}
                 <div class="teaser__published">
-                  <div class="teaser__published-date"> {{ date }} &bullet;</div>
+                  <span class="sr-only">{% trans %}Created on{% endtrans %}</span>
+                  <div class="teaser__published-date"> {{ date }} <span class="sr-only">&bullet;</span></div>
+                  <span class="sr-only">{% trans %}by{% endtrans %}</span>
                   <div class="teaser__published-author"> {{ author_name }} </div>
                 </div>
               {%- endblock -%}
@@ -134,7 +135,10 @@
             {% if topic_type %}
               {% embed "node--teaser__field.html.twig" %}
                 {%- block field_icon -%} label {%- endblock -%}
-                {%- block field_value -%} {{ topic_type }} {%- endblock -%}
+                {%- block field_value -%}
+                  <span class="sr-only">{% trans %}Topic type:{% endtrans %}</span>
+                  {{ topic_type }}
+                {%- endblock -%}
               {% endembed %}
             {% endif %}
 
@@ -149,11 +153,12 @@
 
       {% if visibility_icon and visibility_label %}
         <div class="badge teaser__badge no-padding"
-             title="{% trans %}The visibility of this content is set to {{ visibility_label }}{% endtrans %} ">
+             title="{% trans %}The visibility of this content is set to {{ visibility_label }}{% endtrans %}">
         <span class="badge__container">
-          <svg class="badge__icon">
+          <svg class="badge__icon" aria-hidden="true">
             <use xlink:href="#icon-{{ visibility_icon }}"></use>
           </svg>
+          <span class="sr-only">{% trans %}The visibility of this content is set to {{ visibility_label }}{% endtrans %}</span>
           <span class="badge__label text-gray">{{ visibility_label|capitalize }}</span>
         </span>
         </div>

--- a/modules/social_features/social_featured_content/templates/node--featured.html.twig
+++ b/modules/social_features/social_featured_content/templates/node--featured.html.twig
@@ -92,7 +92,7 @@
       {% block card_teaser_type %}
         <a href="{{ url }}">
           <div class="teaser__teaser-type">
-            <svg class="teaser__teaser-type-icon">
+            <svg class="teaser__teaser-type-icon" title="{{- node.type.0.entity.label() -}}">
               <use xlink:href="#icon-{{- node.bundle|clean_class -}}"></use>
             </svg>
           </div>
@@ -124,10 +124,10 @@
               {%- block field_icon -%} account_circle {%- endblock -%}
               {%- block field_value %}
                 <div class="teaser__published">
-                  <span class="sr-only">{% trans %}Created on{% endtrans %}</span>
-                  <div class="teaser__published-date"> {{ date }} <span class="sr-only">&bullet;</span></div>
-                  <span class="sr-only">{% trans %}by{% endtrans %}</span>
-                  <div class="teaser__published-author"> {{ author_name }} </div>
+                  <span class="sr-only">{% trans %}Created on{% endtrans %} </span>
+                  <div class="teaser__published-date">{{ date }} <span aria-hidden="true">&bullet;</span></div>
+                  <span class="sr-only"> {% trans %}by{% endtrans %} </span>
+                  <div class="teaser__published-author">{{ author_name }}</div>
                 </div>
               {%- endblock -%}
             {% endembed %}
@@ -158,7 +158,7 @@
           <svg class="badge__icon" aria-hidden="true">
             <use xlink:href="#icon-{{ visibility_icon }}"></use>
           </svg>
-          <span class="sr-only">{% trans %}The visibility of this content is set to {{ visibility_label }}{% endtrans %}</span>
+          <span class="sr-only">{% trans %}The visibility of this content is set to {{ visibility_label }}{% endtrans %} </span>
           <span class="badge__label text-gray">{{ visibility_label|capitalize }}</span>
         </span>
         </div>

--- a/themes/socialbase/assets/js/navbar-collapse.min.js
+++ b/themes/socialbase/assets/js/navbar-collapse.min.js
@@ -1,1 +1,1 @@
-!function(a){Drupal.behaviors.navbarCollapse={attach:function(n,o){a(".dropdown-toggle, #content").on("click",function(){a(".navbar-collapse").collapse("hide")})}}}(jQuery);
+!function(a){Drupal.behaviors.navbarCollapse={attach:function(o,n){a("body").on("click",".dropdown-toggle, #content",function(){a(".navbar-collapse").collapse("hide")})}}}(jQuery);

--- a/themes/socialbase/components/03-molecules/navigation/navbar/navbar-collapse.js
+++ b/themes/socialbase/components/03-molecules/navigation/navbar/navbar-collapse.js
@@ -3,7 +3,9 @@
   Drupal.behaviors.navbarCollapse = {
     attach: function (context, settings) {
 
-      $('.dropdown-toggle, #content').on('click', function() {
+      // Delegate the event to body to prevent screenreaders from thinking
+      // teasers are clickable.
+      $('body').on('click', '.dropdown-toggle, #content', function() {
         $('.navbar-collapse').collapse('hide');
       });
 

--- a/themes/socialbase/templates/group/group--teaser.html.twig
+++ b/themes/socialbase/templates/group/group--teaser.html.twig
@@ -52,7 +52,7 @@
 
 <div{{ attributes.addClass(classes) }}>
 
-  <div class='teaser__image'>
+  <div class='teaser__image' aria-hidden="true">
     {% block card_image %}
       {{ content.field_group_image }}
     {% endblock %}
@@ -90,22 +90,27 @@
 
       {% block card_body %}
         <div class="teaser__content-line">
-          <svg class="teaser__content-type-icon">
+          <svg class="teaser__content-type-icon" aria-hidden="true" title="{% trans %}Group type{% endtrans %}">
             <use xlink:href="#icon-label"></use>
           </svg>
           <span class="teaser__content-text">
+            <span class="sr-only">{% trans %}The group type is{% endtrans %} </span>
             {{ group_type }}
             {{ group_settings_help }}
           </span>
         </div>
         {% if content.field_group_location|render or content.field_group_address|render %}
           <div class="teaser__content-line">
-              <svg class="teaser__content-type-icon">
+              <svg class="teaser__content-type-icon" aria-hidden="true" title="{% trans %}Event location{% endtrans %}">
                   <use xlink:href="#icon-location"></use>
               </svg>
             <span class="teaser__content-text">
-              {{ content.field_group_location }}
-              {% if content.field_group_location|render is not empty and content.field_group_address|render is not empty %} &bullet;{% endif %}
+          <span class="sr-only">{% trans %}located at: {% endtrans %} </span>
+          {{ content.field_group_location }}
+              {% if content.field_group_location|render is not empty and content.field_group_address|render is not empty %}
+                <span class="sr-only">, </span>
+                <span aria-hidden="true"> &bullet; </span>
+              {% endif %}
               {{ content.field_group_address }}
             </span>
           </div>
@@ -117,13 +122,14 @@
       {% block card_actionbar %}
 
         {% if group_members is not empty %}
-          <div class="badge teaser__badge" title="{% trans %}Total amount of group members{% endtrans %}">
+          <div class="badge teaser__badge">
             <span class="badge__container">
-              <svg class="badge__icon">
+              <svg class="badge__icon" aria-hidden="true" title="{% trans %}Number of group members{% endtrans %}">
                 <use xlink:href="#icon-group"></use>
               </svg>
               <span class="badge__label">
                 {{ group_members }}
+                <span class="sr-only"> {% trans %}group members{% endtrans %} </span>
               </span>
             </span>
           </div>
@@ -137,6 +143,7 @@
 
         <a href="{{ url }}" class="card__link" title="{{ label }}">
           {% trans %}Read more{% endtrans %}
+          <span class="visually-hidden">{% trans %}about {{ label }}{% endtrans %} </span>
         </a>
 
       {% endblock %}

--- a/themes/socialbase/templates/node/event/node--event--teaser.html.twig
+++ b/themes/socialbase/templates/node/event/node--event--teaser.html.twig
@@ -4,27 +4,39 @@
 
   {% embed "node--teaser__field.html.twig" %}
     {%- block field_icon -%} event {%- endblock -%}
-    {%- block field_value %} {{ event_date }} {%- endblock -%}
+    {%- block field_value %}
+      <span class="sr-only">{% trans %}Event date{% endtrans %} </span>
+      {{ event_date }}
+    {%- endblock -%}
   {% endembed %}
 
   {% if content.field_event_location|render is not empty %}
     {% embed "node--teaser__field.html.twig" %}
       {%- block field_icon -%} location {%- endblock -%}
-      {%- block field_value -%} {{ content.field_event_location }} {%- endblock -%}
+      {%- block field_value -%}
+        <span class="sr-only">{% trans %}The event will take place at the{% endtrans %} </span>
+        {{ content.field_event_location }}
+      {%- endblock -%}
     {% endembed %}
   {% endif %}
 
   {% if event_type %}
     {% embed "node--teaser__field.html.twig" %}
       {%- block field_icon -%} label {%- endblock -%}
-      {%- block field_value -%} {{ event_type }} {%- endblock -%}
+      {%- block field_value -%}
+        <span class="sr-only">{% trans %}This event has type{% endtrans %} </span>
+        {{ event_type }}
+      {%- endblock -%}
     {% endembed %}
   {% endif %}
 
   {% if content.group_name %}
     {% embed "node--teaser__field.html.twig" %}
       {%- block field_icon -%} group {%- endblock -%}
-      {%- block field_value -%} {{ content.group_name }} {%- endblock -%}
+      {%- block field_value -%}
+        <span class="sr-only">{% trans %}This event is posted in{% endtrans %} </span>
+        {{ content.group_name }}
+      {%- endblock -%}
     {% endembed %}
   {% endif %}
 
@@ -47,7 +59,7 @@
   {% if content.enrollments_count is not empty %}
     <div class="badge teaser__badge" title="{% trans %}Total amount of enrollments{% endtrans %}">
       <span class="badge__container">
-        <svg class="badge__icon">
+        <svg class="badge__icon" aria-hidden="true">
           <use xlink:href="#icon-person"></use>
         </svg>
         <span class="badge__label text-gray">

--- a/themes/socialbase/templates/node/node--teaser.html.twig
+++ b/themes/socialbase/templates/node/node--teaser.html.twig
@@ -129,8 +129,10 @@
             {%- block field_icon -%} account_circle {%- endblock -%}
             {%- block field_value %}
               <div class="teaser__published">
-                <div class="teaser__published-date"> {{ date }} &bullet; </div>
-                <div class="teaser__published-author"> {{ author_name }} </div>
+                <span class="sr-only">{% trans %}Created on{% endtrans %} </span>
+                <div class="teaser__published-date">{{ date }} <span aria-hidden="true">&bullet;</span></div>
+                <span class="sr-only"> {% trans %}by{% endtrans %} </span>
+                <div class="teaser__published-author">{{ author_name }}</div>
               </div>
             {%- endblock -%}
           {% endembed %}
@@ -139,14 +141,20 @@
         {% if topic_type %}
           {% embed "node--teaser__field.html.twig" %}
             {%- block field_icon -%} label {%- endblock -%}
-            {%- block field_value -%} {{ topic_type }} {%- endblock -%}
+            {%- block field_value -%}
+              <span class="sr-only">{% trans %}Topic type:{% endtrans %}</span>
+              {{ topic_type }}
+            {%- endblock -%}
           {% endembed %}
         {% endif %}
 
         {% if content.group_name %}
           {% embed "node--teaser__field.html.twig" %}
             {%- block field_icon -%} group {%- endblock -%}
-            {%- block field_value -%} {{ content.group_name }} {%- endblock -%}
+            {%- block field_value -%}
+              <span class="sr-only">{% trans %}This content is posted in{% endtrans %} </span>
+              {{ content.group_name }}
+            {%- endblock -%}
           {% endembed %}
         {% endif %}
 
@@ -164,7 +172,7 @@
           <div class="badge teaser__badge"
                title="{% trans %}The visibility of this content is set to {{ visibility_label }}{% endtrans %}">
             <span class="badge__container">
-                <svg class="badge__icon">
+                <svg class="badge__icon" aria-hidden="true">
                   <use xlink:href="#icon-{{ visibility_icon }}"></use>
                 </svg>
                 <span class="badge__label text-gray">{{ visibility_label|capitalize }}</span>
@@ -176,7 +184,7 @@
         {% if likes_count is not empty %}
           <div class="badge teaser__badge" title="{% trans %}Total amount of likes{% endtrans %}">
             <span class="badge__container">
-              <svg class="badge__icon">
+              <svg class="badge__icon" aria-hidden="true">
                 <use xlink:href="#icon-like"></use>
               </svg>
               <span class="badge__label text-gray">
@@ -187,9 +195,10 @@
         {% endif %}
 
         {% if comment_count is not empty %}
-          <a href="{{ url }}#section-comments" class="badge badge--pill teaser__badge">
+          <a href="{{ url }}#section-comments" class="badge badge--pill teaser__badge"
+             title="{% trans %}Total amount of comments{% endtrans %}">
             <span class="badge__container">
-              <svg class="badge__icon">
+              <svg class="badge__icon" aria-hidden="true">
                 <use xlink:href="#icon-comment"></use>
               </svg>
               <span class="badge__label text-gray">{{ comment_count }}</span>

--- a/themes/socialbase/templates/node/node--teaser__field.html.twig
+++ b/themes/socialbase/templates/node/node--teaser__field.html.twig
@@ -1,5 +1,5 @@
 <div class="teaser__content-line">
-  <svg class="teaser__content-type-icon">
+  <svg class="teaser__content-type-icon" aria-hidden="true">
       <use xlink:href="#icon-{% block field_icon %}label{% endblock %}"></use>
   </svg>
   <div class="teaser__content-text">

--- a/themes/socialbase/templates/profile/profile--profile--teaser.html.twig
+++ b/themes/socialbase/templates/profile/profile--profile--teaser.html.twig
@@ -25,7 +25,7 @@
 <div class="card teaser">
 
   {% block card_image %}
-    <div class="teaser__image">
+    <div class="teaser__image" aria-hidden="true">
       <a href="{{ profile_home }}">
         {{ content.field_profile_image }}
       </a>
@@ -33,7 +33,7 @@
   {% endblock %}
 
   {% block card_teaser_type %}
-    <a href="{{ profile_home }}">
+    <a href="{{ profile_home }}" aria-hidden="true">
       <div class="teaser__teaser-type">
         <svg class="teaser__teaser-type-icon">
           <use xlink:href="#icon-account_circle"></use>
@@ -56,7 +56,7 @@
       {% block card_body %}
         {% if content.field_profile_function|render or content.field_profile_organization|render %}
         <div class="teaser__content-line">
-          <svg class="teaser__content-type-icon">
+          <svg class="teaser__content-type-icon" aria-hidden="true">
             <use xlink:href="#icon-business_center"></use>
           </svg>
           <span class="teaser__content-text">

--- a/themes/socialblue/templates/node/event/node--event--featured--sky.html.twig
+++ b/themes/socialblue/templates/node/event/node--event--featured--sky.html.twig
@@ -32,12 +32,18 @@
 
     {% embed "node--teaser__field.html.twig" %}
       {%- block field_icon -%} schedule {%- endblock -%}
-      {%- block field_value %} {{ event_date }} {%- endblock -%}
+      {%- block field_value %}
+        <span class="sr-only">{% trans %}Event date{% endtrans %} </span>
+        {{ event_date }}
+      {%- endblock -%}
     {% endembed %}
 
     {% embed "node--teaser__field.html.twig" %}
       {%- block field_icon -%} location {%- endblock -%}
-      {%- block field_value -%} {{ content.field_event_location }} {%- endblock -%}
+      {%- block field_value -%}
+        <span class="sr-only">{% trans %}The event will take place at the{% endtrans %} </span>
+        {{ content.field_event_location }}
+      {%- endblock -%}
     {% endembed %}
 
     {% if content.ongoing %}
@@ -60,7 +66,7 @@
     <a href="{{ url }}#section-comments" class="badge teaser__badge"
        title="{% trans %}Total amount of comments{% endtrans %}">
       <span class="badge__container">
-        <svg class="badge__icon">
+        <svg class="badge__icon" aria-hidden="true">
           <use xlink:href="#icon-comment"></use>
         </svg>
         <span class="badge__label">{{ comment_count }}</span>
@@ -71,7 +77,7 @@
   {% if content.enrollments_count is not empty %}
     <div class="badge teaser__badge" title="{% trans %}Total amount of enrollments{% endtrans %}">
       <span class="badge__container">
-        <svg class="badge__icon">
+        <svg class="badge__icon" aria-hidden="true">
           <use xlink:href="#icon-person"></use>
         </svg>
         <span class="badge__label">

--- a/themes/socialblue/templates/node/event/node--event--teaser--sky.html.twig
+++ b/themes/socialblue/templates/node/event/node--event--teaser--sky.html.twig
@@ -4,20 +4,29 @@
 
   {% embed "node--teaser__field.html.twig" %}
     {%- block field_icon -%} event {%- endblock -%}
-    {%- block field_value %} {{ event_date }} {%- endblock -%}
+    {%- block field_value %}
+      <span class="sr-only">{% trans %}Event date{% endtrans %} </span>
+      {{ event_date }}
+    {%- endblock -%}
   {% endembed %}
 
   {% if content.field_event_location|render is not empty %}
     {% embed "node--teaser__field.html.twig" %}
       {%- block field_icon -%} location {%- endblock -%}
-      {%- block field_value -%} {{ content.field_event_location }} {%- endblock -%}
+      {%- block field_value -%}
+        <span class="sr-only">{% trans %}The event will take place at the{% endtrans %} </span>
+        {{ content.field_event_location }}
+      {%- endblock -%}
     {% endembed %}
   {% endif %}
 
   {% if content.group_name %}
     {% embed "node--teaser__field.html.twig" %}
       {%- block field_icon -%} group {%- endblock -%}
-      {%- block field_value -%} {{ content.group_name }} {%- endblock -%}
+      {%- block field_value -%}
+        <span class="sr-only">{% trans %}This event is posted in{% endtrans %} </span>
+        {{ content.group_name }}
+      {%- endblock -%}
     {% endembed %}
   {% endif %}
 

--- a/themes/socialblue/templates/node/node--featured--sky.html.twig
+++ b/themes/socialblue/templates/node/node--featured--sky.html.twig
@@ -8,11 +8,12 @@
 
     {% if visibility_icon and visibility_label %}
       <div class="badge teaser__badge no-padding"
-           title="{% trans %}The visibility of this content is set to {{ visibility_label }}{% endtrans %} ">
+           title="{% trans %}The visibility of this content is set to {{ visibility_label }}{% endtrans %}">
         <span class="badge__container">
-          <svg class="badge__icon">
+          <svg class="badge__icon" aria-hidden="true">
             <use xlink:href="#icon-{{ visibility_icon }}"></use>
           </svg>
+          <span class="sr-only">{% trans %}The visibility of this content is set to {{ visibility_label }}{% endtrans %} </span>
           <span class="badge__label text-gray">{{ visibility_label|capitalize }}</span>
         </span>
       </div>
@@ -35,8 +36,10 @@
         {%- block field_icon -%} account_circle {%- endblock -%}
         {%- block field_value %}
           <div class="teaser__published">
-            <div class="teaser__published-date"> {{ date }} &bullet;</div>
-            <div class="teaser__published-author"> {{ author_name }} </div>
+            <span class="sr-only">{% trans %}Created on{% endtrans %} </span>
+            <div class="teaser__published-date">{{ date }} <span aria-hidden="true">&bullet;</span></div>
+            <span class="sr-only"> {% trans %}by{% endtrans %} </span>
+            <div class="teaser__published-author">{{ author_name }}</div>
           </div>
         {%- endblock -%}
       {% endembed %}
@@ -51,7 +54,7 @@
     <a href="{{ url }}#section-comments" class="badge teaser__badge"
        title="{% trans %}Total amount of comments{% endtrans %}">
       <span class="badge__container">
-        <svg class="badge__icon">
+        <svg class="badge__icon" aria-hidden="true">
           <use xlink:href="#icon-comment"></use>
         </svg>
         <span class="badge__label">{{ comment_count }}</span>
@@ -62,7 +65,7 @@
   {% if likes_count is not empty %}
     <div class="badge teaser__badge" title="{% trans %}Total amount of likes{% endtrans %}">
       <span class="badge__container">
-        <svg class="badge__icon">
+        <svg class="badge__icon" aria-hidden="true">
           <use xlink:href="#icon-like"></use>
         </svg>
         <span class="badge__label">

--- a/themes/socialblue/templates/node/node--teaser--sky.html.twig
+++ b/themes/socialblue/templates/node/node--teaser--sky.html.twig
@@ -8,8 +8,10 @@
         {%- block field_icon -%} account_circle {%- endblock -%}
         {%- block field_value %}
           <div class="teaser__published">
-            <div class="teaser__published-date"> {{ date }} &bullet;</div>
-            <div class="teaser__published-author"> {{ author_name }} </div>
+            <span class="sr-only">{% trans %}Created on{% endtrans %} </span>
+            <div class="teaser__published-date">{{ date }} <span aria-hidden="true">&bullet;</span></div>
+            <span class="sr-only"> {% trans %}by{% endtrans %} </span>
+            <div class="teaser__published-author">{{ author_name }}</div>
           </div>
         {%- endblock -%}
       {% endembed %}
@@ -19,7 +21,10 @@
   {% if content.group_name %}
     {% embed "node--teaser__field.html.twig" %}
       {%- block field_icon -%} group {%- endblock -%}
-      {%- block field_value -%} {{ content.group_name }} {%- endblock -%}
+      {%- block field_value -%}
+        <span class="sr-only">{% trans %}This content is posted in{% endtrans %} </span>
+        {{ content.group_name }}
+      {%- endblock -%}
     {% endembed %}
   {% endif %}
 


### PR DESCRIPTION
## Problem
Teasers use icons to convey the meaning of values that are shown. These icons do not have alternative labels so it's unclear for users using assistive technology (e.g. screen readers) what information they're being read.

## Solution
Add the title to SVG elements for all type of the teasers

## Issue tracker
https://www.drupal.org/project/social/issues/3171512

## How to test
- [ ] Go to the landing page and create a featured content block with all teasers.
- [ ] Using a screenreader (e.g. VoiceOver on Mac or NVDA on Windows)
- [ ] Navigate to the featured content
- [ ] Verify that it's clear for a screen reader user what title of the icon they've selected (e.g. Topic, Discussion, Group)

## Screenshots
-

## Release notes
Featured content on landing pages should now be easier to navigate using a screenreader. The information conveyed in teasers has a clear title.

## Change Record
-

## Translations
-
