### PR TITLE
3195840: Youtube video's are too short in the stream

### DIFF
--- a/themes/socialbase/assets/css/cards.css
+++ b/themes/socialbase/assets/css/cards.css
@@ -69,6 +69,7 @@
 .card__body iframe {
   max-width: 100% !important;
   width: 100% !important;
+  min-height: 300px;
 }
 
 .card__nested-section {
@@ -132,5 +133,15 @@
 @media (min-width: 900px) {
   .card__body {
     padding: 2.5rem;
+  }
+}
+
+@media screen and (max-width: 600px) {
+  .card__body .twitter-tweet,
+  .card__body .fb_iframe_widget,
+  .card__body iframe {
+    max-width: 100% !important;
+    width: 100% !important;
+    min-height: 200px;
   }
 }

--- a/themes/socialbase/assets/css/fitframe.css
+++ b/themes/socialbase/assets/css/fitframe.css
@@ -7,4 +7,15 @@
 .iframe-container iframe {
   max-width: 100% !important;
   width: 100% !important;
+  min-height: 300px;
+}
+
+@media screen and (max-width: 600px) {
+  .iframe-container .twitter-tweet,
+  .iframe-container .fb_iframe_widget,
+  .iframe-container iframe {
+    max-width: 100% !important;
+    width: 100% !important;
+    min-height: 200px;
+  }
 }


### PR DESCRIPTION
## Problem
When embedding youtube movies, the default dimensions for that are 200x113, which is a bit short to actually watch them properly in a stream. The issue is in the embed vendor, on which we rely to embed external media.

## Solution
The problem cannot be fixed very easy from our end, so therefore we've chosen to quickfix this issue, since many users are having issues with this

## Issue tracker
- https://www.drupal.org/project/social/issues/3195840

## How to test
- [ ] Add posts with youtube links
- [ ] Notice the movies are way too short (before screenshot)
- [ ] Switch to this branch
- [ ] Notice it's a lot beter now (after screenshot)
- [ ] Also tryout stuff like twitter links
- [ ] Also notice that on mobile it's not as high as on desktop but still beter watchable


## Screenshots
before:
![Screenshot 2021-02-01 at 14 39 31](https://user-images.githubusercontent.com/16667744/106466216-58f39900-649b-11eb-8afb-ee4328c5222c.png)


after:
![after](https://user-images.githubusercontent.com/16667744/106466157-437e6f00-649b-11eb-8332-5560caadd1f2.png)


## Release notes
A quick fix to make sure youtube video's are shown less compact in the stream
