### PR TITLE
Issue #3183002 by tBKoT: Add tags filtering to the #lazy_builder

### DIFF
--- a/modules/social_features/social_activity/social_activity.module
+++ b/modules/social_features/social_activity/social_activity.module
@@ -289,6 +289,7 @@ function social_activity_preprocess_block(&$variables) {
         ],
       ];
 
+      // Set vocabulary ID from views filter.
       if (isset($view->filter_vocabulary)) {
         $variables['content']['#lazy_builder'][1] = array_merge(
           $variables['content']['#lazy_builder'][1],
@@ -296,6 +297,7 @@ function social_activity_preprocess_block(&$variables) {
         );
       }
 
+      // Set taxonomy IDs from views filter.
       if (isset($view->filter_tags) && is_array($view->filter_tags)) {
         $variables['content']['#lazy_builder'][1] = array_merge(
           $variables['content']['#lazy_builder'][1],

--- a/modules/social_features/social_activity/social_activity.module
+++ b/modules/social_features/social_activity/social_activity.module
@@ -285,9 +285,17 @@ function social_activity_preprocess_block(&$variables) {
             $variables['content']['#display_id'],
             $node->bundle(),
             $view->getItemsPerPage(),
+            $variables['configuration']['vocabulary'],
           ],
         ],
       ];
+
+      if (is_array($variables['configuration']['tags'])) {
+        $variables['content']['#lazy_builder'][1] = array_merge(
+          $variables['content']['#lazy_builder'][1],
+          array_keys($variables['configuration']['tags'])
+        );
+      }
     }
   }
 }

--- a/modules/social_features/social_activity/social_activity.module
+++ b/modules/social_features/social_activity/social_activity.module
@@ -285,15 +285,21 @@ function social_activity_preprocess_block(&$variables) {
             $variables['content']['#display_id'],
             $node->bundle(),
             $view->getItemsPerPage(),
-            $variables['configuration']['vocabulary'],
           ],
         ],
       ];
 
-      if (is_array($variables['configuration']['tags'])) {
+      if (isset($view->filter_vocabulary)) {
         $variables['content']['#lazy_builder'][1] = array_merge(
           $variables['content']['#lazy_builder'][1],
-          array_keys($variables['configuration']['tags'])
+          [$view->filter_vocabulary]
+        );
+      }
+
+      if (isset($view->filter_tags) && is_array($view->filter_tags)) {
+        $variables['content']['#lazy_builder'][1] = array_merge(
+          $variables['content']['#lazy_builder'][1],
+          array_keys($view->filter_tags)
         );
       }
     }

--- a/modules/social_features/social_activity/src/SocialActivityLazyBuilder.php
+++ b/modules/social_features/social_activity/src/SocialActivityLazyBuilder.php
@@ -52,7 +52,7 @@ class SocialActivityLazyBuilder {
    *   Items to display.
    * @param string|null $vocabulary
    *   Vocabulary ID.
-   * @param array|int $tags
+   * @param mixed $tags
    *   List of tags IDs.
    *
    * @return array|null

--- a/modules/social_features/social_activity/src/SocialActivityLazyBuilder.php
+++ b/modules/social_features/social_activity/src/SocialActivityLazyBuilder.php
@@ -52,13 +52,13 @@ class SocialActivityLazyBuilder {
    *   Items to display.
    * @param string|null $vocabulary
    *   Vocabulary ID.
-   * @param array $tags
+   * @param array|int $tags
    *   List of tags IDs.
    *
    * @return array|null
    *   Render array.
    */
-  public function viewsLazyBuild($view_id, $display_id, $node_type, $item_per_page, $vocabulary = NULL, array ...$tags) {
+  public function viewsLazyBuild($view_id, $display_id, $node_type, $item_per_page, $vocabulary = NULL, ...$tags) {
     // Get view.
     $view_entity = $this->entityTypeManager->getStorage('view')->load($view_id);
     $view = $this->viewExecutable->get($view_entity);

--- a/modules/social_features/social_activity/src/SocialActivityLazyBuilder.php
+++ b/modules/social_features/social_activity/src/SocialActivityLazyBuilder.php
@@ -50,11 +50,15 @@ class SocialActivityLazyBuilder {
    *   Node bundle.
    * @param int $item_per_page
    *   Items to display.
+   * @param string|null $vocabulary
+   *   Vocabulary ID.
+   * @param array $tags
+   *   List of tags IDs.
    *
    * @return array|null
    *   Render array.
    */
-  public function viewsLazyBuild($view_id, $display_id, $node_type, $item_per_page) {
+  public function viewsLazyBuild($view_id, $display_id, $node_type, $item_per_page, $vocabulary = NULL, array ...$tags) {
     // Get view.
     $view_entity = $this->entityTypeManager->getStorage('view')->load($view_id);
     $view = $this->viewExecutable->get($view_entity);
@@ -62,6 +66,12 @@ class SocialActivityLazyBuilder {
     $view->setItemsPerPage($item_per_page);
     $view->preExecute();
     $view->execute($display_id);
+
+    // Add filtration if tags and vocabulary exists.
+    if ($vocabulary && $vocabulary !== '_none' && !empty($tags)) {
+      $view->filter_tags = $tags;
+      $view->filter_vocabulary = $vocabulary;
+    }
 
     // Change entity display and add attachments if views block in dashboard.
     if ($view->id() == "activity_stream" && $node_type === 'dashboard') {

--- a/modules/social_features/social_activity/src/SocialActivityLazyBuilder.php
+++ b/modules/social_features/social_activity/src/SocialActivityLazyBuilder.php
@@ -64,14 +64,15 @@ class SocialActivityLazyBuilder {
     $view = $this->viewExecutable->get($view_entity);
     $view->setDisplay($display_id);
     $view->setItemsPerPage($item_per_page);
-    $view->preExecute();
-    $view->execute($display_id);
 
     // Add filtration if tags and vocabulary exists.
     if ($vocabulary && $vocabulary !== '_none' && !empty($tags)) {
       $view->filter_tags = $tags;
       $view->filter_vocabulary = $vocabulary;
     }
+
+    $view->preExecute();
+    $view->execute($display_id);
 
     // Change entity display and add attachments if views block in dashboard.
     if ($view->id() == "activity_stream" && $node_type === 'dashboard') {


### PR DESCRIPTION
## Problem
New Activity Stream pulls content not defined by selected tag

## Solution
Add tag filter from views to the #lazy_builder

## Issue tracker
https://www.drupal.org/project/social/issues/3183002
https://getopensocial.atlassian.net/browse/YANG-4213

## How to test
*For example*
- [ ] Create a dashboard
- [ ] Add activity stream with tags filter
- [ ] Activity stream shows all activities without filtering


## Screenshots
N/A

## Release notes
N/A

## Change Record
N/A

## Translations
N/A
