### PR TITLE
Issue #3171844 by Kingdutch: The required marker in forms (*) should …

### DIFF
--- a/themes/socialbase/templates/form/form-element-label--switch.html.twig
+++ b/themes/socialbase/templates/form/form-element-label--switch.html.twig
@@ -22,7 +22,7 @@
   <div class="switch__label">
     {{ title }}
     {%- if required -%}
-      <span class="form-required">*</span>
+      <span class="form-required" title="{% trans %}This field is required{% endtrans %}">*</span>
     {%- endif -%}
   </div>
   <div class="switch__options">

--- a/themes/socialbase/templates/form/form-element-label.html.twig
+++ b/themes/socialbase/templates/form/form-element-label.html.twig
@@ -33,7 +33,7 @@
   <label{{ attributes.addClass(classes) }}>
     {{ title }}
     {%- if required and title_display != 'invisible' -%}
-        <span class="form-required">*</span>
+        <span class="form-required" title="{% trans %}This field is required{% endtrans %}">*</span>
     {%- endif -%}
     {%- if description -%}
       <p class="help-block">{{ description }}</p>


### PR DESCRIPTION
…have a screen reader text to explain the field is required

<h3 id="summary-problem-motivation">Problem/Motivation</h3>
We show a red asterisk (*) on fields that are required. However, for screenreaders we do not have any text. 

<h4 id="summary-steps-reproduce">Steps to reproduce</h4>
Compare the Open Social login form to the Drupal.org login form

<h3 id="summary-proposed-resolution">Proposed resolution</h3>
Add a title to the asterisk element, similar to the Drupal.org login form.

## Issue tracker
* https://www.drupal.org/project/social/issues/3171844

## How to test
- [ ] Use the login form (or any form with a required field) using a screenreader

## Screenshots
N.a.

## Release notes
Required form fields will now announce themselves as such as part of the field label for assistive technology.

## Change Record
N.a.

## Translations
New string introduced, no previous strings changed.
