### PR TITLE
Issue #3199704 by SV: URL-link is broken in the e-mail notification

### DIFF
--- a/modules/social_features/social_comment/social_comment.tokens.inc
+++ b/modules/social_features/social_comment/social_comment.tokens.inc
@@ -260,6 +260,7 @@ function social_comment_tokens($type, $tokens, array $data, array $options, Bubb
  */
 function _social_comment_get_summary($text) {
   $summary = html_entity_decode(strip_tags($text));
+  $summary = preg_replace('/\n|\r|\t/m', ' ', $summary);
   $max_length = 280;
 
   if (mb_strlen($summary) > $max_length) {


### PR DESCRIPTION
## Problem
When people receive a notification the URLs / links that you can see in the e-mail notification is always broken. (once you click on the 'post' it does work) even though we do provide the right URL-link.

## Solution
- Cleanup `Carriage return` in the mail text

## Issue tracker
- https://www.drupal.org/project/social/issues/3199704
- https://getopensocial.atlassian.net/browse/YANG-4941

## How to test
*For example*
- [ ] Using the latest version of Open Social with the social_comment module enabled
- [ ] Login as a group member 
- [ ] Then create a post with a link located between paragraphs
- [ ] When checking the notification email I expect to see that the link is correct but instead see that is broken.
- [ ] The expected result is attained when repeating the steps with this fix applied.

## Screenshots
- Actual result:
![Screenshot from 2021-02-22 18-19-24](https://user-images.githubusercontent.com/25609390/108745846-47eef280-7544-11eb-8517-57925bf165f8.png)

- Expected result:
![Screenshot from 2021-02-22 18-29-20](https://user-images.githubusercontent.com/25609390/108745894-53dab480-7544-11eb-867a-722e0b8fec70.png)


## Release notes
Fixes broken links in the notification mail.

