### PR TITLE
Issue #3184502 by navneet0693: Between date on people overview and search not working when selecting one day for both fields

### DIFF
--- a/modules/social_features/social_search/config/install/search_api.index.social_users.yml
+++ b/modules/social_features/social_search/config/install/search_api.index.social_users.yml
@@ -1,12 +1,6 @@
 langcode: en
 status: true
 dependencies:
-  module:
-    - profile
-    - taxonomy
-    - user
-    - search_api
-    - social_search
   config:
     - field.storage.profile.field_profile_expertise
     - field.storage.profile.field_profile_first_name
@@ -15,19 +9,26 @@ dependencies:
     - field.storage.profile.field_profile_profile_tag
     - search_api.server.social_database
     - core.entity_view_mode.profile.search_index
+  module:
+    - taxonomy
+    - profile
+    - user
+    - search_api
+    - social_search
 id: social_users
 name: 'Social Users'
 description: 'Default users index created for the Social distribution.'
 read_only: false
 field_settings:
   created:
-    label: Created
+    label: 'Owner » User » Created'
     datasource_id: 'entity:profile'
-    property_path: created
+    property_path: 'uid:entity:created'
     type: date
     dependencies:
       module:
         - profile
+        - user
   field_profile_expertise:
     label: Expertise
     datasource_id: 'entity:profile'

--- a/modules/social_features/social_search/config/update/social_search_update_10001.yml
+++ b/modules/social_features/social_search/config/update/social_search_update_10001.yml
@@ -1,0 +1,11 @@
+search_api.index.social_users:
+  expected_config: {  }
+  update_actions:
+    change:
+      field_settings:
+        created:
+          dependencies:
+            module:
+              - user
+          label: 'Owner » User » Created'
+          property_path: 'uid:entity:created'

--- a/modules/social_features/social_search/social_search.install
+++ b/modules/social_features/social_search/social_search.install
@@ -194,3 +194,34 @@ function social_search_update_8905() {
     \Drupal::logger('social_search')->info($e->getMessage());
   }
 }
+
+/**
+ * Removed created field for profile and added 'Owner » User » Created' field.
+ */
+function social_search_update_10001() {
+  /** @var \Drupal\update_helper\Updater $updateHelper */
+  $updateHelper = \Drupal::service('update_helper.updater');
+
+  // Execute configuration update definitions with logging of success.
+  $updateHelper->executeUpdate('social_search', 'social_search_update_10001');
+
+  // Output logged messages to related channel of update execution.
+  return $updateHelper->logger()->output();
+}
+
+/**
+ * Update search users with new 'created' field.
+ */
+function social_search_update_10002() {
+  try {
+    $index = Index::load('social_users');
+    if ($index !== NULL && $index->status()) {
+      $index->save();
+      $index->clear();
+      $index->reindex();
+    }
+  }
+  catch (EntityStorageException $e) {
+    \Drupal::logger('social_search')->info($e->getMessage());
+  }
+}


### PR DESCRIPTION
## Problem
When filtering users on the admin user overview and search members, if you select the Between operator and the same date twice, you will get no results.

1. Go to /admin/people, and use the date filters. Set the operator as Between and select the same date as start and end. You'll get no users.
2. Go to /search/users, select the Registration date filter and choose "between".

## Solution
1. Apply the patch in [#2842409] on Drupal core.
2. Create a similar patch in <strong>search_api</strong> on <code>modules/contrib/search_api/src/Plugin/views/filter/SearchApiDate.php</code> and apply it in composer.json of Open Social
3. Remove the created field from search index users, this is from the Profile entity
4. Add the <strong>Owner:uid:created</strong> field, this is from the Users entity (similar to what is used in the admin people overview)
5. Create an update hook to re-index the new field
6. Update configuration for install and update to ensure this is exported

## Issue tracker
https://www.drupal.org/project/social/issues/3184502

## How to test
- [ ] Using version 10.x of Open Social with the social_search module enabled.
- [ ] Check out to this branch.
- [ ] Install the composer.json changes in your project.
- [ ] Run `drush updb -y` command for updating configurations.
- [ ] As a LU
- [ ] Try using the between filter to find out a user registered on a day. Make sure such users exist in the platform.
- [ ] As a sitemanager
- [ ] Try using between filter on people admin overview and find out the registered users on the provided date.

## Screenshots
N.A

## Release notes
We have solved the bug where the platform gave no results on using between operator/filter on people admin overview or 
 on search, users page to find users registered on a particular date (same date).

## Change Record
N.A

## Translations
N.A