### PR TITLE
Issue #3208055 by Kingdutch: [GraphQL] Provide UUIDv4 scalar type

### DIFF
--- a/modules/custom/social_graphql/graphql/open_social.graphqls
+++ b/modules/custom/social_graphql/graphql/open_social.graphqls
@@ -49,6 +49,12 @@ interface Node {
   id: ID!
 }
 
+"""
+A valid version 4 UUID
+"""
+# This should not be used for entity UUIDs which should use ID instead.
+# This can be used for user provided strings such as a clientMutationId.
+scalar UUIDv4
 
 """
 An access role for a user

--- a/modules/custom/social_graphql/src/Wrappers/InputBase.php
+++ b/modules/custom/social_graphql/src/Wrappers/InputBase.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Drupal\social_graphql\Wrappers;
 
+use Drupal\Component\Uuid\Uuid;
+use Drupal\social_graphql\GraphQL\Violation;
+
 /**
  * Provides a base class for input types.
  *
@@ -43,8 +46,13 @@ abstract class InputBase implements RelayMutationInputInterface {
    * {@inheritdoc}
    */
   public function setValues(array $input) : void {
-    if (isset($input['clientMutationId']) && trim($input['clientMutationId']) !== "") {
-      $this->clientMutationId = trim($input['clientMutationId']);
+    if (!empty($input['clientMutationId'])) {
+      if (Uuid::isValid($input['clientMutationId'])) {
+        $this->clientMutationId = $input['clientMutationId'];
+      }
+      else {
+        $this->violations[] = new Violation("INVALID_CLIENT_MUTATION_ID");
+      }
     }
   }
 


### PR DESCRIPTION
<h3 id="summary-problem-motivation">Problem/Motivation</h3>
We want to have specific input and output formats for clientMutationId and related types.


<h3 id="summary-proposed-resolution">Proposed resolution</h3>
Introduce a UUIDv4 scalar that makes it clear what the format should be.

This scalar is separate from GraphQLs built-in ID which is an opaque identifier type that has meaning to the server. The UUIDv4 can be used for the specific string format that may not need to correspond to data within Open Social.

Any use of <code>clientMutationId</code> is changed to follow the UUIDv4 format so that it becomes safe for us to store in the database.


## Issue tracker
https://www.drupal.org/project/social/issues/3208055

## How to test
Not under test, tested by an Open Social extension.

## Screenshots
N/a

## Release notes
N/a unreleased internal change

## Change Record
N/a unreleased internal change

## Translations
N/a API only change