### PR TITLE
Issue #3189847 by tBKoT: Generate consistent aliases for all group tabs

### DIFF
--- a/modules/custom/social_devel/social_devel.module
+++ b/modules/custom/social_devel/social_devel.module
@@ -30,3 +30,11 @@ function social_devel_social_group_default_route_tabs_alter(&$tabs) {
   // Unset the 'Devel' option as default group tab.
   unset($tabs['devel.entities:group.devel_tab']);
 }
+
+/**
+ * Implements hook_social_path_manager_group_tabs_alter().
+ */
+function social_devel_social_path_manager_group_tabs_alter(array &$tabs) {
+  // Unset the 'Devel' option as default group tab.
+  unset($tabs['devel.entities:group.devel_tab']);
+}

--- a/modules/custom/social_path_manager/social_path_manager.module
+++ b/modules/custom/social_path_manager/social_path_manager.module
@@ -174,7 +174,7 @@ function _social_path_manager_group_tabs() {
 function social_path_manager_social_path_manager_group_tabs_alter(array &$tabs) {
   foreach ($tabs as $key => $route) {
     // Only allow tabs that are part of the group.
-    if ($key === 'social_group.stream' || strpos($key, 'social_group') === FALSE) {
+    if (strpos($key, 'layout_builder') !== FALSE) {
       unset($tabs[$key]);
     }
   }
@@ -221,17 +221,26 @@ function _social_path_manager_update_alias(EntityInterface $entity, $op, $bulk =
         /** @var \Drupal\Core\Path\AliasManager $pam */
         $pam = \Drupal::service('path.alias_manager');
 
-        // If it's a bulk generate then get the alias by path.
-        if ($bulk === TRUE) {
-          $url = Url::fromRoute('entity.group.canonical', ['group' => $entity->id()]);
-          $url = $url->getInternalPath();
-
-          $path['alias'] = $pam->getAliasByPath('/' . $url);
+        // If disabled generate automatic link.
+        if (
+          !$entity->get('path')->pathauto &&
+          $entity->get('path')->alias
+        ) {
+          $path = $entity->get('path')->getValue()[0];
         }
         else {
-          // New alias.
-          $path = \Drupal::service('pathauto.generator')
-            ->updateEntityAlias($entity, 'update');
+          // If it's a bulk generate then get the alias by path.
+          if ($bulk === TRUE) {
+            $url = Url::fromRoute('entity.group.canonical', ['group' => $entity->id()]);
+            $url = $url->getInternalPath();
+
+            $path['alias'] = $pam->getAliasByPath('/' . $url);
+          }
+          else {
+            // New alias.
+            $path = \Drupal::service('pathauto.generator')
+              ->updateEntityAlias($entity, 'update');
+          }
         }
 
         // Check if the alias changed.
@@ -239,6 +248,7 @@ function _social_path_manager_update_alias(EntityInterface $entity, $op, $bulk =
         if (!empty($path)) {
           foreach (_social_path_manager_group_tabs() as $route) {
             $suffix = _social_path_manager_get_path_suffix($entity, $route);
+            $entity_language = $entity->language()->getId();
 
             // Get alias of the group tab.
             $grouptab_alias = $pam->getAliasByPath('/group/' . $entity->id() . '/' . $suffix);
@@ -247,12 +257,12 @@ function _social_path_manager_update_alias(EntityInterface $entity, $op, $bulk =
             $pas = \Drupal::service('path.alias_storage');
 
             // Check of the alias is an alias or path.
-            $is_alias = $pas->aliasExists($grouptab_alias, 'und');
+            $is_alias = $pas->aliasExists($grouptab_alias, $entity_language);
 
             // Create a new alias when it does not exist.
             if ($op === 'create' && $is_alias === FALSE) {
               // Insert the alias for the other views.
-              $pas->save('/group/' . $entity->id() . '/' . $suffix, $path['alias'] . '/' . $suffix, 'und');
+              $pas->save('/group/' . $entity->id() . '/' . $suffix, $path['alias'] . '/' . $suffix, $entity_language);
             }
 
             // Update alias by deleting the old one and creating a new one.
@@ -260,7 +270,7 @@ function _social_path_manager_update_alias(EntityInterface $entity, $op, $bulk =
               \Drupal::service('pathauto.alias_storage_helper')
                 ->deleteBySourcePrefix('/group/' . $entity->id() . '/' . $suffix);
 
-              $pas->save('/group/' . $entity->id() . '/' . $suffix, $path['alias'] . '/' . $suffix, 'und');
+              $pas->save('/group/' . $entity->id() . '/' . $suffix, $path['alias'] . '/' . $suffix, $entity_language);
             }
           }
 

--- a/modules/social_features/social_group/social_group.module
+++ b/modules/social_features/social_group/social_group.module
@@ -2023,6 +2023,17 @@ function social_group_social_group_default_route_tabs_alter(&$tabs) {
 }
 
 /**
+ * Implements hook_social_path_manager_group_tabs_alter().
+ */
+function social_group_social_path_manager_group_tabs_alter(array &$tabs) {
+  // Unset some tabs created by group.
+  unset($tabs['group.view'], $tabs['group.edit_form'], $tabs['group.content']);
+
+  // Add manage members tab.
+  $tabs['social_group.membership'] = 'view.group_manage_members.page_group_manage_members';
+}
+
+/**
  * Implements hook_batch_alter().
  */
 function social_group_batch_alter(&$batch) {


### PR DESCRIPTION
## Problem
In the Open Social profile, we have the `social_path_manager` module that generates aliases for group tabs. However, it skips a lot of tabs and generates aliases without correct language from the group entity.

## Solution
1. Modify the alter hook that unset some tabs.
2. Set the language for alias from a group entity.

## Issue tracker
https://www.drupal.org/project/social/issues/3189847
https://getopensocial.atlassian.net/browse/YANG-4014

## How to test
*For example*
- [x] Go to any group
- [x] Set/edit alias
- [x] Save group

## Screenshots
N/A

## Release notes
N/A

## Change Record
N/A

## Translations
N/A
