### PR TITLE
Update GraphQL module to 4.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -143,7 +143,7 @@
         "drupal/flag": "4.0-alpha3",
         "drupal/gin": "3.0.0-alpha34",
         "drupal/gin_toolbar": "^1.0@beta",
-        "drupal/graphql": "^4.0",
+        "drupal/graphql": "^4.1",
         "drupal/group": "1.0-rc5",
         "drupal/image_effects": "3.1",
         "drupal/image_widget_crop": "2.3.0",

--- a/modules/custom/social_graphql/src/GraphQL/ResolverRegistry.php
+++ b/modules/custom/social_graphql/src/GraphQL/ResolverRegistry.php
@@ -2,28 +2,19 @@
 
 namespace Drupal\social_graphql\GraphQL;
 
-use Drupal\graphql\GraphQL\Execution\ResolveContext;
 use Drupal\graphql\GraphQL\ResolverBuilder;
 use Drupal\graphql\GraphQL\ResolverRegistry as ResolverRegistryBase;
-use GraphQL\Type\Definition\ResolveInfo;
 
 /**
  * The Open Social resolver registry.
  *
- * Extends the base ResolverRegistry from GraphQL to try to resolve fields on
- * implemented interfaces when a field resolver for the type isn't found.
+ * Extends the base ResolverRegistry to provide a way to implement common
+ * helpers.
+ *
+ * Previously included resolver inheritance which has been moved into the
+ * GraphQL module.
  */
 class ResolverRegistry extends ResolverRegistryBase {
-
-  /**
-   * Return all field resolvers in the registry.
-   *
-   * @return callable[]
-   *   A nested list of callables, keyed by type and field name.
-   */
-  public function getAllFieldResolvers() : array {
-    return $this->fieldResolvers;
-  }
 
   /**
    * Add a field resolver for a mutation field.
@@ -64,43 +55,6 @@ class ResolverRegistry extends ResolverRegistryBase {
           ->map('input', $builder->fromParent())
       )
     );
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  protected function getRuntimeFieldResolver($value, $args, ResolveContext $context, ResolveInfo $info) {
-    // Try the default implementation but fallback to trying the interfaces.
-    return parent::getRuntimeFieldResolver($value, $args, $context, $info)
-      ?? $this->getRuntimeFieldResolverOnInterface($value, $args, $context, $info);
-  }
-
-  /**
-   * Attempts to find a resolver on an implemented interface.
-   *
-   * @param mixed $value
-   *   Value passed by getRuntimeFieldResolver.
-   * @param string $args
-   *   Args passed by getRuntimeFieldResolver.
-   * @param \Drupal\graphql\GraphQL\Execution\ResolveContext $context
-   *   Context passed by getRuntimeFieldResolver.
-   * @param \GraphQL\Type\Definition\ResolveInfo $info
-   *   Info passed by getRuntimeFieldResolver.
-   *
-   * @return callable|null
-   *   The resolver for the field or null if none was found.
-   */
-  protected function getRuntimeFieldResolverOnInterface($value, $args, ResolveContext $context, ResolveInfo $info) {
-    // Go through the interfaces implemented for the type on which this field is
-    // resolved and check if they lead to a field resolution.
-    $interfaces = $info->parentType->getInterfaces();
-    foreach ($interfaces as $interface) {
-      if ($resolver = $this->getFieldResolver($interface->name, $info->fieldName)) {
-        return $resolver;
-      }
-    }
-
-    return NULL;
   }
 
 }


### PR DESCRIPTION
## Problem / Solution
This version of the module includes support for resolving fields on
interfaces so that code is no longer needed in Open Social's
ResolverRegistry.

We keep the registry class so we don't have to change exsiting modules
and can easily override `graphql` behaviour in the future (if needed).

Replaces https://github.com/goalgorilla/open_social/pull/2194 once https://github.com/drupal-graphql/graphql/pull/1155 is merged.

## Issue tracker
https://www.drupal.org/project/social/issues/3194938

## How to test

- [ ] Visit `/admin/config/graphql/servers/manage/open_social_graphql/validate_resolvers`
- [ ] See an overview of orphaned and/or missing resolvers.

## Screenshots
See related PRs

## Release notes
N/a internal change
