### PR TITLE
Issue #3210717 - As a LU, I want my group membership count to show only active & correct group memberships [backport of PR #2306]

### DIFF
--- a/modules/social_features/social_group/social_group.api.php
+++ b/modules/social_features/social_group/social_group.api.php
@@ -26,6 +26,18 @@ function hook_social_group_types_alter(array &$social_group_types) {
 }
 
 /**
+ * Hide group types used in open social.
+ *
+ * @param array $hidden_types
+ *   List of group type id's which you want to see removed.
+ *
+ * @ingroup social_group_api
+ */
+function hook_social_group_hide_types_alter(array &$hidden_types) {
+  $hidden_types[] = 'challenge';
+}
+
+/**
  * Provide a method to alter the default content visibility for a group type.
  *
  * @param string $visibility

--- a/modules/social_features/social_group/social_group.services.yml
+++ b/modules/social_features/social_group/social_group.services.yml
@@ -5,7 +5,7 @@ services:
       - { name: event_subscriber }
   social_group.helper_service:
     class: Drupal\social_group\SocialGroupHelperService
-    arguments: ['@database']
+    arguments: ['@database', '@module_handler']
   social_group.set_groups_for_node_service:
     class: Drupal\social_group\SetGroupsForNodeService
     arguments: ['@entity_type.manager', '@module_handler']

--- a/modules/social_features/social_group/src/SocialGroupHelperService.php
+++ b/modules/social_features/social_group/src/SocialGroupHelperService.php
@@ -11,9 +11,10 @@ use Drupal\group\Entity\GroupInterface;
 use Drupal\group\Entity\GroupType;
 use Drupal\node\Entity\Node;
 use Drupal\social_post\Entity\Post;
+use Drupal\Core\Extension\ModuleHandlerInterface;
 
 /**
- * Class SocialGroupHelperService.
+ * Helper class for supporting functions.
  *
  * @package Drupal\social_group
  */
@@ -34,13 +35,23 @@ class SocialGroupHelperService {
   protected $database;
 
   /**
+   * Module handler.
+   *
+   * @var \Drupal\Core\Extension\ModuleHandlerInterface
+   */
+  protected $moduleHandler;
+
+  /**
    * Constructor for SocialGroupHelperService.
    *
    * @param \Drupal\Core\Database\Connection $connection
    *   The database connection.
+   * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
+   *   Module handler.
    */
-  public function __construct(Connection $connection) {
+  public function __construct(Connection $connection, ModuleHandlerInterface $module_handler) {
     $this->database = $connection;
+    $this->moduleHandler = $module_handler;
   }
 
   /**
@@ -82,7 +93,7 @@ class SocialGroupHelperService {
     }
 
     if ($entity['target_type'] === 'post') {
-      /* @var /Drupal/social_post/Entity/Post $post */
+      /** @var /Drupal/social_post/Entity/Post $post */
       $post = Post::load($entity['target_id']);
       $recipient_group = $post->get('field_recipient_group')->getValue();
       if (!empty($recipient_group)) {
@@ -197,6 +208,49 @@ class SocialGroupHelperService {
     }
 
     return $groups[$uid];
+  }
+
+  /**
+   * Count all group memberships for a certain user.
+   *
+   * @param string $uid
+   *   The UID for which we fetch the groups it is member of.
+   *
+   * @return int
+   *   Count of groups a user is a member of.
+   */
+  public function countGroupMembershipsForUser($uid): int {
+    $count = &drupal_static(__FUNCTION__);
+
+    // Get the count of memberships for the user if they aren't known yet.
+    if (!isset($count[$uid])) {
+      $hidden_types = [];
+      $this->moduleHandler->alter('social_group_hide_types', $hidden_types);
+
+      $group_content_types = GroupContentType::loadByEntityTypeId('user');
+      $group_content_types = array_keys($group_content_types);
+      $query = $this->database->select('group_content_field_data', 'gcfd');
+      $query->addField('gcfd', 'gid');
+      $query->condition('gcfd.entity_id', $uid);
+      $query->condition('gcfd.type', $group_content_types, 'IN');
+      if (!empty($hidden_types)) {
+        foreach ($hidden_types as $group_type) {
+          $query->condition('gcfd.type', '%' . $this->database->escapeLike($group_type) . '%', 'NOT LIKE');
+        }
+      }
+      // We need to add another like for the fact that we have more plugins
+      // than memberships for a User, like request or invite which are not
+      // group memberships yet.
+      $query->condition('gcfd.type', '%group_membership', 'LIKE');
+      // Add a query tag for other modules to alter, this query.
+      $query->addTag('count_memberships_for_user');
+      $query->execute()->fetchAll();
+
+      $group_ids = $query->countQuery()->execute()->fetchField();
+      $count[$uid] = $group_ids;
+    }
+
+    return $count[$uid];
   }
 
   /**

--- a/modules/social_features/social_profile/social_profile.module
+++ b/modules/social_features/social_profile/social_profile.module
@@ -35,12 +35,12 @@ function social_profile_field_widget_form_alter(&$element, FormStateInterface $f
   $field_definition = $context['items']->getFieldDefinition();
   switch ($field_definition->getName()) {
     case 'field_profile_phone_number':
-      // @todo: remove this when rule for .form-tel elements will be added.
+      // @todo remove this when rule for .form-tel elements will be added.
       $element['value']['#attributes']['class'][] = 'form-text';
       break;
 
     case 'field_profile_address':
-      // @todo: remove this when script for custom selects will be added.
+      // @todo remove this when script for custom selects will be added.
       $element['country_code']['#attributes']['class'][] = 'browser-default';
       break;
   }
@@ -131,7 +131,11 @@ function social_profile_form_profile_profile_edit_form_alter(array &$form, FormS
   // Check if the Social Profile Fields module is on.
   if (\Drupal::moduleHandler()->moduleExists('social_profile_fields')) {
     // Load the profile fields and check if at least one of them can be changed.
-    if ($profile_fields = \Drupal::entityManager()->getStorage('field_config')->loadByProperties(['entity_type' => 'profile', 'bundle' => 'profile'])) {
+    if ($profile_fields = \Drupal::entityManager()->getStorage('field_config')
+      ->loadByProperties([
+        'entity_type' => 'profile',
+        'bundle' => 'profile',
+      ])) {
       $empty_profile = TRUE;
 
       /** @var \Drupal\field\Entity\FieldConfig $field_config */
@@ -399,7 +403,7 @@ function social_profile_preprocess_profile(array &$variables) {
     $user_statistics = \Drupal::service('social_profile.user_statistics');
     $variables['profile_topics'] = $user_statistics->nodeCount($user->id(), 'topic');
     $variables['profile_events'] = $user_statistics->nodeCount($user->id(), 'event');
-    $variables['profile_groups'] = count(\Drupal::service('social_group.helper_service')->getAllGroupsForUser($user->id()));
+    $variables['profile_groups'] = \Drupal::service('social_group.helper_service')->countGroupMembershipsForUser($user->id());
   }
 }
 
@@ -529,7 +533,7 @@ function social_profile_form_user_form_alter(&$form, FormStateInterface $form_st
   $profile = _social_profile_get_profile_from_route();
 
   if ($profile instanceof Profile) {
-    // @TODO: Move privacy settings to a separate entity.
+    // @todo Move privacy settings to a separate entity.
     // Check what the global value is.
     $social_profile_settings_config = \Drupal::config('social_profile.settings');
     $global_values = [
@@ -602,7 +606,7 @@ function _social_profile_form_user_form_submit(array $form, FormStateInterface $
 
     $uid = $profile->get('uid')->target_id;
     // Save language info in the user data.
-    // @TODO: Move privacy settings to a separate entity.
+    // @todo Move privacy settings to a separate entity.
     $user_data = \Drupal::service('user.data');
     $user_data->set('social_profile_privacy', $uid, 'lang_info', $profile_privacy['social_profile_show_language']);
     // Invalidate profile cache tags.
@@ -816,6 +820,7 @@ function social_profile_social_user_account_header_items_alter(array &$menu_item
   // Provide a render array as image which will overrule the user icon.
   $menu_items['account_box']['#image'] = \Drupal::entityTypeManager()
     ->getViewBuilder('profile')
-    ->view($profile, 'small');;
+    ->view($profile, 'small');
+  ;
 
 }

--- a/tests/behat/features/capabilities/group/group-invite-members.feature
+++ b/tests/behat/features/capabilities/group/group-invite-members.feature
@@ -1,0 +1,99 @@
+@api @notifications @stability @stability-3 @YANG-4199 @group-invite-members
+Feature: Send invite group email notifications
+  Benefit: Email notifications attract users to the platform
+  Role: As a SM
+  Goal/desire: I want to be able to invite group members
+
+  @email-spool
+  Scenario: Send group invite email for new user
+
+    Given I set the configuration item "system.site" with key "name" to "Open Social"
+    Given users:
+      | name   | mail  | status | roles |
+      | site_manager_1 | site_manager_1@example.com | 1      | sitemanager  |
+      | existing_user_1 | existing_user_1@example.com | 1      |   |
+    Given groups:
+      | title             | description                    | author          | type           | language |
+      | Test-invite-group | Something that wanted share..  | site_manager_1  | flexible_group | en       |
+
+    # Lets first check if sending mail works properly
+    Given I am logged in as an "administrator"
+    And I go to "/admin/config/swiftmailer/test"
+    And I should see "This page allows you to send a test e-mail to a recipient of your choice."
+    When I fill in the following:
+      | E-mail | site_manager_1@example.com |
+    Then I press "Send"
+    And I should have an email with subject "Swift Mailer has been successfully configured!" and in the content:
+      | This e-mail has been sent from Open Social by the Swift Mailer module. |
+
+    # Enable "Allow invited user to skip email verification" option for groups
+    When I go to "/admin/config/opensocial/social-group"
+    Then I click the element with css selector ".claro-details__summary"
+    And I should see "Allow invited user to skip email verification"
+    Then I check the box "email_verification"
+    And I press "Save configuration"
+
+    # Send invite to the new user.
+    Given I am logged in as "site_manager_1"
+    When I click the xth "0" element with the css ".navbar-nav .profile"
+    And I click "My groups"
+    And I click "Test-invite-group"
+    When I click "Manage members"
+    Then I should see "Add members"
+    When I click the xth "1" element with the css ".btn.dropdown-toggle"
+    And I click "Invite users"
+    Then I should see "Invite members to group: Test-invite-group"
+    And I fill in select2 input ".form-type-select" with "new_test_user@example.com" and select "new_test_user@example.com"
+    And I press "Send your invite(s) by email"
+    Then I wait for the batch job to finish
+    And I wait for the queue to be empty
+    Then I should see "Invite sent to new_test_user@example.com"
+    And I should have an email with subject "site_manager_1 has invited you to join a group on Open Social." and in the content:
+      | Hi, I would like to invite you to join my group Test-invite-group on Open Social. Kind regards, site_manager_1  Accept invite	About Open Social |
+
+    # Register as new user and accept invitation.
+    Given I logout
+    And I intend to create a user named "new_test_user"
+    Then I open register page with prefilled "new_test_user@example.com" and destination to invited group "Test-invite-group"
+
+    When I fill in the following:
+      | Username | new_test_user |
+      | Password | new_test_pass |
+      | Confirm password | new_test_pass |
+    And I press "Create new account"
+    Then I should see "Registration successful. You are now logged in."
+    And I should see "You have accepted the invitation"
+    And I should see "Joined"
+
+    # Send invite to existing user.
+    Given I logout
+    And I am logged in as "site_manager_1"
+    When I click the xth "0" element with the css ".navbar-nav .profile"
+    And I click "My groups"
+    And I click "Test-invite-group"
+    When I click "Manage members"
+    Then I should see "Add members"
+    When I click the xth "1" element with the css ".btn.dropdown-toggle"
+    And I click "Invite users"
+    Then I should see "Invite members to group: Test-invite-group"
+    And I fill in select2 input ".form-type-select" with "existing_user_1@example.com" and select "existing_user_1@example.com"
+    And I press "Send your invite(s) by email"
+    Then I wait for the batch job to finish
+    And I wait for the queue to be empty
+    Then I should see "Invite sent to existing_user_1"
+
+    And I should have an email with subject "site_manager_1 has invited you to join a group on Open Social." and in the content:
+      | Hi, I would like to invite you to join my group Test-invite-group on Open Social. Kind regards, site_manager_1  Accept invite	About Open Social |
+
+    # Login and check if invite has been sent to existing user.
+    Given I logout
+    And I am logged in as "existing_user_1"
+    Then I go to "/my-invites"
+    And I should see "1 group invite"
+    And I should see "Test-invite-group"
+
+    # Make sure the invite is not shown as part of the "group membership count" when on SKY theme in the profile block.
+    Given I set the configuration item "socialblue.settings" with key "style" to "sky"
+    And I am on "/my-groups"
+    Then I should see "0" in the ".card__counter-quantity" element
+    And I set the configuration item "socialblue.settings" with key "style" to "default"


### PR DESCRIPTION
## Original PR
https://github.com/goalgorilla/open_social/pull/2306

## Problem
Right now in the Profile statistics block, we count users group memberships according to

```$variables['profile_groups'] = count(\Drupal::service('social_group.helper_service')->getAllGroupsForUser($user->id()));```

This however doesn't take into account what kind of groups/memberships there are.

For example, a Group type could be filtered which makes sure the membership count isn't correctly reflected compared to the Groups overview.
For example, a user could get an invite or request to join a group, there aren't full memberships until accepted so they shouldn't be part of the count.

## Solution
The current count isn't flexible enough, it counts all occurrences of group plugins but that doesn't allow us to filter out-group types, or plugins easily without breaking BC or cache.

So instead we:
1. Created a separate helper function to count a users group membership
2. Add a query tag so people can alter the query
3. Add an alter hook, so people can filter out certain group types

## Issue tracker
https://www.drupal.org/node/3210717

## How to test
- [x] Enable SKY as a theme so the Profile statistics block is shown
- [x] As a site manager, invite user Chris Hall to a new group
- [x] Go to the profile -> Groups overview of Chris Hall
- [x] See that invites are removed from the Group count and the group count is the same as the joined groups in the group's overview

## Release notes
We ensured the count of groups in the profile statistics block shows the correct count and allows for better altering if certain groups should not be reflected there.