### PR TITLE
YANG-4717 by tBKoT: Add ability to follow a parent tag and improve star icon appearing

### DIFF
--- a/modules/social_features/social_follow_taxonomy/assets/js/follow_popup.js
+++ b/modules/social_features/social_follow_taxonomy/assets/js/follow_popup.js
@@ -39,6 +39,27 @@
         });
       });
 
+      $(context).ajaxSuccess(function (event, xhr, settings) {
+        if (settings.url.startsWith('/flag/flag/follow_term')) {
+          var add = true;
+        }
+        else if (settings.url.startsWith('/flag/unflag/follow_term')) {
+          var add = false;
+        }
+
+        if (add !== undefined) {
+          var response = xhr.responseJSON[0];
+          var $selector = $(response.selector);
+          var $badge = $selector.closest('.group-action').find('.btn-action__term')
+          if (add) {
+            $badge.addClass('term-followed');
+          }
+          else {
+            $badge.removeClass('term-followed');
+          }
+        }
+      });
+
     }
   };
 })(jQuery, Drupal);

--- a/modules/social_features/social_follow_taxonomy/modules/social_follow_tag/social_follow_tag.module
+++ b/modules/social_features/social_follow_taxonomy/modules/social_follow_tag/social_follow_tag.module
@@ -75,19 +75,21 @@ function social_follow_tag_preprocess_social_tagging_split(&$variables) {
       // Get current term parent.
       $parents = $term_storage->loadParents($current_term->id());
       if (!empty($parents)) {
-        $parent = reset($parents);
-
-        // Adding additional data to the term variable to extend the template.
-        $variables['taghierarchy'][$parent->id()]['tags'][$current_term->id()] = [
-          'url' => $tag_info['url'],
-          'name' => $tag_info['name'],
-          'flag' => social_follow_taxonomy_flag_link($current_term),
-          'related_nodes_count' => social_follow_taxonomy_related_nodes_count($current_term, 'social_tagging'),
-          'followers_count' => social_follow_taxonomy_term_followers_count($current_term),
-          'follow' => social_follow_taxonomy_term_followed($current_term),
-        ];
-
+        $wrapped_term = reset($parents);
       }
+      else {
+        $wrapped_term = $current_term;
+      }
+
+      // Adding additional data to the term variable to extend the template.
+      $variables['taghierarchy'][$wrapped_term->id()]['tags'][$current_term->id()] = [
+        'url' => $tag_info['url'],
+        'name' => $tag_info['name'],
+        'flag' => social_follow_taxonomy_flag_link($current_term),
+        'related_nodes_count' => social_follow_taxonomy_related_nodes_count($current_term, 'social_tagging'),
+        'followers_count' => social_follow_taxonomy_term_followers_count($current_term),
+        'follow' => social_follow_taxonomy_term_followed($current_term),
+      ];
     }
   }
 


### PR DESCRIPTION
## Problem
Follow taxonomy issues for 10.x release
 - When the user follows a tag there should be a star icon after the tag.
 - User cannot follow the parent content tag

## Solution
Fix existing issues

## Issue tracker
https://www.drupal.org/project/social/issues/3193963
https://getopensocial.atlassian.net/browse/YANG-4717
https://getopensocial.atlassian.net/browse/YANG-4716

## How to test
N/A

## Screenshots
![image](https://user-images.githubusercontent.com/11648677/105491282-be3ad380-5cbe-11eb-9a30-376683e1ce6c.png)
![image](https://user-images.githubusercontent.com/11648677/105491315-c85cd200-5cbe-11eb-8ffb-600e4d0489f1.png)

## Release notes
Now users can follow the parent term.

## Change Record
N/A

## Translations
N/a
