### PR TITLE
Issue #3210685 by rolki: Add a query_access handler to the comment entity type

### DIFF
--- a/modules/social_features/social_comment/config/schema/social_comment.schema.yml
+++ b/modules/social_features/social_comment/config/schema/social_comment.schema.yml
@@ -5,3 +5,6 @@ social_comment.comment_settings:
     redirect_comment_to_entity:
       type: boolean
       label: 'Redirect a comment view to its parent entity'
+    remove_author_field:
+      type: boolean
+      label: 'Whether the author field should be removed from comment forms'

--- a/modules/social_features/social_comment/social_comment.module
+++ b/modules/social_features/social_comment/social_comment.module
@@ -13,6 +13,7 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Link;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\Url;
+use Drupal\social_comment\Entity\Access\CommentQueryAccessHandler;
 use Drupal\social_comment\Entity\Comment;
 use Drupal\social_comment\SocialCommentFieldItemList;
 use Drupal\social_comment\SocialCommentViewBuilder;
@@ -24,6 +25,8 @@ function social_comment_entity_type_alter(array &$entity_types) {
   if (isset($entity_types['comment'])) {
     $entity_types['comment']->setClass(Comment::class);
     $entity_types['comment']->setViewBuilderClass(SocialCommentViewBuilder::class);
+
+    $entity_types['comment']->setHandlerClass('query_access', CommentQueryAccessHandler::class);
   }
 }
 

--- a/modules/social_features/social_comment/src/Entity/Access/CommentQueryAccessHandler.php
+++ b/modules/social_features/social_comment/src/Entity/Access/CommentQueryAccessHandler.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Drupal\social_comment\Entity\Access;
+
+use Drupal\Core\Entity\EntityPublishedInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\entity\QueryAccess\ConditionGroup;
+use Drupal\entity\QueryAccess\QueryAccessHandlerBase;
+use Drupal\user\EntityOwnerInterface;
+
+/**
+ * Controls query access for comment entities.
+ *
+ * @see \Drupal\entity\QueryAccess\QueryAccessHandler
+ */
+class CommentQueryAccessHandler extends QueryAccessHandlerBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildConditions($operation, AccountInterface $account) {
+    $entity_type_id = $this->entityType->id();
+    $has_owner = $this->entityType->entityClassImplements(EntityOwnerInterface::class);
+    $has_published = $this->entityType->entityClassImplements(EntityPublishedInterface::class);
+    // Guard against broken/incomplete entity type definitions.
+    if ($has_owner && !$this->entityType->hasKey('owner')) {
+      throw new \RuntimeException(sprintf('The "%s" entity type did not define a "owner" key.', $entity_type_id));
+    }
+    if ($has_published && !$this->entityType->hasKey('published')) {
+      throw new \RuntimeException(sprintf('The "%s" entity type did not define a "published" key', $entity_type_id));
+    }
+
+    if ($account->hasPermission("administer comments")) {
+      // The user has full access to all operations, no conditions needed.
+      $conditions = new ConditionGroup('OR');
+      $conditions->addCacheContexts(['user.permissions']);
+      return $conditions;
+    }
+
+    if ($has_owner) {
+      $entity_conditions = $this->buildEntityOwnerConditions($operation, $account);
+    }
+    else {
+      $entity_conditions = $this->buildEntityConditions($operation, $account);
+    }
+
+    $conditions = NULL;
+    if ($operation == 'view' && $has_published) {
+      $published_key = $this->entityType->getKey('published');
+      $published_conditions = NULL;
+
+      if ($entity_conditions) {
+        // Restrict the existing conditions to published entities only.
+        $published_conditions = new ConditionGroup('AND');
+        $published_conditions->addCacheContexts(['user.permissions']);
+        $published_conditions->addCondition($entity_conditions);
+        $published_conditions->addCondition($published_key, '1');
+      }
+
+      if ($published_conditions) {
+        $conditions = $published_conditions;
+      }
+    }
+    else {
+      $conditions = $entity_conditions;
+    }
+
+    if (!$conditions) {
+      // The user doesn't have access to any entities.
+      // Falsify the query to ensure no results are returned.
+      $conditions = new ConditionGroup('OR');
+      $conditions->addCacheContexts(['user.permissions']);
+      $conditions->alwaysFalse();
+    }
+
+    return $conditions;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function buildEntityOwnerConditions($operation, AccountInterface $account) {
+    $conditions = new ConditionGroup('OR');
+    $conditions->addCacheContexts(['user.permissions']);
+    if ($account->hasPermission("access comments")) {
+      // The user has full access, no conditions needed.
+      return $conditions;
+    }
+
+    return $conditions->count() ? $conditions : NULL;
+  }
+
+}

--- a/modules/social_features/social_comment/tests/src/Kernel/CommentViewAccessTest.php
+++ b/modules/social_features/social_comment/tests/src/Kernel/CommentViewAccessTest.php
@@ -1,0 +1,181 @@
+<?php
+
+namespace Drupal\Tests\social_comment\Kernel;
+
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\KernelTests\Core\Entity\EntityKernelTestBase;
+use Drupal\Tests\node\Traits\NodeCreationTrait;
+
+/**
+ * Tests comment view level access.
+ *
+ * @group social_comment
+ */
+class CommentViewAccessTest extends EntityKernelTestBase {
+
+  use NodeCreationTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static $modules = [
+    // For the comment functionality.
+    'social_comment',
+    'comment',
+    // For checking access to comments.
+    'entity',
+    // For the comment author and viewer.
+    'social_user',
+    'user',
+    // User creation in social_user requires a service in role_delegation.
+    "role_delegation",
+    // social_comment configures comments for nodes.
+    'node',
+    // The default comment config contains a body text field.
+    'field',
+    'text',
+    'filter',
+  ];
+
+  /**
+   * The comment storage.
+   *
+   * @var \Drupal\Core\Entity\EntityStorageInterface
+   */
+  private $storage;
+
+  /**
+   * Node entity to use in this test.
+   *
+   * @var \Drupal\node\Entity\Node
+   */
+  private $node;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $this->installEntitySchema('node');
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('comment');
+    $this->installSchema('comment', 'comment_entity_statistics');
+    $this->installConfig(['filter', 'comment', 'social_comment']);
+
+    $this->storage = $this->entityTypeManager->getStorage('comment');
+    $this->node = $this->createNode();
+  }
+
+  /**
+   * Test that a user can not view their own unpublished comment.
+   *
+   * This mirrors the functionality of the distribution at the time of writing
+   * the test.
+   */
+  public function testUserCanNotViewOwnUnpublishedComment() {
+    // Create an unpublished comment on a node.
+    $user = $this->createUser([], ['access comments']);
+    $this->setCurrentUser($user);
+    $this->createComment($this->node, $user, ['status' => 0]);
+
+    $this->assertEmpty($this->getCommentIds($this->node, $user));
+  }
+
+  /**
+   * Test that a user can view their own published comment.
+   *
+   * This mirrors the functionality of the distribution at the time of writing
+   * the test.
+   */
+  public function testUserCanViewOwnPublishedComment() {
+    // Create an unpublished comment on a node.
+    $user = $this->createUser([], ['access comments']);
+    $this->setCurrentUser($user);
+    $this->createComment($this->node, $user, ['status' => 1]);
+
+    $this->assertNotEmpty($this->getCommentIds($this->node, $user));
+  }
+
+  /**
+   * Test that a user can not view another person's unpublished comment.
+   */
+  public function testUserCanNotViewOtherUnpublishedComment() {
+    // Create an unpublished comment on a node.
+    $first_user = $this->createUser([], ['access comments']);
+    $this->createComment($this->node, $first_user, ['status' => 0]);
+
+    // Create another user to try and view the comment.
+    $second_user = $this->createUser([], ['access comments']);
+    $this->setCurrentUser($second_user);
+
+    $this->assertEmpty($this->getCommentIds($this->node, $first_user));
+  }
+
+  /**
+   * Test that a user can view another person's published comment.
+   */
+  public function testUserCanViewOtherPublishedComment() {
+    // Create an unpublished comment on a node.
+    $first_user = $this->createUser([], ['access comments']);
+    $this->createComment($this->node, $first_user, ['status' => 1]);
+
+    // Create another user to try and view the comment.
+    $second_user = $this->createUser([], ['access comments']);
+    $this->setCurrentUser($second_user);
+
+    $this->assertNotEmpty($this->getCommentIds($this->node, $first_user));
+  }
+
+  /**
+   * Create the comment entity.
+   *
+   * @param \Drupal\Core\Entity\EntityInterface $entity
+   *   The entity the comment is made on.
+   * @param \Drupal\Core\Session\AccountInterface|null $user
+   *   An optional user to create the comment as.
+   * @param mixed[] $values
+   *   An optional array of values to pass to Comment::create.
+   *
+   * @throws \Drupal\Core\Entity\EntityStorageException
+   */
+  private function createComment(EntityInterface $entity, ?AccountInterface $user = NULL, array $values = []): void {
+    if ($user !== NULL) {
+      $values += ['uid' => $user->id()];
+    }
+
+    $this->storage->create(
+      $values +
+      [
+        'entity_id' => $entity->id(),
+        'entity_type' => $entity->getEntityTypeId(),
+        'comment_type' => 'comment',
+        'field_name' => 'comments',
+      ]
+    )->save();
+  }
+
+  /**
+   * Get a list of comment IDs whose user have access.
+   *
+   * @param \Drupal\Core\Entity\EntityInterface $entity
+   *   The entity the comment is made on.
+   * @param \Drupal\Core\Session\AccountInterface $user
+   *   The user to create the comment as.
+   *
+   * @return array
+   *   An array of comment IDs.
+   */
+  private function getCommentIds(EntityInterface $entity, AccountInterface $user): array {
+    return $this->storage
+      ->getQuery()
+      ->currentRevision()
+      ->accessCheck()
+      ->condition('entity_id', $entity->id())
+      ->condition('comment_type', 'comment')
+      ->condition('uid', $user->id())
+      ->execute();
+  }
+
+}

--- a/modules/social_features/social_core/social_core.info.yml
+++ b/modules/social_features/social_core/social_core.info.yml
@@ -29,4 +29,5 @@ dependencies:
   # TODO: Issue #3109479
   - views_bulk_operations:views_bulk_operations
   - gin_toolbar:gin_toolbar
+  - drupal:entity
 package: Social


### PR DESCRIPTION
## Problem
Access checks based on published status or ownership for comments aren't performed during an entity query. This means that these checks need to be done after an entity is loaded. This causes issues for pagination, most notably in GraphQL, as outlined in #2979294: Improve pagination DX (a core issue for the JSON:API).

This problem is illustrated by `QueryCommentsTest::testUserRequiresAccessCommentsPermission` and `QueryCommentsTest::testUserCanviewOnlyOwnOrOtherPublishedComments` introduced in https://github.com/goalgorilla/open_social/pull/2285.

## Solution
As Open Social already depends on the entity module that contains the new entity access API we can use this in our solution.

We should duplicate the access checking logic for comments into the entity access API so that these access checks can be performed at query time. This needs to be done in a backwards compatible manner since existing installations may have customised their comment access checks in a way that we can not anticipate. To achieve this we'll introduce a new configuration setting in Drupal core (enabled for new sites, disabled for existing sites, enabled when social_graphql is used). This setting will be deprecated as being removed in Open Social 11.0.0 at which point we will require all sites to use the Entity Access API and sites should have adjusted its queries if they have changed comment access checks.

To indicate that the new Entity Access API can be used by any functionality extending Open Social we will add a dependency on this module i social_core.

## Issue tracker
https://www.drupal.org/project/social/issues/3210685

## How to test
- [ ] Use [this](https://github.com/goalgorilla/open_social/pull/2285) PR as a patch
- [ ] Write some GraphQL query
```
  comments(first: 10) {
    nodes {
      id
      body
    }
  }
```
- [ ] You should not see unpublished comments in the response

## Screenshots

**Before changes:**

<img width="1730" alt="Снимок экрана 2021-05-05 в 11 34 04" src="https://user-images.githubusercontent.com/50984627/117115860-57858580-ad96-11eb-9907-b6af038e5134.png">
<img width="1730" alt="Снимок экрана 2021-05-05 в 11 38 20" src="https://user-images.githubusercontent.com/50984627/117116165-b0551e00-ad96-11eb-8559-2ded5b1b998f.png">

**After changes:**

<img width="1730" alt="Снимок экрана 2021-05-05 в 11 40 59" src="https://user-images.githubusercontent.com/50984627/117116284-d975ae80-ad96-11eb-8bc5-0ba7032b80d9.png">
<img width="1730" alt="Снимок экрана 2021-05-05 в 11 42 27" src="https://user-images.githubusercontent.com/50984627/117116542-29547580-ad97-11eb-9665-4ada735d422e.png">

