### PR TITLE
by ronaldtebrake, robertragas, jochemvn: fix a check that when updati…

### DIFF
--- a/modules/social_features/social_event/social_event.module
+++ b/modules/social_features/social_event/social_event.module
@@ -918,14 +918,14 @@ function social_event_entity_operation_alter(array &$operations, EntityInterface
  * Delete the event enrollments request if type is changed to directly.
  */
 function social_event_node_update(EntityInterface $entity) {
-  if ($entity->getType() === 'event') {
+  if ($entity instanceof NodeInterface && $entity->getType() === 'event') {
     $enroll_state_original = $entity->original->get('field_enroll_method')->getString();
-
+    $enroll_new_state = $entity->get('field_enroll_method')->getString();
     // If the request to enroll was turned off then delete the request.
-    if ((int) $enroll_state_original === 2) {
+    if ((int) $enroll_state_original === 2 && (int) $enroll_new_state !== 2) {
       /** @var \Drupal\social_event\EventEnrollmentStatusHelper $enrollments */
       $enrollments = \Drupal::service('social_event.status_helper');
-
+      /** @var \Drupal\social_event\Entity\EventEnrollment $enrollment */
       foreach ($enrollments->getAllEventEnrollments($entity->id(), TRUE) as $enrollment) {
         // Check if the field is not empty before getting the value,
         // Since (int) will otherwise return 0 and give false positives.
@@ -936,6 +936,7 @@ function social_event_node_update(EntityInterface $entity) {
     }
   }
 }
+
 
 /**
  * Implements template_preprocess_views_view().


### PR DESCRIPTION
## Problem
With events you can let users request to join an event. When there are open requests and you update the node, these requests are gone.

## Solution
The social event module has a protection to keep pending enrollments when changed from request to enroll to invite only, but this does not sufficiently check the state. This check also needs to keep the current state in mind, not only the original.

## Issue tracker
*Paste a link to the drupal.org issue queue item. If any other issue trackers were used, include links to those too.*

## How to test
- [ ] Create an event with request to enroll
- [ ] Enroll to the event as another user
- [ ] Check the event and see someone requested...now edit the node and update the description.
- [ ] See that the request enrollment is gone
- [ ] Check out to this branch and see it stays now

## Release notes
We solved an issue where if you have an event with pending enrollment request, it would delete those requests after updating the event itself with for example the description or title.
