### PR TITLE
Issue #3196407: Lets add a test to install Open Social through the browser

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -79,6 +79,8 @@ script:
   - if [ "$TEST_SUITE" = "install_stability_4" ]; then docker exec -it social_ci_behat sh /var/www/scripts/social/behatstability.sh "stability-4 --stop-on-failure --strict"; fi
   - if [ "$TEST_SUITE" = "install_update" ]; then docker exec -it social_ci_behat sh /var/www/scripts/social/behatstability.sh "stability-1&&~DS-1136&&~DS-3605 --stop-on-failure --strict"; fi
   - if [ "$TEST_SUITE" = "install_without_optional" ]; then docker exec -it social_ci_behat sh /var/www/scripts/social/behatstability.sh "stability-1&&~DS-1136&&~DS-3605 --stop-on-failure --strict"; fi
+  # For install_stability_1 we also run Drupal UI install tests, for that we need to reset the database etc.
+  - if [ "$TEST_SUITE" = "install_stability_1" ]; then docker exec -it social_ci_behat sh /var/www/scripts/social/behatstability.sh "install --stop-on-failure --strict"; fi
   - if [ "$TEST_SUITE" = "accessibility" ]; then docker exec -it social_ci_web bash /var/www/scripts/social/check-accessibility.sh install; fi
 
 after_success:

--- a/tests/behat/features/bootstrap/FeatureContext.php
+++ b/tests/behat/features/bootstrap/FeatureContext.php
@@ -64,7 +64,7 @@ class FeatureContext extends RawMinkContext implements Context
     }
 
   /**
-   * @AfterScenario
+   * @AfterScenario @tour
    *
    * @param $event
    */

--- a/tests/behat/features/bootstrap/SocialDrupalContext.php
+++ b/tests/behat/features/bootstrap/SocialDrupalContext.php
@@ -3,6 +3,7 @@
 
 namespace Drupal\social\Behat;
 
+use Behat\Mink\Element\NodeElement;
 use Drupal\DrupalExtension\Context\DrupalContext;
 use Drupal\user\Entity\User;
 use Drupal\big_pipe\Render\Placeholder\BigPipeStrategy;
@@ -24,7 +25,7 @@ class SocialDrupalContext extends DrupalContext {
    * Original PR here:
    * https://github.com/jhedstrom/drupalextension/pull/325
    *
-   * @BeforeScenario
+   * @BeforeScenario @api
    */
   public function prepareBigPipeNoJsCookie(BeforeScenarioScope $scope) {
     // Start a session if not already done.
@@ -329,6 +330,20 @@ class SocialDrupalContext extends DrupalContext {
   }
 
   /**
+   * @Given I reset the Open Social install
+   */
+  public function iResetOpenSocial()
+  {
+    $schema = \Drupal::database()->schema();
+    $tables = $schema->findTables('%');
+    if ($tables) {
+      foreach ($tables as $key => $table_name) {
+        $schema->dropTable($table_name);
+      }
+    }
+  }
+
+  /**
    * @Given I am logged in as :name with the :permissions permission(s)
    */
   public function assertLoggedInWithPermissionsByName($name, $permissions) {
@@ -349,5 +364,48 @@ class SocialDrupalContext extends DrupalContext {
     // Login.
     $this->login($user);
   }
+
+  /**
+   * Task is done.
+   *
+   * @Then /^task "([^"]*)" is done$/
+   */
+  public function taskIsDone($text) {
+    $doneTask = [
+      'Choose language'                        => 'body > div > div > aside > ol > li:nth-child(1)',
+      'Verify requirements'                    => 'body > div > div > aside > ol > li:nth-child(2)',
+      'Set up database'                        => 'body > div > div > aside > ol > li:nth-child(3)',
+      'Select optional modules'                => 'body > div > div > aside > ol > li:nth-child(4)',
+      'Install site'                           => 'body > div > div > aside > ol > li:nth-child(5)',
+      'Configure site'                         => 'body > div > div > aside > ol > li:nth-child(6)',
+    ];
+
+    // En sure we have our task set.
+    $task = $this->getSession()->getPage()->findAll('css', $doneTask[$text]);
+
+    if ($task === NULL) {
+      throw new \InvalidArgumentException(sprintf('Could not evaluate CSS selector: "%s"', $doneTask[$text]));
+    }
+
+    /** @var NodeElement $result */
+    foreach ($task as $result) {
+      if ($result->hasClass('done')) {
+        break;
+      }
+    }
+  }
+
+  /**
+   * Wait for the Batch API to finish.
+   *
+   * Wait until the id="updateprogress" element is gone,
+   * or timeout after 30 minutes (1800000 ms).
+   *
+   * @Given /^I wait for the installer to finish$/
+   */
+  public function iWaitForTheInstallerBatchJobToFinish() {
+    $this->getSession()->wait(1800000, 'jQuery("#updateprogress").length === 0');
+  }
+
 
 }

--- a/tests/behat/features/capabilities/install/install.feature
+++ b/tests/behat/features/capabilities/install/install.feature
@@ -1,0 +1,46 @@
+@install @stability
+  Feature: Install through web UI
+  Benefit: In order to let our Drupal users install through the interface
+  Role: AN
+  Goal/desire: Intall Open Social
+
+  Scenario: I want to install Open Social via the web browser
+    Given I reset the Open Social install
+    And I am on "/core/install.php"
+    And I should see "Open Social"
+    And I press the "Save and continue" button
+    Then I should see "Requirements review"
+    And task "Choose language" is done
+    And I should see "continue anyway"
+    When I follow "continue anyway"
+    Then task "Verify requirements" is done
+#    This is already coming from our settings.php, no need to test it but for clarity:
+#    Then I fill in "edit-mysql-database" with "social"
+#    Then I fill in "edit-mysql-username" with "root"
+#    Then I fill in "edit-mysql-password" with "root"
+#    Then I fill in "edit-mysql-host" with "db"
+#    Then I fill in "edit-mysql-port" with "3306"
+#    Then I submit the form
+    And task "Set up database" is done
+
+    And I should see "Install optional modules"
+    And I should see "enable additional features"
+    And I should see checked the box "edit-optional-modules-social-group-flexible-group"
+    And I should see unchecked the box "edit-optional-modules-social-wootric"
+    When I press the "Save and continue" button
+    Then I should see "Installing Open Social"
+    And I wait for the installer to finish
+
+    Then I should see "Configure site"
+    And I fill in "site_name" with "Some site name"
+    And I fill in "site_mail" with "site@example.com"
+    And I fill in "edit-account-name" with "admin"
+    And I fill in "edit-account-pass-pass1" with "password"
+    And I fill in "edit-account-pass-pass2" with "password"
+    And I fill in "edit-account-mail" with "admin@example.com"
+
+    And I uncheck the box "edit-enable-update-status-emails"
+    And I uncheck the box "edit-enable-update-status-module"
+    And I press the "Save and continue" button
+    Then task "Configure site" is done
+    And I am on the homepage


### PR DESCRIPTION
## Problem
Eventhough we tend to stick to Drush there is always also the opportunity to install Open Social to the browser, however we are lacking a browser test here.

## Solution
Add a new install step to re-install through the Browser, to see if that helps.

## Issue tracker
It's already a closed issue I'm re-using to assign it to a discussion there:
https://www.drupal.org/project/social/issues/3196407

## How to test
- [ ] Think about any additional things we can test on web install
- [ ] Let travis go green to ensure it all works

## Screenshots
<img width="573" alt="Screenshot 2021-02-18 at 16 02 21" src="https://user-images.githubusercontent.com/16667281/108375921-b52c1c00-7202-11eb-8a42-8b73161169aa.png">


## Release notes
[Internal] We are now running a behat test to check if we can (re)install Open Social through the browser including optional modules.
