### PR TITLE
Issue #3189003 by mdeny: Expand Social Tagging feature on user profiles

### DIFF
--- a/modules/social_features/social_profile/modules/social_profile_organization_tag/src/SocialProfileOrgTagConfigOverride.php
+++ b/modules/social_features/social_profile/modules/social_profile_organization_tag/src/SocialProfileOrgTagConfigOverride.php
@@ -45,18 +45,18 @@ class SocialProfileOrgTagConfigOverride implements ConfigFactoryOverrideInterfac
       $overrides[$config_name] = [
         'third_party_settings' => [
           'field_group' => [
-            'group_organization_tag' => [
+            'group_tags' => [
               'children' => [
                 'field_profile_organization_tag',
               ],
               'parent_name' => '',
               'weight' => 99,
-              'label' => t('Organization tag')->render(),
+              'label' => t('Tags')->render(),
               'format_type' => 'fieldset',
               'format_settings' => [
-                'label' => t('Organization tag')->render(),
+                'label' => t('Tags')->render(),
                 'required_fields' => FALSE,
-                'id' => 'organization_tag',
+                'id' => 'group_tags',
                 'classes' => 'scrollspy',
               ],
             ],

--- a/modules/social_features/social_tagging/social_tagging.install
+++ b/modules/social_features/social_tagging/social_tagging.install
@@ -6,6 +6,8 @@
  */
 
 use Drupal\Core\Entity\EntityStorageException;
+use Drupal\Core\Field\BaseFieldDefinition;
+use Drupal\Core\Field\FieldStorageDefinitionInterface;
 
 /**
  * Install the module.
@@ -76,4 +78,52 @@ function _social_tagging_field_definitions_update() {
   // Create field storage for the 'Highlight' base field.
   \Drupal::entityTypeManager()->clearCachedDefinitions();
   \Drupal::service('entity.definition_update_manager')->applyUpdates();
+}
+
+/**
+ * Install Tagging base field to profile entity type.
+ */
+function social_tagging_update_8003() {
+  $field_storage_definition = BaseFieldDefinition::create('entity_reference')
+    ->setLabel(t('Tagging'))
+    ->setDescription(t('Tagging field.'))
+    ->setSetting('target_type', 'taxonomy_term')
+    ->setSetting('handler', 'default:taxonomy_term')
+    ->setSetting('handler_settings', [
+      'target_bundles' => [
+        'social_tagging' => 'social_tagging',
+      ],
+    ])
+    ->setCardinality(FieldStorageDefinitionInterface::CARDINALITY_UNLIMITED)
+    ->setDisplayOptions('view', [
+      'type' => 'hidden',
+    ])
+    ->setDisplayOptions('form', [
+      'type' => 'options_select',
+      'weight' => 3,
+      'settings' => [],
+    ])
+    ->setDisplayConfigurable('form', TRUE)
+    ->setDisplayConfigurable('view', TRUE);
+
+  \Drupal::entityDefinitionUpdateManager()
+    ->installFieldStorageDefinition('social_tagging', 'profile', 'social_tagging', $field_storage_definition);
+}
+
+/**
+ * Toggle user index.
+ */
+function social_tagging_update_8004() {
+  // Update field definitions.
+  _social_tagging_field_definitions_update();
+  // Toggle the index users.
+  try {
+    // If the search module is enabled we need to update the group index.
+    if (\Drupal::moduleHandler()->moduleExists('social_search')) {
+      social_search_resave_search_indexes(['social_users']);
+    }
+  }
+  catch (EntityStorageException $e) {
+    \Drupal::logger('social_tagging')->info($e->getMessage());
+  }
 }

--- a/modules/social_features/social_tagging/social_tagging.module
+++ b/modules/social_features/social_tagging/social_tagging.module
@@ -117,6 +117,7 @@ function social_tagging_form_alter(&$form, FormStateInterface $form_state, $form
         break;
 
       case 'group':
+      case 'profile':
         $type = $form_entity->getEntityTypeId();
         $tag_enabled = $tag_settings->get('tag_type_' . $type);
         break;
@@ -185,6 +186,16 @@ function social_tagging_form_alter(&$form, FormStateInterface $form_state, $form
         unset($form['social_tagging']);
         $form['tagging']['social_tagging']['#group'] = 'group_tagging';
       }
+
+      if ($form_entity->getEntityTypeId() === 'profile') {
+        if (isset($form['#fieldgroups']['group_tags'])) {
+          $form['tagging']['#type'] = 'container';
+          $form['tagging']['#group'] = 'group_tags';
+        }
+        else {
+          $form['tagging']['#title'] = t('Tags');
+        }
+      }
     }
   }
 }
@@ -201,7 +212,7 @@ function _social_tagging_entity_validate($form, FormStateInterface $form_state) 
   $tagging_values = [];
   $counter = 0;
   // Loop over the categories.
-  foreach ($categories as $tid => $category) {
+  foreach ($categories as $category) {
     if (!empty($form_state->getValue('social_tagging_' . social_tagging_to_machine_name($category)))) {
       foreach ($form_state->getValue('social_tagging_' . social_tagging_to_machine_name($category)) as $selected) {
         $tagging_values[] = [
@@ -225,7 +236,7 @@ function _social_tagging_node_form_defaults_values(EntityInterface $entity) {
   $default_value = [];
   // If the node exists, we need to get the default value.
   if ($entity instanceof EntityInterface && $entity->id() !== NULL) {
-    foreach ($entity->get('social_tagging')->getValue() as $key => $value) {
+    foreach ($entity->get('social_tagging')->getValue() as $value) {
       if (isset($value['target_id'])) {
         $default_value[] = $value['target_id'];
       }
@@ -240,8 +251,14 @@ function _social_tagging_node_form_defaults_values(EntityInterface $entity) {
 function social_tagging_entity_base_field_info(EntityTypeInterface $entity_type) {
   $fields = [];
 
-  // Add a 'Highlight' base field to all node types.
-  if ($entity_type->id() === 'node' || $entity_type->id() === 'group') {
+  $entity_types = [
+    'node',
+    'group',
+    'profile',
+  ];
+
+  // Add a Tagging base field.
+  if (in_array($entity_type->id(), $entity_types)) {
     $fields['social_tagging'] = BaseFieldDefinition::create('entity_reference')
       ->setLabel(t('Tagging'))
       ->setDescription(t('Tagging field.'))
@@ -364,6 +381,8 @@ function social_tagging_form_views_exposed_form_alter(&$form, FormStateInterface
     'views-exposed-form-search-content-page',
     'views-exposed-form-search-groups-page-no-value',
     'views-exposed-form-search-groups-page',
+    'views-exposed-form-search-users-page-no-value',
+    'views-exposed-form-search-users-page',
     'views-exposed-form-latest-topics-page-latest-topics',
     'views-exposed-form-upcoming-events-page-community-events',
     'views-exposed-form-topics-page-profile',
@@ -440,4 +459,27 @@ function social_tagging_to_machine_name($text) {
   $text = str_replace(' ', '', $text);
 
   return $text;
+}
+
+/**
+ * Implements hook_preprocess_profile().
+ */
+function social_tagging_preprocess_profile(array &$variables) {
+  /** @var \Drupal\social_tagging\SocialTaggingService $tag_service */
+  $tag_service = \Drupal::service('social_tagging.tag_service');
+
+  $variables['social_tagging_profile_active'] = FALSE;
+  if ($tag_service->active() && $tag_service->profileActive()) {
+    $variables['social_tagging_profile_active'] = TRUE;
+
+    /** @var \Drupal\profile\Entity\ProfileInterface $profile */
+    $profile = $variables['profile'];
+
+    if (!$profile->get('social_tagging')->isEmpty()) {
+      $tags = $profile->get('social_tagging')->getValue();
+
+      $variables['social_tagging_allow_split'] = $tag_service->allowSplit();
+      $variables['social_tagging_hierarchy'] = $tag_service->buildHierarchy($tags, 'profile');
+    }
+  }
 }

--- a/modules/social_features/social_tagging/src/Form/SocialTaggingSettingsForm.php
+++ b/modules/social_features/social_tagging/src/Form/SocialTaggingSettingsForm.php
@@ -2,13 +2,15 @@
 
 namespace Drupal\social_tagging\Form;
 
+use Drupal\Core\Cache\CacheTagsInvalidatorInterface;
 use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Database\Connection;
 use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Form\ConfigFormBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Link;
-use Drupal\node\Entity\NodeType;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -26,11 +28,41 @@ class SocialTaggingSettingsForm extends ConfigFormBase implements ContainerInjec
   protected $moduleHandler;
 
   /**
+   * Entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * Database connection.
+   *
+   * @var \Drupal\Core\Database\Connection
+   */
+  protected $database;
+
+  /**
+   * Cache tags invalidator.
+   *
+   * @var \Drupal\Core\Cache\CacheTagsInvalidatorInterface
+   */
+  protected $cacheTagsInvalidator;
+
+  /**
    * {@inheritdoc}
    */
-  public function __construct(ConfigFactoryInterface $config_factory, ModuleHandlerInterface $moduleHandler) {
+  public function __construct(
+    ConfigFactoryInterface $config_factory,
+    ModuleHandlerInterface $module_handler,
+    EntityTypeManagerInterface $entity_type_manager,
+    Connection $database,
+    CacheTagsInvalidatorInterface $cache_tags_invalidator
+  ) {
     parent::__construct($config_factory);
-    $this->moduleHandler = $moduleHandler;
+    $this->moduleHandler = $module_handler;
+    $this->entityTypeManager = $entity_type_manager;
+    $this->database = $database;
+    $this->cacheTagsInvalidator = $cache_tags_invalidator;
   }
 
   /**
@@ -39,7 +71,10 @@ class SocialTaggingSettingsForm extends ConfigFormBase implements ContainerInjec
   public static function create(ContainerInterface $container) {
     return new static(
       $container->get('config.factory'),
-      $container->get('module_handler')
+      $container->get('module_handler'),
+      $container->get('entity_type.manager'),
+      $container->get('database'),
+      $container->get('cache_tags.invalidator')
     );
   }
 
@@ -65,9 +100,11 @@ class SocialTaggingSettingsForm extends ConfigFormBase implements ContainerInjec
     // Get the configuration file.
     $config = $this->config('social_tagging.settings');
 
+    /** @var \Drupal\node\NodeTypeInterface[] $node_types */
+    $node_types = $this->entityTypeManager->getStorage('node_type')->loadMultiple();
+
     $content_types = [];
-    foreach (NodeType::loadMultiple() as $node_type) {
-      /* @var NodeType $node_type */
+    foreach ($node_types as $node_type) {
       $content_types[] = $node_type->get('name');
     }
 
@@ -99,8 +136,14 @@ class SocialTaggingSettingsForm extends ConfigFormBase implements ContainerInjec
       '#required' => FALSE,
     ];
 
-    /** @var \Drupal\node\Entity\NodeType $nodetype */
-    foreach (NodeType::loadMultiple() as $nodetype) {
+    $form['node_type_settings']['tag_type_profile'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Profile'),
+      '#default_value' => $config->get('tag_type_profile'),
+      '#required' => FALSE,
+    ];
+
+    foreach ($node_types as $nodetype) {
       $field_name = 'tag_node_type_' . $nodetype->id();
       $value = $config->get($field_name);
       $default_value = isset($value) ? $config->get($field_name) : TRUE;
@@ -121,16 +164,24 @@ class SocialTaggingSettingsForm extends ConfigFormBase implements ContainerInjec
    * {@inheritdoc}
    */
   public function submitForm(array &$form, FormStateInterface $form_state) {
-
     // Get the configuration file.
     $config = $this->config('social_tagging.settings');
     $config->set('enable_content_tagging', $form_state->getValue('enable_content_tagging'))->save();
     $config->set('allow_category_split', $form_state->getValue('allow_category_split'))->save();
     $config->set('tag_type_group', $form_state->getValue('tag_type_group'))->save();
+    $config->set('tag_type_profile', $form_state->getValue('tag_type_profile'))->save();
 
-    /** @var \Drupal\node\Entity\NodeType $nodetype */
-    foreach (NodeType::loadMultiple() as $nodetype) {
-      $config_name = 'tag_node_type_' . $nodetype->id();
+    // Clear cache tags of profiles.
+    $query = $this->database->select('cachetags', 'ct');
+    $query->fields('ct', ['tag']);
+    $query->condition('ct.tag', 'profile:%', 'LIKE');
+    $result = $query->execute()->fetchCol();
+    $this->cacheTagsInvalidator->invalidateTags($result);
+
+    /** @var \Drupal\node\NodeTypeInterface[] $node_types */
+    $node_types = $this->entityTypeManager->getStorage('node_type')->loadMultiple();
+    foreach ($node_types as $node_type) {
+      $config_name = 'tag_node_type_' . $node_type->id();
       $config->set($config_name, $form_state->getValue($config_name))->save();
     }
 

--- a/modules/social_features/social_tagging/src/SocialTaggingOverrides.php
+++ b/modules/social_features/social_tagging/src/SocialTaggingOverrides.php
@@ -12,13 +12,6 @@ use Drupal\Core\Config\StorageInterface;
 class SocialTaggingOverrides implements ConfigFactoryOverrideInterface {
 
   /**
-   * The tagging helper service.
-   *
-   * @var \Drupal\social_tagging\SocialTaggingService
-   */
-  protected $tagService;
-
-  /**
    * Whether this config override should apply to the provided configurations.
    *
    * Used to check what to return in loadOverrides as well as in the metadata
@@ -34,8 +27,10 @@ class SocialTaggingOverrides implements ConfigFactoryOverrideInterface {
     $config_names = [
       'views.view.search_content',
       'views.view.search_groups',
+      'views.view.search_users',
       'search_api.index.social_content',
       'search_api.index.social_groups',
+      'search_api.index.social_users',
       'views.view.latest_topics',
       'views.view.upcoming_events',
       'views.view.topics',
@@ -43,6 +38,7 @@ class SocialTaggingOverrides implements ConfigFactoryOverrideInterface {
       'views.view.group_topics',
       'views.view.group_events',
       'views.view.newest_groups',
+      'core.entity_view_display.profile.profile.default',
     ];
 
     // We loop over the provided names instead of the config names we override
@@ -67,9 +63,11 @@ class SocialTaggingOverrides implements ConfigFactoryOverrideInterface {
 
     $overrides = [];
 
+    /** @var \Drupal\social_tagging\SocialTaggingService $tag_service */
+    $tag_service = \Drupal::service('social_tagging.tag_service');
+
     // Check if tagging is active.
-    $tagService = \Drupal::service('social_tagging.tag_service');
-    if (!($tagService->active() && $tagService->hasContent())) {
+    if (!($tag_service->active() && $tag_service->hasContent())) {
       return $overrides;
     }
 
@@ -77,13 +75,16 @@ class SocialTaggingOverrides implements ConfigFactoryOverrideInterface {
     $config_search = [
       'search_api.index.social_content' => 'node',
     ];
-    if ($tagService->groupActive()) {
+    if ($tag_service->groupActive()) {
       $config_search['search_api.index.social_groups'] = 'group';
+    }
+    if ($tag_service->profileActive()) {
+      $config_search['search_api.index.social_users'] = 'profile';
     }
 
     foreach ($config_search as $config_name => $type) {
       if (in_array($config_name, $names)) {
-        $field_settings = \Drupal::service('config.factory')->getEditable($config_name)
+        $field_settings = \Drupal::configFactory()->getEditable($config_name)
           ->get('field_settings');
 
         $field_settings['social_tagging'] = [
@@ -102,10 +103,10 @@ class SocialTaggingOverrides implements ConfigFactoryOverrideInterface {
       'label' => 'Tags',
     ];
 
-    if ($tagService->allowSplit()) {
+    if ($tag_service->allowSplit()) {
       $fields = [];
-      foreach ($tagService->getCategories() as $tid => $value) {
-        if (!empty($tagService->getChildren($tid))) {
+      foreach ($tag_service->getCategories() as $tid => $value) {
+        if (!empty($tag_service->getChildren($tid))) {
           $fields['social_tagging_' . $tid] = [
             'identifier' => social_tagging_to_machine_name($value),
             'label' => $value,
@@ -118,8 +119,11 @@ class SocialTaggingOverrides implements ConfigFactoryOverrideInterface {
     $config_views = [
       'views.view.search_content' => 'search_api_index_social_content',
     ];
-    if ($tagService->groupActive()) {
+    if ($tag_service->groupActive()) {
       $config_views['views.view.search_groups'] = 'search_api_index_social_groups';
+    }
+    if ($tag_service->profileActive()) {
+      $config_views['views.view.search_users'] = 'search_api_index_social_users';
     }
 
     foreach ($config_views as $config_name => $type) {
@@ -203,10 +207,10 @@ class SocialTaggingOverrides implements ConfigFactoryOverrideInterface {
       'label' => 'Tags',
     ];
 
-    if ($tagService->allowSplit()) {
+    if ($tag_service->allowSplit()) {
       $fields = [];
-      foreach ($tagService->getCategories() as $tid => $value) {
-        if (!empty($tagService->getChildren($tid))) {
+      foreach ($tag_service->getCategories() as $tid => $value) {
+        if (!empty($tag_service->getChildren($tid))) {
           $fields['social_tagging_target_id_' . $tid] = [
             'identifier' => social_tagging_to_machine_name($value),
             'label' => $value,
@@ -300,6 +304,20 @@ class SocialTaggingOverrides implements ConfigFactoryOverrideInterface {
         }
 
       }
+    }
+
+    $config_name = 'core.entity_view_display.profile.profile.default';
+    if (in_array($config_name, $names)) {
+      $overrides[$config_name]['content']['social_tagging'] = [
+        'weight' => 7,
+        'label' => 'visually_hidden',
+        'settings' => [
+          'link' => 'true',
+        ],
+        'third_party_settings' => [],
+        'type' => 'entity_reference_label',
+        'region' => 'content',
+      ];
     }
 
     return $overrides;

--- a/modules/social_features/social_tagging/src/SocialTaggingOverrides.php
+++ b/modules/social_features/social_tagging/src/SocialTaggingOverrides.php
@@ -347,7 +347,7 @@ class SocialTaggingOverrides implements ConfigFactoryOverrideInterface {
     $metadata = new CacheableMetadata();
     // Calls to SocialTaggingService's methods active, groupActive, allowSplit
     // all depend on the settings under the hood.
-    $metadata->addCacheContexts(['config:social_tagging.settings']);
+    $metadata->addCacheTags(['config:social_tagging.settings']);
     // The loadOverrides method calls the getCategories and getChildren methods
     // to build the fields that are shown in the views and the values they have.
     // The output of these methods ultimately depends on the contents of the

--- a/themes/socialbase/templates/profile/profile--profile--default.html.twig
+++ b/themes/socialbase/templates/profile/profile--profile--default.html.twig
@@ -128,9 +128,31 @@
       {% endfor %}
     {% endif %}
 
+    {% if content.social_tagging['#items'] and social_tagging_profile_active %}
+      {% if social_tagging_allow_split %}
+        {% for item in social_tagging_hierarchy %}
+          <h5>{{ item.title }}</h5>
+          {% for tag in item.tags %}
+            <a href="{{ tag.url }}">
+              <div class="badge badge--pill badge--large badge-default">{{ tag.name }}</div>
+            </a>
+          {% endfor %}
+        {% endfor %}
+      {% else %}
+        <h5>{% trans %}Tags{% endtrans %}</h5>
+        {% for item in social_tagging_hierarchy %}
+          {% for tag in item.tags %}
+            <a href="{{ tag.url }}">
+              <div class="badge badge--pill badge--large badge-default">{{ tag.name }}</div>
+            </a>
+          {% endfor %}
+        {% endfor %}
+      {% endif %}
+    {% endif %}
+
     {{  content|without('field_profile_phone_number', 'user_mail', 'field_profile_address',
       'field_profile_self_introduction', 'field_profile_interests', 'field_profile_expertise',
-      'field_profile_profile_tag', 'field_manager_notes', 'user_lang') }}
+      'field_profile_profile_tag', 'field_manager_notes', 'user_lang', 'social_tagging') }}
 
     {% if (content|render is empty and user_mail is empty and user_lang is empty)%}
         {% trans %}{{ profile_name }} {{ profile_name_extra }} has not shared profile information.{% endtrans %}

--- a/themes/socialblue/templates/profile/profile--profile--default--sky.html.twig
+++ b/themes/socialblue/templates/profile/profile--profile--default--sky.html.twig
@@ -132,9 +132,39 @@
       </div>
     {% endif %}
 
+    {% if content.social_tagging['#items'] and social_tagging_profile_active %}
+      {% if social_tagging_allow_split %}
+        {% for item in social_tagging_hierarchy %}
+          <div class="card--content-merged__list">
+            <h5>{{ item.title }}</h5>
+            <div class="list-item__text">
+              {% for tag in item.tags %}
+                <a href="{{ tag.url }}">
+                  <div class="badge badge--pill badge--large badge-default">{{ tag.name }}</div>
+                </a>
+              {% endfor %}
+            </div>
+          </div>
+        {% endfor %}
+      {% else %}
+        <div class="card--content-merged__list">
+          <h5>{% trans %}Tags{% endtrans %}</h5>
+          <div class="list-item__text">
+            {% for item in social_tagging_hierarchy %}
+              {% for tag in item.tags %}
+                <a href="{{ tag.url }}">
+                  <div class="badge badge--pill badge--large badge-default">{{ tag.name }}</div>
+                </a>
+              {% endfor %}
+            {% endfor %}
+          </div>
+        </div>
+      {% endif %}
+    {% endif %}
+
     {{  content|without('field_profile_phone_number', 'user_mail', 'field_profile_address',
       'field_profile_self_introduction', 'field_profile_interests', 'field_profile_expertise',
-      'field_profile_profile_tag', 'field_manager_notes') }}
+      'field_profile_profile_tag', 'field_manager_notes', 'social_tagging') }}
 
     {% if (content|render is empty and user_mail is empty)%}
         {% trans %}{{ profile_name }} {{ profile_name_extra }} has not shared profile information.{% endtrans %}


### PR DESCRIPTION
## Problem
As a LU I want to be able to filter on all the attributes added to the profile

## Solution
Expand Social Tagging feature on user profiles

## Issue tracker

- https://www.drupal.org/project/social/issues/3189003
- https://getopensocial.atlassian.net/browse/YANG-4352

## How to test
- [ ] profile entities as selectable option should be on settings form of social_tagging module
- [ ] tags should appear as filters on search (user tab) automatically
- [ ] selected tags should show on the user profile detail page similar to expertise / interests
- [ ] it should be properly integrated in profile edit form

## Design
https://www.figma.com/proto/eFn9UYCaSnerZgx9vxsmbR/Open-Social-Design-System?node-id=5097%3A4&viewport=639%2C775%2C0.5&scaling=min-zoom