### PR TITLE
Issue #3207801 by vnech: Display error messages (if exist) on Ajax Comments

### DIFF
--- a/modules/custom/social_ajax_comments/src/Controller/AjaxCommentsController.php
+++ b/modules/custom/social_ajax_comments/src/Controller/AjaxCommentsController.php
@@ -175,20 +175,28 @@ class AjaxCommentsController extends ContribController {
         !$this->errors &&
         $this->currentUser()->hasPermission('skip comment approval')
       ) {
-        $selector = $cid;
+        $selector = static::getCommentSelectorPrefix() . $cid;
         $position = 'before';
       }
       // If the new comment is not to be shown immediately, or if there are
       // errors, insert the message directly below the parent comment.
       else {
-        $selector = $comment->get('pid')->target_id;
-        $position = 'after';
+        if (!empty($pid = $comment->get('pid')->target_id)) {
+          $selector = static::getCommentSelectorPrefix() . $pid;
+          $position = 'after';
+        }
+        else {
+          // If parent comment is not available insert messages to form.
+          $selectors = $this->tempStore->getSelectors($request);
+          $selector = $selectors['form_html_id'] ?? '';
+          $position = 'before';
+        }
       }
 
       $response = $this->addMessages(
         $request,
         $response,
-        static::getCommentSelectorPrefix() . $selector,
+        $selector,
         $position
       );
     }


### PR DESCRIPTION
## Problem
If I try to submit a comment (for example, on "Topic" page) with an empty body the error messages don't displays.

## Solution
Refactor code and add a correct selector for AjaxCommand.

## Issue tracker
- https://www.drupal.org/project/social/issues/3207801
- https://getopensocial.atlassian.net/browse/YANG-5392

## How to test
- [ ] Log in as a LU
- [ ] Go to any Topic view page
- [ ] Add a comment with empty body

## Release notes
Fix error message displaying on comments.
