### PR TITLE
Issue #3198528 by tBKoT: Improve Follow taxonomy block performance

### DIFF
--- a/modules/social_features/social_follow_taxonomy/modules/social_follow_tag/social_follow_tag.module
+++ b/modules/social_features/social_follow_taxonomy/modules/social_follow_tag/social_follow_tag.module
@@ -106,7 +106,6 @@ function social_follow_tag_preprocess_social_tagging_split(&$variables) {
             'social_follow_tag.lazy_builder:popupLazyBuild',
             [
               $tag_info['url'],
-              $tag_info['name'],
               $current_term->id(),
               'social_tagging',
               $entity_type,
@@ -159,7 +158,6 @@ function social_follow_tag_preprocess_social_tagging_nosplit(&$variables) {
           'social_follow_tag.lazy_builder:popupLazyBuild',
           [
             $tag_info['url'],
-            $tag_info['name'],
             $current_term->id(),
             'social_tagging',
             $entity_type,

--- a/modules/social_features/social_follow_taxonomy/modules/social_follow_tag/social_follow_tag.module
+++ b/modules/social_features/social_follow_taxonomy/modules/social_follow_tag/social_follow_tag.module
@@ -143,7 +143,7 @@ function social_follow_tag_preprocess_social_tagging_nosplit(&$variables) {
   foreach ($variables['tags'] as $tag_name => $tag_info) {
     // Get term id from the transmitted url string.
     $term_id_from_string = explode('/search/content?tag%5B%5D=', $tag_info);
-    if($entity_type === 'group') {
+    if ($entity_type === 'group') {
       $term_id_from_string = explode('/search/groups?tag%5B%5D=', $tag_info);
     }
     if (isset($term_id_from_string[1])) {

--- a/modules/social_features/social_follow_taxonomy/modules/social_follow_tag/social_follow_tag.module
+++ b/modules/social_features/social_follow_taxonomy/modules/social_follow_tag/social_follow_tag.module
@@ -26,6 +26,15 @@ function social_follow_tag_theme() {
         'tags' => NULL,
       ],
     ],
+    'social_tagging_popup' => [
+      'variables' => [
+        'url' => NULL,
+        'name' => NULL,
+        'flag' => NULL,
+        'followers_count' => NULL,
+        'related_entity_count' => NULL,
+      ],
+    ],
   ];
 
 }
@@ -91,11 +100,20 @@ function social_follow_tag_preprocess_social_tagging_split(&$variables) {
 
       // Adding additional data to the term variable to extend the template.
       $variables['taghierarchy'][$wrapped_term->id()]['tags'][$current_term->id()] = [
-        'url' => $tag_info['url'],
+        'popup' => [
+          '#create_placeholder' => TRUE,
+          '#lazy_builder' => [
+            'social_follow_tag.lazy_builder:popupLazyBuild',
+            [
+              $tag_info['url'],
+              $tag_info['name'],
+              $current_term->id(),
+              'social_tagging',
+              $entity_type,
+            ],
+          ],
+        ],
         'name' => $tag_info['name'],
-        'flag' => social_follow_taxonomy_flag_link($current_term),
-        'related_entity_count' => social_follow_taxonomy_related_entity_count($current_term, 'social_tagging', $entity_type),
-        'followers_count' => social_follow_taxonomy_term_followers_count($current_term),
         'follow' => social_follow_taxonomy_term_followed($current_term),
       ];
 
@@ -135,11 +153,20 @@ function social_follow_tag_preprocess_social_tagging_nosplit(&$variables) {
 
     // Adding additional data to the term variable to extend the template.
     $variables['tags'][$tag_name] = [
-      'url' => $tag_info,
+      'popup' => [
+        '#create_placeholder' => TRUE,
+        '#lazy_builder' => [
+          'social_follow_tag.lazy_builder:popupLazyBuild',
+          [
+            $tag_info['url'],
+            $tag_info['name'],
+            $current_term->id(),
+            'social_tagging',
+            $entity_type,
+          ],
+        ],
+      ],
       'name' => $tag_name,
-      'flag' => social_follow_taxonomy_flag_link($current_term),
-      'related_entity_count' => social_follow_taxonomy_related_entity_count($current_term, 'social_tagging', $entity_type),
-      'followers_count' => social_follow_taxonomy_term_followers_count($current_term),
       'follow' => social_follow_taxonomy_term_followed($current_term),
     ];
 

--- a/modules/social_features/social_follow_taxonomy/modules/social_follow_tag/social_follow_tag.module
+++ b/modules/social_features/social_follow_taxonomy/modules/social_follow_tag/social_follow_tag.module
@@ -70,17 +70,17 @@ function social_follow_tag_preprocess_social_tagging_split(&$variables) {
     return;
   }
 
+  // Get entity type for rendered tags.
+  $entity_type = $variables['entity_type'];
+
+  /** @var \Drupal\taxonomy\TermStorageInterface $term_storage */
+  $term_storage = \Drupal::entityTypeManager()->getStorage('taxonomy_term');
+
   // Iterate over an array with parent terms (category).
   foreach ($variables['taghierarchy'] as $parent_tag) {
     if (!isset($parent_tag['tags'])) {
       continue;
     }
-
-    // Get entity type for rendered tags.
-    $entity_type = $variables['entity_type'];
-
-    /** @var \Drupal\taxonomy\TermStorageInterface $term_storage */
-    $term_storage = \Drupal::entityTypeManager()->getStorage('taxonomy_term');
 
     // Iterate over an array with terms in each category.
     foreach ($parent_tag['tags'] as $tag_id => $tag_info) {
@@ -134,10 +134,12 @@ function social_follow_tag_preprocess_social_tagging_nosplit(&$variables) {
     return;
   }
 
-  $term_storage = \Drupal::entityTypeManager()->getStorage('taxonomy_term');
-
   // Get entity type for rendered tags.
   $entity_type = $variables['entity_type'];
+
+  /** @var \Drupal\taxonomy\TermStorageInterface $term_storage */
+  $term_storage = \Drupal::entityTypeManager()->getStorage('taxonomy_term');
+
   foreach ($variables['tags'] as $tag_name => $tag_info) {
     // Get term id from the transmitted url string.
     $term_id_from_string = explode('/search/content?tag%5B%5D=', $tag_info);

--- a/modules/social_features/social_follow_taxonomy/modules/social_follow_tag/social_follow_tag.module
+++ b/modules/social_features/social_follow_taxonomy/modules/social_follow_tag/social_follow_tag.module
@@ -143,6 +143,9 @@ function social_follow_tag_preprocess_social_tagging_nosplit(&$variables) {
   foreach ($variables['tags'] as $tag_name => $tag_info) {
     // Get term id from the transmitted url string.
     $term_id_from_string = explode('/search/content?tag%5B%5D=', $tag_info);
+    if($entity_type === 'group') {
+      $term_id_from_string = explode('/search/groups?tag%5B%5D=', $tag_info);
+    }
     if (isset($term_id_from_string[1])) {
       $current_term = $term_storage->load($term_id_from_string[1]);
     }
@@ -159,7 +162,7 @@ function social_follow_tag_preprocess_social_tagging_nosplit(&$variables) {
         '#lazy_builder' => [
           'social_follow_tag.lazy_builder:popupLazyBuild',
           [
-            $tag_info['url'],
+            $tag_info,
             $current_term->id(),
             'social_tagging',
             $entity_type,

--- a/modules/social_features/social_follow_taxonomy/modules/social_follow_tag/src/SocialFollowTagLazyBuilder.php
+++ b/modules/social_features/social_follow_taxonomy/modules/social_follow_tag/src/SocialFollowTagLazyBuilder.php
@@ -184,7 +184,8 @@ class SocialFollowTagLazyBuilder implements TrustedCallbackInterface {
    * @return array
    *   Render array.
    */
-  public function popupLazyBuild($url, $term_id, $field, $entity_type){
+  public function popupLazyBuild($url, $term_id, $field, $entity_type) {
+    /** @var \Drupal\taxonomy\TermInterface $term */
     $term = $this->entityTypeManager->getStorage('taxonomy_term')->load($term_id);
     return [
       '#theme' => 'social_tagging_popup',

--- a/modules/social_features/social_follow_taxonomy/modules/social_follow_tag/src/SocialFollowTagLazyBuilder.php
+++ b/modules/social_features/social_follow_taxonomy/modules/social_follow_tag/src/SocialFollowTagLazyBuilder.php
@@ -170,10 +170,40 @@ class SocialFollowTagLazyBuilder implements TrustedCallbackInterface {
   }
 
   /**
+   * Returns render array for tag follow popup.
+   *
+   * @param string $url
+   *   ULR of related content.
+   * @param string|int $term_id
+   *   Taxonomy term ID.
+   * @param string $field
+   *   Entity field name related to taxonomy.
+   * @param string $entity_type
+   *   Entity type for related content counter.
+   *
+   * @return array
+   *   Render array.
+   */
+  public function popupLazyBuild($url, $term_id, $field, $entity_type){
+    $term = $this->entityTypeManager->getStorage('taxonomy_term')->load($term_id);
+    return [
+      '#theme' => 'social_tagging_popup',
+      '#url' => $url,
+      '#name' => $term->label(),
+      '#flag' => social_follow_taxonomy_flag_link($term),
+      '#followers_count' => social_follow_taxonomy_term_followers_count($term),
+      '#related_entity_count' => social_follow_taxonomy_related_entity_count($term, $field, $entity_type),
+    ];
+  }
+
+  /**
    * {@inheritdoc}
    */
   public static function trustedCallbacks() {
-    return ['lazyBuild'];
+    return [
+      'lazyBuild',
+      'popupLazyBuild',
+    ];
   }
 
 }

--- a/modules/social_features/social_follow_taxonomy/modules/social_follow_tag/templates/social-tagging-nosplit.html.twig
+++ b/modules/social_features/social_follow_taxonomy/modules/social_follow_tag/templates/social-tagging-nosplit.html.twig
@@ -31,38 +31,7 @@
             </g>
           </svg>
         </a>
-        <div class="popup-info">
-          <div class="card teaser">
-            <div class="teaser__body">
-              <div class="teaser__content">
-                <div class="teaser__tag">{% trans %}TAG{% endtrans %}</div>
-
-                <h4 class="teaser__title">
-                  {{ tag.name }}
-                </h4>
-
-                <div class="teaser__related-content">
-                  {% trans %} 1 item {% plural tag.related_entity_count %} @count items{% endtrans %}
-                  {% if term.followers_count %}
-                    |
-                    <span class="teaser__followers-count">
-                    {% trans %} 1 follower {% plural tag.followers_count %} @count followers{% endtrans %}
-                    </span>
-                  {% endif %}
-                </div>
-
-                <div class="actions">
-                  {{ tag.flag }}
-                  {% if(tag.url) %}
-                    <a href="{{ tag.url }}" class="btn btn-default">
-                      {% trans %}See related content{% endtrans %}
-                    </a>
-                  {% endif %}
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
+        {{ tag.popup }}
       </div>
     {% endfor %}
   </div>

--- a/modules/social_features/social_follow_taxonomy/modules/social_follow_tag/templates/social-tagging-popup.html.twig
+++ b/modules/social_features/social_follow_taxonomy/modules/social_follow_tag/templates/social-tagging-popup.html.twig
@@ -1,0 +1,50 @@
+{#
+/**
+ * @social-tagging-popup.html.twig
+ * Default theme implementation to present follow taxonomy popup.
+ *
+ * This template is used when viewing follow tag block.
+ *
+ *
+ * Available variables:
+ * - url: Lisk to search page with related entities.
+ * - name: Taxonomy term name.
+ * - flag: Link to follow/unfollow tag.
+ * - followers_count: Countt of users tthat follow that tag.
+ * - related_entity_count: Count of related entities.
+ *
+ * @ingroup themeable
+ */
+#}
+<div class="popup-info">
+  <div class="card teaser">
+    <div class="teaser__body">
+      <div class="teaser__content">
+        <div class="teaser__tag">{% trans %}TAG{% endtrans %}</div>
+
+        <h4 class="teaser__title">
+          {{ name }}
+        </h4>
+
+        <div class="teaser__related-content">
+          {% trans %} 1 item {% plural related_entity_count %} @count items{% endtrans %}
+          {% if followers_count %}
+            |
+            <span class="teaser__followers-count">
+                      {% trans %} 1 follower {% plural followers_count %} @count followers{% endtrans %}
+                      </span>
+          {% endif %}
+        </div>
+
+        <div class="actions">
+          {{ flag }}
+          {% if(url) %}
+            <a href="{{ url }}" class="btn btn-default">
+              {% trans %}See related content{% endtrans %}
+            </a>
+          {% endif %}
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/modules/social_features/social_follow_taxonomy/modules/social_follow_tag/templates/social-tagging-split.html.twig
+++ b/modules/social_features/social_follow_taxonomy/modules/social_follow_tag/templates/social-tagging-split.html.twig
@@ -31,38 +31,7 @@
               </g>
             </svg>
           </a>
-          <div class="popup-info">
-            <div class="card teaser">
-              <div class="teaser__body">
-                <div class="teaser__content">
-                  <div class="teaser__tag">{% trans %}TAG{% endtrans %}</div>
-
-                  <h4 class="teaser__title">
-                    {{ tag.name }}
-                  </h4>
-
-                  <div class="teaser__related-content">
-                    {% trans %} 1 item {% plural tag.related_entity_count %} @count items{% endtrans %}
-                    {% if term.followers_count %}
-                      |
-                      <span class="teaser__followers-count">
-                      {% trans %} 1 follower {% plural tag.followers_count %} @count followers{% endtrans %}
-                      </span>
-                    {% endif %}
-                  </div>
-
-                  <div class="actions">
-                    {{ tag.flag }}
-                    {% if(tag.url) %}
-                      <a href="{{ tag.url }}" class="btn btn-default">
-                        {% trans %}See related content{% endtrans %}
-                      </a>
-                    {% endif %}
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
+          {{ tag.popup }}
         </div>
       {% endfor %}
     </div>


### PR DESCRIPTION
## Problem
Improve Follow taxonomy block performance and extendability

## Solution
Implement Lazy Load or AJAX for a popup with counters for performance improvements. Count followed users and related content inside the popup rendering instead of block preprocess.

## Issue tracker
https://www.drupal.org/project/social/issues/3198528
https://getopensocial.atlassian.net/browse/YANG-4810

## How to test
N/A

## Screenshots
N/A

## Release notes
Popup for the following taxonomy badges now loads through the lazy builder.
All counts are calculated in popup rendering.

## Change Record
N/A

## Translations
N/A
