### PR TITLE
Capitalise MadeToShare hashtag

### DIFF
--- a/modules/social_features/social_footer/config/optional/block.block.socialblue_footer_powered.yml
+++ b/modules/social_features/social_footer/config/optional/block.block.socialblue_footer_powered.yml
@@ -18,7 +18,7 @@ settings:
   label_display: '0'
   logo: ''
   text:
-    value: "<p>#madetoshare</p>\r\n<p>by Open Social</p>\r\n"
+    value: "<p>#MadeToShare</p>\r\n<p>by Open Social</p>\r\n"
     format: basic_html
   link:
     url: 'https://getopensocial.com/'

--- a/modules/social_features/social_swiftmail/social_swiftmail.module
+++ b/modules/social_features/social_swiftmail/social_swiftmail.module
@@ -69,7 +69,7 @@ function social_swiftmail_preprocess_swiftmailer(array &$variables) {
     ];
     $variables['site_name'] = Link::fromTextAndUrl(t('Open Social'), $url = Url::fromUri('https://www.getopensocial.com/', $options));
     $variables['site_slogan'] = '"' . t('Create digital spaces that empower your members to share') . '"';
-    $variables['site_sub_slogan'] = Link::fromTextAndUrl(t('#madetoshare'), $url = Url::fromUri('https://twitter.com/search?q=%23madetoshare%20%23opensocial'));
+    $variables['site_sub_slogan'] = Link::fromTextAndUrl(t('#MadeToShare'), $url = Url::fromUri('https://twitter.com/search?q=%23MadeToShare%20%23opensocial'));
   }
 
   // Check if a custom e-mail header is set and apply the configuration


### PR DESCRIPTION
## Problem
Hashtags are more accessible when the individual words are capitalised: https://www.boia.org/blog/make-your-hashtags-accessible

## Solution
Capitalise the individual words of the hashtag. This improves readability for sighted users and ensures proper
pronounciation for screenreaders. An all-around accessibility win.

Tagged as bugfix as per our accessibility considerations.

## Issue tracker
https://www.drupal.org/project/social/issues/3199257

## How to test

- [ ] Check the footer block on the site
- [ ] Check the footer in e-mail notifications
- [ ] Ensure that the text is now #MadeToShare for both new and existing sites.

## Release notes
A slight improvement in the #MadeToShare campaign to improve legibility.
