### PR TITLE
Issue #3189783 by agami4: Add extra wrappers for the body on the post featured

### DIFF
--- a/modules/social_features/social_post/templates/post--featured.html.twig
+++ b/modules/social_features/social_post/templates/post--featured.html.twig
@@ -42,8 +42,11 @@
         {% endblock %}
 
         <div class="margin-top-s iframe-container">
-
-          {{ content|without('links', 'like_and_dislike', 'field_post_comments', 'field_post_image', 'user_id') }}
+          <div class="post-body--stream">
+            <div class="post-body--stream-body">
+              {{ content|without('links', 'like_and_dislike', 'field_post_comments', 'field_post_image', 'user_id') }}
+            </div>
+          </div>
 
           {% if content.field_post_image|render %}
             <p>{{ content.field_post_image }}</p>


### PR DESCRIPTION
## Problem
The more" link has the wrong position and style

## Solution
Add extra wrappers for the body for the post featured

## Issue tracker
https://getopensocial.atlassian.net/browse/YANG-4377
https://www.drupal.org/project/social/issues/3189783

## How to test
*For example*
- [ ] Go to dashboard and create/check the general stream posts

## Screenshots
-

## Release notes
Add extra wrappers for the body for the post featured(for the dashboard page)

## Change Record
-

## Translations
-
