### PR TITLE
Issue #3187257 by sjoerdvandervis: add stylesheet of files when files are attached

### DIFF
--- a/modules/social_features/social_event/social_event.install
+++ b/modules/social_features/social_event/social_event.install
@@ -1643,7 +1643,7 @@ function social_event_update_8906() {
  * Add image file extensions to be added as attachments.
  */
 function social_event_update_8907() {
-  $config_file = drupal_get_path('module', 'social_topic') . '/config/static/field.field.node.event.field_files_8907.yml';
+  $config_file = drupal_get_path('module', 'social_event') . '/config/static/field.field.node.event.field_files_8907.yml';
 
   if (is_file($config_file)) {
     $settings = Yaml::parse(file_get_contents($config_file));

--- a/themes/socialbase/templates/node/field--node--field-files.html.twig
+++ b/themes/socialbase/templates/node/field--node--field-files.html.twig
@@ -1,3 +1,4 @@
+{{ attach_library('socialbase/file') }}
 <section class="card-files">
   <h5 class="card-files__title">{{ "Files"|t }}</h5>
   <ul class="card-files__grid">


### PR DESCRIPTION
## Problem
In https://github.com/goalgorilla/open_social/pull/2095 , we made it possible to attach files of image types to a node. However, if only images are uploaded, the correct stylesheet is not included in the page. Therefor, the page looks formatted incorrectly.

## Solution
We will now add the stylesheet whenever the field_files is shown for the node.

## Issue tracker
https://www.drupal.org/project/social/issues/3187257

## How to test
*For example*
- [x] `drush updb -y`
- [x] Log in as a LU
- [x] Add a new topic and add attachments;
- [ ] See that all files are shown in a grid layout; when this concerns an image, we show the thumbnail. For all other attachment types, we show a placeholder with a file type icon.

## Screenshots
![Screenshot 2020-12-08 at 15 14 20](https://user-images.githubusercontent.com/19951173/101494869-27ad8f80-3968-11eb-8b22-011177ee28ec.png)

## Release notes
We've included the option to add images to events, topics and pages as attachments. When uploading images as attachments to events / topics / pages, they will now be shown as thumbnails instead of a regular file icon.