### PR TITLE
#3188715: fix incorrect conversion into email addresses on filter output

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -115,6 +115,9 @@
             },
             "drupal/views_infinite_scroll" : {
                 "Headers in table format repeat on load more instead of adding rows": "https://www.drupal.org/files/issues/2019-08-15/table_tbody_append-2899705-26.patch"
+            },
+            "drupal/filter" : {
+                "Links with @ are converted into email addresses even if there is no domain suffix present.": "https://www.drupal.org/files/issues/2019-03-21/d8-require-tld-for-mailto-links-2016739-73.patch"
             }
         }
     },


### PR DESCRIPTION
## Problem
Drupal core incorrectly converts some texts to links (email addresses). EG: "work@home" will be converted into a mailto link.

## Solution
Make a better assumption of when something is an email address.

## Issue tracker
- https://www.drupal.org/project/social/issues/3188715
- https://www.drupal.org/project/drupal/issues/2016739
- https://getopensocial.atlassian.net/browse/TB-5364

## How to test
- [ ] Create a post with some text like: "Today I work@home". Notice that the work@home part is converted to an email address.
- [ ] create a topic with something similar in the title: "Fit@Work"
- [ ] create a comment on this topic
- [ ] as another use like the comment on the topic
- [ ] login as the first user and check your notifications (also check `/notificitions`)
- [ ] not good right?
- [ ] apply the patch and clear caches
- [ ] notice that everything is correct now


## Release notes
Some phrases like "work@home" or "fit@work" were mistakenly taken for email addresses and thus converted in links. This created weird links, but also broke the layout of the notification centre. The check to wether a string is in fact an email address or not has been improved.
