### PR TITLE
Issue #3190090 by agami4: Update download link color for the social_certificate module

### DIFF
--- a/themes/socialblue/assets/css/brand.css
+++ b/themes/socialblue/assets/css/brand.css
@@ -216,7 +216,7 @@ fieldset[disabled] .btn-accent.focus {
 .field--name-field-accord-description a:not(.btn),
 .field--name-field-accord-description a:not(.btn):hover,
 .field--name-field-text a:not(.btn),
-.field--name-field-accord-description a:not(.btn):hover,
+.field--name-field-text a:not(.btn):hover,
 .body-text a:not(.btn),
 .body-text a:not(.btn):hover {
   color: #33b5e5;
@@ -572,6 +572,14 @@ html:not(.js) .navbar-default .dropdown:hover > button .navbar-nav__icon {
 
 .block-data-policy .card__title {
   background: #1f80aa;
+}
+
+.social__dialog-badge.social__certificate .social__certificate--no-bg .social__certificate--content .footer a {
+  color: #29abe2;
+}
+
+.social__dialog-badge.social__certificate .social__certificate--no-bg .social__certificate--content .footer a .icon {
+  fill: #29abe2;
 }
 
 @media (min-width: 900px) {

--- a/themes/socialblue/components/brand.scss
+++ b/themes/socialblue/components/brand.scss
@@ -702,3 +702,15 @@ html:not(.js) .navbar-default {
 .block-data-policy .card__title {
   background: $brand-secondary;
 }
+
+.social__dialog-badge.social__certificate {
+  .social__certificate--no-bg {
+    .social__certificate--content .footer a {
+      color: $brand-primary;
+
+      .icon {
+        fill: $brand-primary;
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Problem
The download link on the no-background certificate has the wrong color.

## Solution
Update download link color on the no-background certificate.

## Issue tracker
https://www.drupal.org/project/social/issues/3190090

## How to test
*For example*
- [ ] Go to the profile-information page and open the no-background certificate.

## Screenshots
<img width="973" alt="download-link" src="https://user-images.githubusercontent.com/16086340/103223264-83978280-492e-11eb-8616-175c42a3cb2c.png">

## Release notes
The download link has a primary color on the no-background certificate.

## Change Record
-

## Translations
-