### PR TITLE
Issue #3192078 by laykin: Fatal errors after added custom content list block to a landing page

### DIFF
--- a/modules/social_features/social_content_block/modules/social_content_block_landing_page/src/Service/SocialContentBlockLandingPageContentBuilder.php
+++ b/modules/social_features/social_content_block/modules/social_content_block_landing_page/src/Service/SocialContentBlockLandingPageContentBuilder.php
@@ -42,7 +42,7 @@ class SocialContentBlockLandingPageContentBuilder extends ContentBuilder {
       '#weight' => 0,
     ];
 
-    if (!isset($build['content']['entities']['#markup'])) {
+    if (!isset($build['content']['entities']['#markup']) && !isset($build['content']['entities']['#lazy_builder'])) {
       $build['content']['entities']['#prefix'] = str_replace(
         'content-list__items',
         'field--name-field-featured-items',
@@ -56,8 +56,8 @@ class SocialContentBlockLandingPageContentBuilder extends ContentBuilder {
   /**
    * {@inheritdoc}
    */
-  protected function getEntities(BlockContentInterface $block_content) {
-    $elements = parent::getEntities($block_content);
+  public function getEntities($block_id) {
+    $elements = parent::getEntities($block_id);
 
     foreach (Element::children($elements) as $delta) {
       $elements[$delta]['#custom_content_list_section'] = TRUE;

--- a/modules/social_features/social_content_block/src/ContentBuilder.php
+++ b/modules/social_features/social_content_block/src/ContentBuilder.php
@@ -86,8 +86,6 @@ class ContentBuilder implements ContentBuilderInterface {
    *
    * @param string|int $block_id
    *   The block id where we get the settings from.
-   * @param string $entity_bundle
-   *   The bundle of the entity.
    *
    * @return array
    *   Returns the entities found.
@@ -96,7 +94,7 @@ class ContentBuilder implements ContentBuilderInterface {
    * @throws \Drupal\Component\Plugin\Exception\PluginException
    * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
    */
-  public function getEntities($block_id, $entity_bundle) {
+  public function getEntities($block_id) {
     $block_content = $this->entityTypeManager->getStorage('block_content')->load($block_id);
 
     $plugin_id = $block_content->field_plugin_id->value;


### PR DESCRIPTION
## Problem
Fatal errors after added custom content list block to a landing page or when block Custom content list block placed (exist) on the landing page.

## Steps to reproduce
As an Admin, create Custom block on /admin/structure/block/block-content page

go /node/add/landing_page page and add new section with Custom content list block

Add your custom block to that section

Press save button

ER: User can create a landing page with custom block

AR: Server error appears after user clicks Save button

## Solution
Update ContentBuilder class and method getEntities in child to ContentBuilder classes.

## Issue tracker
https://www.drupal.org/project/social/issues/3192078

## How to test
As an Admin, create Custom block on /admin/structure/block/block-content page
go /node/add/landing_page page and add new section with Custom content list block
Add your custom block to that section
Press save buttons an Admin, create Custom block on /admin/structure/block/block-content page
go /node/add/landing_page page and add new section with Custom content list block
Add your custom block to that section
Press the save button.