### PR TITLE
Issue #3195082 by Kingdutch: [GraphQL] Use dependency injection for e…

### DIFF
--- a/modules/custom/social_graphql/src/Plugin/GraphQL/DataProducer/Entity/EntityDataProducerPluginBase.php
+++ b/modules/custom/social_graphql/src/Plugin/GraphQL/DataProducer/Entity/EntityDataProducerPluginBase.php
@@ -6,6 +6,9 @@ namespace Drupal\social_graphql\Plugin\GraphQL\DataProducer\Entity;
 
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\graphql\GraphQL\Buffers\EntityBuffer;
+use Drupal\graphql\GraphQL\Buffers\EntityRevisionBuffer;
+use Drupal\graphql\GraphQL\Buffers\EntityUuidBuffer;
 use Drupal\graphql\Plugin\GraphQL\DataProducer\DataProducerPluginBase;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -22,6 +25,27 @@ class EntityDataProducerPluginBase extends DataProducerPluginBase implements Con
   protected $entityTypeManager;
 
   /**
+   * The GraphQL entity buffer.
+   *
+   * @var \Drupal\graphql\GraphQL\Buffers\EntityBuffer
+   */
+  protected $graphqlEntityBuffer;
+
+  /**
+   * The GraphQL entity UUID buffer.
+   *
+   * @var \Drupal\graphql\GraphQL\Buffers\EntityUuidBuffer
+   */
+  protected $graphqlEntityUuidBuffer;
+
+  /**
+   * The GraphQL entity revision buffer.
+   *
+   * @var \Drupal\graphql\GraphQL\Buffers\EntityRevisionBuffer
+   */
+  protected $graphqlEntityRevisionBuffer;
+
+  /**
    * {@inheritdoc}
    *
    * @codeCoverageIgnore
@@ -31,7 +55,10 @@ class EntityDataProducerPluginBase extends DataProducerPluginBase implements Con
       $configuration,
       $plugin_id,
       $plugin_definition,
-      $container->get('entity_type.manager')
+      $container->get('entity_type.manager'),
+      $container->get('graphql.buffer.entity'),
+      $container->get('graphql.buffer.entity_uuid'),
+      $container->get('graphql.buffer.entity_revision')
     );
   }
 
@@ -46,6 +73,12 @@ class EntityDataProducerPluginBase extends DataProducerPluginBase implements Con
    *   The plugin definition array.
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
    *   The entity type manager service.
+   * @param \Drupal\graphql\GraphQL\Buffers\EntityBuffer $graphqlEntityBuffer
+   *   The GraphQL entity buffer.
+   * @param \Drupal\graphql\GraphQL\Buffers\EntityUuidBuffer $graphqlEntityUuidBuffer
+   *   The GraphQL entity uuid buffer.
+   * @param \Drupal\graphql\GraphQL\Buffers\EntityRevisionBuffer $graphqlEntityRevisionBuffer
+   *   The GraphQL entity revision buffer.
    *
    * @codeCoverageIgnore
    */
@@ -53,10 +86,16 @@ class EntityDataProducerPluginBase extends DataProducerPluginBase implements Con
     array $configuration,
     $pluginId,
     array $pluginDefinition,
-    EntityTypeManagerInterface $entityTypeManager
+    EntityTypeManagerInterface $entityTypeManager,
+    EntityBuffer $graphqlEntityBuffer,
+    EntityUuidBuffer $graphqlEntityUuidBuffer,
+    EntityRevisionBuffer $graphqlEntityRevisionBuffer
   ) {
     parent::__construct($configuration, $pluginId, $pluginDefinition);
     $this->entityTypeManager = $entityTypeManager;
+    $this->graphqlEntityBuffer = $graphqlEntityBuffer;
+    $this->graphqlEntityUuidBuffer = $graphqlEntityUuidBuffer;
+    $this->graphqlEntityRevisionBuffer = $graphqlEntityRevisionBuffer;
   }
 
 }

--- a/modules/social_features/social_user/src/GraphQL/QueryHelper/UserQueryHelper.php
+++ b/modules/social_features/social_user/src/GraphQL/QueryHelper/UserQueryHelper.php
@@ -4,6 +4,7 @@ namespace Drupal\social_user\GraphQL\QueryHelper;
 
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Entity\Query\QueryInterface;
+use Drupal\graphql\GraphQL\Buffers\EntityBuffer;
 use Drupal\social_graphql\GraphQL\ConnectionQueryHelperInterface;
 use Drupal\social_graphql\Wrappers\Cursor;
 use Drupal\social_graphql\Wrappers\Edge;
@@ -25,6 +26,13 @@ class UserQueryHelper implements ConnectionQueryHelperInterface {
   protected EntityTypeManagerInterface $entityTypeManager;
 
   /**
+   * The GraphQL entity buffer.
+   *
+   * @var \Drupal\graphql\GraphQL\Buffers\EntityBuffer
+   */
+  protected EntityBuffer $graphqlEntityBuffer;
+
+  /**
    * The key that is used for sorting.
    *
    * @var string
@@ -34,12 +42,15 @@ class UserQueryHelper implements ConnectionQueryHelperInterface {
   /**
    * UserQueryHelper constructor.
    *
+   * @param \Drupal\graphql\GraphQL\Buffers\EntityBuffer $graphql_entity_buffer
+   *   The GraphQL entity buffer.
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
    *   The Drupal entity type manager.
    * @param string $sort_key
    *   The key that is used for sorting.
    */
-  public function __construct(EntityTypeManagerInterface $entity_type_manager, string $sort_key) {
+  public function __construct(EntityBuffer $graphql_entity_buffer, EntityTypeManagerInterface $entity_type_manager, string $sort_key) {
+    $this->graphqlEntityBuffer = $graphql_entity_buffer;
     $this->entityTypeManager = $entity_type_manager;
     $this->sortKey = $sort_key;
   }
@@ -109,8 +120,7 @@ class UserQueryHelper implements ConnectionQueryHelperInterface {
     // ensure the entities for this query are only loaded once. Even if the
     // results are used multiple times.
     else {
-      $buffer = \Drupal::service('graphql.buffer.entity');
-      $callback = $buffer->add('user', array_values($result));
+      $callback = $this->graphqlEntityBuffer->add('user', array_values($result));
     }
 
     return new Deferred(

--- a/modules/social_features/social_user/src/Plugin/GraphQL/DataProducer/QueryUser.php
+++ b/modules/social_features/social_user/src/Plugin/GraphQL/DataProducer/QueryUser.php
@@ -74,7 +74,7 @@ class QueryUser extends EntityDataProducerPluginBase {
    * @todo https://www.drupal.org/project/social/issues/3191637
    */
   public function resolve(?int $first, ?string $after, ?int $last, ?string $before, bool $reverse, string $sortKey, RefinableCacheableDependencyInterface $metadata) {
-    $query_helper = new UserQueryHelper($this->entityTypeManager, $sortKey);
+    $query_helper = new UserQueryHelper($this->graphqlEntityBuffer, $this->entityTypeManager, $sortKey);
     $metadata->addCacheableDependency($query_helper);
 
     $connection = new EntityConnection($query_helper);


### PR DESCRIPTION
…ntity buffer in Query Helpers

## Problem
Our query helpers currently don't use dependency injection to get the buffer that they need.

## Solution
We make all the GraphQL entity buffers available on our data producer base. This shouldn't incur a performance penalty since these will always be used somewhere in a request. However, it makes sure that developers can easily and properly make them available through dependency injection which makes testing easier.

## Issue tracker
https://www.drupal.org/project/social/issues/3195082

## How to test

- [ ] Unit tests should pass

## Screenshots
N/a

## Release notes
N/a - Internal unreleased change

## Change Record
N/a 

## Translations
N/a