### PR TITLE
Issue #3189030: Dependencies added in config override may not contain dots

### DIFF
--- a/modules/social_features/social_group/modules/social_group_flexible_group/src/SocialGroupFlexibleGroupConfigOverride.php
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/src/SocialGroupFlexibleGroupConfigOverride.php
@@ -440,7 +440,7 @@ class SocialGroupFlexibleGroupConfigOverride implements ConfigFactoryOverrideInt
       $overrides['search_api.index.social_groups'] = [
         'dependencies' => [
           'config' => [
-            'field.storage.group.field_group_allowed_join_method' => 'field.storage.group.field_group_allowed_join_method',
+            'field_storage_group_field_group_allowed_join_method' => 'field.storage.group.field_group_allowed_join_method',
           ],
         ],
         'field_settings' => [
@@ -451,7 +451,7 @@ class SocialGroupFlexibleGroupConfigOverride implements ConfigFactoryOverrideInt
             'type' => 'string',
             'dependencies' => [
               'config' => [
-                'field.storage.group.field_group_allowed_join_method' => 'field.storage.group.field_group_allowed_join_method',
+                'field_storage_group_field_group_allowed_join_method' => 'field.storage.group.field_group_allowed_join_method',
               ],
             ],
           ],


### PR DESCRIPTION

<h3 id="summary-problem-motivation">Problem/Motivation</h3>
To ensure that dependencies for configurations added in configuration overrides are merged properly, we're not allowed to use numerical indices. Drupal uses <code>NestedArray::mergeDeep</code> to merge these arrays and this function will override any numerical indices. To get around this we use string keys which are properly preserved and allow to add to these arrays in multiple different places. This works without issues for simple keys and values, such as module names.

A problem arises when the dependency that's added contains dots and this value is used as key without modification. For example when the dependency is for another configuration object. The <code>Drupal\Core\Config\Schema\ArrayElement</code> class contains logic on how to traverse configuration (see <code>get</code> method). When a configuration name contains a dot then this method will interpret that as a nested path. However, for values in these dependencies arrays there are no nested values. This causes a fatal error <code>InvalidArgumentException: "The configuration property $name doesn't exist."</code>.

This was discovered in <code>SocialGroupFlexibleGroupConfigOverride</code> and a file search showed no other such issues. However, the issue may also be present in code outside of Open Social that follows a similar pattern.

<h4 id="summary-steps-reproduce">Steps to reproduce</h4>
<ol>
<li>Enable the <code>social_group_flexible_group</code> module</li>
<li>Enable the <a href="https://www.drupal.org/project/config_inspector"><code>config_inspector</code></a> module </li>
<li>Visit the config inspector report page at <code>/admin/reports/config-inspector</code></li>
</ol>

<h3 id="summary-proposed-resolution">Proposed resolution</h3>
Replace the dots in the key with underscores. This ensures that the key are still non-numeric and unique, which keeps the functionality for merging the overridden arrays. It also avoids providing a dot to the traversal logic in <code>ArrayElement</code> solving the issue.

## Issue tracker
https://www.drupal.org/project/social/issues/3189030

## Screenshots
N.a.

## Release notes
Fixes issues when inspecting config.

## Change Record
N.a.

## Translations
N.a.