### PR TITLE
Issue #3179807 by laykin: Added patch for fix error with unsupported operand types on challenge form

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -103,7 +103,8 @@
                 "Fix display mode issue": "https://www.drupal.org/files/issues/2020-10-19/ajax_comments-ajax_not_working_when_using_non_default_view_mode-2896916-37-beta1.patch"
             },
             "drupal/field_group": {
-                "Undefined property: stdClass::$region in field_group_form_process().": "https://www.drupal.org/files/issues/2020-06-15/3059614-37.patch"
+                "Undefined property: stdClass::$region in field_group_form_process().": "https://www.drupal.org/files/issues/2020-06-15/3059614-37.patch",
+                "Error: Unsupported operand types": "https://www.drupal.org/files/issues/2020-12-18/3032426-10.patch"
             },
             "drupal/views_bulk_operations": {
                 "Make sure select all gets fired for socialbase theme": "https://www.drupal.org/files/issues/2019-09-19/3042494-trigger-vbo-action-on-jquery-checkbox-change-5.patch"


### PR DESCRIPTION
## Problem
After Open Social updated to version 9.4 or latest, I’m getting fatal errors when I switch to the add or edit form for the challenge and secret challenge.

## Solution
Add patch for fix error with unsupported operand types on field group module.

## Issue tracker
https://www.drupal.org/project/social/issues/3179807
https://getopensocial.atlassian.net/browse/YANG-4537

## How to test
1. Update OS to version 9.4 or the latest
2. Go to the edit form for the challenge or secret challenge
