### PR TITLE
#3190319 by jochemvn: add 'featured' view mode for secret groups

### DIFF
--- a/modules/social_features/social_group/modules/social_group_secret/modules/social_secret_group_featured/config/install/core.entity_view_display.group.secret_group.featured.yml
+++ b/modules/social_features/social_group/modules/social_group_secret/modules/social_secret_group_featured/config/install/core.entity_view_display.group.secret_group.featured.yml
@@ -1,0 +1,51 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.group.featured
+    - field.field.group.secret_group.field_group_address
+    - field.field.group.secret_group.field_group_description
+    - field.field.group.secret_group.field_group_image
+    - field.field.group.secret_group.field_group_location
+    - group.type.secret_group
+    - image.style.social_featured
+  module:
+    - address
+    - image
+    - social_group_secret
+    - social_landing_page
+id: group.secret_group.featured
+targetEntityType: group
+bundle: secret_group
+mode: featured
+content:
+  field_group_address:
+    type: address_plain
+    weight: 1
+    region: content
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+  field_group_image:
+    type: image
+    weight: 0
+    region: content
+    label: hidden
+    settings:
+      image_style: social_featured
+      image_link: content
+    third_party_settings: {  }
+  field_group_location:
+    type: string
+    weight: 2
+    region: content
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+hidden:
+  changed: true
+  created: true
+  field_group_description: true
+  label: true
+  uid: true

--- a/modules/social_features/social_group/modules/social_group_secret/modules/social_secret_group_featured/social_secret_group_featured.info.yml
+++ b/modules/social_features/social_group/modules/social_group_secret/modules/social_secret_group_featured/social_secret_group_featured.info.yml
@@ -1,0 +1,9 @@
+name: 'Social Secret Group on Landing pages'
+description: 'Provides a Secret Group featured view mode for use on landing pages.'
+type: module
+core: 8.x
+dependencies:
+  - social:social_group_secret
+  - social:social_landing_page
+package: Social
+core_incompatible: false

--- a/modules/social_features/social_landing_page/social_landing_page.install
+++ b/modules/social_features/social_landing_page/social_landing_page.install
@@ -667,3 +667,15 @@ function social_landing_page_update_8809() {
     user_role_grant_permissions($role, ['link to any page']);
   }
 }
+
+/**
+ * Enable helper modules if secret group is enabled.
+ */
+function social_landing_page_update_8810() {
+  // If we have secret groups enabled, we want to enable the helper module
+  // social_secret_group_featured which provides a featured view mode to be
+  // used on landing pages.
+  if (\Drupal::moduleHandler()->moduleExists('social_group_secret')) {
+    \Drupal::service('module_installer')->install(['social_secret_group_featured']);
+  }
+}


### PR DESCRIPTION
## Problem
When featuring a secret group on a landing page, the group image is not shown. This is due to the absence of a 'featured' view mode.

## Solution
This solution provides the 'featured' view mode for secret groups.

## Issue tracker
- https://www.drupal.org/project/social/issues/3190319
- https://getopensocial.atlassian.net/browse/SUP-457

## How to test
- [ ] make sure the modules social_secret_group and social_landing_page are enabled
- [ ] create a secret group with an image
- [ ] create a landing page and add a featured content section
- [ ] add the secret group to the featured content section on the landing page
- [ ] view the landing page and notice you don't see the image
- [ ] run `drush updb --yes`
- [ ] reload the page and notice now you do see the image of the secret group on the landing page.v
- [ ] can also be verified that on `/admin/group/types/manage/secret_group/` you can see the view_mode 'featured'

## Release notes
Fixed an issue when featuring secret groups on a landing page, the image would not show.

