### PR TITLE
Issue #3186003 by navneet0693: Enable extension to declare list of nodes to be presented in new content form style.

### DIFF
--- a/modules/social_features/social_book/social_book.module
+++ b/modules/social_features/social_book/social_book.module
@@ -45,3 +45,10 @@ function social_book_social_user_account_header_create_links($context) {
     ] + Url::fromRoute('node.add', ['node_type' => 'book'])->toRenderArray(),
   ];
 }
+
+/**
+ * Implements hook_social_core_compatible_content_forms_alter().
+ */
+function social_book_social_core_compatible_content_forms_alter(&$compatible_content_type_forms) {
+  $compatible_content_type_forms[] = 'node_book_form';
+}

--- a/modules/social_features/social_book/social_book.module
+++ b/modules/social_features/social_book/social_book.module
@@ -51,4 +51,5 @@ function social_book_social_user_account_header_create_links($context) {
  */
 function social_book_social_core_compatible_content_forms_alter(&$compatible_content_type_forms) {
   $compatible_content_type_forms[] = 'node_book_form';
+  $compatible_content_type_forms[] = 'node_book_edit_form';
 }

--- a/modules/social_features/social_core/social_core.api.php
+++ b/modules/social_features/social_core/social_core.api.php
@@ -97,5 +97,18 @@ function hook_social_content_type_alter(array &$page_to_exclude) {
 }
 
 /**
+ * Provide method to allows extensions to use the new content style on a node.
+ *
+ * @param array $compatible_content_type_forms
+ *   Array of the nodes.
+ *
+ * @see social_core_form_node_form_alter()
+ * @ingroup social_core_api
+ */
+function hook_social_core_compatible_content_forms(array &$compatible_content_type_forms) {
+  $compatible_content_type_forms[] = 'node_landing_page_form';
+}
+
+/**
  * @} End of "hidedefaultitle hooks".
  */

--- a/modules/social_features/social_core/social_core.module
+++ b/modules/social_features/social_core/social_core.module
@@ -706,8 +706,11 @@ function social_core_form_node_form_alter(&$form, FormStateInterface $form_state
   // rendered outside of a card.
   $compatible_content_type_forms = [
     'node_event_form',
+    'node_event_edit_form',
     'node_topic_form',
+    'node_topic_edit_form',
     'node_page_form',
+    'node_page_edit_form',
   ];
 
   // Create new alter hook which allows extensions to add nodes

--- a/modules/social_features/social_core/social_core.module
+++ b/modules/social_features/social_core/social_core.module
@@ -699,13 +699,28 @@ function social_core_path_validate(array &$element, FormStateInterface $form_sta
  * Implements hook_form_FORM_ID_alter().
  */
 function social_core_form_node_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+  // Array of node types, which have the new group_settings fieldset,
+  // these nodes can use the new content style, and have $form['advanced']
+  // removed.
+  // if we remove it for nodes which don't have that fieldset, fields will be
+  // rendered outside of a card.
+  $compatible_content_type_forms = [
+    'node_event_form',
+    'node_topic_form',
+    'node_page_form',
+  ];
+
+  // Create new alter hook which allows extensions to add nodes
+  // to this list once they have added the group_settings.
+  \Drupal::moduleHandler()->alter('social_core_compatible_content_forms', $compatible_content_type_forms);
+
   // Let's remove the form elements not needed by Open Social.
   // We understand this is quite BC breaking, url_redirects / revision info
   // we don't use as Open Social, you might use. So by
   // changing the theme setting in social blue, you can go back to the
   // old settings and use Field UI to change the other fields.
   $use_social_content_forms = theme_get_setting('content_entity_form_style');
-  if ($use_social_content_forms === 'open_social') {
+  if ($use_social_content_forms === 'open_social' && in_array($form_id, $compatible_content_type_forms)) {
     // We want to move all the fields from $form['advanced'] to our new
     // field sets which are created as part of #3186003.
     if (!empty($form['advanced'])) {

--- a/modules/social_features/social_landing_page/social_landing_page.module
+++ b/modules/social_features/social_landing_page/social_landing_page.module
@@ -294,4 +294,5 @@ function social_landing_page_theme_suggestions_page_alter(array &$suggestions, a
  */
 function social_landing_page_social_core_compatible_content_forms_alter(&$compatible_content_type_forms) {
   $compatible_content_type_forms[] = 'node_landing_page_form';
+  $compatible_content_type_forms[] = 'node_landing_page_edit_form';
 }

--- a/themes/socialblue/theme-settings.php
+++ b/themes/socialblue/theme-settings.php
@@ -162,13 +162,13 @@ function socialblue_form_system_theme_settings_alter(&$form, FormStateInterface 
         '#title' => t('Render Content Entity forms in Open Social style'),
         '#description' => t('Allows you to render the Content Entity Forms in Open Social style. This means we remove a lot of Drupal look and feel and logic.
         Buttons on the create content are changed from Save to Create. The advanced details, e.g. the vertical tabs added in Drupal core
-        are not rendered anymore, instead we use a collapsible fieldset. 
+        are not rendered anymore, instead we use a collapsible fieldset.
         Fields like revision, URL Redirect are unset. The preview button is removed and more.'),
         '#options' => [
           'drupal' => t('Default Drupal'),
           'open_social' => t('Open Social'),
         ],
-        '#default_value' => $config->get('entity_forms') ?: 'open_social',
+        '#default_value' => $config->get('content_entity_form_style') ?? 'open_social',
       ];
 
       // When GIN is our admin theme, update the GIN colors.


### PR DESCRIPTION
## Problem
Make sure that existing content types not served by Open Social can be presented in new content form style as reported during bugfixing day.

## Solution
Add an alter hook to enable extensions to declare list of node types forms to be included.

## Issue tracker
https://www.drupal.org/node/3186003
https://getopensocial.atlassian.net/browse/DS-7506

## How to test
- [ ] Check that added alter hook works.
- [ ] See that landing pages and albums work like expected with the vertical tabs, untill they are ready to be released

## Screenshots
![Screenshot 2021-01-11 at 15 25 51](https://user-images.githubusercontent.com/16667281/104194394-924b6280-5421-11eb-8aed-a221849b728d.png)


## Release notes
N>A

## Change Record
The extensions/modules which adds a new content type to Open Social default distro will be able to add a hook_social_core_compatible_content_forms_alter to add/modify the list of nodes which can be presented in new content form style.

## Translations
N.A