### PR TITLE
Issue #3209694 by Kingdutch: [GraphQL] PayloadInterface return type a…

### DIFF
--- a/modules/custom/social_graphql/src/GraphQL/Payload/PayloadInterface.php
+++ b/modules/custom/social_graphql/src/GraphQL/Payload/PayloadInterface.php
@@ -17,8 +17,8 @@ interface PayloadInterface {
    * @param \Drupal\social_graphql\GraphQL\ViolationInterface $violation
    *   A violation.
    *
-   * @return \Drupal\social_graphql\GraphQL\Payload\PayloadInterface
-   *   This response.
+   * @return $this
+   *   This payload.
    */
   public function addViolation(ViolationInterface $violation): self;
 
@@ -28,8 +28,8 @@ interface PayloadInterface {
    * @param array $violations
    *   An array of violations.
    *
-   * @return \Drupal\social_graphql\GraphQL\Payload\PayloadInterface
-   *   This response.
+   * @return $this
+   *   This payload.
    */
   public function addViolations(array $violations): self;
 


### PR DESCRIPTION
…nnotation should be $this

<h3 id="summary-problem-motivation">Problem/Motivation</h3>
PHPStan complains when chaining or return from calls to <code>PayloadInterface::addViolation(s)</code> since it claims to return <code>PayloadInterface</code> only but should actually return whatever class it was called on and not downgrade to something different.

<h3 id="summary-proposed-resolution">Proposed resolution</h3>
Change the return type annotation to <code>$this</code> so automated systems understand the call returns the same instance and supports chaining.


## Issue tracker
https://www.drupal.org/project/social/issues/3209694

## How to test
- [ ] PHPUnit tests should pass

## Screenshots
N/a docblock change

## Release notes
N/a unsupported experimental feature

## Change Record
N/a unsupported experimental feature

## Translations
N/a