### PR TITLE
Require minimum 14.5.0 of webonyx/graphql-php

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -115,9 +115,6 @@
             },
             "drupal/views_infinite_scroll" : {
                 "Headers in table format repeat on load more instead of adding rows": "https://www.drupal.org/files/issues/2019-08-15/table_tbody_append-2899705-26.patch"
-            },
-            "webonyx/graphql-php": {
-                "GitHub PR 740 Support interfaces implementing interfaces": "https://www.drupal.org/files/issues/2021-01-08/webonyx-graphql-php-pr-740_0.diff"
             }
         }
     },
@@ -206,6 +203,7 @@
         "npm-asset/slick-carousel": "~1.8.1",
         "npm-asset/tablesaw": "~3.1.0",
         "npm-asset/timepicker": "~1.11.14",
+        "webonyx/graphql-php": ">=14.5.0",
         "zaporylie/composer-drupal-optimizations": "^1.0"
     },
     "require-dev": {


### PR DESCRIPTION
## Problem/Solution
This commit removes the patch for interfaces implementing interfaces support
since the functionality has been merged into the module. The new minor version
is within the version constraints of `drupal/graphql` which causes it to be installed,
this then causes the patch to fail to apply.

We can safely remove the patch but must add our own requirement on a minimum
version to ensure that we have the new feature that we require. Using `>=` is fine here
because it allows `drupal/graphql` to supply the actual constraint and it allows us to 
update with that module to newer major versions, since the Drupal module contains most
of the surface that affects us in terms of compatibility.

## Issue tracker
https://www.drupal.org/project/social/issues/3194508

webonyx/graphql-php release notes: https://github.com/webonyx/graphql-php/releases/tag/v14.5.0

## How to test

- [ ] Composer installation should install 14.5.0 without problems.
- [ ] PHPUnit tests should pass

## Release notes
Not needed: no functional change
