### PR TITLE
Issue #3176854 by tBKoT: Add iCal option to the 'Add to calendar' feature

### DIFF
--- a/modules/social_features/social_event/modules/social_event_addtocal/social_event_addtocal.routing.yml
+++ b/modules/social_features/social_event/modules/social_event_addtocal/social_event_addtocal.routing.yml
@@ -7,3 +7,11 @@ social_event_addtocal.settings:
     _permission: 'administer social_event settings'
   options:
     _admin_route: TRUE
+
+social_event_addtocal.add_to_calendar_ics:
+  path: '/add-to-calendar/ics'
+  defaults:
+    _controller: '\Drupal\social_event_addtocal\Controller\AddToCalendarIcsController::downloadIcs'
+    _title: 'Add event to Calendar'
+  requirements:
+    _user_is_logged_in: 'TRUE'

--- a/modules/social_features/social_event/modules/social_event_addtocal/src/Controller/AddToCalendarIcsController.php
+++ b/modules/social_features/social_event/modules/social_event_addtocal/src/Controller/AddToCalendarIcsController.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace Drupal\social_event_addtocal\Controller;
+
+use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\File\FileSystemInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Class AddToCalendarIcsController.
+ */
+class AddToCalendarIcsController extends ControllerBase {
+
+  /**
+   * The current request.
+   *
+   * @var \Symfony\Component\HttpFoundation\Request
+   */
+  protected $request;
+
+  /**
+   * The file system service.
+   *
+   * @var \Drupal\Core\File\FileSystemInterface
+   */
+  protected $fileSystem;
+
+  /**
+   * AddToCalendarIcsController constructor.
+   *
+   * @param \Symfony\Component\HttpFoundation\Request $request
+   *   The current request.
+   * @param \Drupal\Core\File\FileSystemInterface $file_system
+   *   The file system service.
+   */
+  public function __construct(Request $request, FileSystemInterface $file_system) {
+    $this->request = $request;
+    $this->fileSystem = $file_system;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('request_stack')->getCurrentRequest(),
+      $container->get('file_system')
+    );
+  }
+
+  /**
+   * Download generated ICS file.
+   *
+   * @return \Symfony\Component\HttpFoundation\BinaryFileResponse
+   *   Empty array.
+   */
+  public function downloadIcs() {
+    // Event dates.
+    $dates = $this->request->get('dates');
+
+    // Array for serialization.
+    $serialize = [
+      'nid' => $this->request->get('nid'),
+      'date' => $dates['both'],
+    ];
+
+    // Create ICS filename.
+    $name = md5(serialize($serialize));
+    $filename = $name . '.ics';
+
+    // ICS file destination.
+    $file = 'temporary://' . $filename;
+
+    // Generate data for ICS file if it not exists.
+    if (!file_exists($file)) {
+      // Set initial data.
+      $file_data = [
+        'BEGIN:VCALENDAR',
+        'VERSION:2.0',
+        'METHOD:PUBLISH',
+        'BEGIN:VEVENT',
+        'UID:' . $name,
+        'SUMMARY:' . $this->request->get('title'),
+      ];
+
+      // Set dates.
+      if ($dates['all_day']) {
+        $file_data[] = 'DTSTART:' . $dates['start'];
+        $file_data[] = 'DTEND:' . $dates['end'];
+      }
+      else {
+        $file_data[] = 'DTSTART;TZID=' . $dates['start'];
+        $file_data[] = 'DTEND;TZID=' . $dates['end'];
+      }
+
+      // Set location.
+      if ($this->request->get('description')) {
+        $file_data[] = 'DESCRIPTION:' . $this->request->get('description');
+      }
+
+      // Set description.
+      if ($this->request->get('location')) {
+        $file_data[] = 'LOCATION:' . $this->request->get('location');
+      }
+
+      // Set end of file.
+      $file_data[] = 'END:VEVENT';
+      $file_data[] = 'END:VCALENDAR';
+
+      // Convert array to correct ICS format.
+      $data = implode("\r\n", $file_data);
+
+      // Save datta to file.
+      $this->fileSystem->saveData($data, $file, FileSystemInterface::EXISTS_REPLACE);
+    }
+
+    // Set response for file download.
+    $response = new BinaryFileResponse($file);
+    $response->headers->set('Content-Type', 'application/calendar; charset=utf-8');
+    $response->setContentDisposition('attachment', $filename);
+
+    return $response;
+  }
+
+}

--- a/modules/social_features/social_event/modules/social_event_addtocal/src/Controller/AddToCalendarIcsController.php
+++ b/modules/social_features/social_event/modules/social_event_addtocal/src/Controller/AddToCalendarIcsController.php
@@ -60,14 +60,8 @@ class AddToCalendarIcsController extends ControllerBase {
     // Event dates.
     $dates = $this->request->get('dates');
 
-    // Array for serialization.
-    $serialize = [
-      'nid' => $this->request->get('nid'),
-      'date' => $dates['both'],
-    ];
-
     // Create ICS filename.
-    $name = md5(serialize($serialize));
+    $name = md5(serialize($this->request->query->all()));
     $filename = $name . '.ics';
 
     // ICS file destination.
@@ -85,7 +79,7 @@ class AddToCalendarIcsController extends ControllerBase {
         'SUMMARY:' . $this->request->get('title'),
       ];
 
-      // Set dates.
+      // Set start and end datetime for event.
       if ($dates['all_day']) {
         $file_data[] = 'DTSTART:' . $dates['start'];
         $file_data[] = 'DTEND:' . $dates['end'];

--- a/modules/social_features/social_event/modules/social_event_addtocal/src/Plugin/SocialAddToCalendar/AddToICal.php
+++ b/modules/social_features/social_event/modules/social_event_addtocal/src/Plugin/SocialAddToCalendar/AddToICal.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Drupal\social_event_addtocal\Plugin\SocialAddToCalendar;
+
+use Drupal\Core\Url;
+use Drupal\node\NodeInterface;
+use Drupal\social_event_addtocal\Plugin\SocialAddToCalendarBase;
+
+/**
+ * Provides add to Google calendar plugin.
+ *
+ * @SocialAddToCalendar(
+ *   id = "ical",
+ *   label = @Translation("iCal"),
+ *   url = "social_event_addtocal.add_to_calendar_ics",
+ *   dateFormat = "e:Ymd\THis",
+ *   utcDateFormat = "e:Ymd\THis\Z"
+ * )
+ */
+class AddToICal extends SocialAddToCalendarBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function generateUrl(NodeInterface $node) {
+    $settings = $this->generateSettings($node);
+    $options = [
+      'query' => $settings,
+      'attributes' => [
+        'target' => '_blank',
+      ],
+    ];
+
+    return Url::fromRoute($this->pluginDefinition['url'], [], $options);
+  }
+
+}

--- a/modules/social_features/social_event/modules/social_event_addtocal/src/Plugin/SocialAddToCalendarBase.php
+++ b/modules/social_features/social_event/modules/social_event_addtocal/src/Plugin/SocialAddToCalendarBase.php
@@ -39,6 +39,7 @@ abstract class SocialAddToCalendarBase extends PluginBase implements SocialAddTo
       'timezone' => date_default_timezone_get() !== DateTimeItemInterface::STORAGE_TIMEZONE ? date_default_timezone_get() : '',
       'description' => $this->getEventDescription($node),
       'location' => $this->getEventLocation($node),
+      'nid' => $node->id(),
     ];
   }
 


### PR DESCRIPTION
## Problem
Need to add the `iCal` option to the `Add to Calendar` feature.

## Solution
Create a plugin with the `iCal` option.
Create a controller to download the ICS file.

## Issue tracker
https://www.drupal.org/project/social/issues/3176854
https://getopensocial.atlassian.net/browse/YANG-3712

## How to test
- [x] Enable the `social_event_addtocal`
- [x] Enable the `Add to Calendar` button in `/admin/config/opensocial/event-addtocal`
- [x] Choose `iCal` option
- [x] Go to any event as LU
- [x] Press the `Add to Calendar` button and click `iCal` if needed
- [x] You should resave the ICS file for event importing to your calendar.

## Screenshots
![image](https://user-images.githubusercontent.com/11648677/95996340-3af62000-0e3b-11eb-9885-314b62d8ba31.png)


## Release notes
Now SM could choose the `iCal` as one of the options for adding the event to the calendar

## Change Record
N/A

## Translations
N/A
