### PR TITLE
Issue #3191823 by agami4: UI issues with popover and modal close button

### DIFF
--- a/themes/socialbase/assets/css/modal.css
+++ b/themes/socialbase/assets/css/modal.css
@@ -19,22 +19,26 @@
 @-webkit-keyframes fadein_scale {
   from {
     opacity: 0;
-    transform: translateY(-30px);
+    -webkit-transform: translateY(-30px);
+            transform: translateY(-30px);
   }
   to {
     opacity: 1;
-    transform: translateY(0);
+    -webkit-transform: translateY(0);
+            transform: translateY(0);
   }
 }
 
 @keyframes fadein_scale {
   from {
     opacity: 0;
-    transform: translateY(-30px);
+    -webkit-transform: translateY(-30px);
+            transform: translateY(-30px);
   }
   to {
     opacity: 1;
-    transform: translateY(0);
+    -webkit-transform: translateY(0);
+            transform: translateY(0);
   }
 }
 
@@ -80,7 +84,8 @@
   z-index: 1050;
   background-color: #fff;
   border: 1px solid rgba(0, 0, 0, 0.2);
-  box-shadow: 0 3px 9px rgba(0, 0, 0, 0.5);
+  -webkit-box-shadow: 0 3px 9px rgba(0, 0, 0, 0.5);
+          box-shadow: 0 3px 9px rgba(0, 0, 0, 0.5);
   background-clip: padding-box;
   -webkit-backface-visibility: hidden;
           backface-visibility: hidden;
@@ -100,9 +105,15 @@
 }
 
 .ui-dialog-titlebar {
+  display: -webkit-box;
+  display: -ms-flexbox;
   display: flex;
-  align-items: center;
-  justify-content: space-between;
+  -webkit-box-align: center;
+      -ms-flex-align: center;
+          align-items: center;
+  -webkit-box-pack: justify;
+      -ms-flex-pack: justify;
+          justify-content: space-between;
   padding: 12px 1rem;
   border-bottom: 1px solid #e6e6e6;
 }
@@ -130,16 +141,20 @@
   border: 0;
   outline: 0;
   -webkit-appearance: none;
+  -webkit-transition: 0.3s;
   transition: 0.3s;
   position: relative;
 }
 
 .ui-dialog-titlebar-close:before {
   content: 'x';
+  display: block;
   position: absolute;
   text-indent: 0;
-  top: 0;
+  top: -2px;
   right: 0;
+  left: 0;
+  margin: auto;
 }
 
 .ui-dialog-titlebar-close:hover {
@@ -154,8 +169,11 @@
 .ui-dialog-content {
   position: relative;
   overflow: auto;
-  box-shadow: none;
-  flex: 1 1 auto;
+  -webkit-box-shadow: none;
+          box-shadow: none;
+  -webkit-box-flex: 1;
+      -ms-flex: 1 1 auto;
+          flex: 1 1 auto;
   padding: 1rem;
 }
 
@@ -177,12 +195,17 @@
 }
 
 .modal.fade .modal-dialog {
-  transform: translate(0, -25%);
+  -webkit-transform: translate(0, -25%);
+          transform: translate(0, -25%);
+  -webkit-transition: -webkit-transform 0.3s ease-out;
+  transition: -webkit-transform 0.3s ease-out;
   transition: transform 0.3s ease-out;
+  transition: transform 0.3s ease-out, -webkit-transform 0.3s ease-out;
 }
 
 .modal.in .modal-dialog {
-  transform: translate(0, 0);
+  -webkit-transform: translate(0, 0);
+          transform: translate(0, 0);
 }
 
 .modal-open .modal {
@@ -202,7 +225,8 @@
   border: 1px solid #999;
   border: 1px solid rgba(0, 0, 0, 0.2);
   border-radius: 12px;
-  box-shadow: 0 3px 9px rgba(0, 0, 0, 0.5);
+  -webkit-box-shadow: 0 3px 9px rgba(0, 0, 0, 0.5);
+          box-shadow: 0 3px 9px rgba(0, 0, 0, 0.5);
   background-clip: padding-box;
   outline: 0;
 }
@@ -239,9 +263,15 @@
 }
 
 .social-dialog .form-actions {
+  display: -webkit-box;
+  display: -ms-flexbox;
   display: flex;
-  justify-content: space-between;
-  flex: 0 0 50%;
+  -webkit-box-pack: justify;
+      -ms-flex-pack: justify;
+          justify-content: space-between;
+  -webkit-box-flex: 0;
+      -ms-flex: 0 0 50%;
+          flex: 0 0 50%;
   margin-bottom: 0;
 }
 
@@ -256,7 +286,9 @@
 }
 
 .social-dialog .pull-left {
-  order: -1;
+  -webkit-box-ordinal-group: 0;
+      -ms-flex-order: -1;
+          order: -1;
   margin-left: 0 !important;
   margin-right: 1rem;
 }

--- a/themes/socialbase/assets/css/modal.css
+++ b/themes/socialbase/assets/css/modal.css
@@ -104,6 +104,37 @@
   right: -2px;
 }
 
+.ui-dialog .ui-dialog-titlebar .ui-dialog-titlebar-close {
+  font-size: 1.5rem;
+  font-weight: 400;
+  line-height: 1;
+  color: #000;
+  text-shadow: 0 1px 0 #fff;
+  opacity: .5;
+  cursor: pointer;
+  background: 0 0;
+  border: none;
+  outline: none;
+  -webkit-appearance: none;
+  -webkit-transition: 0.3s;
+  transition: 0.3s;
+  margin-top: 3px;
+}
+
+.ui-dialog .ui-dialog-titlebar .ui-dialog-titlebar-close:before {
+  content: 'x';
+  display: block;
+  position: absolute;
+  text-indent: 0;
+  right: 0;
+  left: 0;
+  margin: auto;
+}
+
+.ui-dialog .ui-dialog-titlebar .ui-dialog-titlebar-close:hover {
+  opacity: .75;
+}
+
 .ui-dialog-titlebar {
   display: -webkit-box;
   display: -ms-flexbox;
@@ -126,39 +157,6 @@
   overflow: hidden;
   text-overflow: ellipsis;
   font-size: 1rem;
-}
-
-.ui-dialog-titlebar-close {
-  font-size: 1.5rem;
-  font-weight: 400;
-  line-height: 1;
-  color: #000;
-  text-shadow: 0 1px 0 #fff;
-  opacity: .5;
-  padding: 0 0 0 1em;
-  cursor: pointer;
-  background: 0 0;
-  border: 0;
-  outline: 0;
-  -webkit-appearance: none;
-  -webkit-transition: 0.3s;
-  transition: 0.3s;
-  position: relative;
-}
-
-.ui-dialog-titlebar-close:before {
-  content: 'x';
-  display: block;
-  position: absolute;
-  text-indent: 0;
-  top: -2px;
-  right: 0;
-  left: 0;
-  margin: auto;
-}
-
-.ui-dialog-titlebar-close:hover {
-  opacity: .75;
 }
 
 .ui-button-icon-only {

--- a/themes/socialbase/assets/css/popover.css
+++ b/themes/socialbase/assets/css/popover.css
@@ -110,7 +110,8 @@
   word-wrap: normal;
   font-size: 0.875rem;
   background-clip: padding-box;
-  box-shadow: 0 5px 10px rgba(0, 0, 0, 0.2);
+  -webkit-box-shadow: 0 5px 10px rgba(0, 0, 0, 0.2);
+          box-shadow: 0 5px 10px rgba(0, 0, 0, 0.2);
 }
 
 .popover.top {
@@ -215,4 +216,13 @@
 
 [data-toggle="popover"].icon-before:before {
   margin-right: 0.3em;
+}
+
+@media (min-width: 976px) {
+  .gin--vertical-toolbar .popover {
+    margin-left: 90px;
+  }
+  .gin--vertical-toolbar .popover > .arrow {
+    margin-left: -103px;
+  }
 }

--- a/themes/socialbase/components/03-molecules/popover/popover.scss
+++ b/themes/socialbase/components/03-molecules/popover/popover.scss
@@ -182,3 +182,16 @@
     margin-right: 0.3em;
   }
 }
+
+// Popover styles if gin vertical toolbar is active.
+.gin--vertical-toolbar {
+  @media (min-width: 976px) {
+    .popover {
+      margin-left: 90px;
+
+      > .arrow {
+        margin-left: -103px;
+      }
+    }
+  }
+}

--- a/themes/socialbase/components/04-organisms/modal/modal.scss
+++ b/themes/socialbase/components/04-organisms/modal/modal.scss
@@ -129,10 +129,13 @@
 
   &:before {
     content: 'x';
+    display: block;
     position: absolute;
     text-indent: 0;
-    top: 0;
+    top: -2px;
     right: 0;
+    left: 0;
+    margin: auto;
   }
 
   &:hover {

--- a/themes/socialbase/components/04-organisms/modal/modal.scss
+++ b/themes/socialbase/components/04-organisms/modal/modal.scss
@@ -91,6 +91,36 @@
       right: -2px;
     }
   }
+
+  .ui-dialog-titlebar .ui-dialog-titlebar-close {
+    font-size: 1.5rem;
+    font-weight: 400;
+    line-height: 1;
+    color: #000;
+    text-shadow: 0 1px 0 #fff;
+    opacity: .5;
+    cursor: pointer;
+    background: 0 0;
+    border: none;
+    outline: none;
+    -webkit-appearance: none;
+    transition: 0.3s;
+    margin-top: 3px;
+
+    &:before {
+      content: 'x';
+      display: block;
+      position: absolute;
+      text-indent: 0;
+      right: 0;
+      left: 0;
+      margin: auto;
+    }
+
+    &:hover {
+      opacity: .75;
+    }
+  }
 }
 
 .ui-dialog-titlebar {
@@ -112,35 +142,6 @@
 }
 
 .ui-dialog-titlebar-close {
-  font-size: 1.5rem;
-  font-weight: 400;
-  line-height: 1;
-  color: #000;
-  text-shadow: 0 1px 0 #fff;
-  opacity: .5;
-  padding: 0 0 0 1em;
-  cursor: pointer;
-  background: 0 0;
-  border: 0;
-  outline: 0;
-  -webkit-appearance: none;
-  transition: 0.3s;
-  position: relative;
-
-  &:before {
-    content: 'x';
-    display: block;
-    position: absolute;
-    text-indent: 0;
-    top: -2px;
-    right: 0;
-    left: 0;
-    margin: auto;
-  }
-
-  &:hover {
-    opacity: .75;
-  }
 
 }
 


### PR DESCRIPTION
## Problem
The popover information is overlapped with the toolbar menu on the flexible group create page.
The different styles for the modal close button.

## Solution
Add style updates for the popover if the gin theme is active,
Make the same behavior for all modal close buttons.

## Issue tracker
https://getopensocial.atlassian.net/browse/YANG-4560
https://getopensocial.atlassian.net/browse/YANG-4561
https://www.drupal.org/project/social/issues/3191823

## How to test
*For example*
- [ ] Go to the topic/event page and click on the `like`(with 0 and 1 like) button on the bottom of the hero block.
- [ ] Go to the flexible group create page and check the behavior `Group visibility` popover
<img width="765" alt="flexible group create page" src="https://user-images.githubusercontent.com/16086340/104093328-95641880-5292-11eb-9870-95260c59e6bd.png">

## Screenshots
before:
![image-20210104-105808](https://user-images.githubusercontent.com/16086340/104093545-c98c0900-5293-11eb-8fba-6409ed3db15c.png)
<img width="1182" alt="Screenshot 2021-01-04 at 12 01 51" src="https://user-images.githubusercontent.com/16086340/104093546-cdb82680-5293-11eb-9e27-145d4fa9614e.png">

after:
<img width="615" alt="Add Flexible group | ECI Demo 2021-01-09 15-59-50" src="https://user-images.githubusercontent.com/16086340/104093549-d1e44400-5293-11eb-8657-99c7e1790a09.png">
<img width="649" alt="Open Social is still evolving 2021-01-09 15-59-16" src="https://user-images.githubusercontent.com/16086340/104093552-d577cb00-5293-11eb-9845-302b4194ab86.png">


## Release notes
The popover has a correct position if the Gin theme is active.
The general modal close buttons have the same behavior and styles.

## Change Record
-

## Translations
-
