### PR TITLE
Issue #3199157 by rolki: Use group_content storage instead of groupInvitationLoader service for checking invitation

### DIFF
--- a/modules/social_features/social_group/modules/social_group_invite/src/Form/SocialBulkGroupInvitation.php
+++ b/modules/social_features/social_group/modules/social_group_invite/src/Form/SocialBulkGroupInvitation.php
@@ -321,6 +321,7 @@ class SocialBulkGroupInvitation extends BulkGroupInvitation {
           }
         }
         else {
+          /** @var \Drupal\group\Entity\Storage\GroupContentStorageInterface $group_content_storage */
           $group_content_storage = $this->entityTypeManager->getStorage('group_content');
           // If the invitation has already been send, unset it from the list.
           // For some reason groupInvitationLoader service doesn't work

--- a/modules/social_features/social_group/modules/social_group_invite/src/Form/SocialBulkGroupInvitation.php
+++ b/modules/social_features/social_group/modules/social_group_invite/src/Form/SocialBulkGroupInvitation.php
@@ -321,7 +321,7 @@ class SocialBulkGroupInvitation extends BulkGroupInvitation {
           }
         }
         else {
-          /** @var \Drupal\group\Entity\GroupContentInterface $group_content_storage */
+          /** @var \Drupal\group\Entity\GroupContent $group_content_storage */
           $group_content_storage = $this->entityTypeManager->getStorage('group_content');
           // If the invitation has already been send, unset it from the list.
           // For some reason groupInvitationLoader service doesn't work

--- a/modules/social_features/social_group/modules/social_group_invite/src/Form/SocialBulkGroupInvitation.php
+++ b/modules/social_features/social_group/modules/social_group_invite/src/Form/SocialBulkGroupInvitation.php
@@ -321,6 +321,7 @@ class SocialBulkGroupInvitation extends BulkGroupInvitation {
           }
         }
         else {
+          /** @var \Drupal\group\Entity\GroupContentInterface $group_content_storage */
           $group_content_storage = $this->entityTypeManager->getStorage('group_content');
           // If the invitation has already been send, unset it from the list.
           // For some reason groupInvitationLoader service doesn't work

--- a/modules/social_features/social_group/modules/social_group_invite/src/Form/SocialBulkGroupInvitation.php
+++ b/modules/social_features/social_group/modules/social_group_invite/src/Form/SocialBulkGroupInvitation.php
@@ -321,7 +321,6 @@ class SocialBulkGroupInvitation extends BulkGroupInvitation {
           }
         }
         else {
-          /** @var \Drupal\group\Entity\GroupContent $group_content_storage */
           $group_content_storage = $this->entityTypeManager->getStorage('group_content');
           // If the invitation has already been send, unset it from the list.
           // For some reason groupInvitationLoader service doesn't work

--- a/modules/social_features/social_group/modules/social_group_invite/src/Form/SocialBulkGroupInvitation.php
+++ b/modules/social_features/social_group/modules/social_group_invite/src/Form/SocialBulkGroupInvitation.php
@@ -321,8 +321,11 @@ class SocialBulkGroupInvitation extends BulkGroupInvitation {
           }
         }
         else {
+          $group_content_storage = $this->entityTypeManager->getStorage('group_content');
           // If the invitation has already been send, unset it from the list.
-          if ($this->groupInvitationLoader->loadByGroup($this->group, NULL, $email)) {
+          // For some reason groupInvitationLoader service doesn't work
+          // properly.
+          if (!empty($group_content_storage->loadByGroup($this->group, 'group_invitation', ['invitee_mail' => $email]))) {
             $form_state->unsetValue(['users_fieldset', 'user', $user]);
           }
         }
@@ -449,6 +452,11 @@ class SocialBulkGroupInvitation extends BulkGroupInvitation {
     // Remove select2 ID parameter.
     $string = str_replace('$ID:', '', $string);
     preg_match_all("/[\._a-zA-Z0-9+-]+@[\._a-zA-Z0-9+-]+/i", $string, $matches);
+
+    if (is_array($matches[0]) && count($matches[0]) === 1) {
+      return reset($matches[0]);
+    }
+
     return $matches[0];
   }
 


### PR DESCRIPTION
## Problem
Group invite doesn't work in the latest OS version for new users

## Solution
It seems the problem in the `groupInvitationLoader` service, it returns wrong results, so as around way we can use group content storage to check if the user was already invited or not.

## Issue tracker
- https://getopensocial.atlassian.net/browse/YANG-4986
- https://www.drupal.org/project/social/issues/3199157

## How to test
- [ ] Go to the "Manager members" tab on some flexible group
- [ ] Click "Add members" and then "Invite members"
- [ ] Enter some mail for not existing member
- [ ] That member should receive an email notification

## Screenshots
![image](https://user-images.githubusercontent.com/50984627/108341840-c7965d80-71e2-11eb-8508-9ff2d1fa9752.png)
![image](https://user-images.githubusercontent.com/50984627/108341865-cfee9880-71e2-11eb-9c03-aa7c4e7d0df6.png)
![image](https://user-images.githubusercontent.com/50984627/108341938-e1d03b80-71e2-11eb-9786-441656dcb827.png)
