### PR TITLE
Enable entity module in GraphQL tests

### DIFF
--- a/modules/custom/social_graphql/tests/src/Kernel/SocialGraphQLTestBase.php
+++ b/modules/custom/social_graphql/tests/src/Kernel/SocialGraphQLTestBase.php
@@ -19,6 +19,7 @@ abstract class SocialGraphQLTestBase extends GraphQLTestBase {
    * {@inheritdoc}
    */
   public static $modules = [
+    "entity",
     "social_graphql",
   ];
 


### PR DESCRIPTION
## Problem
The things we're building with GraphQL require the entity query access API from the entity module. Our GraphQL tests extend `SocialGraphQLTestBase` so it makes sense to always enable the `entity` module.

## Solution
Add the `entity` module to `SocialGraphQLTestBase.php`

## Issue tracker
Omitted, internal CI testing change.

## How to test
*For example*
- [ ] Existing PHPUnit tests for GraphQL should pass.

## Screenshots
N/a

## Release notes
N/a internal testing change

## Change Record
N/a

## Translations
N/a