### PR TITLE
Reporting (ajax) comments leads to white screen 

### DIFF
--- a/modules/social_features/social_content_report/social_content_report.module
+++ b/modules/social_features/social_content_report/social_content_report.module
@@ -14,6 +14,12 @@ use Drupal\social_post\Entity\PostInterface;
  * Implements hook_form_alter().
  */
 function social_content_report_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+
+  // No need to do anything here, if it's not a flagging related form.
+  if (strpos($form_id, 'flagging_') === FALSE) {
+    return;
+  }
+
   // Get all 'report_' flags.
   $report_types = \Drupal::service('social_content_report.content_report_service')->getReportFlagTypes();
 

--- a/modules/social_features/social_content_report/social_content_report.services.yml
+++ b/modules/social_features/social_content_report/social_content_report.services.yml
@@ -10,7 +10,7 @@ services:
       - { name: event_subscriber }
   social_content_report.content_report_service:
     class: Drupal\social_content_report\ContentReportService
-    arguments: ['@flag', '@current_user', '@module_handler']
+    arguments: ['@flag', '@current_user', '@module_handler', '@request_stack']
   social_content_report.route_subscriber:
     class: Drupal\social_content_report\Routing\RouteSubscriber
     tags:

--- a/modules/social_features/social_content_report/src/ContentReportService.php
+++ b/modules/social_features/social_content_report/src/ContentReportService.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\social_content_report;
 
+use Drupal\comment\CommentInterface;
 use Drupal\Component\Serialization\Json;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
@@ -9,6 +10,7 @@ use Drupal\Core\Session\AccountProxyInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Core\Url;
 use Drupal\flag\FlagServiceInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
  * Provides a content report service.
@@ -39,6 +41,13 @@ class ContentReportService implements ContentReportServiceInterface {
   protected $moduleHandler;
 
   /**
+   * The current request.
+   *
+   * @var \Symfony\Component\HttpFoundation\RequestStack
+   */
+  protected $requestStack;
+
+  /**
    * Constructor for ContentReportService.
    *
    * @param \Drupal\flag\FlagServiceInterface $flag_service
@@ -47,15 +56,18 @@ class ContentReportService implements ContentReportServiceInterface {
    *   Current user.
    * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
    *   The module handler.
+   * @param \Symfony\Component\HttpFoundation\RequestStack $requestStack
    */
   public function __construct(
     FlagServiceInterface $flag_service,
     AccountProxyInterface $current_user,
-    ModuleHandlerInterface $module_handler
+    ModuleHandlerInterface $module_handler,
+    RequestStack $requestStack
   ) {
     $this->flagService = $flag_service;
     $this->currentUser = $current_user;
     $this->moduleHandler = $module_handler;
+    $this->requestStack = $requestStack;
   }
 
   /**
@@ -78,6 +90,7 @@ class ContentReportService implements ContentReportServiceInterface {
 
   /**
    * {@inheritdoc}
+   * @throws \Drupal\Core\Entity\EntityMalformedException
    */
   public function getModalLink(EntityInterface $entity, $flag_id, $is_button = FALSE): ?array {
     // Check if users may flag this entity.
@@ -85,8 +98,12 @@ class ContentReportService implements ContentReportServiceInterface {
       return NULL;
     }
 
+    $flagging = FALSE;
     $flag = $this->flagService->getFlagById($flag_id);
-    $flagging = $this->flagService->getFlagging($flag, $entity, $this->currentUser);
+
+    if ($flag !== NULL) {
+      $flagging = $this->flagService->getFlagging($flag, $entity, $this->currentUser);
+    }
 
     // If the user already flagged this, we return a disabled link to nowhere.
     if ($flagging) {
@@ -115,6 +132,21 @@ class ContentReportService implements ContentReportServiceInterface {
     }
 
     // Return the modal link if the user did not yet flag this content.
+    $currentUrl = Url::fromRoute('<current>')->toString();
+
+    $currentRequest = $this->requestStack->getCurrentRequest();
+    // If there's a request and it's an ajax request, we need to do something different.
+    // Current url will now be determined based on something else.
+    if ($entity instanceof CommentInterface && $currentRequest !== NULL && $currentRequest->isXmlHttpRequest() === TRUE) {
+      // Determine the parent entity, so we can reditect to the entity the comment was added to.
+      $parentEntity = $entity->getCommentedEntity();
+
+      if ($parentEntity !== NULL) {
+        $currentUrl = $parentEntity->toUrl()->toString();
+      }
+    }
+
+    /** @var \Drupal\comment\Entity\Comment $entity */
     return [
       'title' => $this->t('Report'),
       'url' => Url::fromRoute('flag.field_entry',
@@ -124,7 +156,7 @@ class ContentReportService implements ContentReportServiceInterface {
         ],
         [
           'query' => [
-            'destination' => Url::fromRoute('<current>')->toString(),
+            'destination' => $currentUrl,
           ],
         ]
       ),


### PR DESCRIPTION
## Problem
Critical bug in AJAX Comments + Report. When:
a) posting a comment
b) directly report that comment for abuse
c) system crashes

## Solution
The solution is to create a different destination url on the report form, when the comment was inserted in the DOM through an ajax request.

## Issue tracker
https://getopensocial.atlassian.net/browse/TB-5356
https://www.drupal.org/project/social/issues/3186203

## How to test
- [ ] Enabled both `social_ajax_comments` and `social_content_report`
- [ ] Create a comment somewhere
- [ ] Immediately report is as abusive
- [ ] Notice you end up on a page with a textarea (with callback information)
- [ ] Try again on this branch and notice you're being redirected to the parent entity (the comment was made on)

## Release notes
An issue was fixed, where one would report one's own comment (made with ajax), a redirect would be made to a white screen with nothing more than a textarea. 
