### PR TITLE
Issue #3186003 by navneet0693: DS-7442 - Updated fieldsets and re-arranged fields in new order for "Basic Page" CT

### DIFF
--- a/modules/social_features/social_core/social_core.module
+++ b/modules/social_features/social_core/social_core.module
@@ -711,7 +711,7 @@ function social_core_form_node_form_alter(&$form, FormStateInterface $form_state
     if (!empty($form['advanced'])) {
       unset($form['advanced']);
 
-      // Unset optional fields
+      // Unset optional fields.
       if (isset($form['revision'])) {
         unset($form['revision']);
       }
@@ -771,7 +771,7 @@ function social_core_form_node_form_alter(&$form, FormStateInterface $form_state
           }
         }
 
-        // Move the node Menu settings to group_settings
+        // Move the node Menu settings to group_settings.
         if (!empty($form['menu'])) {
           $form['menu']['#group'] = 'group_settings';
           $form['menu']['#weight'] = 200;

--- a/modules/social_features/social_core/social_core.module
+++ b/modules/social_features/social_core/social_core.module
@@ -709,17 +709,75 @@ function social_core_form_node_form_alter(&$form, FormStateInterface $form_state
     // We want to move all the fields from $form['advanced'] to our new
     // field sets which are created as part of #3186003.
     if (!empty($form['advanced'])) {
-      unset(
-        $form['advanced'],
-        $form['revision'],
-        $form['revision_information'],
-        $form['revision_log'],
-        $form['meta'],
-        $form['url_redirects']
-      );
+      unset($form['advanced']);
 
-      // Move the status label to group_settings.
+      // Unset optional fields
+      if (isset($form['revision'])) {
+        unset($form['revision']);
+      }
+
+      if (isset($form['revision_log'])) {
+        unset($form['revision_log']);
+      }
+
+      if (isset($form['revision_information'])) {
+        unset($form['revision_information']);
+      }
+
+      if (isset($form['url_redirects'])) {
+        unset($form['url_redirects']);
+      }
+
+      if (isset($form['meta'])) {
+        unset($form['meta']);
+      }
+
+      // Hide the automatic URL alias.
+      if (isset($form['path']['widget'][0]['pathauto'])) {
+        $form['path']['widget'][0]['pathauto']['#type'] = 'hidden';
+        // Path uses the above checkbox to decide whether or not to save
+        // the automatically generated alias, or use a custom one.
+        // since we hide the element, and the default is checked,
+        // the path will never be overridden if someone updates it.
+        // So we need to check this in our custom submit handler.
+        // It should perform before path auto runs.
+        array_unshift($form['actions']['submit']['#submit'], '_social_core_path_widget_submit');
+      }
+
+      // For now we hide the menu outline as well, regardless of the
+      // Drupal settings.
+      if (isset($form['menu'])) {
+        unset($form['menu']);
+      }
+
+      // Move the fields from advanced to group_settings.
       if (!empty($form['#fieldgroups']['group_settings'])) {
+        // Move the book outline fields to the group settings.
+        // #502430 we need to remove this ourselves, users with permission
+        // can see the book outline even when not configured as part
+        // of the book settings.
+        if (!empty($form['book']) &&
+          $form_state->getFormObject() !== NULL &&
+          \Drupal::moduleHandler()->moduleExists('book')) {
+          // Grab the Entity to see if books are enabled for this one.
+          $entity = $form_state->getFormObject()->getEntity();
+          if (!empty($entity->getType()) && is_string($entity->getType())) {
+            $enabled = book_type_is_allowed($entity->getType());
+            $form['book']['#group'] = 'group_settings';
+            // If it's not enabled we can just safely unset it.
+            if (!$enabled) {
+              unset($form['book']);
+            }
+          }
+        }
+
+        // Move the node Menu settings to group_settings
+        if (!empty($form['menu'])) {
+          $form['menu']['#group'] = 'group_settings';
+          $form['menu']['#weight'] = 200;
+        }
+
+        // Move the Published status to group settings with a new wrapper.
         if (!empty($form['status'])) {
           // Add an details element to status.
           $form['status_label'] = [
@@ -808,6 +866,35 @@ function social_core_form_node_form_alter(&$form, FormStateInterface $form_state
         unset($form['actions']['preview']);
       }
     }
+  }
+}
+
+/**
+ * Custom form submit handler for handling an path alias update.
+ *
+ * @param array $form
+ *   The form array.
+ * @param \Drupal\Core\Form\FormStateInterface $form_state
+ *   Form state.
+ *
+ * @throws \Drupal\Core\Entity\EntityStorageException
+ */
+function _social_core_path_widget_submit(array $form, FormStateInterface $form_state) {
+  // Path uses the pathauto checkbox to decide whether or not to save
+  // the automatically generated alias, or use a custom one.
+  // since we hide the element, and the default is checked,
+  // the path will never be overridden if someone updates it.
+  // So we need to check this in our custom submit handler.
+  $default_path = $form['path']['widget'][0]['alias']['#default_value'];
+  $input = $form_state->getUserInput();
+  $updated_path = isset($input['path'][0]['alias']) ? $input['path'][0]['alias'] : '';
+  // If we don't have a match, make sure we override the checkbox as well.
+  if ($updated_path !== $default_path) {
+    // Override the User input, act as if this was changed.
+    $input['path'][0]['pathauto'] = "0";
+    $form_state->setUserInput($input);
+    // Override the value.
+    $form_state->setValue(['path', '0', 'pathauto'], "0");
   }
 }
 

--- a/modules/social_features/social_page/config/install/core.entity_form_display.node.page.default.yml
+++ b/modules/social_features/social_page/config/install/core.entity_form_display.node.page.default.yml
@@ -66,6 +66,7 @@ third_party_settings:
         - created
         - field_page_comments
         - path
+        - status
       parent_name: ''
       weight: 20
       format_type: details

--- a/modules/social_features/social_page/config/install/core.entity_form_display.node.page.default.yml
+++ b/modules/social_features/social_page/config/install/core.entity_form_display.node.page.default.yml
@@ -22,53 +22,61 @@ third_party_settings:
       children:
         - title
         - field_page_image
+        - body
       parent_name: ''
       weight: 0
-      label: Content
+      label: 'Basic details'
       format_type: fieldset
       format_settings:
-        label: Content
+        description: ''
         required_fields: true
         id: content
         classes: 'card '
-    group_page_description:
-      children:
-        - body
-      parent_name: ''
-      weight: 2
-      label: 'Page description'
-      format_type: fieldset
-      format_settings:
-        label: 'Page description'
-        required_fields: true
-        id: description
-        classes: 'card '
+      region: hidden
     group_attachments:
       children:
         - field_files
       parent_name: ''
       weight: 3
-      label: Attachments
-      format_type: fieldset
+      label: 'Additional details'
+      format_type: details
       format_settings:
-        label: Attachments
+        description: ''
         required_fields: true
         id: attachments
-        classes: 'card '
+        classes: social-collapsible-fieldset
+        open: false
+      region: hidden
     group_page_visibility:
       children:
         - field_content_visibility
       parent_name: ''
       weight: 1
-      label: Visibility
+      label: 'Access permissions'
       format_type: fieldset
       format_settings:
-        label: Visibility
+        description: ''
         required_fields: true
         id: visibility
         classes: 'card '
-_core:
-  default_config_hash: 3Z-1RH4Ygf-ZS11i1tHHb08h_tsEQ6BwTPx3gUUH3Wo
+      region: hidden
+    group_settings:
+      children:
+        - uid
+        - created
+        - field_page_comments
+        - path
+      parent_name: ''
+      weight: 20
+      format_type: details
+      region: hidden
+      format_settings:
+        id: ''
+        classes: social-collapsible-fieldset
+        description: ''
+        open: false
+        required_fields: true
+      label: Settings
 id: node.page.default
 targetEntityType: node
 bundle: page
@@ -76,16 +84,17 @@ mode: default
 content:
   body:
     type: text_textarea_with_summary
-    weight: 2
+    weight: 3
     settings:
       rows: 9
       summary_rows: 3
       placeholder: ''
+      show_summary: false
     third_party_settings: {  }
     region: content
   created:
     type: datetime_timestamp
-    weight: 5
+    weight: 8
     settings: {  }
     third_party_settings: {  }
     region: content
@@ -103,7 +112,7 @@ content:
     type: file_generic
     region: content
   field_page_comments:
-    weight: 6
+    weight: 5
     settings: {  }
     third_party_settings: {  }
     type: comment_default
@@ -119,12 +128,14 @@ content:
         - hero
         - teaser
       progress_indicator: throbber
+      crop_types_required: {  }
+      warn_multiple_usages: true
     third_party_settings: {  }
     type: image_widget_crop
     region: content
   path:
     type: path
-    weight: 7
+    weight: 6
     settings: {  }
     third_party_settings: {  }
     region: content
@@ -145,7 +156,7 @@ content:
     region: content
   uid:
     type: entity_reference_autocomplete
-    weight: 4
+    weight: 7
     settings:
       match_operator: CONTAINS
       size: 60

--- a/modules/social_features/social_page/config/install/field.field.node.page.field_files.yml
+++ b/modules/social_features/social_page/config/install/field.field.node.page.field_files.yml
@@ -6,13 +6,11 @@ dependencies:
     - node.type.page
   module:
     - file
-_core:
-  default_config_hash: X7oF_vls-1z6d5kzBBjQfYuCq-zuJvrZFhZanIIf7RM
 id: node.page.field_files
 field_name: field_files
 entity_type: node
 bundle: page
-label: Files
+label: Attachment
 description: ''
 required: false
 translatable: true

--- a/modules/social_features/social_page/config/update/social_page_update_8905.yml
+++ b/modules/social_features/social_page/config/update/social_page_update_8905.yml
@@ -1,0 +1,100 @@
+core.entity_form_display.node.page.default:
+  expected_config: { }
+  update_actions:
+    delete:
+      third_party_settings:
+        field_group:
+          group_attachments:
+            format_settings:
+              label: Attachments
+          group_page_content:
+            format_settings:
+              label: Content
+          group_page_description:
+            children:
+              - body
+            format_settings:
+              label: 'Page description'
+          group_page_visibility:
+            format_settings:
+              label: Visibility
+    add:
+      content:
+        body:
+          settings:
+            show_summary: false
+        field_page_image:
+          settings:
+            crop_types_required: {  }
+            warn_multiple_usages: true
+      third_party_settings:
+        field_group:
+          group_attachments:
+            region: hidden
+          group_page_content:
+            children:
+              - body
+            format_settings:
+              description: ''
+            region: hidden
+          group_page_description:
+            region: hidden
+          group_page_visibility:
+            format_settings:
+              description: ''
+            region: hidden
+          group_settings:
+            children:
+              - uid
+              - created
+              - field_page_comments
+              - path
+            format_settings:
+              classes: social-collapsible-fieldset
+              description: ''
+              id: ''
+              open: false
+              required_fields: true
+            format_type: details
+            label: Settings
+            parent_name: ''
+            region: hidden
+            weight: 20
+    change:
+      content:
+        body:
+          weight: 3
+        created:
+          weight: 8
+        field_page_comments:
+          weight: 5
+        path:
+          weight: 6
+        uid:
+          weight: 7
+        url_redirects:
+          region: content
+          settings: {  }
+          third_party_settings: {  }
+          weight: 50
+      third_party_settings:
+        field_group:
+          group_attachments:
+            format_settings:
+              classes: social-collapsible-fieldset
+              description: ''
+              open: false
+            format_type: details
+            label: 'Additional details'
+          group_page_content:
+            label: 'Basic details'
+          group_page_description:
+            children: {  }
+          group_page_visibility:
+            label: 'Access permissions'
+field.field.node.page.field_files:
+  expected_config:
+    label: Files
+  update_actions:
+    change:
+      label: Attachment

--- a/modules/social_features/social_page/config/update/social_page_update_8905.yml
+++ b/modules/social_features/social_page/config/update/social_page_update_8905.yml
@@ -49,6 +49,7 @@ core.entity_form_display.node.page.default:
               - created
               - field_page_comments
               - path
+              - status
             format_settings:
               classes: social-collapsible-fieldset
               description: ''

--- a/modules/social_features/social_page/social_page.install
+++ b/modules/social_features/social_page/social_page.install
@@ -152,3 +152,30 @@ function social_page_update_8904() {
     }
   }
 }
+
+/**
+ * Updated fieldsets and field arrangement in entity form view of basic page.
+ */
+function social_page_update_8905() {
+  /** @var \Drupal\update_helper\Updater $updateHelper */
+  $updateHelper = \Drupal::service('update_helper.updater');
+
+  // Execute configuration update definitions with logging of success.
+  $updateHelper->executeUpdate('social_page', 'social_page_update_8905');
+
+  // Output logged messages to related channel of update execution.
+  return $updateHelper->logger()->output();
+}
+
+/**
+ * Remove group_topic_description fieldgroup from topic content type.
+ */
+function social_page_update_8906() {
+  // There can be possibility that someone might have added fields in
+  // fieldgroup we are removing. So, we want to skip removal if there are any
+  // children present in fieldgroup.
+  $group = field_group_load_field_group('group_page_description', 'node', 'page', 'form', 'default');
+  if ($group && empty($group->children)) {
+    field_group_delete_field_group($group);
+  }
+}

--- a/modules/social_features/social_tagging/social_tagging.module
+++ b/modules/social_features/social_tagging/social_tagging.module
@@ -147,7 +147,12 @@ function social_tagging_form_alter(&$form, FormStateInterface $form_state, $form
       ];
 
       // We want to move the tagging field in new fieldset "Additional details".
-      if (isset($form['#fieldgroups']['group_attachments'])) {
+      // Only when the theme settings are updated.
+      $use_social_content_forms = theme_get_setting('content_entity_form_style');
+      if (isset($form['#fieldgroups']['group_attachments']) &&
+        $use_social_content_forms === 'open_social') {
+        $form['tagging']['#type'] = 'details';
+        $form['tagging']['#title'] = t('Tags');
         $form['#fieldgroups']['group_attachments']->children[] = 'tagging';
         $form['#group_children']['tagging'] = 'group_attachments';
       }


### PR DESCRIPTION
## Problem
Rename the fieldset labels and move the field to new fieldsets for Page content type.

## Solution
1. Rename Content → Basic details
2. Rename Group & Visibility → Access permissions
3. Rename Attachments → Additional details
4. Add Settings
5. Move description field to Basic details
6. Remove Description fieldset
7. Add the following fields to the new “Settings” fieldset: Comment setting, URL Alias, Author information, Published status

## Issue tracker
https://www.drupal.org/node/3186003

## How to test
- [ ] Check out this branch, do an update of your DB
- [ ] As a LU create a Page
- [ ] See that the labels are updated
- [ ] Go to Structure -> Content type -> Page -> Manage form display and check for new "Settings" fieldset.
- [ ] Check that the fields are re-structured.

## Screenshots
**Page - Before**
![image](https://user-images.githubusercontent.com/8435994/102486256-0dab3580-4069-11eb-85e9-60141c665265.png)

**Page - After**
![image](https://user-images.githubusercontent.com/8435994/102486077-ca50c700-4068-11eb-945a-dab3ce9f7f6d.png)

## Release notes
Will be dealt with in the parent issue.