### PR TITLE
Rename `currentUser` field to `viewer`

### DIFF
--- a/modules/social_features/social_user/graphql/social_user_schema_extension.extension.graphqls
+++ b/modules/social_features/social_user/graphql/social_user_schema_extension.extension.graphqls
@@ -4,7 +4,7 @@ extend type Query {
 
   NULL if you're not authenticated.
   """
-  currentUser : User
+  viewer : User
 
   """
   List of users.

--- a/modules/social_features/social_user/src/Plugin/GraphQL/DataProducer/QueryUser.php
+++ b/modules/social_features/social_user/src/Plugin/GraphQL/DataProducer/QueryUser.php
@@ -75,6 +75,7 @@ class QueryUser extends EntityDataProducerPluginBase {
    */
   public function resolve(?int $first, ?string $after, ?int $last, ?string $before, bool $reverse, string $sortKey, RefinableCacheableDependencyInterface $metadata) {
     $query_helper = new UserQueryHelper($this->entityTypeManager, $sortKey);
+    $metadata->addCacheableDependency($query_helper);
 
     $connection = new EntityConnection($query_helper);
     $connection->setPagination($first, $after, $last, $before, $reverse);

--- a/modules/social_features/social_user/src/Plugin/GraphQL/SchemaExtension/UserSchemaExtension.php
+++ b/modules/social_features/social_user/src/Plugin/GraphQL/SchemaExtension/UserSchemaExtension.php
@@ -25,7 +25,7 @@ class UserSchemaExtension extends SdlSchemaExtensionPluginBase {
     $builder = new ResolverBuilder();
 
     // Root Query fields.
-    $registry->addFieldResolver('Query', 'currentUser',
+    $registry->addFieldResolver('Query', 'viewer',
       $builder->produce('viewer')
     );
 

--- a/modules/social_features/social_user/tests/src/Kernel/GraphQL/GraphQLUsersEndpointTest.php
+++ b/modules/social_features/social_user/tests/src/Kernel/GraphQL/GraphQLUsersEndpointTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Drupal\Tests\social_user\Kernel;
+namespace Drupal\Tests\social_user\Kernel\GraphQL;
 
 use Drupal\Tests\social_graphql\Kernel\SocialGraphQLTestBase;
 use Drupal\user\Entity\User;
@@ -79,9 +79,9 @@ class GraphQLUsersEndpointTest extends SocialGraphQLTestBase {
     // available in an all-access scenario.
     $this->setCurrentUser(User::load(1));
     $test_user = $this->createUser();
-    $query = "
-      query {
-        user(id: \"{$test_user->uuid()}\") {
+    $query = '
+      query ($id: ID!) {
+        user(id: $id) {
           id
           displayName
           mail
@@ -91,25 +91,28 @@ class GraphQLUsersEndpointTest extends SocialGraphQLTestBase {
           roles
         }
       }
-    ";
+    ';
     $expected_data = [
-      'data' => [
-        'user' => [
-          'id' => $test_user->uuid(),
-          'displayName' => $test_user->getDisplayName(),
-          'mail' => $test_user->getEmail(),
-          'created' => $test_user->getCreatedTime(),
-          'updated' => $test_user->getChangedTime(),
-          'status' => 'ACTIVE',
-          'roles' => ['authenticated'],
-        ],
+      'user' => [
+        'id' => $test_user->uuid(),
+        'displayName' => $test_user->getDisplayName(),
+        'mail' => $test_user->getEmail(),
+        'created' => $test_user->getCreatedTime(),
+        'updated' => $test_user->getChangedTime(),
+        'status' => 'ACTIVE',
+        'roles' => ['authenticated'],
       ],
     ];
 
-    // TODO: Move to QueryResultAssertionTrait::assertResults and add metadata.
-    $result = $this->query($query);
-    self::assertSame(200, $result->getStatusCode(), 'user fields are present');
-    self::assertSame($expected_data, json_decode($result->getContent(), TRUE), 'user fields are present');
+    $this->assertResults(
+      $query,
+      ['id' => $test_user->uuid()],
+      $expected_data,
+      $this->defaultCacheMetaData()
+        ->addCacheableDependency($test_user)
+        // @todo It's unclear why this cache context is added.
+        ->addCacheContexts(['languages:language_interface'])
+    );
   }
 
 }

--- a/modules/social_features/social_user/tests/src/Kernel/GraphQL/GraphQLViewerEndpointTest.php
+++ b/modules/social_features/social_user/tests/src/Kernel/GraphQL/GraphQLViewerEndpointTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Drupal\Tests\social_user\Kernel\GraphQL;
+
+use Drupal\Tests\social_graphql\Kernel\SocialGraphQLTestBase;
+
+/**
+ * Tests the root viewer endpoint.
+ *
+ * @group social_graphql
+ */
+class GraphQLViewerEndpointTest extends SocialGraphQLTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static $modules = [
+    "social_user",
+    // User creation in social_user requires a service in role_delegation.
+    // TODO: Possibly untangle this?
+    "role_delegation",
+  ];
+
+  /**
+   * It loads the current user.
+   */
+  public function testViewerLoadsCurrentUser() : void {
+    $user = $this->createUser();
+    $this->setCurrentUser($user);
+
+    $this->assertResults(
+      "
+        query {
+          viewer {
+            id
+          }
+        }
+      ",
+      [],
+      [
+        'viewer' => [
+          'id' => $user->uuid(),
+        ],
+      ],
+      $this->defaultCacheMetaData()
+        ->setCacheMaxAge(0)
+        ->addCacheableDependency($user)
+        // @todo It's unclear why this cache context is added.
+        ->addCacheContexts(['languages:language_interface'])
+    );
+  }
+
+}


### PR DESCRIPTION
## Problem / Solution
This is a shorter name and better matches other places of fields that
relate to information about the current actor. Other GraphQL APIs also
already commonly use this name for the field, most notably the GitHub
API.

Tests are adapted to use the built-in assertResults trait instead of
manually executing and matching the query. This requires adding some
cache metadata to match with. This cache metadata is not necessarily
what we want it to be yet but it provides us a place to change our
expectations and implement a fix.

## Issue tracker
N/a unreleased internal change

## How to test

- [ ] Tests pass

## Screenshots
N/a API only

## Release notes
N/a unreleased internal change

## Change Record
N/a unreleased internal change
