### PR TITLE
Issue #3192510: Name for files in the topics.

### DIFF
--- a/themes/socialbase/assets/css/file.css
+++ b/themes/socialbase/assets/css/file.css
@@ -87,7 +87,7 @@
 .card-file__link {
   display: block;
   position: relative;
-  height: 100px;
+  height: 145px;
   padding: 12px;
   color: inherit;
   text-decoration: none;
@@ -97,7 +97,7 @@
   overflow: hidden;
   position: relative;
   line-height: 1.35em;
-  max-height: 2.7em;
+  max-height: 8em;
   padding-right: 1em;
   display: block;
   word-break: break-word;

--- a/themes/socialbase/templates/file/file-link--card.html.twig
+++ b/themes/socialbase/templates/file/file-link--card.html.twig
@@ -17,7 +17,7 @@
 {% spaceless %}
 
   <li class="card-file">
-    <a class="card-file__link" href="{{ link.url.uri }}" title="{{ 'Open or download file'|t }}" target="_blank">
+    <a class="card-file__link" href="{{ link.url.uri }}" title="{{ link.text|replace({'_': ' '}) }}" target="_blank">
       <span class="card-file__title">{{ link.text|replace({'_': ' '}) }}</span>
       <span class="card-file__type">
         <img class="card-file__icon" src="/{{ path_to_socialbase }}/assets/images/mime-icons/icon_1_{{ node_icon }}_x16.png" srcset="/{{ path_to_socialbase }}/assets/images/mime-icons/icon_1_{{ node_icon }}_x32.png 2x" alt="{{ node_icon }}" />


### PR DESCRIPTION
## Problem
The file names functionality for the topics is currently a bit limited. If the name of my file is a bit long, it is not possible for the user to read the full name. It would be good if there was more space for showing the file name, or if by hovering the cursor on top of the file, the user could see the full name of the file.

## Solution
- We can make the title visible in 3 lines instead of 2, so more text can be displayed
- Add hover text that shows the full title of the document

## Issue tracker
- https://www.drupal.org/project/social/issues/3192510
- https://getopensocial.atlassian.net/browse/YANG-3796

## How to test
In the example from the picture below, I have three files whose names start with "Interactive roundtable on...". Although they have 3 different names, the users have no way to know which is which.

## Screenshots
![image](https://www.drupal.org/files/issues/2021-01-13/image-20200928-130945.png)