### PR TITLE
DS-7491 - Issues with Albums added to existing albums from the post form

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -63,7 +63,8 @@
                 "Group: Don't try to re-save deleted entities": "https://www.drupal.org/files/issues/2018-11-01/3010896-02.patch",
                 "Request membership feature": "https://www.drupal.org/files/issues/2019-07-04/group-request_membership_feature_grequest_module-2752603-110.patch",
                 "Rely on toUrl defaults for Entity url link": "https://www.drupal.org/files/issues/2019-12-04/group-3098675-2.patch",
-                "Group Invite": "https://www.drupal.org/files/issues/2020-03-26/ginvite_module_port-2801603-112.patch"
+                "Group Invite": "https://www.drupal.org/files/issues/2020-03-26/ginvite_module_port-2801603-112.patch",
+                "Cache context update": "https://www.drupal.org/files/issues/2018-05-04/group-cache-context-2882102-2.patch"
             },
             "drupal/image_widget_crop": {
                 "Remove theme function override for verticalTabs": "https://www.drupal.org/files/issues/2019-02-13/3032584-verticaltabs-theme-override-removal-2.patch"

--- a/modules/social_features/social_album/social_album.module
+++ b/modules/social_features/social_album/social_album.module
@@ -443,7 +443,7 @@ function _social_album_post_submit(array $form, FormStateInterface $form_state) 
     // Add default content visibility based on post visibility.
     // @todo ensure this is more flexible.
     $post_visibility = $form_state->getValue('field_visibility');
-    // lets try and map it if possible
+    // Lets try and map it if possible.
     if (!empty($post_visibility)) {
       $default_visibility = $mapping[$post_visibility[0]['value']];
       $node = \Drupal::entityTypeManager()->getStorage('node')->create([

--- a/modules/social_features/social_album/social_album.module
+++ b/modules/social_features/social_album/social_album.module
@@ -435,12 +435,25 @@ function _social_album_post_submit(array $form, FormStateInterface $form_state) 
       return;
     }
 
-    $node = \Drupal::entityTypeManager()->getStorage('node')->create([
-      'type' => 'album',
-      'title' => $input['title'],
-    ]);
+    $mapping = [
+      '1' => 'public',
+      '2' => 'community',
+      '3' => 'group',
+    ];
+    // Add default content visibility based on post visibility.
+    // @todo ensure this is more flexible.
+    $post_visibility = $form_state->getValue('field_visibility');
+    // lets try and map it if possible
+    if (!empty($post_visibility)) {
+      $default_visibility = $mapping[$post_visibility[0]['value']];
+      $node = \Drupal::entityTypeManager()->getStorage('node')->create([
+        'type' => 'album',
+        'title' => $input['title'],
+        'field_content_visibility' => $default_visibility,
+      ]);
 
-    $node->save();
+      $node->save();
+    }
 
     \Drupal::service('social_group.set_groups_for_node_service')->addGroupContent($node, $post->field_recipient_group->entity);
 

--- a/modules/social_features/social_album/social_album.module
+++ b/modules/social_features/social_album/social_album.module
@@ -340,6 +340,19 @@ function social_album_form_social_post_entity_form_alter(&$form, FormStateInterf
 /**
  * Implements hook_form_FORM_ID_alter().
  */
+function social_album_form_node_album_edit_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+  // We don't allow changing albums group as the post and comments inside
+  // won't be updated.
+  // @todo update the content within the album if an album changes group types
+  if (!empty($form['groups'])) {
+    $form['groups']['#disabled'] = TRUE;
+    $form['groups']['widget']['#description'] = t("Changing groups and visibility isn't allowed for Albums yet, consider creating a new Album instead.");
+  }
+}
+
+/**
+ * Implements hook_form_FORM_ID_alter().
+ */
 function social_album_form_node_album_form_alter(&$form, FormStateInterface $form_state, $form_id) {
   $form['actions']['submit']['#submit'][] = '_social_album_create_post';
 }

--- a/modules/social_features/social_album/src/Plugin/Field/FieldWidget/SocialAlbumOptionsSelectWidget.php
+++ b/modules/social_features/social_album/src/Plugin/Field/FieldWidget/SocialAlbumOptionsSelectWidget.php
@@ -33,10 +33,19 @@ class SocialAlbumOptionsSelectWidget extends OptionsSelectWidget {
 
     unset($options['_none']);
 
+    // @todo FIX issues with options, if user selects an option
+    // we need to update the Post visibility accordingly with ajax.
+    // imagine a user on the home stream, selecting an existing album in a
+    // close group, the visibility needs to be updated to Group members, which
+    // it doesn't, so for now we're not rendering any other option.
+    // return [
+    //   '_none' => $option,
+    //   '_add' => $this->t('Create new album'),
+    // ] + $options;
     return [
       '_none' => $option,
       '_add' => $this->t('Create new album'),
-    ] + $options;
+    ];
   }
 
   /**
@@ -80,9 +89,22 @@ class SocialAlbumOptionsSelectWidget extends OptionsSelectWidget {
       ($title = $form_state->getValue([$field, 'title']))
     ) {
       if ($form_state->getTriggeringElement()['#name'] === 'op' && $has_images) {
+        $mapping = [
+          '1' => 'public',
+          '2' => 'community',
+          '3' => 'group',
+        ];
+        // Add default content visibility based on post visibility.
+        $post_visibility = $form_state->getValue('field_visibility');
+        $default_visibility = 'community';
+        // lets try and map it if possible
+        if (!empty($post_visibility)) {
+          $default_visibility = $mapping[$post_visibility[0]];
+        }
         $node = \Drupal::entityTypeManager()->getStorage('node')->create([
           'type' => 'album',
           'title' => $title,
+          'field_content_visibility' => $default_visibility,
         ]);
 
         $node->save();

--- a/modules/social_features/social_album/src/Plugin/Field/FieldWidget/SocialAlbumOptionsSelectWidget.php
+++ b/modules/social_features/social_album/src/Plugin/Field/FieldWidget/SocialAlbumOptionsSelectWidget.php
@@ -38,10 +38,7 @@ class SocialAlbumOptionsSelectWidget extends OptionsSelectWidget {
     // imagine a user on the home stream, selecting an existing album in a
     // close group, the visibility needs to be updated to Group members, which
     // it doesn't, so for now we're not rendering any other option.
-    // return [
-    //   '_none' => $option,
-    //   '_add' => $this->t('Create new album'),
-    // ] + $options;
+    // Return [...] + $options.
     return [
       '_none' => $option,
       '_add' => $this->t('Create new album'),
@@ -97,7 +94,7 @@ class SocialAlbumOptionsSelectWidget extends OptionsSelectWidget {
         // Add default content visibility based on post visibility.
         $post_visibility = $form_state->getValue('field_visibility');
         $default_visibility = 'community';
-        // lets try and map it if possible
+        // Lets try and map it if possible.
         if (!empty($post_visibility)) {
           $default_visibility = $mapping[$post_visibility[0]];
         }

--- a/modules/social_features/social_album/src/SocialAlbumConfigOverride.php
+++ b/modules/social_features/social_album/src/SocialAlbumConfigOverride.php
@@ -137,6 +137,27 @@ class SocialAlbumConfigOverride implements ConfigFactoryOverrideInterface {
       }
     }
 
+    $config_names = [
+      'core.entity_form_display.node.album.default',
+    ];
+    foreach ($config_names as $config_name) {
+      if (in_array($config_name, $names)) {
+        $config = \Drupal::service('config.factory')->getEditable($config_name);
+        // Add the field to the content.
+        $content = $config->get('content');
+        $content['groups'] = [];
+        $content['groups']['type'] = 'social_group_selector_widget';
+        $content['groups']['settings'] = [];
+        $content['groups']['region'] = 'content';
+        $content['groups']['third_party_settings'] = [];
+
+        $overrides[$config_name] = [
+          'content' => $content,
+        ];
+
+      }
+    }
+
     return $overrides;
   }
 

--- a/modules/social_features/social_post/src/Form/PostForm.php
+++ b/modules/social_features/social_post/src/Form/PostForm.php
@@ -158,8 +158,11 @@ class PostForm extends ContentEntityForm {
       else {
         $form['field_visibility']['widget'][0]['#default_value'] = '2';
       }
-
-      unset($form['field_visibility']['widget'][0]['#options'][3]);
+      $current_group = _social_group_get_current_group();
+      // We unset the group visibility if we don't have a group.
+      if (empty($current_group)) {
+        unset($form['field_visibility']['widget'][0]['#options'][3]);
+      }
     }
     // If we're not posting to the community then the visibility depends on the
     // group type (if it's a group post) or it's simply limited to the community


### PR DESCRIPTION
## Problem
1) When adding post albums to existing albums from the post form, the context of existing albums is causing potential security issues where the post visibility isnt updated according to the album context. Also bugfixed the creation of albums from the Post form, to ensure it gets the visibility defaulted from the post on creation.

2) When adding an album through node/add/album if you select an existing group the visbility isn't updated accordingly

3) Ensure we can't update the "group" section on edit anymore, as we dont have a bulk update for the post and its comments inside an album

## Solution
1) Removed existing options for now, so we can only add it directly to a newly created Album
Make sure the newly created Album either personal or within a group is using the post visibility field as the visibility field for the Album as well.

2) added config override similar as `SocialGroupSelectorWidgetConfigOverride.php`

3) Disabled the group section on album edit 

## Issue tracker
- [ ] https://getopensocial.atlassian.net/browse/YANG-4769 (but it's just a quickfix, you can leave that ticket open)

## How to test
- [x] Enable social_album
- [x] Try adding a post to a new album from the home stream, see that you can create this album community or public
- [x] Create a closed group
- [x] Try adding a post to a new album from the group stream, see that you can create this album only with members
- [x] Try adding an album through the + icon to an existing group and see the visibility is updated