### PR TITLE
Issue #3179807 by laykin: Updated group_type form element structure on social_group module

### DIFF
--- a/modules/social_features/social_group/social_group.module
+++ b/modules/social_features/social_group/social_group.module
@@ -725,7 +725,7 @@ function social_group_form_alter(&$form, FormStateInterface $form_state, $form_i
         }
       }
 
-      $form['#fieldgroups']['group_settings']->children[] = 'group_type';
+      $form['#fieldgroups']['group_content']->children[] = 'group_type';
       $form['#group_children']['group_type'] = 'group_settings';
 
       $form['actions']['submit']['#submit'][] = '_social_group_type_edit_submit';


### PR DESCRIPTION
## Problem
After Open Social updated to version 9.4, I’m getting fatal errors when I switch to the add or edit form for the challenge and secret challenge.

## Solution
Update group_type form element structure on social_group module for visibility (disables all group types that can't be edited).

## Issue tracker
https://www.drupal.org/project/social/issues/3179807

## How to test
1. Update OS to version 9.4
2. Go to edit form for the challenge or secret challenge
