### PR TITLE
Issue #3214731 by nkoporec: As an authenticated user I should not see the revision log field when editing my profile

### DIFF
--- a/modules/social_features/social_profile/modules/social_profile_fields/social_profile_fields.module
+++ b/modules/social_features/social_profile/modules/social_profile_fields/social_profile_fields.module
@@ -116,6 +116,37 @@ function social_profile_fields_form_alter(&$form, FormStateInterface $form_state
 }
 
 /**
+ * Implements hook_form_FORM_ID_alter().
+ */
+function social_profile_fields_form_profile_profile_edit_form_alter(&$form, FormStateInterface $form_state) {
+  /** @var \Drupal\Core\Entity\ContentEntityFormInterface $form_object */
+  $form_object = $form_state->getFormObject();
+  /** @var \Drupal\profile\Entity\ProfileInterface $form_entity */
+  $form_entity = $form_object->getEntity();
+
+  $user = \Drupal::currentUser();
+  $hide_revision_field = FALSE;
+
+  // Don't show revision field, if the user can't edit all profiles.
+  if (!$user->hasPermission('update any profile profile')) {
+    $hide_revision_field = TRUE;
+  }
+
+  // Don't show the revision field, if user is editing it's own profile.
+  if (
+    $form_object instanceof ContentEntityFormInterface &&
+    $form_entity->getEntityTypeId() === 'profile' &&
+    $user->id() == $form_entity->getOwnerId()
+  ) {
+    $hide_revision_field = TRUE;
+  }
+
+  if ($hide_revision_field) {
+    $form['revision_log_message']['#access'] = FALSE;
+  }
+}
+
+/**
  * Implements hook_social_user_name_display_suggestions().
  *
  * Adds the nickname as a possible display name.


### PR DESCRIPTION
## Problem
As a regular user, with no special roles or permissions, I can see a revision log at the bottom of the edit profile form.

## Solution
The revision log field should only display for users that have the permission to edit all profiles and the field should also not show up if you are editing your own profile, since it does not make sense to set a revision message for it.

## Issue tracker
https://www.drupal.org/project/social/issues/3214731

## How to test
1. Enable social_profile and social_profile_fields
2. Login in as an authenticated user
3. Go to 'Edit my profile' page.

## Screenshots

Before:
![Screenshot from 2021-05-19 13-02-52](https://user-images.githubusercontent.com/35064680/118802637-a5c07b80-b8a2-11eb-9209-39538a0255c6.png)

After:
![Screenshot from 2021-05-19 13-03-17](https://user-images.githubusercontent.com/35064680/118802656-ace78980-b8a2-11eb-831f-5fcf84fb0fa4.png)


