### PR TITLE
Issue #3195069 by navneet0693: Link account display name in account header block to user profile page.

### DIFF
--- a/modules/social_features/social_user/src/Plugin/Block/AccountHeaderBlock.php
+++ b/modules/social_features/social_user/src/Plugin/Block/AccountHeaderBlock.php
@@ -190,7 +190,7 @@ class AccountHeaderBlock extends BlockBase implements ContainerFactoryPluginInte
             'class' => ['dropdown-header', 'header-nav-current-user'],
           ],
           '#type' => 'inline_template',
-          '#template' => '{{ tagline }} <a href="' . "{{ path('entity.user.canonical', {'user': $account_id }) }}" . '"><strong class="text-truncate">{{ object }} </strong></a>',
+          '#template' => '<a href="/user">{{ tagline }}<strong class="text-truncate">{{ object }} </strong></a>',
           '#context' => [
             'tagline' => $this->t('Signed in as'),
             'object'  => $account_name,

--- a/modules/social_features/social_user/src/Plugin/Block/AccountHeaderBlock.php
+++ b/modules/social_features/social_user/src/Plugin/Block/AccountHeaderBlock.php
@@ -170,6 +170,7 @@ class AccountHeaderBlock extends BlockBase implements ContainerFactoryPluginInte
       }
 
       $account_name = $account->getDisplayName();
+      $account_id = $account->id();
 
       $menu_items['account_box'] = [
         '#type' => 'account_header_element',
@@ -189,7 +190,7 @@ class AccountHeaderBlock extends BlockBase implements ContainerFactoryPluginInte
             'class' => ['dropdown-header', 'header-nav-current-user'],
           ],
           '#type' => 'inline_template',
-          '#template' => '{{ tagline }} <strong class="text-truncate">{{ object }} </strong>',
+          '#template' => '{{ tagline }} <a href="' . "{{ path('entity.user.canonical', {'user': $account_id }) }}" . '"><strong class="text-truncate">{{ object }} </strong></a>',
           '#context' => [
             'tagline' => $this->t('Signed in as'),
             'object'  => $account_name,

--- a/modules/social_features/social_user/src/Plugin/Block/AccountHeaderBlock.php
+++ b/modules/social_features/social_user/src/Plugin/Block/AccountHeaderBlock.php
@@ -170,7 +170,6 @@ class AccountHeaderBlock extends BlockBase implements ContainerFactoryPluginInte
       }
 
       $account_name = $account->getDisplayName();
-      $account_id = $account->id();
 
       $menu_items['account_box'] = [
         '#type' => 'account_header_element',


### PR DESCRIPTION
## Problem
After a user has logged in and it clicks on its user profile icon it is presented with "Signed in as" and followed by current user's display name on next line. it would really great if it becomes clickable and links to user profile page.

## Solution
Link account display after 'Signed in as' in AccountHeaderBlock to user profile page.

## Issue tracker
https://www.drupal.org/project/social/issues/3195069

## How to test
- [ ] Login in as LU
- [ ] Click on user profile icon in account header block
- [ ] It should link to user profile page

## Screenshots
![image](https://user-images.githubusercontent.com/8435994/106106850-27fa2800-616c-11eb-891a-02fa092e6e36.png)

## Release notes
We have updated the account header block which contains the user menu. Now, when a user will click it's own display name it will be link to it's own profile page.

## Change Record
N.A

## Translations
N.A