### PR TITLE
by jochemvn: fix notice on almost every page load

### DIFF
--- a/modules/social_features/social_group/src/SocialGroupHelperService.php
+++ b/modules/social_features/social_group/src/SocialGroupHelperService.php
@@ -66,7 +66,7 @@ class SocialGroupHelperService {
     $cache_type = $entity['target_type'];
     $cache_id = $entity['target_id'];
 
-    if ($read_cache && is_array($this->cache[$cache_type]) && isset($this->cache[$cache_type][$cache_id])) {
+    if ($read_cache && is_array($this->cache) && is_array($this->cache[$cache_type]) && isset($this->cache[$cache_type][$cache_id])) {
       return $this->cache[$cache_type][$cache_id];
     }
 


### PR DESCRIPTION
## Problem
There's a notice on almost every page load: `Notice: Trying to access array offset on value of type null in Drupal\social_group\SocialGroupHelperService->getGroupFromEntity() (line 69 of profiles/contrib/social/modules/social_features/social_group/src/SocialGroupHelperService.php).`

## Solution
Check if the protected cache is an array itself, before trying to access its value.

## How to test
- [ ] Turn on notices and clear caches
- [ ] Reload the homepage
- [ ] See you get the notice described
- [ ] Checkout this branch and clear caches again
- [ ] See that the notice is now gone.

