### PR TITLE
#3183709: Add installer options yaml file to all optional modules

### DIFF
--- a/modules/social_features/social_event/modules/social_event_an_enroll_enrolments_export/social_event_an_enroll_enrolments_export.installer_options.yml
+++ b/modules/social_features/social_event/modules/social_event_an_enroll_enrolments_export/social_event_an_enroll_enrolments_export.installer_options.yml
@@ -1,0 +1,2 @@
+name: Anonymous Event Enrolments Export
+description: Allows users to export anonymous event enrollees for their events as comma separated value (csv) files.

--- a/modules/social_features/social_event/modules/social_event_invite/social_event_invite.installer_options.yml
+++ b/modules/social_features/social_event/modules/social_event_invite/social_event_invite.installer_options.yml
@@ -1,0 +1,3 @@
+name: Invite to Event
+description: Allows event managers to invite people to the event.
+default: true

--- a/modules/social_features/social_event/modules/social_event_managers/social_event_managers.installer_options.yml
+++ b/modules/social_features/social_event/modules/social_event_managers/social_event_managers.installer_options.yml
@@ -1,2 +1,3 @@
 name: Event Organisers
 description: Allows users to add organisers to events besides the creator of the event itself.
+default: true

--- a/modules/social_features/social_group/modules/social_group_gvbo/social_group_gvbo.installer_options.yml
+++ b/modules/social_features/social_group/modules/social_group_gvbo/social_group_gvbo.installer_options.yml
@@ -1,0 +1,3 @@
+name: Group Views Bulk Operations Integration
+description: Integrates Views Bulk Operations with the Group management overviews.
+default: true

--- a/modules/social_features/social_group/modules/social_group_invite/social_group_invite.installer_options.yml
+++ b/modules/social_features/social_group/modules/social_group_invite/social_group_invite.installer_options.yml
@@ -1,0 +1,3 @@
+name: Invite to Group
+description: Allows group managers to invite people to the group.
+default: true

--- a/modules/social_features/social_group/modules/social_group_members_export/social_group_members_export.installer_options.yml
+++ b/modules/social_features/social_group/modules/social_group_members_export/social_group_members_export.installer_options.yml
@@ -1,0 +1,2 @@
+name: Group Members Export
+description: Allows users to export group members for their groups as comma separated value (csv) files.

--- a/modules/social_features/social_group/modules/social_group_quickjoin/social_group_quickjoin.installer_options.yml
+++ b/modules/social_features/social_group/modules/social_group_quickjoin/social_group_quickjoin.installer_options.yml
@@ -1,0 +1,2 @@
+name: Quickly join groups
+description: Allows users to skip confirmation to quickly join groups.

--- a/modules/social_features/social_group/modules/social_group_request/social_group_request.installer_options.yml
+++ b/modules/social_features/social_group/modules/social_group_request/social_group_request.installer_options.yml
@@ -1,0 +1,2 @@
+name: Secret groups
+description: Adds the secret group type which allows users to create groups that are not shown on the platform unless you're a member.

--- a/modules/social_features/social_group/modules/social_group_welcome_message/social_group_welcome_message.installer_options.yml
+++ b/modules/social_features/social_group/modules/social_group_welcome_message/social_group_welcome_message.installer_options.yml
@@ -1,0 +1,2 @@
+name: Group Request to Join
+description: Adds the option for users to request to join a group, it's configurable for the group manager.


### PR DESCRIPTION
## Problem
The installer options, which was introduced earlier this year, has not been applied to all optional modules. This needs to be done so these modules can be enabled (or not) on installation.

## Solution
Add the installer options to all optional modules missing one.

## Issue tracker
- https://www.drupal.org/project/social/issues/3183709

## How to test
TBD

## Screenshots
N/a

## Release notes
TBD

## Change Record
N/a

## Translations
N/a