### PR TITLE
Issue #3203225 by Kingdutch, ronaldtebrake: Standardise package name …

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ before_install:
   - if [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TEST_SUITE" = "accessibility" ]; then exit 0; fi
   - phpenv config-rm xdebug.ini
   # Lets set-up our helper repository with all the docker config and use correct version in composer.json.
-  - git clone --branch master https://github.com/goalgorilla/drupal_social.git install
+  - git clone --branch feature/standardise-package-name https://github.com/goalgorilla/drupal_social.git install
   - cd install
   - export PR=https://api.github.com/repos/$TRAVIS_REPO_SLUG/pulls/$TRAVIS_PULL_REQUEST
   - export BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_BRANCH; else echo $TRAVIS_PULL_REQUEST_BRANCH; fi)

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ before_install:
   # Pull Open Social from GitHub instead of Drupal's Packagist so all our dev branches are available.
   - composer config repositories.social git https://github.com/goalgorilla/open_social.git
   # 8.x-8.x-composer-update-to-10-branch has some composer breaking changes for scaffolding, we couldnt release but helps us with testing our update path.
-  - if [ "$TEST_SUITE" = "install_update" ]; then composer require drupal/social:dev-social-8.x-8.x-composer-update-to-10-branch --prefer-dist; fi
+  - if [ "$TEST_SUITE" = "install_update" ]; then composer require --update-with-dependencies drupal/social:dev-social-8.x-8.x-composer-update-to-10-branch --prefer-dist; fi
   # For Pull Requests that are not from Open Social's own repo we must overwrite the repository we set earlier so we can pull in the work done by the external contributor.
   - if [ "$TRAVIS_PULL_REQUEST" != "false" ] && [ "$TRAVIS_PULL_REQUEST_SLUG" != "goalgorilla/open_social" ]; then composer config repositories.social git https://github.com/$TRAVIS_PULL_REQUEST_SLUG.git; fi
   - if [ "$TEST_SUITE" != "install_update" ] && [ "$TRAVIS_PULL_REQUEST" != "false" ]; then composer require drupal/social:dev-${BRANCH}#${COMMIT} --prefer-dist; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -70,7 +70,8 @@ before_install:
 install:
   - if [ "$TEST_SUITE" = "install_stability_1" ] || [ "$TEST_SUITE" = "install_stability_2" ] || [ "$TEST_SUITE" = "install_stability_3" ] || [ "$TEST_SUITE" = "install_stability_4" ]; then docker exec -i social_ci_web bash /var/www/scripts/social/install/install_script.sh --with-optional --localsettings; fi
   - if [ "$TEST_SUITE" = "install_without_optional" ]; then docker exec -i social_ci_web bash /var/www/scripts/social/install/install_script.sh --localsettings; fi
-  - if [ "$TEST_SUITE" = "install_update" ]; then bash scripts/social/ci/build-install-update.sh $PR $BRANCH $COMMIT; fi
+  - if [ "$TEST_SUITE" = "install_update" ] && [ "$TRAVIS_PULL_REQUEST" != "false" ]; then bash scripts/social/ci/build-install-update.sh drupal/social:dev-${BRANCH}#${COMMIT}; fi
+  - if [ "$TEST_SUITE" = "install_update" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then bash scripts/social/ci/build-install-update.sh drupal/social:${BRANCH}-dev#${COMMIT}; fi
 
 script:
   - set -e

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ before_install:
   # Pull Open Social from GitHub instead of Drupal's Packagist so all our dev branches are available.
   - composer config repositories.social git https://github.com/goalgorilla/open_social.git
   # 8.x-8.x-composer-update-to-10-branch has some composer breaking changes for scaffolding, we couldnt release but helps us with testing our update path.
-  - if [ "$TEST_SUITE" = "install_update" ]; then composer require drupal/social:dev-8.x-8.x-composer-update-to-10-branch --prefer-dist; fi
+  - if [ "$TEST_SUITE" = "install_update" ]; then composer require drupal/social:dev-social-8.x-8.x-composer-update-to-10-branch --prefer-dist; fi
   # For Pull Requests that are not from Open Social's own repo we must overwrite the repository we set earlier so we can pull in the work done by the external contributor.
   - if [ "$TRAVIS_PULL_REQUEST" != "false" ] && [ "$TRAVIS_PULL_REQUEST_SLUG" != "goalgorilla/open_social" ]; then composer config repositories.social git https://github.com/$TRAVIS_PULL_REQUEST_SLUG.git; fi
   - if [ "$TEST_SUITE" != "install_update" ] && [ "$TRAVIS_PULL_REQUEST" != "false" ]; then composer require drupal/social:dev-${BRANCH}#${COMMIT} --prefer-dist; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,12 +53,15 @@ before_install:
   - export BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_BRANCH; else echo $TRAVIS_PULL_REQUEST_BRANCH; fi)
   - export COMMIT=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_COMMIT; else echo $TRAVIS_PULL_REQUEST_SHA; fi)
   - echo "TRAVIS_BRANCH=$TRAVIS_BRANCH, PR=$PR, BRANCH=$BRANCH, COMMIT=$COMMIT"
+  # Pull Open Social from GitHub instead of Drupal's Packagist so all our dev branches are available.
+  - composer config repositories.social git https://github.com/goalgorilla/open_social.git
   # 8.x-8.x-composer-update-to-10-branch has some composer breaking changes for scaffolding, we couldnt release but helps us with testing our update path.
-  - if [ "$TEST_SUITE" = "install_update" ]; then composer require goalgorilla/open_social:dev-8.x-8.x-composer-update-to-10-branch --prefer-dist; fi
+  - if [ "$TEST_SUITE" = "install_update" ]; then composer require drupal/social:dev-8.x-8.x-composer-update-to-10-branch --prefer-dist; fi
+  # For Pull Requests that are not from Open Social's own repo we must overwrite the repository we set earlier so we can pull in the work done by the external contributor.
   - if [ "$TRAVIS_PULL_REQUEST" != "false" ] && [ "$TRAVIS_PULL_REQUEST_SLUG" != "goalgorilla/open_social" ]; then composer config repositories.social git https://github.com/$TRAVIS_PULL_REQUEST_SLUG.git; fi
-  - if [ "$TEST_SUITE" != "install_update" ] && [ "$TRAVIS_PULL_REQUEST" != "false" ]; then composer require goalgorilla/open_social:dev-${BRANCH}#${COMMIT} --prefer-dist; fi
-  # if its not a PR build, we need to composer require goalgorilla/open_social 10.0.x-dev#commithash instead of dev-10.0.x#commithash
-  - if [ "$TEST_SUITE" != "install_update" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then composer require goalgorilla/open_social:${BRANCH}-dev#${COMMIT} --prefer-dist; fi
+  - if [ "$TEST_SUITE" != "install_update" ] && [ "$TRAVIS_PULL_REQUEST" != "false" ]; then composer require drupal/social:dev-${BRANCH}#${COMMIT} --prefer-dist; fi
+  # if its not a PR build, we need to composer require 10.0.x-dev#commithash instead of dev-10.0.x#commithash
+  - if [ "$TEST_SUITE" != "install_update" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then composer require drupal/social:${BRANCH}-dev#${COMMIT} --prefer-dist; fi
 
   # Install docker and our docker containers.
   - sh scripts/social/ci/install-docker.sh

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "goalgorilla/open_social",
+    "name": "drupal/social",
     "description": "Open Social is a distribution for building social communities and intranets.",
     "type": "drupal-profile",
     "license": "GPL-2.0-or-later",
@@ -202,5 +202,8 @@
         "drupal/coder": "8.3.11",
         "mglaman/phpstan-drupal": "0.12",
         "mglaman/drupal-check": "^1.0"
+    },
+    "replace": {
+      "goalgorilla/open_social": "self.version"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -205,5 +205,8 @@
     },
     "replace": {
       "goalgorilla/open_social": ">=10.0.0 <11.0.0"
+    },
+    "conflict": {
+      "goalgorilla/open_social": "<10.0.0 || >=11.0.0"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -204,6 +204,6 @@
         "mglaman/drupal-check": "^1.0"
     },
     "replace": {
-      "goalgorilla/open_social": "self.version"
+      "goalgorilla/open_social": ">=10.0.0 <11.0.0"
     }
 }


### PR DESCRIPTION
…on drupal/social

<h3 id="summary-problem-motivation">Problem/Motivation</h3>
The GitHub repository has <code>goalgorilla/open_social</code> as package name ever since the first version. This version is also published to the public packagist. However, Drupal's packagist overwrites this to <code>drupal/social</code>.

This causes two versions of the same code to be published and makes it difficult for other packages to depend on either. It also causes issues when configuring the install location using the composer-installer package unless you include both.

<h4 id="summary-steps-reproduce">Steps to reproduce</h4>


<h3 id="summary-proposed-resolution">Proposed resolution</h3>
Standardise on <code>drupal/social</code> and no longer publish new versions to the public Packagist (all downloads should come through Drupal's packagist).

## Issue tracker
https://www.drupal.org/project/social/issues/3203225

## How to test

- [ ] Tests should pass (our goalgorilla/drupal_social contains a `goalgorilla/open_social` dependency while our tests should properly pull in `drupal/social`)

## Screenshots
N/a

## Release notes
Moving forward Open Social will only be published under the <code>drupal/social</code> name and no updates for the  <code>goalgorilla/open_social</code> name will be published. Check out the [change record](https://www.drupal.org/node/3203229) for update instructions.

## Change Record
https://www.drupal.org/node/3203229

## Translations
N/a

Closes #2263