### PR TITLE
Internal - Lets see if we can use a cached mirror for our public images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,10 @@ services:
   - docker
 
 before_install:
+  - echo 'DOCKER_OPTS="$DOCKER_OPTS --registry-mirror=https://mirror.gcr.io"'
+  - sudo service docker restart
+  - docker system info
+
   # Composer Configurations.
   - export COMPOSER_MEMORY_LIMIT=-1 # Set php memory limit to -1 so composer update will not fail
   - export COMPOSER_EXIT_ON_PATCH_FAILURE=1 # To enforce throwing an error and stopping package installation/update immediately


### PR DESCRIPTION
## Problem

We run in to this:

> You have reached your pull rate limit. You may increase the limit by authenticating and upgrading: https://www.docker.com/increase-rate-limit

## Solution

https://travis-ci.community/t/docker-hub-you-have-reached-your-pull-rate-limit/10517/9
Use a mirror which can cache our public available images so it gets the cached image and doesn't hurt the rate limits.