### PR TITLE
Issue #3171606 by agami4: Add "legend" HTML tag to the fieldset

### DIFF
--- a/themes/socialbase/assets/css/form-elements.css
+++ b/themes/socialbase/assets/css/form-elements.css
@@ -248,6 +248,16 @@ span.form-required {
   cursor: auto;
 }
 
+fieldset.card legend.card__title {
+  width: 100%;
+  top: 1.5rem;
+  margin-bottom: 1.25rem;
+}
+
+legend.control-label {
+  margin-bottom: 5px;
+}
+
 @media (min-width: 600px) {
   .form-inline .form-group {
     display: inline-block;

--- a/themes/socialbase/components/03-molecules/form-elements/form-elements.scss
+++ b/themes/socialbase/components/03-molecules/form-elements/form-elements.scss
@@ -350,3 +350,16 @@ span.form-required {
     }
   }
 }
+
+// Fieldset and fieldset elemenets styles.
+fieldset.card {
+  legend.card__title {
+    width: 100%;
+    top: 1.5rem;
+    margin-bottom: 1.25rem;
+  }
+}
+
+legend.control-label {
+  margin-bottom: 5px;
+}

--- a/themes/socialbase/templates/card/bootstrap-panel.html.twig
+++ b/themes/socialbase/templates/card/bootstrap-panel.html.twig
@@ -57,13 +57,13 @@
     {# Heading #}
     {% if heading %}
       {% block heading %}
-        <h4 class="card__title card__title--underline">
+        <legend class="card__title card__title--underline">
           {% if collapsible %}
             <a{{ heading_attributes }} href="{{ target }}">{{ heading }}</a>
           {% else %}
-            <div{{ heading_attributes }}>{{ heading }}</div>
+            <span{{ heading_attributes }}>{{ heading }}</span>
           {% endif %}
-        </h4>
+        </legend>
       {% endblock %}
     {% endif %}
 

--- a/themes/socialbase/templates/form/fieldset.html.twig
+++ b/themes/socialbase/templates/form/fieldset.html.twig
@@ -39,13 +39,13 @@
     ]
   %}
   {#  Always wrap fieldset legends in a SPAN for CSS positioning. #}
-  <label{{ legend.attributes.addClass(label_classes) }}>
+  <legend{{ legend.attributes.addClass(label_classes) }}>
     <span{{ legend_span.attributes }}>{{ legend.title }}</span>
-  </label>
 
-  {%- if required -%}
-    <span class="form-required">*</span>
-  {%- endif -%}
+    {%- if required -%}
+      <span class="form-required">*</span>
+    {%- endif -%}
+  </legend>
 
   {% if description.content %}
     <div{{ description.attributes.addClass('help-block') }}>{{ description.content }}</div>

--- a/themes/socialbase/templates/form/form--group.html.twig
+++ b/themes/socialbase/templates/form/form--group.html.twig
@@ -36,9 +36,9 @@
     ]
   %}
   {#  Always wrap fieldset legends in a SPAN for CSS positioning. #}
-  <label{{ legend.attributes.addClass(label_classes) }}>
+  <legend{{ legend.attributes.addClass(label_classes) }}>
     <span{{ legend_span.attributes }}>{{ legend.title }}</span>
-  </label>
+  </legend>
   <div class="fieldset-wrapper">
     {% if errors %}
       <div>


### PR DESCRIPTION
## Problem
In Open Social we have two templates in socialbase that produce fieldset output in many places. However, these fieldsets don't properly use the legend tag, causing difficulties for users of screenreaders while filling in the form.

## Solution
Add `legend` HTML tag to the `fieldset`.

## Issue tracker
https://www.drupal.org/project/social/issues/3171606

## How to test
*For example*
- [ ] Go to the create/edit page(node, group) and check fieldset element(`bootstrap-panel.html.twig`)
- [ ] Go to the create/edit landing(landing page) and check fieldset element(`fieldset.html.twig`)

## Screenshots
-

## Release notes
The fieldset elements have a legend HTML tag.

## Change Record
-

## Translations
-
