### PR TITLE
Issue #3204775 - Update patch for ajax comments based on beta 3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -99,7 +99,7 @@
                 "Make sure lazy doesnt do anything on cron": "https://www.drupal.org/files/issues/2019-07-30/3071331-lazy-cron-empty-path-2.patch"
             },
             "drupal/ajax_comments": {
-                "Fix display mode issue": "https://www.drupal.org/files/issues/2021-02-19/ajax_comments-ajax_not_working_when_using_non_default_view_mode-2896916-41-beta1.patch"
+                "Fix display mode issue": "https://www.drupal.org/files/issues/2021-03-19/ajax_comments-ajax_not_working_when_using_non_default_view_mode-2896916-beta3.patch"
             },
             "drupal/field_group": {
                 "Undefined property: stdClass::$region in field_group_form_process().": "https://www.drupal.org/files/issues/2020-06-15/3059614-37.patch"

--- a/modules/social_features/social_event/modules/social_event_managers/social_event_managers.module
+++ b/modules/social_features/social_event/modules/social_event_managers/social_event_managers.module
@@ -57,15 +57,7 @@ function social_event_managers_views_data_alter(array &$data) {
 }
 
 /**
- * Add notification settings display on user Profile for the EO notification.
- *
- * @param array &$items
- *   An array of groups that contain a title and an array of templates that are
- *   contained in this settings group.
- * @param array $email_message_templates
- *   Message templates enabled for sending by email.
- *
- * @see activity_send_email_form_user_form_alter()
+ * Implement hook_activity_send_email_notifications_alter().
  */
 function social_event_managers_activity_send_email_notifications_alter(array &$items, array $email_message_templates) {
   // If a member_added_by_event_organiser template is enabled then we add it in

--- a/modules/social_features/social_event/social_event.module
+++ b/modules/social_features/social_event/social_event.module
@@ -801,15 +801,7 @@ function social_event_date_is_all_day(DrupalDateTime $date) {
 }
 
 /**
- * Add notification settings display on user Profile for the EO notification.
- *
- * @param array &$items
- *   An array of groups that contain a title and an array of templates that are
- *   contained in this settings group.
- * @param array $email_message_templates
- *   Message templates enabled for sending by email.
- *
- * @see activity_send_email_form_user_form_alter()
+ * Implement hook_activity_send_email_notifications_alter().
  */
 function social_event_activity_send_email_notifications_alter(array &$items, array $email_message_templates) {
   // If a activity_on_events_im_organizing template is enabled then we add it in

--- a/tests/behat/features/capabilities/security/private-file-uploads.feature
+++ b/tests/behat/features/capabilities/security/private-file-uploads.feature
@@ -1,4 +1,4 @@
-@api @security @stability @perfect @critical @DS-3605 @DS-5350 @YANG-4759 @stability-1 @private-file-uploads
+@api @security @stability @perfect @critical @DS-3605 @DS-5350 @YANG-4759 @private-file-uploads
 Feature: Private files
   Benefit: Upload files to private file directory
   Role: As a LU


### PR DESCRIPTION
## Problem
There is no restriction in the version of ajax_comments, this resulted in it automatically updating to beta 3 which ensured our patch wasn't applying anymore

## Solution
Update patch to ensure it applies to beta3

## Issue tracker
https://www.drupal.org/project/social/issues/3204775#comment-14037093

## How to test
- [x] Enable social_ajax_comments
- [x] See that it still works as expected
- [x] https://www.drupal.org/project/ajax_comments/releases/8.x-1.0-beta3 test beta 3 release to check if this release is applicable for OS or we need to lock it to beta2
- [x] See that the patch still works for `Ajax not working when using non-default view mode.`

## Release notes
Ajax comments is now updated to it's newest version
