### PR TITLE
Issue #3208317 by Kingdutch: Introduce OpenSocial::VERSION and OpenSo…

### DIFF
--- a/src/Social.php
+++ b/src/Social.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Drupal\social;
+
+/**
+ * Static Open Social metadata.
+ */
+class Social {
+
+  /**
+   * The current system version.
+   */
+  public const VERSION = '10.0.0';
+
+  /**
+   * The count of service container changes.
+   *
+   * This can be used in the deployment_identifier to ensure the services
+   * container is properly invalidated before updates.
+   *
+   * ```
+   * $settings['deployment_identifier'] = \Drupal::VERSION . "-" . Social::VERSION . "-" . Social::CONTAINER_COUNTER;
+   * ```
+   */
+  public const CONTAINER_COUNTER = '1';
+
+}


### PR DESCRIPTION
…cial::CONTAINER_COUNTER constants

<h3 id="summary-problem-motivation">Problem/Motivation</h3>
Drupal uses a <code>deployment_identifier</code> to identify when it needs to throw away its services cache before a request and/or before updates. It recommends basing this on <code>\Drupal::VERSION</code>. However, that constant may change a lot less often than Open Social changes things in the service container, so it does not adequately solve our caching problem.

<h4 id="summary-steps-reproduce">Steps to reproduce</h4>


<h3 id="summary-proposed-resolution">Proposed resolution</h3>
Introduce a <code>Social::CONTAINER_COUNTER</code> constant that developers update when they make changes to a `services.yml` file anywhere in Open Social. This ensures that updating to that commit will properly clear the service container before running updates.

While we're at it we introduce <code>Social::VERSION</code> which may be useful to someone somewhere.

Update:

The `Social::VERSION` should also be added to the deployment_identifier so that updating between Open Social versions with the same CONTAINER_COUNTER (e.g. due to backports) still changes the container cache.

## Issue tracker
https://www.drupal.org/project/social/issues/3208317

## How to test
*For example*
- [ ] Tests should pass

## Screenshots
N/a

## Release notes
Open Social now contains a `Drupal\social\Social` class that contains the Open Social `VERSION` and `CONTAINER_COUNTER` constants. Both should be added to your `deployment_identifier` in settings if you currently use `\Drupal::VERSION` to ensure that the service container is invalidated before Open Social updates.

```
$settings['deployment_identifier'] = \Drupal::VERSION . "-" . Social::VERSION . "-" . Social::CONTAINER_COUNTER;
```

## Change Record
Don't think this needs a change record? Although it may help for a code sample?

## Translations
N/a
