### PR TITLE
Developer task - Use github actions for coding standards check on a PR.

### DIFF
--- a/.github/workflows/drupalCodingStandards.yml
+++ b/.github/workflows/drupalCodingStandards.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      # Install composer depdencies so we have drupal/coder which adds our codesniffer, the bin/phpcs file
+      # Install composer dependencies so we have drupal/coder which adds our codesniffer, the bin/phpcs file
       # and dealerdirect/phpcodesniffer-composer-installer which changes the installer_path configuring all sniffs.
       - name: Install dependencies
         run: composer install --dev --prefer-dist --no-progress --no-suggest

--- a/.github/workflows/drupalCodingStandards.yml
+++ b/.github/workflows/drupalCodingStandards.yml
@@ -1,0 +1,19 @@
+name: Drupal coding standards
+
+on: [pull_request]
+
+jobs:
+  phpcs:
+    name: PHPCS
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      # Install composer depdencies so we have drupal/coder which adds our codesniffer, the bin/phpcs file
+      # and dealerdirect/phpcodesniffer-composer-installer which changes the installer_path configuring all sniffs.
+      - name: Install dependencies
+        run: composer install --dev --prefer-dist --no-progress --no-suggest
+
+      - name: PHPCS check
+        uses: chekalsky/phpcs-action@v1
+        with:
+          phpcs_bin_path: './vendor/bin/phpcs'

--- a/.travis.yml
+++ b/.travis.yml
@@ -73,7 +73,6 @@ install:
 
 script:
   - set -e
-#  - if [ "$TEST_SUITE" = "install_stability_1" ]; then docker exec -i social_ci_web bash /var/www/scripts/social/check-coding-standards.sh full; fi @TODO fix this so the \Drupal::register issue doesn't occur
   - if [ "$TEST_SUITE" = "install_stability_1" ]; then docker exec -i social_ci_web_scripts /var/www/scripts/social/unit-tests.sh; fi
   - if [ "$TEST_SUITE" = "install_stability_1" ]; then docker exec -it social_ci_behat sh /var/www/scripts/social/behatstability.sh "stability-1 --stop-on-failure --strict"; fi
   - if [ "$TEST_SUITE" = "install_stability_2" ]; then docker exec -it social_ci_behat sh /var/www/scripts/social/behatstability.sh "notifications --stop-on-failure --strict"; fi

--- a/composer.json
+++ b/composer.json
@@ -120,10 +120,10 @@
     },
     "require": {
         "cweagans/composer-patches": "^1.6.0",
-        "composer/installers": "^1.9",
-        "oomphinc/composer-installers-extender": "^1.1",
+        "composer/installers": "~1.0 || ~2.0",
+        "oomphinc/composer-installers-extender": "~1.0 || ~2.0",
         "drupal/core": "~8.9.9",
-        "drupal/core-composer-scaffold": "~8.8.8",
+        "drupal/core-composer-scaffold": "~8.9",
         "drupal/address": "1.7",
         "drupal/admin_toolbar": "1.27",
         "drupal/ajax_comments": "^1.0",
@@ -202,5 +202,12 @@
         "npm-asset/react": "^16.7.0",
         "npm-asset/react-dom": "^16.7.0",
         "zaporylie/composer-drupal-optimizations": "^1.0"
+    },
+    "require-dev": {
+        "dealerdirect/phpcodesniffer-composer-installer": "~0.6 || ~0.7",
+        "squizlabs/php_codesniffer": "3.5.6",
+        "mglaman/drupal-check": "^1.0",
+        "palantirnet/drupal-rector": "^0.5.6",
+        "drupal/coder": "8.3.11"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -205,7 +205,6 @@
     },
     "require-dev": {
         "dealerdirect/phpcodesniffer-composer-installer": "~0.6 || ~0.7",
-        "squizlabs/php_codesniffer": "3.5.6",
         "mglaman/drupal-check": "^1.0",
         "palantirnet/drupal-rector": "^0.5.6",
         "drupal/coder": "8.3.11"

--- a/modules/custom/activity_creator/activity_creator.post_update.php
+++ b/modules/custom/activity_creator/activity_creator.post_update.php
@@ -119,7 +119,7 @@ function activity_creator_post_update_8802_remove_orphaned_activities(&$sandbox)
     // 'activities_per_batch' is a custom amount that we’ll use to limit
     // how many activities we’re processing in each batch.
     // The variables value can be declared in settings file of Drupal.
-    $sandbox['activities_per_batch'] = Settings::get('activity_update_batch_size', 5000);;
+    $sandbox['activities_per_batch'] = Settings::get('activity_update_batch_size', 5000);
   }
 
   // Initialization code done.
@@ -196,7 +196,7 @@ function activity_creator_post_update_8803_remove_activities_with_no_related_ent
     // 'activities_per_batch' is a custom amount that we’ll use to limit
     // how many activities we’re processing in each batch.
     // The variables value can be declared in settings file of Drupal.
-    $sandbox['activities_per_batch'] = Settings::get('activity_update_batch_size', 100);;
+    $sandbox['activities_per_batch'] = Settings::get('activity_update_batch_size', 100);
   }
 
   // Extract activity ids for deletion.

--- a/modules/custom/dropdown/src/Plugin/Field/FieldType/Dropdown.php
+++ b/modules/custom/dropdown/src/Plugin/Field/FieldType/Dropdown.php
@@ -148,7 +148,7 @@ class Dropdown extends FieldItemBase {
     $lines = [];
     foreach ($values as $key => $value) {
       if (is_array($value)) {
-        $lines[$key] = implode("|", $value);;
+        $lines[$key] = implode("|", $value);
       }
     }
     return implode("\n", $lines);

--- a/modules/social_features/social_event/src/Plugin/views/sort/EventPassedDesc.php
+++ b/modules/social_features/social_event/src/Plugin/views/sort/EventPassedDesc.php
@@ -7,8 +7,10 @@ use Drupal\views\Plugin\views\sort\Date;
 /**
  * Basic sort handler for passed events.
  *
- * @deprecated in Open Social 9.1.
- *  Use Drupal\social_event\Plugin\views\sort\EventDate.
+ * @deprecated
+ *   in Open Social 9.1.
+ *
+ * @see Drupal\social_event\Plugin\views\sort\EventDate.
  *
  * @ViewsSort("event_passed_upcoming_sort")
  */

--- a/modules/social_features/social_like/social_like.module
+++ b/modules/social_features/social_like/social_like.module
@@ -55,7 +55,7 @@ function social_like_entity_delete(EntityInterface $entity) {
 }
 
 /**
- * Implements social_like_invalidate_cache().
+ * Implements hook_invalidate_cache().
  */
 function social_like_invalidate_cache(EntityInterface $entity) {
   $cache_tag = [

--- a/modules/social_features/social_profile/social_profile.module
+++ b/modules/social_features/social_profile/social_profile.module
@@ -27,8 +27,6 @@ define('SOCIAL_PROFILE_SUGGESTIONS_ALL', 'all');
 
 /**
  * Implements hook_field_widget_form_alter().
- *
- * Fix theme issues in profile fields.
  */
 function social_profile_field_widget_form_alter(&$element, FormStateInterface $form_state, $context) {
   /** @var \Drupal\Core\Field\FieldDefinitionInterface $field_definition */
@@ -812,6 +810,6 @@ function social_profile_social_user_account_header_items_alter(array &$menu_item
   // Provide a render array as image which will overrule the user icon.
   $menu_items['account_box']['#image'] = \Drupal::entityTypeManager()
     ->getViewBuilder('profile')
-    ->view($profile, 'small');;
+    ->view($profile, 'small');
 
 }

--- a/modules/social_features/social_search/social_search.module
+++ b/modules/social_features/social_search/social_search.module
@@ -259,7 +259,7 @@ function _social_search_retrigger_profile(User $user) {
   // Loop over the indexes that need to be updated.
   foreach ($indexes as $index_id) {
     $index = Index::load($index_id);
-    if ($index instanceof  Index) {
+    if ($index instanceof Index) {
       // Init.
       $profile_ids = [];
       /** @var \Drupal\user\Entity\User $original_user */

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -17,7 +17,7 @@
     <exclude-pattern>*.css</exclude-pattern>
     <exclude-pattern>*/assets/*</exclude-pattern>
     <exclude-pattern>*/components/*</exclude-pattern>
-    <exclude-pattern>*social.info.yml</exclude-pattern>
+    <exclude-pattern>social.info.yml</exclude-pattern>
     <exclude-pattern>*.md</exclude-pattern>
     <exclude-pattern>PULL_REQUEST_TEMPLATE\.md</exclude-pattern>
 

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ruleset name="drupal">
+    <description>PHP CodeSniffer configuration for Drupal coding standards in Open Social.</description>
+    <file>./modules/custom</file>
+    <file>./modules/social_features</file>
+    <file>./social.profile</file>
+    <file>./social.install</file>
+    <file>./themes/socialbase</file>
+    <file>./themes/socialblue</file>
+    <config name="ignore_errors_on_exit" value="0"/>
+    <config name="ignore_warnings_on_exit" value="0"/>
+    <config name="default_standard" value="Drupal"/>
+
+    <arg name="extensions" value="php,module,inc,install,test,profile,theme" />
+
+    <exclude-pattern>*/node_modules/*</exclude-pattern>
+    <exclude-pattern>*.css</exclude-pattern>
+    <exclude-pattern>*/assets/*</exclude-pattern>
+    <exclude-pattern>*/components/*</exclude-pattern>
+    <exclude-pattern>*social.info.yml</exclude-pattern>
+    <exclude-pattern>*.md</exclude-pattern>
+    <exclude-pattern>PULL_REQUEST_TEMPLATE\.md</exclude-pattern>
+
+    <config name="drupal_core_version" value="8" />
+    <!--  Include all Drupal related rules but exclude some so we can gradually fix these. -->
+    <rule ref="Drupal">
+        <exclude name="Drupal.Commenting.GenderNeutralComment.GenderNeutral"/>
+        <exclude name="Drupal.Commenting.VariableComment.Missing"/>
+        <exclude name="Drupal.Commenting.Deprecated.IncorrectTextLayout"/>
+        <exclude name="Drupal.Arrays.Array.LongLineDeclaration"/>
+        <exclude name="Drupal.Semantics.FunctionTriggerError.TriggerErrorTextLayoutStrict"/>
+    </rule>
+
+    <!-- We need to fix the DateTime and DateTimeZone in this class. -->
+    <rule ref="Drupal.Classes.UseGlobalClass.RedundantUseStatement">
+        <exclude-pattern>SocialAddToCalendarBase\.php</exclude-pattern>
+    </rule>
+
+</ruleset>

--- a/themes/socialbase/src/Plugin/Preprocess/SocialBaseImageWidget.php
+++ b/themes/socialbase/src/Plugin/Preprocess/SocialBaseImageWidget.php
@@ -9,4 +9,4 @@ namespace Drupal\socialbase\Plugin\Preprocess;
  * @deprecated
  * @see \Drupal\socialbase\Plugin\Preprocess\ImageWidget
  */
-class SocialbaseImageWidget extends ImageWidget {}
+class SocialBaseImageWidget extends ImageWidget {}


### PR DESCRIPTION
## Problem
Travis gave us quite some issues with coding standards, we decided travis is not the way forward as it's also not fully free for open source software anymore.

## Solution
We took the liberty to move towards github actions instead. While doing so we also added the following:
- (Potentially Composer v2 support, not verified yet but it seems it runs on v2)
- phpcs.xml where we configure the coding standards 
- Update drupal/coder so we benefit from the latest coding standards
- Unfortunately this gave a ton of errors which we cant fix that easily, so we decided to exclude some in our phpcs.xml

## Issue tracker
None - Only internal usage as coding standards applied before.

## How to test
See the new github actions are green!

## Release notes
None - Internal only.