### PR TITLE
Issue #3108608 - Stability of Ajax comments

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -101,7 +101,7 @@
                 "Make sure lazy doesnt do anything on cron": "https://www.drupal.org/files/issues/2019-07-30/3071331-lazy-cron-empty-path-2.patch"
             },
             "drupal/ajax_comments": {
-                "Fix display mode issue": "https://www.drupal.org/files/issues/2020-10-07/ajax_comments-ajax_not_working_when_using_non_default_view_mode-2896916-34.patch"
+                "Fix display mode issue": "https://www.drupal.org/files/issues/2020-10-19/ajax_comments-ajax_not_working_when_using_non_default_view_mode-2896916-37-beta1.patch"
             },
             "drupal/field_group": {
                 "Undefined property: stdClass::$region in field_group_form_process().": "https://www.drupal.org/files/issues/2020-06-15/3059614-37.patch"

--- a/composer.json
+++ b/composer.json
@@ -101,7 +101,7 @@
                 "Make sure lazy doesnt do anything on cron": "https://www.drupal.org/files/issues/2019-07-30/3071331-lazy-cron-empty-path-2.patch"
             },
             "drupal/ajax_comments": {
-                "Fix display mode issue": "https://www.drupal.org/files/issues/2019-11-05/ajax_comments-ajax_not_working_when_using_non_default_view_mode-2896916-22.patch"
+                "Fix display mode issue": "https://www.drupal.org/files/issues/2020-10-07/ajax_comments-ajax_not_working_when_using_non_default_view_mode-2896916-34.patch"
             },
             "drupal/field_group": {
                 "Undefined property: stdClass::$region in field_group_form_process().": "https://www.drupal.org/files/issues/2020-06-15/3059614-37.patch"

--- a/modules/custom/social_ajax_comments/social_ajax_comments.info.yml
+++ b/modules/custom/social_ajax_comments/social_ajax_comments.info.yml
@@ -2,6 +2,6 @@ name: Social Ajax Comments
 type: module
 description: Integration with Ajax Comments.
 core: 8.x
-package: Social (experimental)
+package: Social
 dependencies:
   - ajax_comments:ajax_comments

--- a/modules/custom/social_ajax_comments/social_ajax_comments.module
+++ b/modules/custom/social_ajax_comments/social_ajax_comments.module
@@ -129,4 +129,4 @@ function social_ajax_comments_ajax_comments_wrapper_id_alter(&$wrapper_html_id, 
       $commented_entity->getEntityTypeId() . '-' . $commented_entity->bundle() . '-' . 'field_post_comments' . '-' . $commented_entity->id()
     );
   }
-} interdiff > interdiff_30-34.txt
+}

--- a/modules/custom/social_ajax_comments/social_ajax_comments.module
+++ b/modules/custom/social_ajax_comments/social_ajax_comments.module
@@ -72,6 +72,24 @@ function social_ajax_comments_form_comment_post_comment_delete_form_alter(&$form
 }
 
 /**
+ * Implements hook_form_alter().
+ */
+function social_ajax_comments_form_comment_comment_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+  // If AJAX is enabled on the form.
+  if ($form_state->getUserInput()['_drupal_ajax']) {
+    // Grab the Comment from the Form Object to see if it has a parent.
+    // this means its a reply so we can add proper classes.
+    /** @var \Drupal\comment\CommentInterface $comment */
+    $comment = $form_state->getFormObject()->getEntity();
+    // For viewing comments the prefix is added in SocialCommentViewBuilder.
+    if (!empty($comment->getParentComment())) {
+      $form['#prefix'] = '<div class="comments">';
+      $form['#suffix'] = '<div>';
+    }
+  }
+}
+
+/**
  * Implements hook_form_FORM_ID_alter().
  *
  * Triggers on form for deleting a comment on a node.

--- a/modules/custom/social_ajax_comments/social_ajax_comments.module
+++ b/modules/custom/social_ajax_comments/social_ajax_comments.module
@@ -13,7 +13,6 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Url;
 use Drupal\node\Entity\Node;
 use Drupal\social_post\Entity\Post;
-use Drupal\Core\Entity\EntityInterface;
 
 /**
  * Implements hook_entity_display_build_alter().

--- a/modules/custom/social_ajax_comments/social_ajax_comments.module
+++ b/modules/custom/social_ajax_comments/social_ajax_comments.module
@@ -72,24 +72,6 @@ function social_ajax_comments_form_comment_post_comment_delete_form_alter(&$form
 }
 
 /**
- * Implements hook_form_alter().
- */
-function social_ajax_comments_form_comment_comment_form_alter(&$form, FormStateInterface $form_state, $form_id) {
-  // If AJAX is enabled on the form.
-  if ($form_state->getUserInput()['_drupal_ajax']) {
-    // Grab the Comment from the Form Object to see if it has a parent.
-    // this means its a reply so we can add proper classes.
-    /** @var \Drupal\comment\CommentInterface $comment */
-    $comment = $form_state->getFormObject()->getEntity();
-    // For viewing comments the prefix is added in SocialCommentViewBuilder.
-    if ($comment->hasParentComment()) {
-      $form['#prefix'] = '<div class="comments">';
-      $form['#suffix'] = '<div>';
-    }
-  }
-}
-
-/**
  * Implements hook_form_FORM_ID_alter().
  *
  * Triggers on form for deleting a comment on a node.

--- a/modules/custom/social_ajax_comments/social_ajax_comments.module
+++ b/modules/custom/social_ajax_comments/social_ajax_comments.module
@@ -82,7 +82,7 @@ function social_ajax_comments_form_comment_comment_form_alter(&$form, FormStateI
     /** @var \Drupal\comment\CommentInterface $comment */
     $comment = $form_state->getFormObject()->getEntity();
     // For viewing comments the prefix is added in SocialCommentViewBuilder.
-    if (!empty($comment->getParentComment())) {
+    if ($comment->hasParentComment()) {
       $form['#prefix'] = '<div class="comments">';
       $form['#suffix'] = '<div>';
     }

--- a/modules/custom/social_ajax_comments/social_ajax_comments.module
+++ b/modules/custom/social_ajax_comments/social_ajax_comments.module
@@ -86,45 +86,6 @@ function social_ajax_comments_form_comment_comment_delete_form_alter(&$form, For
 }
 
 /**
- * Implements hook_entity_view_mode_alter().
- */
-function social_ajax_comments_entity_view_mode_alter(&$view_mode, EntityInterface $entity, $context) {
-  // We need this to alter the view modes for Nodes as ajax_comments
-  // doesn't handle this correctly. And will add it as activity.
-  /** @var \Drupal\ajax_comments\FieldSettingsHelper $field_settings_helper */
-  $field_settings_helper = \Drupal::service('ajax_comments.field_settings_helper');
-
-  // We lookup through the node fields
-  // and check out that the attached file was provided.
-  $nodeFields = \Drupal::service('entity_field.manager')->getFieldDefinitions($entity->getEntityTypeId(), $entity->bundle());
-  foreach ($nodeFields as $nodeField) {
-    if ($nodeField->getType() === 'comment') {
-      // Load the configuration entity for the entity's view display settings.
-      /** @var \Drupal\Core\Entity\Display\EntityDisplayInterface $view_display */
-      $view_display = \Drupal::service('entity_type.manager')
-        ->getStorage('entity_view_display')
-        ->load($entity->getEntityTypeId() . '.' . $entity->bundle() . '.' . $view_mode);
-
-      if (empty($view_display)) {
-        continue;
-      }
-      $comment_formatter = $field_settings_helper->getFieldFormatter($view_display, $nodeField->getName(), $nodeField, $view_mode);
-
-      if (!empty($comment_formatter) && $field_settings_helper->isEnabled($comment_formatter)) {
-        /** @var \Drupal\ajax_comments\TempStore $tempStore */
-        $tempStore = \Drupal::service('ajax_comments.temp_store');
-        $route_match = \Drupal::routeMatch();
-        if ($entity instanceof Node && $route_match->getRouteName() === 'entity.node.canonical') {
-          $view_mode = 'default';
-        }
-        $tempStore->setViewMode($entity->getEntityType()->getLabel(), $view_mode);
-      }
-    }
-  }
-
-}
-
-/**
  * Implements hook_comment_links_alter().
  *
  * Alter the links of a comment.
@@ -168,4 +129,4 @@ function social_ajax_comments_ajax_comments_wrapper_id_alter(&$wrapper_html_id, 
       $commented_entity->getEntityTypeId() . '-' . $commented_entity->bundle() . '-' . 'field_post_comments' . '-' . $commented_entity->id()
     );
   }
-}
+} interdiff > interdiff_30-34.txt

--- a/modules/custom/social_ajax_comments/social_ajax_comments.routing.yml
+++ b/modules/custom/social_ajax_comments/social_ajax_comments.routing.yml
@@ -1,10 +1,19 @@
-social_ajax_comments.unpublish:
-  path: '/ajax_comments/{comment}/unpublish'
+social_ajax_comments.cancel:
+  path: '/ajax_comments/{cid}/cancel'
   defaults:
-    _controller: 'Drupal\social_ajax_comments\Controller\AjaxCommentsController::unpublish'
+    _controller: '\Drupal\social_ajax_comments\Controller\AjaxCommentsController::socialCancel'
   requirements:
-    _permission: 'administer comments'
+    _access: 'TRUE'
+    cid: ^[0-9]+
+
+social_ajax_comments.add:
+  path: '/ajax_comments/add/{entity_type}/{entity}/{field_name}/{pid}'
+  defaults:
+    _controller: '\Drupal\social_ajax_comments\Controller\AjaxCommentsController::socialAdd'
+    pid: ~
+  requirements:
+    _access: 'TRUE'
   options:
     parameters:
-      comment:
-        type: entity:comment
+      entity:
+        type: entity:{entity_type}

--- a/modules/custom/social_ajax_comments/social_ajax_comments.services.yml
+++ b/modules/custom/social_ajax_comments/social_ajax_comments.services.yml
@@ -1,0 +1,5 @@
+services:
+  social_ajax_comments.route_subscriber:
+    class: Drupal\social_ajax_comments\Routing\RouteSubscriber
+    tags:
+      - { name: event_subscriber }

--- a/modules/custom/social_ajax_comments/src/Controller/AjaxCommentsController.php
+++ b/modules/custom/social_ajax_comments/src/Controller/AjaxCommentsController.php
@@ -47,7 +47,7 @@ class AjaxCommentsController extends ContribController {
 
     // Replace the # from the form_html_id selector and add .social_ so we know
     // that we are sure we are just removing our specific form class.
-    $social_form_id = str_replace('#', '.social_', $form_html_id);
+    $social_form_id = str_replace('#', '.social_reply_form_wrapper_', $form_html_id);
     // Remove the form, based on $variables['comment_wrapper'] in form.inc.
     $response->addCommand(new RemoveCommand($social_form_id));
 

--- a/modules/custom/social_ajax_comments/src/Controller/AjaxCommentsController.php
+++ b/modules/custom/social_ajax_comments/src/Controller/AjaxCommentsController.php
@@ -2,8 +2,10 @@
 
 namespace Drupal\social_ajax_comments\Controller;
 
-use Drupal\comment\CommentInterface;
 use Drupal\Core\Ajax\AjaxResponse;
+use Drupal\Core\Ajax\InvokeCommand;
+use Drupal\Core\Ajax\RemoveCommand;
+use Drupal\Core\Entity\EntityInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Drupal\ajax_comments\Controller\AjaxCommentsController as ContribController;
 
@@ -13,45 +15,183 @@ use Drupal\ajax_comments\Controller\AjaxCommentsController as ContribController;
 class AjaxCommentsController extends ContribController {
 
   /**
-   * Builds ajax response for unpublishing a comment.
+   * Cancel handler for the cancel form.
    *
    * @param \Symfony\Component\HttpFoundation\Request $request
    *   The current request object.
-   * @param \Drupal\comment\CommentInterface $comment
-   *   The comment entity.
+   * @param int $cid
+   *   The id of the comment being edited, or 0 if this is a new comment.
    *
    * @return \Drupal\Core\Ajax\AjaxResponse
    *   The Ajax response.
    */
-  public function unpublish(Request $request, CommentInterface $comment) {
+  public function socialCancel(Request $request, $cid) {
+    // This is based on AjaxCommentsController::cancel.
+    // the only change is we have some more wrappers we need to remove,
+    // we can't tell this to ajax_comments because we render it in our template
+    // so instead we will just remove whatever we need.
+    $response = new AjaxResponse();
+
+    // Get the selectors.
+    $selectors = $this->tempStore->getSelectors($request, $overwrite = TRUE);
+    $wrapper_html_id = $selectors['wrapper_html_id'];
+    $form_html_id = $selectors['form_html_id'];
+
+    if ($cid != 0) {
+      // Show the hidden anchor.
+      $response->addCommand(new InvokeCommand('a#comment-' . $cid, 'show', [200, 'linear']));
+
+      // Show the hidden comment.
+      $response->addCommand(new InvokeCommand(static::getCommentSelectorPrefix() . $cid, 'show', [200, 'linear']));
+    }
+
+    // Replace the # from the form_html_id selector and add .social_ so we know
+    // that we are sure we are just removing our specific form class.
+    $social_form_id = str_replace('#', '.social_', $form_html_id);
+    // Remove the form, based on $variables['comment_wrapper'] in form.inc.
+    $response->addCommand(new RemoveCommand($social_form_id));
+
+    // Remove any messages, if applicable.
+    $response->addCommand(new RemoveCommand($wrapper_html_id . ' .js-ajax-comments-messages'));
+
+    // Clear out the tempStore variables.
+    $this->tempStore->deleteAll();
+
+    return $response;
+  }
+
+  /**
+   * Builds ajax response for adding a new comment without a parent comment.
+   *
+   * This is copied from AjaxCommentsController::add because a reply on
+   * a reply is using the add new Form with a mention. While Ajax comments uses
+   * the save function for a reply. This results in status message not being
+   * rendered correctly.
+   * The only change here is the addMessage is placed above the reply.
+   *
+   * @param \Symfony\Component\HttpFoundation\Request $request
+   *   The current request object.
+   * @param \Drupal\Core\Entity\EntityInterface $entity
+   *   The entity this comment belongs to.
+   * @param string $field_name
+   *   The field_name to which the comment belongs.
+   * @param int $pid
+   *   (optional) Some comments are replies to other comments. In those cases,
+   *   $pid is the parent comment's comment ID. Defaults to NULL.
+   *
+   * @return \Drupal\Core\Ajax\AjaxResponse
+   *   The Ajax response.
+   *
+   * @see \Drupal\comment\Controller\CommentController::getReplyForm()
+   */
+  public function socialAdd(Request $request, EntityInterface $entity, $field_name, $pid = NULL) {
     $response = new AjaxResponse();
 
     // Store the selectors from the incoming request, if applicable.
     // If the selectors are not in the request, the stored ones will
     // not be overwritten.
+    $this->tempStore->getSelectors($request, $overwrite = TRUE);
+
+    // Check the user's access to reply.
+    // The user should not have made it this far without proper permission,
+    // but adding this access check as a fallback.
+    $this->replyAccess($request, $response, $entity, $field_name, $pid);
+
+    // If $this->replyAccess() added any commands to the AjaxResponse,
+    // it means that access was denied, so we should NOT submit the form
+    // and rebuild the comment field. Just return the response with the
+    // error message.
+    if (!empty($response->getCommands())) {
+      return $response;
+    }
+
+    // Build the comment entity form.
+    // This approach is very similar to the one taken in
+    // \Drupal\comment\CommentLazyBuilders::renderForm().
+    $comment = $this->entityTypeManager()->getStorage('comment')->create([
+      'entity_id' => $entity->id(),
+      'pid' => $pid,
+      'entity_type' => $entity->getEntityTypeId(),
+      'field_name' => $field_name,
+    ]);
+
     // Rebuild the form to trigger form submission.
-    $this->tempStore->setSelector('form_html_id', 'node-topic-field-topic-comments');
-    $comment->setUnpublished();
+    $form = $this->entityFormBuilder()->getForm($comment);
 
-    // Build the updated comment field and insert into a replaceWith response.
-    // Also prepend any status messages in the response.
-    $response = $this->buildCommentFieldResponse(
-      $request,
-      $response,
-      $comment->getCommentedEntity(),
-      $comment->get('field_name')->value
-    );
+    // Check for errors.
+    if (empty(drupal_get_messages('error', FALSE))) {
+      // If there are no errors, set the ajax-updated
+      // selector value for the form.
+      $this->tempStore->setSelector('form_html_id', $form['#attributes']['id']);
 
-    // Add message to the existing comment.
-    $response = $this->addMessages(
-      $request,
-      $response,
-      static::getCommentSelectorPrefix() . $comment->id(),
-      'before'
-    );
+      // Build the updated comment field and insert into a replaceWith
+      // response.
+      $response = $this->buildCommentFieldResponse(
+        $request,
+        $response,
+        $entity,
+        $field_name
+      );
+    }
+    else {
+      // Retrieve the selector values for use in building the response.
+      $selectors = $this->tempStore->getSelectors($request, $overwrite = TRUE);
+      $wrapper_html_id = $selectors['wrapper_html_id'];
+
+      // If there are errors, remove old messages.
+      $response->addCommand(new RemoveCommand($wrapper_html_id . ' .js-ajax-comments-messages'));
+    }
+
+    // This ensures for a reply we will render the comment above the reply.
+    if ($comment->isNew()) {
+      // Retrieve the comment id of the new comment, which was saved in
+      // AjaxCommentsForm::save() during the previous HTTP request.
+      $cid = $this->tempStore->getCid();
+
+      // Try to insert the message above the new comment.
+      if (!empty($cid) && !$errors && \Drupal::currentUser()->hasPermission('skip comment approval')) {
+        $selector = static::getCommentSelectorPrefix() . $cid;
+        $response = $this->addMessages(
+          $request,
+          $response,
+          $selector,
+          'before'
+        );
+      }
+      // If the new comment is not to be shown immediately, or if there are
+      // errors, insert the message directly below the parent comment.
+      else {
+        $response = $this->addMessages(
+          $request,
+          $response,
+          static::getCommentSelectorPrefix() . $comment->get('pid')->target_id,
+          'after'
+        );
+      }
+    }
 
     // Clear out the tempStore variables.
     $this->tempStore->deleteAll();
+
+    // Remove the libraries from the response, otherwise when
+    // core/misc/drupal.js is reinserted into the DOM, the following line of
+    // code will execute, causing Drupal.attachBehaviors() to run on the entire
+    // document, and reattach behaviors to DOM elements that already have them:
+    // @code
+    // // Attach all behaviors.
+    // domready(function(){Drupal.attachBehaviors(document,drupalSettings);});
+    // @endcode
+    $attachments = $response->getAttachments();
+    // Need to have only 'core/drupalSettings' in the asset library list.
+    // If neither 'core/drupalSettings', nor a library with a dependency on it,
+    // is in the list of libraries, drupalSettings will be stripped out of the
+    // ajax response by \Drupal\Core\Asset\AssetResolver::getJsAssets().
+    $attachments['library'] = ['core/drupalSettings'];
+    // We need to keep the drupalSettings in the response, otherwise the
+    // #ajax properties in the form definition won't be properly attached to
+    // the rebuilt comment field returned in the ajax response, and subsequent
+    // ajax interactions will be broken.
+    $response->setAttachments($attachments);
 
     return $response;
   }

--- a/modules/custom/social_ajax_comments/src/Routing/RouteSubscriber.php
+++ b/modules/custom/social_ajax_comments/src/Routing/RouteSubscriber.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Drupal\social_ajax_comments\Routing;
+
+use Drupal\Core\Routing\RouteSubscriberBase;
+use Symfony\Component\Routing\RouteCollection;
+
+/**
+ * Listens to the dynamic route events.
+ */
+class RouteSubscriber extends RouteSubscriberBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function alterRoutes(RouteCollection $collection) {
+    // Replace "ajax_comments.cancel" with our implementation.
+    // We need this custom implementation because we need to remove and invoke
+    // additional ajax commands due to our theme.
+    if ($route = $collection->get('ajax_comments.cancel')) {
+      $route->setDefaults([
+        '_controller' => '\Drupal\social_ajax_comments\Controller\AjaxCommentsController::socialCancel',
+      ]);
+    }
+
+    // Replace "ajax_comments.add" with our implementation.
+    // We need this custom implementation because we don't use reply on a reply
+    // the same way as comments do. We use reply on a reply by using the normal
+    // add form with a mention. Therefor we need to override the message display
+    // so ajax comments understands where to put the status message.
+    if ($route = $collection->get('ajax_comments.add')) {
+      $route->setDefaults([
+        '_controller' => '\Drupal\social_ajax_comments\Controller\AjaxCommentsController::socialAdd',
+      ]);
+    }
+  }
+
+}

--- a/modules/custom/social_ajax_comments/src/Routing/RouteSubscriber.php
+++ b/modules/custom/social_ajax_comments/src/Routing/RouteSubscriber.php
@@ -18,9 +18,9 @@ class RouteSubscriber extends RouteSubscriberBase {
     // We need this custom implementation because we need to remove and invoke
     // additional ajax commands due to our theme.
     if ($route = $collection->get('ajax_comments.cancel')) {
-      $route->setDefaults([
-        '_controller' => '\Drupal\social_ajax_comments\Controller\AjaxCommentsController::socialCancel',
-      ]);
+      $defaults = $route->getDefaults();
+      $defaults['_controller'] = '\Drupal\social_ajax_comments\Controller\AjaxCommentsController::socialCancel';
+      $route->setDefaults($defaults);
     }
 
     // Replace "ajax_comments.add" with our implementation.
@@ -29,9 +29,9 @@ class RouteSubscriber extends RouteSubscriberBase {
     // add form with a mention. Therefor we need to override the message display
     // so ajax comments understands where to put the status message.
     if ($route = $collection->get('ajax_comments.add')) {
-      $route->setDefaults([
-        '_controller' => '\Drupal\social_ajax_comments\Controller\AjaxCommentsController::socialAdd',
-      ]);
+      $defaults = $route->getDefaults();
+      $defaults['_controller'] = '\Drupal\social_ajax_comments\Controller\AjaxCommentsController::socialAdd';
+      $route->setDefaults($defaults);
     }
   }
 

--- a/modules/social_features/social_comment/src/SocialCommentLazyRenderer.php
+++ b/modules/social_features/social_comment/src/SocialCommentLazyRenderer.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\social_comment;
 
+use Drupal\ajax_comments\Utility;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 
 /**
@@ -60,7 +61,14 @@ class SocialCommentLazyRenderer {
       return [];
     }
 
-    return $this->entityTypeManager->getViewBuilder('comment')->viewMultiple($comments);
+    $build_comments = $this->entityTypeManager->getViewBuilder('comment')->viewMultiple($comments);
+    // Since we are rendering it as lazy builder, make sure we attach classes
+    // required by ajax_comments. In order to render reply forms etc.
+    if (!empty($build_comments) && \Drupal::moduleHandler()->moduleExists('ajax_comments')) {
+      Utility::addCommentClasses($build_comments);
+    }
+
+    return $build_comments;
   }
 
 }

--- a/modules/social_features/social_mentions/js/social_mentions.js
+++ b/modules/social_features/social_mentions/js/social_mentions.js
@@ -146,14 +146,23 @@
             mentionsInput = $textarea.data("mentionsInput"),
             editor = CKEDITOR.instances[$textarea.attr("id")];
 
-          $(".comments .comment__reply-btn a").on("click", function () {
-            $("html, body").animate({
-              scrollTop: $("[data-drupal-selector=\"comment-form\"]").offset().top
-            }, 1000)
-          });
+          if (typeof $("[data-drupal-selector=\"comment-form\"]").offset() !== "undefined") {
+            $(".comments .comment__reply-btn a").on("click", function () {
+              $("html, body").animate({
+                scrollTop: $("[data-drupal-selector=\"comment-form\"]").offset().top
+              }, 1000)
+            });
+          }
 
           $(".mention-reply").on("click", function (e) {
             e.preventDefault();
+            // Make sure we remove any open reply comment forms,
+            // we want to add "replying" to main comment form.
+            // we ensure this class is only added to reply forms in
+            // socialbase/includes/form.inc.
+            $(".ajax-comments-form-reply").once("socialMentionsReplyFormClose").each(function (i, e) {
+              $(this).remove();
+            });
 
             var author = $(this).data("author");
 

--- a/modules/social_features/social_mentions/js/social_mentions.js
+++ b/modules/social_features/social_mentions/js/social_mentions.js
@@ -150,9 +150,19 @@
             $(".comments .comment__reply-btn a").on("click", function () {
               $("html, body").animate({
                 scrollTop: $("[data-drupal-selector=\"comment-form\"]").offset().top
-              }, 1000)
+              }, 1000);
             });
           }
+
+          // Make sure we remove any open reply comment forms,
+          // we want to add "replying" to main comment form.
+          // we ensure this class is only added to reply forms in
+          // socialbase/includes/form.inc.
+          $(".js-comment .comment__reply-btn a").on("click", function () {
+            $(".ajax-comments-form-reply").once("socialMentionsReplyFormClose").each(function (i, e) {
+              $(this).remove();
+            });
+          });
 
           $(".mention-reply").on("click", function (e) {
             e.preventDefault();
@@ -160,7 +170,7 @@
             // we want to add "replying" to main comment form.
             // we ensure this class is only added to reply forms in
             // socialbase/includes/form.inc.
-            $(".ajax-comments-form-reply").once("socialMentionsReplyFormClose").each(function (i, e) {
+            $(".ajax-comments-form-reply").once("socialMentionsReplyOnReplyFormClose").each(function (i, e) {
               $(this).remove();
             });
 

--- a/modules/social_features/social_mentions/js/social_mentions.js
+++ b/modules/social_features/social_mentions/js/social_mentions.js
@@ -160,6 +160,7 @@
           // socialbase/includes/form.inc.
           $(".js-comment .comment__reply-btn a").on("click", function () {
             $(".ajax-comments-form-reply").once("socialMentionsReplyFormClose").each(function (i, e) {
+              $(this).parent('.comments').remove();
               $(this).remove();
             });
           });

--- a/themes/socialbase/includes/form.inc
+++ b/themes/socialbase/includes/form.inc
@@ -48,10 +48,10 @@ function socialbase_preprocess_form(&$variables) {
             ->getViewBuilder('profile')
             ->view($user_profile, 'compact');
           $variables['current_user_picture'] = $content;
+          $variables['comment_wrapper'] = new Attribute();
           // Used for example for ajax comments in form--comment.html.twig, see
           // Drupal\social_ajax_comments\Controller::socialCancel().
           if (!empty($element['form_html_id']['#value'])) {
-            $variables['comment_wrapper'] = new Attribute();
             $variables['comment_wrapper']->addClass('social_' . $element['form_html_id']['#value']);
             // Only on reply ajax call add another class.
             // we need this class so ajax_comments understand to remove this

--- a/themes/socialbase/includes/form.inc
+++ b/themes/socialbase/includes/form.inc
@@ -49,15 +49,18 @@ function socialbase_preprocess_form(&$variables) {
             ->view($user_profile, 'compact');
           $variables['current_user_picture'] = $content;
           $variables['comment_wrapper'] = new Attribute();
+          $variables['comment_reply_form_wrapper'] = new Attribute();
           // Used for example for ajax comments in form--comment.html.twig, see
           // Drupal\social_ajax_comments\Controller::socialCancel().
           if (!empty($element['form_html_id']['#value'])) {
             $variables['comment_wrapper']->addClass('social_' . $element['form_html_id']['#value']);
-            // Only on reply ajax call add another class.
+            // Only on reply ajax call add another class and wrapper.
             // we need this class so ajax_comments understand to remove this
             // element so there wont be multiple reply forms opened.
             if (!empty($element['#action']) && strpos($element['#action'], 'ajax_comments/reply') !== FALSE) {
-              $variables['comment_wrapper']->addClass('ajax-comments-form-reply');
+              $variables['comment_reply_form_wrapper']->addClass('ajax-comments-form-reply');
+              $variables['comment_reply_form_wrapper']->addClass('comments');
+              $variables['comment_reply_form_wrapper']->addClass('social_reply_form_wrapper_' . $element['form_html_id']['#value']);
             }
           }
         }

--- a/themes/socialbase/includes/form.inc
+++ b/themes/socialbase/includes/form.inc
@@ -7,6 +7,7 @@
 
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Link;
+use Drupal\Core\Template\Attribute;
 use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
 
 /**
@@ -47,6 +48,18 @@ function socialbase_preprocess_form(&$variables) {
             ->getViewBuilder('profile')
             ->view($user_profile, 'compact');
           $variables['current_user_picture'] = $content;
+          // Used for example for ajax comments in form--comment.html.twig, see
+          // Drupal\social_ajax_comments\Controller::socialCancel().
+          if (!empty($element['form_html_id']['#value'])) {
+            $variables['comment_wrapper'] = new Attribute();
+            $variables['comment_wrapper']->addClass('social_' . $element['form_html_id']['#value']);
+            // Only on reply ajax call add another class.
+            // we need this class so ajax_comments understand to remove this
+            // element so there wont be multiple reply forms opened.
+            if (!empty($element['#action']) && strpos($element['#action'], 'ajax_comments/reply') !== FALSE) {
+              $variables['comment_wrapper']->addClass('ajax-comments-form-reply');
+            }
+          }
         }
       }
     }

--- a/themes/socialbase/socialbase.theme
+++ b/themes/socialbase/socialbase.theme
@@ -89,23 +89,34 @@ function _socialbase_get_visibility_icon($title) {
  * Get comment count for a node.
  */
 function _socialbase_node_get_comment_count(Node $node, $comment_field_name) {
-  $count = 0;
+  $comment_count = &drupal_static(__FUNCTION__);
 
-  $cids = \Drupal::entityQuery('comment')
-    ->condition('entity_id', $node->id())
-    ->condition('entity_type', 'node')
-    ->sort('cid', 'DESC')
-    ->execute();
+  // Calculate the comment_count for this page request.
+  if (is_null($comment_count)) {
+    $count = 0;
 
-  $comments = Comment::loadMultiple($cids);
+    $cids = \Drupal::entityQuery('comment')
+      ->condition('entity_id', $node->id())
+      ->condition('entity_type', 'node')
+      ->sort('cid', 'DESC')
+      ->execute();
 
-  foreach ($comments as $comment) {
-    /* @var \Drupal\comment\Entity\Comment $comment */
-    if ($comment->isPublished()) {
-      // Published main comments or published replies on published main comments
-      // are counted for users without 'administer comments' permission.
-      if (!$comment->hasParentComment() || ($comment->hasParentComment() && $comment->getParentComment()->isPublished())) {
-        $count++;
+    $comments = Comment::loadMultiple($cids);
+
+    foreach ($comments as $comment) {
+      /* @var \Drupal\comment\Entity\Comment $comment */
+      if ($comment->isPublished()) {
+        // Published main comments or published replies on published main comments
+        // are counted for users without 'administer comments' permission.
+        if (!$comment->hasParentComment() || ($comment->hasParentComment() && $comment->getParentComment()
+              ->isPublished())) {
+          $count++;
+        }
+        elseif (\Drupal::currentUser()->hasPermission('administer comments')) {
+          // User with 'administer comments' permission can also see the comment
+          // as being unpublished, so let's count it.
+          $count++;
+        }
       }
       elseif (\Drupal::currentUser()->hasPermission('administer comments')) {
         // User with 'administer comments' permission can also see the comment
@@ -113,14 +124,13 @@ function _socialbase_node_get_comment_count(Node $node, $comment_field_name) {
         $count++;
       }
     }
-    elseif (\Drupal::currentUser()->hasPermission('administer comments')) {
-      // User with 'administer comments' permission can also see the comment
-      // as being unpublished, so let's count it.
-      $count++;
-    }
+
+    // Make sure our static cache knows it doesnt have to recalculate it this
+    // request.
+    $comment_count = $count;
   }
 
-  return $count;
+  return $comment_count;
 }
 
 /**

--- a/themes/socialbase/socialbase.theme
+++ b/themes/socialbase/socialbase.theme
@@ -105,11 +105,11 @@ function _socialbase_node_get_comment_count(Node $node, $comment_field_name) {
 
     foreach ($comments as $comment) {
       /* @var \Drupal\comment\Entity\Comment $comment */
+      // Published main comments or published replies on published main comments
+      // are counted for users without 'administer comments' permission.
       if ($comment->isPublished()) {
-        // Published main comments or published replies on published main comments
-        // are counted for users without 'administer comments' permission.
-        if (!$comment->hasParentComment() || ($comment->hasParentComment() && $comment->getParentComment()
-              ->isPublished())) {
+        if (!$comment->hasParentComment() ||
+          ($comment->hasParentComment() && $comment->getParentComment()->isPublished())) {
           $count++;
         }
         elseif (\Drupal::currentUser()->hasPermission('administer comments')) {

--- a/themes/socialbase/src/Plugin/Preprocess/Field.php
+++ b/themes/socialbase/src/Plugin/Preprocess/Field.php
@@ -54,26 +54,25 @@ class Field extends PreprocessBase {
           $element[1]['#url']->setOptions($url_options_1);
         }
         break;
-
-      // Adds the comment title with the amount of comments, done in here
-      // so Ajax can also update this title. Node preprocess doesn't get called
-      // when Ajax updates the below fields.
-      case 'field_topic_comments':
-      case 'field_event_comments':
-        // Grab the attached Event or Topic.
-        $attached = $element->getArray();
-        $node = !empty($attached['#object']) ? $attached['#object'] : NULL;
-        // Count the amount of comments placed on a Node..
-        if ($node instanceof Node) {
-          $comment_count = _socialbase_node_get_comment_count($node, $element['#field_name']);
-          // Add it to the title.
-          $variables['comment_count'] = $comment_count;
-        }
-        break;
     }
 
     if ($element['#view_mode'] == 'teaser') {
       $variables['part_of_teaser'] = TRUE;
+    }
+
+    // Adds the comment title with the amount of comments, done in here
+    // so Ajax can also update this title. Node preprocess doesn't get called
+    // when Ajax updates the below fields.
+    if ($element['#field_type'] === 'comment') {
+      // Grab the attached Event or Topic.
+      $attached = $element->getArray();
+      $node = !empty($attached['#object']) ? $attached['#object'] : NULL;
+      // Count the amount of comments placed on a Node..
+      if ($node instanceof Node) {
+        $comment_count = _socialbase_node_get_comment_count($node, $element['#field_name']);
+        // Add it to the title.
+        $variables['comment_count'] = $comment_count;
+      }
     }
 
     switch ($element['#entity_type']) {

--- a/themes/socialbase/src/Plugin/Preprocess/Field.php
+++ b/themes/socialbase/src/Plugin/Preprocess/Field.php
@@ -5,6 +5,7 @@ namespace Drupal\socialbase\Plugin\Preprocess;
 use Drupal\bootstrap\Plugin\Preprocess\PreprocessBase;
 use Drupal\bootstrap\Utility\Element;
 use Drupal\bootstrap\Utility\Variables;
+use Drupal\node\Entity\Node;
 
 /**
  * Pre-processes variables for the "field" theme hook.
@@ -54,6 +55,21 @@ class Field extends PreprocessBase {
         }
         break;
 
+      // Adds the comment title with the amount of comments, done in here
+      // so Ajax can also update this title. Node preprocess doesn't get called
+      // when Ajax updates the below fields.
+      case 'field_topic_comments':
+      case 'field_event_comments':
+        // Grab the attached Event or Topic.
+        $attached = $element->getArray();
+        $node = !empty($attached['#object']) ? $attached['#object'] : NULL;
+        // Count the amount of comments placed on a Node..
+        if ($node instanceof Node) {
+          $comment_count = _socialbase_node_get_comment_count($node, $element['#field_name']);
+          // Add it to the title.
+          $variables['comment_count'] = $comment_count;
+        }
+        break;
     }
 
     if ($element['#view_mode'] == 'teaser') {

--- a/themes/socialbase/src/Plugin/Preprocess/Node.php
+++ b/themes/socialbase/src/Plugin/Preprocess/Node.php
@@ -170,7 +170,7 @@ class Node extends PreprocessBase {
       // comment count, and add the comment count to the node.
       if ($node->$comment_field_name->status != CommentItemInterface::HIDDEN) {
         $comment_count = _socialbase_node_get_comment_count($node, $comment_field_name);
-        $variables['below_content'][$comment_field_name]['#title'] = $comment_count === 0 ? t('Be the first one to comment') : t('Comments (:num_comments)', [':num_comments' => $comment_count]);
+        $variables['below_content'][$comment_field_name]['#title'] = $comment_count === 0 ? t('Be the first one to comment') : t('Comments');
 
         // If it's closed, we only show the comment section when there are
         // comments placed. Closed means we show comments but you are not able

--- a/themes/socialbase/templates/comment/field--comment.html.twig
+++ b/themes/socialbase/templates/comment/field--comment.html.twig
@@ -36,7 +36,7 @@
     {% if not label_hidden %}
       {{ title_prefix }}
       {# extra condition to add the count when Ajax is used see src/Plugin/Preprocess/Field.php #}
-      {% if comment_count is not empty %}
+      {% if comment_count is not empty and comment_count > 0 %}
         <h4{{ title_attributes.addClass('section-title') }}>{{ label }} ({{ comment_count }})</h4>
       {% else %}
         <h4{{ title_attributes.addClass('section-title') }}>{{ label }}</h4>

--- a/themes/socialbase/templates/comment/field--comment.html.twig
+++ b/themes/socialbase/templates/comment/field--comment.html.twig
@@ -35,7 +35,12 @@
 
     {% if not label_hidden %}
       {{ title_prefix }}
-      <h4{{ title_attributes.addClass('section-title') }}>{{ label }}</h4>
+      {# extra condition to add the count when Ajax is used see src/Plugin/Preprocess/Field.php #}
+      {% if comment_count is not empty %}
+        <h4{{ title_attributes.addClass('section-title') }}>{{ label }} ({{ comment_count }})</h4>
+      {% else %}
+        <h4{{ title_attributes.addClass('section-title') }}>{{ label }}</h4>
+      {% endif %}
       {{ title_suffix }}
     {% endif %}
 

--- a/themes/socialbase/templates/comment/form--comment.html.twig
+++ b/themes/socialbase/templates/comment/form--comment.html.twig
@@ -22,6 +22,11 @@
     ]
 %}
 
+{# wrap our form for reply forms with indentation classes added in form.inc #}
+{% if comment_reply_form_wrapper is not empty %}
+<div {{ comment_reply_form_wrapper }}>
+{% endif %}
+
 <div {{ comment_wrapper.addClass(classes) }}>
   <div class="comment__avatar">{{ current_user_picture }}</div>
   <div class="comment__content">
@@ -32,3 +37,7 @@
     </form>
   </div>
 </div>
+
+{% if comment_reply_form_wrapper is not empty %}
+</div>
+{% endif %}

--- a/themes/socialbase/templates/comment/form--comment.html.twig
+++ b/themes/socialbase/templates/comment/form--comment.html.twig
@@ -13,7 +13,16 @@
  */
 #}
 {{ attach_library('socialbase/comment')}}
-<div class="js-comment comment comment-form__wrapper">
+
+{%
+    set classes = [
+        'js-comment',
+        'comment',
+        'comment-form__wrapper',
+    ]
+%}
+
+<div {{ comment_wrapper.addClass(classes) }}>
   <div class="comment__avatar">{{ current_user_picture }}</div>
   <div class="comment__content">
     <form{{ attributes }}>


### PR DESCRIPTION
## Problem
We have tried to solve several issues which were encountered when using Ajax comments.

1. Ajax comments breaks landing pages and dashboards, when using the Views block, content in de activity stream is rendered using a wrong display mode.
2. Ajax comments and the lazy builder do not work well together, see: 2018
3. Replying on a reply, or replying on a comment do not render correctly. Messages are in the wrong place.
4. Error with "top" undefined when clicking on the reply button

## Solution
Make sure we stabilize social_ajax_comments. Update the ajax_comments patch and help it being committed.

## Issue tracker
All the below should be fixed:
https://www.drupal.org/project/social/issues/3108608
https://www.drupal.org/project/social/issues/3167492

## How to test
- [ ] Enable social_landing_page
- [ ] Enable social_ajax_comment
- [ ] As LU+ we should be able to comment on a post, topic or node without a page refresh.

## Release notes
Ajax comments are now stable.