### PR TITLE
Issue #3208734 by vnech: Update form display configuration for Public, Open, Closed and Secret group types

### DIFF
--- a/modules/social_features/social_group/config/install/core.entity_form_display.group.closed_group.default.yml
+++ b/modules/social_features/social_group/config/install/core.entity_form_display.group.closed_group.default.yml
@@ -44,13 +44,15 @@ third_party_settings:
         id: ''
         required_fields: true
     group_settings:
-      children: {  }
+      children:
+        - path
       parent_name: ''
-      weight: -5
-      format_type: fieldset
+      weight: 10
+      format_type: details
       format_settings:
         id: ''
-        classes: ''
+        classes: 'social-collapsible-fieldset'
+        open: false
         description: ''
         required_fields: true
       label: Settings

--- a/modules/social_features/social_group/config/install/core.entity_form_display.group.closed_group.default.yml
+++ b/modules/social_features/social_group/config/install/core.entity_form_display.group.closed_group.default.yml
@@ -23,7 +23,7 @@ third_party_settings:
         - field_group_image
       parent_name: ''
       weight: 0
-      label: Content
+      label: 'Basic information'
       format_type: fieldset
       format_settings:
         description: ''

--- a/modules/social_features/social_group/config/install/core.entity_form_display.group.open_group.default.yml
+++ b/modules/social_features/social_group/config/install/core.entity_form_display.group.open_group.default.yml
@@ -44,13 +44,15 @@ third_party_settings:
         id: ''
         required_fields: true
     group_settings:
-      children: {  }
+      children:
+        - path
       parent_name: ''
-      weight: -5
-      format_type: fieldset
+      weight: 10
+      format_type: details
       format_settings:
         id: ''
-        classes: ''
+        classes: 'social-collapsible-fieldset'
+        open: false
         description: ''
         required_fields: true
       label: Settings

--- a/modules/social_features/social_group/config/install/core.entity_form_display.group.open_group.default.yml
+++ b/modules/social_features/social_group/config/install/core.entity_form_display.group.open_group.default.yml
@@ -23,7 +23,7 @@ third_party_settings:
         - field_group_image
       parent_name: ''
       weight: 0
-      label: Content
+      label: 'Basic information'
       format_type: fieldset
       format_settings:
         description: ''

--- a/modules/social_features/social_group/config/install/core.entity_form_display.group.public_group.default.yml
+++ b/modules/social_features/social_group/config/install/core.entity_form_display.group.public_group.default.yml
@@ -44,13 +44,15 @@ third_party_settings:
         id: ''
         required_fields: true
     group_settings:
-      children: {  }
+      children:
+        - path
       parent_name: ''
-      weight: -5
-      format_type: fieldset
+      weight: 10
+      format_type: details
       format_settings:
         id: ''
-        classes: ''
+        classes: 'social-collapsible-fieldset'
+        open: false
         description: ''
         required_fields: true
       label: Settings

--- a/modules/social_features/social_group/config/install/core.entity_form_display.group.public_group.default.yml
+++ b/modules/social_features/social_group/config/install/core.entity_form_display.group.public_group.default.yml
@@ -23,7 +23,7 @@ third_party_settings:
         - field_group_image
       parent_name: ''
       weight: 0
-      label: Content
+      label: 'Basic information'
       format_type: fieldset
       format_settings:
         description: ''

--- a/modules/social_features/social_group/config/update/social_group_update_8905.yml
+++ b/modules/social_features/social_group/config/update/social_group_update_8905.yml
@@ -4,6 +4,8 @@ core.entity_form_display.group.open_group.default:
     change:
       third_party_settings:
         field_group:
+          group_content:
+            label: 'Basic information'
           group_settings:
             children:
               - path
@@ -18,6 +20,8 @@ core.entity_form_display.group.closed_group.default:
     change:
       third_party_settings:
         field_group:
+          group_content:
+            label: 'Basic information'
           group_settings:
             children:
               - path
@@ -32,6 +36,8 @@ core.entity_form_display.group.public_group.default:
     change:
       third_party_settings:
         field_group:
+          group_content:
+            label: 'Basic information'
           group_settings:
             children:
               - path

--- a/modules/social_features/social_group/config/update/social_group_update_8905.yml
+++ b/modules/social_features/social_group/config/update/social_group_update_8905.yml
@@ -1,0 +1,42 @@
+core.entity_form_display.group.open_group.default:
+  expected_config: {  }
+  update_actions:
+    change:
+      third_party_settings:
+        field_group:
+          group_settings:
+            children:
+              - path
+            format_type: details
+            format_settings:
+              classes: social-collapsible-fieldset
+              open: false
+            weight: 10
+core.entity_form_display.group.closed_group.default:
+  expected_config: {  }
+  update_actions:
+    change:
+      third_party_settings:
+        field_group:
+          group_settings:
+            children:
+              - path
+            format_type: details
+            format_settings:
+              classes: social-collapsible-fieldset
+              open: false
+            weight: 10
+core.entity_form_display.group.public_group.default:
+  expected_config: {  }
+  update_actions:
+    change:
+      third_party_settings:
+        field_group:
+          group_settings:
+            children:
+              - path
+            format_type: details
+            format_settings:
+              classes: social-collapsible-fieldset
+              open: false
+            weight: 10

--- a/modules/social_features/social_group/modules/social_group_secret/config/install/core.entity_form_display.group.secret_group.default.yml
+++ b/modules/social_features/social_group/modules/social_group_secret/config/install/core.entity_form_display.group.secret_group.default.yml
@@ -45,13 +45,15 @@ third_party_settings:
         id: ''
         required_fields: true
     group_settings:
-      children: {  }
+      children:
+        - path
       parent_name: ''
-      weight: -5
-      format_type: fieldset
+      weight: 10
+      format_type: details
       format_settings:
         id: ''
-        classes: ''
+        classes: 'social-collapsible-fieldset'
+        open: false
         description: ''
         required_fields: true
       label: Settings

--- a/modules/social_features/social_group/modules/social_group_secret/config/install/core.entity_form_display.group.secret_group.default.yml
+++ b/modules/social_features/social_group/modules/social_group_secret/config/install/core.entity_form_display.group.secret_group.default.yml
@@ -24,7 +24,7 @@ third_party_settings:
         - field_group_image
       parent_name: ''
       weight: 0
-      label: Content
+      label: 'Basic information'
       format_type: fieldset
       format_settings:
         description: ''

--- a/modules/social_features/social_group/modules/social_group_secret/config/update/social_group_secret_update_8901.yml
+++ b/modules/social_features/social_group/modules/social_group_secret/config/update/social_group_secret_update_8901.yml
@@ -1,0 +1,14 @@
+core.entity_form_display.group.secret_group.default:
+  expected_config: {  }
+  update_actions:
+    change:
+      third_party_settings:
+        field_group:
+          group_settings:
+            children:
+              - path
+            format_type: details
+            format_settings:
+              classes: social-collapsible-fieldset
+              open: false
+            weight: 10

--- a/modules/social_features/social_group/modules/social_group_secret/config/update/social_group_secret_update_8901.yml
+++ b/modules/social_features/social_group/modules/social_group_secret/config/update/social_group_secret_update_8901.yml
@@ -4,6 +4,8 @@ core.entity_form_display.group.secret_group.default:
     change:
       third_party_settings:
         field_group:
+          group_content:
+            label: 'Basic information'
           group_settings:
             children:
               - path

--- a/modules/social_features/social_group/modules/social_group_secret/social_group_secret.install
+++ b/modules/social_features/social_group/modules/social_group_secret/social_group_secret.install
@@ -84,3 +84,17 @@ function social_group_secret_update_8801() {
   // Output logged messages to related channel of update execution.
   return $updateHelper->logger()->output();
 }
+
+/**
+ * Update form display for "Secret Group" according new 10.x UX design.
+ */
+function social_group_secret_update_8901() {
+  /** @var \Drupal\update_helper\Updater $updateHelper */
+  $updateHelper = \Drupal::service('update_helper.updater');
+
+  // Execute configuration update definitions with logging of success.
+  $updateHelper->executeUpdate('social_group_secret', 'social_group_secret_update_8901');
+
+  // Output logged messages to related channel of update execution.
+  return $updateHelper->logger()->output();
+}

--- a/modules/social_features/social_group/social_group.install
+++ b/modules/social_features/social_group/social_group.install
@@ -599,3 +599,17 @@ function social_group_update_8904() {
   $config = \Drupal::configFactory()->getEditable('social_group.settings');
   $config->set('social_group_type_required', FALSE)->save();
 }
+
+/**
+ * Update form displays for group types according new 10.x UX design.
+ */
+function social_group_update_8905() {
+  /** @var \Drupal\update_helper\Updater $updateHelper */
+  $updateHelper = \Drupal::service('update_helper.updater');
+
+  // Execute configuration update definitions with logging of success.
+  $updateHelper->executeUpdate('social_group', 'social_group_update_8905');
+
+  // Output logged messages to related channel of update execution.
+  return $updateHelper->logger()->output();
+}


### PR DESCRIPTION
## Problem
These group types have incorrect fields order on add/edit pages:
- Public group
- Open group
- Closed group
- Secret group

## Solution
Update form display configuration for group types

## Issue tracker
- https://www.drupal.org/project/social/issues/3208734
- https://getopensocial.atlassian.net/browse/ECI-1160

## How to test
- [x] Login as CM+
- [x] Visit add/edit any metioned group page

## Release notes
Update form display configuration for group types: Public group, Open group, Closed group, Secret group"