### PR TITLE
Issue #3205376: Make sure mentions and background tasks are working in the notification center

### DIFF
--- a/modules/custom/activity_viewer/src/Plugin/views/filter/ActivityNotificationVisibilityAccess.php
+++ b/modules/custom/activity_viewer/src/Plugin/views/filter/ActivityNotificationVisibilityAccess.php
@@ -186,11 +186,17 @@ class ActivityNotificationVisibilityAccess extends FilterPluginBase {
       $or->condition($comments_on_content);
     }
 
-    // For likes we can safely assume these end up only in the recipient user,
-    // which is usually the entity owner which got liked.
+    // For likes, mentions, private messages and background tasks we can safely
+    // assume these end up only in the recipient user. The context takes care
+    // of only sending notifications if they have actual access.
     if ($authenticated) {
       $vote_access = new Condition('AND');
-      $vote_access->condition('activity__field_activity_entity.field_activity_entity_target_type', 'vote');
+      $vote_access->condition('activity__field_activity_entity.field_activity_entity_target_type', [
+        'vote',
+        'mentions',
+        'private_message',
+        'queue_storage_entity',
+      ], 'IN');
       $vote_access->condition('activity__field_activity_recipient_user.field_activity_recipient_user_target_id', (string) $account->id());
       $or->condition($vote_access);
     }

--- a/tests/behat/features/bootstrap/SocialDrupalContext.php
+++ b/tests/behat/features/bootstrap/SocialDrupalContext.php
@@ -3,6 +3,8 @@
 
 namespace Drupal\social\Behat;
 
+use Drupal\advancedqueue\Annotation\AdvancedQueueJobType;
+use Drupal\advancedqueue\Commands\AdvancedQueueCommands;
 use Drupal\DrupalExtension\Context\DrupalContext;
 use Drupal\user\Entity\User;
 use Drupal\big_pipe\Render\Placeholder\BigPipeStrategy;
@@ -292,6 +294,14 @@ class SocialDrupalContext extends DrupalContext {
           }
         }
       }
+    }
+    if (\Drupal::moduleHandler()->moduleExists('advancedqueue')) {
+      $queue_storage = \Drupal::service("entity_type.manager")->getStorage('advancedqueue_queue');
+      /** @var \Drupal\advancedqueue\Entity\QueueInterface $queue */
+      $queue = $queue_storage->load('default');
+      /** @var \Drupal\advancedqueue\Processor $processor */
+      $processor = \Drupal::service('advancedqueue.processor');
+      $processor->processQueue($queue);
     }
   }
 

--- a/tests/behat/features/capabilities/administration/export-users.feature
+++ b/tests/behat/features/capabilities/administration/export-users.feature
@@ -1,0 +1,23 @@
+@account @user @stability @stability-4 @perfect @api @export-users
+Feature: Export users
+  Benefit: A user with the SM role can export users.
+  Role: SM
+  Goal/desire: Export users outside of Open Social.
+
+  Scenario: As a SM I should be able to export users of my platform
+    Given I enable the module "social_user_export"
+    When I am logged in as a user with the "sitemanager" role
+    And I am on "admin/people"
+    When I check the box "edit-views-bulk-operations-bulk-form-0"
+    And I check the box "edit-views-bulk-operations-bulk-form-1"
+    And I check the box "edit-views-bulk-operations-bulk-form-2"
+    And I select "Export the selected users to CSV" from "Action"
+    And I press the "Apply to selected items" button
+    Then I should see the text "Selected 3 entities"
+
+    When I press the "Apply" button
+    Then I should see the text "Are you sure you wish to perform"
+    And I press the "Execute action" button
+    And I wait for the batch job to finish
+    Then I should see the text "Export is complete."
+    Then I should see the text "Download file"

--- a/tests/behat/features/capabilities/administration/mail-users.feature
+++ b/tests/behat/features/capabilities/administration/mail-users.feature
@@ -1,0 +1,33 @@
+@api @notifications @stability @stability-3 @bulk-mails
+Feature: Send bulk email
+  Benefit: Be able to notify community members
+  Role: As a SM
+  Goal/desire: I want to be able to notify one or more community members
+
+  @email-spool
+  Scenario: Send bulk email as SM
+    When I am logged in as a user with the "sitemanager" role
+    And I am on "admin/people"
+    When I check the box "edit-views-bulk-operations-bulk-form-0"
+    And I check the box "edit-views-bulk-operations-bulk-form-1"
+    And I check the box "edit-views-bulk-operations-bulk-form-2"
+    And I select "Send email" from "Action"
+    And I press the "Apply to selected items" button
+    Then I should see the text "Send an email to 3 members"
+
+    When I fill in the following:
+      | Subject | This is the e-mail subject |
+    And I fill in the "edit-message-value" WYSIWYG editor with "The body for the e-mail to send"
+    And I press the "Send email" button
+    Then I should see the text "Are you sure you wish to perform"
+    And I press the "Execute action" button
+    And I wait for the batch job to finish
+    Then I should see the text "The email(s) will be send in the background. You will be notified upon completion."
+
+    When I wait for the queue to be empty
+    And I am at "notifications"
+    Then I should see the text "Background process"
+    And I should see the text "This is the e-mail subject"
+    And I should see the text "has finished"
+    And I should have an email with subject "This is the e-mail subject" and in the content:
+      | The body for the e-mail to send |

--- a/tests/behat/features/capabilities/mention/mention-post.feature
+++ b/tests/behat/features/capabilities/mention/mention-post.feature
@@ -19,5 +19,9 @@ Feature: Create Mention in a Post
     And I should see the link "user_3"
     When I click "user_2"
     Then I should see "Isaac Newton"
-#    Then I should see "Albert Einstein mentioned Isaac Newton in a post"
-#    And I should see "Hello user_2, user_3!"
+
+    # Test if the user gets a notification.
+    When I am logged in as "user_2"
+    And I wait for the queue to be empty
+    And I am at "notifications"
+    Then I should see text matching "Albert Einstein mentioned you in a post"


### PR DESCRIPTION
## Problem
See #2272

The activity notification filter for follow taxonomy filters out content related to mentions and backgroundtasks as well.

This was a regression created in #2201 where the goal was to filter out notifications for content created based on tags you are following. This could be that you saw content which was placed in a group you are not a member of, but because it had a tag you're following it showed up in the notification list.


## Solution
Ensure we allow the mentions / background tasks again as part of the notification centre and filter with test coverage so we dont have this regression anymore.

## Issue tracker
https://www.drupal.org/project/social/issues/3205376

## How to test
- [ ] Send an e-mail through admin/people
- [ ] Run the advanced queue cron
- [ ] See you get a nice notification about the background task being finished
- [ ] Mention someone in a post, run the cron/queue see that you get a nice notification in the centre

## Screenshots
<img width="760" alt="Screenshot 2021-05-20 at 12 24 48" src="https://user-images.githubusercontent.com/16667281/118964538-e3d3a300-b967-11eb-9d6c-a790b5689a4c.png">
<img width="710" alt="Screenshot 2021-05-20 at 12 25 08" src="https://user-images.githubusercontent.com/16667281/118964547-e7672a00-b967-11eb-9b31-cd908994e3ac.png">
<img width="720" alt="Screenshot 2021-05-20 at 12 24 57" src="https://user-images.githubusercontent.com/16667281/118964553-e7ffc080-b967-11eb-821e-384de5a4a010.png">

![Screenshot 2021-05-20 at 12 35 30](https://user-images.githubusercontent.com/16667281/118965034-7f651380-b968-11eb-84ac-987bddda3a23.png)


## Release notes
We have fixed the mentions & background task notifications in the notification center, they will pop up again as expected.
