### PR TITLE
Issue #3205288 by robertragas: make sure our automatic path alias wor…

### DIFF
--- a/modules/social_features/social_core/social_core.module
+++ b/modules/social_features/social_core/social_core.module
@@ -925,7 +925,7 @@ function _social_core_path_widget_submit(array $form, FormStateInterface $form_s
   // since we hide the element, and the default is checked,
   // the path will never be overridden if someone updates it.
   // So we need to check this in our custom submit handler.
-  $default_path = $form['path']['widget'][0]['alias']['#default_value'];
+  $default_path = isset($form['path']['widget'][0]['alias']['#default_value']) ? $form['path']['widget'][0]['alias']['#default_value'] : '';
   $input = $form_state->getUserInput();
   $updated_path = isset($input['path'][0]['alias']) ? $input['path'][0]['alias'] : '';
   // If we don't have a match, make sure we override the checkbox as well.
@@ -935,6 +935,13 @@ function _social_core_path_widget_submit(array $form, FormStateInterface $form_s
     $form_state->setUserInput($input);
     // Override the value.
     $form_state->setValue(['path', '0', 'pathauto'], "0");
+
+    // If the updated path is empty, make it automatic again.
+    if (empty($updated_path)) {
+      $input['path'][0]['pathauto'] = "1";
+      $form_state->setUserInput($input);
+      $form_state->setValue(['path', '0', 'pathauto'], "1");
+    }
   }
 }
 


### PR DESCRIPTION
…ks when the alias field is empty

## Problem
When creating new content with the new Open Social form refactoring the automatic path alias does not kick in.

## Solution
We have a custom submit function which sets the automatic alias or not based on a few checks. These were not checking every use case.

## Issue tracker
https://www.drupal.org/project/social/issues/3205288

## How to test
- [ ] Go to the theme appearance and set form to "Open Social" style.
- [ ] Create new content and don't fill in an alias under the settings tab.
- [ ] Notice it will end up in node/x
- [ ] Check out to this branch and try again. 
Make sure to test out with having an empty alias, a custom alias, and also removing the custom alias again to see it goes automatic again.

## Release notes
We have fixed a bug that was introduced with the new Open Social form style that automatic path aliases were not created.
