### PR TITLE
Issue #3171587 by dspachos, Kingdutch: Login error message uses a fak…

### DIFF
--- a/modules/social_features/social_user/src/Form/SocialUserLoginForm.php
+++ b/modules/social_features/social_user/src/Form/SocialUserLoginForm.php
@@ -251,11 +251,13 @@ class SocialUserLoginForm extends UserLoginForm {
    */
   protected function setGeneralErrorMessage(array &$form, FormStateInterface $form_state) {
     $form_state->setErrorByName('name_or_mail', $this->t('
-        Oops, there was an error. This may have happened for the following reasons: <br>
-        - Invalid username/email and password combination. <br>
-        - There has been more than one failed login attempt for this account. It is temporarily blocked. <br>
-        - Too many failed login attempts from your computer (IP address). This IP address is temporarily blocked. <br> <br>
-        To solve the issue, try using different login information, try again later, or <a href=":url">request a new password</a>',
+        <p>Oops, there was an error. This may have happened for the following reasons:</p>
+        <ul>
+          <li>Invalid username/email and password combination. </li>
+          <li>There has been more than one failed login attempt for this account. It is temporarily blocked. </li>
+          <li>Too many failed login attempts from your computer (IP address). This IP address is temporarily blocked. </li>
+        </ul>
+        <p>To solve the issue, try using different login information, try again later, or <a href=":url">request a new password</a></p>',
       ['%name_or_email' => $form_state->getValue('name_or_mail'), ':url' => $this->url('user.pass')]));
   }
 

--- a/translations.php
+++ b/translations.php
@@ -25,6 +25,14 @@ die('This file should not be run directly.');
 // new TranslatableMarkup('Example');
 // new PluralTranslatableMarkup($count, '1 example', '@count examples');.
 
+// Changed in version 8.7, 9.4, 10.0
+new TranslatableMarkup('
+        Oops, there was an error. This may have happened for the following reasons: <br>
+        - Invalid username/email and password combination. <br>
+        - There has been more than one failed login attempt for this account. It is temporarily blocked. <br>
+        - Too many failed login attempts from your computer (IP address). This IP address is temporarily blocked. <br> <br>
+        To solve the issue, try using different login information, try again later, or <a href=":url">request a new password</a>');
+
 // Change in version 8.3.
 new TranslatableMarkup("Set wether event types field is required or not.");
 new TranslatableMarkup("Determine wether users can upload documents to comments.");


### PR DESCRIPTION
…e list but should use a semantic list instead

<h3 id="summary-problem-motivation">Problem/Motivation</h3>
The error message for an incorrect entry on the login form contains text that's formatted as a list. However, this is not actually an HTML list making it more difficult for screenreaders to read.

The following is the current text.
<code>
        Oops, there was an error. This may have happened for the following reasons: <br>
        - Invalid username/email and password combination. <br>
        - There has been more than one failed login attempt for this account. It is temporarily blocked. <br>
        - Too many failed login attempts from your computer (IP address). This IP address is temporarily blocked. <br> <br>
        To solve the issue, try using different login information, try again later, or <a href="/user/password">request a new password</a>
</code>

<h3 id="summary-proposed-resolution">Proposed resolution</h3>
Change the user login error message to
<code>
Oops, there was an error. This may have happened for the following reasons:
        <ul>
          <li>Invalid username/email and password combination. </li>
        <li>There has been more than one failed login attempt for this account. It is temporarily blocked. </li>
        <li>Too many failed login attempts from your computer (IP address). This IP address is temporarily blocked. </li>
  </ul><br>
        To solve the issue, try using different login information, try again later, or <a href="/user/password">request a new password</a>
</code>
## Issue tracker
* https://www.drupal.org/project/social/issues/3171587

## How to test

- [ ] Fill in an incorrect username/password on the /user/login page.

## Screenshots

![afbeelding](https://user-images.githubusercontent.com/327697/95477291-78b0ff80-0988-11eb-8cd5-db24af8f35d7.png)


## Release notes
The error message in the login form now uses proper markup to indicate a list of reasons.

## Change Record
None 

## Translations
*Translatable strings are always extracted from the latest development branch. To ensure translations remain available for platforms running older versions of Open Social the original string should be added to `translations.php` when it's changed or removed.*
- [ ] Changed or removed source strings are added to the `translations.php` file.
