### PR TITLE
Issue #3197706 by rolki: Provide a method to alter array of group types used in social group request

### DIFF
--- a/modules/social_features/social_group/modules/social_group_request/social_group_request.api.php
+++ b/modules/social_features/social_group/modules/social_group_request/social_group_request.api.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * @file
+ * Hooks provided by the Social Group Request module.
+ */
+
+/**
+ * @addtogroup hooks
+ * @{
+ */
+
+/**
+ * Provide a method to alter array of group types used in social group request.
+ *
+ * @param array $group_types
+ *   List of group types used in open social.
+ *
+ * @ingroup social_group_api
+ */
+function hook_social_group_request_alter(array &$group_types) {
+  $group_types[] = 'flexible_group';
+}

--- a/modules/social_features/social_group/modules/social_group_request/social_group_request.module
+++ b/modules/social_features/social_group/modules/social_group_request/social_group_request.module
@@ -155,8 +155,9 @@ function social_group_request_preprocess_group(&$variables) {
   }
 
   $group_types = ['flexible_group'];
+  \Drupal::moduleHandler()->alter('social_group_request', $group_types);
 
-  if (in_array($group_type->id(), \Drupal::moduleHandler()->alter('social_group_request', $group_types))) {
+  if (in_array($group_type->id(), $group_types)) {
     $join_methods = $group->get('field_group_allowed_join_method')->getValue();
 
     $request_option = in_array('request', array_column($join_methods, 'value'), FALSE);

--- a/modules/social_features/social_group/modules/social_group_request/social_group_request.module
+++ b/modules/social_features/social_group/modules/social_group_request/social_group_request.module
@@ -154,7 +154,9 @@ function social_group_request_preprocess_group(&$variables) {
     }
   }
 
-  if ($group_type->id() === 'flexible_group') {
+  $group_types = ['flexible_group'];
+
+  if (in_array($group_type->id(), \Drupal::moduleHandler()->alter('social_group_request', $group_types))) {
     $join_methods = $group->get('field_group_allowed_join_method')->getValue();
 
     $request_option = in_array('request', array_column($join_methods, 'value'), FALSE);

--- a/modules/social_features/social_group/social_group.module
+++ b/modules/social_features/social_group/social_group.module
@@ -229,10 +229,10 @@ function social_group_preprocess_group(array &$variables) {
   $variables['group_type_id'] = $group_type_id;
   $variables['group_type'] = $group->getGroupType()->label();
 
-  // From 10.0.0 onwards, we want to show group types differently.
-  // It will be the value chosen while adding the group instead of saying
-  // 'Flexible group'.
-  if ($group_type_id === 'flexible_group'
+  $group_types = ['flexible_group'];
+  \Drupal::moduleHandler()->alter('social_group_request', $group_types);
+
+  if (in_array($group_type_id, $group_types)
     && $group->hasField('field_group_type')
     && !empty($term = $group->get('field_group_type')->entity)
     && \Drupal::config('social_group.settings')->get('social_group_type_required')) {
@@ -257,7 +257,8 @@ function social_group_preprocess_group(array &$variables) {
   elseif ($group->hasPermission('join group', $account)) {
     // @todo switch this to get URL from routes correctly.
     $variables['group_operations_url'] = Url::fromRoute('entity.group.join', ['group' => $group->id()]);
-    if ($group_type_id === 'flexible_group') {
+
+    if (in_array($group_type_id, $group_types)) {
       $join_methods = $group->get('field_group_allowed_join_method')->getValue();
       $direct_option = in_array('direct', array_column($join_methods, 'value'), FALSE);
       if (!$direct_option) {

--- a/modules/social_features/social_group/social_group.module
+++ b/modules/social_features/social_group/social_group.module
@@ -945,10 +945,17 @@ function social_group_form_alter(&$form, FormStateInterface $form_state, $form_i
       array_unshift($form['actions']['submit']['#submit'], '_social_group_delete_group');
     }
   }
-  if (in_array($form_id, [
-    'group_flexible_group_edit_form',
-    'group_flexible_group_add_form',
-  ])) {
+
+  $group_types = ['flexible_group'];
+  \Drupal::moduleHandler()->alter('social_group_request', $group_types);
+
+  $group_form_ids = [];
+  foreach ($group_types as $group_type) {
+    $group_form_ids[] = 'group_' . $group_type . '_edit_form';
+    $group_form_ids[] = 'group_' . $group_type . '_add_form';
+  }
+
+  if (in_array($form_id, $group_form_ids)) {
     $join_method_default_value = 'added';
     // Ensure we have a better descriptive label.
     if (array_key_exists('added', $form['field_group_allowed_join_method']['widget']['#options'])) {


### PR DESCRIPTION
## Problem
There is no way to add join methods for group types except flexible group.

## Solution
Use the custom hook to add other group types

## Issue tracker
- https://www.drupal.org/node/3197706
- https://getopensocial.atlassian.net/browse/YANG-4740
- https://www.drupal.org/project/social/issues/3199293

## How to test
- [ ] Add these changes https://github.com/goalgorilla/social_course/pull/38 
- [ ] For the course_basic install social_course_basic_request module
- [ ] Got to some basic course edit page
- [ ] You should be able to select join methods for the course

## Screenshots
![image](https://user-images.githubusercontent.com/50984627/107950785-ed7ff000-6f9f-11eb-9ed0-568497987ba9.png)

## Release Notes
Provide a method to alter array of group types used in social group request
