### PR TITLE
Issue #3215111 by nkoporec: InvalidQueryException when viewing all notifications

### DIFF
--- a/modules/custom/activity_viewer/src/Plugin/views/filter/ActivityNotificationVisibilityAccess.php
+++ b/modules/custom/activity_viewer/src/Plugin/views/filter/ActivityNotificationVisibilityAccess.php
@@ -218,7 +218,12 @@ class ActivityNotificationVisibilityAccess extends FilterPluginBase {
       $membership_access->condition('activity__field_activity_entity.field_activity_entity_target_type', 'group_content');
       $membership_or_node = new Condition('OR');
       $membership_or_node->condition('activity__field_activity_recipient_user.field_activity_recipient_user_target_id', (string) $account->id());
-      $membership_or_node->condition('activity__field_activity_recipient_group.field_activity_recipient_group_target_id', $groups_unique, 'IN');
+
+      // Check if the user is part of any groups.
+      if ($groups_unique) {
+        $membership_or_node->condition('activity__field_activity_recipient_group.field_activity_recipient_group_target_id', $groups_unique, 'IN');
+      }
+
       $membership_access->condition($membership_or_node);
       $or->condition($membership_access);
     }


### PR DESCRIPTION
## Problem
If the user is not part of any groups and is also not a GM, then the notifications page does not work (WSOD) due to a bug in the ActivityNotificationVisibilityAccess class.

## Solution
Fix the ActivityNotificationVisibilityAccess, so that the /notifications page will not break.

## Issue tracker
https://www.drupal.org/project/social/issues/3215111

## How to test
1. Delete all groups
2. Try visiting /notifications page

## Screenshots
Before:
![Screenshot from 2021-05-21 10-33-39](https://user-images.githubusercontent.com/35064680/119108020-0fb25f80-ba20-11eb-8545-384b656dfafb.png)

After:
![Screenshot from 2021-05-21 10-32-45](https://user-images.githubusercontent.com/35064680/119108040-14771380-ba20-11eb-9f9b-02653e3ead1d.png)


## Release notes

Fixed broken /notifications page, if the user is not part of any group.

## Change Record

## Translations
