### PR TITLE
Issue #3189814 by agami4: Add indication for comments section that comments are loading

### DIFF
--- a/themes/socialbase/assets/css/comment.css
+++ b/themes/socialbase/assets/css/comment.css
@@ -194,6 +194,39 @@ details[open] .details__close-icon {
 .comment .photoswipe-gallery-custom {
   margin-top: .5rem;
 }
+
+/* Loading-throbber when comments are loading. */
+@-webkit-keyframes glyphicon-spin {
+  0% {
+    -webkit-transform: rotate(0deg);
+    transform: rotate(0deg);
+  }
+  100% {
+    -webkit-transform: rotate(359deg);
+    transform: rotate(359deg);
+  }
+}
+@keyframes glyphicon-spin {
+  0% {
+    -webkit-transform: rotate(0deg);
+    transform: rotate(0deg);
+  }
+  100% {
+    -webkit-transform: rotate(359deg);
+    transform: rotate(359deg);
+  }
+}
+
+.card__comment_section [data-big-pipe-placeholder-id]:first-child {
+  display: block;
+  width: 20px;
+  height: 20px;
+  margin: auto;
+  background: url("../images/icons/icon-autorenew.svg") no-repeat center center/auto 100%;
+  -webkit-animation: glyphicon-spin 1s infinite linear;
+          animation: glyphicon-spin 1s infinite linear;
+}
+
 @media (min-width: 600px) {
   .comment__avatar {
     margin-right: 12px;
@@ -205,11 +238,13 @@ details[open] .details__close-icon {
     display: none;
   }
 }
+
 @media (min-width: 900px) {
   .comments {
     margin-left: 56px;
   }
 }
+
 @media (max-width: 599px) {
   .comment-form .btn--comment-submit {
     padding-left: 6px;

--- a/themes/socialbase/components/04-organisms/comment/comment.scss
+++ b/themes/socialbase/components/04-organisms/comment/comment.scss
@@ -245,3 +245,28 @@ details[open] .details__close-icon {
 .comment .photoswipe-gallery-custom {
   margin-top: .5rem;
 }
+
+/* Loading-throbber when comments are loading. */
+@keyframes glyphicon-spin {
+  0% {
+    -webkit-transform: rotate(0deg);
+    transform: rotate(0deg);
+  }
+  100% {
+    -webkit-transform: rotate(359deg);
+    transform: rotate(359deg);
+  }
+}
+
+.card__comment_section {
+  [data-big-pipe-placeholder-id] {
+    &:first-child {
+      display: block;
+      width: 20px;
+      height: 20px;
+      margin: auto;
+      background: url('../images/icons/icon-autorenew.svg') no-repeat center center/auto 100%;
+      animation: glyphicon-spin 1s infinite linear;
+    }
+  }
+}

--- a/themes/socialbase/templates/comment/field--comment.html.twig
+++ b/themes/socialbase/templates/comment/field--comment.html.twig
@@ -45,7 +45,7 @@
     {% endif %}
 
     <div class="card">
-      <div class="card__block">
+      <div class="card__block card__comment_section">
 
         {{ comments }}
 


### PR DESCRIPTION
## Problem
The comment block has not loading-throbber icon when comments are loading.

## Solution
Add loading-throbber for the comment section on all content types.

## Issue tracker

- https://www.drupal.org/project/social/issues/3189814
- https://getopensocial.atlassian.net/browse/YANG-4041

## How to test
*For example*
- [x] Go to the node(with the comment section).
- [x] Go to the comment section.

## Screenshots
<img width="850" alt="comment-throbber" src="https://user-images.githubusercontent.com/16086340/103095363-0fe13700-4609-11eb-917d-615dac58cf94.png">

## Release notes
When comments are loading you will see the loading-throbber icon.

## Change Record
-

## Translations
-
