### PR TITLE
Issue #3196837 by sjoerdvandervis: Backport of #2225: validation node form loses content visibility when a group is selected

### DIFF
--- a/modules/social_features/social_group/social_group.module
+++ b/modules/social_features/social_group/social_group.module
@@ -1052,7 +1052,7 @@ function social_group_field_widget_form_alter(&$element, FormStateInterface $for
   /** @var \Drupal\Core\Field\FieldDefinitionInterface $field_definition */
   $field_definition = $context['items']->getFieldDefinition();
 
-  // Unset the public options on visibility field.
+  // Unset the visibility field options which are not enabled.
   if ($field_definition->getType() == 'entity_access_field') {
     $default_value = $context['items']->getValue();
     if (isset($default_value[0]['value'])) {
@@ -1069,6 +1069,8 @@ function social_group_field_widget_form_alter(&$element, FormStateInterface $for
     if (!empty($current_group)) {
       $group_type = $current_group->getGroupType();
       $group_type_id = $group_type->id();
+      // If it's an existing entity we dont need to set the default
+      // rather follow the saved one.
       if (!$entity->id()) {
         $element['#default_value'] = \Drupal::service('social_group.helper_service')->getDefaultGroupVisibility($group_type_id);
       }
@@ -1084,8 +1086,38 @@ function social_group_field_widget_form_alter(&$element, FormStateInterface $for
     foreach ($visibility_options as $visibility => $allowed) {
       $element[$visibility]['#disabled'] = !$allowed;
     }
-  }
 
+    // This contains the group that is passed back from the form_state as
+    // chosen by selecting a group in the $form['groups'] select widget.
+    // With this we can ensure that on validation the content visibility
+    // field is disabling the correct values based on the selected group.
+    if (!empty($form_state->getValue('groups'))) {
+      $group_id = NULL;
+      $group_value = $form_state->getValue('groups');
+      if (is_array($group_value)) {
+        $group_id = $group_value[0]['target_id'];
+      }
+      if (is_string($group_value)) {
+        $group_id = (int) $group_value;
+      }
+      // Load the correct group.
+      $selected_groups = Group::loadMultiple([$group_id]);
+
+      // Ensure we disable the correct visibility options.
+      foreach ($selected_groups as $current_group) {
+        if (!empty($current_group)) {
+          $group_type = $current_group->getGroupType();
+          $group_type_id = $group_type->id();
+
+          $visibility_options = social_group_get_allowed_visibility_options_per_group_type($group_type_id, NULL, NULL, $current_group);
+
+          foreach ($visibility_options as $visibility => $allowed) {
+            $element[$visibility]['#disabled'] = !$allowed;
+          }
+        }
+      }
+    }
+  }
 }
 
 /**

--- a/tests/behat/features/capabilities/group/group-edit-content-in-group.feature
+++ b/tests/behat/features/capabilities/group/group-edit-content-in-group.feature
@@ -12,9 +12,10 @@ Feature: Move content after creation
       | sally | 1234 | sally@example.com | 1      |               |
       | smith | 1234 | sm@example.com    | 1      |  sitemanager  |
     Given groups:
-      | title      | description    | author | type       | language |
-      | Motorboats | Vroem vroem..  | sally  | open_group | en       |
-      | Kayaking   | Kayaking in NY | harry  | open_group | en       |
+      | title      | description    | author | type         | language |
+      | Motorboats | Vroem vroem..  | sally  | open_group   | en       |
+      | Kayaking   | Kayaking in NY | harry  | open_group   | en       |
+      | Closed one | Kayaking in NY | harry  | closed_group | en       |
     # Create a new topic
     When I am logged in as "harry"
     And I am on "/all-groups"
@@ -22,7 +23,16 @@ Feature: Move content after creation
     And I click "Join"
     And I press "Join group"
     And I am on "node/add/topic"
-    And I click radio button "Discussion"
+    And I select group "Closed one"
+    And I wait for AJAX to finish
+    Then I should see "Changing the group may have impact on the visibility settings and may cause author/co-authors to lose access."
+    # Ensure we trigger validation to see if our group is still selected with the correct visibility.
+    And I press "Create topic"
+    Then I should see "Type field is required."
+    And I should see "Title field is required."
+    And I should see "Description field is required."
+    And I should see checked the box "Group members"
+
     And I fill in "Title" with "I love this sport"
     And I fill in the "edit-body-0-value" WYSIWYG editor with "Do you to?"
     And I select group "Kayaking"


### PR DESCRIPTION
## Problem
Whenever you try to save a node and you have a group selected in the access permission group section this isn't referenced correctly by the widget. Which means when the form validation kicks in, the widget renders a default state.
While you have a group selected and the widget should take the groups visibility settings in to account.

## Solution
As the $form_state is being rebuilt already and we can check if it contains any values for the $form['groups'] selection widget, we can base our default state on that value being set.
So whenever validation kicks in, this is taken in to account by our widget and the correct visibility is rendered including the disabled state.

***NOTE** This is a backport of https://github.com/goalgorilla/open_social/pull/2225 to be able to merge this into 8.x-9.x.*

## Issue tracker
https://www.drupal.org/project/social/issues/3196837

## How to test
*For example*
 - [ ] Login as SM
 - [ ] Create a topic / event
 - [ ] Don't fill in any details, just select a group
 - [ ] See that the visibility is being updated based on the group settings
 - [ ] When you press create topic the validation should kick in nicely
 - [ ] See that the visibility and the group is still as you've selected
 - [ ] See that you can change the settings as you wish and save it after
 - [ ] See that it also works on editing a topic / event

## Screenshots

https://user-images.githubusercontent.com/19951173/107646340-25262980-6c7a-11eb-8ecd-725537ff5959.mov

## Release notes
When saving content which is able to be placed in a group, if some validation error was triggerd, it could be the content visibility field value was reset which shouldn't happen. Now if there is a validation error we will make sure to base our visibility setting on the group it's placed in.