### PR TITLE
Travis self-updates to v2 of composer while we don't support it (yet).

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,6 +52,9 @@ before_install:
   - export PR=https://api.github.com/repos/$TRAVIS_REPO_SLUG/pulls/$TRAVIS_PULL_REQUEST
   - export BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_BRANCH; else echo $TRAVIS_PULL_REQUEST_BRANCH; fi)
   - export COMMIT=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_COMMIT; else echo $TRAVIS_PULL_REQUEST_SHA; fi)
+  # Travis self-updates it's PHP and Composer dependencies every 30-60 days, so it automatically updates to version 2
+  # which we don't support. There for we self-update to --1 until we support version 2.
+  - composer self-update --1
   # Installing hirak/prestissimo allows composer to parallelise downloads which speeds up the composer install.
   - composer global require hirak/prestissimo
   - echo "TRAVIS_BRANCH=$TRAVIS_BRANCH, PR=$PR, BRANCH=$BRANCH, COMMIT=$COMMIT"


### PR DESCRIPTION
## Problem
Travis runs

```

composer self-update
Upgrading to version 2.0.6 (stable channel).
   
Use composer self-update --rollback to return to version 2.0.4
```

While we don't support it yet, breaking our tests.



## Solution
**Solution 1. Rollback to v1 untill we support it.** 
Solution 2. In a separate PR is to remove hirak/prestissimo and see if v2 actually does work in tests. hirak/prestissimo isn't necessary anymore for composer v2 since performance is much improved (also they announced it themselves) 
Solution 2 is tested in #2059 

So lets see which one is green!

## Issue tracker
None

## How to test
See if tests succeed.