### PR TITLE
PHPCS - Fix github actions / ubuntu-latest which uses PHP 8.0 we don't support yet.

### DIFF
--- a/.github/workflows/drupalCodingStandards.yml
+++ b/.github/workflows/drupalCodingStandards.yml
@@ -16,8 +16,8 @@ jobs:
           composer_version: '2'
       # Install composer dependencies so we have drupal/coder which adds our codesniffer, the bin/phpcs file
       # and dealerdirect/phpcodesniffer-composer-installer which changes the installer_path configuring all sniffs.
-      - name: Install dependencies
-        run: composer install --dev --prefer-dist --no-progress
+#      - name: Install dependencies
+#        run: composer install --dev --prefer-dist --no-progress
 
       - name: PHPCS check
         uses: chekalsky/phpcs-action@v1

--- a/.github/workflows/drupalCodingStandards.yml
+++ b/.github/workflows/drupalCodingStandards.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: php-actions/composer@v4
         with:
-          php-version: '7.4'
+          php_version: '7.4'
           composer_version: '2'
       # Install composer dependencies so we have drupal/coder which adds our codesniffer, the bin/phpcs file
       # and dealerdirect/phpcodesniffer-composer-installer which changes the installer_path configuring all sniffs.

--- a/.github/workflows/drupalCodingStandards.yml
+++ b/.github/workflows/drupalCodingStandards.yml
@@ -5,9 +5,13 @@ on: [pull_request]
 jobs:
   phpcs:
     name: PHPCS
+    # Need to define php version as per https://github.com/actions/virtual-environments/issues/1816
+    # ubuntu-latest uses php 8.0 by default so checks will fail.
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          php-version: '7.4'
       # Install composer dependencies so we have drupal/coder which adds our codesniffer, the bin/phpcs file
       # and dealerdirect/phpcodesniffer-composer-installer which changes the installer_path configuring all sniffs.
       - name: Install dependencies

--- a/.github/workflows/drupalCodingStandards.yml
+++ b/.github/workflows/drupalCodingStandards.yml
@@ -9,9 +9,10 @@ jobs:
     # ubuntu-latest uses php 8.0 by default so checks will fail.
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: php-actions/composer@v4
         with:
           php-version: '7.4'
+          composer_version: '2'
       # Install composer dependencies so we have drupal/coder which adds our codesniffer, the bin/phpcs file
       # and dealerdirect/phpcodesniffer-composer-installer which changes the installer_path configuring all sniffs.
       - name: Install dependencies

--- a/.github/workflows/drupalCodingStandards.yml
+++ b/.github/workflows/drupalCodingStandards.yml
@@ -9,6 +9,7 @@ jobs:
     # ubuntu-latest uses php 8.0 by default so checks will fail.
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v2
       - uses: php-actions/composer@v4
         with:
           php_version: '7.4'
@@ -16,7 +17,7 @@ jobs:
       # Install composer dependencies so we have drupal/coder which adds our codesniffer, the bin/phpcs file
       # and dealerdirect/phpcodesniffer-composer-installer which changes the installer_path configuring all sniffs.
       - name: Install dependencies
-        run: composer install --dev --prefer-dist --no-progress --no-suggest
+        run: composer install --dev --prefer-dist --no-progress
 
       - name: PHPCS check
         uses: chekalsky/phpcs-action@v1

--- a/.github/workflows/drupalCodingStandards.yml
+++ b/.github/workflows/drupalCodingStandards.yml
@@ -5,19 +5,17 @@ on: [pull_request]
 jobs:
   phpcs:
     name: PHPCS
-    # Need to define php version as per https://github.com/actions/virtual-environments/issues/1816
-    # ubuntu-latest uses php 8.0 by default so checks will fail.
     runs-on: ubuntu-latest
     steps:
+      # Checks out to current workspace.
       - uses: actions/checkout@v2
+      # Ensures to run composer install, also makes sure we have impact on the version of PHP / composer as we
+      # need to define php version as per https://github.com/actions/virtual-environments/issues/1816
+      # ubuntu-latest uses php 8.0 by default so checks will fail.
       - uses: php-actions/composer@v4
         with:
           php_version: '7.4'
           composer_version: '2'
-      # Install composer dependencies so we have drupal/coder which adds our codesniffer, the bin/phpcs file
-      # and dealerdirect/phpcodesniffer-composer-installer which changes the installer_path configuring all sniffs.
-#      - name: Install dependencies
-#        run: composer install --dev --prefer-dist --no-progress
 
       - name: PHPCS check
         uses: chekalsky/phpcs-action@v1


### PR DESCRIPTION
## Problem
PHPCS is failing, lets fix it.
https://github.com/actions/virtual-environments/issues/1816
By using ubuntu-latest by default github actions use the latest supported PHP version, which is 8.0

## Solution
Either use 18.04 of ubuntu, or specify the php version.

## Issue tracker
None.

## How to test
Lets see test turn green.
