### PR TITLE
YANG-4490: Make the prepareTermOptions as public method

### DIFF
--- a/modules/social_features/social_tagging/src/SocialTaggingService.php
+++ b/modules/social_features/social_tagging/src/SocialTaggingService.php
@@ -285,7 +285,7 @@ class SocialTaggingService {
    * @return array
    *   Returns a list of terms options.
    */
-  private function prepareTermOptions(array $terms) {
+  public function prepareTermOptions(array $terms) {
     $options = [];
     foreach ($terms as $category) {
       $options[$category->tid] = $category->name;


### PR DESCRIPTION
## Problem
It is not possible to use the `prepareTermOptions` method from the `SocialTaggingService` somewhere else outside the service.

## Solution
Make the method public.

## Issue tracker
https://getopensocial.atlassian.net/browse/YANG-4490