### PR TITLE
Issue #3208696 by nkoporec: I shouldn’t be able to share the 'Delete node' page

### DIFF
--- a/modules/social_features/social_sharing/social_sharing.module
+++ b/modules/social_features/social_sharing/social_sharing.module
@@ -22,6 +22,7 @@ function social_sharing_block_access(Block $block, $operation, AccountInterface 
     $excluded_routes = [
       'node.add',
       'entity.node.edit_form',
+      'entity.node.delete_form',
     ];
 
     // Call module handler service.


### PR DESCRIPTION
## Problem
When I'm deleting a public page, I should't be able to share it via the Share this page block.

## Solution
I added the 'entity.node.delete_form' route to the excluded routes in the Social Sharing module.

## Issue tracker
https://www.drupal.org/project/social/issues/3208696

## How to test
- [ ] Enable the Social Sharing module
- [ ] Create a new 'Basic page'
- [ ] Set visibility to Public
- [ ] Try to delete the newly created page, on the confirmation page the "Share this page" block will still be visible.

## Screenshots

Before:

![share-this-block-before](https://user-images.githubusercontent.com/35064680/114692514-faf3f500-9d18-11eb-94af-6c41ef27e1fe.png)

After:

![share-this-block-after](https://user-images.githubusercontent.com/35064680/114692558-05ae8a00-9d19-11eb-82e3-35c8727ed5df.png)


## Release notes
Add 'entity.node.delete_form' to the excluded routes in Social Sharing module
