### PR TITLE
Issue #3205805 by ribel: Add request event enrollment message template to email notification settings

### DIFF
--- a/modules/custom/activity_send/modules/activity_send_email/activity_send_email.module
+++ b/modules/custom/activity_send/modules/activity_send_email/activity_send_email.module
@@ -328,6 +328,7 @@ function _activity_send_email_default_template_items() {
       'templates' => [
         'create_comment_author_node_post',
         'join_to_group',
+        'request_event_enrollment',
       ],
     ],
     'what_follow' => [


### PR DESCRIPTION
## Problem
We are getting a ton of immediate notification to our site manager account when people respond to an event invite or request enrollment to an event.

I don't see an option to set this notification type to other timeframes under the "What i manage" section of notification options.

## Solution
Add request_event_enrollment message template to the "What i manage" section of notification options, so they don't receive all of these immediately, but instead daily or weekly based on preference.

## Issue tracker
- https://www.drupal.org/project/social/issues/3205805
- https://getopensocial.atlassian.net/browse/YANG-5121

## How to test
*For example*
- [ ] Using version 9.x or 10.x of Open Social with the Social Event module enabled
- [ ] As a user go to account Settings
- [ ] I should see "A user request an enrollment for event" in "What i manage" section of Email notification fieldset

## Screenshots
![image](https://user-images.githubusercontent.com/2241917/112622657-0055d200-8e34-11eb-97e0-1dc75d2d8bbd.png)

## Release notes
Users now see "A user request an enrollment for event" in "What i manage" section of Email notification settings, so they don't receive all of these immediately, but instead daily or weekly based on preference.

## Change Record
N/A

## Translations
N/A
