### PR TITLE
Issue #3198521 by Ressinel: Fix PHP warning when add event enrollees

### DIFF
--- a/modules/social_features/social_event/modules/social_event_managers/src/Element/SocialEnrollmentAutocomplete.php
+++ b/modules/social_features/social_event/modules/social_event_managers/src/Element/SocialEnrollmentAutocomplete.php
@@ -37,12 +37,13 @@ class SocialEnrollmentAutocomplete extends EntityAutocomplete {
       $nid = $node;
     }
 
-    // Grab all the input values so we can get the ID's out of them.
-    $input_values = Tags::explode($element['#value']);
-
     // If we use the select 2 widget then we already got a nice array.
     if ($select2 === TRUE) {
       $input_values = $element['#value'];
+    }
+    else {
+      // Grab all the input values so we can get the ID's out of them.
+      $input_values = Tags::explode($element['#value']);
     }
 
     foreach ($input_values as $input) {
@@ -95,6 +96,13 @@ class SocialEnrollmentAutocomplete extends EntityAutocomplete {
         // to render an error after all checks are gone.
         if (!empty($enrollments)) {
           $duplicated_values[] = $input;
+        }
+
+        // We need set "validate_reference" for element to prevent
+        // receive the following notice:
+        // Undefined index: #validate_reference
+        if (!isset($element['#validate_reference'])) {
+          $element['#validate_reference'] = FALSE;
         }
 
         // Validate input for every single user. This way we make sure that

--- a/modules/social_features/social_event/modules/social_event_managers/src/Element/SocialEnrollmentAutocomplete.php
+++ b/modules/social_features/social_event/modules/social_event_managers/src/Element/SocialEnrollmentAutocomplete.php
@@ -37,11 +37,9 @@ class SocialEnrollmentAutocomplete extends EntityAutocomplete {
       $nid = $node;
     }
 
-    // If we use the select 2 widget then we already got a nice array.
-    if ($select2 === TRUE) {
-      $input_values = $element['#value'];
-    }
-    else {
+    $input_values = $element['#value'];
+
+    if ($select2 !== TRUE) {
       // Grab all the input values so we can get the ID's out of them.
       $input_values = Tags::explode($element['#value']);
     }

--- a/modules/social_features/social_event/modules/social_event_managers/src/Element/SocialEnrollmentAutocomplete.php
+++ b/modules/social_features/social_event/modules/social_event_managers/src/Element/SocialEnrollmentAutocomplete.php
@@ -99,8 +99,7 @@ class SocialEnrollmentAutocomplete extends EntityAutocomplete {
         }
 
         // We need set "validate_reference" for element to prevent
-        // receive the following notice:
-        // Undefined index: #validate_reference
+        // receive notice Undefined index #validate_reference.
         if (!isset($element['#validate_reference'])) {
           $element['#validate_reference'] = FALSE;
         }


### PR DESCRIPTION
## Problem
After adding member through "Add directly" receive:

`Warning: preg_match_all() expects parameter 2 to be string, array given in Drupal\Component\Utility\Tags::explode() (line 25 of core/lib/Drupal/Component/Utility/Tags.php).`

`Notice: Undefined index: #validate_reference in Drupal\Core\Entity\Element\EntityAutocomplete::validateEntityAutocomplete() (line 242 of core/lib/Drupal/Core/Entity/Element/EntityAutocomplete.php).`

## Solution
Make fixes in `/modules/social_features/social_event/modules/social_event_managers/src/Form/SocialEventManagersAddEnrolleeForm.php`

## Issue tracker
- https://www.drupal.org/project/social/issues/3198521
- https://getopensocial.atlassian.net/browse/YANG-4480

## How to test
- [x] Log in as SM or any other user
- [x] Create an event
- [x] Go to “Manage Enrollments" page
- [x] Add a new member to the event using “Add directly" option from “Add enrollees" drop-down

## Screenshots
![Warning: preg_match_all](https://user-images.githubusercontent.com/10220937/107962382-8f5b0900-6faf-11eb-9b25-40f0e1e077aa.png)

## Release notes
*Fixed warnings after adding member through "Add directly" to event enrollments.*

## Change Record
N/A

## Translations
N/A
