### PR TITLE
Issue #3175829 by Kingdutch: It's unclear that dropdown menu items ar…

### DIFF
--- a/themes/socialbase/templates/navigation/menu.html.twig
+++ b/themes/socialbase/templates/navigation/menu.html.twig
@@ -48,7 +48,9 @@
       %}
       {% if (menu_level == 0 and item.is_expanded) or (menu_level == 1 and item.is_expanded) %}
         <li{{ item.attributes.addClass(item_classes) }}>
-        <a href="{{ item.url }}" class="dropdown-toggle" data-toggle="dropdown">{{ item.title }} <span class="caret"></span></a>
+        <a href="{{ item.url }}" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
+          {{ item.title }} <span class="caret"></span>
+        </a>
       {% else %}
         <li>
         {{ link(item.title, item.url) }}


### PR DESCRIPTION
…e expandable

<h3 id="summary-problem-motivation">Problem/Motivation</h3>
Open Social navigations often contain dropdowns with multiple pages (e.g. the default Explore dropdown). However the caret is only a visual indication that this menu is expandable, there is no such indication for screenreaders.

<h4 id="summary-steps-reproduce">Steps to reproduce</h4>
Navigate the dropdown with a screenreader.

## Solution
We look at the Bootstrap example and add the missing `aria-haspopup` and
`aria-expanded` attributes. The `aria-haspopup` attribute indicates to
assistive technology that there is a submenu present. The
`aria-expanded` attribute indicates the state of that submenu. The
`aria-expanded` attribute was already updated by the included JavaScript
but the initial `false` state was missing from the Twig rendered markup.

In addition we add the `role='button'` to indicate to screenreaders that 
this is a menu button which makes it clearer that the button can be 
pressed for more options.

## Issue tracker
https://www.drupal.org/project/social/issues/3175829

## How to test
- [ ] Using a screenreader open the homepage
- [ ] Use the dropdown menu in the main navigation

## Screenshots
N.a.

## Release notes
We've fixed a bug that prevented assistive technology from discovering submenus in the main navigation.

## Change Record
N.a.

## Translations
N.a.
