### PR TITLE
Issue #3203225: revert the package name to goalgorilla/open_social and use an updated travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,12 +56,12 @@ before_install:
   # Pull Open Social from GitHub instead of Drupal's Packagist so all our dev branches are available.
   - composer config repositories.social git https://github.com/goalgorilla/open_social.git
   # 8.x-8.x-composer-update-to-10-branch has some composer breaking changes for scaffolding, we couldnt release but helps us with testing our update path.
-  - if [ "$TEST_SUITE" = "install_update" ]; then composer require --update-with-dependencies drupal/social:dev-social-8.x-8.x-composer-update-to-10-branch --prefer-dist; fi
+  - if [ "$TEST_SUITE" = "install_update" ]; then composer require goalgorilla/open_social:dev-8.x-8.x-composer-update-to-10-branch --prefer-dist; fi
   # For Pull Requests that are not from Open Social's own repo we must overwrite the repository we set earlier so we can pull in the work done by the external contributor.
   - if [ "$TRAVIS_PULL_REQUEST" != "false" ] && [ "$TRAVIS_PULL_REQUEST_SLUG" != "goalgorilla/open_social" ]; then composer config repositories.social git https://github.com/$TRAVIS_PULL_REQUEST_SLUG.git; fi
-  - if [ "$TEST_SUITE" != "install_update" ] && [ "$TRAVIS_PULL_REQUEST" != "false" ]; then composer require drupal/social:dev-${BRANCH}#${COMMIT} --prefer-dist; fi
+  - if [ "$TEST_SUITE" != "install_update" ] && [ "$TRAVIS_PULL_REQUEST" != "false" ]; then composer require goalgorilla/open_social:dev-${BRANCH}#${COMMIT} --prefer-dist; fi
   # if its not a PR build, we need to composer require 10.0.x-dev#commithash instead of dev-10.0.x#commithash
-  - if [ "$TEST_SUITE" != "install_update" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then composer require drupal/social:${BRANCH}-dev#${COMMIT} --prefer-dist; fi
+  - if [ "$TEST_SUITE" != "install_update" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then composer require goalgorilla/open_social:${BRANCH}-dev#${COMMIT} --prefer-dist; fi
 
   # Install docker and our docker containers.
   - sh scripts/social/ci/install-docker.sh
@@ -70,8 +70,8 @@ before_install:
 install:
   - if [ "$TEST_SUITE" = "install_stability_1" ] || [ "$TEST_SUITE" = "install_stability_2" ] || [ "$TEST_SUITE" = "install_stability_3" ] || [ "$TEST_SUITE" = "install_stability_4" ]; then docker exec -i social_ci_web bash /var/www/scripts/social/install/install_script.sh --with-optional --localsettings; fi
   - if [ "$TEST_SUITE" = "install_without_optional" ]; then docker exec -i social_ci_web bash /var/www/scripts/social/install/install_script.sh --localsettings; fi
-  - if [ "$TEST_SUITE" = "install_update" ] && [ "$TRAVIS_PULL_REQUEST" != "false" ]; then bash scripts/social/ci/build-install-update.sh drupal/social:dev-${BRANCH}#${COMMIT}; fi
-  - if [ "$TEST_SUITE" = "install_update" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then bash scripts/social/ci/build-install-update.sh drupal/social:${BRANCH}-dev#${COMMIT}; fi
+  - if [ "$TEST_SUITE" = "install_update" ] && [ "$TRAVIS_PULL_REQUEST" != "false" ]; then bash scripts/social/ci/build-install-update.sh goalgorilla/open_social:dev-${BRANCH}#${COMMIT}; fi
+  - if [ "$TEST_SUITE" = "install_update" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then bash scripts/social/ci/build-install-update.sh goalgorilla/open_social:${BRANCH}-dev#${COMMIT}; fi
 
 script:
   - set -e

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "drupal/social",
+    "name": "goalgorilla/open_social",
     "description": "Open Social is a distribution for building social communities and intranets.",
     "type": "drupal-profile",
     "license": "GPL-2.0-or-later",
@@ -204,7 +204,7 @@
         "mglaman/drupal-check": "^1.0"
     },
     "replace": {
-      "goalgorilla/open_social": ">=10.0.0 <11.0.0"
+      "drupal/social": "self.version"
     },
     "conflict": {
       "goalgorilla/open_social": "<10.0.0 || >=11.0.0"

--- a/composer.json
+++ b/composer.json
@@ -205,8 +205,5 @@
     },
     "replace": {
       "drupal/social": "self.version"
-    },
-    "conflict": {
-      "goalgorilla/open_social": "<10.0.0 || >=11.0.0"
     }
 }


### PR DESCRIPTION
This PR is in favor of #2278

## Problem
Resolves an issue introduced in #2259 where standardizing our package name caused issues with drupal's infrastructure, as well as the fact we have widened `goalgorilla/open_social` replace range caused composer to think that 10.1.x-dev can
replace 10.0.3, which the replace key says is true but it's not what we want. 

## Solution
Revert the package name to `goalgorilla/open_social` whilst maintaining some of our travis improvements. Also we make sure we add `drupal/social` to our composer.json replace attribute using the `self.version` to make sure external dependencies can still depend on drupal/social versions

## Issue tracker
https://www.drupal.org/project/social/issues/3203225

## How to test
- [ ] Test should pass.
- [ ] You should be able to install open social again through our social template once 

## Change Record
We can postpone https://www.drupal.org/node/3203229 untill we can finally standardize our package name.
