### PR TITLE
Issue #3171824 by Kingdutch, agami4: Some buttons don't have a text

### DIFF
--- a/themes/socialbase/templates/form/form.html.twig
+++ b/themes/socialbase/templates/form/form.html.twig
@@ -44,6 +44,7 @@
       <div class="form-group">
         <button class="btn--close-search-take-over" type="button">
           <svg class="icon-search-form-close">
+            <title>{% trans %}Close{% endtrans %}</title>
             <use xlink:href="#icon-close"></use>
           </svg>
         </button>

--- a/themes/socialbase/templates/private_message/private-message-thread.html.twig
+++ b/themes/socialbase/templates/private_message/private-message-thread.html.twig
@@ -56,6 +56,7 @@
           <div class="message__thread-actions btn-group">
             <button type="button" data-toggle="dropdown" aria-expanded="false" aria-haspopup="true" class="btn btn-icon-toggle dropdown-toggle">
               <svg class="btn-icon icon-gray">
+                <title>{% trans %}Actions for this thread{% endtrans %}</title>
                 <use xlink:href="#icon-expand_more"></use>
               </svg>
             </button>


### PR DESCRIPTION
<h3 id="summary-problem-motivation">Problem/Motivation</h3>
There are some buttons in Open Social that may contain an icon but don't contain any text. This makes them inaccessible.

<ul>
<li>The action dropdown in a private message conversation (that contains the "delete conversation" action)</li>
<li>The close button for the search overlay</li>
</ul>

<h3 id="summary-proposed-resolution">Proposed resolution</h3>
Provide texts on the buttons (for screenreaders) that clearly states what the button does.

## Issue tracker
* https://www.drupal.org/project/social/issues/3171824

## How to test

- [ ] View the mentioned screens in a screenreader

## Screenshots
N.a.

## Release notes
The contextual menu on private messages and the close button on the search overlay now provide an alternative text for assistive technology.

## Change Record
N.a.

## Translations
N.a.