### PR TITLE
Issue #3202609 by vnech: Improve UX of "Tab management" widget to match changes for groups in OS 10.x

### DIFF
--- a/modules/social_features/social_group/modules/social_group_default_route/social_group_default_route.module
+++ b/modules/social_features/social_group/modules/social_group_default_route/social_group_default_route.module
@@ -57,7 +57,7 @@ function social_group_default_route_form_alter(&$form, FormStateInterface $form_
     // The default route field.
     $form['tab_settings']['default_route'] = [
       '#type' => 'select',
-      '#title' => t('Group members landing tab'),
+      '#title' => t('@group members landing tab', ['@group' => $group->getGroupType()->label()]),
       '#default_value' => $default_route,
       '#options' => $options,
     ];


### PR DESCRIPTION
## Problem
Improve UX of "Tab management" widget to match changes for groups in OS 10.x

## Solution
Add small improvements to change "Tab management" field title

## Issue tracker
- https://www.drupal.org/project/social/issues/3202609
- https://getopensocial.atlassian.net/browse/ECI-1141

## How to test
- [ ] Visit add/edit "Open Group" group type page;