### PR TITLE
Issue #3204850: Make sure SM / Admin can still visit flexible groups marked as secret

### DIFF
--- a/modules/social_features/social_group/modules/social_group_flexible_group/src/Access/FlexibleGroupContentAccessCheck.php
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/src/Access/FlexibleGroupContentAccessCheck.php
@@ -49,6 +49,11 @@ class FlexibleGroupContentAccessCheck implements AccessInterface {
       return AccessResult::allowed();
     }
 
+    // A user with this access can definitely do everything.
+    if ($account->hasPermission('manage all groups')) {
+      return AccessResult::allowed();
+    }
+
     // Handling the visibility of a group.
     if ($group->hasField('field_flexible_group_visibility')) {
       $group_visibility_value = $group->getFieldValue('field_flexible_group_visibility', 'value');
@@ -72,11 +77,6 @@ class FlexibleGroupContentAccessCheck implements AccessInterface {
     $type = $group->getGroupType();
     // Don't interfere if the group isn't a flexible group.
     if ($type instanceof GroupTypeInterface && $type->id() !== 'flexible_group') {
-      return AccessResult::allowed();
-    }
-
-    // A user with this access can definitely do everything.
-    if ($account->hasPermission('manage all groups')) {
       return AccessResult::allowed();
     }
 

--- a/tests/behat/features/capabilities/group/group-create-flexible.feature
+++ b/tests/behat/features/capabilities/group/group-create-flexible.feature
@@ -233,8 +233,8 @@ Feature: Create flexible Group
     Then I should see the link "Stream"
     And I should see the link "About"
     And I should see the link "Members"
-    And I should not see the link "Events"
-    And I should not see the link "Topics"
+    And I should see the link "Events"
+    And I should see the link "Topics"
 
     # Test flexible group with community visibility and members only / invite for closed group.
     Given I am logged in as "GivenUserOne"
@@ -254,7 +254,7 @@ Feature: Create flexible Group
     Then I am on "all-groups"
     And I should not see "Flexible group - Closed option"
 
-    # Check this as an user with SM permissions.
+    # Check this as an user with LU permissions.
     Given I am logged in as an "authenticated user"
     When I am on "all-groups"
     And I should see "Flexible group - Closed option"
@@ -262,8 +262,8 @@ Feature: Create flexible Group
     Then I should not see the link "Stream"
     And I should see the link "About"
     And I should see the link "Members"
-    And I should see the link "Events"
-    And I should see the link "Topics"
+    And I should not see the link "Events"
+    And I should not see the link "Topics"
 
     # And a GM receives a notification about the joined user.
     When I am logged in as "GivenUserOne"

--- a/tests/behat/features/capabilities/group/group-create-flexible.feature
+++ b/tests/behat/features/capabilities/group/group-create-flexible.feature
@@ -262,8 +262,8 @@ Feature: Create flexible Group
     Then I should not see the link "Stream"
     And I should see the link "About"
     And I should see the link "Members"
-    And I should not see the link "Events"
-    And I should not see the link "Topics"
+    And I should see the link "Events"
+    And I should see the link "Topics"
 
     # And a GM receives a notification about the joined user.
     When I am logged in as "GivenUserOne"

--- a/tests/behat/features/capabilities/group/group-create-flexible.feature
+++ b/tests/behat/features/capabilities/group/group-create-flexible.feature
@@ -7,10 +7,11 @@ Feature: Create flexible Group
   Scenario: Successfully create flexible group
     Given I enable the module "social_group_flexible_group"
     Given users:
-      | name           | mail                     | status |
-      | GivenUserOne   | group_user_1@example.com | 1      |
-      | GivenUserTwo   | group_user_2@example.com | 1      |
-      | GivenUserThree | group_user_2@example.com | 1      |
+      | name           | mail                     | status | roles |
+      | GivenUserOne   | group_user_1@example.com | 1      |       |
+      | GivenUserTwo   | group_user_2@example.com | 1      |       |
+      | GivenUserThree | group_user_2@example.com | 1      |       |
+      | SiteManagerOne | site_manager@example.com | 1      | sitemanager  |
     Given "event_types" terms:
       | name     |
       | Webinar  |
@@ -194,7 +195,7 @@ Feature: Create flexible Group
     And I should see the link "Events"
     And I should see the link "Topics"
     And I should see the link "Members"
-    # Check this as an user with SM permissions.
+    # Check this as an user with LU permissions.
     Given I am logged in as an "authenticated user"
     When I am on "all-groups"
     And I click "Cheesy test of flexible group"
@@ -219,10 +220,21 @@ Feature: Create flexible Group
     Then I am on "all-groups"
     And I should not see "Flexible group - Secret option"
 
-    # Check this as an user with SM permissions.
+    # Check this as an user with LU permissions.
     Given I am logged in as an "authenticated user"
     When I am on "all-groups"
     And I should not see "Flexible group - Secret option"
+
+    # Check this as an user with SM permissions.
+    Given I am logged in as "SiteManagerOne"
+    When I am on "all-groups"
+    Then I should see "Flexible group - Secret option"
+    When I click "Flexible group - Secret option"
+    Then I should see the link "Stream"
+    And I should see the link "About"
+    And I should see the link "Members"
+    And I should not see the link "Events"
+    And I should not see the link "Topics"
 
     # Test flexible group with community visibility and members only / invite for closed group.
     Given I am logged in as "GivenUserOne"


### PR DESCRIPTION
## Problem
In #2270 a regression was introduced where SM / Admin can't visit flexible groups which have the "secret" selected.

## Solution
Make sure we check users with manage all groups permissions before we do the field value checks, this is more performant for them and also makes sure we can escape this access check when users have these powerfull global permissions.

## Issue tracker
https://www.drupal.org/project/social/issues/3204850

## How to test
- [x] Login as LU - Create a Flexible group with Secret group visibility
- [x] Login as SM - See you get an access denied
- [x] Go to this branch and repeat, see the access denied is fixed for SM / Admin but is there for non members.

## Release notes
As a SM you get an access denied whilst visiting a flexible group with the "Secret" configuration. That is now fixed as a SM should be able to see this always.
