### PR TITLE
Issue #3203202 by vnech: Fatal error in "social_group/src/Plugin/EntityReferenceSelection/SocialGroupSelection.php"

### DIFF
--- a/modules/social_features/social_group/src/Plugin/EntityReferenceSelection/SocialGroupSelection.php
+++ b/modules/social_features/social_group/src/Plugin/EntityReferenceSelection/SocialGroupSelection.php
@@ -56,7 +56,7 @@ class SocialGroupSelection extends DefaultSelection {
     if ($excluded_group_types) {
       $query->condition(
         $this->entityTypeManager->getDefinition($configuration['target_type'])->getKey('bundle'),
-        array_diff($all_group_types, $excluded_group_types),
+        array_diff($all_group_types, $excluded_group_types) ?: [0],
         'IN'
       );
     }


### PR DESCRIPTION

## Problem
We have a field "Group" in the entities that can be not a part of any group. This causes a fatal error if we visit the entity add/edit page. The error is raised in the file: modules/social_features/social_group/src/Plugin/EntityReferenceSelection/SocialGroupSelection.php

## Solution
Add additional checking to prevent query to an empty array.

## Issue tracker
- https://www.drupal.org/project/social/issues/3203202
- https://getopensocial.atlassian.net/browse/ECI-1131

## How to test
- [ ] Visit any entity (probably node) which is not a part of any group
