### PR TITLE
Issue #2946442 by basvanos, Kingdutch, xinyuma, ok_lyndsey, agami4: I…

### DIFF
--- a/modules/social_features/social_post/modules/social_post_photo/social_post_photo.module
+++ b/modules/social_features/social_post/modules/social_post_photo/social_post_photo.module
@@ -22,11 +22,13 @@ function social_post_photo_form_post_form_alter(&$form, FormStateInterface $form
  * Implements hook_photo_preprocess_image_formatter().
  */
 function social_post_photo_preprocess_image_formatter(&$variables) {
-  if ($variables['image_style'] == "social_post_photo" && empty($variables['image']['#alt'])) {
-    // Set the image alt to the filename.
-    $uri = $variables['image']['#uri'];
-    $alt = substr(strrchr($uri, "/"), 1);
-    $variables['image']['#alt'] = $alt;
+  if ($variables['image_style'] === "social_post_photo" && empty($variables['image']['#alt'])) {
+    // At the moment there is no good alt text for photos in posts and the posts
+    // are usually descriptive enough that the images can be considered
+    // decorative. To properly indicate this we include an empty string as
+    // alt-text. This is better than using the filename which is meaningless in
+    // most cases. See Issue #2946442.
+    $variables['image']['#alt'] = "";
   }
 }
 


### PR DESCRIPTION
…mages in a post don't have a useful alternatieve text

<h3>Problem </h3>
Images in the stream do not have a alternatieve text. The alternative text is used by a screen reader to read aloud the purpose of the image for a visually impaired user. A file name is rarely of use, as everything is read out, including underscore and slash.

<h3>Proposed solution</h3>
For the time being we propose to include images in posts with an empty alt-text. We see that in the majority of cases they are decorative in nature and accompany longer texts that can be understood and discussed without the images.

We understand that this is not an accessible end-point. In the future we wish to improve the image upload widgets to allow for alt-texts and contain a space to explain to users <a href="https://www.a11ywithlindsey.com/blog/writing-alternative-text-matters">how to write a proper alt-text</a>. However, we don't have the resources to make such an implementation at this time.

We believe that making the alt-texts of images in posts empty text (<code>""</code>) is at least an improvement from the current status quo which uses the filenames.


<img src="/files/issues/Schermafbeelding%202018-02-21%20om%2014.28.17.png" alt="Example of post " />


<h3>Reference</h3>
https://www.w3.org/WAI/WCAG20/quickref/?showtechniques=11

## Issue tracker
https://www.drupal.org/project/social/issues/2946442

## How to test
*For example*
- [ ] Create a photo in the stream
- [ ] See that a screenreader doesn't mention it.

## Screenshots
N.a.

## Release notes
Photo's in posts are now marked as decorative for assistive technology. Previously they would read out the file name which is unhelpful in most cases.

## Change Record
N.a.

## Translations
N.a.
