### PR TITLE
Revert "Widen goalgorilla/open_social replace range"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -204,7 +204,7 @@
         "mglaman/drupal-check": "^1.0"
     },
     "replace": {
-      "goalgorilla/open_social": ">=10.0.0 <11.0.0"
+      "goalgorilla/open_social": "self.version"
     },
     "conflict": {
       "goalgorilla/open_social": "<10.0.0 || >=11.0.0"


### PR DESCRIPTION
## Problem
Widening the replace range caused composer to think that 10.1.x-dev can
replace 10.0.3, which the `replace` key says is true but it's not what
we want.

The widening was done to satisfy tests because earlier versions of
the repository were not available with the `drupal/social` name.
However, widening the replace range causes issue and is not the
solution. Instead we should've tagged older versions or fixed our
upgrade flow.

`drupal/social` is only ever compatible with the same version of
`goalgorilla/open_social`.

## Solution
This reverts commit ac13c56d87fbc583b48b8d9e9c3981e361f78584.

Resolves an issue introduced in #2259

## Issue tracker
https://www.drupal.org/project/social/issues/3203225

## How to test
*For example*
- [ ] Tests should pass

## Screenshots
N/a

## Release notes
N/a (fix for unreleased change)

## Change Record
N/a (part of linked issue's CR)

## Translations
N/a