### PR TITLE
TB-4516 - Determine where user goes after registration.

### DIFF
--- a/modules/custom/alternative_frontpage/src/Form/AlternativeFrontpageSettings.php
+++ b/modules/custom/alternative_frontpage/src/Form/AlternativeFrontpageSettings.php
@@ -82,6 +82,14 @@ class AlternativeFrontpageSettings extends ConfigFormBase {
       '#size' => 64,
       '#default_value' => $config->get('frontpage_for_authenticated_user'),
     ];
+    $form['redirect_after_signup'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Redirect new users to specific page'),
+      '#description' => $this->t('The page where we want to redirect new signed-up users towards. Enter the path starting with a forward slash. Default: /stream.'),
+      '#maxlength' => 64,
+      '#size' => 64,
+      '#default_value' => $config->get('redirect_after_signup'),
+    ];
     return parent::buildForm($form, $form_state);
   }
 
@@ -91,6 +99,7 @@ class AlternativeFrontpageSettings extends ConfigFormBase {
   public function validateForm(array &$form, FormStateInterface $form_state) {
     $frontpage_for_anonymous_user = $form_state->getValue('frontpage_for_anonymous_users');
     $frontpage_for_authenticated_user = $form_state->getValue('frontpage_for_authenticated_user');
+    $redirect_after_signup = $form_state->getValue('redirect_after_signup');
 
     if ($frontpage_for_anonymous_user) {
       if (!$this->pathValidator->getUrlIfValidWithoutAccessCheck($frontpage_for_anonymous_user)) {
@@ -115,6 +124,18 @@ class AlternativeFrontpageSettings extends ConfigFormBase {
       }
       elseif (!$this->isAllowedPath($frontpage_for_authenticated_user)) {
         $form_state->setErrorByName('frontpage_for_authenticated_user', $this->t('The path for the authenticated frontpage is not allowed.'));
+      }
+    }
+
+    if ($redirect_after_signup) {
+      if (!$this->pathValidator->getUrlIfValidWithoutAccessCheck($redirect_after_signup)) {
+        $form_state->setErrorByName('redirect_after_signup', $this->t('The path for the redirect after signup is not valid.'));
+      }
+      elseif (substr($redirect_after_signup, 0, 1) !== '/') {
+        $form_state->setErrorByName('redirect_after_signup', $this->t('The path for the redirect after signup should start with a forward slash.'));
+      }
+      elseif (!$this->isAllowedPath($redirect_after_signup)) {
+        $form_state->setErrorByName('redirect_after_signup', $this->t('The path for the redirect after signup is not allowed.'));
       }
     }
   }
@@ -154,6 +175,9 @@ class AlternativeFrontpageSettings extends ConfigFormBase {
       ->save();
 
     $this->configFactory->getEditable('system.site')->set('page.front', $form_state->getValue('frontpage_for_anonymous_users'))->save();
+    $this->config('alternative_frontpage.settings')
+      ->set('redirect_after_signup', $form_state->getValue('redirect_after_signup'))
+      ->save();
   }
 
 }

--- a/modules/social_features/social_profile/social_profile.module
+++ b/modules/social_features/social_profile/social_profile.module
@@ -209,6 +209,14 @@ function _social_profile_profile_edit_form_submit(array $form, FormStateInterfac
         'user' => $uid,
       ]
     );
+    // If this was the first login and alternative frontpage is enabled,
+    // send the user elsewhere.
+    $first_time_login = \Drupal::request()->get('first_time_login');
+    if ($first_time_login && \Drupal::moduleHandler()->moduleExists('alternative_frontpage')) {
+      $redirect_after_signup = \Drupal::configFactory()->get('alternative_frontpage.settings')->get('redirect_after_signup');
+      $redirect = Url::fromUserInput($redirect_after_signup);
+      $form_state->setRedirectUrl($redirect);
+    }
   }
 }
 

--- a/modules/social_features/social_profile/social_profile.module
+++ b/modules/social_features/social_profile/social_profile.module
@@ -214,8 +214,10 @@ function _social_profile_profile_edit_form_submit(array $form, FormStateInterfac
     $first_time_login = \Drupal::request()->get('first_time_login');
     if ($first_time_login && \Drupal::moduleHandler()->moduleExists('alternative_frontpage')) {
       $redirect_after_signup = \Drupal::configFactory()->get('alternative_frontpage.settings')->get('redirect_after_signup');
-      $redirect = Url::fromUserInput($redirect_after_signup);
-      $form_state->setRedirectUrl($redirect);
+      if (isset($redirect_after_signup)) {
+        $redirect = Url::fromUserInput($redirect_after_signup);
+        $form_state->setRedirectUrl($redirect);
+      }
     }
   }
 }

--- a/modules/social_features/social_user/social_user.module
+++ b/modules/social_features/social_user/social_user.module
@@ -339,9 +339,9 @@ function _social_user_pass_reset_submit($form, FormStateInterface $form_state) {
         [
           'user' => $submitted_user_id,
           'profile_type' => 'profile',
+          'first_time_login' => TRUE,
           [],
         ]);
-      $form_state->set('first_time_login', FALSE);
     }
     else {
       // We redirect them to the home page stream.

--- a/modules/social_features/social_user/social_user.module
+++ b/modules/social_features/social_user/social_user.module
@@ -342,6 +342,7 @@ function _social_user_pass_reset_submit($form, FormStateInterface $form_state) {
           'first_time_login' => TRUE,
           [],
         ]);
+      $form_state->set('first_time_login', FALSE);
     }
     else {
       // We redirect them to the home page stream.


### PR DESCRIPTION
## Problem
* When a new user signs up for an open social platform, we let him / her fill in the account details and profile details. Afterwards, they are sent towards their own profile. This does not help onboarding them; it would be nice if we could send this user to a configurable page.

## Solution
Added an argument to use when the user first time logs in. If so, we check on saving the already created profile (it is not new, unfortunately) where we send the user. When this is configured correctly, we send the user to the configured page

## Issue tracker
https://www.drupal.org/project/social/issues/3181460

## How to test
- [ ] As admin, enable the alternative_frontpage module and configure their paths at `/admin/config/alternative_frontpage`
- [ ] Register as a new user
- [ ] Use your one-time login link
- [ ] Complete your account and your profile and see you get sent to the path you configured.

## Release notes
We made it possible to configure where a user goes after registering with the platform, using the alternative frontpage module.
