### PR TITLE
Issue #3186442 by agami4: Fix styles for the tag select on the filter form and fix position for the filter button on the mobile screen

### DIFF
--- a/themes/socialbase/assets/css/form-controls.css
+++ b/themes/socialbase/assets/css/form-controls.css
@@ -9,7 +9,8 @@ form:not(.layout-builder-configure-block) {
   /* Disabled style */
 }
 
-form:not(.layout-builder-configure-block) .form-control {
+form:not(.layout-builder-configure-block) .form-control,
+form:not(.layout-builder-configure-block) .select2-container .select2-selection {
   display: block;
   width: 100%;
   max-width: 23rem;
@@ -24,18 +25,35 @@ form:not(.layout-builder-configure-block) .form-control {
   transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s, -webkit-box-shadow ease-in-out .15s;
 }
 
-form:not(.layout-builder-configure-block) .form-control::-moz-placeholder {
+form:not(.layout-builder-configure-block) .form-control::-moz-placeholder,
+form:not(.layout-builder-configure-block) .select2-container .select2-selection::-moz-placeholder {
   opacity: 1;
 }
 
-form:not(.layout-builder-configure-block) .form-control::-ms-expand {
+form:not(.layout-builder-configure-block) .form-control::-ms-expand,
+form:not(.layout-builder-configure-block) .select2-container .select2-selection::-ms-expand {
   border: 0;
   background-color: transparent;
 }
 
+form:not(.layout-builder-configure-block) .form-control .select2-selection__arrow,
+form:not(.layout-builder-configure-block) .select2-container .select2-selection .select2-selection__arrow {
+  display: none;
+}
+
+form:not(.layout-builder-configure-block) .form-control .select2-selection__placeholder,
+form:not(.layout-builder-configure-block) .select2-container .select2-selection .select2-selection__placeholder {
+  color: #555555;
+}
+
 form:not(.layout-builder-configure-block) .form-control:disabled,
 fieldset[disabled] form:not(.layout-builder-configure-block) .form-control,
-.form-disabled form:not(.layout-builder-configure-block) .form-control {
+.form-disabled form:not(.layout-builder-configure-block) .form-control,
+form:not(.layout-builder-configure-block) .select2-container .select2-selection:disabled,
+fieldset[disabled]
+form:not(.layout-builder-configure-block) .select2-container .select2-selection,
+.form-disabled
+form:not(.layout-builder-configure-block) .select2-container .select2-selection {
   cursor: not-allowed;
   color: rgba(0, 0, 0, 0.26);
 }
@@ -439,13 +457,15 @@ form:not(.layout-builder-configure-block) .form-disabled .select-wrapper::after 
 }
 
 @media (min-width: 900px) {
-  form:not(.layout-builder-configure-block) .form-control {
+  form:not(.layout-builder-configure-block) .form-control,
+  form:not(.layout-builder-configure-block) .select2-container .select2-selection {
     font-size: 16px;
   }
 }
 
 @media screen and (-webkit-min-device-pixel-ratio: 0) {
-  form:not(.layout-builder-configure-block) .form-control {
+  form:not(.layout-builder-configure-block) .form-control,
+  form:not(.layout-builder-configure-block) .select2-container .select2-selection {
     font-size: 16px;
   }
   form:not(.layout-builder-configure-block) input[type="time"].form-control,

--- a/themes/socialbase/assets/css/form-controls.css
+++ b/themes/socialbase/assets/css/form-controls.css
@@ -58,6 +58,38 @@ form:not(.layout-builder-configure-block) .select2-container .select2-selection 
   color: rgba(0, 0, 0, 0.26);
 }
 
+form:not(.layout-builder-configure-block) .select2-container .select2-selection.select2-selection--multiple {
+  height: auto;
+  min-height: 38px;
+  padding-top: 1px;
+  padding-bottom: 1px;
+}
+
+form:not(.layout-builder-configure-block) .select2-container .select2-selection.select2-selection--multiple .select2-search__field {
+  padding: 0;
+  color: #555555;
+}
+
+form:not(.layout-builder-configure-block) .select2-container .select2-selection.select2-selection--multiple .select2-search__field::-moz-placeholder {
+  color: #555555;
+}
+
+form:not(.layout-builder-configure-block) .select2-container .select2-selection.select2-selection--multiple .select2-search__field::-webkit-input-placeholder {
+  color: #555555;
+}
+
+form:not(.layout-builder-configure-block) .select2-container .select2-selection.select2-selection--multiple .select2-search__field:-ms-input-placeholder {
+  color: #555555;
+}
+
+form:not(.layout-builder-configure-block) .select2-container .select2-selection.select2-selection--multiple .select2-search__field::-ms-input-placeholder {
+  color: #555555;
+}
+
+form:not(.layout-builder-configure-block) .select2-container .select2-selection.select2-selection--multiple .select2-search__field::placeholder {
+  color: #555555;
+}
+
 form:not(.layout-builder-configure-block) .form-control--autogrow {
   resize: none;
   min-height: 38px;

--- a/themes/socialbase/components/02-atoms/form-controls/form-controls.scss
+++ b/themes/socialbase/components/02-atoms/form-controls/form-controls.scss
@@ -32,7 +32,8 @@
  */
 form:not(.layout-builder-configure-block) {
 
-  .form-control {
+  .form-control,
+  .select2-container .select2-selection {
     display: block;
     width: 100%;
     max-width: $form-control-max-width;
@@ -60,6 +61,14 @@ form:not(.layout-builder-configure-block) {
 
     @include for-tablet-landscape-up {
       font-size: $font-size-base;
+    }
+
+    .select2-selection__arrow {
+      display: none;
+    }
+
+    .select2-selection__placeholder {
+      color: $gray;
     }
 
     &:disabled,

--- a/themes/socialbase/components/02-atoms/form-controls/form-controls.scss
+++ b/themes/socialbase/components/02-atoms/form-controls/form-controls.scss
@@ -81,6 +81,39 @@ form:not(.layout-builder-configure-block) {
     // [converter] extracted textarea& to textarea.form-control
   }
 
+  .select2-container .select2-selection {
+    &.select2-selection--multiple {
+      height: auto;
+      min-height: 38px;
+      padding-top: 1px;
+      padding-bottom: 1px;
+
+      .select2-search__field {
+        padding: 0;
+        color: $gray;
+
+        // Placeholder Firefox
+        &::-moz-placeholder {
+          color: $gray;
+        }
+
+        // Edge
+        &::-webkit-input-placeholder {
+          color: $gray;
+        }
+
+        // Internet Explorer 10-11
+        &:-ms-input-placeholder {
+          color: $gray;
+        }
+
+        &::placeholder {
+          color: $gray;
+        }
+      }
+    }
+  }
+
   .form-control--autogrow {
     resize: none;
     min-height: 38px;

--- a/themes/socialbase/templates/block/block--views-exposed-filter-block.html.twig
+++ b/themes/socialbase/templates/block/block--views-exposed-filter-block.html.twig
@@ -47,7 +47,7 @@
 #}
 {{ attach_library('socialbase/offcanvas')}}
 
-<div{{ attributes }}>
+<div{{ attributes }} data-class="exposed-filter-block">
   <div class="btn--offcanvas-trigger">
     <a href="#block-filter" class="btn btn-default btn-raised ">
       <svg class="btn-icon">

--- a/themes/socialblue/assets/css/offcanvas--sky.css
+++ b/themes/socialblue/assets/css/offcanvas--sky.css
@@ -8,5 +8,6 @@
   }
   .socialblue--sky[class*='path-all'] [data-class='exposed-filter-block'] {
     padding: 0;
+    margin: 0;
   }
 }

--- a/themes/socialblue/assets/css/offcanvas--sky.css
+++ b/themes/socialblue/assets/css/offcanvas--sky.css
@@ -1,5 +1,6 @@
 @media (max-width: 899px) {
-  .socialblue--sky .views-exposed-form {
-    top: -3rem;
+  .socialblue--sky [data-class='exposed-filter-block'] {
+    position: static;
+    margin: 1rem 0;
   }
 }

--- a/themes/socialblue/assets/css/offcanvas--sky.css
+++ b/themes/socialblue/assets/css/offcanvas--sky.css
@@ -1,6 +1,12 @@
 @media (max-width: 899px) {
   .socialblue--sky [data-class='exposed-filter-block'] {
     position: static;
+  }
+  .socialblue--sky [data-class='exposed-filter-block'].views-exposed-form {
     margin: 1rem 0;
+    padding: 0 1rem;
+  }
+  .socialblue--sky[class*='path-all'] [data-class='exposed-filter-block'] {
+    padding: 0;
   }
 }

--- a/themes/socialblue/components/04-organisms/offcanvas/offcanvas--sky.scss
+++ b/themes/socialblue/components/04-organisms/offcanvas/offcanvas--sky.scss
@@ -16,6 +16,7 @@
     [data-class='exposed-filter-block'] {
       @include for-tablet-landscape-down {
         padding: 0;
+        margin: 0;
       }
     }
   }

--- a/themes/socialblue/components/04-organisms/offcanvas/offcanvas--sky.scss
+++ b/themes/socialblue/components/04-organisms/offcanvas/offcanvas--sky.scss
@@ -4,7 +4,19 @@
   [data-class='exposed-filter-block'] {
     @include for-tablet-landscape-down {
       position: static;
-      margin: 1rem 0;
+
+      &.views-exposed-form {
+        margin: 1rem 0;
+        padding: 0 1rem;
+      }
+    }
+  }
+
+  &[class*='path-all'] {
+    [data-class='exposed-filter-block'] {
+      @include for-tablet-landscape-down {
+        padding: 0;
+      }
     }
   }
 }

--- a/themes/socialblue/components/04-organisms/offcanvas/offcanvas--sky.scss
+++ b/themes/socialblue/components/04-organisms/offcanvas/offcanvas--sky.scss
@@ -1,9 +1,10 @@
 @import "settings";
 
 .socialblue--sky {
-  .views-exposed-form {
+  [data-class='exposed-filter-block'] {
     @include for-tablet-landscape-down {
-      top: -3rem;
+      position: static;
+      margin: 1rem 0;
     }
   }
 }


### PR DESCRIPTION
## Problem

1. The select has the wrong styles
2. Filter button isn't visible on the mobile screen

## Solution
Add style update for the select and filter button(on the mobile screen)

## Issue tracker

- https://www.drupal.org/project/social/issues/3186442

## How to test
- [x] Go to all topics page 
- [x] You should see correct filter block on the left sidebar

## Screenshots
widget before:
![image-20201130-150852](https://user-images.githubusercontent.com/16086340/101152916-6374ec00-362c-11eb-8b39-61676cb44b74.png)
widget after:
<img width="402" alt="filter-block" src="https://user-images.githubusercontent.com/16086340/101152953-6f60ae00-362c-11eb-846e-15a9c4fef675.png">

filter before:
![image-20201130-161139](https://user-images.githubusercontent.com/16086340/101152931-67087300-362c-11eb-85ab-68b3cb9367da.png)

filter after:
<img width="441" alt="fb-all-teaser-page" src="https://user-images.githubusercontent.com/16086340/101152949-6e2f8100-362c-11eb-8ea9-41d1591be48d.png">


## Release notes
Social tagging select widget has the correct styles and the filter button is visible on the mobile screen.

## Change Record
-

## Translations
-
