### PR TITLE
Issue #3191206 by navneet0693: Updated weight of banner image field on profile.

### DIFF
--- a/modules/social_features/social_profile/config/install/core.entity_form_display.profile.profile.default.yml
+++ b/modules/social_features/social_profile/config/install/core.entity_form_display.profile.profile.default.yml
@@ -29,8 +29,8 @@ third_party_settings:
       children:
         - field_profile_first_name
         - field_profile_last_name
-        - field_profile_image
         - field_profile_banner_image
+        - field_profile_image
       parent_name: ''
       weight: 0
       label: 'Names and profile image'
@@ -81,8 +81,6 @@ third_party_settings:
         required_fields: true
         id: contact
         classes: scollspy
-_core:
-  default_config_hash: q5dRMlfrlHczeboqgnggDsIvBp1Z0aun2cMsa4qIDbQ
 id: profile.profile.default
 targetEntityType: profile
 bundle: profile
@@ -96,7 +94,7 @@ content:
     type: address_default
     region: content
   field_profile_banner_image:
-    weight: 4
+    weight: 10
     settings:
       show_crop_area: true
       show_default_crop: true
@@ -110,7 +108,7 @@ content:
     type: image_widget_crop
     region: content
   field_profile_expertise:
-    weight: 6
+    weight: 13
     settings:
       match_operator: CONTAINS
       size: 60
@@ -120,7 +118,7 @@ content:
     type: entity_reference_autocomplete_tags
     region: content
   field_profile_first_name:
-    weight: 1
+    weight: 8
     settings:
       size: 60
       placeholder: ''
@@ -128,7 +126,7 @@ content:
     type: string_textfield
     region: content
   field_profile_function:
-    weight: 2
+    weight: 16
     settings:
       size: 60
       placeholder: ''
@@ -136,7 +134,7 @@ content:
     type: string_textfield
     region: content
   field_profile_image:
-    weight: 3
+    weight: 11
     settings:
       show_default_crop: true
       preview_image_style: social_x_large
@@ -152,7 +150,7 @@ content:
     type: image_widget_crop
     region: content
   field_profile_interests:
-    weight: 7
+    weight: 14
     settings:
       match_operator: CONTAINS
       size: 60
@@ -162,7 +160,7 @@ content:
     type: entity_reference_autocomplete_tags
     region: content
   field_profile_last_name:
-    weight: 2
+    weight: 9
     settings:
       size: 60
       placeholder: ''
@@ -170,7 +168,7 @@ content:
     type: string_textfield
     region: content
   field_profile_organization:
-    weight: 3
+    weight: 17
     settings:
       size: 60
       placeholder: ''
@@ -185,13 +183,13 @@ content:
     type: telephone_default
     region: content
   field_profile_profile_tag:
-    weight: 8
+    weight: 15
     settings: {  }
     third_party_settings: {  }
     type: options_buttons
     region: content
   field_profile_self_introduction:
-    weight: 5
+    weight: 12
     settings:
       rows: 5
       placeholder: ''

--- a/modules/social_features/social_profile/config/update/social_profile_update_8803.yml
+++ b/modules/social_features/social_profile/config/update/social_profile_update_8803.yml
@@ -1,0 +1,25 @@
+core.entity_form_display.profile.profile.default:
+  expected_config: { }
+  update_actions:
+    change:
+      content:
+        field_profile_banner_image:
+          weight: 10
+        field_profile_expertise:
+          weight: 13
+        field_profile_first_name:
+          weight: 8
+        field_profile_function:
+          weight: 16
+        field_profile_image:
+          weight: 11
+        field_profile_interests:
+          weight: 14
+        field_profile_last_name:
+          weight: 9
+        field_profile_organization:
+          weight: 17
+        field_profile_profile_tag:
+          weight: 15
+        field_profile_self_introduction:
+          weight: 12

--- a/modules/social_features/social_profile/social_profile.install
+++ b/modules/social_features/social_profile/social_profile.install
@@ -418,3 +418,17 @@ function social_profile_update_8802(&$sandbox) {
     }
   }
 }
+
+/**
+ * Moved the profile's banner field above image field.
+ */
+function social_profile_update_8803() {
+  /** @var \Drupal\update_helper\Updater $updateHelper */
+  $updateHelper = \Drupal::service('update_helper.updater');
+
+  // Execute configuration update definitions with logging of success.
+  $updateHelper->executeUpdate('social_profile', 'social_profile_update_8803');
+
+  // Output logged messages to related channel of update execution.
+  return $updateHelper->logger()->output();
+}


### PR DESCRIPTION
## Problem
Right now the profile picture input field is rendered above the banner input field.
This usually means the banner field is pushed below the fold after users upload a banner and we noticed a lot of users actually don't upload one, while it has a huge visual impact.

## Solution
Move the banner field above profile image field.

## Issue tracker
https://www.drupal.org/project/social/issues/3191206

## How to test
- [ ] Use this PR as patch or checkout to this branch.
- [ ] Run `drush updb -y`
- [ ] Login as LU and edit your profile.
- [ ] Check if banner image field appear before profile image field.

## Screenshots
<img width="768" alt="Screen Shot 2021-01-07 at 7 27 17 PM" src="https://user-images.githubusercontent.com/8435994/103918374-bc0c3d00-5134-11eb-9b02-cdb3d0e22e75.png">


## Release notes
We have adjusted the banner image to appear before profile image field when you edit your profile.

## Change Record
N.A

## Translations
N.A