### PR TITLE
[Internal] Change link from getopensocial.com/services to Review Open Social on Capterra

### DIFF
--- a/modules/custom/social_lets_connect/modules/social_lets_connect_contact/social_lets_connect_contact.links.menu.yml
+++ b/modules/custom/social_lets_connect/modules/social_lets_connect_contact/social_lets_connect_contact.links.menu.yml
@@ -4,10 +4,10 @@ social_lets_connect_contact.extensions:
   url: https://www.getopensocial.com/extensions
   weight: -6
 
-social_lets_connect_contact.services:
-  title: 'Services'
+social_lets_connect_contact.review:
+  title: 'Review Open Social'
   parent: social_lets_connect.main
-  url: https://www.getopensocial.com/services
+  url: https://reviews.capterra.com/new/179231
   weight: -5
 
 social_lets_connect_contact.contact:


### PR DESCRIPTION
## Problem
The link in the social_lets_connect_contact module to `Services` leads to a 404 on getopensocial.com . We would like to change this to Review Open Social on Capterra.

## Solution
Change the link in said module to link (Distro) users to reviewing Open Social on Capterra.

## Issue tracker
https://getopensocial.atlassian.net/browse/SAL-21

## How to test
- [ ] As an SM, see that the link in the social_lets_connect_contact module now points to the review page on Capterra.