### PR TITLE
Remove 'select account cancellation method' from default user roles i…

### DIFF
--- a/modules/social_features/social_user/social_user.install
+++ b/modules/social_features/social_user/social_user.install
@@ -161,7 +161,6 @@ function _social_user_get_permissions($role) {
     'access user profiles',
     'cancel account',
     'change own username',
-    'select account cancellation method',
   ]);
 
   // Content manager.


### PR DESCRIPTION
…n social_user.install.

## Problem
Users are able to select the cancellation method when they close their account

## Solution
Remove the permission from the installer

## Issue tracker
none yet

## How to test
- install basic setup
- create test account
- login to test account
- cancel the account
With this patch you should not be able to select the method, the site will just inform you (based on the cancellation settings)

## Screenshots
Before:
![image](https://user-images.githubusercontent.com/1320261/109475664-45c1f200-7a76-11eb-99c0-7eb67012b567.png)

After:
![image](https://user-images.githubusercontent.com/1320261/109475628-3c388a00-7a76-11eb-9259-099f83caf4ce.png)

## Release notes
Removed the 'select account cancellation method' permission from authenticated user role.
