### PR TITLE
Issue #3199893 by rolki: Notifications don't work for the group types that install the "Group request membership" plugin except for flexible group

### DIFF
--- a/modules/social_features/social_group/modules/social_group_request/social_group_request.module
+++ b/modules/social_features/social_group/modules/social_group_request/social_group_request.module
@@ -281,7 +281,11 @@ function social_group_request_form_alter(array &$form, FormStateInterface $form_
   if (in_array($form_id, $group_forms)) {
     /** @var \Drupal\group\Entity\GroupTypeInterface $group_type */
     $group_type = $form_state->getFormObject()->getEntity()->getGroupType();
-    if ($group_type->id() === 'flexible_group' || !$group_type->hasContentPlugin('group_membership_request')) {
+
+    $group_types = ['flexible_group'];
+    \Drupal::moduleHandler()->alter('social_group_request', $group_types);
+
+    if (in_array($group_type->id(), $group_types) || !$group_type->hasContentPlugin('group_membership_request')) {
       unset($form['allow_request']);
     }
   }

--- a/modules/social_features/social_group/modules/social_group_request/src/Plugin/Block/SocialGroupRequestMembershipNotification.php
+++ b/modules/social_features/social_group/modules/social_group_request/src/Plugin/Block/SocialGroupRequestMembershipNotification.php
@@ -54,6 +54,13 @@ class SocialGroupRequestMembershipNotification extends BlockBase implements Cont
   protected $translation;
 
   /**
+   * The module handler.
+   *
+   * @var \Drupal\Core\Extension\ModuleHandlerInterface
+   */
+  protected $moduleHandler;
+
+  /**
    * Constructs SocialGroupRequestMembershipNotification.
    *
    * @param array $configuration
@@ -68,6 +75,8 @@ class SocialGroupRequestMembershipNotification extends BlockBase implements Cont
    *   The entity type manager.
    * @param \Drupal\Core\StringTranslation\TranslationManager $translation
    *   The translation manager.
+   * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
+   *   The module handler.
    */
   public function __construct(
     array $configuration,
@@ -75,13 +84,15 @@ class SocialGroupRequestMembershipNotification extends BlockBase implements Cont
     $plugin_definition,
     AccountInterface $account,
     EntityTypeManagerInterface $entity_type_manager,
-    TranslationManager $translation
+    TranslationManager $translation,
+    ModuleHandlerInterface $module_handler
   ) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
     $this->account = $account;
     $this->group = _social_group_get_current_group();
     $this->entityTypeManager = $entity_type_manager;
     $this->translation = $translation;
+    $this->moduleHandler = $module_handler;
   }
 
   /**
@@ -94,7 +105,8 @@ class SocialGroupRequestMembershipNotification extends BlockBase implements Cont
       $plugin_definition,
       $container->get('current_user'),
       $container->get('entity_type.manager'),
-      $container->get('string_translation')
+      $container->get('string_translation'),
+      $container->get('module_handler')
     );
   }
 
@@ -106,7 +118,10 @@ class SocialGroupRequestMembershipNotification extends BlockBase implements Cont
       return [];
     }
 
-    if ($this->group->getGroupType()->id() === 'flexible_group') {
+    $group_types = ['flexible_group'];
+    $this->moduleHandler->alter('social_group_request', $group_types);
+
+    if (in_array($this->group->getGroupType()->id(), $group_types)) {
       $join_methods = $this->group->get('field_group_allowed_join_method')->getValue();
       $request_option = in_array('request', array_column($join_methods, 'value'), FALSE);
       if (!$request_option) {

--- a/modules/social_features/social_group/modules/social_group_request/src/Plugin/Block/SocialGroupRequestMembershipNotification.php
+++ b/modules/social_features/social_group/modules/social_group_request/src/Plugin/Block/SocialGroupRequestMembershipNotification.php
@@ -6,6 +6,7 @@ use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Block\BlockBase;
 use Drupal\Core\Cache\Cache;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Link;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Session\AccountInterface;


### PR DESCRIPTION
## Problem
See https://getopensocial.atlassian.net/browse/YANG-5001
When we install the "Group membership" plugin for some group type, then we have an issue with notifications since it hardcoded only for the flexible group.

## Solution
Use hook alter to get the list of request group types instead of the only flexible group.

## Issue tracker
- https://getopensocial.atlassian.net/browse/YANG-5001
- https://www.drupal.org/project/social/issues/3199893

## How to test
- [ ] For example, take the course group
- [ ] Go to some course under not a member with "Request to join" option
- [ ] Click "Request to join button"
- [ ] Fill the message in the pop-up and submit
- [ ] The course manager should receive notification about new request
