### PR TITLE
Issue #3199367 by SV: Allow member to add a table in the description of node

### DIFF
--- a/modules/social_features/social_editor/config/install/editor.editor.basic_html.yml
+++ b/modules/social_features/social_editor/config/install/editor.editor.basic_html.yml
@@ -40,6 +40,10 @@ settings:
           items:
             - Source
             - Maximize
+        -
+          name: Tables
+          items:
+            - Table
   plugins:
     stylescombo:
       styles: ''

--- a/modules/social_features/social_editor/config/install/filter.format.basic_html.yml
+++ b/modules/social_features/social_editor/config/install/filter.format.basic_html.yml
@@ -13,7 +13,7 @@ filters:
     status: true
     weight: -10
     settings:
-      allowed_html: '<a href hreflang title id target rel class=""> <em> <strong> <cite> <blockquote cite> <code> <ul type> <ol start type> <li> <dl> <dt> <dd> <h2 id> <h3 id> <h4 id> <h5 id> <h6 id> <p> <br> <span> <img src alt height width data-entity-type data-entity-uuid data-align data-caption> <mention id>'
+      allowed_html: '<a href hreflang title id target rel class=""> <em> <strong> <cite> <blockquote cite> <code> <ul type> <ol start type> <li> <dl> <dt> <dd> <h2 id> <h3 id> <h4 id> <h5 id> <h6 id> <p> <br> <span> <img src alt height width data-entity-type data-entity-uuid data-align data-caption> <mention id> <table style cellspacing cellpadding border> <caption> <tbody> <thead> <tfoot> <th scope> <td> <tr>'
       filter_html_help: false
       filter_html_nofollow: false
   filter_align:

--- a/modules/social_features/social_editor/config/update/social_editor_update_8904.yml
+++ b/modules/social_features/social_editor/config/update/social_editor_update_8904.yml
@@ -1,0 +1,77 @@
+filter.format.basic_html:
+  expected_config:
+    filters:
+      filter_html:
+        settings:
+          allowed_html: '<a href hreflang title id target rel class=""> <em> <strong> <cite> <blockquote cite> <code> <ul type> <ol start type> <li> <dl> <dt> <dd> <h2 id> <h3 id> <h4 id> <h5 id> <h6 id> <p> <br> <span> <img src alt height width data-entity-type data-entity-uuid data-align data-caption> <mention id>'
+  update_actions:
+    change:
+      filters:
+        filter_html:
+          settings:
+            allowed_html: '<a href hreflang title id target rel class=""> <em> <strong> <cite> <blockquote cite> <code> <ul type> <ol start type> <li> <dl> <dt> <dd> <h2 id> <h3 id> <h4 id> <h5 id> <h6 id> <p> <br> <span> <img src alt height width data-entity-type data-entity-uuid data-align data-caption> <mention id> <table style cellspacing cellpadding border> <caption> <tbody> <thead> <tfoot> <th scope> <td> <tr>'
+
+editor.editor.basic_html:
+  expected_config:
+    settings:
+      toolbar:
+        rows:
+          -
+            - name: Formatting
+              items:
+                - Bold
+                - Italic
+            - name: Linking
+              items:
+                - DrupalLink
+                - DrupalUnlink
+            - name: Lists
+              items:
+                - BulletedList
+                - NumberedList
+            - name: Media
+              items:
+                - Blockquote
+                - DrupalImage
+            - name: 'Block Formatting'
+              items:
+                - Format
+            - name: Tools
+              items:
+                - Source
+                - Maximize
+  update_actions:
+    delete:
+      settings:
+        toolbar: { }
+    change:
+      settings:
+        toolbar:
+          rows:
+            -
+              - name: Formatting
+                items:
+                  - Bold
+                  - Italic
+              - name: Linking
+                items:
+                  - DrupalLink
+                  - DrupalUnlink
+              - name: Lists
+                items:
+                  - BulletedList
+                  - NumberedList
+              - name: Media
+                items:
+                  - Blockquote
+                  - DrupalImage
+              - name: 'Block Formatting'
+                items:
+                  - Format
+              - name: Tools
+                items:
+                  - Source
+                  - Maximize
+              - name: Tables
+                items:
+                  - Table

--- a/modules/social_features/social_editor/social_editor.install
+++ b/modules/social_features/social_editor/social_editor.install
@@ -25,3 +25,17 @@ function social_editor_update_8903() {
   // Output logged messages to related channel of update execution.
   return $updateHelper->logger()->output();
 }
+
+/**
+ * Added editor table widget for basic_html format.
+ */
+function social_editor_update_8904() {
+  /** @var \Drupal\update_helper\Updater $updateHelper */
+  $updateHelper = \Drupal::service('update_helper.updater');
+
+  // Execute configuration update definitions with logging of success.
+  $updateHelper->executeUpdate('social_editor', 'social_editor_update_8904');
+
+  // Output logged messages to related channel of update execution.
+  return $updateHelper->logger()->output();
+}


### PR DESCRIPTION
## Problem
Currently, authorized users can create/edit new nodes but they are not able to use a table widget because they have access only to the `basic_html` format which does not provide that possibility.

## Solution
Adjust `basic_html` format and add table widget

## Issue tracker
- https://www.drupal.org/project/social/issues/3199367
- https://getopensocial.atlassian.net/browse/YANG-4987

## How to test
- [ ] Using the latest version of Open Social with the social_discussion module enabled
- [ ] Login as a member of group where enabled discussion(or any other node type) 
- [ ] When creating a new node I expect to see a table widget in CKEditor bu it doesn't exist.
- [ ] The expected result is attained when repeating the steps with this fix applied.

## Screenshots
![Screenshot from 2021-02-19 20-09-50](https://user-images.githubusercontent.com/25609390/108543984-7e333480-72ee-11eb-823c-788571ae05d6.png)


## Release notes
Extends basic_html format and add table widget. So, authorized users will be able to use it when create/edit nodes
