### PR TITLE
Issue #3215151 by SV: Display "Join" button for anonymous user on the public flexible groups

### DIFF
--- a/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.module
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.module
@@ -15,6 +15,7 @@ use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Field\FieldDefinitionInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\Url;
 use Drupal\block\Entity\Block;
 use Drupal\field\Entity\FieldStorageConfig;
 use Drupal\group\Entity\Group;
@@ -887,4 +888,30 @@ function _social_group_flexible_group_type_change_topic_icon_ajax(array $form, F
   $response->addCommand(new ReplaceCommand('.icon-svg-wrapper', $replaced));
 
   return $response;
+}
+
+/**
+ * Implements hook_preprocess_group().
+ */
+function social_group_flexible_group_preprocess_group(&$variables) {
+  /** @var \Drupal\group\Entity\GroupInterface $group */
+  $group = $variables['group'];
+  $group_type = $group->getGroupType();
+
+  $account = \Drupal::currentUser();
+  // If the user is already a member we don't bother processing any further.
+  if ($group->getMember($account)) {
+    return;
+  }
+
+  // Non logged in users should still see "join" button on a group page.
+  if ($account->isAnonymous() && $group_type->id() === 'flexible_group') {
+    $join_methods = $group->get('field_group_allowed_join_method')->getValue();
+
+    $direct_option = in_array('direct', array_column($join_methods, 'value'), FALSE);
+    if ($direct_option) {
+      $variables['group_operations_url'] = Url::fromRoute('entity.group.join', ['group' => $group->id()]);
+      return;
+    }
+  }
 }

--- a/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.module
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.module
@@ -15,7 +15,6 @@ use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Field\FieldDefinitionInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Session\AccountInterface;
-use Drupal\Core\Url;
 use Drupal\block\Entity\Block;
 use Drupal\field\Entity\FieldStorageConfig;
 use Drupal\group\Entity\Group;
@@ -888,30 +887,4 @@ function _social_group_flexible_group_type_change_topic_icon_ajax(array $form, F
   $response->addCommand(new ReplaceCommand('.icon-svg-wrapper', $replaced));
 
   return $response;
-}
-
-/**
- * Implements hook_preprocess_group().
- */
-function social_group_flexible_group_preprocess_group(&$variables) {
-  /** @var \Drupal\group\Entity\GroupInterface $group */
-  $group = $variables['group'];
-  $group_type = $group->getGroupType();
-
-  $account = \Drupal::currentUser();
-  // If the user is already a member we don't bother processing any further.
-  if ($group->getMember($account)) {
-    return;
-  }
-
-  // Non logged in users should still see "join" button on a group page.
-  if ($account->isAnonymous() && $group_type->id() === 'flexible_group') {
-    $join_methods = $group->get('field_group_allowed_join_method')->getValue();
-
-    $direct_option = in_array('direct', array_column($join_methods, 'value'), FALSE);
-    if ($direct_option) {
-      $variables['group_operations_url'] = Url::fromRoute('entity.group.join', ['group' => $group->id()]);
-      return;
-    }
-  }
 }

--- a/modules/social_features/social_group/social_group.module
+++ b/modules/social_features/social_group/social_group.module
@@ -258,14 +258,13 @@ function social_group_preprocess_group(array &$variables) {
     // @todo switch this to get URL from routes correctly.
     $variables['group_operations_url'] = Url::fromRoute('entity.group.join', ['group' => $group->id()]);
 
-    if (in_array($group_type_id, $group_types)) {
-      $join_methods = $group->get('field_group_allowed_join_method')->getValue();
-      $direct_option = in_array('direct', array_column($join_methods, 'value'), FALSE);
-      if (!$direct_option) {
-        $variables['group_operations_url'] = Url::fromRoute('entity.group.join', ['group' => $group->id()]);
-        $variables['closed_group'] = TRUE;
-        $variables['cta'] = t('Invitation only');
-      }
+    if (
+      in_array($group_type_id, $group_types) &&
+      !social_group_flexible_group_can_join_directly($group)
+    ) {
+      $variables['group_operations_url'] = Url::fromRoute('entity.group.join', ['group' => $group->id()]);
+      $variables['closed_group'] = TRUE;
+      $variables['cta'] = t('Invitation only');
     }
   }
   // If the group type is a closed_group.
@@ -274,6 +273,15 @@ function social_group_preprocess_group(array &$variables) {
     $variables['group_operations_url'] = Url::fromRoute('entity.group.join', ['group' => $group->id()]);
     $variables['closed_group'] = TRUE;
     $variables['cta'] = t('Invitation only');
+  }
+  // Non logged in users should still see "join" button on a group page.
+  if (
+    $account->isAnonymous() &&
+    (in_array($group_type_id, $group_types) &&
+    social_group_flexible_group_can_join_directly($group) ||
+    in_array($group_type_id, ['public_group']))
+  ) {
+    $variables['group_operations_url'] = Url::fromRoute('entity.group.join', ['group' => $group->id()]);
   }
 
   // Add the hero styled image.


### PR DESCRIPTION
## Problem
A user should still see this button and then be prompted to log in so they can join.
otherwise, we are missing out on a large number of users getting a call to action that they can in fact interact with the page.

## Solution
Display "Join" button for an anonymous user on the public flexible groups with "open to join" visibility option

## Issue tracker
- https://www.drupal.org/project/social/issues/3215151
- https://getopensocial.atlassian.net/browse/YANG-5688

## How to test
- [ ] Using version  the latest of Open Social with the example module enabled
- [ ] As a sitemanager
- [ ] Create/edit flexible group with "Public" & "Open to join" visibility options
- [ ] As anonymous open that group and I expect the "Join" button is displayed
- [ ] The expected result is attained when repeating the steps with this fix applied.

## Screenshots

After fix applied:
![Screenshot from 2021-05-21 14-37-55](https://user-images.githubusercontent.com/25609390/119133428-8c573500-ba44-11eb-8eb5-1af1dd6f6154.png)


## Release notes
Display "Join" button for anonymous users on the public flexible groups so they can join.
