### PR TITLE
Issue #3199146: [GraphQL] Improve Violation representation

### DIFF
--- a/modules/custom/social_graphql/graphql/open_social.graphqls
+++ b/modules/custom/social_graphql/graphql/open_social.graphqls
@@ -53,6 +53,13 @@ A valid URL
 scalar Url
 
 """
+A UNIX timestamp.
+
+The number of seconds since the Unix Epoch on January 1st, 1970 at UTC.
+"""
+scalar Timestamp
+
+"""
 A phone number.
 """
 # For now we treat PhoneNumber as a special string but we may want to build it
@@ -108,11 +115,8 @@ A date and time.
 type DateTime {
   """
   The date and time as UNIX timestamp.
-
-  A UNIX timestamp is the number of seconds since the Unix Epoch
-  on January 1st, 1970 at UTC.
   """
-  timestamp: Int!
+  timestamp: Timestamp!
 }
 
 ################################################################################

--- a/modules/custom/social_graphql/src/GraphQL/ResolverRegistry.php
+++ b/modules/custom/social_graphql/src/GraphQL/ResolverRegistry.php
@@ -3,6 +3,7 @@
 namespace Drupal\social_graphql\GraphQL;
 
 use Drupal\graphql\GraphQL\Execution\ResolveContext;
+use Drupal\graphql\GraphQL\ResolverBuilder;
 use Drupal\graphql\GraphQL\ResolverRegistry as ResolverRegistryBase;
 use GraphQL\Type\Definition\ResolveInfo;
 
@@ -22,6 +23,47 @@ class ResolverRegistry extends ResolverRegistryBase {
    */
   public function getAllFieldResolvers() : array {
     return $this->fieldResolvers;
+  }
+
+  /**
+   * Add a field resolver for a mutation field.
+   *
+   * Calling this function is equivalent to writing out the following code
+   * manually:
+   *
+   * ```
+   * $field_name = camelCaseTOsnake_case($fieldName);
+   * $this->addFieldResolver('Mutation', $fieldName,
+   *   $builder->compose(
+   *     $builder->produce($field_name . "_input")
+   *       ->map('input', $builder->fromArgument('input')),
+   *     $builder->produce($field_name)
+   *       ->map('input', $builder->fromParent())
+   *   )
+   * );
+   * ```
+   *
+   * @param \Drupal\graphql\GraphQL\ResolverBuilder $builder
+   *   The resolver builder.
+   * @param string $field_name
+   *   A camelCased field name. This will be converted into snake_case for the
+   *   IDs of the used data producers.
+   */
+  public function addMutationResolver(ResolverBuilder $builder, string $field_name) : void {
+    $words = array_map(
+      'strtolower',
+      preg_split('/(?=[A-Z])/', $field_name, -1, PREG_SPLIT_NO_EMPTY)
+    );
+    $data_producer = implode("_", $words);
+
+    $this->addFieldResolver('Mutation', $field_name,
+      $builder->compose(
+        $builder->produce($data_producer . "_input")
+          ->map('input', $builder->fromArgument('input')),
+        $builder->produce($data_producer)
+          ->map('input', $builder->fromParent())
+      )
+    );
   }
 
   /**

--- a/modules/custom/social_graphql/src/GraphQL/Violation.php
+++ b/modules/custom/social_graphql/src/GraphQL/Violation.php
@@ -33,4 +33,15 @@ class Violation implements ViolationInterface {
     return $this->id;
   }
 
+  /**
+   * Magic method called during serialization to string.
+   *
+   * @return string
+   *   String representation of the object
+   */
+  public function __toString() : string {
+    $encoded = json_encode($this);
+    return $encoded === FALSE ? "" : $encoded;
+  }
+
 }

--- a/modules/custom/social_graphql/src/Plugin/GraphQL/DataProducer/Payload/PayloadViolations.php
+++ b/modules/custom/social_graphql/src/Plugin/GraphQL/DataProducer/Payload/PayloadViolations.php
@@ -5,6 +5,7 @@ namespace Drupal\social_graphql\Plugin\GraphQL\DataProducer\Payload;
 use Drupal\graphql\Plugin\DataProducerPluginCachingInterface;
 use Drupal\graphql\Plugin\GraphQL\DataProducer\DataProducerPluginBase;
 use Drupal\social_graphql\GraphQL\Payload\PayloadInterface;
+use Drupal\social_graphql\GraphQL\ViolationInterface;
 
 /**
  * Returns the violations in a payload.
@@ -38,7 +39,7 @@ class PayloadViolations extends DataProducerPluginBase implements DataProducerPl
     // Explicitly turn empty arrays into NULL so that clients can perform an
     // is_null check to figure out if there are errors.
     $violations = $payload->getViolations();
-    return empty($violations) ? NULL : $violations;
+    return empty($violations) ? NULL : array_map(fn (ViolationInterface $v) => $v->jsonSerialize(), $violations);
   }
 
 }

--- a/modules/social_features/social_user/src/Plugin/GraphQL/DataProducer/UserFromWrapper.php
+++ b/modules/social_features/social_user/src/Plugin/GraphQL/DataProducer/UserFromWrapper.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Drupal\social_user\Plugin\GraphQL\DataProducer;
+
+use Drupal\graphql\Plugin\GraphQL\DataProducer\DataProducerPluginBase;
+use Drupal\social_user\Wrappers\UserAwareInterface;
+use Drupal\user\UserInterface;
+
+/**
+ * Get the user information from a relationship.
+ *
+ * @DataProducer(
+ *   id = "user_from_wrapper",
+ *   name = @Translation("User from data structure"),
+ *   description = @Translation("The user information for a UserAwareInterface implementing type."),
+ *   produces = @ContextDefinition("entity:user",
+ *     label = @Translation("User entity")
+ *   ),
+ *   consumes = {
+ *     "data" = @ContextDefinition("any",
+ *       label = @Translation("Data"),
+ *       description = @Translation("A class instance containing user information."),
+ *       required = TRUE
+ *     )
+ *   }
+ * )
+ */
+class UserFromWrapper extends DataProducerPluginBase {
+
+  /**
+   * Resolves the value.
+   *
+   * @param \Drupal\social_user\Wrappers\UserAwareInterface $data
+   *   A class that contains user information.
+   *
+   * @return \Drupal\user\UserInterface|null
+   *   The user entity.
+   */
+  public function resolve(UserAwareInterface $data) : ?UserInterface {
+    return $data->getUser();
+  }
+
+}

--- a/modules/social_features/social_user/src/Wrappers/UserAwareInterface.php
+++ b/modules/social_features/social_user/src/Wrappers/UserAwareInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Drupal\social_user\Wrappers;
+
+use Drupal\user\UserInterface;
+
+/**
+ * Provides a common interface for data that may contain a user entity.
+ */
+interface UserAwareInterface {
+
+  /**
+   * Return the user information.
+   *
+   * @return \Drupal\user\UserInterface|null
+   *   The user entity.
+   */
+  public function getUser() : ?UserInterface;
+
+}


### PR DESCRIPTION
<h3 id="summary-problem-motivation">Problem/Motivation</h3>
Violations can't currently be output. Before we fix [#3191621] this is a quick fix to make sure that violations can actually be accessed.


<h3 id="summary-proposed-resolution">Proposed resolution</h3>
Fix the string representation.

## Issue tracker
https://www.drupal.org/project/social/issues/3199146

## How to test

- [x] Tested by PHPUnit

## Release notes
N/A Unsupported internal change
