### PR TITLE
[Internal] - Fix phpstan latest issues + stability on the private file upload test

### DIFF
--- a/modules/custom/activity_creator/activity_creator.tokens.inc
+++ b/modules/custom/activity_creator/activity_creator.tokens.inc
@@ -63,7 +63,7 @@ function activity_creator_tokens($type, $tokens, array $data, array $options, Bu
                     ->load($target_id);
 
                   if (!empty($recipient_user)) {
-                    /** @var \Drupal\user\Entity\User $recipient_user_entity */
+                    /** @var \Drupal\user\Entity\User $recipient_user */
                     $replacements[$original] = $recipient_user->getDisplayName();
                   }
                 }

--- a/modules/social_features/social_private_message/src/Plugin/UserExportPlugin/UserAnalyticsPrivateMessage.php
+++ b/modules/social_features/social_private_message/src/Plugin/UserExportPlugin/UserAnalyticsPrivateMessage.php
@@ -29,7 +29,6 @@ class UserAnalyticsPrivateMessage extends UserExportPluginBase {
   public function getValue(UserInterface $entity) {
     $value = '';
 
-    /** @var \Drupal\private_message\Entity\PrivateMessage $storage */
     try {
       $storage = $this->entityTypeManager->getStorage('private_message');
       if (!empty($storage)) {

--- a/modules/social_features/social_profile/social_profile.module
+++ b/modules/social_features/social_profile/social_profile.module
@@ -139,7 +139,6 @@ function social_profile_form_profile_profile_edit_form_alter(array &$form, FormS
     if ($profile_fields) {
       $empty_profile = TRUE;
 
-      /** @var \Drupal\field\Entity\FieldConfig $field_config */
       foreach ($profile_fields as $field) {
         if (isset($form[$field->get('field_name')]) && $form[$field->get('field_name')]['#access'] === TRUE) {
           $empty_profile = FALSE;

--- a/modules/social_features/social_user_export/src/Plugin/UserExportPluginBase.php
+++ b/modules/social_features/social_user_export/src/Plugin/UserExportPluginBase.php
@@ -126,7 +126,6 @@ abstract class UserExportPluginBase extends PluginBase implements UserExportPlug
   public function getProfile(UserInterface $entity) {
     $user_profile = NULL;
 
-    /** @var \Drupal\profile\ProfileStorageInterface $storage */
     try {
       $storage = $this->entityTypeManager->getStorage('profile');
       if (!empty($storage)) {

--- a/tests/behat/features/capabilities/security/private-file-uploads.feature
+++ b/tests/behat/features/capabilities/security/private-file-uploads.feature
@@ -1,4 +1,4 @@
-@api @security @stability @perfect @critical @DS-3605 @DS-5350 @YANG-4759 @stability-1 @private-file-uploads @ronald
+@api @security @stability @perfect @critical @DS-3605 @DS-5350 @YANG-4759 @stability-1 @private-file-uploads
 Feature: Private files
   Benefit: Upload files to private file directory
   Role: As a LU

--- a/tests/behat/features/capabilities/security/private-file-uploads.feature
+++ b/tests/behat/features/capabilities/security/private-file-uploads.feature
@@ -1,4 +1,4 @@
-@api @security @stability @perfect @critical @DS-3605 @DS-5350 @YANG-4759 @stability-1 @private-file-uploads
+@api @security @stability @perfect @critical @DS-3605 @DS-5350 @YANG-4759 @stability-1 @private-file-uploads @ronald
 Feature: Private files
   Benefit: Upload files to private file directory
   Role: As a LU
@@ -21,7 +21,7 @@ Feature: Private files
     And I fill in the "edit-body-0-value" WYSIWYG editor with "Private: topic text"
     And I attach the file "/files/opensocial.jpg" to "Image"
     And I wait for AJAX to finish
-    And I attach the file "/files/humans.txt" to "Attachments"
+    And I attach the file "/files/humans.txt" to "edit-field-files-0-upload"
     And I wait for AJAX to finish
     And I press "Create topic"
     Then I should see "Topic Private: topic has been created."


### PR DESCRIPTION
## Problem
PHPstan encountered some new issues, these are fixed.
We see the private file upload test fail regularly as a false negative on travis, lets see if this makes it more robust.

## Solution
Updated the `Variable ... in PHPDoc tag @var does not exist` issues
Updated the private file test to not use a label but the id of the input itself

## Issue tracker
None - Internal robustness.

## How to test
- [ ] See that test pass.

## Screenshots
None needed.

## Release notes
None needed.