### PR TITLE
Issue #3210386 by Ressinel: Fix - Users see hidden First name and Last name.

### DIFF
--- a/modules/social_features/social_profile/modules/social_profile_privacy/social_profile_privacy.module
+++ b/modules/social_features/social_profile/modules/social_profile_privacy/social_profile_privacy.module
@@ -316,18 +316,112 @@ function social_profile_privacy_entity_field_access($operation, FieldDefinitionI
  * users that are allowed to see a full name even when there's a nickname.
  */
 function social_profile_privacy_social_user_name_display_suggestions_alter(array &$suggestions, AccountInterface $account) {
+  $current_user = \Drupal::currentUser();
   $config = \Drupal::config('social_profile_privacy.settings');
 
   if (
     $config->get('limit_search_and_mention')
     && isset($suggestions['full_name'], $suggestions['nickname'])
-    && \Drupal::currentUser()->hasPermission('social profile privacy always show full name')
+    && $current_user->hasPermission('social profile privacy always show full name')
   ) {
     $suggestions['nickname_with_full_name'] = [
       'weight' => -PHP_INT_MAX,
       'name' => $suggestions['nickname']['name'] . ' (' . $suggestions['full_name']['name'] . ')',
     ];
   }
+
+  // If the current user has whether permission to view full name or hidden
+  // fields then do nothing here.
+  if ($current_user->hasPermission('social profile privacy always show full name') || $current_user->hasPermission('social profile privacy view hidden fields')) {
+    return;
+  }
+
+  $uid = $account->id();
+  $fields = social_profile_privacy_private_fields_list($uid);
+
+  // If First name and Last name are hidden then suggestion with check access
+  // for those fields doesn't add for Full name.
+  // @see social_profile_privacy_social_user_name_display_suggestions()
+  // So we need to remove the Full name suggestion if all of those fields are
+  // hidden.
+  if (isset($suggestions['full_name'])) {
+    // Profile fields which use for composing the full name.
+    $account_name_fields = [
+      'field_profile_first_name',
+      'field_profile_last_name',
+    ];
+    $account_name_hidden = TRUE;
+    // If at least one field is not hidden then we don't need to remove the
+    // Full name suggestion.
+    foreach ($account_name_fields as $account_name_field) {
+      if (!in_array($account_name_field, $fields)) {
+        $account_name_hidden = FALSE;
+        break;
+      }
+    }
+    if ($account_name_hidden) {
+      unset($suggestions['full_name']);
+    }
+  }
+
+  // Remove nickname suggestion if module social_profile_fields are installed
+  // and field is hidden.
+  if (\Drupal::moduleHandler()->moduleExists('social_profile_fields') && isset($suggestions['nickname']) && in_array('field_profile_nick_name', $fields)) {
+    unset($suggestions['nickname']);
+  }
+}
+
+/**
+ * Implements hook_social_user_name_display_suggestions().
+ *
+ * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
+ * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
+ */
+function social_profile_privacy_social_user_name_display_suggestions(AccountInterface $account) : array {
+  $current_user = \Drupal::currentUser();
+  // If the current user has whether permission to view full name or hidden
+  // fields then do nothing here.
+  if ($current_user->hasPermission('social profile privacy always show full name') || $current_user->hasPermission('social profile privacy view hidden fields')) {
+    return [];
+  }
+
+  $suggestions = [];
+
+  /** @var \Drupal\profile\ProfileStorageInterface $storage */
+  $storage = \Drupal::entityTypeManager()->getStorage('profile');
+
+  if ($user_profile = $storage->loadByUser($account, 'profile', TRUE)) {
+    $uid = $account->id();
+    $fields = social_profile_privacy_private_fields_list($uid);
+
+    $account_name = [];
+
+    // Profile fields which use for composing the full name.
+    $account_name_fields = [
+      'field_profile_first_name',
+      'field_profile_last_name',
+    ];
+
+    // Add field name to full name only in case it is no hidden.
+    foreach ($account_name_fields as $account_name_field) {
+      if (!in_array($account_name_field, $fields)) {
+        $account_name[] = trim($user_profile->get($account_name_field)->getString());
+      }
+    }
+
+    // Here we need to compose the full name.
+    $account_name = implode(' ', $account_name);
+
+    // If the full name is not empty we add suggestion.
+    if (strlen($account_name) > 0) {
+      // Add the full name with a default weight.
+      $suggestions['full_name'] = [
+        'name' => trim($account_name),
+      ];
+    }
+  }
+
+  return $suggestions;
 }
 
 /**


### PR DESCRIPTION
## Problem
If you enable social_profile_privacy module and set the First name or Last name as hidden, users will see Fullname anyway in all places where it shows.

## Solution
Add additional checks in social_profile_privacy module

## Issue tracker
- https://www.drupal.org/project/social/issues/3210386

## How to test
- [ ] Enable social_profile_privacy module
- [ ] Go to the settings page `/admin/config/people/social-profile`
- [ ] Select "Hide for others" for First name or Last name
- [ ] As LU you see Fullname (First name + Last name) for all users

## Screenshots
N/A

## Release notes
N/A

## Change Record
N/A

## Translations
N/A
