### PR TITLE
Issue #3197235 by SV: Display featured profile section for anonymous users

### DIFF
--- a/modules/social_features/social_profile/social_profile.module
+++ b/modules/social_features/social_profile/social_profile.module
@@ -17,6 +17,7 @@ use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\Core\Url;
 use Drupal\file\Entity\File;
 use Drupal\image\Entity\ImageStyle;
+use Drupal\node\Entity\Node;
 use Drupal\profile\Entity\Profile;
 use Drupal\profile\Entity\ProfileType;
 use Drupal\user\Entity\User;
@@ -838,12 +839,31 @@ function social_profile_social_user_account_header_items_alter(array &$menu_item
  */
 function social_profile_profile_access(EntityInterface $entity, $operation, AccountInterface $account) {
 
+  $display_profile_teaser = FALSE;
+  $route_match = \Drupal::service('current_route_match');
+  $allowed_node_types = [
+    'landing_page',
+    'dashboard',
+  ];
+
+  if ($route_match->getRouteName() === 'entity.node.canonical') {
+    $node = $route_match->getParameter('node');
+
+    if (!is_null($node) && !$node instanceof Node) {
+      $node = Node::load($node);
+    }
+    if ($node instanceof Node && in_array($node->getType(), $allowed_node_types)) {
+      $display_profile_teaser = TRUE;
+    }
+  }
+
   // Provides access only to viewing user profile info, like referenced data in
-  // featured items, if the current user has no permissions.
+  // featured items for landing & dashboard pages, if the current user has no
+  // permissions.
   if (
     $operation === 'view' &&
-    !$account->hasPermission('view any profile profile') &&
-    \Drupal::routeMatch()->getRouteName() !== 'entity.profile.canonical'
+    $display_profile_teaser &&
+    !$account->hasPermission('view any profile profile')
   ) {
     return AccessResult::allowed();
   }

--- a/modules/social_features/social_profile/social_profile.module
+++ b/modules/social_features/social_profile/social_profile.module
@@ -5,6 +5,7 @@
  * The Social profile module.
  */
 
+use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Cache\Cache;
 use Drupal\Core\Entity\Display\EntityViewDisplayInterface;
 use Drupal\Core\Entity\EntityInterface;
@@ -831,4 +832,20 @@ function social_profile_social_user_account_header_items_alter(array &$menu_item
     ->getViewBuilder('profile')
     ->view($profile, 'small');
 
+}
+
+/**
+ * Implements hook_ENTITY_TYPE_access().
+ */
+function social_profile_profile_access(EntityInterface $entity, $operation, AccountInterface $account) {
+
+  // Provides access only to viewing user profile info, like referenced data in
+  // featured items, if the current user has no permissions.
+  if (
+    $operation === 'view' &&
+    !$account->hasPermission('view any profile profile') &&
+    \Drupal::routeMatch()->getRouteName() !== 'entity.profile.canonical'
+  ) {
+    return AccessResult::allowed();
+  }
 }

--- a/tests/behat/features/capabilities/landing-page/featured-profile-create.feature
+++ b/tests/behat/features/capabilities/landing-page/featured-profile-create.feature
@@ -31,7 +31,6 @@ Feature: Create Landing Page and add Featured Content section with user profile
 
     # Ses as LU
     Then I should see "Landing page This is a dynamic page has been created."
-    And I should see "Member"
     And I should see the link "Open teaser profile"
     And I should see the link "Read more"
 
@@ -44,7 +43,6 @@ Feature: Create Landing Page and add Featured Content section with user profile
     # See as AN
     Given I logout
     And I go to "landingpage-teaser-profile"
-    Then I should see "Member"
     And I should see the link "Open teaser profile"
     And I should see the link "Read more"
 

--- a/tests/behat/features/capabilities/landing-page/featured-profile-create.feature
+++ b/tests/behat/features/capabilities/landing-page/featured-profile-create.feature
@@ -26,9 +26,8 @@ Feature: Create Landing Page and add Featured Content section with user profile
     And I wait for AJAX to finish
 
     # Set URL Alias
-    And I click "URL path settings"
     And I set alias as "landingpage-teaser-profile"
-    And I press "Save"
+    And I press "Create landing page"
 
     # Ses as LU
     Then I should see "Landing page This is a dynamic page has been created."

--- a/tests/behat/features/capabilities/landing-page/featured-profile-create.feature
+++ b/tests/behat/features/capabilities/landing-page/featured-profile-create.feature
@@ -1,0 +1,56 @@
+@api @landing-page @stability @javascript @perfect @critical @DS-4130 @stability-4 @landing-page-create-featured-profile
+Feature: Create Landing Page and add Featured Content section with user profile
+  Benefit: In order to share useful information with users
+  Role: AN
+  Goal/desire: I want to create dynamic content which is accessible for LU/AN
+
+  Scenario: Successfully create Landing Page with Featured Content section
+
+    Given I enable the module "social_featured_content"
+    And users:
+      | name   | mail                     | status | field_profile_first_name | field_profile_last_name | field_profile_nick_name |
+      | user_profile_1 | user_profile_1@example.localhost | 1      | Open teaser profile                   |                     |                         |
+
+    # Create Landing Page featured content section with profiles.
+    Given I am logged in as an "contentmanager"
+    When I am on "node/add/landing_page"
+    And I fill in the following:
+      | Title | This is a dynamic page |
+    And I click radio button "Public - visible to everyone including people who are not a member" with the id "edit-field-content-visibility-public"
+    And I press "Add Section"
+    And I wait for AJAX to finish
+    And I press "Add Featured Content"
+    And I wait for AJAX to finish
+    And I select "profile" from "field_landing_page_section[0][subform][field_section_paragraph][0][subform][field_featured_items][0][target_type]"
+    And I fill in "user_profile_1" for "field_landing_page_section[0][subform][field_section_paragraph][0][subform][field_featured_items][0][target_id]"
+    And I wait for AJAX to finish
+
+    # Set URL Alias
+    And I click "URL path settings"
+    And I set alias as "landingpage-teaser-profile"
+    And I press "Save"
+
+    # Ses as LU
+    Then I should see "Landing page This is a dynamic page has been created."
+    And I should see "Member"
+    And I should see the link "Open teaser profile"
+    And I should see the link "Read more"
+
+    # Open stream/profile pages as LU
+    When I click "Read more"
+    Then I should see the link "See full profile"
+    When I click "See full profile"
+    Then I should see "Open teaser profile has not shared profile information."
+
+    # See as AN
+    Given I logout
+    And I go to "landingpage-teaser-profile"
+    Then I should see "Member"
+    And I should see the link "Open teaser profile"
+    And I should see the link "Read more"
+
+    # Open stream/profile pages as AN
+    When I click "Read more"
+    Then I should see "Access denied. You must log in to view this page."
+    When I am on "/profile/1"
+    Then I should see "Access denied. You must log in to view this page."

--- a/tests/behat/features/capabilities/landing-page/featured-profile-create.feature
+++ b/tests/behat/features/capabilities/landing-page/featured-profile-create.feature
@@ -1,4 +1,4 @@
-@api @landing-page @stability @javascript @perfect @critical @DS-4130 @stability-4 @landing-page-create-featured-profile
+@api @landing-page @stability @javascript @perfect @critical @YANG-4800 @stability-4 @landing-page-create-featured-profile
 Feature: Create Landing Page and add Featured Content section with user profile
   Benefit: In order to share useful information with users
   Role: AN
@@ -16,7 +16,7 @@ Feature: Create Landing Page and add Featured Content section with user profile
     When I am on "node/add/landing_page"
     And I fill in the following:
       | Title | This is a dynamic page |
-    And I click radio button "Public - visible to everyone including people who are not a member" with the id "edit-field-content-visibility-public"
+    And I click radio button "Public" with the id "edit-field-content-visibility-public"
     And I press "Add Section"
     And I wait for AJAX to finish
     And I press "Add Featured Content"

--- a/tests/behat/features/capabilities/landing-page/featured-profile-create.feature
+++ b/tests/behat/features/capabilities/landing-page/featured-profile-create.feature
@@ -36,9 +36,10 @@ Feature: Create Landing Page and add Featured Content section with user profile
 
     # Open stream/profile pages as LU
     When I click "Read more"
-    Then I should see the link "See full profile"
-    When I click "See full profile"
-    Then I should see "Open teaser profile has not shared profile information."
+    Then I should see the link "Information"
+    When I click "Information"
+    Then I should see "Contact information"
+    And I should see "user_profile_1@example.localhost"
 
     # See as AN
     Given I logout


### PR DESCRIPTION
## Problem
Profile teasers added as "featured content" items on landing pages do not display for non-logged-in users. Page permissions are set to public and it is a bit confusing that added block displays as empty

## Solution
Provides access for AN (users who don't have `view any profile profile` permission) to preview teasers profiles but only for landing & dashboard pages.

## Issue tracker
- https://www.drupal.org/project/social/issues/3197235
- https://getopensocial.atlassian.net/browse/SUP-560

## How to test
*For example*
- [ ] Using the latest version of Open Social with the example module enabled
- [ ] As a site manager
- [ ] Try to create a landing page, add "featured content" section and select any profile entities
- [ ] When I open the created page as anonymous I expect to see added profiles but instead I don't see any new items.
- [ ] The expected result is attained when repeating the steps with this fix applied.

## Screenshots
Create a section with profiels:
![Screenshot from 2021-02-08 17-20-47](https://user-images.githubusercontent.com/25609390/107240538-b2773d00-6a32-11eb-9eac-91b595600c91.png)

Landing page for LU
![Screenshot-from-2021-02-08-17-22-47-png-1841×888-](https://user-images.githubusercontent.com/25609390/107240655-d2a6fc00-6a32-11eb-9834-0252a894b837.png)

Landing page for AN
![Screenshot from 2021-02-08 17-18-58](https://user-images.githubusercontent.com/25609390/107240712-e4889f00-6a32-11eb-8c41-3f95e7d577e2.png)


## Release notes
Allow view profile teasers which added as "featured content" items on landing or dashboard pages for anonymous users.
