### PR TITLE
Issue #3201182 by Kingdutch: [GraphQL] Introduce an Actor interface

### DIFF
--- a/modules/custom/social_graphql/graphql/open_social.graphqls
+++ b/modules/custom/social_graphql/graphql/open_social.graphqls
@@ -22,7 +22,14 @@ schema {
 The schema's entry-point for queries. This acts as the public, top-level API
 from which all queries must start.
 """
-type Query
+type Query {
+  """
+  Get information about the currently authenticated user.
+
+  NULL if you're not authenticated.
+  """
+  viewer : Actor
+}
 
 """
 The schema's entry-point for subscriptions. This acts as the public, top-level
@@ -35,6 +42,14 @@ type Subscription
 ################################################################################
 #                                Basic Types                                   #
 ################################################################################
+"""
+A concrete fetchable type that is addressable by an id.
+"""
+interface Node {
+  id: ID!
+}
+
+
 """
 An access role for a user
 
@@ -119,6 +134,21 @@ type DateTime {
   timestamp: Timestamp!
 }
 
+"""
+An actor is an entity that can perform actions and own content within Open Social.
+"""
+interface Actor implements Node {
+  """
+  The uuid of the Actor
+  """
+  id: ID!
+
+  """
+  The display name of the actor.
+  """
+  displayName: String!
+}
+
 ################################################################################
 #                                Media Types                                   #
 #                                                                              #
@@ -171,13 +201,6 @@ type Image implements Media & Node {
 A cursor for use in pagination.
 """
 scalar Cursor
-
-"""
-A node on an edge.
-"""
-interface Node {
-  id: ID!
-}
 
 """
 An edge in a connection.

--- a/modules/custom/social_graphql/src/GraphQL/DecoratableTypeResolver.php
+++ b/modules/custom/social_graphql/src/GraphQL/DecoratableTypeResolver.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Drupal\social_graphql\GraphQL;
+
+/**
+ * A decoratable type resolver to resolve GraphQL interfaces to concrete types.
+ *
+ * Type resolvers should extend this class so that they can be chained in
+ * schema extensions plugins.
+ *
+ * For example with the following class defined.
+ * ```php
+ * class ConcreteTypeResolver extends DecoratableTypeResolver {
+ *
+ *   protected function resolve($object) : ?string {
+ *     return $object instanceof MyType ? 'MyType' : NULL;
+ *   }
+ * }
+ * ```
+ *
+ * A schema extension would call:
+ * ```php
+ * $registry->addTypeResolver(
+ *   'InterfaceType',
+ *   new ConcreteTypeResolver($registry->getTypeResolver('InterfaceType'))
+ * );
+ * ```
+ *
+ * TypeResolvers should not extend other type resolvers but always extend this
+ * class directly. Classes will be called in the reverse order of being added
+ * (classes added last will be called first).
+ *
+ * @package Drupal\social_graphql\GraphQL
+ */
+abstract class DecoratableTypeResolver {
+
+  /**
+   * The previous type resolver that was set in the chain.
+   */
+  private ?DecoratableTypeResolver $decorated;
+
+  /**
+   * Create a new decoratable type resolver.
+   *
+   * @param \Drupal\social_graphql\GraphQL\DecoratableTypeResolver|null $resolver
+   *   The previous type resolver if any.
+   */
+  public function __construct(?self $resolver) {
+    $this->decorated = $resolver;
+  }
+
+  /**
+   * Resolve the type for the provided object.
+   *
+   * @param mixed $object
+   *   The object to resolve to a concrete type.
+   *
+   * @return string|null
+   *   The GraphQL type name or NULL if this resolver could not determine it.
+   */
+  abstract protected function resolve($object) : ?string;
+
+  /**
+   * Allows this type resolver to be called by the GraphQL library.
+   *
+   * Takes care of chaining the various type resolvers together and invokes the
+   * `resolve` method for each concrete implementation in the chain.
+   *
+   * @param mixed $object
+   *   The object to resolve to a concrete type.
+   *
+   * @return string
+   *   The resolved GraphQL type name.
+   *
+   * @throws \RuntimeException
+   *   When a type was passed for which no type resolver exists in the chain.
+   */
+  public function __invoke($object) : string {
+    $type = $this->resolve($object);
+    if ($type !== NULL) {
+      return $type;
+    }
+
+    if ($this->decorated !== NULL) {
+      $type = $this->decorated->__invoke($object);
+      if ($type !== NULL) {
+        return $type;
+      }
+    }
+
+    $klass = get_class($object);
+    throw new \RuntimeException("Can not map instance of '${klass}' to concrete GraphQL Type.");
+  }
+
+}

--- a/modules/social_features/social_user/graphql/social_user_schema_extension.base.graphqls
+++ b/modules/social_features/social_user/graphql/social_user_schema_extension.base.graphqls
@@ -4,7 +4,7 @@
 """
 An Open Social user.
 """
-type User implements Node {
+type User implements Node & Actor {
   """
   The Universally Unique Identifier for the user.
   """

--- a/modules/social_features/social_user/graphql/social_user_schema_extension.extension.graphqls
+++ b/modules/social_features/social_user/graphql/social_user_schema_extension.extension.graphqls
@@ -1,12 +1,5 @@
 extend type Query {
   """
-  Get information about the currently authenticated user.
-
-  NULL if you're not authenticated.
-  """
-  viewer : User
-
-  """
   List of users.
 
   If no limits are specified will limit to 10 results.

--- a/modules/social_features/social_user/src/GraphQL/UserActorTypeResolver.php
+++ b/modules/social_features/social_user/src/GraphQL/UserActorTypeResolver.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Drupal\social_user\GraphQL;
+
+use Drupal\social_graphql\GraphQL\DecoratableTypeResolver;
+use Drupal\user\UserInterface;
+
+/**
+ * Type resolver for User concrete class of Actor interface.
+ */
+class UserActorTypeResolver extends DecoratableTypeResolver {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function resolve($actor) : ?string {
+    return $actor instanceof UserInterface ? 'User' : NULL;
+  }
+
+}

--- a/modules/social_features/social_user/src/Plugin/GraphQL/SchemaExtension/UserSchemaExtension.php
+++ b/modules/social_features/social_user/src/Plugin/GraphQL/SchemaExtension/UserSchemaExtension.php
@@ -5,6 +5,7 @@ namespace Drupal\social_user\Plugin\GraphQL\SchemaExtension;
 use Drupal\graphql\GraphQL\ResolverBuilder;
 use Drupal\graphql\GraphQL\ResolverRegistryInterface;
 use Drupal\graphql\Plugin\GraphQL\SchemaExtension\SdlSchemaExtensionPluginBase;
+use Drupal\social_user\GraphQL\UserActorTypeResolver;
 
 /**
  * Adds user data to the Open Social GraphQL API.
@@ -23,6 +24,9 @@ class UserSchemaExtension extends SdlSchemaExtensionPluginBase {
    */
   public function registerResolvers(ResolverRegistryInterface $registry) {
     $builder = new ResolverBuilder();
+
+    // Type resolvers.
+    $registry->addTypeResolver('Actor', new UserActorTypeResolver($registry->getTypeResolver('Actor')));
 
     // Root Query fields.
     $registry->addFieldResolver('Query', 'viewer',


### PR DESCRIPTION

<h3 id="summary-problem-motivation">Problem/Motivation</h3>
Currently we always expect things to be done by users. However, with the introduction of third-party applications and server-to-server OAuth authentication we may also see other systems perform actions (like creating content or triggering actions that perform notifications). Additionally for some data Open Social itself may be the cause.

An example where we already have something like this in our current UI is commenting as anonymous users. It would be useful to distinguish in the API between anonymous users (i.e. we have no data about them) and anonymized users (i.e. registered platform users acting anonymously). This can also help link actions by the same user, for example in anonymized discussions.

## Solution
This commit introduces the `Actor` interface. An `Actor` indicates a
person or machine that has a representation on the platform and can
perform actions.

The `User` type is a real person implementation of an `Actor` indicating
a human user on the platform.

An example of a future `Actor` may be a `Bot` which could be used for
automated chat interactions or an `ExternalUser` which may be used to
post content from other platforms without having an account on the
platform itself.

This commit introduces a `DecoratableTypeResolver` which should be used
for all type resolvers in Open Social's GraphQL API. This allows other
modules to extend the types that are returned for interfaces or unions
by decorating existing type resolvers.


## Issue tracker
https://www.drupal.org/project/social/issues/3201182

## How to test
Automated tests should still pass.

## Screenshots
N/a

## Release notes
Unsupported internal changes. N/a

## Change Record
Unsupported internal changes. N/a

## Translations
N/a