### PR TITLE
Issue #3186003 - Update form submit label to use Create -> node type label

### DIFF
--- a/modules/social_features/social_core/social_core.module
+++ b/modules/social_features/social_core/social_core.module
@@ -855,10 +855,10 @@ function social_core_form_node_form_alter(&$form, FormStateInterface $form_state
       // Change the button text from Save to Create topic / event etc.
       // Only on node add pages.
       if ($form_state->getFormObject()->getOperation() !== 'edit') {
-        /** @var \Drupal\Core\Entity\EntityInterface $entity */
+        /** @var \Drupal\Node\NodeInterface $entity */
         $entity = $form_state->getFormObject()->getEntity();
-        if (!empty($entity->getType()) && is_string($entity->getType())) {
-          $form['actions']['submit']['#value'] = t('Create @entity', ['@entity' => $entity->getType()]);
+        if (!empty(node_get_type_label($entity)) && is_string(node_get_type_label($entity))) {
+          $form['actions']['submit']['#value'] = t('Create @entity', ['@entity' => strtolower(node_get_type_label($entity))]);
         }
       }
 

--- a/tests/behat/features/capabilities/landing-page/landing-page-as-404.feature
+++ b/tests/behat/features/capabilities/landing-page/landing-page-as-404.feature
@@ -22,7 +22,7 @@ Feature: Use a landing page as 404 page
       | field_landing_page_section[0][subform][field_section_paragraph][0][subform][field_hero_subtitle][0][value]                                  | Hero subtitle |
     # Set URL Alias
     And I set alias as "page-not-found"
-    And I press "Create landing_page"
+    And I press "Create landing page"
     And I wait for "3" seconds
     # See as LU
     Then I should see "Landing page Page not found has been created."

--- a/tests/behat/features/capabilities/landing-page/landing-page-create.feature
+++ b/tests/behat/features/capabilities/landing-page/landing-page-create.feature
@@ -80,7 +80,7 @@ Feature: Create Landing Page
       | field_landing_page_section[3][subform][field_section_paragraph][0][subform][field_block_link][0][title] | Block Link |
     # Set URL Alias
     And I set alias as "landingpage"
-    And I press "Create landing_page"
+    And I press "Create landing page"
     # Ses as LU
     Then I should see "Landing page This is a dynamic page has been created."
     And I should see "Hero title"

--- a/tests/behat/features/capabilities/page/page-create.feature
+++ b/tests/behat/features/capabilities/page/page-create.feature
@@ -10,7 +10,7 @@ Feature: Create Page
     When I fill in the following:
       | title[0][value] | This is a static page |
     And I fill in the "edit-body-0-value" WYSIWYG editor with "Body description text"
-    And I press "Create page"
+    And I press "Create basic page"
     Then I should see "Page This is a static page has been created."
     And I should see "This is a static page" in the "Hero block"
     And I should see "Body description text" in the "Main content"


### PR DESCRIPTION
## Problem
The submit button on our nodes used the machine name from the Node type. For most this was OK, but for landing pages it resulted in Create landing_page. 

## Solution
Use the node type label instead, lowercase this so we dont have unnecessary capitals in there. 

## Issue tracker
Bugfix - Part of https://drupal.org/node/3186003
