### PR TITLE
Issue #3215132 by agami4: Fix gin toolbar settings

### DIFF
--- a/modules/social_features/social_core/social_core.install
+++ b/modules/social_features/social_core/social_core.install
@@ -1345,3 +1345,16 @@ function social_core_update_10103() {
     $config->save();
   }
 }
+
+/**
+ * Add default classic_toolbar of the Gin theme.
+ */
+function social_core_update_10104() {
+  $config = \Drupal::configFactory()->getEditable('gin.settings');
+  if (!empty($config->getRawData())) {
+    $gin_config = $config->getRawData();
+    $gin_config['classic_toolbar'] = 'vertical';
+    $config->setData($gin_config);
+    $config->save();
+  }
+}


### PR DESCRIPTION
## Problem
The `gin--vertical-toolbar` class is absent when we have a gin vertical toolbar.

## Solution
Add vertical toolbar setting to the gin.settings.yml file.

## Issue tracker
https://www.drupal.org/project/social/issues/3215132

## How to test
- [x] Logged like SM and go to the home page.

## Screenshots
before:
![Site Admin | ECI Demo 2021-05-21 13-08-51](https://user-images.githubusercontent.com/16086340/119122223-f8cb3780-ba36-11eb-9535-2bdcb018b3ba.png)
after:
![Site Admin | ECI Demo 2021-05-21 13-22-40](https://user-images.githubusercontent.com/16086340/119122995-cb32be00-ba37-11eb-8134-c0b782c90d8c.png)

## Release notes
The header has a correct position relative to the gin toolbar.
