### PR TITLE
Developer task - Update the custom step.

### DIFF
--- a/tests/behat/features/bootstrap/FeatureContext.php
+++ b/tests/behat/features/bootstrap/FeatureContext.php
@@ -145,8 +145,11 @@ class FeatureContext extends RawMinkContext implements Context, SnippetAccepting
 
       $iframe_source = $element->getAttribute('src');
 
-      if ($iframe_source !== $src) {
-        throw new \InvalidArgumentException(sprintf('The iframe does not have the src: "%s"', $src));
+      // the sources could contain certain metadata making it hard to test
+      // if it matches the given source. So we don't strict check rather
+      // check if part of the source matches.
+      if (strpos($iframe_source, $src) === FALSE) {
+        throw new \InvalidArgumentException(sprintf('The iframe source does not contain the src: "%s" it is however: "%s"', $src, $iframe_source));
       }
     }
 


### PR DESCRIPTION
## Problem
Whenever you embed a link in an iFrame sometimes it strips out the query fragments/attributes resulting in the src not completely matching what you put in.

That could result in adding a link like:
`https://www.youtube.com/embed/lh3xOx8eutQ"

But the link inside the iFrame contains

`src="https://www.youtube.com/embed/lh3xOx8eutQ?feature=oembed"`

## Solution
Try to not exactly match the source, but see if the source contains.