### PR TITLE
CP-104: Fix album teaser styles

### DIFF
--- a/modules/social_features/social_album/assets/css/social-album--teaser.scss
+++ b/modules/social_features/social_album/assets/css/social-album--teaser.scss
@@ -30,6 +30,8 @@
   .teaser {
     margin: 0 1% 20px;
     flex: 0 0 98%;
+    flex-direction: column;
+    height: auto;
     max-width: 98%;
     overflow: hidden;
 
@@ -47,7 +49,10 @@
 
     .teaser__image {
       background: #f3f3f3;
-      height: 200px;
+      border-radius: 0;
+      display: block;
+      flex-basis: auto;
+      height: auto;
 
       .no-feature-image {
         display: none;
@@ -59,6 +64,18 @@
         height: 100%;
         object-fit: cover;
       }
+    }
+
+    .teaser__teaser-type {
+      border-radius: 0 0 10px 0;
+      position: absolute;
+      left: 0;
+    }
+
+    .teaser__body {
+      flex-basis: auto;
+      flex-shrink: 0;
+      max-width: 100%;
     }
 
     .teaser__content {


### PR DESCRIPTION
## Problem
The album teaser styles were broken on **Group Albums** page (like `/group/5/albums`) when `socialbase` or `socialblue` themes were used. This PR fixes the issue.

## Screenshots
### Desktop
Before:
![image](https://user-images.githubusercontent.com/39520000/113264048-30d9b800-92db-11eb-9e1f-d29f9664fcd5.png)

After:
![image](https://user-images.githubusercontent.com/39520000/113263876-02f47380-92db-11eb-81ff-9e26a67e9c4e.png)

### Tablet
Before:
![image](https://user-images.githubusercontent.com/39520000/113263989-228b9c00-92db-11eb-9a66-f77bf6f5062e.png)

After:
![image](https://user-images.githubusercontent.com/39520000/113263831-f5d78480-92da-11eb-8ff4-9d6c5a3ea191.png)

### Phone
Before:
![image](https://user-images.githubusercontent.com/39520000/113263932-143d8000-92db-11eb-864f-4a25a023d217.png)

After:
![image](https://user-images.githubusercontent.com/39520000/113265377-bca01400-92dc-11eb-9fda-1a5e499edce4.png)

## Release notes
The css files should be regenerated as scss files only were updated here.