### PR TITLE
Create dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,39 @@
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions - Update once every week.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "saturday"
+    labels:
+      - "type: update"
+      - "team: nucleus"  
+
+  # Maintain dependencies for Composer.
+  - package-ecosystem: "composer"
+    directory: "/"
+    # Make sure we don't clog our automated tests, so we runt it after midnight.
+    schedule:
+      interval: "daily"
+      time: "01:00"
+      timezone: "Europe/Amsterdam"
+    labels:
+      - "type: update"
+      - "team: nucleus"
+    # Let Nucleus team members review it.
+    reviewers:
+      - "navneet0693"
+      - "ronaldtebrake"
+    # Allow updates for all Drupal modules, lets leave the rest for now.  
+    allow:
+      - dependency-name: "drupal*"
+    ignore:
+      - dependency-name: "npm*"
+    # Prefix all commit messages with "Composer"
+    # include a list of updated dependencies
+    commit-message:
+      prefix: "Updates: "
+      include: "scope"
+    # Allow up to 5 open pull requests for Drupal dependencies as we have some to go.
+    open-pull-requests-limit: 5  

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,10 +21,9 @@ updates:
     labels:
       - "type: update"
       - "team: nucleus"
-    # Let Nucleus team members review it.
+    # Let core team maintainers review it.
     reviewers:
-      - "navneet0693"
-      - "ronaldtebrake"
+      - "goalgorilla/maintainers"
     # Allow updates for all Drupal modules, lets leave the rest for now.  
     allow:
       - dependency-name: "drupal*"


### PR DESCRIPTION
## Problem
Even if it's a seemingly small task, it's a tedious job for people to create PR's with updates using a fork versus the ease of using something that can do this automated.

## Solution
Use a dependency update manager. 
In this case we went for GitHub's built in dependabot.

With configuration:
- For now focus on updating github actions and composer packages
- Do github actions once per week, nothing fancy
- For Drupal we do it every night after midnight, so we are not clogging our github actions & CI/QA tools
- Assign Nucleus team members by default
- Dismiss npm/other non drupal packages for now
- Have only 5 PR's opened at once, we are running behind on our updates and we can finish them one at a time. Once we are finished 5 should be enough as well.

## Issue tracker
No drupal.org ticket will be created, we can create separate drupal.org tickets for the updates that will be created by Dependabot.

## How to test
We can merge it after getting an OK of team Nucleus, this will only add 5 PR's with updates

## Release notes
Not needed, Internal process update.