### PR TITLE
Issue #3174548 by rolki: Add basic node scope coverage

### DIFF
--- a/modules/social_features/social_node/social_node.module
+++ b/modules/social_features/social_node/social_node.module
@@ -5,9 +5,11 @@
  * The social node module alterations.
  */
 
+use Drupal\Core\Database\Query\SelectInterface;
+use Drupal\social_node\Entity\Access\NodeQueryAccessHandler;
 use Drupal\social_node\Entity\Node;
-use Drupal\social_node\SocialNodeForm;
 use Drupal\social_node\NodeViewBuilder;
+use Drupal\social_node\SocialNodeForm;
 
 /**
  * Implements hook_entity_type_alter().
@@ -20,6 +22,78 @@ function social_node_entity_type_alter(array &$entity_types) {
 
     foreach (['default', 'edit'] as $operation) {
       $entity_types['node']->setFormClass($operation, SocialNodeForm::class);
+    }
+    $entity_types['node']->setHandlerClass('query_access', NodeQueryAccessHandler::class);
+  }
+}
+
+/**
+ * Implements hook_query_TAG_alter().
+ */
+function social_node_query_entity_query_alter(SelectInterface $query) {
+  if ($query->getTables()['base_table']['table'] == 'node') {
+    $account = \Drupal::currentUser();
+
+    if ($account->isValidOauth2Account()) {
+      /** @var \Drupal\oauth2_server\OAuth2Storage $storage */
+      $storage = \Drupal::service('oauth2_server.storage');
+      $client_scope = $storage->getClientScope($account->getAccountAccessToken()['client_id']);
+      $request_scope = $account->getAccountAccessToken()['scope'];
+
+      $request_scopes = explode(' ', $request_scope);
+      $client_scopes = explode(' ', $client_scope ?? '');
+
+      foreach ($request_scopes as $scope) {
+        if (in_array($scope, $client_scopes)) {
+          $scope_with_access[] = $scope;
+        }
+      }
+
+      $node_types = \Drupal::entityTypeManager()
+        ->getStorage('node_type')
+        ->getQuery()
+        ->execute();
+
+      $public_bundles = [];
+      $community_bundles = [];
+      foreach ($scope_with_access ?? [] as $element) {
+        $scopes = explode(':', $element);
+        [$bundle, $visibility] = $scopes;
+
+        if ($visibility === 'public' && in_array($bundle, $node_types) && !in_array($bundle, $community_bundles)) {
+          $public_bundles[] = $bundle;
+        }
+        elseif ($visibility === 'community' && in_array($bundle, $node_types) && !in_array($bundle, $public_bundles)) {
+          $community_bundles[] = $bundle;
+        }
+      }
+
+      if (!empty($public_bundles) || !empty($community_bundles)) {
+        $query->innerJoin('node__field_content_visibility', 'nfv');
+
+        $and1 = $query->andConditionGroup();
+        $and2 = $query->andConditionGroup();
+
+        $or = $query->orConditionGroup();
+        if (!empty($public_bundles)) {
+          $and1->condition('nfv.field_content_visibility_value', 'public');
+          $and1->condition('node_field_data.type', $public_bundles, 'IN');
+
+          $or->condition($and1);
+        }
+        if (!empty($community_bundles)) {
+          $and2->condition('nfv.field_content_visibility_value', ['public', 'community'], 'IN');
+          $and2->condition('node_field_data.type', $community_bundles, 'IN');
+
+          $or->condition($and2);
+        }
+
+        $query->condition($or);
+        $query->where('node_field_data.nid=nfv.entity_id');
+      }
+      else {
+        $query->where('1 = 0');
+      }
     }
   }
 }

--- a/modules/social_features/social_node/src/Entity/Access/NodeQueryAccessHandler.php
+++ b/modules/social_features/social_node/src/Entity/Access/NodeQueryAccessHandler.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Drupal\social_node\Entity\Access;
+
+use Drupal\Core\Session\AccountInterface;
+use Drupal\entity\QueryAccess\QueryAccessHandlerBase;
+
+/**
+ * Controls query access for node entities.
+ *
+ * @see \Drupal\entity\QueryAccess\QueryAccessHandler
+ */
+class NodeQueryAccessHandler extends QueryAccessHandlerBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildConditions($operation, AccountInterface $account) {
+    $conditions = parent::buildConditions($operation, $account);
+
+    // The user doesn't have access to any entities by default, but in this case
+    // anonymous can view some content, so then following logic added below.
+    // See social_node_query_entity_query_alter.
+    if ($account->isValidOauth2Account() && $conditions->isAlwaysFalse()) {
+      return $conditions->alwaysFalse(FALSE);
+    }
+
+    return $conditions;
+  }
+
+}

--- a/modules/social_features/social_user/social_user.services.yml
+++ b/modules/social_features/social_user/social_user.services.yml
@@ -17,3 +17,9 @@ services:
     arguments: ['@current_route_match', '@current_user', '@config.factory']
     tags:
       - { name: event_subscriber }
+  social_user.current_user:
+    class: Drupal\social_user\SocialAccountProxy
+    decorates: current_user
+    decoration_priority: 5
+    public: false
+    arguments: ['@event_dispatcher', '@oauth2_server.oauth_helper', '@request_stack', '@oauth2_server.storage']

--- a/modules/social_features/social_user/src/SocialAccountProxy.php
+++ b/modules/social_features/social_user/src/SocialAccountProxy.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace Drupal\social_user;
+
+use Drupal\Core\Session\AccountProxy;
+use Drupal\oauth2_server\OAuth2HelperInterface;
+use Drupal\oauth2_server\OAuth2StorageInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/**
+ * Class for adding new methods to the user account to check if this user comes
+ * from Oauth2.
+ *
+ * Decorates the current_user service.
+ */
+class SocialAccountProxy extends AccountProxy {
+
+  /**
+   * The token data.
+   *
+   * @var array
+   */
+  private array $token;
+
+  /**
+   * The OAuth2Helper service.
+   *
+   * @var \Drupal\oauth2_server\OAuth2HelperInterface
+   */
+  protected $oauth2Helper;
+
+  /**
+   * The related request stack.
+   *
+   * @var \Symfony\Component\HttpFoundation\Request
+   */
+  protected $request;
+
+  /**
+   * The OAuth2Storage.
+   *
+   * @var \Drupal\oauth2_server\OAuth2StorageInterface
+   */
+  protected $oauth2Storage;
+
+  /**
+   * SocialAccountProxy constructor.
+   *
+   * @param \Symfony\Component\EventDispatcher\EventDispatcherInterface|null $eventDispatcher
+   *   Event dispatcher.
+   * @param \Drupal\oauth2_server\OAuth2HelperInterface $oauth2_helper
+   *   The OAuth2Helper service.
+   * @param \Symfony\Component\HttpFoundation\RequestStack $request_stack
+   *   The request stack.
+   * @param \Drupal\oauth2_server\OAuth2StorageInterface $oauth2_storage
+   *   The OAuth2 storage service.
+   */
+  public function __construct(
+    EventDispatcherInterface $eventDispatcher = NULL,
+    OAuth2HelperInterface $oauth2_helper,
+    RequestStack $request_stack,
+    OAuth2StorageInterface $oauth2_storage
+  ) {
+    parent::__construct($eventDispatcher);
+
+    $this->oauth2Helper = $oauth2_helper;
+    $this->request = $request_stack->getCurrentRequest();
+    $this->oauth2Storage = $oauth2_storage;
+  }
+
+  /**
+   * Checks if the user authorized via Oauth2.
+   *
+   * @return bool
+   *   TRUE if the user authorized via Oauth2, FALSE otherwise.
+   */
+  public function isValidOauth2Account(): bool {
+    $token = $this->oauth2Helper->getTokenFromRequest($this->request);
+    $valid_authentication = $this->oauth2Helper->hasValidOauth2Authentication($this->request);
+
+    if ($valid_authentication) {
+      $access_token = $this->oauth2Storage->getAccessToken($token);
+
+      if ($access_token) {
+        $this->setAccountAccessToken($access_token);
+        return TRUE;
+      }
+    }
+
+    return FALSE;
+  }
+
+  /**
+   * Gets the token data.
+   *
+   * @return array|null
+   *   An array of token data.
+   */
+  public function getAccountAccessToken(): ?array {
+    if ($this->isValidOauth2Account()) {
+      return $this->token;
+    }
+
+    return NULL;
+  }
+
+  /**
+   * Set the token data for a specific user.
+   *
+   * @param $token
+   *   An array of token data.
+   */
+  private function setAccountAccessToken($token) {
+    $this->token = $token;
+  }
+
+}


### PR DESCRIPTION
## Problem
Any user can submit a request and access private data using `GraphQL`, unless a `query_access` entity handler is added.
So it means I can send something like this via GraphQL and received data about users:
```
query {
  users(first: 5) {
    nodes {
      displayName
      mail
    }
  }
}
```

## Solution
Add a scope implementation, that is, an unauthenticated user should not receive any data after sending the request. Only if the user or application has the appropriate permissions (scopes), and he is authenticated and authorized, only then give access to the data to which he has access.

Probably we can use entity API to implement this (see https://www.drupal.org/project/entity/issues/2909970).

## Issue tracker
- https://www.drupal.org/project/social/issues/3174548
- https://getopensocial.atlassian.net/browse/YANG-5435

## How to test
*For example*
- [ ] Using version X.Y.Z of Open Social with the example module enabled
- [ ] As a sitemanager
- [ ] Try to enable the option B on screen c/d/e
- [ ] When saving I expect the result to be F but instead see G.
- [ ] The expected result F is attained when repeating the steps with this fix applied.

## Screenshots
*If this Pull Request makes visual changes then please include some screenshots that show what has changed here. A before and after screenshot helps the reviewer determine what changes were made.*

## Release notes
*A short summary of the changes that were made that can be included in release notes.*

## Change Record
*If this Pull Request changes the way that developers should do things or introduces a new API for developers then a change record to document this is needed. Please provide a draft for a change record or a link to an unpublished change record below. [Existing change records](https://www.drupal.org/list-changes/social) can be consulted as example.*

## Translations
*Translatable strings are always extracted from the latest development branch. To ensure translations remain available for platforms running older versions of Open Social the original string should be added to `translations.php` when it's changed or removed.*
- [ ] Changed or removed source strings are added to the `translations.php` file.
