### PR TITLE
 Issue #3209986 by nkoporec: The 'Newest members' block is not displaying correctly

### DIFF
--- a/modules/social_features/social_tagging/social_tagging.services.yml
+++ b/modules/social_features/social_tagging/social_tagging.services.yml
@@ -4,7 +4,7 @@ services:
     arguments: ['@entity_type.manager', '@config.factory', '@language_manager']
   social_tagging.overrider:
     class: Drupal\social_tagging\SocialTaggingOverrides
-    arguments: ['@current_route_match','@current_route_match', '@social_tagging.tag_service']
+    arguments: ['@config.factory', '@current_route_match', '@social_tagging.tag_service']
     tags:
       - { name: config.factory.override, priority: 5 }
   social_tagging.translation_defaults:

--- a/modules/social_features/social_tagging/social_tagging.services.yml
+++ b/modules/social_features/social_tagging/social_tagging.services.yml
@@ -4,7 +4,7 @@ services:
     arguments: ['@entity_type.manager', '@config.factory', '@language_manager']
   social_tagging.overrider:
     class: Drupal\social_tagging\SocialTaggingOverrides
-    arguments: ['@config.factory']
+    arguments: ['@current_route_match','@current_route_match', '@social_tagging.tag_service']
     tags:
       - { name: config.factory.override, priority: 5 }
   social_tagging.translation_defaults:

--- a/modules/social_features/social_tagging/src/SocialTaggingOverrides.php
+++ b/modules/social_features/social_tagging/src/SocialTaggingOverrides.php
@@ -7,6 +7,7 @@ use Drupal\Core\Config\ConfigFactoryOverrideInterface;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Config\StorageInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\Core\Routing\RouteMatchInterface;
 
 /**
  * Configuration override.
@@ -22,14 +23,34 @@ class SocialTaggingOverrides implements ConfigFactoryOverrideInterface {
    */
   protected $configFactory;
 
+    /**
+   * The current route match.
+   *
+   * @var \Drupal\Core\Routing\RouteMatchInterface
+   */
+  protected $currentRouteMatch;
+
+  /**
+   * Social tagging service.
+   *
+   * @var \Drupal\social_tagging\SocialTaggingService
+   */
+  protected $socialTaggingService;
+
   /**
    * Constructs the service.
    *
    * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
    *   The config factory.
+   * @param \Drupal\Core\Routing\RouteMatchInterface $currentRouteMatch
+   *   The request stack.
+   * @param \Drupal\social_tagging\SocialTaggingService $socialTaggingService
+   *   The request stack.
    */
-  public function __construct(ConfigFactoryInterface $config_factory) {
+  public function __construct(ConfigFactoryInterface $config_factory, RouteMatchInterface $currentRouteMatch, SocialTaggingService $socialTaggingService) {
     $this->configFactory = $config_factory;
+    $this->currentRouteMatch = $currentRouteMatch;
+    $this->socialTaggingService = $socialTaggingService;
   }
 
   /**
@@ -87,11 +108,7 @@ class SocialTaggingOverrides implements ConfigFactoryOverrideInterface {
     $overrides = [];
 
     /** @var \Drupal\social_tagging\SocialTaggingService $tag_service */
-    $tag_service = \Drupal::service('social_tagging.tag_service');
-
-    /** @var \Drupal\social_core\Service\MachineName $machine_name */
-    $machine_name_service = \Drupal::service('social_core.machine_name');
-
+    $tag_service = $this->socialTaggingService;
     $config = $this->configFactory;
 
     // Check if tagging is active.
@@ -264,7 +281,7 @@ class SocialTaggingOverrides implements ConfigFactoryOverrideInterface {
       'views.view.newest_groups' => 'page_all_groups',
     ];
 
-    $route_name = \Drupal::routeMatch()->getRouteName();
+    $route_name = $this->currentRouteMatch->getRouteName();
     if ($tag_service->profileActive() && $route_name == 'view.newest_users.page_newest_users') {
       $config_overviews['views.view.newest_users'] = 'page_newest_users';
     }

--- a/modules/social_features/social_tagging/src/SocialTaggingOverrides.php
+++ b/modules/social_features/social_tagging/src/SocialTaggingOverrides.php
@@ -264,7 +264,8 @@ class SocialTaggingOverrides implements ConfigFactoryOverrideInterface {
       'views.view.newest_groups' => 'page_all_groups',
     ];
 
-    if ($tag_service->profileActive()) {
+    $route_name = \Drupal::routeMatch()->getRouteName();
+    if ($tag_service->profileActive() && $route_name == 'view.newest_users.page_newest_users') {
       $config_overviews['views.view.newest_users'] = 'page_newest_users';
     }
 

--- a/modules/social_features/social_tagging/src/SocialTaggingOverrides.php
+++ b/modules/social_features/social_tagging/src/SocialTaggingOverrides.php
@@ -23,7 +23,7 @@ class SocialTaggingOverrides implements ConfigFactoryOverrideInterface {
    */
   protected $configFactory;
 
-    /**
+  /**
    * The current route match.
    *
    * @var \Drupal\Core\Routing\RouteMatchInterface


### PR DESCRIPTION
## Problem
If you enable social tagging module and set profile tagging then the 'Newest Members' block stops showing users.

## Solution
Only alter the config when on view.newest_users.page_newest_users display.

## Issue tracker
https://www.drupal.org/project/social/issues/3209986

## How to test
1. Enable social_tagging module
2. Set profile tagging
3. Check the 'Newest members' block

## Screenshots
<img width="393" alt="Screen Shot 2021-04-14 at 11 09 44 AM" src="https://user-images.githubusercontent.com/35064680/115576629-fd7bbf00-a2c3-11eb-9287-868d055e4c34.png">

