### PR TITLE
Issue #3186003 - Part 1: Enabler - Create re-usable details element, which is collapsible.

### DIFF
--- a/themes/socialbase/src/Plugin/Alter/ThemeSuggestions.php
+++ b/themes/socialbase/src/Plugin/Alter/ThemeSuggestions.php
@@ -122,6 +122,11 @@ class ThemeSuggestions extends BaseThemeSuggestions {
           $suggestions[] = 'details__comment';
         }
 
+        // Template suggestion for upload attachments in comments.
+        if (isset($variables['element']['#attributes']['class']) && in_array('social-collapsible-fieldset', $variables['element']['#attributes']['class'])) {
+          $suggestions[] = 'details__collapsible';
+        }
+
         break;
 
       case 'file_link':

--- a/themes/socialbase/templates/system/details--collapsible.html.twig
+++ b/themes/socialbase/templates/system/details--collapsible.html.twig
@@ -1,0 +1,37 @@
+{#
+/**
+ * @file
+ * Default theme implementation for a details element.
+ *
+ * Available variables
+ * - attributes: A list of HTML attributes for the details element.
+ * - errors: (optional) Any errors for this details element, may not be set.
+ * - title: (optional) The title of the element, may not be set.
+ * - description: (optional) The description of the element, may not be set.
+ * - children: (optional) The children of the element, may not be set.
+ * - value: (optional) The value of the element, may not be set.
+ *
+ * @see template_preprocess_details()
+ *
+ * @ingroup themeable
+ */
+#}
+<details{{ attributes.removeAttribute('open').addClass('form-horizontal form-item js-form-item form-wrapper js-form-wrapper card panel panel-default') }}>
+  {%- if title -%}
+    <summary{{ summary_attributes.addClass('card__title card__title--underline') }}>
+      {{ title }}
+    </summary>
+  {%- endif -%}
+
+  <div class="card__block">
+    {% if errors %}
+      <div>
+        {{ errors }}
+      </div>
+    {% endif %}
+
+    {{ description }}
+    {{ children }}
+    {{ value }}
+  </div>
+</details>


### PR DESCRIPTION
## Problem
Right now our details element is not working properly, we have created it custom within code but that is not extendable enough, also see screenshots for the current issue. 
We want it to look more appealing, whilst also being able to re-use it using Drupals Field UI and adding fields to it / remove it / ordering weights etc.

## Solution
We have added a new theme suggestion, for those who want to use this element please use the below settings in the manage form display:

![Screenshot 2020-12-02 at 14 49 15](https://user-images.githubusercontent.com/16667281/100880918-a197d180-34ad-11eb-821d-23fd81733b16.png)

## Issue tracker
- http://drupal.org/node/3186003 - Doesn't need to be closed, this is just an enabler for the work later.

## How to test
- [x] Add a new detail to any form using the settings as per above
- [x] See that all children elements are rendered as expected

## Screenshots
Before:
![43929438-6262-4f4c-94a2-a6ff2c7a3d61](https://user-images.githubusercontent.com/16667281/100881314-10752a80-34ae-11eb-8b88-25687b732c2f.gif)

After:
![chrome-capture (3)](https://user-images.githubusercontent.com/16667281/100881334-179c3880-34ae-11eb-9e28-570d84c827e6.gif)


## Release notes
Will be added later, this is just an enabler for the epic.