### PR TITLE
Issue #3205787 by Kingdutch: Default permissions don't allow the Open…

### DIFF
--- a/modules/custom/social_graphql/social_graphql.install
+++ b/modules/custom/social_graphql/social_graphql.install
@@ -1,0 +1,16 @@
+<?php
+
+/**
+ * @file
+ * Install, update and uninstall functions for the social_graphql module.
+ */
+
+/**
+ * Implements hook_install().
+ */
+function social_graphql_install() {
+  // Ensure users can use GraphQL powered applications with our default server.
+  // We rely on normal access rules for authorization.
+  user_role_grant_permissions('anonymous', ['execute open_social_graphql arbitrary graphql requests']);
+  user_role_grant_permissions('authenticated', ['execute open_social_graphql arbitrary graphql requests']);
+}


### PR DESCRIPTION
… Social GraphQL endpoint to be used

<h3 id="summary-problem-motivation">Problem/Motivation</h3>
By default users don't get the "execute arbitrary query" permission on GraphQL servers, but this is basically what every GraphQL application does.

Since we rely on the default user permissions (and OAuth scopes for applications in the future) we at least require the endpoint itself to be accessible.

<h3 id="summary-proposed-resolution">Proposed resolution</h3>
Provide the <code>execute open_social_graphql arbitrary graphql requests</code> permission to <code>anonymous</code> and <code>authenticated</code> users.


## Issue tracker
https://www.drupal.org/project/social/issues/3205787

## How to test
- [ ] Install the module
- [ ] Making a GraphQL request should now succeed without any extra changes

## Screenshots
N/a

## Release notes
N/a, hidden/unsupported change

## Change Record
N/a

## Translations
N/a