### PR TITLE
Issue #3188183 by aangel: Update Swiftmailer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,8 +67,8 @@ before_install:
   - docker-compose -f docker-compose-ci.yml up -d
 
 install:
-  - if [ "$TEST_SUITE" = "install_stability_1" ] || [ "$TEST_SUITE" = "install_stability_2" ] || [ "$TEST_SUITE" = "install_stability_3" ] || [ "$TEST_SUITE" = "install_stability_4" ]; then docker exec -i social_ci_web bash /var/www/scripts/social/install/install_script.sh --with-optional; fi
-  - if [ "$TEST_SUITE" = "install_without_optional" ]; then docker exec -i social_ci_web bash /var/www/scripts/social/install/install_script.sh; fi
+  - if [ "$TEST_SUITE" = "install_stability_1" ] || [ "$TEST_SUITE" = "install_stability_2" ] || [ "$TEST_SUITE" = "install_stability_3" ] || [ "$TEST_SUITE" = "install_stability_4" ]; then docker exec -i social_ci_web bash /var/www/scripts/social/install/install_script.sh --with-optional --localsettings; fi
+  - if [ "$TEST_SUITE" = "install_without_optional" ]; then docker exec -i social_ci_web bash /var/www/scripts/social/install/install_script.sh --localsettings; fi
   - if [ "$TEST_SUITE" = "install_update" ]; then bash scripts/social/ci/build-install-update.sh $PR $BRANCH $COMMIT; fi
 
 script:

--- a/composer.json
+++ b/composer.json
@@ -81,9 +81,6 @@
             "drupal/search_api": {
                 "Ensure field definition allowed values callbacks are used for field filter callbacks": "https://www.drupal.org/files/issues/2020-06-03/2949022-12--views_filter_options_callback.patch"
             },
-            "drupal/swiftmailer": {
-                "Fix missing filter_format after update to beta2": "https://www.drupal.org/files/issues/2018-03-26/2948607-fix-filter-format-1.patch"
-            },
             "drupal/block_field": {
                 "Add pre-render hooks to be able to alter content": "https://www.drupal.org/files/issues/2018-06-11/block_field-add-proper-alter-hooks-for-field-rendering-2978883-2.patch"
             },
@@ -163,7 +160,7 @@
         "drupal/shariff": "1.5",
         "drupal/social_api": "1.1",
         "drupal/social_auth": "1.0",
-        "drupal/swiftmailer" : "1.0-beta2",
+        "drupal/swiftmailer" : "2.0-beta1",
         "drupal/select2": "1.8",
         "drupal/token": "1.5",
         "drupal/update_helper": "1.3",
@@ -183,7 +180,7 @@
         "php-http/message": "^1.7",
         "zoonman/linkedin-api-php-client": "dev-master#d06531c48d5efc8aaf7dc074a5320f5ba3f906c9",
         "abraham/twitteroauth": "^0.7.4",
-        "swiftmailer/swiftmailer" : "v5.4.12",
+        "swiftmailer/swiftmailer" : "6.2.4",
         "bower-asset/waves": "0.7.6",
         "bower-asset/timepicker": "~1.11.14",
         "bower-asset/tablesaw": "~3.1.0",

--- a/modules/social_features/social_swiftmail/src/Plugin/Mail/SocialSwiftMailer.php
+++ b/modules/social_features/social_swiftmail/src/Plugin/Mail/SocialSwiftMailer.php
@@ -2,9 +2,15 @@
 
 namespace Drupal\social_swiftmail\Plugin\Mail;
 
+use Drupal\Component\Render\MarkupInterface;
+use Drupal\Component\Utility\Html;
+use Drupal\Core\Asset\AttachedAssets;
 use Drupal\Core\Render\Markup;
 use Drupal\Core\Site\Settings;
+use Drupal\mailsystem\MailsystemManager;
 use Drupal\swiftmailer\Plugin\Mail\SwiftMailer;
+use Html2Text\Html2Text;
+use TijsVerkoyen\CssToInlineStyles\CssToInlineStyles;
 
 /**
  * Provides a 'Forced HTML SwiftMailer' plugin to send emails.
@@ -18,18 +24,33 @@ use Drupal\swiftmailer\Plugin\Mail\SwiftMailer;
 class SocialSwiftMailer extends SwiftMailer {
 
   /**
-   * Massages the message body into the format expected for rendering.
-   *
-   * @param array $message
-   *   The message.
-   *
-   * @return array
-   *   The massaged message.
+   * {@inheritdoc}
    */
-  public function massageMessageBody(array $message) {
-
-    // @see: SwiftMailer::massageMessageBody()
+  protected function massageMessageBody(array &$message, $is_html) {
+    $text_format = $message['params']['text_format'] ?? $this->config['message']['text_format'] ?: NULL;
     $line_endings = Settings::get('mail_line_endings', PHP_EOL);
+    $body = [];
+
+    foreach ($message['body'] as $part) {
+      if (!($part instanceof MarkupInterface)) {
+        if ($is_html) {
+          // Convert to HTML. The default 'plain_text' format escapes markup,
+          // converts new lines to <br> and converts URLs to links.
+          $body[] = check_markup($part, $text_format);
+        }
+        else {
+          // The body will be plain text. However we need to convert to HTML
+          // to render the template then convert back again. Use a fixed
+          // conversion because we don't want to convert URLs to links.
+          $body[] = preg_replace("|\n|", "<br />\n", HTML::escape($part)) . "<br />\n";
+        }
+      }
+      else {
+        $body[] = $part . $line_endings;
+      }
+    }
+
+    // Merge all lines in the e-mail body and treat the result as safe markup.
     $message['body'] = Markup::create(implode($line_endings, array_map(function ($body) {
       // If the field contains no html tags we can assume newlines will need be
       // converted to <br>.
@@ -39,7 +60,46 @@ class SocialSwiftMailer extends SwiftMailer {
       }
       return check_markup($body, 'full_html');
     }, $message['body'])));
-    return $message;
+    
+    // Attempt to use the mail theme defined in MailSystem.
+    if ($this->mailManager instanceof MailsystemManager) {
+      $mail_theme = $this->mailManager->getMailTheme();
+    }
+    // Default to the active theme if MailsystemManager isn't used.
+    else {
+      $mail_theme = $this->themeManager->getActiveTheme()->getName();
+    }
+
+    $render = [
+      '#theme' => $message['params']['theme'] ?? 'swiftmailer',
+      '#message' => $message,
+      '#is_html' => $is_html,
+    ];
+
+    if ($is_html) {
+      $render['#attached']['library'] = ["$mail_theme/swiftmailer"];
+    }
+
+    $message['body'] = $this->renderer->renderPlain($render);
+
+    if ($is_html) {
+      // Process CSS from libraries.
+      $assets = AttachedAssets::createFromRenderArray($render);
+      $css = '';
+      // Request optimization so that the CssOptimizer performs essential
+      // processing such as @include.
+      foreach ($this->assetResolver->getCssAssets($assets, TRUE) as $css_asset) {
+        $css .= file_get_contents($css_asset['data']);
+      }
+
+      if ($css) {
+        $message['body'] = (new CssToInlineStyles())->convert($message['body'], $css);
+      }
+    }
+    else {
+      // Convert to plain text.
+      $message['body'] = (new Html2Text($message['body']))->getText();
+    }
   }
 
 }


### PR DESCRIPTION
## Problem
drupal/sendgrid_integration could not be installed with the old version of swiftmailer.

## Solution

1. Removed the patch for the drupal/swiftmailer 1.0-beta2.
2. Updated to drupal/swiftmailer 2.0-beta1 and swiftmailer/swiftmailer:6.2.4
3. We also needed to ensure our SocialSwiftMailer is up to date with SwiftMailers massageMessageBody
4. And since PHP is not supported as a swiftmailer send option we need to use mailcatchers smtp

See https://www.drupal.org/project/swiftmailer/issues/3143292

```
$config['swiftmailer.transport']['transport'] = 'smtp';
$config['swiftmailer.transport']['smtp_host'] = 'mailcatcher';
$config['swiftmailer.transport']['smtp_port'] = '1025';
```

Should do the trick.

Or use the re-install script with the new `--localsettings` flag. This should ensure your settings are added on installation.

```
docker exec -i social_web bash /var/www/scripts/social/install/install_script.sh --localsettings
```


## Issue tracker
https://www.drupal.org/project/social/issues/3188183

## How to test

- [ ] Run composer and confirm new versions are in composer.lock.
- [ ] Reinstall Open Social and see if mails are being sent correctly.
- [ ] Test update path from Older versions, we should still be backwards compatible
- [ ] Test sending of mails like invite for groups or events. 
- [ ] Test any notification triggered for email, creating a comment etc.

## Screenshots
![Screenshot 2020-12-28 at 15 31 57](https://user-images.githubusercontent.com/16667281/103221125-2dbcdd80-4922-11eb-9018-21f9c445c500.png)
![Screenshot 2020-12-28 at 15 32 01](https://user-images.githubusercontent.com/16667281/103221127-2e557400-4922-11eb-9d41-373e9534e8e1.png)


## Release notes
Updated to swiftmailer to 2.0 beta 1