### PR TITLE
Issue #3198953 by ribel: As a LU I want to be able to filter on the all members overview page

### DIFF
--- a/modules/social_features/social_profile/config/install/views.view.newest_users.yml
+++ b/modules/social_features/social_profile/config/install/views.view.newest_users.yml
@@ -359,6 +359,7 @@ display:
         title: false
       display_description: ''
       title: 'All members'
+      exposed_block: true
     cache_metadata:
       max-age: -1
       contexts:

--- a/modules/social_features/social_profile/config/optional/block.block.exposedformnewest_userspage_newest_users.yml
+++ b/modules/social_features/social_profile/config/optional/block.block.exposedformnewest_userspage_newest_users.yml
@@ -1,4 +1,3 @@
-uuid: f11d766f-b9dd-48b6-b5c0-7b7f5a13da79
 langcode: en
 status: true
 dependencies:

--- a/modules/social_features/social_profile/config/optional/block.block.exposedformnewest_userspage_newest_users.yml
+++ b/modules/social_features/social_profile/config/optional/block.block.exposedformnewest_userspage_newest_users.yml
@@ -1,0 +1,29 @@
+uuid: f11d766f-b9dd-48b6-b5c0-7b7f5a13da79
+langcode: en
+status: true
+dependencies:
+  config:
+    - views.view.newest_users
+  module:
+    - system
+    - views
+  theme:
+    - socialbase
+id: exposedformnewest_userspage_newest_users
+theme: socialbase
+region: complementary_top
+weight: 0
+provider: null
+plugin: 'views_exposed_filter_block:newest_users-page_newest_users'
+settings:
+  id: 'views_exposed_filter_block:newest_users-page_newest_users'
+  label: ''
+  provider: views
+  label_display: visible
+  views_label: Filter
+visibility:
+  request_path:
+    id: request_path
+    pages: /all-members
+    negate: false
+    context_mapping: {  }

--- a/modules/social_features/social_profile/config/optional/block.block.socialblue_exposedformnewest_userspage_newest_users.yml
+++ b/modules/social_features/social_profile/config/optional/block.block.socialblue_exposedformnewest_userspage_newest_users.yml
@@ -1,0 +1,29 @@
+uuid: f11d766f-b9dd-48b6-b5c0-7b7f5a13da79
+langcode: en
+status: true
+dependencies:
+  config:
+    - views.view.newest_users
+  module:
+    - system
+    - views
+  theme:
+    - socialblue
+id: socialblue_exposedformnewest_userspage_newest_users
+theme: socialblue
+region: complementary_top
+weight: 0
+provider: null
+plugin: 'views_exposed_filter_block:newest_users-page_newest_users'
+settings:
+  id: 'views_exposed_filter_block:newest_users-page_newest_users'
+  label: ''
+  provider: views
+  label_display: visible
+  views_label: Filter
+visibility:
+  request_path:
+    id: request_path
+    pages: /all-members
+    negate: false
+    context_mapping: {  }

--- a/modules/social_features/social_profile/config/optional/block.block.socialblue_exposedformnewest_userspage_newest_users.yml
+++ b/modules/social_features/social_profile/config/optional/block.block.socialblue_exposedformnewest_userspage_newest_users.yml
@@ -1,4 +1,3 @@
-uuid: f11d766f-b9dd-48b6-b5c0-7b7f5a13da79
 langcode: en
 status: true
 dependencies:

--- a/modules/social_features/social_profile/config/static/block.block.exposedformnewest_userspage_newest_users_8901.yml
+++ b/modules/social_features/social_profile/config/static/block.block.exposedformnewest_userspage_newest_users_8901.yml
@@ -1,4 +1,3 @@
-uuid: f11d766f-b9dd-48b6-b5c0-7b7f5a13da79
 langcode: en
 status: true
 dependencies:

--- a/modules/social_features/social_profile/config/static/block.block.exposedformnewest_userspage_newest_users_8901.yml
+++ b/modules/social_features/social_profile/config/static/block.block.exposedformnewest_userspage_newest_users_8901.yml
@@ -1,0 +1,29 @@
+uuid: f11d766f-b9dd-48b6-b5c0-7b7f5a13da79
+langcode: en
+status: true
+dependencies:
+  config:
+    - views.view.newest_users
+  module:
+    - system
+    - views
+  theme:
+    - socialbase
+id: exposedformnewest_userspage_newest_users
+theme: socialbase
+region: complementary_top
+weight: 0
+provider: null
+plugin: 'views_exposed_filter_block:newest_users-page_newest_users'
+settings:
+  id: 'views_exposed_filter_block:newest_users-page_newest_users'
+  label: ''
+  provider: views
+  label_display: visible
+  views_label: Filter
+visibility:
+  request_path:
+    id: request_path
+    pages: /all-members
+    negate: false
+    context_mapping: {  }

--- a/modules/social_features/social_profile/config/static/block.block.socialblue_exposedformnewest_userspage_newest_users_8901.yml
+++ b/modules/social_features/social_profile/config/static/block.block.socialblue_exposedformnewest_userspage_newest_users_8901.yml
@@ -1,0 +1,29 @@
+uuid: f11d766f-b9dd-48b6-b5c0-7b7f5a13da79
+langcode: en
+status: true
+dependencies:
+  config:
+    - views.view.newest_users
+  module:
+    - system
+    - views
+  theme:
+    - socialblue
+id: socialblue_exposedformnewest_userspage_newest_users
+theme: socialblue
+region: complementary_top
+weight: 0
+provider: null
+plugin: 'views_exposed_filter_block:newest_users-page_newest_users'
+settings:
+  id: 'views_exposed_filter_block:newest_users-page_newest_users'
+  label: ''
+  provider: views
+  label_display: visible
+  views_label: Filter
+visibility:
+  request_path:
+    id: request_path
+    pages: /all-members
+    negate: false
+    context_mapping: {  }

--- a/modules/social_features/social_profile/config/static/block.block.socialblue_exposedformnewest_userspage_newest_users_8901.yml
+++ b/modules/social_features/social_profile/config/static/block.block.socialblue_exposedformnewest_userspage_newest_users_8901.yml
@@ -1,4 +1,3 @@
-uuid: f11d766f-b9dd-48b6-b5c0-7b7f5a13da79
 langcode: en
 status: true
 dependencies:

--- a/modules/social_features/social_profile/config/update/social_profile_update_8902.yml
+++ b/modules/social_features/social_profile/config/update/social_profile_update_8902.yml
@@ -1,0 +1,8 @@
+views.view.newest_users:
+  expected_config: {  }
+  update_actions:
+    add:
+      display:
+        page_newest_users:
+          display_options:
+            exposed_block: true

--- a/modules/social_features/social_profile/social_profile.install
+++ b/modules/social_features/social_profile/social_profile.install
@@ -457,3 +457,17 @@ function social_profile_update_8901() {
     }
   }
 }
+
+/**
+ * Enable exposed filters block on all-members views.
+ */
+function social_profile_update_8902() {
+  /** @var \Drupal\update_helper\Updater $updateHelper */
+  $updateHelper = \Drupal::service('update_helper.updater');
+
+  // Execute configuration update definitions with logging of success.
+  $updateHelper->executeUpdate('social_profile', 'social_profile_update_8902');
+
+  // Output logged messages to related channel of update execution.
+  return $updateHelper->logger()->output();
+}

--- a/modules/social_features/social_profile/social_profile.install
+++ b/modules/social_features/social_profile/social_profile.install
@@ -446,7 +446,6 @@ function social_profile_update_8901() {
     'block.block.socialblue_exposedformnewest_userspage_newest_users' => drupal_get_path('module', 'social_profile') . '/config/static/block.block.socialblue_exposedformnewest_userspage_newest_users_8901.yml',
   ];
 
-
   foreach ($config_files as $key => $config_file) {
     if (is_file($config_file)) {
       $settings = Yaml::parse(file_get_contents($config_file));

--- a/modules/social_features/social_profile/social_profile.install
+++ b/modules/social_features/social_profile/social_profile.install
@@ -15,6 +15,7 @@ use Drupal\block\Entity\Block;
 use Drupal\profile\Entity\Profile;
 use Drupal\profile\Entity\ProfileType;
 use Drupal\user\Entity\User;
+use Symfony\Component\Yaml\Yaml;
 
 /**
  * Implements hook_install().
@@ -432,4 +433,28 @@ function social_profile_update_8803() {
 
   // Output logged messages to related channel of update execution.
   return $updateHelper->logger()->output();
+}
+
+/**
+ * Add a new block to display filters (social_tagging) on all-members page.
+ *
+ * Load in a config file from an specific update hook that will never change.
+ */
+function social_profile_update_8901() {
+  $config_files = [
+    'block.block.exposedformnewest_userspage_newest_users' => drupal_get_path('module', 'social_profile') . '/config/static/block.block.exposedformnewest_userspage_newest_users_8901.yml',
+    'block.block.socialblue_exposedformnewest_userspage_newest_users' => drupal_get_path('module', 'social_profile') . '/config/static/block.block.socialblue_exposedformnewest_userspage_newest_users_8901.yml',
+  ];
+
+
+  foreach ($config_files as $key => $config_file) {
+    if (is_file($config_file)) {
+      $settings = Yaml::parse(file_get_contents($config_file));
+      if (is_array($settings)) {
+        $config = \Drupal::configFactory()
+          ->getEditable($key);
+        $config->setData($settings)->save(TRUE);
+      }
+    }
+  }
 }

--- a/modules/social_features/social_profile/social_profile.module
+++ b/modules/social_features/social_profile/social_profile.module
@@ -871,7 +871,7 @@ function social_profile_profile_access(EntityInterface $entity, $operation, Acco
 }
 
 /**
- * Custom permission check, to see if people have access to users' topics.
+ * Show exposed filters block only when tagging filters are enabled for profile.
  *
  * Implements hook_block_access().
  */

--- a/modules/social_features/social_profile/social_profile.module
+++ b/modules/social_features/social_profile/social_profile.module
@@ -23,6 +23,7 @@ use Drupal\profile\Entity\ProfileType;
 use Drupal\user\Entity\User;
 use Drupal\user\UserInterface;
 use Drupal\social_profile\SocialProfileUserFormAlter;
+use Drupal\block\Entity\Block;
 
 define('SOCIAL_PROFILE_SUGGESTIONS_USERNAME', 'username');
 define('SOCIAL_PROFILE_SUGGESTIONS_FULL_NAME', 'full_name');
@@ -141,6 +142,7 @@ function social_profile_form_profile_profile_edit_form_alter(array &$form, FormS
     if ($profile_fields) {
       $empty_profile = TRUE;
 
+      /** @var \Drupal\field\Entity\FieldConfig $field_config */
       foreach ($profile_fields as $field) {
         if (isset($form[$field->get('field_name')]) && $form[$field->get('field_name')]['#access'] === TRUE) {
           $empty_profile = FALSE;
@@ -867,4 +869,26 @@ function social_profile_profile_access(EntityInterface $entity, $operation, Acco
   ) {
     return AccessResult::allowed();
   }
+}
+
+/**
+ * Custom permission check, to see if people have access to users' topics.
+ *
+ * Implements hook_block_access().
+ */
+function social_profile_block_access(Block $block, $operation, AccountInterface $account) {
+  if ($operation === 'view' && ($block->getPluginId() === 'views_exposed_filter_block:newest_users-page_newest_users')) {
+    $access = AccessResult::forbidden();
+    if (\Drupal::moduleHandler()->moduleExists('social_tagging')) {
+      /** @var \Drupal\social_tagging\SocialTaggingService $tag_service */
+      $tag_service = \Drupal::service('social_tagging.tag_service');
+      if ($tag_service->profileActive()) {
+        $access = AccessResult::allowed();
+      }
+    }
+    return $access;
+  }
+
+  // No opinion.
+  return AccessResult::neutral();
 }

--- a/modules/social_features/social_profile/social_profile.module
+++ b/modules/social_features/social_profile/social_profile.module
@@ -142,7 +142,6 @@ function social_profile_form_profile_profile_edit_form_alter(array &$form, FormS
     if ($profile_fields) {
       $empty_profile = TRUE;
 
-      /** @var \Drupal\field\Entity\FieldConfig $field_config */
       foreach ($profile_fields as $field) {
         if (isset($form[$field->get('field_name')]) && $form[$field->get('field_name')]['#access'] === TRUE) {
           $empty_profile = FALSE;

--- a/modules/social_features/social_tagging/social_tagging.module
+++ b/modules/social_features/social_tagging/social_tagging.module
@@ -428,6 +428,7 @@ function social_tagging_form_views_exposed_form_alter(&$form, FormStateInterface
     'views-exposed-form-group-topics-page-group-topics',
     'views-exposed-form-group-events-page-group-events',
     'views-exposed-form-newest-groups-page-all-groups',
+    'views-exposed-form-newest-users-page-newest-users',
   ];
 
   // Must be either one of these form_ids.

--- a/modules/social_features/social_tagging/src/SocialTaggingOverrides.php
+++ b/modules/social_features/social_tagging/src/SocialTaggingOverrides.php
@@ -38,6 +38,7 @@ class SocialTaggingOverrides implements ConfigFactoryOverrideInterface {
       'views.view.group_topics',
       'views.view.group_events',
       'views.view.newest_groups',
+      'views.view.newest_users',
       'core.entity_view_display.profile.profile.default',
     ];
 
@@ -237,6 +238,10 @@ class SocialTaggingOverrides implements ConfigFactoryOverrideInterface {
       'views.view.newest_groups' => 'page_all_groups',
     ];
 
+    if ($tag_service->profileActive()) {
+      $config_overviews['views.view.newest_users'] = 'default';
+    }
+
     foreach ($config_overviews as $config_name => $display) {
       if (in_array($config_name, $names)) {
 
@@ -253,6 +258,10 @@ class SocialTaggingOverrides implements ConfigFactoryOverrideInterface {
 
         $relationship = ($config_name === 'views.view.group_topics' || $config_name === 'views.view.group_events') ? 'gc__node' : 'none';
         $table = ($config_name === 'views.view.newest_groups') ? 'group__social_tagging' : 'node__social_tagging';
+
+        if ($tag_service->profileActive()) {
+          $table = 'profile__social_tagging';
+        }
 
         foreach ($fields as $field => $data) {
           $overrides[$config_name]['display'][$display]['display_options']['filters'][$field] = [


### PR DESCRIPTION
## Problem
The profile tags are not showing up in the all members tab.
There is no filter, where you can filter out the tags created.

## Solution
Display social tagging filters on all members page.
Valid only if they are enabled for the profile.
Reuse functionality from all topics overview page.

## Issue tracker
- https://www.drupal.org/project/social/issues/3198953
- https://getopensocial.atlassian.net/browse/YANG-4909
- https://github.com/goalgorilla/open_social/pull/2137

## How to test
*For example*
- [ ] Using version 10.0 of Open Social with the Social Tagging module enabled
- [ ] As SM enable Profile in Social Tagging settings
- [ ] You should be able to use filters on the all-members page
- [ ] As SM disable Profile in Social Tagging settings
- [ ] You should not see filters on the all-members page

## Screenshots
![image](https://user-images.githubusercontent.com/2241917/108224459-9d419300-7143-11eb-848c-d62c6ce9e17f.png)

## Release notes
Add filters block when social tags on profile are enabled to the all members overview page.

## Change Record
- N/A

## Translations
- N/A
