### PR TITLE
Issue #3212793 by Kingdutch: Remove drupal/file_mdm dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -140,7 +140,6 @@
         "drupal/exif_orientation": "^1.0",
         "drupal/features": "3.8",
         "drupal/field_group": "3.1",
-        "drupal/file_mdm": "1.1",
         "drupal/flag": "4.0-alpha3",
         "drupal/gin": "3.0-alpha20",
         "drupal/gin_toolbar": "^1.0@beta",


### PR DESCRIPTION
<h3 id="summary-problem-motivation">Problem/Motivation</h3>
[#3010020] updated the image_effects module and introduced a specific version requirement for <code>drupal/file_mdm</code>. The drupal/file_mdm module is now a few versions up and the version we require uses the <code>lsolesen/pel</code> library which causes a lot of warnings on PHP 7.4

<code>
Deprecated function: Array and string offset access syntax with curly braces is deprecated in include() (line 478 of /var/www/vendor/composer/ClassLoader.php)

#0 /var/www/html/core/includes/bootstrap.inc(600): _drupal_error_handler_real(8192, 'Array and strin...', '/var/www/vendor...', 410, Array)
#1 /var/www/vendor/composer/ClassLoader.php(478): _drupal_error_handler(8192, 'Array and strin...', '/var/www/vendor...', 410, Array)
#2 /var/www/vendor/composer/ClassLoader.php(478): include()
#3 /var/www/vendor/composer/ClassLoader.php(346): Composer\Autoload\includeFile('/var/www/vendor...')
#4 [internal function]: Composer\Autoload\ClassLoader->loadClass('lsolesen\\pel\\Pe...')
#5 /var/www/vendor/lsolesen/pel/src/PelDataWindow.php(96): spl_autoload_call('lsolesen\\pel\\Pe...')
#6 /var/www/vendor/lsolesen/pel/src/PelJpeg.php(286): lsolesen\pel\PelDataWindow->__construct('\xFF\xD8\xFF\xE0\x00\x10JFIF\x00\x01\x01\x00\x00...')
#7 /var/www/vendor/lsolesen/pel/src/PelJpeg.php(123): lsolesen\pel\PelJpeg->loadFile('public://04.jpg')
#8 /var/www/html/modules/contrib/file_mdm/file_mdm_exif/src/Plugin/FileMetadata/Exif.php(108): lsolesen\pel\PelJpeg->__construct('public://04.jpg')
</code>

We added the module as per [#2856573] mentioned in https://github.com/goalgorilla/open_social/pull/1069#issuecomment-450328821 

An additional issue is that image effects requires file_mdm 2 but doesn't actually get it (this requirement can be seen in image_effects/composer.json)
<code>
        "drupal/file_mdm_exif": "^2",
        "drupal/file_mdm_font": "^2"
</code>

<h4 id="summary-steps-reproduce">Steps to reproduce</h4>


<h3 id="summary-proposed-resolution">Proposed resolution</h3>
Remove our dependency on <code>drupal/file_mdm</code> as we don't actually use the module directly. The correct version will be installed by the image_effects module.

## Issue tracker
https://www.drupal.org/project/social/issues/3212793

## How to test

- [ ] Tests should pass

## Screenshots
N/a

## Release notes
N/a no changes

## Change Record
N/a

## Translations
N/a