### PR TITLE
Issue #3177932 by Kingdutch, ronaldtebrake: Allow modules to add cust…

### DIFF
--- a/modules/custom/improved_theme_settings/improved_theme_settings.api.php
+++ b/modules/custom/improved_theme_settings/improved_theme_settings.api.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * @file
+ * Hooks provided by the improved_theme_settings module.
+ */
+
+/**
+ * @addtogroup hooks
+ * @{
+ */
+
+/**
+ * Allows modules to add additional CSS based on theme settings.
+ *
+ * @param string $theme
+ *   The name of the them that's being rendered.
+ *
+ * @return string
+ *   Returns a string that will be added as CSS.
+ *
+ * @ingroup improved_theme_settings
+ */
+function hook_improved_theme_settings_add(string $theme) {
+  $style_to_add = '';
+
+  $card_radius = improved_theme_settings_get_setting('card_radius', $theme);
+
+  if ($card_radius >= 0) {
+    $style_to_add .= '
+      .my-custom-selector {
+        border-radius: ' . $card_radius . 'px;
+      }
+    ';
+  }
+
+  return $style_to_add;
+}
+
+/**
+ * @} End of "addtogroup hooks".
+ */

--- a/modules/custom/improved_theme_settings/improved_theme_settings.module
+++ b/modules/custom/improved_theme_settings/improved_theme_settings.module
@@ -192,6 +192,11 @@ function improved_theme_settings_page_attachments(array &$page) {
         }
       ';
 
+      // Add any styles from modules that define selector with configurable
+      // styles.
+      $module_styles = \Drupal::moduleHandler()->invokeAll('improved_theme_settings_add', [$system_theme_settings]);
+      $style_to_add .= implode("\n", $module_styles);
+
       if (!empty($style_to_add)) {
         $page['#attached']['html_head'][] = [
           [

--- a/themes/socialblue/assets/css/tokens.css
+++ b/themes/socialblue/assets/css/tokens.css
@@ -1,0 +1,17 @@
+/**
+ * This file contains token based CSS definitions that can be used as filler for
+ * components that are pulled in from the updated design system.
+ *
+ * Modules may have defined additional tokens by implementing
+ * hook_improved_theme_settings_add().
+ *
+ * EXPERIMENTAL: The tokens in this file are experimental and subject to change
+ * they should not be relied upon by third-party code.
+ */
+.button-background-primary {
+  background-color: #29abe2;
+}
+
+.button-text-primary {
+  color: #e6e6e6;
+}

--- a/themes/socialblue/color/color.inc
+++ b/themes/socialblue/color/color.inc
@@ -89,6 +89,7 @@ $info = [
   'css' => [
     'assets/css/brand.css',
     'assets/css/brand--sky.css',
+    'assets/css/tokens.css',
   ],
 
   // Files to copy.

--- a/themes/socialblue/components/tokens.scss
+++ b/themes/socialblue/components/tokens.scss
@@ -1,0 +1,19 @@
+/**
+ * This file contains token based CSS definitions that can be used as filler for
+ * components that are pulled in from the updated design system.
+ *
+ * Modules may have defined additional tokens by implementing
+ * hook_improved_theme_settings_add().
+ *
+ * EXPERIMENTAL: The tokens in this file are experimental and subject to change
+ * they should not be relied upon by third-party code.
+ */
+@import 'settings';
+
+.button-background-primary {
+  background-color: $brand-primary;
+}
+
+.button-text-primary {
+  color: $gray-lighter;
+}


### PR DESCRIPTION
…om CSS to improved_theme_settings

<h3 id="summary-problem-motivation">Problem/Motivation</h3>
Some modules may require different selectors than are supported in the improved_theme_settings module. They may need this to hook into theme settings with their own styling. It's impractical to support every possible module in the improve_theme_settings module itself. 

<h3 id="summary-proposed-resolution">Proposed resolution</h3>
Add an info hook that is called when improved_theme_settings generates its CSS. This allows modules to query the current theme settings and generate their own selector. One such use case is an internal Open Social extension that is adopting utility based CSS.

Follow ups to this ticket could be created to move some of the very specific queries currently included in improved_theme_settings to their own modules, this cleans up the CSS when those modules are not enabled.

## Issue tracker
https://www.drupal.org/project/social/issues/3177932

## How to test

- [ ] Implement a custom hook in a separate module
- [ ] Enable that module
- [ ] See that the styles are added

## Screenshots
N.a.

## Release notes
Modules can now inject their own CSS that depends on theme settings using `hook_improved_theme_settings_add`.

## Change Record
N.a.

## Translations
