### PR TITLE
Issue #3178204 by Kingdutch: Allow account header menu items to be bu…

### DIFF
--- a/modules/social_features/social_user/src/Element/AccountHeaderElement.php
+++ b/modules/social_features/social_user/src/Element/AccountHeaderElement.php
@@ -127,15 +127,33 @@ class AccountHeaderElement extends RenderElement {
       ],
     ];
 
-    $element = [
-      "#type" => "unwrapped_container",
-      "link" => [
-        "#type" => "link",
-        "#attributes" => $link_attributes,
-        "#url" => $item["#url"],
-        "#title" => $link_text,
-      ],
-    ];
+    // If the URL is empty then we use a button instead.
+    if ($item['#url'] === "") {
+      // A custom button is rendered because the Drupal built in button element
+      // is not meant to be used outside of forms.
+      $element = [
+        "#type" => "unwrapped_container",
+        "link" => [
+          "#type" => "inline_template",
+          '#template' => "<button {{ attributes }}>{{ label }}</button>",
+          '#context' => [
+            "attributes" => new Attribute($link_attributes),
+            "label" => $link_text,
+          ],
+        ],
+      ];
+    }
+    else {
+      $element = [
+        "#type" => "unwrapped_container",
+        "link" => [
+          "#type" => "link",
+          "#attributes" => $link_attributes,
+          "#url" => $item["#url"],
+          "#title" => $link_text,
+        ],
+      ];
+    }
 
     // If there are children we add them to a sublist.
     if (!empty($children)) {

--- a/themes/socialbase/assets/css/navbar.css
+++ b/themes/socialbase/assets/css/navbar.css
@@ -4,17 +4,27 @@
   list-style: none;
 }
 
-.nav > li > a {
+.nav > li > a,
+.nav > li > button {
   position: relative;
   display: block;
   padding: 0.5em 10px;
+  border: none;
 }
 
-.nav > li > a:hover, .nav > li > a:focus {
+.nav > li > a:hover, .nav > li > a:focus,
+.nav > li > button:hover,
+.nav > li > button:focus {
   text-decoration: none;
 }
 
-.nav > li.disabled > a:hover, .nav > li.disabled > a:focus {
+.nav > li > button {
+  background-color: transparent;
+}
+
+.nav > li.disabled > a:hover, .nav > li.disabled > a:focus,
+.nav > li.disabled > button:hover,
+.nav > li.disabled > button:focus {
   text-decoration: none;
   background-color: transparent;
   cursor: not-allowed;
@@ -37,33 +47,24 @@
 }
 
 .container--navbar {
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
 }
 
 .navbar-user {
   margin-left: auto;
-  -webkit-box-ordinal-group: 2;
-      -ms-flex-order: 1;
-          order: 1;
+  order: 1;
 }
 
 .navbar-header {
-  -webkit-box-ordinal-group: 1;
-      -ms-flex-order: 0;
-          order: 0;
+  order: 0;
 }
 
 .navbar-nav {
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
-  -ms-flex-wrap: wrap;
-      flex-wrap: wrap;
+  flex-wrap: wrap;
 }
 
-.navbar-nav > li > a {
+.navbar-nav > li > a, .navbar-nav > li > button {
   padding-top: 10px;
   padding-bottom: 10px;
   line-height: 24px;
@@ -74,8 +75,7 @@
 }
 
 .navbar-nav > li > ul > li.expanded .caret {
-  -webkit-transform: rotate(0);
-          transform: rotate(0);
+  transform: rotate(0);
 }
 
 .navbar-nav > li > ul > li.expanded > .dropdown-menu {
@@ -88,7 +88,9 @@
 }
 
 .navbar-user > li > a,
-.navbar-user .navbar-nav > li > a {
+.navbar-user > li > button,
+.navbar-user .navbar-nav > li > a,
+.navbar-user .navbar-nav > li > button {
   padding: 13px 10px 8px;
   height: 50px;
 }
@@ -97,9 +99,7 @@
   overflow-x: visible;
   border-top: 1px solid transparent;
   -webkit-overflow-scrolling: touch;
-  -webkit-box-ordinal-group: 3;
-      -ms-flex-order: 2;
-          order: 2;
+  order: 2;
   max-height: 340px;
 }
 
@@ -108,8 +108,7 @@
 }
 
 .navbar-fixed-top {
-  -webkit-box-shadow: 0 0 4px rgba(0, 0, 0, 0.14), 0 4px 8px rgba(0, 0, 0, 0.28);
-          box-shadow: 0 0 4px rgba(0, 0, 0, 0.14), 0 4px 8px rgba(0, 0, 0, 0.28);
+  box-shadow: 0 0 4px rgba(0, 0, 0, 0.14), 0 4px 8px rgba(0, 0, 0, 0.28);
   position: fixed;
   top: 0;
   right: 0;
@@ -176,10 +175,7 @@
   margin-bottom: 0;
 }
 
-.navbar-default .navbar-nav > .open > a,
-.navbar-default .navbar-nav > .open > a:focus,
-.navbar-default .navbar-nav > .open > a:hover {
-  -webkit-transition: color .2s ease, background-color .2s ease;
+.navbar-default .navbar-nav > .open > a, .navbar-default .navbar-nav > .open > a:focus, .navbar-default .navbar-nav > .open > a:hover, .navbar-default .navbar-nav > .open > button, .navbar-default .navbar-nav > .open > button:focus, .navbar-default .navbar-nav > .open > button:hover {
   transition: color .2s ease, background-color .2s ease;
 }
 
@@ -197,9 +193,7 @@
   width: 50px;
   height: 50px;
   padding: 0;
-  -webkit-transform-origin: 50%;
-          transform-origin: 50%;
-  -webkit-transition: all 0.7s cubic-bezier(0.4, 0, 0.2, 1);
+  transform-origin: 50%;
   transition: all 0.7s cubic-bezier(0.4, 0, 0.2, 1);
   z-index: 10;
 }
@@ -208,7 +202,6 @@
   position: absolute;
   top: 14px;
   left: 13px;
-  -webkit-transition: 0.2s ease-in-out;
   transition: 0.2s ease-in-out;
   pointer-events: none;
 }
@@ -250,58 +243,49 @@
 }
 
 .navbar-secondary {
-  -webkit-box-shadow: 0 -1px 0 #e0e0e0, 0 0 2px rgba(0, 0, 0, 0.12), 0 2px 4px rgba(0, 0, 0, 0.24);
-          box-shadow: 0 -1px 0 #e0e0e0, 0 0 2px rgba(0, 0, 0, 0.12), 0 2px 4px rgba(0, 0, 0, 0.24);
+  box-shadow: 0 -1px 0 #e0e0e0, 0 0 2px rgba(0, 0, 0, 0.12), 0 2px 4px rgba(0, 0, 0, 0.24);
   z-index: 1;
   min-height: 46px;
 }
 
 .navbar-secondary .navbar-nav {
-  -webkit-box-pack: center;
-      -ms-flex-pack: center;
-          justify-content: center;
-  -ms-flex-wrap: nowrap;
-      flex-wrap: nowrap;
+  justify-content: center;
+  flex-wrap: nowrap;
   font-size: 16px;
 }
 
-.navbar-secondary .navbar-nav a {
-  -webkit-transition: all 0.3s;
+.navbar-secondary .navbar-nav a, .navbar-secondary .navbar-nav button {
   transition: all 0.3s;
   white-space: nowrap;
   opacity: 0.75;
   border-bottom: 2px solid transparent;
 }
 
-.navbar-secondary .navbar-nav li.active a {
+.navbar-secondary .navbar-nav li.active a, .navbar-secondary .navbar-nav li.active button {
   border-bottom: 2px solid transparent;
   opacity: 1;
 }
 
-.navbar-secondary .navbar-nav li.active a:hover, .navbar-secondary .navbar-nav li.active a:focus {
+.navbar-secondary .navbar-nav li.active a:hover, .navbar-secondary .navbar-nav li.active a:focus, .navbar-secondary .navbar-nav li.active button:hover, .navbar-secondary .navbar-nav li.active button:focus {
   cursor: default;
 }
 
 @media (min-width: 768px) and (max-width: 1024px) {
-  .navbar-nav > li > ul > li.expanded > .dropdown-menu > li > a {
+  .navbar-nav > li > ul > li.expanded > .dropdown-menu > li > a, .navbar-nav > li > ul > li.expanded > .dropdown-menu > li > button {
     padding-left: 30px;
   }
-  .navbar-nav > li > ul > li.expanded > .dropdown-menu > li > a:hover, .navbar-nav > li > ul > li.expanded > .dropdown-menu > li > a.is-active {
+  .navbar-nav > li > ul > li.expanded > .dropdown-menu > li > a:hover, .navbar-nav > li > ul > li.expanded > .dropdown-menu > li > a.is-active, .navbar-nav > li > ul > li.expanded > .dropdown-menu > li > button:hover, .navbar-nav > li > ul > li.expanded > .dropdown-menu > li > button.is-active {
     background: #fff;
   }
 }
 
 @media (min-width: 900px) {
   .navbar-user {
-    -webkit-box-ordinal-group: 11;
-        -ms-flex-order: 10;
-            order: 10;
+    order: 10;
   }
   .block-social-language,
   .block-language {
-    -webkit-box-ordinal-group: 5;
-        -ms-flex-order: 4;
-            order: 4;
+    order: 4;
     margin-left: auto;
   }
   .block-social-language a.dropdown-toggle,
@@ -315,7 +299,7 @@
   .navbar-search {
     display: none;
   }
-  .navbar-nav > li > a {
+  .navbar-nav > li > a, .navbar-nav > li > button {
     padding-top: 13px;
     padding-bottom: 13px;
   }
@@ -326,8 +310,6 @@
     padding-right: 0;
   }
   .navbar-collapse.collapse {
-    display: -webkit-box !important;
-    display: -ms-flexbox !important;
     display: flex !important;
     height: auto !important;
     padding-bottom: 0;
@@ -354,18 +336,14 @@
     width: 100%;
     z-index: 1050;
     pointer-events: none;
-    -webkit-transition: all 0.3s ease-in-out;
     transition: all 0.3s ease-in-out;
   }
   .search-take-over .form-group {
     margin: auto;
     width: 80%;
     max-width: 600px;
-    display: -webkit-box;
-    display: -ms-flexbox;
     display: flex;
-    -ms-flex-wrap: wrap;
-        flex-wrap: wrap;
+    flex-wrap: wrap;
   }
   .search-take-over .form-text {
     font-size: 1.625em;
@@ -378,21 +356,13 @@
     border-bottom: 2px solid;
     font-weight: 500;
     max-width: none;
-    -webkit-box-flex: 1;
-        -ms-flex: 1 1 80%;
-            flex: 1 1 80%;
+    flex: 1 1 80%;
     min-width: 0;
   }
   .search-take-over .form-submit {
-    display: -webkit-box;
-    display: -ms-flexbox;
     display: flex;
-    -webkit-box-align: center;
-        -ms-flex-align: center;
-            align-items: center;
-    -webkit-box-pack: center;
-        -ms-flex-pack: center;
-            justify-content: center;
+    align-items: center;
+    justify-content: center;
     width: 60px;
     height: 60px;
     min-width: 60px;
@@ -402,17 +372,14 @@
     font-size: 0;
     text-indent: -9999px;
     cursor: pointer;
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 60px;
-            flex: 0 0 60px;
+    flex: 0 0 60px;
   }
   .search-take-over .form-submit svg {
     width: 50px;
     height: 50px;
   }
   .search-take-over .social-search-suggestions {
-    -ms-flex-preferred-size: 100%;
-        flex-basis: 100%;
+    flex-basis: 100%;
   }
   .btn--close-search-take-over {
     background-color: transparent;
@@ -424,9 +391,7 @@
     top: 80px;
     right: 80px;
     opacity: 0;
-    -webkit-transform: translate(10px, 0) rotate(90deg);
-            transform: translate(10px, 0) rotate(90deg);
-    -webkit-transition: all 0.5s ease-in-out 0.5s;
+    transform: translate(10px, 0) rotate(90deg);
     transition: all 0.5s ease-in-out 0.5s;
     outline: 0;
   }
@@ -442,11 +407,9 @@
     pointer-events: all;
   }
   .mode-search .navbar__open-search-block {
-    -webkit-transform: scale(70);
-            transform: scale(70);
+    transform: scale(70);
     -moz-transform: scale(70) rotate(0.02deg);
-    -webkit-box-shadow: 0 0 4px rgba(0, 0, 0, 0.14), 0 4px 8px rgba(0, 0, 0, 0.28);
-            box-shadow: 0 0 4px rgba(0, 0, 0, 0.14), 0 4px 8px rgba(0, 0, 0, 0.28);
+    box-shadow: 0 0 4px rgba(0, 0, 0, 0.14), 0 4px 8px rgba(0, 0, 0, 0.28);
   }
   .mode-search .navbar-nav__icon {
     opacity: 0;
@@ -456,8 +419,7 @@
     pointer-events: none;
   }
   .mode-search .btn--close-search-take-over {
-    -webkit-transform: none;
-            transform: none;
+    transform: none;
     opacity: 1;
     pointer-events: all;
   }
@@ -480,8 +442,7 @@
     position: absolute;
     top: 44%;
     right: 10px;
-    -webkit-transform: rotate(-90deg) translateY(-50%);
-            transform: rotate(-90deg) translateY(-50%);
+    transform: rotate(-90deg) translateY(-50%);
   }
   .navbar-nav > li > ul > li.expanded > .dropdown-menu {
     display: none;
@@ -516,12 +477,8 @@
             user-select: none;
     overflow-x: scroll;
     overflow-y: hidden;
-    display: -webkit-box;
-    display: -ms-flexbox;
     display: flex;
-    -webkit-box-pack: start;
-        -ms-flex-pack: start;
-            justify-content: flex-start;
+    justify-content: flex-start;
   }
   .navbar-scrollable .navbar-nav::-webkit-scrollbar {
     display: none;
@@ -540,21 +497,19 @@
 
 @media (max-width: 899px) {
   .container--navbar {
-    -ms-flex-wrap: wrap;
-        flex-wrap: wrap;
+    flex-wrap: wrap;
   }
-  .navbar-nav > li > ul > li.expanded > .dropdown-menu > li > a {
+  .navbar-nav > li > ul > li.expanded > .dropdown-menu > li > a, .navbar-nav > li > ul > li.expanded > .dropdown-menu > li > button {
     padding-left: 45px;
   }
-  .navbar-nav > li > ul > li.expanded > .dropdown-menu > li > a:hover, .navbar-nav > li > ul > li.expanded > .dropdown-menu > li > a.is-active {
+  .navbar-nav > li > ul > li.expanded > .dropdown-menu > li > a:hover, .navbar-nav > li > ul > li.expanded > .dropdown-menu > li > a.is-active, .navbar-nav > li > ul > li.expanded > .dropdown-menu > li > button:hover, .navbar-nav > li > ul > li.expanded > .dropdown-menu > li > button.is-active {
     background: #e6e6e6;
     color: #4d4d4d;
   }
   .navbar-fixed-top .navbar-nav .open .dropdown-menu {
     background-color: #fff;
     border: 0;
-    -webkit-box-shadow: 0 0 6px rgba(0, 0, 0, 0.16), 0 6px 12px rgba(0, 0, 0, 0.32);
-            box-shadow: 0 0 6px rgba(0, 0, 0, 0.16), 0 6px 12px rgba(0, 0, 0, 0.32);
+    box-shadow: 0 0 6px rgba(0, 0, 0, 0.16), 0 6px 12px rgba(0, 0, 0, 0.32);
     position: fixed;
     top: auto;
     margin: 0;
@@ -570,19 +525,12 @@
             backface-visibility: hidden;
   }
   .navbar-collapse {
-    -webkit-box-flex: 1;
-        -ms-flex: 1 0 100%;
-            flex: 1 0 100%;
+    flex: 1 0 100%;
   }
   .navbar-collapse .navbar-nav {
     margin: 6.5px 0;
-    -webkit-box-orient: vertical;
-    -webkit-box-direction: normal;
-        -ms-flex-direction: column;
-            flex-direction: column;
-    -webkit-box-ordinal-group: 2;
-        -ms-flex-order: 1;
-            order: 1;
+    flex-direction: column;
+    order: 1;
   }
   .navbar-collapse .navbar-nav > li > a {
     padding: 5px 15px;
@@ -598,10 +546,10 @@
     float: none;
     max-width: none;
     padding-top: 0;
-    -webkit-box-shadow: none;
-            box-shadow: none;
+    box-shadow: none;
   }
-  .navbar-collapse .dropdown-menu li a {
+  .navbar-collapse .dropdown-menu li a,
+  .navbar-collapse .dropdown-menu li button {
     padding: 5px 15px 5px 30px;
   }
   .navbar__open-search-control {
@@ -623,8 +571,7 @@
   .navbar-nav > li > ul > li.expanded > .dropdown-menu {
     position: static !important;
     display: block !important;
-    -webkit-box-shadow: none;
-            box-shadow: none;
+    box-shadow: none;
     background: #f5f5f5;
   }
 }
@@ -633,14 +580,13 @@
   .navbar-nav > li > ul > li.expanded > .dropdown-menu {
     position: static !important;
     display: block !important;
-    -webkit-box-shadow: none;
-            box-shadow: none;
+    box-shadow: none;
     background: #f5f5f5;
   }
-  .navbar-nav > li > ul > li.expanded > .dropdown-menu > li > a {
+  .navbar-nav > li > ul > li.expanded > .dropdown-menu > li > a, .navbar-nav > li > ul > li.expanded > .dropdown-menu > li > button {
     padding-left: 30px;
   }
-  .navbar-nav > li > ul > li.expanded > .dropdown-menu > li > a:hover, .navbar-nav > li > ul > li.expanded > .dropdown-menu > li > a.is-active {
+  .navbar-nav > li > ul > li.expanded > .dropdown-menu > li > a:hover, .navbar-nav > li > ul > li.expanded > .dropdown-menu > li > a.is-active, .navbar-nav > li > ul > li.expanded > .dropdown-menu > li > button:hover, .navbar-nav > li > ul > li.expanded > .dropdown-menu > li > button.is-active {
     background: #fff;
   }
 }
@@ -649,14 +595,13 @@
   .navbar-nav > li > ul > li.expanded > .dropdown-menu {
     position: static !important;
     display: block !important;
-    -webkit-box-shadow: none;
-            box-shadow: none;
+    box-shadow: none;
     background: #f5f5f5;
   }
-  .navbar-nav > li > ul > li.expanded > .dropdown-menu > li > a {
+  .navbar-nav > li > ul > li.expanded > .dropdown-menu > li > a, .navbar-nav > li > ul > li.expanded > .dropdown-menu > li > button {
     padding-left: 30px;
   }
-  .navbar-nav > li > ul > li.expanded > .dropdown-menu > li > a:hover, .navbar-nav > li > ul > li.expanded > .dropdown-menu > li > a.is-active {
+  .navbar-nav > li > ul > li.expanded > .dropdown-menu > li > a:hover, .navbar-nav > li > ul > li.expanded > .dropdown-menu > li > a.is-active, .navbar-nav > li > ul > li.expanded > .dropdown-menu > li > button:hover, .navbar-nav > li > ul > li.expanded > .dropdown-menu > li > button.is-active {
     background: #fff;
   }
 }

--- a/themes/socialbase/components/03-molecules/navigation/navbar/navbar.scss
+++ b/themes/socialbase/components/03-molecules/navigation/navbar/navbar.scss
@@ -17,18 +17,26 @@
 
   > li {
 
-    > a {
+    > a,
+    > button {
       position: relative;
       display: block;
       padding: $nav-link-padding;
+      border: none;
+
       &:hover,
       &:focus {
         text-decoration: none;
       }
     }
 
+    > button {
+      background-color: transparent;
+    }
+
     // Disabled state sets text to gray and nukes hover/tab effects
-    &.disabled > a {
+    &.disabled > a,
+    &.disabled > button {
 
       &:hover,
       &:focus {
@@ -124,7 +132,7 @@
   display: flex;
   flex-wrap: wrap;
 
-  > li > a {
+  > li > a, > li > button {
     padding-top: 10px;
     padding-bottom: 10px;
     line-height: $line-height-computed;
@@ -133,7 +141,7 @@
   // Uncollapse the nav
   @include for-tablet-landscape-up {
 
-    > li > a {
+    > li > a, > li > button {
       padding-top: $navbar-padding-vertical;
       padding-bottom: $navbar-padding-vertical;
     }
@@ -182,7 +190,7 @@
 
         @include dropdown-Ipad;
 
-        > li > a {
+        > li > a, > li > button {
           @media(min-width: 768px) and (max-width: 1024px) {
             @include dropdown-el;
           }
@@ -215,7 +223,9 @@
 }
 
 .navbar-user > li > a,
-.navbar-user .navbar-nav > li > a {
+.navbar-user > li > button,
+.navbar-user .navbar-nav > li > a,
+.navbar-user .navbar-nav > li > button {
   padding: 13px 10px 8px;
   height: 50px;
 }
@@ -438,7 +448,8 @@
       padding-top: 0;
       box-shadow: none;
 
-      li a {
+      li a,
+      li button {
         padding: 5px 15px 5px 30px;
       }
 
@@ -448,10 +459,12 @@
 
 }
 
-.navbar-default .navbar-nav > .open > a,
-.navbar-default .navbar-nav > .open > a:focus,
-.navbar-default .navbar-nav > .open > a:hover {
-  transition: color .2s ease, background-color .2s ease;
+.navbar-default .navbar-nav > .open {
+  > a, > button {
+    &, &:focus, &:hover {
+      transition: color .2s ease, background-color .2s ease;
+    }
+  }
 }
 
 // Display profile dropdown links inline when larger than tab portrait
@@ -686,14 +699,14 @@
     flex-wrap: nowrap;
     font-size: $font-size-base;
 
-    a {
+    a, button {
       transition: all 0.3s;
       white-space: nowrap;
       opacity: 0.75;
       border-bottom: 2px solid transparent;
     }
 
-    li.active a {
+    li.active a, li.active button {
       border-bottom: 2px solid transparent;
       opacity: 1;
 

--- a/themes/socialblue/assets/css/brand.css
+++ b/themes/socialblue/assets/css/brand.css
@@ -3,8 +3,7 @@
 }
 
 [type="radio"]:focus + label:before {
-  -webkit-box-shadow: 0 0 3px 2px #29abe2;
-          box-shadow: 0 0 3px 2px #29abe2;
+  box-shadow: 0 0 3px 2px #29abe2;
 }
 
 [type="checkbox"]:checked + label:after,
@@ -44,8 +43,7 @@
 .hero-form[role='search'] .form-control:focus, .hero-form[role='search'] .form-control:active,
 .hero-form[role='search'] .form-control:focus ~ .search-icon,
 .hero-form[role='search'] .form-control:active ~ .search-icon {
-  -webkit-box-shadow: 0 2px 0 0 #1f80aa;
-          box-shadow: 0 2px 0 0 #1f80aa;
+  box-shadow: 0 2px 0 0 #1f80aa;
 }
 
 .hero-form[role='search'] .search-icon {
@@ -54,8 +52,7 @@
 
 .form-control:focus {
   border-color: #29abe2;
-  -webkit-box-shadow: 0 2px 0 0 #29abe2;
-          box-shadow: 0 2px 0 0 #29abe2;
+  box-shadow: 0 2px 0 0 #29abe2;
 }
 
 .select2-container--social.select2-container--focus .select2-selection, .select2-container--social.select2-container--open .select2-selection, .select2-container--social .select2-dropdown {
@@ -87,7 +84,6 @@
 .btn-primary.dropdown-toggle:hover {
   background-color: #29abe2;
   border-color: #29abe2;
-  background-image: -webkit-gradient(linear, left top, left bottom, from(rgba(0, 0, 0, 0.2)), to(rgba(0, 0, 0, 0.2)));
   background-image: linear-gradient(to bottom, rgba(0, 0, 0, 0.2) 0%, rgba(0, 0, 0, 0.2) 100%);
 }
 
@@ -109,7 +105,6 @@ fieldset[disabled]
 .btn-primary.focus {
   background-color: #29abe2;
   border-color: #29abe2;
-  background-image: -webkit-gradient(linear, left top, left bottom, from(rgba(0, 0, 0, 0.2)), to(rgba(0, 0, 0, 0.2)));
   background-image: linear-gradient(to bottom, rgba(0, 0, 0, 0.2) 0%, rgba(0, 0, 0, 0.2) 100%);
 }
 
@@ -122,7 +117,6 @@ fieldset[disabled]
 .open > .btn-secondary.dropdown-toggle, .btn-secondary.dropdown-toggle:hover {
   background-color: #1f80aa;
   border-color: #1f80aa;
-  background-image: -webkit-gradient(linear, left top, left bottom, from(rgba(0, 0, 0, 0.2)), to(rgba(0, 0, 0, 0.2)));
   background-image: linear-gradient(to bottom, rgba(0, 0, 0, 0.2) 0%, rgba(0, 0, 0, 0.2) 100%);
 }
 
@@ -132,7 +126,6 @@ fieldset[disabled] .btn-secondary:focus,
 fieldset[disabled] .btn-secondary.focus {
   background-color: #1f80aa;
   border-color: #1f80aa;
-  background-image: -webkit-gradient(linear, left top, left bottom, from(rgba(0, 0, 0, 0.2)), to(rgba(0, 0, 0, 0.2)));
   background-image: linear-gradient(to bottom, rgba(0, 0, 0, 0.2) 0%, rgba(0, 0, 0, 0.2) 100%);
 }
 
@@ -150,7 +143,6 @@ fieldset[disabled] .btn-secondary.focus {
 .open > .btn-accent.dropdown-toggle, .btn-accent.dropdown-toggle:hover {
   background-color: #ffc142;
   border-color: #ffc142;
-  background-image: -webkit-gradient(linear, left top, left bottom, from(rgba(0, 0, 0, 0.2)), to(rgba(0, 0, 0, 0.2)));
   background-image: linear-gradient(to bottom, rgba(0, 0, 0, 0.2) 0%, rgba(0, 0, 0, 0.2) 100%);
 }
 
@@ -160,7 +152,6 @@ fieldset[disabled] .btn-accent:focus,
 fieldset[disabled] .btn-accent.focus {
   background-color: #ffc142;
   border-color: #ffc142;
-  background-image: -webkit-gradient(linear, left top, left bottom, from(rgba(0, 0, 0, 0.2)), to(rgba(0, 0, 0, 0.2)));
   background-image: linear-gradient(to bottom, rgba(0, 0, 0, 0.2) 0%, rgba(0, 0, 0, 0.2) 100%);
 }
 
@@ -179,6 +170,9 @@ fieldset[disabled] .btn-accent.focus {
 .nav-tabs > li.active > a,
 .nav-tabs > li.active > a:hover,
 .nav-tabs > li.active > a:focus,
+.nav-tabs > li.active > button,
+.nav-tabs > li.active > button:hover,
+.nav-tabs > li.active > button:focus,
 .card__link,
 .card__link:focus,
 .card__link:hover,
@@ -231,21 +225,19 @@ blockquote {
   background-color: #1f7ea7;
 }
 
-.navbar-secondary .navbar-nav a {
+.navbar-secondary .navbar-nav a, .navbar-secondary .navbar-nav button {
   color: #f9f9f9;
 }
 
-.navbar-secondary .navbar-nav li.active a {
+.navbar-secondary .navbar-nav li.active a, .navbar-secondary .navbar-nav li.active button {
   border-bottom-color: #f9f9f9;
 }
 
 .navbar-scrollable:before {
-  background: -webkit-gradient(linear, left top, right top, from(#1f7ea7), to(transparent));
   background: linear-gradient(90deg, #1f7ea7, transparent);
 }
 
 .navbar-scrollable:after {
-  background: -webkit-gradient(linear, right top, left top, from(#1f7ea7), to(transparent));
   background: linear-gradient(-90deg, #1f7ea7, transparent);
 }
 
@@ -262,40 +254,58 @@ blockquote {
   background-color: #1f1f1f;
 }
 
-.navbar-default .navbar-nav > li > a {
+.navbar-default .navbar-nav > li > a,
+.navbar-default .navbar-nav > li > button {
   color: #ffffff;
   fill: #ffffff;
 }
 
-.navbar-default .navbar-nav > li > a:hover, .navbar-default .navbar-nav > li > a:focus {
+.navbar-default .navbar-nav > li > a:hover, .navbar-default .navbar-nav > li > a:focus,
+.navbar-default .navbar-nav > li > button:hover,
+.navbar-default .navbar-nav > li > button:focus {
   color: #f3f3f3;
   background-color: #1f1f1f;
 }
 
-.navbar-default .navbar-nav > li > a:hover .navbar-nav__icon, .navbar-default .navbar-nav > li > a:focus .navbar-nav__icon {
+.navbar-default .navbar-nav > li > a:hover .navbar-nav__icon, .navbar-default .navbar-nav > li > a:focus .navbar-nav__icon,
+.navbar-default .navbar-nav > li > button:hover .navbar-nav__icon,
+.navbar-default .navbar-nav > li > button:focus .navbar-nav__icon {
   fill: #f3f3f3;
 }
 
-.navbar-default .navbar-nav > .open > a, .navbar-default .navbar-nav > .open > a:hover, .navbar-default .navbar-nav > .open > a:focus {
+.navbar-default .navbar-nav > .open > a, .navbar-default .navbar-nav > .open > a:hover, .navbar-default .navbar-nav > .open > a:focus,
+.navbar-default .navbar-nav > .open > button,
+.navbar-default .navbar-nav > .open > button:hover,
+.navbar-default .navbar-nav > .open > button:focus {
   background-color: #1f1f1f;
   color: #f3f3f3;
 }
 
 .navbar-default .navbar-nav > li > a.is-active, .navbar-default .navbar-nav > li > a.is-active:hover, .navbar-default .navbar-nav > li > a.is-active:focus,
+.navbar-default .navbar-nav > li > button.is-active,
+.navbar-default .navbar-nav > li > button.is-active:hover,
+.navbar-default .navbar-nav > li > button.is-active:focus,
 .navbar-default .navbar-nav > .active > a,
 .navbar-default .navbar-nav > .active > a:hover,
-.navbar-default .navbar-nav > .active > a:focus {
+.navbar-default .navbar-nav > .active > a:focus,
+.navbar-default .navbar-nav > .active > button,
+.navbar-default .navbar-nav > .active > button:hover,
+.navbar-default .navbar-nav > .active > button:focus {
   color: #f3f3f3;
   fill: #f3f3f3;
   background-color: #1f1f1f;
 }
 
-html:not(.js) .navbar-default .dropdown:focus > a, html:not(.js) .navbar-default .dropdown:hover > a {
+html:not(.js) .navbar-default .dropdown:focus > a,
+html:not(.js) .navbar-default .dropdown:focus > button, html:not(.js) .navbar-default .dropdown:hover > a,
+html:not(.js) .navbar-default .dropdown:hover > button {
   color: #f3f3f3;
   background-color: #1f1f1f;
 }
 
-html:not(.js) .navbar-default .dropdown:focus > a .navbar-nav__icon, html:not(.js) .navbar-default .dropdown:hover > a .navbar-nav__icon {
+html:not(.js) .navbar-default .dropdown:focus > a .navbar-nav__icon,
+html:not(.js) .navbar-default .dropdown:focus > button .navbar-nav__icon, html:not(.js) .navbar-default .dropdown:hover > a .navbar-nav__icon,
+html:not(.js) .navbar-default .dropdown:hover > button .navbar-nav__icon {
   fill: #f3f3f3;
 }
 
@@ -513,8 +523,7 @@ html:not(.js) .navbar-default .dropdown:focus > a .navbar-nav__icon, html:not(.j
   }
   .search-take-over .form-text:focus {
     border-color: #ffffff;
-    -webkit-box-shadow: 0 2px 0 0 #ffffff;
-            box-shadow: 0 2px 0 0 #ffffff;
+    box-shadow: 0 2px 0 0 #ffffff;
   }
   .btn--close-search-take-over svg,
   .search-take-over svg {

--- a/themes/socialblue/assets/css/navbar--sky.css
+++ b/themes/socialblue/assets/css/navbar--sky.css
@@ -6,8 +6,7 @@
 .socialblue--sky .navbar-secondary {
   width: 100%;
   min-height: 44px;
-  -webkit-box-shadow: none;
-          box-shadow: none;
+  box-shadow: none;
 }
 
 .socialblue--sky .navbar-secondary .navbar-scrollable {
@@ -15,19 +14,19 @@
   height: 44px;
 }
 
-.socialblue--sky .navbar-secondary .navbar-nav li a {
+.socialblue--sky .navbar-secondary .navbar-nav li a, .socialblue--sky .navbar-secondary .navbar-nav li button {
   padding: 9px 20px 8px;
   opacity: 1;
   border-bottom-width: 3px;
 }
 
-.socialblue--sky .navbar-secondary .navbar-nav li a:hover, .socialblue--sky .navbar-secondary .navbar-nav li a:active, .socialblue--sky .navbar-secondary .navbar-nav li a:focus {
+.socialblue--sky .navbar-secondary .navbar-nav li a:hover, .socialblue--sky .navbar-secondary .navbar-nav li a:active, .socialblue--sky .navbar-secondary .navbar-nav li a:focus, .socialblue--sky .navbar-secondary .navbar-nav li button:hover, .socialblue--sky .navbar-secondary .navbar-nav li button:active, .socialblue--sky .navbar-secondary .navbar-nav li button:focus {
   background: transparent;
   border-bottom-color: #fff;
   color: #fff;
 }
 
-.socialblue--sky .navbar-secondary .navbar-nav li.active a {
+.socialblue--sky .navbar-secondary .navbar-nav li.active a, .socialblue--sky .navbar-secondary .navbar-nav li.active button {
   color: #fff;
   border-bottom-color: #fff;
 }
@@ -37,22 +36,17 @@
     padding-right: 1.625rem;
   }
   .socialblue--sky.mode-search .navbar__open-search-block {
-    -webkit-transform: scale(100);
-            transform: scale(100);
+    transform: scale(100);
   }
   .socialblue--sky .navbar-secondary .navbar-scrollable {
     border-radius: 0 5px 0 0;
     overflow: visible;
   }
   .socialblue--sky.path-user .layout--with-complementary .navbar-secondary, .socialblue--sky.path-group .layout--with-complementary .navbar-secondary {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 66.66667%;
-            flex: 0 0 66.66667%;
+    flex: 0 0 66.66667%;
     max-width: 66.66667%;
     border-radius: 5px 5px 0 0;
-    -webkit-box-ordinal-group: 2;
-        -ms-flex-order: 1;
-            order: 1;
+    order: 1;
   }
   .socialblue--sky.path-user .layout--with-complementary .navbar-secondary .navbar-nav, .socialblue--sky.path-group .layout--with-complementary .navbar-secondary .navbar-nav {
     width: 100%;
@@ -69,25 +63,17 @@
     right: 15px;
     border-width: 6px 6px 0;
     border-top-color: #fff;
-    -webkit-transform: translateY(-50%);
-            transform: translateY(-50%);
+    transform: translateY(-50%);
     cursor: pointer;
   }
   .socialblue--sky.path-user .layout--with-complementary .navbar-secondary .navbar-nav .caret.active, .socialblue--sky.path-group .layout--with-complementary .navbar-secondary .navbar-nav .caret.active {
-    -webkit-transform: translateY(-50%) rotate(180deg);
-            transform: translateY(-50%) rotate(180deg);
+    transform: translateY(-50%) rotate(180deg);
   }
   .socialblue--sky.path-user .layout--with-complementary .navbar-secondary .navbar-nav .visible-list, .socialblue--sky.path-group .layout--with-complementary .navbar-secondary .navbar-nav .visible-list {
-    display: -webkit-box;
-    display: -ms-flexbox;
     display: flex;
     height: 44px;
-    -webkit-box-align: center;
-        -ms-flex-align: center;
-            align-items: center;
-    -webkit-box-pack: center;
-        -ms-flex-pack: center;
-            justify-content: center;
+    align-items: center;
+    justify-content: center;
     padding: 0 25px;
   }
   .socialblue--sky.path-user .layout--with-complementary .navbar-secondary .navbar-nav .visible-list a, .socialblue--sky.path-group .layout--with-complementary .navbar-secondary .navbar-nav .visible-list a {
@@ -108,13 +94,13 @@
     display: block;
     text-align: left;
   }
-  .socialblue--sky.path-user .layout--with-complementary .navbar-secondary .navbar-nav .hidden-list li a, .socialblue--sky.path-group .layout--with-complementary .navbar-secondary .navbar-nav .hidden-list li a {
+  .socialblue--sky.path-user .layout--with-complementary .navbar-secondary .navbar-nav .hidden-list li a, .socialblue--sky.path-user .layout--with-complementary .navbar-secondary .navbar-nav .hidden-list li button, .socialblue--sky.path-group .layout--with-complementary .navbar-secondary .navbar-nav .hidden-list li a, .socialblue--sky.path-group .layout--with-complementary .navbar-secondary .navbar-nav .hidden-list li button {
     display: block;
     width: 100%;
     padding: .5rem 2rem;
     color: #9b9b9b;
   }
-  .socialblue--sky.path-user .layout--with-complementary .navbar-secondary .navbar-nav .hidden-list li a:focus, .socialblue--sky.path-group .layout--with-complementary .navbar-secondary .navbar-nav .hidden-list li a:focus {
+  .socialblue--sky.path-user .layout--with-complementary .navbar-secondary .navbar-nav .hidden-list li a:focus, .socialblue--sky.path-user .layout--with-complementary .navbar-secondary .navbar-nav .hidden-list li button:focus, .socialblue--sky.path-group .layout--with-complementary .navbar-secondary .navbar-nav .hidden-list li a:focus, .socialblue--sky.path-group .layout--with-complementary .navbar-secondary .navbar-nav .hidden-list li button:focus {
     background: transparent;
   }
 }

--- a/themes/socialblue/assets/css/navbar.css
+++ b/themes/socialblue/assets/css/navbar.css
@@ -3,11 +3,14 @@
   background-color: transparent;
 }
 
-.nav > li.disabled > a {
+.nav > li.disabled > a,
+.nav > li.disabled > button {
   color: #777;
 }
 
-.nav > li.disabled > a:hover, .nav > li.disabled > a:focus {
+.nav > li.disabled > a:hover, .nav > li.disabled > a:focus,
+.nav > li.disabled > button:hover,
+.nav > li.disabled > button:focus {
   color: #777;
 }
 
@@ -15,29 +18,39 @@
   background-color: #333333;
 }
 
-.navbar-default .navbar-nav > li > a {
+.navbar-default .navbar-nav > li > a,
+.navbar-default .navbar-nav > li > button {
   color: #ffffff;
   fill: #ffffff;
 }
 
-.navbar-default .navbar-nav > li > a:hover, .navbar-default .navbar-nav > li > a:focus {
+.navbar-default .navbar-nav > li > a:hover, .navbar-default .navbar-nav > li > a:focus,
+.navbar-default .navbar-nav > li > button:hover,
+.navbar-default .navbar-nav > li > button:focus {
   color: #e6e6e6;
   fill: #e6e6e6;
   background-color: #1a8dbe;
 }
 
-.navbar-default .navbar-nav > .active > a,
-.navbar-default .navbar-nav > .active > a:hover,
-.navbar-default .navbar-nav > .active > a:focus,
+.navbar-default .navbar-nav > .active > a, .navbar-default .navbar-nav > .active > a:hover, .navbar-default .navbar-nav > .active > a:focus,
+.navbar-default .navbar-nav > .active > button,
+.navbar-default .navbar-nav > .active > button:hover,
+.navbar-default .navbar-nav > .active > button:focus,
 .navbar-default .navbar-nav > li > a.is-active,
 .navbar-default .navbar-nav > li > a.is-active:hover,
-.navbar-default .navbar-nav > li > a.is-active:focus {
+.navbar-default .navbar-nav > li > a.is-active:focus,
+.navbar-default .navbar-nav > li > button.is-active,
+.navbar-default .navbar-nav > li > button.is-active:hover,
+.navbar-default .navbar-nav > li > button.is-active:focus {
   color: #f3f3f3;
   fill: #f3f3f3;
   background-color: #1f1f1f;
 }
 
-.navbar-default .navbar-nav > .disabled > a, .navbar-default .navbar-nav > .disabled > a:hover, .navbar-default .navbar-nav > .disabled > a:focus {
+.navbar-default .navbar-nav > .disabled > a, .navbar-default .navbar-nav > .disabled > a:hover, .navbar-default .navbar-nav > .disabled > a:focus,
+.navbar-default .navbar-nav > .disabled > button,
+.navbar-default .navbar-nav > .disabled > button:hover,
+.navbar-default .navbar-nav > .disabled > button:focus {
   color: #ccc;
   fill: #ccc;
   background-color: transparent;
@@ -48,17 +61,22 @@
   border-top-right-radius: 0;
 }
 
-.navbar-default .dropdown-menu > li > a:hover, .navbar-default .dropdown-menu > li > a:focus {
+.navbar-default .dropdown-menu > li > a:hover, .navbar-default .dropdown-menu > li > a:focus,
+.navbar-default .dropdown-menu > li > button:hover,
+.navbar-default .dropdown-menu > li > button:focus {
   background-color: #f5f5f5;
 }
 
-.navbar-default .dropdown-menu > li > a.is-active {
+.navbar-default .dropdown-menu > li > a.is-active,
+.navbar-default .dropdown-menu > li > button.is-active {
   background-color: #e6e6e6;
   color: #4d4d4d;
   font-weight: 500;
 }
 
-.navbar-default .dropdown-menu > li > a.is-active:hover, .navbar-default .dropdown-menu > li > a.is-active:focus {
+.navbar-default .dropdown-menu > li > a.is-active:hover, .navbar-default .dropdown-menu > li > a.is-active:focus,
+.navbar-default .dropdown-menu > li > button.is-active:hover,
+.navbar-default .dropdown-menu > li > button.is-active:focus {
   cursor: default;
 }
 
@@ -74,7 +92,10 @@
   border-color: #ffffff;
 }
 
-.navbar-default .navbar-nav > .open > a, .navbar-default .navbar-nav > .open > a:hover, .navbar-default .navbar-nav > .open > a:focus {
+.navbar-default .navbar-nav > .open > a, .navbar-default .navbar-nav > .open > a:hover, .navbar-default .navbar-nav > .open > a:focus,
+.navbar-default .navbar-nav > .open > button,
+.navbar-default .navbar-nav > .open > button:hover,
+.navbar-default .navbar-nav > .open > button:focus {
   background-color: #1f1f1f;
   color: #f3f3f3;
 }
@@ -110,16 +131,18 @@
   background-color: #1f80aa;
 }
 
-.navbar-secondary .navbar-nav a {
+.navbar-secondary .navbar-nav a, .navbar-secondary .navbar-nav button {
   color: #fff;
 }
 
-.navbar-secondary .navbar-nav li.active a {
+.navbar-secondary .navbar-nav li.active a, .navbar-secondary .navbar-nav li.active button {
   border-bottom-color: #fff;
 }
 
 .navbar-secondary .navbar-nav li:not(.active) a:hover,
-.navbar-secondary .navbar-nav li:not(.active) a:focus {
+.navbar-secondary .navbar-nav li:not(.active) button:hover,
+.navbar-secondary .navbar-nav li:not(.active) a:focus,
+.navbar-secondary .navbar-nav li:not(.active) button:focus {
   outline: none;
   background-color: rgba(0, 0, 0, 0.3);
   border-bottom-color: rgba(0, 0, 0, 0.3);
@@ -140,42 +163,63 @@
 }
 
 @media (max-width: 599px) {
-  .navbar-default .navbar-nav .open .dropdown-menu > li > a {
+  .navbar-default .navbar-nav .open .dropdown-menu > li > a,
+  .navbar-default .navbar-nav .open .dropdown-menu > li > button {
     color: #ffffff;
   }
-  .navbar-default .navbar-nav .open .dropdown-menu > li > a:hover, .navbar-default .navbar-nav .open .dropdown-menu > li > a:focus {
+  .navbar-default .navbar-nav .open .dropdown-menu > li > a:hover, .navbar-default .navbar-nav .open .dropdown-menu > li > a:focus,
+  .navbar-default .navbar-nav .open .dropdown-menu > li > button:hover,
+  .navbar-default .navbar-nav .open .dropdown-menu > li > button:focus {
     color: #e6e6e6;
     background-color: #1a8dbe;
   }
-  .navbar-default .navbar-nav .open .dropdown-menu > .active > a, .navbar-default .navbar-nav .open .dropdown-menu > .active > a:hover, .navbar-default .navbar-nav .open .dropdown-menu > .active > a:focus {
+  .navbar-default .navbar-nav .open .dropdown-menu > .active > a, .navbar-default .navbar-nav .open .dropdown-menu > .active > a:hover, .navbar-default .navbar-nav .open .dropdown-menu > .active > a:focus,
+  .navbar-default .navbar-nav .open .dropdown-menu > .active > button,
+  .navbar-default .navbar-nav .open .dropdown-menu > .active > button:hover,
+  .navbar-default .navbar-nav .open .dropdown-menu > .active > button:focus {
     color: #f3f3f3;
     background-color: #1f1f1f;
   }
-  .navbar-default .navbar-nav .open .dropdown-menu > .disabled > a, .navbar-default .navbar-nav .open .dropdown-menu > .disabled > a:hover, .navbar-default .navbar-nav .open .dropdown-menu > .disabled > a:focus {
+  .navbar-default .navbar-nav .open .dropdown-menu > .disabled > a, .navbar-default .navbar-nav .open .dropdown-menu > .disabled > a:hover, .navbar-default .navbar-nav .open .dropdown-menu > .disabled > a:focus,
+  .navbar-default .navbar-nav .open .dropdown-menu > .disabled > button,
+  .navbar-default .navbar-nav .open .dropdown-menu > .disabled > button:hover,
+  .navbar-default .navbar-nav .open .dropdown-menu > .disabled > button:focus {
     color: #ccc;
     background-color: transparent;
   }
 }
 
 @media (max-width: 899px) {
-  .navbar-collapse .dropdown-menu li a {
+  .navbar-collapse .dropdown-menu li a,
+  .navbar-collapse .dropdown-menu li button {
     color: #ffffff;
   }
-  .navbar-collapse .dropdown-menu li a:hover, .navbar-collapse .dropdown-menu li a:focus {
+  .navbar-collapse .dropdown-menu li a:hover, .navbar-collapse .dropdown-menu li a:focus,
+  .navbar-collapse .dropdown-menu li button:hover,
+  .navbar-collapse .dropdown-menu li button:focus {
     background-color: #1f80aa;
   }
-  .navbar-default .navbar-nav .open .dropdown-menu > li > a {
+  .navbar-default .navbar-nav .open .dropdown-menu > li > a,
+  .navbar-default .navbar-nav .open .dropdown-menu > li > button {
     color: #4d4d4d;
   }
-  .navbar-default .navbar-nav .open .dropdown-menu > li > a:hover, .navbar-default .navbar-nav .open .dropdown-menu > li > a:focus {
+  .navbar-default .navbar-nav .open .dropdown-menu > li > a:hover, .navbar-default .navbar-nav .open .dropdown-menu > li > a:focus,
+  .navbar-default .navbar-nav .open .dropdown-menu > li > button:hover,
+  .navbar-default .navbar-nav .open .dropdown-menu > li > button:focus {
     color: #404040;
     background-color: #f5f5f5;
   }
-  .navbar-default .navbar-nav .open .dropdown-menu > .active > a, .navbar-default .navbar-nav .open .dropdown-menu > .active > a:hover, .navbar-default .navbar-nav .open .dropdown-menu > .active > a:focus {
+  .navbar-default .navbar-nav .open .dropdown-menu > .active > a, .navbar-default .navbar-nav .open .dropdown-menu > .active > a:hover, .navbar-default .navbar-nav .open .dropdown-menu > .active > a:focus,
+  .navbar-default .navbar-nav .open .dropdown-menu > .active > button,
+  .navbar-default .navbar-nav .open .dropdown-menu > .active > button:hover,
+  .navbar-default .navbar-nav .open .dropdown-menu > .active > button:focus {
     color: #ffffff;
     background-color: #1f80aa;
   }
-  .navbar-default .navbar-nav .open .dropdown-menu > .disabled > a, .navbar-default .navbar-nav .open .dropdown-menu > .disabled > a:hover, .navbar-default .navbar-nav .open .dropdown-menu > .disabled > a:focus {
+  .navbar-default .navbar-nav .open .dropdown-menu > .disabled > a, .navbar-default .navbar-nav .open .dropdown-menu > .disabled > a:hover, .navbar-default .navbar-nav .open .dropdown-menu > .disabled > a:focus,
+  .navbar-default .navbar-nav .open .dropdown-menu > .disabled > button,
+  .navbar-default .navbar-nav .open .dropdown-menu > .disabled > button:hover,
+  .navbar-default .navbar-nav .open .dropdown-menu > .disabled > button:focus {
     color: #4d4d4d;
     background-color: #777;
   }

--- a/themes/socialblue/components/03-molecules/navigation/navbar/navbar--sky.scss
+++ b/themes/socialblue/components/03-molecules/navigation/navbar/navbar--sky.scss
@@ -39,7 +39,7 @@
 
     .navbar-nav {
       li {
-        a {
+        a, button {
           padding: 9px 20px 8px;
           opacity: 1;
           border-bottom-width: 3px;
@@ -54,7 +54,7 @@
         }
 
         &.active {
-          a {
+          a, button {
             color: #fff;
             border-bottom-color: #fff;
           }
@@ -131,7 +131,7 @@
                 display: block;
                 text-align: left;
 
-                a {
+                a, button {
                   display: block;
                   width: 100%;
                   padding: .5rem 2rem;

--- a/themes/socialblue/components/03-molecules/navigation/navbar/navbar.scss
+++ b/themes/socialblue/components/03-molecules/navigation/navbar/navbar.scss
@@ -7,7 +7,8 @@
     background-color: $nav-link-hover-bg;
   }
 
-  &.disabled > a {
+  &.disabled > a,
+  &.disabled > button {
     color: $nav-disabled-link-color;
 
     &:hover,
@@ -24,7 +25,8 @@
   background-color: $navbar-default-bg;
 
   .navbar-nav {
-    > li > a {
+    > li > a,
+    > li > button {
       color: $navbar-default-link-color;
       fill: $navbar-default-link-color;
 
@@ -37,17 +39,20 @@
     }
 
     > .active > a,
-    > .active > a:hover,
-    > .active > a:focus,
+    > .active > button,
     > li > a.is-active,
-    > li > a.is-active:hover,
-    > li > a.is-active:focus {
-      color: $navbar-default-link-active-color;
-      fill: $navbar-default-link-active-color;
-      background-color: $navbar-default-link-active-bg;
+    > li > button.is-active {
+      &,
+      &:hover,
+      &:focus {
+        color: $navbar-default-link-active-color;
+        fill: $navbar-default-link-active-color;
+        background-color: $navbar-default-link-active-bg;
+      }
     }
 
-    > .disabled > a {
+    > .disabled > a,
+    > .disabled > button {
       &,
       &:hover,
       &:focus {
@@ -63,7 +68,8 @@
     border-top-left-radius: 0;
     border-top-right-radius: 0;
 
-    > li > a {
+    > li > a,
+    > li > button {
 
       &:hover,
       &:focus {
@@ -101,7 +107,8 @@
   // Dropdown menu items
   .navbar-nav {
     // Remove background color from open dropdown
-    > .open > a {
+    > .open > a,
+    > .open > button {
       &,
       &:hover,
       &:focus {
@@ -113,7 +120,8 @@
     @include for-phone-only {
       // Dropdowns get custom display when collapsed
       .open .dropdown-menu {
-        > li > a {
+        > li > a,
+        > li > button {
           color: $navbar-default-link-color;
           &:hover,
           &:focus {
@@ -121,7 +129,8 @@
             background-color: $navbar-default-link-hover-bg;
           }
         }
-        > .active > a {
+        > .active > a,
+        > .active > button {
           &,
           &:hover,
           &:focus {
@@ -129,7 +138,8 @@
             background-color: $navbar-default-link-active-bg;
           }
         }
-        > .disabled > a {
+        > .disabled > a,
+        > .disabled > button {
           &,
           &:hover,
           &:focus {
@@ -144,7 +154,8 @@
 }
 
 @include for-tablet-landscape-down {
-  .navbar-collapse .dropdown-menu li a {
+  .navbar-collapse .dropdown-menu li a,
+  .navbar-collapse .dropdown-menu li button {
     color: #ffffff;
 
     &:hover,
@@ -156,7 +167,8 @@
 
   .navbar-default .navbar-nav .open .dropdown-menu {
 
-    > li > a {
+    > li > a,
+    > li > button {
       color: $dropdown-link-color;
       &:hover,
       &:focus {
@@ -164,7 +176,8 @@
         background-color: $dropdown-link-hover-bg;
       }
     }
-    > .active > a {
+    > .active > a,
+    > .active > button {
       &,
       &:hover,
       &:focus {
@@ -172,7 +185,8 @@
         background-color: $dropdown-link-active-bg;
       }
     }
-    > .disabled > a {
+    > .disabled > a,
+    > .disabled > button {
       &,
       &:hover,
       &:focus {
@@ -237,16 +251,18 @@
 
   .navbar-nav {
 
-    a {
+    a, button {
       color: #fff;
     }
 
-    li.active a {
+    li.active a, li.active button {
       border-bottom-color: #fff;
     }
 
     li:not(.active) a:hover,
-    li:not(.active) a:focus {
+    li:not(.active) button:hover,
+    li:not(.active) a:focus,
+    li:not(.active) button:focus {
       outline: none;
       background-color: rgba(0,0,0,0.3);
       border-bottom-color: rgba(0,0,0,0.3);

--- a/themes/socialblue/components/brand.scss
+++ b/themes/socialblue/components/brand.scss
@@ -187,6 +187,9 @@
 .nav-tabs > li.active > a,
 .nav-tabs > li.active > a:hover,
 .nav-tabs > li.active > a:focus,
+.nav-tabs > li.active > button,
+.nav-tabs > li.active > button:hover,
+.nav-tabs > li.active > button:focus,
 .card__link,
 .card__link:focus,
 .card__link:hover,
@@ -240,11 +243,11 @@ blockquote {
 
   .navbar-nav {
 
-    a {
+    a, button {
       color: #f9f9f9;
     }
 
-    li.active a {
+    li.active a, li.active button {
       border-bottom-color: #f9f9f9;
     }
 
@@ -273,7 +276,8 @@ blockquote {
   }
 
   .navbar-nav {
-    > li > a {
+    > li > a,
+    > li > button {
       color: $navbar-default-link-color;
       fill: $navbar-default-link-color;
 
@@ -288,7 +292,8 @@ blockquote {
       }
     }
 
-    > .open > a {
+    > .open > a,
+    > .open > button {
       &,
       &:hover,
       &:focus {
@@ -298,7 +303,9 @@ blockquote {
     }
 
     > li > a.is-active,
-    > .active > a {
+    > li > button.is-active,
+    > .active > a,
+    > .active > button {
       &,
       &:hover,
       &:focus {
@@ -332,7 +339,8 @@ html:not(.js) .navbar-default {
     &:focus,
     &:hover {
 
-      > a {
+      > a,
+      > button {
         color: $navbar-default-link-active-color;
         background-color: $navbar-default-link-active-bg;
 


### PR DESCRIPTION
…ttons

<h3 id="summary-problem-motivation">Problem/Motivation</h3>
It sometimes makes more semantic sense to have a button in the account header menu instead of a link. For example when a button should open a modal and doesn't lead to a separate page. However, adding a button element in the account header menu causes an improperly styled menu.


<h3 id="summary-proposed-resolution">Proposed resolution</h3>
Adjust the navbar CSS to style a button the same as a link element. Additionally allow creating buttons in the account header menu by declaring the URL as an empty string (doing this currently leads to no output at all).

## Issue tracker
https://www.drupal.org/project/social/issues/3178204

## How to test
- [ ] Adjust an account header link implementation to have an empty URL (`""`)
- [ ] See that the navigation now contains a properly styled button rather than a link

## Screenshots
N.a.

## Release notes
To enable some future features we're making it possible to programmatically add buttons in the account header items. Hook implementations can now leave the URL empty to make use of this feature.

## Change Record
N.a.

## Translations
N.a.