### PR TITLE
Issue #3182368 by tBKoT: Don't send any message if user don't have permission to view it

### DIFF
--- a/modules/social_features/social_group/modules/social_group_welcome_message/social_group_welcome_message.module
+++ b/modules/social_features/social_group/modules/social_group_welcome_message/social_group_welcome_message.module
@@ -94,11 +94,18 @@ function social_group_welcome_message_group_content_insert(GroupContentInterface
     $g_type_id = $group->getGroupType()->id();
 
     // Load the account of the user who just joined.
+    /** @var \Drupal\user\UserInterface $account */
     $account = $group_content->getEntity();
 
     // Skip sending notifications to the owner of the group. They probably know
     // they created the group a second ago.
     if ($group->getOwnerId() === $account->id()) {
+      return;
+    }
+
+    // Do not send mail for user that don't have permission to view private
+    // message.
+    if (!$account->hasPermission('use private messaging system')) {
       return;
     }
 

--- a/modules/social_features/social_private_message/src/Plugin/ActivityContext/PrivateMessageActivityContext.php
+++ b/modules/social_features/social_private_message/src/Plugin/ActivityContext/PrivateMessageActivityContext.php
@@ -10,7 +10,7 @@ use Drupal\Core\Entity\Query\Sql\QueryFactory;
 use Drupal\private_message\Entity\PrivateMessageInterface;
 use Drupal\private_message\Entity\PrivateMessageThreadInterface;
 use Drupal\private_message\Service\PrivateMessageServiceInterface;
-use Drupal\user\Entity\User;
+use Drupal\user\UserInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -106,9 +106,14 @@ class PrivateMessageActivityContext extends ActivityContextBase {
 
               // Loop over all PMT participants.
               foreach ($members as $member) {
-                if ($member instanceof User) {
+                if ($member instanceof UserInterface) {
                   // Filter out the author of this message.
                   if ($member->id() == $data['actor']) {
+                    continue;
+                  }
+
+                  // Continue if member have permission to view private message.
+                  if (!$member->hasPermission('use private messaging system')) {
                     continue;
                   }
 

--- a/modules/social_features/social_private_message/src/Plugin/EntityReferenceSelection/UserSelection.php
+++ b/modules/social_features/social_private_message/src/Plugin/EntityReferenceSelection/UserSelection.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Drupal\social_private_message\Plugin\EntityReferenceSelection;
+
+use Drupal\social_profile\Plugin\EntityReferenceSelection\UserSelection as UserSelectionBase;
+use Drupal\user\RoleInterface;
+
+/**
+ * Provides specific access control for the user entity type.
+ *
+ * @EntityReferenceSelection(
+ *   id = "social_private_message:user",
+ *   label = @Translation("Social user selection"),
+ *   entity_types = {"user"},
+ *   group = "social_private_message",
+ *   weight = 1
+ * )
+ */
+class UserSelection extends UserSelectionBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function buildEntityQuery($match = NULL, $match_operator = 'CONTAINS', array $ids = []) {
+    /** @var \Drupal\user\RoleStorageInterface $r_storage */
+    $role_storage = $this->entityTypeManager->getStorage('user_role');
+
+    // Continue if authenticated users has permission to view private messages.
+    if ($role_storage->load(RoleInterface::AUTHENTICATED_ID)->hasPermission('use private messaging system')) {
+      return parent::buildEntityQuery($match, $match_operator, $ids);
+    }
+
+    // Gets all roles that have permission to view private messages.
+    /** @var \Drupal\user\RoleInterface[] $all_roles */
+    $all_roles = $role_storage->loadMultiple();
+    $rids = array_keys(array_filter($all_roles, static function ($role) {
+      return $role->hasPermission('use private messaging system');
+    }));
+
+    // Gets users IDs that have permission to view private messages.
+    $uids = $this->entityTypeManager->getStorage('user')->getQuery()
+      ->condition('roles', $rids, 'IN')
+      ->condition('uid', $this->currentUser->id(), '<>')
+      ->execute();
+
+    $query = parent::buildEntityQuery($match, $match_operator, $ids);
+    $query->condition('uid', $uids, 'IN');
+    return $query;
+  }
+
+}

--- a/modules/social_features/social_private_message/src/Plugin/Field/FieldWidget/SocialPrivateMessageThreadMemberWidget.php
+++ b/modules/social_features/social_private_message/src/Plugin/Field/FieldWidget/SocialPrivateMessageThreadMemberWidget.php
@@ -24,7 +24,7 @@ class SocialPrivateMessageThreadMemberWidget extends PrivateMessageThreadMemberW
    * {@inheritdoc}
    */
   public function formElement(FieldItemListInterface $items, $delta, array $element, array &$form, FormStateInterface $form_state) {
-    $element['#selection_handler'] = 'social';
+    $element['#selection_handler'] = 'social_private_message';
     $element = parent::formElement($items, $delta, $element, $form, $form_state);
     $element['target_id']['#type'] = 'social_private_message_entity_autocomplete';
     $element['target_id']['#tags'] = TRUE;

--- a/modules/social_features/social_private_message/src/Service/PrivateMessageMailer.php
+++ b/modules/social_features/social_private_message/src/Service/PrivateMessageMailer.php
@@ -17,7 +17,10 @@ class PrivateMessageMailer extends PrivateMessageMailerBase {
    */
   public function send(PrivateMessageInterface $message, PrivateMessageThreadInterface $thread, array $members = []) {
     foreach ($members as $id => $member) {
-      if (!($member instanceof UserInterface)) {
+      if (
+        !($member instanceof UserInterface) ||
+        !$member->hasPermission('use private messaging system')
+      ) {
         unset($members[$id]);
       }
     }

--- a/modules/social_features/social_profile/social_profile.module
+++ b/modules/social_features/social_profile/social_profile.module
@@ -46,7 +46,11 @@ function social_profile_field_widget_form_alter(&$element, FormStateInterface $f
   }
   // This replaces all user entity references with our EntityReferenceSelection.
   if ($field_definition->getType() === 'entity_reference') {
-    if (isset($element['target_id']['#target_type']) && $element['target_id']['#target_type'] === 'user') {
+    if (
+      isset($element['target_id']['#target_type']) &&
+      $element['target_id']['#target_type'] === 'user' &&
+      $element['target_id']['#type'] !== 'social_private_message_entity_autocomplete'
+    ) {
       $element['target_id']['#selection_handler'] = 'social';
     }
   }


### PR DESCRIPTION
## Problem
As LU I only want to be able to write messages to users that have permission to see them

## Solution
Check if the user has the `use private messaging system` permission before sending him an email related to private messages.

## Issue tracker
https://www.drupal.org/project/social/issues/3182368
https://getopensocial.atlassian.net/browse/YANG-3889

## How to test
- [x] Create a new group with welcome message.
- [x] Add members (with and without permission to view private messages) directly to the group.
- [x] Only users with permission to view private messages should receive an email.

## Screenshots
N/A

## Release notes
Now users that don't have permission to view private messages do not receive emails. 

## Change Record
N/A

## Translations
N/A
