### PR TITLE
Issue #3205576 by robertragas: Change the header icon condition to bools

### DIFF
--- a/modules/social_features/social_group/social_group.module
+++ b/modules/social_features/social_group/social_group.module
@@ -2098,7 +2098,7 @@ function social_group_social_user_account_header_create_links($context) {
  * site manager.
  */
 function social_group_social_user_account_header_items(array $context) {
-  if (\Drupal::config('social_user.navigation.settings')->get('display_my_groups_icon') !== 1) {
+  if (\Drupal::config('social_user.navigation.settings')->get('display_my_groups_icon') !== TRUE) {
     return [];
   }
 

--- a/modules/social_features/social_private_message/social_private_message.module
+++ b/modules/social_features/social_private_message/social_private_message.module
@@ -493,7 +493,7 @@ function social_private_message_activity_send_email_notifications_alter(array &$
  * it's enabled by the site manager.
  */
 function social_private_message_social_user_account_header_items(array $context) {
-  if (\Drupal::config('social_user.navigation.settings')->get('display_social_private_message_icon') !== 1) {
+  if (\Drupal::config('social_user.navigation.settings')->get('display_social_private_message_icon') !== TRUE) {
     return [];
   }
 


### PR DESCRIPTION
## Problem
On the top right we have an account header menu where we can add some optional icons defined on
admin/config/opensocial/navigation-settings

These settings do not work anymore on a 10.x install.

## Solution
In an older PR https://github.com/goalgorilla/open_social/pull/1994/files changes got made to replace the value being set to a bool. The check itself in the header menu does not take this new bool into account, always resulting in returning.
We also need to update this value to check for the bool.

## Issue tracker
https://www.drupal.org/project/social/issues/3205576

## How to test
- [ ] Install Open Social on 10.x
- [ ] Enable social_private_message
- [ ] Go to admin/config/opensocial/navigation-settings and see both are enabled
- [ ] See they are not showing in the header menu
- [ ] Check out to this branch and check again

## Screenshots
*If this Pull Request makes visual changes then please include some screenshots that show what has changed here. A before and after screenshot helps the reviewer determine what changes were made.*

## Release notes
We have solved a bug where a fresh install on 10.x would not show the header icons of private messages and groups correctly when enabled.

