### PR TITLE
Add TugboatQA configuration

### DIFF
--- a/.tugboat/composer.json
+++ b/.tugboat/composer.json
@@ -1,0 +1,78 @@
+{
+    "name": "goalgorilla/open_social_tugboat",
+    "description": "Tugboat project set-up for Open Social previews.",
+    "type": "project",
+    "license": "UNLICENSED",
+    "minimum-stability": "dev",
+    "prefer-stable": true,
+    "require": {},
+    "require-dev": {
+        "drupal/coder": "8.3.x-dev",
+        "dealerdirect/phpcodesniffer-composer-installer": "dev-master",
+        "drush/drush": "^8",
+        "mikey179/vfsstream": "^1.6",
+        "mglaman/phpstan-drupal": "^0.12",
+        "phpstan/extension-installer": "^1.1.0",
+        "phpstan/phpstan-deprecation-rules": "^0.12",
+        "phpstan/phpstan-phpunit": "^0.12",
+        "phpunit/phpunit": "^7.5",
+        "squizlabs/php_codesniffer": "^3.6.0"
+    },
+    "repositories": [
+        {
+            "type": "git",
+            "url": "https://github.com/goalgorilla/open_social"
+        },
+        {
+            "type": "composer",
+            "url": "https://packages.drupal.org/8"
+        },
+        {
+            "type": "composer",
+            "url": "https://asset-packagist.org"
+        }
+    ],
+    "extra": {
+        "drupal-scaffold": {
+            "locations": {
+                "web-root": "html/"
+            }
+        },
+        "installer-types": [
+            "bower-asset",
+            "npm-asset"
+        ],
+        "installer-paths": {
+            "html/core": [
+                "type:drupal-core"
+            ],
+            "html/modules/contrib/{$name}": [
+                "type:drupal-module",
+                "type:drupal-module-custom"
+            ],
+            "html/profiles/contrib/social": [
+                "goalgorilla/open_social"
+            ],
+            "html/profiles/contrib/${name}": [
+                "type:drupal-profile"
+            ],
+            "html/themes/contrib/{$name}": [
+                "type:drupal-theme"
+            ],
+            "scripts/{$name}": [
+                "goalgorilla/open_social_scripts",
+                "goalgorilla/gpi_scripts",
+                "goalgorilla/enterprise_scripts"
+            ],
+            "html/libraries/{$name}": [
+                "type:drupal-library",
+                "type:bower-asset",
+                "type:npm-asset"
+            ],
+            "drush/contrib/{$name}": [
+                "type:drupal-drush"
+            ]
+        },
+        "enable-patching": true
+    }
+}

--- a/.tugboat/config.yml
+++ b/.tugboat/config.yml
@@ -22,6 +22,9 @@ services:
         mkdir -p $DOCROOT/../config/sync
         # Create a private file path.
         mkdir -p $DOCROOT/../files_private
+        # Find the branch name regardless of preview type. This does fail for
+        # non-GitHub PRs or branches until Tugboat provdes a better way.
+        export BRANCH_NAME=$([ "$TUGBOAT_PREVIEW_TYPE" == "pullrequest" ] && echo "$TUGBOAT_GITHUB_HEAD" || echo "$TUGBOAT_PREVIEW_REF")
         # Find the project name from the root composer.json file
         export COMPOSER_PROJECT_NAME=`cat "$TUGBOAT_ROOT/composer.json" | jq -r '.name'`
         # Copy the composer.json test project file.
@@ -29,7 +32,7 @@ services:
         # Add the GitHub repository that the branch is in.
         composer config repositories.open_social git "https://github.com/$TUGBOAT_GITHUB_OWNER/$TUGBOAT_GITHUB_REPO"
         # Install our preview version through private packagist from BitBucket.
-        composer require $COMPOSER_PROJECT_NAME:dev-$TUGBOAT_GITHUB_HEAD#$TUGBOAT_PREVIEW_SHA
+        composer require $COMPOSER_PROJECT_NAME:dev-$BRANCH_NAME#$TUGBOAT_PREVIEW_SHA
         # Use the tugboat-specific Drupal settings.
         cat $DOCROOT/sites/default/default.settings.php | \
           sed -z "s@#\n# if (file_exists(\$app_root . '/' . \$site_path . '/settings.local.php')) {\n#   include \$app_root . '/' . \$site_path . '/settings.local.php';\n# }@if (file_exists(__DIR__ . '/settings.local.php')) {\n  include __DIR__ . '/settings.local.php';\n}@" \
@@ -63,8 +66,9 @@ services:
         chown -R www-data:www-data $DOCROOT
       build: |
         cd $DOCROOT/..
+        export BRANCH_NAME=$([ "$TUGBOAT_PREVIEW_TYPE" == "pullrequest" ] && echo "$TUGBOAT_GITHUB_HEAD" || echo "$TUGBOAT_PREVIEW_REF")
         export COMPOSER_PROJECT_NAME=`cat "$TUGBOAT_ROOT/composer.json" | jq -r '.name'`
-        composer require --update-with-all-dependencies $COMPOSER_PROJECT_NAME:dev-$TUGBOAT_GITHUB_HEAD#$TUGBOAT_PREVIEW_SHA
+        composer require --update-with-all-dependencies $COMPOSER_PROJECT_NAME:dev-$BRANCH_NAME#$TUGBOAT_PREVIEW_SHA
         composer install --optimize-autoloader
         cd html && ../vendor/bin/drush updatedb -y
 

--- a/.tugboat/config.yml
+++ b/.tugboat/config.yml
@@ -1,0 +1,73 @@
+services:
+  # The main webserver contains our Open Social distribution.
+  webserver:
+    image: kingdutch/social-docker-php:latest
+    default: true
+    depends:
+      - db
+    commands:
+      init:
+        - composer config --global github-protocols https
+        # Undo the weird symlink in the default Tugboat image.
+        - rm -rf $DOCROOT/html.original $DOCROOT/html
+      # Update is run as single string rather than individual steps since
+      # individual steps are executed in separate shell instances.
+      update: |
+        set -e
+        # Docroot for the PHP image points to /var/www/html so we set-up Open
+        # Social one folder up so that our web files are in the html folder.
+        cd $DOCROOT/..
+        # Create a config/sync directory so Drupal stops complaining, even if we
+        # don't need it.
+        mkdir -p $DOCROOT/../config/sync
+        # Create a private file path.
+        mkdir -p $DOCROOT/../files_private
+        # Find the project name from the root composer.json file
+        export COMPOSER_PROJECT_NAME=`cat "$TUGBOAT_ROOT/composer.json" | jq -r '.name'`
+        # Copy the composer.json test project file.
+        cp $TUGBOAT_ROOT/.tugboat/composer.json .
+        # Add the GitHub repository that the branch is in.
+        composer config repositories.open_social git "https://github.com/$TUGBOAT_GITHUB_OWNER/$TUGBOAT_GITHUB_REPO"
+        # Install our preview version through private packagist from BitBucket.
+        composer require $COMPOSER_PROJECT_NAME:dev-$TUGBOAT_GITHUB_HEAD#$TUGBOAT_PREVIEW_SHA
+        # Use the tugboat-specific Drupal settings.
+        cat $DOCROOT/sites/default/default.settings.php | \
+          sed -z "s@#\n# if (file_exists(\$app_root . '/' . \$site_path . '/settings.local.php')) {\n#   include \$app_root . '/' . \$site_path . '/settings.local.php';\n# }@if (file_exists(__DIR__ . '/settings.local.php')) {\n  include __DIR__ . '/settings.local.php';\n}@" \
+          > $DOCROOT/sites/default/settings.php
+        cp "${TUGBOAT_ROOT}/.tugboat/settings.local.php" "${DOCROOT}/sites/default/"
+        mkdir -p ${DOCROOT}/sites/default/files && chmod -R 755 ${DOCROOT}/sites/default/files
+        chown -R www-data:www-data $DOCROOT/..
+        # Install Open Social.
+        cd html
+        ../vendor/bin/drush \
+          --yes \
+          --site-name="Open Social QA" \
+          --account-pass=${ADMIN_PASSWORD} \
+          site:install social
+        # Install the database log, it's bad for performance but helps in quickly
+        # capturing errors while testing.
+        ../vendor/bin/drush \
+          --yes \
+          en dblog
+        # Enable the demo content.
+        ../vendor/bin/drush \
+          --yes \
+          en social_demo
+        ../vendor/bin/drush \
+          sda \
+          file user group topic event eventenrollment post comment like
+        # Allow site managers to enable modules so developers can change the
+        # set-up during testing.
+        ../vendor/bin/drush role:add:perm --yes 'sitemanager' 'administer modules'
+        # Change file owner again because of the way demo content is copied.
+        chown -R www-data:www-data $DOCROOT
+      build: |
+        cd $DOCROOT/..
+        export COMPOSER_PROJECT_NAME=`cat "$TUGBOAT_ROOT/composer.json" | jq -r '.name'`
+        composer require --update-with-all-dependencies $COMPOSER_PROJECT_NAME:dev-$TUGBOAT_GITHUB_HEAD#$TUGBOAT_PREVIEW_SHA
+        composer install --optimize-autoloader
+        cd html && ../vendor/bin/drush updatedb -y
+
+  # A database for storage of Open Social data.
+  db:
+    image: tugboatqa/mariadb:latest

--- a/.tugboat/config.yml
+++ b/.tugboat/config.yml
@@ -24,7 +24,7 @@ services:
         mkdir -p $DOCROOT/../files_private
         # Find the branch name regardless of preview type. This does fail for
         # non-GitHub PRs or branches until Tugboat provdes a better way.
-        export BRANCH_NAME=$([ "$TUGBOAT_PREVIEW_TYPE" == "pullrequest" ] && echo "$TUGBOAT_GITHUB_HEAD" || echo "$TUGBOAT_PREVIEW_REF")
+        export BRANCH_NAME=$([ "$TUGBOAT_PREVIEW_TYPE" = "pullrequest" ] && echo "$TUGBOAT_GITHUB_HEAD" || echo "$TUGBOAT_PREVIEW_REF")
         # Find the project name from the root composer.json file
         export COMPOSER_PROJECT_NAME=`cat "$TUGBOAT_ROOT/composer.json" | jq -r '.name'`
         # Copy the composer.json test project file.
@@ -66,7 +66,7 @@ services:
         chown -R www-data:www-data $DOCROOT
       build: |
         cd $DOCROOT/..
-        export BRANCH_NAME=$([ "$TUGBOAT_PREVIEW_TYPE" == "pullrequest" ] && echo "$TUGBOAT_GITHUB_HEAD" || echo "$TUGBOAT_PREVIEW_REF")
+        export BRANCH_NAME=$([ "$TUGBOAT_PREVIEW_TYPE" = "pullrequest" ] && echo "$TUGBOAT_GITHUB_HEAD" || echo "$TUGBOAT_PREVIEW_REF")
         export COMPOSER_PROJECT_NAME=`cat "$TUGBOAT_ROOT/composer.json" | jq -r '.name'`
         composer require --update-with-all-dependencies $COMPOSER_PROJECT_NAME:dev-$BRANCH_NAME#$TUGBOAT_PREVIEW_SHA
         composer install --optimize-autoloader

--- a/.tugboat/settings.local.php
+++ b/.tugboat/settings.local.php
@@ -1,0 +1,32 @@
+<?php
+
+$databases['default']['default'] = [
+  'database' => 'tugboat',
+  'username' => 'tugboat',
+  'password' => 'tugboat',
+  'prefix' => '',
+  'host' => 'db',
+  'port' => '3306',
+  'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
+  'driver' => 'mysql',
+];
+
+$settings['trusted_host_patterns'] = [
+  '^' . getenv('TUGBOAT_DEFAULT_SERVICE_URL_HOST') . '$',
+];
+
+// Use the TUGBOAT_REPO_ID to generate a hash salt for Tugboat sites.
+$settings['hash_salt'] = hash('sha256', getenv('TUGBOAT_REPO_ID'));
+
+// Use the TUGBOAT_PREVIEW_ID to let Drupal know when to rebuild caches.
+$settings['deployment_identifier'] = getenv('TUGBOAT_PREVIEW_ID');
+
+// Send e-mail using Tugboat's SMTP server so they are captured.
+$config['swiftmailer.transport']['transport'] = 'smtp';
+$config['swiftmailer.transport']['smtp_host'] = getenv('TUGBOAT_SMTP');
+
+// Set a config sync directory to stop Drupal from showing us errors.
+$settings['config_sync_directory'] = "/var/www/config/sync";
+
+// Specify where the private files can be stored.
+$settings['file_private_path'] = "/var/www/files_private";


### PR DESCRIPTION
## Solution in search of a Problem
This sets up a simple Open Social installation using a custom PHP image
based on open_social_docker but using the TugboatQA/php image as base
(the default php image is not supported).

The site is installed without optional modules so that it's easy to test
that modules only require the things they actually need or to build up
an environment as needed. Additionally we don't provide admin access
(although we can store a Tugboat configured admin password in LastPass
as back-up) to encourage testing with properly permissioned user.

As a compromise to allow modules to be enabled we provide this
permission to site managers. Addtionally we start out with demo content
so that there is a base to start manual testing from.

We use a custom composer.json file rather than trying to pull in
social_template so that we can control the tools we have available in
the preview environment more easily.

## Issue tracker
N/a
