### PR TITLE
Issue #3171775 by Megha_kundar, Kingdutch: Alert messages in Open Soc…

### DIFF
--- a/themes/socialbase/components/03-molecules/form-elements/inline-form-error.twig
+++ b/themes/socialbase/components/03-molecules/form-elements/inline-form-error.twig
@@ -2,8 +2,10 @@
   <label class="control-label" for="exampleInputEmail1">Email address</label><span class="form-required">*</span>
   <input type="email" id="exampleInputEmail1" required class="form-control" placeholder="Enter email">
   <div class="form-item--error-message alert alert-danger alert-sm alert-dismissible form-control-radius">
-    <a href="#" role="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">×</span></a>
     Email field is required.
+    <button type="button" class="close" data-dismiss="alert" aria-label="{{ "Close"|t }}">
+      <span aria-hidden="true">×</span>
+    </button>
   </div>
   <div class="help-block">We'll never share your email with anyone else.</div>
 </div>

--- a/themes/socialbase/templates/form/datetime-wrapper.html.twig
+++ b/themes/socialbase/templates/form/datetime-wrapper.html.twig
@@ -38,8 +38,10 @@
 {{ content }}
 {% if errors %}
   <div class="form-item--error-message alert alert-danger alert-sm alert-dismissible form-control-radius">
-    <a href="#" role="button" class="close" data-dismiss="alert" aria-label="{{ 'Close'|t }}"><span aria-hidden="true">&times;</span></a>
     {{ errors }}
+    <button type="button" class="close" data-dismiss="alert" aria-label="{{ "Close"|t }}">
+      <span aria-hidden="true">&times;</span>
+    </button>
   </div>
   <br />
 {% endif %}

--- a/themes/socialbase/templates/form/fieldset.html.twig
+++ b/themes/socialbase/templates/form/fieldset.html.twig
@@ -63,8 +63,10 @@
 
   {% if errors %}
     <div class="form-item--error-message alert alert-danger alert-sm alert-dismissible form-control-radius">
-      <a href="#" role="button" class="close" data-dismiss="alert" aria-label="{{ 'Close'|t }}"><span aria-hidden="true">&times;</span></a>
       {{ errors }}
+      <button type="button" class="close" data-dismiss="alert" aria-label="{{ "Close"|t }}">
+        <span aria-hidden="true">×</span>
+      </button>
     </div>
   {% endif %}
 

--- a/themes/socialbase/templates/form/form-element.html.twig
+++ b/themes/socialbase/templates/form/form-element.html.twig
@@ -97,8 +97,10 @@
 
   {% if errors %}
     <div class="form-item--error-message alert alert-danger alert-sm alert-dismissible form-control-radius">
-      <a href="#" role="button" class="close" data-dismiss="alert" aria-label="{{ 'Close'|t }}"><span aria-hidden="true">&times;</span></a>
       {{ errors }}
+      <button type="button" class="close" data-dismiss="alert" aria-label="{{ "Close"|t }}">
+        <span aria-hidden="true">&times;</span>
+      </button>
     </div>
   {% endif %}
 

--- a/themes/socialbase/templates/system/status-messages.html.twig
+++ b/themes/socialbase/templates/system/status-messages.html.twig
@@ -50,8 +50,7 @@
     'card-radius',
   ]
 %}
-<div{{ attributes.addClass(classes) }} role="alert">
-  <a href="#" role="button" class="close" data-dismiss="alert" aria-label="{{ 'Close'|t }}"><span aria-hidden="true">&times;</span></a>
+<div{{ attributes.addClass(classes) }}>
   {% if status_headings[type] %}
     <h4 class="sr-only">{{ status_headings[type] }}</h4>
   {% endif %}
@@ -66,5 +65,9 @@
   {% endif %}
   {# Remove type specific classes. #}
   {% set attributes = attributes.removeClass(classes) %}
+
+  <button type="button" class="close" data-dismiss="alert" aria-label="{{ "Close"|t }}">
+    <span aria-hidden="true">&times;</span>
+  </button>
 </div>
 {% endfor %}


### PR DESCRIPTION
…ial are inaccessible

<h3 id="summary-problem-motivation">Problem/Motivation</h3>
Alerts have a clickable dismiss icon. However, we use a link tag (<code>a</code>) instead of a button (<code>button</code>) element for these dismiss buttons. This causes them not to be included in standard keyboard navigation.

Additionally the close button is usually at the start of the alert which is confusing for people using screenreaders. The close button is announced before the content that it closes.

The system messages alert implementation also adds the <code>role="alert"</code> which should not be used for our alert messages but should be used for warnings that are updated in real-time (for example for interaction using JavaScript). This is not the case for our system messages or form errors.

From: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/Alert_Role
<blockquote>The most important thing to know about the alert role is that it is for dynamic content. It is perfect for situations such as when a user fills out a form and JavaScript is used to add an error message - the alert would immediately read out the message. It should not be used on HTML where the user hasn't interacted with it. For example, if a page loads with multiple visible alerts scattered throughout, none would be read because they are not dynamically triggered. </blockquote>

<h4 id="summary-steps-reproduce">Steps to reproduce</h4>
Go to the user login page and fill in an incorrect username or password. You now see an alert telling you your login credentials are invalid. Pressing the tab keys you're unable to select the little cross for the alerts that allows you to dismiss the alerts.

<h3 id="summary-proposed-resolution">Proposed resolution</h3>
In the following files in socialbase:
<ul>
<li>fieldset.html.twig</li>
<li>alert.twig</li>
<li>inline-form-error.twig</li>
<li>datetime-wrapper.html.twig</li>
<li>form-element.html.twig</li>
<li>status-messages.html.twig</li>
</ul>

<ul>
<li>Change the element for the close icon from a link to a button.</li>
<li>Move the button beneath the alert content</li>
<li>Ensure the alert container does not have a <code>role="alert"</code> attribute</li>
</ul>

The files with the <code>.twig</code> extension are for the styleguide and do not need renaming.

## Issue tracker
* https://www.drupal.org/project/social/issues/3171775

## Screenshots
N.a.

## Release notes
Alerts are now properly dismissible with the keyboard. Additionally, assistive technology will read the contents of the alert before suggesting to dismiss it.

## Change Record
N.a.

## Translations
N.a.