### PR TITLE
Issue #3171613 by dspachos: Views exposed filter block doesn't have a…

### DIFF
--- a/themes/socialbase/templates/block/block--views-exposed-filter-block.html.twig
+++ b/themes/socialbase/templates/block/block--views-exposed-filter-block.html.twig
@@ -61,7 +61,7 @@
 
     {{ title_prefix }}
     {% if label %}
-      <header{{ title_attributes.addClass('complementary-title') }}>{{ label }}</header>
+      <h2 {{ title_attributes.addClass('complementary-title', 'no-margin') }}>{{ label }}</h2>
     {% endif %}
     {{ title_suffix }}
 


### PR DESCRIPTION
… title element
<h3 id="summary-problem-motivation">Problem/Motivation</h3>
The block used for exposed filters on content overview pages such as <code>/all-topics</code> does not contain a heading element.

<h3 id="summary-proposed-resolution">Proposed resolution</h3>
I think using an <code>h2</code> element for this would be a good idea since it's usually used on a page whose primary purpose is to filter the content. To make styling easier we can also move the title classes to be on the heading.

Replace <code><header{{ title_attributes.addClass('complementary-title') }}>{{ label }}</header></code> with <code><header><h2 {{ title_attributes.addClass('complementary-title') }}>{{ label }}</h2></header></code>

## Issue tracker
* https://www.drupal.org/project/social/issues/3171613

## How to test

- [ ] Apply the patch
- [ ] See that there are no visual changes to the filter block on explore and search pages
- [ ] See that the "Filter" or "Sort and Filter" text is now a proper heading.


## Screenshots
N.a.

## Release notes
The header of a filter block is now properly marked as heading. No visual changes.

## Change Record
None 

## Translations
None