### PR TITLE
Issue #3210685 by rolki: Add a query_access handler to the comment entity type

### DIFF
--- a/modules/custom/social_graphql/social_graphql.install
+++ b/modules/custom/social_graphql/social_graphql.install
@@ -13,4 +13,28 @@ function social_graphql_install() {
   // We rely on normal access rules for authorization.
   user_role_grant_permissions('anonymous', ['execute open_social_graphql arbitrary graphql requests']);
   user_role_grant_permissions('authenticated', ['execute open_social_graphql arbitrary graphql requests']);
+
+  // Set default settings to use entity access API as TRUE.
+  $config = \Drupal::configFactory()->getEditable('social_core.settings');
+  $config->set('use_entity_access_api', 1)->save();
+}
+
+/**
+ * Implements hook_update_dependencies().
+ */
+function social_graphql_update_dependencies() {
+  // Run the update hook only after an update hook in social_core.
+  $dependencies['social_graphql'][8901] = [
+    'social_core' => 10103,
+  ];
+
+  return $dependencies;
+}
+
+/**
+ * Set default settings to use entity access API as TRUE.
+ */
+function social_graphql_update_8901() {
+  $config = \Drupal::configFactory()->getEditable('social_core.settings');
+  $config->set('use_entity_access_api', 1)->save();
 }

--- a/modules/custom/social_graphql/social_graphql.install
+++ b/modules/custom/social_graphql/social_graphql.install
@@ -14,7 +14,8 @@ function social_graphql_install() {
   user_role_grant_permissions('anonymous', ['execute open_social_graphql arbitrary graphql requests']);
   user_role_grant_permissions('authenticated', ['execute open_social_graphql arbitrary graphql requests']);
 
-  // Set default settings to use entity access API as TRUE.
+  // GraphQL resolvers require the entity access API for proper access checks in
+  // queries, so we enable the setting when this module is installed.
   $config = \Drupal::configFactory()->getEditable('social_core.settings');
   $config->set('use_entity_access_api', 1)->save();
 }
@@ -32,9 +33,9 @@ function social_graphql_update_dependencies() {
 }
 
 /**
- * Set default settings to use entity access API as TRUE.
+ * Opt-in to the new entity access API.
  */
-function social_graphql_update_8901() {
+function social_graphql_update_10101() {
   $config = \Drupal::configFactory()->getEditable('social_core.settings');
   $config->set('use_entity_access_api', 1)->save();
 }

--- a/modules/social_features/social_comment/config/schema/social_comment.schema.yml
+++ b/modules/social_features/social_comment/config/schema/social_comment.schema.yml
@@ -5,3 +5,6 @@ social_comment.comment_settings:
     redirect_comment_to_entity:
       type: boolean
       label: 'Redirect a comment view to its parent entity'
+    remove_author_field:
+      type: boolean
+      label: 'Whether the author field should be removed from comment forms'

--- a/modules/social_features/social_comment/social_comment.module
+++ b/modules/social_features/social_comment/social_comment.module
@@ -13,6 +13,7 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Link;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\Url;
+use Drupal\social_comment\Entity\Access\CommentQueryAccessHandler;
 use Drupal\social_comment\Entity\Comment;
 use Drupal\social_comment\SocialCommentFieldItemList;
 use Drupal\social_comment\SocialCommentViewBuilder;
@@ -24,6 +25,8 @@ function social_comment_entity_type_alter(array &$entity_types) {
   if (isset($entity_types['comment'])) {
     $entity_types['comment']->setClass(Comment::class);
     $entity_types['comment']->setViewBuilderClass(SocialCommentViewBuilder::class);
+
+    $entity_types['comment']->setHandlerClass('query_access', CommentQueryAccessHandler::class);
   }
 }
 

--- a/modules/social_features/social_comment/social_comment.module
+++ b/modules/social_features/social_comment/social_comment.module
@@ -26,7 +26,12 @@ function social_comment_entity_type_alter(array &$entity_types) {
     $entity_types['comment']->setClass(Comment::class);
     $entity_types['comment']->setViewBuilderClass(SocialCommentViewBuilder::class);
 
-    $entity_types['comment']->setHandlerClass('query_access', CommentQueryAccessHandler::class);
+    // When the platform has opted in to using the entity_access api we set our
+    // custom handler. This ensures we don't break existing projects who may
+    // already have their own query_access handlers.
+    if (\Drupal::config('social_core.settings')->get('use_entity_access_api')) {
+      $entity_types['comment']->setHandlerClass('query_access', CommentQueryAccessHandler::class);
+    }
   }
 }
 

--- a/modules/social_features/social_comment/src/Entity/Access/CommentQueryAccessHandler.php
+++ b/modules/social_features/social_comment/src/Entity/Access/CommentQueryAccessHandler.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Drupal\social_comment\Entity\Access;
+
+use Drupal\Core\Entity\EntityPublishedInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\entity\QueryAccess\ConditionGroup;
+use Drupal\entity\QueryAccess\QueryAccessHandlerBase;
+use Drupal\user\EntityOwnerInterface;
+
+/**
+ * Controls query access for comment entities.
+ *
+ * @see \Drupal\entity\QueryAccess\QueryAccessHandler
+ */
+class CommentQueryAccessHandler extends QueryAccessHandlerBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildConditions($operation, AccountInterface $account) {
+    $entity_type_id = $this->entityType->id();
+    $has_owner = $this->entityType->entityClassImplements(EntityOwnerInterface::class);
+    $has_published = $this->entityType->entityClassImplements(EntityPublishedInterface::class);
+    // Guard against broken/incomplete entity type definitions.
+    if ($has_owner && !$this->entityType->hasKey('owner')) {
+      throw new \RuntimeException(sprintf('The "%s" entity type did not define a "owner" key.', $entity_type_id));
+    }
+    if ($has_published && !$this->entityType->hasKey('published')) {
+      throw new \RuntimeException(sprintf('The "%s" entity type did not define a "published" key', $entity_type_id));
+    }
+
+    if ($account->hasPermission("administer comments")) {
+      // The user has full access to all operations, no conditions needed.
+      $conditions = new ConditionGroup('OR');
+      $conditions->addCacheContexts(['user.permissions']);
+      return $conditions;
+    }
+
+    if ($has_owner) {
+      $entity_conditions = $this->buildEntityOwnerConditions($operation, $account);
+    }
+    else {
+      $entity_conditions = $this->buildEntityConditions($operation, $account);
+    }
+
+    $conditions = NULL;
+    if ($operation == 'view' && $has_published) {
+      $published_key = $this->entityType->getKey('published');
+      $published_conditions = NULL;
+
+      if ($entity_conditions) {
+        // Restrict the existing conditions to published entities only.
+        $published_conditions = new ConditionGroup('AND');
+        $published_conditions->addCacheContexts(['user.permissions']);
+        $published_conditions->addCondition($entity_conditions);
+        $published_conditions->addCondition($published_key, '1');
+      }
+
+      if ($published_conditions) {
+        $conditions = $published_conditions;
+      }
+    }
+    else {
+      $conditions = $entity_conditions;
+    }
+
+    if (!$conditions) {
+      // The user doesn't have access to any entities.
+      // Falsify the query to ensure no results are returned.
+      $conditions = new ConditionGroup('OR');
+      $conditions->addCacheContexts(['user.permissions']);
+      $conditions->alwaysFalse();
+    }
+
+    return $conditions;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function buildEntityOwnerConditions($operation, AccountInterface $account) {
+    $conditions = new ConditionGroup('OR');
+    $conditions->addCacheContexts(['user.permissions']);
+    if ($account->hasPermission("access comments")) {
+      // The user has full access, no conditions needed.
+      return $conditions;
+    }
+
+    return $conditions->count() ? $conditions : NULL;
+  }
+
+}

--- a/modules/social_features/social_comment/tests/src/Kernel/CommentViewAccessTest.php
+++ b/modules/social_features/social_comment/tests/src/Kernel/CommentViewAccessTest.php
@@ -1,0 +1,223 @@
+<?php
+
+namespace Drupal\Tests\social_comment\Kernel;
+
+use Drupal\comment\CommentInterface;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\KernelTests\Core\Entity\EntityKernelTestBase;
+use Drupal\Tests\node\Traits\NodeCreationTrait;
+
+/**
+ * Tests comment view level access.
+ *
+ * @group social_comment
+ */
+class CommentViewAccessTest extends EntityKernelTestBase {
+
+  use NodeCreationTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static $modules = [
+    // For the comment functionality.
+    'social_comment',
+    'comment',
+    // For checking access to a comment.
+    'entity',
+    // For the comment author and viewer.
+    'social_user',
+    'user',
+    // User creation in social_user requires a service in role_delegation.
+    "role_delegation",
+    // social_comment configures comments for nodes.
+    'node',
+    // The default comment config contains a body text field.
+    'field',
+    'text',
+    'filter',
+  ];
+
+  /**
+   * The comment storage.
+   *
+   * @var \Drupal\Core\Entity\EntityStorageInterface
+   */
+  private $storage;
+
+  /**
+   * Node entity to use in this test.
+   *
+   * @var \Drupal\node\Entity\Node
+   */
+  private $node;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $this->installEntitySchema('node');
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('comment');
+    $this->installSchema('comment', 'comment_entity_statistics');
+    $this->installConfig(['filter', 'comment', 'social_comment']);
+
+    $this->storage = $this->entityTypeManager->getStorage('comment');
+    $this->node = $this->createNode();
+  }
+
+  /**
+   * {@inheritdoc}
+   *
+   * Until https://www.drupal.org/project/drupal/issues/3039955 is fixed.
+   */
+  protected function setUpCurrentUser(array $values = [], array $permissions = [], $admin = FALSE) {
+    self::assertFalse($admin, "The current setUpCurrentUser workaround doesn't support admin users.");
+    $user = $this->createUser($values, $permissions);
+    $this->setCurrentUser($user);
+    return $user;
+  }
+
+  /**
+   * Test that a user can not view comment without permission.
+   *
+   * Regardless of published status.
+   */
+  public function testUserCanNotViewCommentWithoutPermission() : void {
+    $this->setUpCurrentUser([], ['access comments']);
+    $this->createComment($this->node, ['status' => CommentInterface::NOT_PUBLISHED]);
+    $this->createComment($this->node, ['status' => CommentInterface::PUBLISHED]);
+
+    // Create another user to try and view the comment.
+    $this->setUpCurrentUser();
+
+    $all_comments = $this->storage
+      ->getQuery()
+      ->accessCheck(FALSE)
+      ->condition('entity_id', $this->node->id())
+      ->condition('comment_type', 'comment')
+      ->execute();
+    self::assertCount(2, $all_comments);
+
+    $visible_comments = $this->storage
+      ->getQuery()
+      ->accessCheck(TRUE)
+      ->condition('entity_id', $this->node->id())
+      ->condition('comment_type', 'comment')
+      ->execute();
+    self::assertCount(0, $visible_comments);
+  }
+
+  /**
+   * Test that a user can't view their own unpublished comments.
+   */
+  public function testUserCanNotViewOwnUnpublishedComment() : void {
+    $this->setUpCurrentUser([], ['access comments']);
+    $this->createComment($this->node, ['status' => CommentInterface::NOT_PUBLISHED]);
+
+    $all_comments = $this->storage
+      ->getQuery()
+      ->accessCheck(FALSE)
+      ->condition('entity_id', $this->node->id())
+      ->condition('comment_type', 'comment')
+      ->execute();
+    self::assertCount(1, $all_comments);
+
+    $visible_comments = $this->storage
+      ->getQuery()
+      ->accessCheck(TRUE)
+      ->condition('entity_id', $this->node->id())
+      ->condition('comment_type', 'comment')
+      ->execute();
+
+    self::assertCount(0, $visible_comments);
+  }
+
+  /**
+   * Test that a user can't view other people's unpublished comments.
+   */
+  public function testUserCanNotViewOtherUnpublishedComment() : void {
+    // Create a published comment.
+    $this->setUpCurrentUser([], ['access comments']);
+    $this->createComment($this->node, ['status' => CommentInterface::NOT_PUBLISHED]);
+
+    // Create another user to view the comment.
+    $this->setUpCurrentUser([], ['access comments']);
+
+    $all_comments = $this->storage
+      ->getQuery()
+      ->accessCheck(FALSE)
+      ->condition('entity_id', $this->node->id())
+      ->condition('comment_type', 'comment')
+      ->execute();
+    self::assertCount(1, $all_comments);
+
+    $visible_comments = $this->storage
+      ->getQuery()
+      ->accessCheck(TRUE)
+      ->condition('entity_id', $this->node->id())
+      ->condition('comment_type', 'comment')
+      ->execute();
+    self::assertCount(0, $visible_comments);
+  }
+
+  /**
+   * Test that a user can view everyone's published comments.
+   */
+  public function testUserCanViewOnlyPublishedComment() {
+    $this->setUpCurrentUser([], ['access comments']);
+    $this->createComment($this->node, ['status' => CommentInterface::PUBLISHED]);
+
+    // Create another user to try and view the comment.
+    $this->setUpCurrentUser([], ['access comments']);
+    $this->createComment($this->node, ['status' => CommentInterface::PUBLISHED]);
+
+    $all_comments = $this->storage
+      ->getQuery()
+      ->accessCheck(FALSE)
+      ->condition('entity_id', $this->node->id())
+      ->condition('comment_type', 'comment')
+      ->execute();
+    self::assertCount(2, $all_comments);
+
+    $visible_comments = $this->storage
+      ->getQuery()
+      ->accessCheck(TRUE)
+      ->condition('entity_id', $this->node->id())
+      ->condition('comment_type', 'comment')
+      ->execute();
+    self::assertCount(2, $visible_comments);
+  }
+
+  /**
+   * Create and save a comment entity.
+   *
+   * @param \Drupal\Core\Entity\EntityInterface $entity
+   *   The entity the comment is made on.
+   * @param mixed[] $values
+   *   An optional array of values to pass to Comment::create.
+   *
+   * @return \Drupal\comment\CommentInterface
+   *   The created comment.
+   *
+   * @throws \Drupal\Core\Entity\EntityStorageException
+   */
+  private function createComment(EntityInterface $entity, array $values = []): CommentInterface {
+    /** @var \Drupal\comment\CommentInterface $comment */
+    $comment = $this->storage->create(
+      $values +
+      [
+        'entity_id' => $entity->id(),
+        'entity_type' => $entity->getEntityTypeId(),
+        'comment_type' => 'comment',
+        'field_name' => 'comments',
+      ]
+    );
+    $comment->save();
+
+    return $comment;
+  }
+
+}

--- a/modules/social_features/social_comment/tests/src/Kernel/CommentViewAccessTest.php
+++ b/modules/social_features/social_comment/tests/src/Kernel/CommentViewAccessTest.php
@@ -20,6 +20,8 @@ class CommentViewAccessTest extends EntityKernelTestBase {
    * {@inheritdoc}
    */
   public static $modules = [
+    // For its `use_entity_access_api` setting.
+    'social_core',
     // For the comment functionality.
     'social_comment',
     'comment',
@@ -57,6 +59,14 @@ class CommentViewAccessTest extends EntityKernelTestBase {
    */
   protected function setUp(): void {
     parent::setUp();
+
+    // Manually enable query_access checks, until `use_entity_access_api` is no
+    // longer a setting. Installing all the `social_core` config doesn't work at
+    // the time of writing. This must happen before the comment entity is
+    // installed or its handlers will be incorrect.
+    $this->config('social_core.settings')
+      ->set('use_entity_access_api', TRUE)
+      ->save(TRUE);
 
     $this->installEntitySchema('node');
     $this->installEntitySchema('user');

--- a/modules/social_features/social_core/config/install/social_core.settings.yml
+++ b/modules/social_features/social_core/config/install/social_core.settings.yml
@@ -1,0 +1,1 @@
+use_entity_access_api: true

--- a/modules/social_features/social_core/config/schema/social_core.schema.yml
+++ b/modules/social_features/social_core/config/schema/social_core.schema.yml
@@ -1,0 +1,7 @@
+social_core.settings:
+  type: config_object
+  label: 'Social Core Settings'
+  mapping:
+    use_entity_access_api:
+      type: boolean
+      label: 'Use entity access API'

--- a/modules/social_features/social_core/config/schema/social_core.schema.yml
+++ b/modules/social_features/social_core/config/schema/social_core.schema.yml
@@ -4,4 +4,15 @@ social_core.settings:
   mapping:
     use_entity_access_api:
       type: boolean
-      label: 'Use entity access API'
+      label: 'Opt-in to Entity Access API'
+      description: >-
+        Whether to opt-in to Open Social's implementation for the query access handlers.
+        This alters query_access handler's for Drupal's built-in entities to work with Open Social.
+        This is opt-in because it may interfere with custom query_access handlers platforms already
+        have in place. This is required when using the GraphQL API.
+      deprecated: >-
+        The 'use_entity_access_api' setting is deprecated in social:10.2.0 and is removed from social:11.0.0
+        at which point custom query_access handlers should extend or decorate the query_access handlers from
+        Open Social and the Open Social query_access handlers will be unconditionally enabled.
+        See: https://www.drupal.org/project/social/issues/3210685
+

--- a/modules/social_features/social_core/social_core.info.yml
+++ b/modules/social_features/social_core/social_core.info.yml
@@ -29,4 +29,5 @@ dependencies:
   # TODO: Issue #3109479
   - views_bulk_operations:views_bulk_operations
   - gin_toolbar:gin_toolbar
+  - drupal:entity
 package: Social

--- a/modules/social_features/social_core/social_core.info.yml
+++ b/modules/social_features/social_core/social_core.info.yml
@@ -29,5 +29,5 @@ dependencies:
   # TODO: Issue #3109479
   - views_bulk_operations:views_bulk_operations
   - gin_toolbar:gin_toolbar
-  - drupal:entity
+  - entity:entity
 package: Social

--- a/modules/social_features/social_core/social_core.install
+++ b/modules/social_features/social_core/social_core.install
@@ -1349,7 +1349,7 @@ function social_core_update_10103() {
 /**
  * Set default settings to use entity access API as FALSE.
  */
-function social_core_update_10103() {
+function social_core_update_10104() {
   $config = \Drupal::configFactory()->getEditable('social_core.settings');
   $config->set('use_entity_access_api', 0)->save();
 }

--- a/modules/social_features/social_core/social_core.install
+++ b/modules/social_features/social_core/social_core.install
@@ -1345,3 +1345,11 @@ function social_core_update_10103() {
     $config->save();
   }
 }
+
+/**
+ * Set default settings to use entity access API as FALSE.
+ */
+function social_core_update_10103() {
+  $config = \Drupal::configFactory()->getEditable('social_core.settings');
+  $config->set('use_entity_access_api', 0)->save();
+}


### PR DESCRIPTION
## Problem
Access checks based on published status or ownership for comments aren't performed during an entity query. This means that these checks need to be done after an entity is loaded. This causes issues for pagination, most notably in GraphQL, as outlined in #2979294: Improve pagination DX (a core issue for the JSON:API).

This problem is illustrated by `QueryCommentsTest::testUserRequiresAccessCommentsPermission` and `QueryCommentsTest::testUserCanviewOnlyOwnOrOtherPublishedComments` introduced in https://github.com/goalgorilla/open_social/pull/2285.

## Solution
As Open Social already depends on the entity module that contains the new entity access API we can use this in our solution.

We should duplicate the access checking logic for comments into the entity access API so that these access checks can be performed at query time. This needs to be done in a backwards compatible manner since existing installations may have customised their comment access checks in a way that we can not anticipate. To achieve this we'll introduce a new configuration setting in Drupal core (enabled for new sites, disabled for existing sites, enabled when social_graphql is used). This setting will be deprecated as being removed in Open Social 11.0.0 at which point we will require all sites to use the Entity Access API and sites should have adjusted its queries if they have changed comment access checks.

To indicate that the new Entity Access API can be used by any functionality extending Open Social we will add a dependency on this module i social_core.

## Issue tracker
https://www.drupal.org/project/social/issues/3210685

## Release Notes
Open Social now includes entity query access checks for comments based on the query access API from the entity module. This is enabled for new sites by default but opt-in for existing sites using the `use_entity_access_api` setting in `social_core`. This improvement allows simplifying some queries that were previously doing their own access checks.

## How to test
- [ ] Use [this](https://github.com/goalgorilla/open_social/pull/2285) PR as a patch
- [ ] Write some GraphQL query
```
  comments(first: 10) {
    nodes {
      id
      body
    }
  }
```
- [ ] You should not see unpublished comments in the response

## Screenshots

**Before changes:**

<img width="1730" alt="Снимок экрана 2021-05-05 в 11 34 04" src="https://user-images.githubusercontent.com/50984627/117115860-57858580-ad96-11eb-9907-b6af038e5134.png">
<img width="1730" alt="Снимок экрана 2021-05-05 в 11 38 20" src="https://user-images.githubusercontent.com/50984627/117116165-b0551e00-ad96-11eb-8559-2ded5b1b998f.png">

**After changes:**

<img width="1730" alt="Снимок экрана 2021-05-05 в 11 40 59" src="https://user-images.githubusercontent.com/50984627/117116284-d975ae80-ad96-11eb-8bc5-0ba7032b80d9.png">
<img width="1730" alt="Снимок экрана 2021-05-05 в 11 42 27" src="https://user-images.githubusercontent.com/50984627/117116542-29547580-ad97-11eb-9665-4ada735d422e.png">

