### PR TITLE
Issue #3176619 by robertragas: Enable redirect module to prevent inde…

### DIFF
--- a/modules/social_features/social_core/social_core.info.yml
+++ b/modules/social_features/social_core/social_core.info.yml
@@ -11,6 +11,7 @@ dependencies:
   - field_group:field_group
   - drupal:file
   - drupal:image
+  - redirect:redirect
   - image_effects:image_effects
   - image_widget_crop:image_widget_crop
   - drupal:link

--- a/modules/social_features/social_core/social_core.install
+++ b/modules/social_features/social_core/social_core.install
@@ -1229,3 +1229,10 @@ function social_core_update_8902() {
     }
   }
 }
+
+/**
+ * Install the redirect module to prevent index.php from being accessed.
+ */
+function social_core_update_8903() {
+  \Drupal::service('module_installer')->install(['redirect']);
+}


### PR DESCRIPTION
…x.php from being accessed

## Problem
Links are currently accessible through 2 instances
- The normal link
- The link with index.php in it

During a cache clear it can happen that an anonymous user that visits a index.php triggers the cache rebuild with this url which then will end up for all anonymous users in the menulinks.

This causes 2 problems
- Google will start indexing urls with index.php, causing bad results in Google.
- If SSO is enabled it will add this index.php to the url and get blocked because it's not in the whitelist.

## Solution
Because of the social_path_manager we already have the redirect module as a dependency, just not enabled.
We should enable this module as it will come with the default option to "enforce clean urls". This will make sure that if someone opens the index.php link it will redirect to the clean url.

## Issue tracker
https://www.drupal.org/project/social/issues/3176619

## How to test
- [x] Try to update OS or clean install and note that the redirect module is enabled
- [x] Check the redirect settings page and see that "enforce clean url's" is enabled
- [x] Try to go to url index.php/user/login and see it gets redirect to /user/login
- [x] Enable the social_sso and configure facebook. See that the button doesn't link to index.php in the redirect to facebook.
- [x] Try to enable social_path_manager and see this still enables without errors and doesn't change the redirect settings
- [x] Try the index.php out for multiple urls

## Release notes
We have enabled the redirect module by default. This will make sure that if someone visits index.php/url by accident they will get redirected to the clean url. Google won't index these faulty urls avoiding duplicate content and also when single-sign-on is enabled it will not fail to login due to whitelisting errors.
