### PR TITLE
Issue #3202292 by vnech: Fix hiding of "Tagging" field in the Inline Entity Form

### DIFF
--- a/modules/social_features/social_tagging/social_tagging.module
+++ b/modules/social_features/social_tagging/social_tagging.module
@@ -137,14 +137,14 @@ function social_tagging_form_alter(&$form, FormStateInterface $form_state, $form
  * @param \Drupal\Core\Entity\EntityInterface $form_entity
  *   Entity object.
  */
-function social_tagging_social_tagging_field_form_alter(&$form, FormStateInterface &$form_state, EntityInterface $form_entity) {
+function social_tagging_social_tagging_field_form_alter(array &$form, FormStateInterface &$form_state, EntityInterface $form_entity) {
   if (!empty($form['social_tagging'])) {
     // Load tag config..
     $tag_settings = \Drupal::getContainer()->get('config.factory')->getEditable('social_tagging.settings');
     // Switch for the entity_type.
     switch ($form_entity->getEntityTypeId()) {
       case 'node':
-        $type = $form_entity->type->entity->id();
+        $type = $form_entity->bundle();
         $tag_enabled = $tag_settings->get('tag_node_type_' . $type);
         break;
 

--- a/modules/social_features/social_tagging/social_tagging.module
+++ b/modules/social_features/social_tagging/social_tagging.module
@@ -101,15 +101,46 @@ function social_tagging_form_taxonomy_overview_terms_alter(&$form, FormStateInte
 }
 
 /**
+ * Implements hook_inline_entity_form_entity_form_alter().
+ *
+ * This hook allows to have a compatibility with "Inline Entity Form" module.
+ */
+function social_tagging_inline_entity_form_entity_form_alter(&$entity_form, &$form_state) {
+  // Act if the form has the tagging field.
+  if (isset($entity_form['social_tagging'])) {
+    // "Inline entity form" module has an entity object in the "form" variable.
+    social_tagging_social_tagging_field_form_alter($entity_form, $form_state, $entity_form['#entity']);
+  }
+}
+
+/**
  * Implements hook_form_alter().
  */
 function social_tagging_form_alter(&$form, FormStateInterface $form_state, $form_id) {
   // Act if the form has the tagging field.
   if (isset($form['social_tagging'])) {
+    if (method_exists($form_state->getFormObject(), 'getEntity')) {
+      /** @var \Drupal\Core\Entity\EntityInterface $entity */
+      $entity = $form_state->getFormObject()->getEntity();
+      social_tagging_social_tagging_field_form_alter($form, $form_state, $entity);
+    }
+  }
+}
+
+/**
+ * Function do a changes related to social_tagging field.
+ *
+ * @param array $form
+ *   Form array.
+ * @param \Drupal\Core\Form\FormStateInterface $form_state
+ *   Form State object.
+ * @param \Drupal\Core\Entity\EntityInterface $form_entity
+ *   Entity object.
+ */
+function social_tagging_social_tagging_field_form_alter(&$form, FormStateInterface &$form_state, EntityInterface $form_entity) {
+  if (!empty($form['social_tagging'])) {
     // Load tag config..
     $tag_settings = \Drupal::getContainer()->get('config.factory')->getEditable('social_tagging.settings');
-    /** @var \Drupal\Core\Entity\EntityBase $form_entity */
-    $form_entity = $form_state->getFormObject()->getEntity();
     // Switch for the entity_type.
     switch ($form_entity->getEntityTypeId()) {
       case 'node':


### PR DESCRIPTION
## Problem
We have a few modifications for "Tagging" field in the function social_tagging_form_alter(). The issue is that if we render entities with "Inline Entity Form" module widgets this hook doesn't trigger....

## Solution
Add addition hook allows compatibility with the "Inline Entity Form" module widgets

## Issue tracker
- https://www.drupal.org/project/social/issues/3202292
- https://getopensocial.atlassian.net/browse/YANG-5012

## How to test
- [ ] Enable "Social Course" module and log in as SM
- [ ] Create a new "Course" (for example - _/group/add/course_advanced_)
- [ ] Go to the course view page and click on the tab "Sections", then click on the button "Create a section"
- [ ] In the field "Parts" add any entity which bundle is enabled on "Tagging Settings" page - _/admin/config/opensocial/tagging-settings_
- [ ] You should see "Tagging" field even the entity bundle is disabled on "Tagging Settings" page

