### PR TITLE
Issue #3183500: Update drupal core to 8.9^

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,7 +73,7 @@ install:
 
 script:
   - set -e
-#  - if [ "$TEST_SUITE" = "install_stability_1" ]; then docker exec -i social_ci_web bash /var/www/scripts/social/check-coding-standards.sh full; fi
+#  - if [ "$TEST_SUITE" = "install_stability_1" ]; then docker exec -i social_ci_web bash /var/www/scripts/social/check-coding-standards.sh full; fi @TODO fix this so the \Drupal::register issue doesn't occur
   - if [ "$TEST_SUITE" = "install_stability_1" ]; then docker exec -i social_ci_web_scripts /var/www/scripts/social/unit-tests.sh; fi
   - if [ "$TEST_SUITE" = "install_stability_1" ]; then docker exec -it social_ci_behat sh /var/www/scripts/social/behatstability.sh "stability-1 --stop-on-failure --strict"; fi
   - if [ "$TEST_SUITE" = "install_stability_2" ]; then docker exec -it social_ci_behat sh /var/www/scripts/social/behatstability.sh "notifications --stop-on-failure --strict"; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 dist: trusty
 sudo: required
 
-cache:
-  directories:
-    - $HOME/.composer/cache/files
+#cache:
+#  directories:
+#    - $HOME/.composer/cache/files
 
 addons:
   artifacts:
@@ -73,7 +73,7 @@ install:
 
 script:
   - set -e
-#  - if [ "$TEST_SUITE" = "install_stability_1" ]; then docker exec -i social_ci_web bash /var/www/scripts/social/check-coding-standards.sh full; fi
+  - if [ "$TEST_SUITE" = "install_stability_1" ]; then docker exec -i social_ci_web bash /var/www/scripts/social/check-coding-standards.sh full; fi
   - if [ "$TEST_SUITE" = "install_stability_1" ]; then docker exec -i social_ci_web_scripts /var/www/scripts/social/unit-tests.sh; fi
   - if [ "$TEST_SUITE" = "install_stability_1" ]; then docker exec -it social_ci_behat sh /var/www/scripts/social/behatstability.sh "stability-1 --stop-on-failure --strict"; fi
   - if [ "$TEST_SUITE" = "install_stability_2" ]; then docker exec -it social_ci_behat sh /var/www/scripts/social/behatstability.sh "notifications --stop-on-failure --strict"; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -73,7 +73,7 @@ install:
 
 script:
   - set -e
-  - if [ "$TEST_SUITE" = "install_stability_1" ]; then docker exec -i social_ci_web bash /var/www/scripts/social/check-coding-standards.sh full; fi
+#  - if [ "$TEST_SUITE" = "install_stability_1" ]; then docker exec -i social_ci_web bash /var/www/scripts/social/check-coding-standards.sh full; fi
   - if [ "$TEST_SUITE" = "install_stability_1" ]; then docker exec -i social_ci_web_scripts /var/www/scripts/social/unit-tests.sh; fi
   - if [ "$TEST_SUITE" = "install_stability_1" ]; then docker exec -it social_ci_behat sh /var/www/scripts/social/behatstability.sh "stability-1 --stop-on-failure --strict"; fi
   - if [ "$TEST_SUITE" = "install_stability_2" ]; then docker exec -it social_ci_behat sh /var/www/scripts/social/behatstability.sh "notifications --stop-on-failure --strict"; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 dist: trusty
 sudo: required
 
-#cache:
-#  directories:
-#    - $HOME/.composer/cache/files
+cache:
+  directories:
+    - $HOME/.composer/cache/files
 
 addons:
   artifacts:
@@ -73,7 +73,7 @@ install:
 
 script:
   - set -e
-  - if [ "$TEST_SUITE" = "install_stability_1" ]; then docker exec -i social_ci_web bash /var/www/scripts/social/check-coding-standards.sh full; fi
+#  - if [ "$TEST_SUITE" = "install_stability_1" ]; then docker exec -i social_ci_web bash /var/www/scripts/social/check-coding-standards.sh full; fi
   - if [ "$TEST_SUITE" = "install_stability_1" ]; then docker exec -i social_ci_web_scripts /var/www/scripts/social/unit-tests.sh; fi
   - if [ "$TEST_SUITE" = "install_stability_1" ]; then docker exec -it social_ci_behat sh /var/www/scripts/social/behatstability.sh "stability-1 --stop-on-failure --strict"; fi
   - if [ "$TEST_SUITE" = "install_stability_2" ]; then docker exec -it social_ci_behat sh /var/www/scripts/social/behatstability.sh "notifications --stop-on-failure --strict"; fi

--- a/composer.json
+++ b/composer.json
@@ -122,7 +122,7 @@
         "cweagans/composer-patches": "^1.6.0",
         "composer/installers": "^1.9",
         "oomphinc/composer-installers-extender": "^1.1",
-        "drupal/core": "~8.8.8",
+        "drupal/core": "~8.9",
         "drupal/core-composer-scaffold": "~8.8.8",
         "drupal/address": "1.7",
         "drupal/admin_toolbar": "1.27",

--- a/composer.json
+++ b/composer.json
@@ -122,7 +122,7 @@
         "cweagans/composer-patches": "^1.6.0",
         "composer/installers": "^1.9",
         "oomphinc/composer-installers-extender": "^1.1",
-        "drupal/core": "~8.9",
+        "drupal/core": "~8.9.9",
         "drupal/core-composer-scaffold": "~8.8.8",
         "drupal/address": "1.7",
         "drupal/admin_toolbar": "1.27",

--- a/tests/behat/features/capabilities/topic/topic-overview-filter.feature
+++ b/tests/behat/features/capabilities/topic/topic-overview-filter.feature
@@ -12,7 +12,7 @@ Feature: Topic Overview Filter
     And I am logged in as an "authenticated user"
     And I am on "/all-topics"
     Then I should see "All topics"
-    And I click the element with css selector "select#edit-field-topic-type-target-id"
+    And I click the element with css selector "select[name=field_topic_type_target_id]"
     And I click "News"
     Then I press the "Apply" button
     And I should see "Topics of type News"


### PR DESCRIPTION
## Problem
Drupal core ^8.8 won't receive support anymore soon. Lets update our 9.x / 8.x versions of OS with this version. 
Drupal core 9.x will be supported in 10.0.x

## Solution
Update core in the composer.json to ~8.9.9 

## Issue tracker
https://www.drupal.org/project/social/issues/3183500

## How to test - TBD
- [x] Test update path, install OS in 8.8 -> Update to this branch (see screenshots for update hooks working)
- [x] See that the latest Core version is installed rather than 8.9.9
- [x] See that you can install OS on this version as well
- [x] Patches should apply
- [x] Site should still work.

## Screenshots
Here you find a screenshot of the update path
<img width="1632" alt="Screenshot 2020-11-26 at 16 02 30" src="https://user-images.githubusercontent.com/16667281/100366450-1f1c9700-3001-11eb-80d4-b7b94efa9b65.png">

## Release notes
We now support Drupal Core 8.9.x versions.