### PR TITLE
Issue #3197794 by tBKoT: Improve the personalised homepage activity filter and allow to alter the query

### DIFF
--- a/modules/custom/activity_viewer/activity_viewer.api.php
+++ b/modules/custom/activity_viewer/activity_viewer.api.php
@@ -15,10 +15,10 @@
  *
  * @param \Drupal\Core\Database\Query\SelectInterface $query
  *   Query from the filter.
- * @param \Drupal\Core\Session\AccountProxyInterface $user
+ * @param \Drupal\Core\Session\AccountInterface $user
  *   Current user.
  */
-function hook_activity_viewer_available_nodes_query_alter(\Drupal\Core\Database\Query\SelectInterface $query, \Drupal\Core\Session\AccountProxyInterface $user) {
+function hook_activity_viewer_available_nodes_query_alter(\Drupal\Core\Database\Query\SelectInterface $query, \Drupal\Core\Session\AccountInterface $user) {
 
 }
 
@@ -27,10 +27,10 @@ function hook_activity_viewer_available_nodes_query_alter(\Drupal\Core\Database\
  *
  * @param \Drupal\Core\Database\Query\SelectInterface $query
  *   Query from the filter.
- * @param \Drupal\Core\Session\AccountProxyInterface $user
+ * @param \Drupal\Core\Session\AccountInterface $user
  *   Current user.
  */
-function hook_activity_viewer_available_posts_query_alter(\Drupal\Core\Database\Query\SelectInterface $query, \Drupal\Core\Session\AccountProxyInterface $user) {
+function hook_activity_viewer_available_posts_query_alter(\Drupal\Core\Database\Query\SelectInterface $query, \Drupal\Core\Session\AccountInterface $user) {
 
 }
 

--- a/modules/custom/activity_viewer/activity_viewer.api.php
+++ b/modules/custom/activity_viewer/activity_viewer.api.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * @file
+ * Hooks provided by the Activity Viewer module.
+ */
+
+/**
+ * @addtogroup hooks
+ * @{
+ */
+
+/**
+ * Alter the query in filter for node visibility in activities.
+ *
+ * @param \Drupal\Core\Database\Query\SelectInterface $query
+ *   Query from the filter.
+ * @param \Drupal\Core\Session\AccountProxyInterface $user
+ *   Current user.
+ */
+function hook_activity_viewer_available_nodes_query_alter(\Drupal\Core\Database\Query\SelectInterface $query, \Drupal\Core\Session\AccountProxyInterface $user) {
+
+}
+
+/**
+ * Alter the query in filter for post visibility in activities.
+ *
+ * @param \Drupal\Core\Database\Query\SelectInterface $query
+ *   Query from the filter.
+ * @param \Drupal\Core\Session\AccountProxyInterface $user
+ *   Current user.
+ */
+function hook_activity_viewer_available_posts_query_alter(\Drupal\Core\Database\Query\SelectInterface $query, \Drupal\Core\Session\AccountProxyInterface $user) {
+
+}
+
+/**
+ * @} End of "addtogroup hooks".
+ */

--- a/modules/custom/activity_viewer/src/Plugin/views/filter/ActivityFilterPersonalisedHomepage.php
+++ b/modules/custom/activity_viewer/src/Plugin/views/filter/ActivityFilterPersonalisedHomepage.php
@@ -212,16 +212,16 @@ class ActivityFilterPersonalisedHomepage extends FilterPluginBase {
     $query->leftJoin('group_content_field_data', 'gcfd', 'gcfd.entity_id = nfd.nid');
     $or = $query->orConditionGroup();
     if ($user->isAuthenticated()) {
-      // Nodes community visibility;
+      // Nodes community visibility.
       $community_access = $or->andConditionGroup()
-        ->condition('nfcv.field_content_visibility_value', ['community', 'public',], 'IN')
+        ->condition('nfcv.field_content_visibility_value', ['community', 'public'], 'IN')
         ->isNull('gcfd.entity_id');
       $or->condition($community_access);
 
       // Node visibility by group.
       if (count($memberships) > 0) {
         $access_by_group = $or->andConditionGroup();
-        $access_by_group->condition('nfcv.field_content_visibility_value', ['group', 'community', 'public',], 'IN');
+        $access_by_group->condition('nfcv.field_content_visibility_value', ['group', 'community', 'public'], 'IN');
         $access_by_group->condition('gcfd.type', '%-group_node-%', 'LIKE');
         $access_by_group->condition('gcfd.gid', $memberships, 'IN');
         $or->condition($access_by_group);
@@ -271,9 +271,9 @@ class ActivityFilterPersonalisedHomepage extends FilterPluginBase {
     if ($user->isAuthenticated()) {
       // Posts for authenticated users if has permission.
       if ($user->hasPermission('view community posts')) {
-        // Posts community visibility;
+        // Posts community visibility.
         $community_access = $or->andConditionGroup()
-          ->condition('pfv.field_visibility_value', ['0', '2'], 'IN')
+          ->condition('pfv.field_visibility_value', ['0', '1', '2'], 'IN')
           ->isNull('pfrg.entity_id');
         $or->condition($community_access);
       }

--- a/modules/custom/activity_viewer/src/Plugin/views/filter/ActivityFilterPersonalisedHomepage.php
+++ b/modules/custom/activity_viewer/src/Plugin/views/filter/ActivityFilterPersonalisedHomepage.php
@@ -5,7 +5,7 @@ namespace Drupal\activity_viewer\Plugin\views\filter;
 use Drupal\Core\Database\Connection;
 use Drupal\Core\Database\Query\Condition;
 use Drupal\Core\Extension\ModuleHandlerInterface;
-use Drupal\Core\Session\AccountProxyInterface;
+use Drupal\Core\Session\AccountInterface;
 use Drupal\social_group\SocialGroupHelperService;
 use Drupal\views\Plugin\views\filter\FilterPluginBase;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -176,15 +176,15 @@ class ActivityFilterPersonalisedHomepage extends FilterPluginBase {
   /**
    * Gets list of node IDs to which user has access.
    *
-   * @param \Drupal\Core\Session\AccountProxyInterface $user
-   *  The current user.
+   * @param \Drupal\Core\Session\AccountInterface $user
+   *   The current user.
    * @param array $memberships
-   *  List of user memberships.
+   *   List of user memberships.
    *
    * @return array
    *   List of node IDs.
    */
-  protected function getAvailableNodeIds(AccountProxyInterface $user, array $memberships) {
+  protected function getAvailableNodeIds(AccountInterface $user, array $memberships) {
     $query = $this->connection->select('node_field_data', 'nfd');
     $query->fields('nfd', ['nid']);
     $query->leftJoin('node__field_content_visibility', 'nfcv', 'nfcv.entity_id = nfd.nid');
@@ -227,15 +227,15 @@ class ActivityFilterPersonalisedHomepage extends FilterPluginBase {
   /**
    * Gets list of post IDs to which user has access.
    *
-   * @param \Drupal\Core\Session\AccountProxyInterface $user
-   *  The current user.
+   * @param \Drupal\Core\Session\AccountInterface $user
+   *   The current user.
    * @param array $memberships
-   *  List of user memberships.
+   *   List of user memberships.
    *
    * @return array
    *   List of post IDs.
    */
-  protected function getAvailablePostIds(AccountProxyInterface $user, array $memberships) {
+  protected function getAvailablePostIds(AccountInterface $user, array $memberships) {
     $query = $this->connection->select('post_field_data', 'pfd');
     $query->fields('pfd', ['id']);
     $query->leftJoin('post__field_visibility', 'pfv', 'pfv.entity_id = pfd.id');

--- a/modules/custom/activity_viewer/src/Plugin/views/filter/ActivityFilterPersonalisedHomepage.php
+++ b/modules/custom/activity_viewer/src/Plugin/views/filter/ActivityFilterPersonalisedHomepage.php
@@ -124,6 +124,7 @@ class ActivityFilterPersonalisedHomepage extends FilterPluginBase {
     $group_memberships = $this->groupHelper->getAllGroupsForUser($account->id());
     $this->query->addTable('activity__field_activity_entity');
     $this->query->addTable('activity__field_activity_recipient_group');
+    $this->query->addTable('activity__field_activity_recipient_user');
 
     // Add queries.
     $and_wrapper = new Condition('AND');
@@ -176,6 +177,14 @@ class ActivityFilterPersonalisedHomepage extends FilterPluginBase {
     // Lets add all the or conditions to the Views query.
     if (!empty($or->conditions()[0])) {
       $and_wrapper->condition($or);
+    }
+
+    // For anonymous show only activities which don't have direct user.
+    if ($account->isAnonymous()) {
+      $anonymous_access = new Condition('OR');
+      $anonymous_access->condition('activity__field_activity_recipient_user.field_activity_recipient_user_target_id', 0);
+      $anonymous_access->isNull('activity__field_activity_recipient_user.field_activity_recipient_user_target_id');
+      $and_wrapper->condition($anonymous_access);
     }
 
     if (!empty($and_wrapper->conditions()[0])) {

--- a/modules/custom/activity_viewer/src/Plugin/views/filter/ActivityFilterPersonalisedHomepage.php
+++ b/modules/custom/activity_viewer/src/Plugin/views/filter/ActivityFilterPersonalisedHomepage.php
@@ -2,10 +2,12 @@
 
 namespace Drupal\activity_viewer\Plugin\views\filter;
 
+use Drupal\Core\Database\Connection;
 use Drupal\Core\Database\Query\Condition;
+use Drupal\Core\Extension\ModuleHandlerInterface;
+use Drupal\Core\Session\AccountProxyInterface;
 use Drupal\social_group\SocialGroupHelperService;
 use Drupal\views\Plugin\views\filter\FilterPluginBase;
-use Drupal\views\Views;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -25,6 +27,20 @@ class ActivityFilterPersonalisedHomepage extends FilterPluginBase {
   protected $groupHelper;
 
   /**
+   * The database connection.
+   *
+   * @var \Drupal\Core\Database\Connection
+   */
+  protected $connection;
+
+  /**
+   * The module handler.
+   *
+   * @var \Drupal\Core\Extension\ModuleHandlerInterface
+   */
+  protected $moduleHandler;
+
+  /**
    * Constructs a Handler object.
    *
    * @param array $configuration
@@ -35,11 +51,24 @@ class ActivityFilterPersonalisedHomepage extends FilterPluginBase {
    *   The plugin implementation definition.
    * @param \Drupal\social_group\SocialGroupHelperService $group_helper
    *   The group helper.
+   * @param \Drupal\Core\Database\Connection $connection
+   *   The database connection.
+   * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
+   *   The module handler.
    */
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, SocialGroupHelperService $group_helper) {
+  public function __construct(
+    array $configuration,
+    $plugin_id,
+    $plugin_definition,
+    SocialGroupHelperService $group_helper,
+    Connection $connection,
+    ModuleHandlerInterface $module_handler
+  ) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
 
     $this->groupHelper = $group_helper;
+    $this->connection = $connection;
+    $this->moduleHandler = $module_handler;
   }
 
   /**
@@ -48,7 +77,9 @@ class ActivityFilterPersonalisedHomepage extends FilterPluginBase {
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
     return new static(
       $configuration, $plugin_id, $plugin_definition,
-      $container->get('social_group.helper_service')
+      $container->get('social_group.helper_service'),
+      $container->get('database'),
+      $container->get('module_handler')
     );
   }
 
@@ -77,147 +108,53 @@ class ActivityFilterPersonalisedHomepage extends FilterPluginBase {
    */
   public function query() {
     $account = $this->view->getUser();
-    $group_memberships = $this->groupHelper->getAllGroupsForUser($account->id());
-
-    // Add tables and joins.
-    $this->query->addTable('activity__field_activity_recipient_group');
-    $this->query->addTable('activity__field_activity_entity');
-
-    $configuration = [
-      'left_table' => 'activity__field_activity_entity',
-      'left_field' => 'field_activity_entity_target_id',
-      'table' => 'post_field_data',
-      'field' => 'id',
-      'operator' => '=',
-      'extra' => [
-        0 => [
-          'left_field' => 'field_activity_entity_target_type',
-          'value' => 'post',
-        ],
-      ],
+    $skip_roles = [
+      'administrator',
+      'contentmanager',
+      'sitemanager',
     ];
-    $join = Views::pluginManager('join')->createInstance('standard', $configuration);
-    $this->query->addRelationship('post', $join, 'activity__field_activity_entity');
+    $nids = $pids = [];
 
-    $configuration = [
-      'left_table' => 'post',
-      'left_field' => 'id',
-      'table' => 'post__field_visibility',
-      'field' => 'entity_id',
-      'operator' => '=',
-    ];
-    $join = Views::pluginManager('join')->createInstance('standard', $configuration);
-    $this->query->addRelationship('post__field_visibility', $join, 'post__field_visibility');
-
-    // Join node table(s).
-    $configuration = [
-      'left_table' => 'activity__field_activity_entity',
-      'left_field' => 'field_activity_entity_target_id',
-      'table' => 'node_access',
-      'field' => 'nid',
-      'operator' => '=',
-      'extra' => [
-        0 => [
-          'left_field' => 'field_activity_entity_target_type',
-          'value' => 'node',
-        ],
-      ],
-    ];
-    $join = Views::pluginManager('join')->createInstance('standard', $configuration);
-    $this->query->addRelationship('node_access', $join, 'node_access_relationship');
-
-    if ($account->isAnonymous()) {
-      $configuration['table'] = 'node_field_data';
-      $join = Views::pluginManager('join')->createInstance('standard', $configuration);
-      $this->query->addRelationship('node_field_data', $join, 'node_field_data');
+    // Skip filter for users that have full access to the site content.
+    if (!empty(array_intersect($skip_roles, $account->getRoles()))) {
+      return;
     }
+
+    $this->ensureMyTable();
+    $group_memberships = $this->groupHelper->getAllGroupsForUser($account->id());
+    $this->query->addTable('activity__field_activity_entity');
 
     // Add queries.
     $and_wrapper = new Condition('AND');
     $or = new Condition('OR');
 
-    // Nodes: retrieve all the nodes 'created' activity by node access grants.
-    $node_access = new Condition('AND');
-    $node_access->condition('activity__field_activity_entity.field_activity_entity_target_type', 'node', '=');
-    $node_access_grants = node_access_grants('view', $account);
-    $grants = new Condition('OR');
-    foreach ($node_access_grants as $realm => $gids) {
-      if (!empty($gids)) {
-        $and = new Condition('AND');
-
-        if ($account->isAnonymous() && strpos($realm, 'field_content_visibility_community') !== FALSE) {
-          $and->condition('node_field_data.uid', 0, '!=');
-        }
-
-        $grants->condition($and
-          ->condition('node_access.gid', $gids, 'IN')
-          ->condition('node_access.realm', $realm)
-        );
+    // Nodes: retrieve all the nodes to which the user has access.
+    if ($account->hasPermission('access content')) {
+      $nids = $this->getAvailableNodeIds($account, $group_memberships);
+      if (!empty($nids)) {
+        $node_access = $or->andConditionGroup()
+          ->condition('activity__field_activity_entity.field_activity_entity_target_type', 'node')
+          ->condition('activity__field_activity_entity.field_activity_entity_target_id', $nids, 'IN');
+        $or->condition($node_access);
       }
     }
-    $node_access->condition($grants);
-    // Get all nodes not posted in groups and in groups of user only.
-    if ($account->isAuthenticated() && count($group_memberships) > 0) {
-      $na_or = new Condition('OR');
-      $node_access->condition($na_or
-        ->isNull('activity__field_activity_recipient_group.field_activity_recipient_group_target_id')
-        ->condition('activity__field_activity_recipient_group.field_activity_recipient_group_target_id', $group_memberships, 'IN')
-      );
+
+    // Posts: retrieve all the posts to which the user has access.
+    $pids = $this->getAvailablePostIds($account, $group_memberships);
+    if (!empty($pids)) {
+      $post_access = $or->andConditionGroup()
+        ->condition('activity__field_activity_entity.field_activity_entity_target_type', 'post')
+        ->condition('activity__field_activity_entity.field_activity_entity_target_id', $pids, 'IN');
+      $or->condition($post_access);
     }
-    else {
-      $node_access->isNull('activity__field_activity_recipient_group.field_activity_recipient_group_target_id');
-    }
-    $or->condition($node_access);
-
-    // Posts: retrieve all the posts in groups the user is a member of.
-    if ($account->isAuthenticated() && count($group_memberships) > 0) {
-      $posts_in_groups = new Condition('AND');
-      $posts_in_groups->condition('activity__field_activity_entity.field_activity_entity_target_type', 'post', '=');
-      $posts_in_groups->condition('activity__field_activity_recipient_group.field_activity_recipient_group_target_id', $group_memberships, 'IN');
-
-      $or->condition($posts_in_groups);
-    }
-
-    // Posts: all the posts the user has access to and posted to community.
-    $post_access = new Condition('AND');
-    $post_access->condition('activity__field_activity_entity.field_activity_entity_target_type', 'post', '=');
-    $post_access->condition('post__field_visibility.field_visibility_value', '3', '!=');
-
-    if (!$account->hasPermission('view public posts')) {
-      $post_access->condition('post__field_visibility.field_visibility_value', '1', '!=');
-    }
-    if (!$account->hasPermission('view community posts')) {
-      $post_access->condition('post__field_visibility.field_visibility_value', '2', '!=');
-      // Also do not show recipient posts (e.g. on open groups).
-      $post_access->condition('post__field_visibility.field_visibility_value', '0', '!=');
-    }
-    $post_access->isNull('activity__field_activity_recipient_group.field_activity_recipient_group_target_id');
-
-    $or->condition($post_access);
-
-    $post_status = new Condition('OR');
-    $post_status->condition('post.status', 1, '=');
-
-    if ($account->hasPermission('view unpublished post entities')) {
-      $post_status->condition('post.status', 0, '=');
-    }
-    $post_status->condition('activity__field_activity_entity.field_activity_entity_target_type', 'post', '!=');
-    $and_wrapper->condition($post_status);
 
     // Comments: retrieve comments the user has access to.
     if ($account->hasPermission('access comments')) {
-      // For comments in groups, the user must be a member of at least 1 group.
-      if (count($group_memberships) > 0) {
-        $comments_on_content_in_groups = new Condition('AND');
-        $comments_on_content_in_groups->condition('activity__field_activity_entity.field_activity_entity_target_type', 'comment', '=');
-        $comments_on_content_in_groups->condition('activity__field_activity_recipient_group.field_activity_recipient_group_target_id', $group_memberships, 'IN');
-        $or->condition($comments_on_content_in_groups);
-      }
-
-      $comments_on_content = new Condition('AND');
-      $comments_on_content->condition('activity__field_activity_entity.field_activity_entity_target_type', 'comment', '=');
-      $comments_on_content->isNull('activity__field_activity_recipient_group.field_activity_recipient_group_target_id');
-      $or->condition($comments_on_content);
+      $cids = $this->getAvailableCommentIds($nids, $pids);
+      $comments_access = $or->andConditionGroup()
+        ->condition('activity__field_activity_entity.field_activity_entity_target_type', 'comment')
+        ->condition('activity__field_activity_entity.field_activity_entity_target_id', $cids, 'IN');
+      $or->condition($comments_access);
     }
 
     // Lets add all the or conditions to the Views query.
@@ -234,6 +171,150 @@ class ActivityFilterPersonalisedHomepage extends FilterPluginBase {
     $contexts[] = 'user';
 
     return $contexts;
+  }
+
+  /**
+   * Gets list of node IDs to which user has access.
+   *
+   * @param \Drupal\Core\Session\AccountProxyInterface $user
+   *  The current user.
+   * @param array $memberships
+   *  List of user memberships.
+   *
+   * @return array
+   *   List of node IDs.
+   */
+  protected function getAvailableNodeIds(AccountProxyInterface $user, array $memberships) {
+    $query = $this->connection->select('node_field_data', 'nfd');
+    $query->fields('nfd', ['nid']);
+    $query->leftJoin('node__field_content_visibility', 'nfcv', 'nfcv.entity_id = nfd.nid');
+    $or = $query->orConditionGroup();
+    if ($user->isAuthenticated()) {
+      // Nodes for authenticated users.
+      $or->condition('nfcv.field_content_visibility_value', 'community');
+
+      // Nodes related to the group where the user is a member.
+      if (count($memberships) > 0) {
+        $query->leftJoin('group_content_field_data', 'gcfd', 'gcfd.entity_id = nfd.nid');
+        $access_by_group = $or->andConditionGroup();
+        $access_by_group->condition('nfcv.field_content_visibility_value', 'group');
+        $access_by_group->condition('gcfd.type', '%-group_node-%', 'LIKE');
+        $access_by_group->condition('gcfd.gid', $memberships, 'IN');
+        $or->condition($access_by_group);
+      }
+    }
+
+    // Public nodes or do not have visibility settings.
+    $or->condition('nfcv.field_content_visibility_value', 'public');
+    $or->isNull('nfcv.entity_id');
+    $query->condition($or);
+
+    // Alter query for custom conditions.
+    $this->moduleHandler->alter('activity_viewer_available_nodes_query', $query, $user);
+
+    // Check node status and user access to it.
+    $node_status = ['1'];
+    if ($user->hasPermission('view any unpublished content')) {
+      $node_status[] = '0';
+    }
+    $query->condition('nfd.status', $node_status, 'IN');
+
+    $nids = $query->execute()->fetchCol();
+
+    return array_unique($nids);
+  }
+
+  /**
+   * Gets list of post IDs to which user has access.
+   *
+   * @param \Drupal\Core\Session\AccountProxyInterface $user
+   *  The current user.
+   * @param array $memberships
+   *  List of user memberships.
+   *
+   * @return array
+   *   List of post IDs.
+   */
+  protected function getAvailablePostIds(AccountProxyInterface $user, array $memberships) {
+    $query = $this->connection->select('post_field_data', 'pfd');
+    $query->fields('pfd', ['id']);
+    $query->leftJoin('post__field_visibility', 'pfv', 'pfv.entity_id = pfd.id');
+    $or = $query->orConditionGroup();
+    if ($user->isAuthenticated()) {
+      // Posts for authenticated users if has permission.
+      if ($user->hasPermission('view community posts')) {
+        $or->condition('pfv.field_visibility_value', ['0', '2'], 'IN');
+      }
+
+      // Posts related to the group where the user is a member.
+      if (count($memberships) > 0) {
+        $query->leftJoin('post__field_recipient_group', 'pfrg', 'pfrg.entity_id = pfd.id');
+        $access_by_group = $or->andConditionGroup();
+        $access_by_group->condition('pfv.field_visibility_value', '3');
+        $access_by_group->condition('pfrg.field_recipient_group_target_id', $memberships, 'IN');
+        $or->condition($access_by_group);
+      }
+    }
+
+    // Public posts or do not have visibility settings.
+    if ($user->hasPermission('view public posts')) {
+      $or->condition('pfv.field_visibility_value', '1');
+    }
+    $or->isNull('pfv.entity_id');
+    $query->condition($or);
+
+    // Alter query for custom conditions.
+    $this->moduleHandler->alter('activity_viewer_available_posts_query', $query, $user);
+
+    // Check posts status and user access to it.
+    $post_status = ['1'];
+    if ($user->hasPermission('view unpublished post entities')) {
+      $post_status[] = '0';
+    }
+    $query->condition('pfd.status', $post_status, 'IN');
+
+    $pids = $query->execute()->fetchCol();
+
+    return array_unique($pids);
+  }
+
+  /**
+   * Gets list of comment IDs to which user has access.
+   *
+   * @param array $node_ids
+   *   List of node IDs.
+   * @param array $post_ids
+   *   List of post IDs.
+   *
+   * @return array
+   *   List of comment IDs.
+   */
+  protected function getAvailableCommentIds(array $node_ids, array $post_ids) {
+    $query = $this->connection->select('comment_field_data', 'cfd');
+    $query->fields('cfd', ['cid']);
+    $or = $query->orConditionGroup();
+
+    // Comments related to available nodes.
+    if (!empty($node_ids)) {
+      $node_access = $or->andConditionGroup();
+      $node_access->condition('entity_type', 'node');
+      $node_access->condition('entity_id', $node_ids, 'IN');
+      $or->condition($node_access);
+    }
+
+    // Comments related to available posts.
+    if (!empty($post_ids)) {
+      $post_access = $or->andConditionGroup();
+      $post_access->condition('entity_type', 'post');
+      $post_access->condition('entity_id', $post_ids, 'IN');
+      $or->condition($post_access);
+    }
+    $query->condition($or);
+    $query->condition('cfd.status', '1');
+
+    $cids = $query->execute()->fetchCol();
+
+    return array_unique($cids);
   }
 
 }

--- a/modules/custom/activity_viewer/src/Plugin/views/filter/ActivityFilterPersonalisedHomepage.php
+++ b/modules/custom/activity_viewer/src/Plugin/views/filter/ActivityFilterPersonalisedHomepage.php
@@ -113,7 +113,7 @@ class ActivityFilterPersonalisedHomepage extends FilterPluginBase {
       'contentmanager',
       'sitemanager',
     ];
-    $nids = $pids = [];
+    $nids = $pids = $cids = [];
 
     // Skip filter for users that have full access to the site content.
     if (!empty(array_intersect($skip_roles, $account->getRoles()))) {
@@ -151,15 +151,19 @@ class ActivityFilterPersonalisedHomepage extends FilterPluginBase {
     // Comments: retrieve comments the user has access to.
     if ($account->hasPermission('access comments')) {
       $cids = $this->getAvailableCommentIds($nids, $pids);
-      $comments_access = $or->andConditionGroup()
-        ->condition('activity__field_activity_entity.field_activity_entity_target_type', 'comment')
-        ->condition('activity__field_activity_entity.field_activity_entity_target_id', $cids, 'IN');
-      $or->condition($comments_access);
+      if (!empty($cids)) {
+        $comments_access = $or->andConditionGroup()
+          ->condition('activity__field_activity_entity.field_activity_entity_target_type', 'comment')
+          ->condition('activity__field_activity_entity.field_activity_entity_target_id', $cids, 'IN');
+        $or->condition($comments_access);
+      }
     }
 
     // Lets add all the or conditions to the Views query.
-    $and_wrapper->condition($or);
-    $this->query->addWhere('visibility', $and_wrapper);
+    if (!empty($or->conditions()[0])) {
+      $and_wrapper->condition($or);
+      $this->query->addWhere('visibility', $and_wrapper);
+    }
   }
 
   /**

--- a/modules/custom/activity_viewer/src/Plugin/views/filter/ActivityFilterPersonalisedHomepage.php
+++ b/modules/custom/activity_viewer/src/Plugin/views/filter/ActivityFilterPersonalisedHomepage.php
@@ -122,9 +122,11 @@ class ActivityFilterPersonalisedHomepage extends FilterPluginBase {
 
     $this->ensureMyTable();
     $group_memberships = $this->groupHelper->getAllGroupsForUser($account->id());
-    $this->query->addTable('activity__field_activity_entity');
-    $this->query->addTable('activity__field_activity_recipient_group');
-    $this->query->addTable('activity__field_activity_recipient_user');
+    /** @var \Drupal\views\Plugin\views\query\Sql $filter_query */
+    $filter_query = $this->query;
+    $filter_query->addTable('activity__field_activity_entity');
+    $filter_query->addTable('activity__field_activity_recipient_group');
+    $filter_query->addTable('activity__field_activity_recipient_user');
 
     // Add queries.
     $and_wrapper = new Condition('AND');
@@ -182,13 +184,13 @@ class ActivityFilterPersonalisedHomepage extends FilterPluginBase {
     // For anonymous show only activities which don't have direct user.
     if ($account->isAnonymous()) {
       $anonymous_access = new Condition('OR');
-      $anonymous_access->condition('activity__field_activity_recipient_user.field_activity_recipient_user_target_id', 0);
+      $anonymous_access->condition('activity__field_activity_recipient_user.field_activity_recipient_user_target_id', '0');
       $anonymous_access->isNull('activity__field_activity_recipient_user.field_activity_recipient_user_target_id');
       $and_wrapper->condition($anonymous_access);
     }
 
     if (!empty($and_wrapper->conditions()[0])) {
-      $this->query->addWhere('visibility', $and_wrapper);
+      $filter_query->addWhere('visibility', $and_wrapper);
     }
   }
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -557,7 +557,7 @@ parameters:
 
 		-
 			message: "#^Call to an undefined method Drupal\\\\views\\\\Plugin\\\\views\\\\query\\\\QueryPluginBase\\:\\:addTable\\(\\)\\.$#"
-			count: 2
+			count: 3
 			path: modules/custom/activity_viewer/src/Plugin/views/filter/ActivityFilterPersonalisedHomepage.php
 
 		-

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -556,26 +556,6 @@ parameters:
 			path: modules/custom/activity_viewer/src/Plugin/views/filter/ActivityExploreVisibilityAccess.php
 
 		-
-			message: "#^Call to an undefined method Drupal\\\\views\\\\Plugin\\\\views\\\\query\\\\QueryPluginBase\\:\\:addTable\\(\\)\\.$#"
-			count: 3
-			path: modules/custom/activity_viewer/src/Plugin/views/filter/ActivityFilterPersonalisedHomepage.php
-
-		-
-			message: "#^Call to an undefined method Drupal\\\\views\\\\Plugin\\\\views\\\\query\\\\QueryPluginBase\\:\\:addRelationship\\(\\)\\.$#"
-			count: 4
-			path: modules/custom/activity_viewer/src/Plugin/views/filter/ActivityFilterPersonalisedHomepage.php
-
-		-
-			message: "#^Parameter \\#2 \\$value of method Drupal\\\\Core\\\\Database\\\\Query\\\\Condition\\:\\:condition\\(\\) expects array\\|Drupal\\\\Core\\\\Database\\\\Query\\\\SelectInterface\\|string\\|null, int given\\.$#"
-			count: 3
-			path: modules/custom/activity_viewer/src/Plugin/views/filter/ActivityFilterPersonalisedHomepage.php
-
-		-
-			message: "#^Call to an undefined method Drupal\\\\views\\\\Plugin\\\\views\\\\query\\\\QueryPluginBase\\:\\:addWhere\\(\\)\\.$#"
-			count: 1
-			path: modules/custom/activity_viewer/src/Plugin/views/filter/ActivityFilterPersonalisedHomepage.php
-
-		-
 			message: "#^\\\\Drupal calls should be avoided in classes, use dependency injection instead$#"
 			count: 2
 			path: modules/custom/activity_viewer/src/Plugin/views/filter/ActivityNotificationVisibilityAccess.php


### PR DESCRIPTION
## Problem
On the UN project is not possible to save activity streams on the dashboard. The 'activity_filter_personalised_homepage' filter is overridden and the SQL query takes too much time.
Also, anonymous user see empty activities because they don't have access to related entities

## Solution
Improve the 'activity_filter_personalised_homepage' filter and allow to alter the query.

## Issue tracker
https://www.drupal.org/project/social/issues/3197794
https://getopensocial.atlassian.net/browse/YANG-3793
https://getopensocial.atlassian.net/browse/YANG-4509
https://getopensocial.atlassian.net/browse/YANG-4887
https://getopensocial.atlassian.net/browse/YANG-4888

## How to test
- [ ] Enable the `social_dashboard` module.
- [ ] Create dashboard.
- [ ] Add the `Activity stream homepage` block.
- [ ] Save dashboard.

## Screenshots
N/A

## Release notes
Added new hooks alter to modify activity filter query.

 - `hook_activity_viewer_available_nodes_query_alter` to add own conditions which nodes available to view.
 - `hook_activity_viewer_available_posts_query_alter` to add own conditions which posts available to view.

## Change Record
N/A

## Translations
N/A
