### PR TITLE
Add an extra menu item to have Extensions added to the Open Social admin menu

### DIFF
--- a/modules/custom/social_lets_connect/modules/social_lets_connect_contact/social_lets_connect_contact.links.menu.yml
+++ b/modules/custom/social_lets_connect/modules/social_lets_connect_contact/social_lets_connect_contact.links.menu.yml
@@ -1,3 +1,9 @@
+social_lets_connect_contact.extensions:
+  title: 'Extensions'
+  parent: social_lets_connect.main
+  url: https://www.getopensocial.com/extensions
+  weight: -6
+
 social_lets_connect_contact.services:
   title: 'Services'
   parent: social_lets_connect.main


### PR DESCRIPTION
## Problem
People using Open Social sometimes do not know of the Extensions offered by Open Social. We want to show this possibility by adding a menu item to the Social Lets Connect module, which is rendered in the admin menu.

## Solution
Add a link to the extensions page to the Open Social menu, visible for CM+ roles.

## How to test
- [ ] Log in as CM+ role to your instance and see that in the Open Social menu, there is a new entry called "Extensions".

## Release notes
We added a link to the Open Social menu that points to the page which describes all our optional extensions.
