### PR TITLE
Issue #3195131 by navneet0693: Remove status messages from image_widget_crop module.

### DIFF
--- a/modules/social_features/social_core/social_core.module
+++ b/modules/social_features/social_core/social_core.module
@@ -1010,3 +1010,23 @@ function _social_core_set_default_email_logo_for_socialblue() {
     }
   }
 }
+
+/**
+ * Implements hook_preprocess_HOOK() for status_messages.
+ */
+function social_core_preprocess_status_messages(&$variables) {
+  // We want to remove stratus messages coming form image_widget_crop module.
+  // These notifications are technical in nature and add no value for the user.
+  // @see: \Drupal\image_widget_crop\ImageWidgetCropManager::saveCrop().
+  if (isset($variables['message_list']['status'])) {
+    // Get all the status messages.
+    $status_messages = $variables['message_list']['status'];
+    // Loop through them to find the relevant messages we are looking for.
+    foreach ($status_messages as $delta => $message) {
+      // Unset them finally.
+      if (strpos((string) $message, 'The crop') !== FALSE) {
+        unset($variables['message_list']['status'][$delta]);
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Problem
After a user selects the crop for image on events page after saving they are presented with status messages. These messages are not useful for the user.

## Solution
Unset the Drupal status messages coming from image_widget_crop module.

## Issue tracker
https://www.drupal.org/project/social/issues/3195131

## How to test
- [ ] As an LU, add an event.
- [ ] Add an image to image field.
- [ ] Set the crop for images (small or large or both).
- [ ] Save the event.
- [ ] You should not see status message about the crop.
- [ ] Edit an existing event and update the crop area of image.
- [ ] Save the node
- [ ] You should not be able to see the status messages.

## Screenshots
**Before**
![image](https://user-images.githubusercontent.com/8435994/106138182-ccdb2c00-6191-11eb-91b6-05272655bac2.png)

**After**
![image](https://user-images.githubusercontent.com/8435994/106138199-d1074980-6191-11eb-9123-c78f4207a072.png)

## Release notes
We have removed the unwanted messages about the cropping of images which user might have seen while after adding/editing a content on the platform.

## Change Record
N.A

## Translations
N.A