### PR TITLE
Issue #3186003 by navneet0693: DS-7438 - Updated fieldsets with new labels and re-arranged fields in Flexible group.

### DIFF
--- a/modules/social_features/social_group/modules/social_group_default_route/social_group_default_route.module
+++ b/modules/social_features/social_group/modules/social_group_default_route/social_group_default_route.module
@@ -33,8 +33,10 @@ function social_group_default_route_form_alter(&$form, FormStateInterface $form_
 
     // Add a (hidden) card for the tabs.
     $form['tab_settings'] = [
-      '#type' => 'fieldset',
+      '#type' => 'details',
       '#title' => t('Tab Management'),
+      '#group' => 'group_settings',
+      '#weight' => '3',
     ];
 
     // Define options for default route.

--- a/modules/social_features/social_group/modules/social_group_flexible_group/config/install/core.entity_form_display.group.flexible_group.default.yml
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/config/install/core.entity_form_display.group.flexible_group.default.yml
@@ -30,9 +30,9 @@ third_party_settings:
       format_type: fieldset
       format_settings:
         description: ''
-        required_fields: true
-        id: ''
         classes: ''
+        id: ''
+        required_fields: true
       region: content
     group_location:
       children:
@@ -55,10 +55,10 @@ third_party_settings:
       weight: 4
       format_type: details
       format_settings:
-        description: ''
-        required_fields: true
         id: ''
         classes: social-collapsible-fieldset
+        description: ''
+        required_fields: true
         open: false
       label: Settings
       region: content
@@ -67,30 +67,29 @@ third_party_settings:
         - field_flexible_group_visibility
         - field_group_allowed_visibility
         - field_group_allowed_join_method
-        - allow_request
-      parent_name: ''
-      weight: 1
-      format_type: fieldset
-      region: content
       format_settings:
-        id: ''
         classes: ''
         description: ''
+        id: ''
         required_fields: true
+      format_type: fieldset
       label: 'Access permissions'
+      parent_name: ''
+      region: content
+      weight: 1
     group_additional_details:
       children: {  }
-      parent_name: ''
-      weight: 3
-      format_type: details
-      region: content
       format_settings:
-        id: ''
         classes: social-collapsible-fieldset
         description: ''
+        id: ''
         open: false
         required_fields: true
+      format_type: details
       label: 'Additional information'
+      parent_name: ''
+      region: content
+      weight: 3
 id: group.flexible_group.default
 targetEntityType: group
 bundle: flexible_group

--- a/modules/social_features/social_group/modules/social_group_flexible_group/config/install/field.field.group.flexible_group.field_group_image.yml
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/config/install/field.field.group.flexible_group.field_group_image.yml
@@ -12,7 +12,7 @@ id: group.flexible_group.field_group_image
 field_name: field_group_image
 entity_type: group
 bundle: flexible_group
-label: 'Group Image'
+label: 'Image'
 description: 'Crop your image to select which part of your image to show on display.'
 required: false
 translatable: false

--- a/modules/social_features/social_group/modules/social_group_flexible_group/config/update/social_group_flexible_group_update_8904.yml
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/config/update/social_group_flexible_group_update_8904.yml
@@ -20,7 +20,6 @@ core.entity_form_display.group.flexible_group.default:
               - field_flexible_group_visibility
               - field_group_allowed_visibility
               - field_group_allowed_join_method
-              - allow_request
             format_settings:
               classes: ''
               description: ''
@@ -33,6 +32,7 @@ core.entity_form_display.group.flexible_group.default:
             weight: 1
           group_content:
             children:
+              - label
               - field_group_description
           group_settings:
             format_settings:

--- a/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.install
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.install
@@ -180,7 +180,7 @@ function social_group_flexible_group_update_8903() {
 }
 
 /**
- * Renamed fieldsets for flexible groups and re-ordered them according to new designs.
+ * Updated fieldsets labels and re-arranged existing fields.
  */
 function social_group_flexible_group_update_8904() {
   /** @var \Drupal\update_helper\Updater $updateHelper */
@@ -205,4 +205,25 @@ function social_group_flexible_group_update_8905() {
 
   // Output logged messages to related channel of update execution.
   return $updateHelper->logger()->output();
+}
+
+/**
+ * Update label for field_group_image field.
+ */
+function social_group_flexible_group_update_8906() {
+  // Load the existing configuration.
+  $config_name = 'field.field.group.flexible_group.field_group_image';
+  $config = \Drupal::configFactory()->getEditable($config_name);
+  $config_data = $config->getRawData();
+
+  if (!empty($config_data['label'])) {
+    // This to ensure any custom added values are not affected.
+    if (strpos($config_data['label'], 'Group Image') !== FALSE) {
+      $config_data['label'] = 'Image';
+    }
+
+    $config->setData($config_data)->save();
+    // Make sure we clear cached definitions for the fields.
+    \Drupal::service('entity_field.manager')->clearCachedFieldDefinitions();
+  }
 }

--- a/modules/social_features/social_group/modules/social_group_welcome_message/src/SocialGroupWelcomeMessageConfigOverride.php
+++ b/modules/social_features/social_group/modules/social_group_welcome_message/src/SocialGroupWelcomeMessageConfigOverride.php
@@ -72,10 +72,10 @@ class SocialGroupWelcomeMessageConfigOverride implements ConfigFactoryOverrideIn
                   'private_message_body',
                   'private_message_send',
                 ],
-                'parent_name' => '',
-                'weight' => 99,
+                'parent_name' => 'group_settings',
+                'weight' => 1,
                 'label' => t('Welcome message')->render(),
-                'format_type' => 'fieldset',
+                'format_type' => 'details',
                 'format_settings' => [
                   'description' => '',
                   'classes' => '',

--- a/modules/social_features/social_tagging/social_tagging.module
+++ b/modules/social_features/social_tagging/social_tagging.module
@@ -146,8 +146,8 @@ function social_tagging_form_alter(&$form, FormStateInterface $form_state, $form
         '#weight' => 50,
       ];
 
-      // We want to move the tagging field in new fieldset "Additional information".
-      // Only when the theme settings are updated.
+      // We want to move the tagging field in new fieldset
+      // "Additional information". Only when the theme settings are updated.
       $use_social_content_forms = theme_get_setting('content_entity_form_style');
       if (isset($form['#fieldgroups']['group_attachments']) &&
         $use_social_content_forms === 'open_social') {
@@ -155,6 +155,16 @@ function social_tagging_form_alter(&$form, FormStateInterface $form_state, $form
         $form['tagging']['#title'] = t('Tags');
         $form['#fieldgroups']['group_attachments']->children[] = 'tagging';
         $form['#group_children']['tagging'] = 'group_attachments';
+      }
+
+      // Add Tags in flexible groups if enabled.
+      if (\Drupal::moduleHandler()->moduleExists('social_group_flexible_group') &&
+        isset($form['#fieldgroups']['group_additional_details']) &&
+        $use_social_content_forms === 'open_social') {
+        $form['tagging']['#type'] = 'details';
+        $form['tagging']['#title'] = t('Tags');
+        $form['#fieldgroups']['group_additional_details']->children[] = 'tagging';
+        $form['#group_children']['tagging'] = 'group_additional_details';
       }
 
       if ($tag_service->allowSplit()) {


### PR DESCRIPTION
## Problem
Follow-up of https://github.com/goalgorilla/open_social/pull/2121. Update sub-modules and social tagging module to add their respective custom fieldsets in correct fieldsets.

## Solution
1. Manually add "-label" key in update helper files.
2. Update social_group_default_route, social_tagging and social_group_welcome_message modules.
3. Change label of Group image field.

## Issue tracker
https://www.drupal.org/node/3186003

## How to test
- [ ] Check out this branch, do an update of your DB
- [ ] As a LU create a flexible group.
- [ ] See that the labels are updated
- [ ] Go to Group -> Flexible Group -> Manage form display.
- [ ] Check that the fields are re-structured.

## Screenshots
![image](https://user-images.githubusercontent.com/8435994/102869259-a5c76700-443b-11eb-8925-000b679042f6.png)

![image](https://user-images.githubusercontent.com/8435994/102869288-aeb83880-443b-11eb-8ece-19dc689e5ed4.png)
