### PR TITLE
Issue #3214521 by vnech: Change "Mentions Filter" filter type

### DIFF
--- a/modules/custom/mentions/src/Plugin/Filter/MentionsFilter.php
+++ b/modules/custom/mentions/src/Plugin/Filter/MentionsFilter.php
@@ -24,7 +24,7 @@ use Drupal\filter\Entity\FilterFormat;
  * id = "filter_mentions",
  * title = @Translation("Mentions Filter"),
  * description = @Translation("Configure via the <a href='/admin/structure/mentions'>Mention types</a> page."),
- * type = Drupal\filter\Plugin\FilterInterface::TYPE_HTML_RESTRICTOR,
+ * type = Drupal\filter\Plugin\FilterInterface::TYPE_MARKUP_LANGUAGE,
  * settings = {
  *   "mentions_filter" = {}
  * },


### PR DESCRIPTION
## Problem
**"Mentions filter"** doesn't allow to use tokens in `href` attribute in **Full HTML** text format.

For example, if I add this string:
```html
<p><a href="[node:author:url:absolute]">This is a link</a></p>
```

.....
the filter will returns:
```html
<p><a href="absolute]">This is a link</a></p>
```

## Solution
Change filter type from `Drupal\filter\Plugin\FilterInterface::TYPE_HTML_RESTRICTOR` to `Drupal\filter\Plugin\FilterInterface::TYPE_MARKUP_LANGUAGE`

## Issue tracker
- https://www.drupal.org/project/social/issues/3214521
- https://getopensocial.atlassian.net/browse/YANG-5657

## How to test
- [ ] Enable "Mentions filter" in "Full HTML" text format
- [ ] Create any entity has text field with CKEditor
- [ ] In the entity in the text field choose "full html" format and type button "source"
- [ ] Add the string - `<a href="[node:author:url:absolute]">This is a link</a>`
- [ ] Save and click "edit" the entity

## Release notes
*A short summary of the changes that were made that can be included in release notes.*
