### PR TITLE
Issue #3171503 by Kingdutch: The SVG icon on the actions dropdown for…

### DIFF
--- a/themes/socialbase/templates/system/links.html.twig
+++ b/themes/socialbase/templates/system/links.html.twig
@@ -43,7 +43,7 @@
   {%- if links.edit or links.report -%}
     <div class="comment__actions pull-right">
       <button type="button" data-toggle="dropdown" aria-expanded="false" aria-haspopup="true" class="btn btn-icon-toggle dropdown-toggle" aria-label="{{ 'More options'|t }}">
-        <svg class="btn-icon icon-gray">
+        <svg class="btn-icon icon-gray" aria-hidden="true">
           <use xlink:href="#icon-expand_more"></use>
         </svg>
       </button>


### PR DESCRIPTION
… activities should not be visible to screenreaders

<h3 id="summary-problem-motivation">Problem/Motivation</h3>
The dropdown button that contains links like "Edit", "Delete" and "Report" that's available on activities and other content contains an arrow SVG that is decorative. The aria-label already tells screenreaders what they need to know so the SVG icon should not be visible to screen readers.

<h3 id="summary-proposed-resolution">Proposed resolution</h3>
Mark the mentioned SVG element as decorative by hiding it from screenreaders.

## Issue tracker
https://www.drupal.org/project/social/issues/3171503

## How to test
- [ ] Use the dropdown with a screenreader
- [ ] Ensure the SVG is not mentioned on its own
- [ ] Ensure it's clear the dropdown can be expanded and used

## Screenshots
N.a.

## Release notes
The contextual menu on content and content teasers will no longer announce the SVG icon to screenreaders.

## Change Record
N.a.

## Translations
N.a.