### PR TITLE
Issue #3215464 by vnech: Add ability for CM+ to remove "Group Admin" role for members

### DIFF
--- a/modules/social_features/social_group/config/install/group.type.closed_group.yml
+++ b/modules/social_features/social_group/config/install/group.type.closed_group.yml
@@ -1,8 +1,6 @@
 langcode: en
 status: true
 dependencies: {  }
-_core:
-  default_config_hash: xroGCpvSEB-Z8oEpr64RsyjOZ2T4BnXvgTpvgo_O5DY
 id: closed_group
 label: 'Closed group'
 description: 'This is a closed group. Users can only join by invitation and the content in the group is hidden from non members.'

--- a/modules/social_features/social_group/config/install/group.type.open_group.yml
+++ b/modules/social_features/social_group/config/install/group.type.open_group.yml
@@ -1,8 +1,6 @@
 langcode: en
 status: true
 dependencies: {  }
-_core:
-  default_config_hash: Uk_6UORiObPWyRN59-gp0zB8x7xIBXd3az6L65RXeGE
 id: open_group
 label: 'Open group'
 description: 'This is an open group. Users may join without approval and all content added in this group will be visible to all community members.'

--- a/modules/social_features/social_group/config/install/group.type.public_group.yml
+++ b/modules/social_features/social_group/config/install/group.type.public_group.yml
@@ -1,8 +1,6 @@
 langcode: en
 status: true
 dependencies: {  }
-_core:
-  default_config_hash: 9RnptqADUkDGf5Gahtu0f6ErAjqvOLUit4TqbEiwg8k
 id: public_group
 label: 'Public group'
 description: 'This is a public group. Users may join without approval and all content added in this group will be visible to all community members and anonymous users.'

--- a/modules/social_features/social_group/modules/social_group_flexible_group/config/install/group.type.flexible_group.yml
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/config/install/group.type.flexible_group.yml
@@ -1,8 +1,6 @@
 langcode: en
 status: true
 dependencies: {  }
-_core:
-  default_config_hash: 0UMYgQUpGfoJEzely-IKuaD4FLRkU2Fvw47evh0TVRQ
 id: flexible_group
 label: 'Flexible group'
 description: 'By choosing this option you can customize many group settings to your needs.'

--- a/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.install
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.install
@@ -363,3 +363,23 @@ function social_group_flexible_group_update_8910(&$sandbox) {
     $sandbox['#finished'] = $sandbox['current'] / $sandbox['total'];
   }
 }
+
+/**
+ * Make group creators as a group managers by default.
+ */
+function social_group_flexible_group_update_8911() {
+  $config_factory = \Drupal::configFactory();
+  $group_type = 'flexible_group';
+
+  $config = $config_factory->getEditable('group.type.' . $group_type);
+  $config->set('creator_membership', TRUE);
+
+  $creator_roles = $config->get('creator_roles');
+  $group_role_id = $group_type . '-group_manager';
+  if (!in_array($group_role_id, $creator_roles)) {
+    $creator_roles[] = $group_role_id;
+    $config->set('creator_roles', $creator_roles);
+  }
+
+  $config->save(TRUE);
+}

--- a/modules/social_features/social_group/modules/social_group_secret/social_group_secret.install
+++ b/modules/social_features/social_group/modules/social_group_secret/social_group_secret.install
@@ -98,3 +98,23 @@ function social_group_secret_update_8901() {
   // Output logged messages to related channel of update execution.
   return $updateHelper->logger()->output();
 }
+
+/**
+ * Make group creators as a group managers by default.
+ */
+function social_group_secret_update_8902() {
+  $config_factory = \Drupal::configFactory();
+  $group_type = 'secret_group';
+
+  $config = $config_factory->getEditable('group.type.' . $group_type);
+  $config->set('creator_membership', TRUE);
+
+  $creator_roles = $config->get('creator_roles');
+  $group_role_id = $group_type . '-group_manager';
+  if (!in_array($group_role_id, $creator_roles)) {
+    $creator_roles[] = $group_role_id;
+    $config->set('creator_roles', $creator_roles);
+  }
+
+  $config->save(TRUE);
+}

--- a/modules/social_features/social_group/social_group.install
+++ b/modules/social_features/social_group/social_group.install
@@ -613,3 +613,30 @@ function social_group_update_8905() {
   // Output logged messages to related channel of update execution.
   return $updateHelper->logger()->output();
 }
+
+/**
+ * Make group creators as a group managers by default.
+ */
+function social_group_update_8906() {
+  $config_factory = \Drupal::configFactory();
+
+  $group_types = [
+    'open_group',
+    'closed_group',
+    'flexible_group',
+  ];
+
+  foreach ($group_types as $group_type) {
+    $config = $config_factory->getEditable('group.type.' . $group_type);
+    $config->set('creator_membership', TRUE);
+
+    $creator_roles = $config->get('creator_roles');
+    $group_role_id = $group_type . '-group_manager';
+    if (!in_array($group_role_id, $creator_roles)) {
+      $creator_roles[] = $group_role_id;
+      $config->set('creator_roles', $creator_roles);
+    }
+
+    $config->save(TRUE);
+  }
+}

--- a/modules/social_features/social_group/social_group.install
+++ b/modules/social_features/social_group/social_group.install
@@ -621,8 +621,10 @@ function social_group_update_8906() {
   $config_factory = \Drupal::configFactory();
 
   $group_types = [
+    'public_group',
     'open_group',
     'closed_group',
+    'secret_group',
     'flexible_group',
   ];
 

--- a/modules/social_features/social_group/social_group.install
+++ b/modules/social_features/social_group/social_group.install
@@ -624,8 +624,6 @@ function social_group_update_8906() {
     'public_group',
     'open_group',
     'closed_group',
-    'secret_group',
-    'flexible_group',
   ];
 
   foreach ($group_types as $group_type) {

--- a/modules/social_features/social_group/social_group.module
+++ b/modules/social_features/social_group/social_group.module
@@ -630,60 +630,6 @@ function social_group_group_visibility_description($key) {
 }
 
 /**
- * Implements hook_entity_insert().
- */
-function social_group_group_insert(GroupInterface $group) {
-  // @todo Remove this when https://www.drupal.org/node/2702743 lands and make.
-  // sure the settings will be implemented accordingly.
-  if ($group->getGroupType()->id() === 'open_group' ||
-    $group->getGroupType()->id() === 'closed_group' ||
-    $group->getGroupType()->id() === 'flexible_group') {
-    // Get the group owner.
-    $account = $group->getOwner();
-    // Get membership.
-    $content = $group->getMember($account)->getGroupContent();
-    // Delete the initial created membership.
-    $content->delete();
-    $grant_group_admin = FALSE;
-    // If the user has this permission inside a group.
-    if ($group->hasPermission('manage all groups', $account)) {
-      // Then we grant this user de Group Admin role.
-      $grant_group_admin = TRUE;
-    }
-    // When a CM+ creates a group, it is given the group_manager role
-    // alongside the group_admin role to keep the full control over the group.
-    if ($grant_group_admin) {
-      // Delete the initial created membership.
-      $content->delete();
-      $plugin = $group->getGroupType()->getContentPlugin('group_membership');
-      $values = [
-        'group_roles' => [
-          $group->bundle() . '-group_admin',
-          $group->bundle() . '-group_manager',
-        ],
-      ];
-      $group_content = GroupContent::create([
-        'type' => $plugin->getContentTypeConfigId(),
-        'gid' => $group->id(),
-        'entity_id' => $group->getOwnerId(),
-      ] + $values);
-      $group_content->save();
-    }
-    else {
-      // Create a new membership.
-      $plugin = $group->getGroupType()->getContentPlugin('group_membership');
-      $values = ['group_roles' => [$group->bundle() . '-group_manager']];
-      $group_content = GroupContent::create([
-        'type' => $plugin->getContentTypeConfigId(),
-        'gid' => $group->id(),
-        'entity_id' => $group->getOwnerId(),
-      ] + $values);
-      $group_content->save();
-    }
-  }
-}
-
-/**
  * Returns a description array for the field_group_allowed_join_method options.
  *
  * @param string $key
@@ -838,15 +784,6 @@ function social_group_form_alter(&$form, FormStateInterface $form_state, $form_i
     // Change titles on membership forms.
     $form['entity_id']['widget'][0]['target_id']['#title'] = t('Find people by name');
     $form['group_roles']['widget']['#title'] = t('Group roles');
-    // Remove the 'group_admin' role in a generic way
-    // for all (future) group types.
-    foreach ($form['group_roles']['widget']['#options'] as $key => $value) {
-      // Hide the submission for the Group Admin role.
-      if (strpos($key, 'group_admin') != FALSE) {
-        unset($form['group_roles']['widget']['#options'][$key]);
-      }
-    }
-
     $form['path']['#type'] = 'hidden';
   }
 
@@ -1195,20 +1132,6 @@ function _social_group_grant_admin_role($uid, $gid) {
  *   The group content.
  */
 function social_group_group_content_insert(GroupContentInterface $group_content) {
-  if ($group_content->getEntity()->getEntityTypeId() == 'user') {
-    if ($group_content->bundle() == $group_content->getGroup()->bundle() . '-group_membership') {
-      _social_group_grant_admin_role($group_content->getEntity()->id(), $group_content->getGroup()->id());
-    }
-  }
-}
-
-/**
- * When updating a group membership.
- *
- * @param \Drupal\group\Entity\GroupContentInterface $group_content
- *   The group content.
- */
-function social_group_group_content_update(GroupContentInterface $group_content) {
   if ($group_content->getEntity()->getEntityTypeId() == 'user') {
     if ($group_content->bundle() == $group_content->getGroup()->bundle() . '-group_membership') {
       _social_group_grant_admin_role($group_content->getEntity()->id(), $group_content->getGroup()->id());


### PR DESCRIPTION
## Problem
There is no possibility to remove the "Group Admin" group role for users who are group members and have CM+ role at the same time.

## Solution
Delete functions (hooks) handled force assign "Group Admin" role for members with CM+ role.

NOTE: This PR saves the ability to make CM+ users as group admins if the one creates a group.

## Issue tracker
- https://www.drupal.org/project/social/issues/3215464
- https://getopensocial.atlassian.net/browse/YANG-5715
- https://getopensocial.atlassian.net/browse/YANG-4990

## How to test

- [ ] Login as an admin
- [ ] Create a new group (flexible group, for example)
- [ ] Add a member with global role CM+ to the group
- [ ] Go to "manage members" page for the created group
- [ ] Try to remove the "Group admin" role for the added member

## Release notes
Add an ability to remove the "Group Admin" role for members with CM+ global roles.
