### PR TITLE
Issue #3176585 by tBKoT: Out of memory on search indexing

### DIFF
--- a/modules/social_features/social_search/config/install/search_api.index.social_all.yml
+++ b/modules/social_features/social_search/config/install/search_api.index.social_all.yml
@@ -352,7 +352,7 @@ processor_settings:
       strong: 2
       u: 1
     weights:
-      preprocess_index: -15
+      preprocess_index: -25
       preprocess_query: -15
   blocked_users:
     weights:

--- a/modules/social_features/social_search/config/install/search_api.index.social_content.yml
+++ b/modules/social_features/social_search/config/install/search_api.index.social_content.yml
@@ -217,7 +217,7 @@ processor_settings:
       strong: 2
       u: 1
     weights:
-      preprocess_index: -10
+      preprocess_index: -15
       preprocess_query: -10
 tracker_settings:
   default:

--- a/modules/social_features/social_search/config/install/search_api.index.social_groups.yml
+++ b/modules/social_features/social_search/config/install/search_api.index.social_groups.yml
@@ -218,7 +218,7 @@ processor_settings:
       strong: 2
       u: 1
     weights:
-      preprocess_index: -10
+      preprocess_index: -15
       preprocess_query: -10
 tracker_settings:
   default:

--- a/modules/social_features/social_search/config/install/search_api.index.social_users.yml
+++ b/modules/social_features/social_search/config/install/search_api.index.social_users.yml
@@ -180,7 +180,7 @@ processor_settings:
       - name
       - rendered_item
     weights:
-      preprocess_index: -10
+      preprocess_index: -15
       preprocess_query: -10
   language_with_fallback: {  }
   rendered_item:

--- a/modules/social_features/social_search/social_search.install
+++ b/modules/social_features/social_search/social_search.install
@@ -138,11 +138,14 @@ function social_search_update_8902() {
  * Change weight of search index processors().
  */
 function social_search_update_8903() {
+  // Config factory.
+  $config_factory = Drupal::configFactory();
+
   // Get search API index configs.
-  $search_all = Drupal::configFactory()->getEditable('search_api.index.social_all');
-  $search_content = Drupal::configFactory()->getEditable('search_api.index.social_content');
-  $search_groups = Drupal::configFactory()->getEditable('search_api.index.social_groups');
-  $search_users = Drupal::configFactory()->getEditable('search_api.index.social_users');
+  $search_all = $config_factory->getEditable('search_api.index.social_all');
+  $search_content = $config_factory->getEditable('search_api.index.social_content');
+  $search_groups = $config_factory->getEditable('search_api.index.social_groups');
+  $search_users = $config_factory->getEditable('search_api.index.social_users');
 
   // Setting that need to be changed.
   $setting = 'processor_settings.html_filter.weights.preprocess_index';

--- a/modules/social_features/social_search/social_search.install
+++ b/modules/social_features/social_search/social_search.install
@@ -133,3 +133,23 @@ function social_search_update_8902() {
     \Drupal::logger('social_search')->info($e->getMessage());
   }
 }
+
+/**
+ * Change weight of search index processors().
+ */
+function social_search_update_8903() {
+  // Get search API index configs.
+  $search_all = Drupal::configFactory()->getEditable('search_api.index.social_all');
+  $search_content = Drupal::configFactory()->getEditable('search_api.index.social_content');
+  $search_groups = Drupal::configFactory()->getEditable('search_api.index.social_groups');
+  $search_users = Drupal::configFactory()->getEditable('search_api.index.social_users');
+
+  // Setting that need to be changed.
+  $setting = 'processor_settings.html_filter.weights.preprocess_index';
+
+  // Set new weight for the 'HTML filter' processors.
+  $search_all->set($setting, -25)->save();
+  $search_content->set($setting, -15)->save();
+  $search_groups->set($setting, -15)->save();
+  $search_users->set($setting, -15)->save();
+}


### PR DESCRIPTION
## Problem
When indexing the nodes' `Rendered HTML` with a very big body (more than 4 000 000 symbols) the Search API index leaked out of memory.

## Solution
Change the weight of Search API index HTML filter processors on indexing.

## Issue tracker
https://www.drupal.org/project/social/issues/3176585
https://getopensocial.atlassian.net/browse/YANG-3892

## How to test
- [x] Create content with a very big body, more than 4 000 000 symbols (HTML tag included)
- [x] Run cron for indexing

## Screenshots
N/A

## Release notes
Changed weight of HTML filter processor for better indexing.

## Change Record
N/A

## Translations
N/A
