### PR TITLE
Issue #3200113 by rolki: Enable visibility states only for the flexible group

### DIFF
--- a/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.module
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.module
@@ -105,16 +105,9 @@ function social_group_flexible_group_form_alter(&$form, FormStateInterface $form
       ];
     }
   }
-
-  $group_types = ['flexible_group'];
-  \Drupal::moduleHandler()->alter('social_group_settings', $group_types);
-
-  foreach ($group_types as $group_type) {
-    $form_ids[] = 'group-' . str_replace('_', '-', $group_type) . '-add-form';
-    $form_ids[] = 'group-' . str_replace('_', '-', $group_type) . '-edit-form';
-  }
   // For adding or editing a flexible group, we alter the visibility fields.
-  if (in_array($form['#id'], $form_ids ?? [])) {
+  if ($form['#id'] === 'group-flexible-group-add-form' ||
+    $form['#id'] === 'group-flexible-group-edit-form') {
     // Change the group visibility on flexible groups.
     if (!empty($form['field_group_allowed_visibility'])) {
       if (!empty($form['field_group_allowed_visibility']['widget']['#title'])) {


### PR DESCRIPTION
## Problem
There are some new issues with saving visibilities for other group types when we use `hook_social_group_settings_alter`, so it means states from flexible group can't be reused for other group types yet.

## Solution
Revert changes for group visibility states

## Issue tracker
https://getopensocial.atlassian.net/browse/YANG-5116
https://www.drupal.org/project/social/issues/3200113

## How to test
- [ ] Add `hook_social_group_settings_alter` to other group type
- [ ] Go to edit or create this group page
- [ ] Select some visibilities
- [ ] After saving visibility saved with the wrong values

## Screenshots
![image](https://user-images.githubusercontent.com/50984627/113394226-875cfa00-93a0-11eb-8834-232742b6f638.png)
