### PR TITLE
Issue #3215978 by nkoporec: Administer social_footer settings permission is missing

### DIFF
--- a/modules/social_features/social_footer/social_footer.install
+++ b/modules/social_features/social_footer/social_footer.install
@@ -12,3 +12,11 @@ function social_footer_install() {
   // Add default permission.
   user_role_grant_permissions('sitemanager', ['administer social_footer_block settings']);
 }
+
+/**
+ * Add required permissions for sitemanagers for editing footer block settings.
+ */
+function social_footer_update_10014() {
+  // Add default permission.
+  user_role_grant_permissions('sitemanager', ['administer social_footer_block settings']);
+}

--- a/modules/social_features/social_footer/social_footer.install
+++ b/modules/social_features/social_footer/social_footer.install
@@ -12,11 +12,3 @@ function social_footer_install() {
   // Add default permission.
   user_role_grant_permissions('sitemanager', ['administer social_footer_block settings']);
 }
-
-/**
- * Add required permissions for sitemanagers for editing footer block settings.
- */
-function social_footer_update_10014() {
-  // Add default permission.
-  user_role_grant_permissions('sitemanager', ['administer social_footer_block settings']);
-}

--- a/modules/social_features/social_footer/social_footer.permissions.yml
+++ b/modules/social_features/social_footer/social_footer.permissions.yml
@@ -1,3 +1,3 @@
-administer social_footer settings:
+administer social_footer_block settings:
   title: 'Administer Social Footer settings'
   description: 'Configure Social Footer'

--- a/modules/social_features/social_footer/social_footer.permissions.yml
+++ b/modules/social_features/social_footer/social_footer.permissions.yml
@@ -1,0 +1,3 @@
+administer social_footer settings:
+  title: 'Administer Social Footer settings'
+  description: 'Configure Social Footer'


### PR DESCRIPTION
## Problem
The social_footer has a route requirement for a permission called 'administer social_footer_block settings' , but this permission does not exists in the module (there is no .permission.yml file for it). So only users that have the permission added programetically can access this route.

## Solution
We need to create a permission.yml file where this permission will be defined.

## Issue tracker
https://www.drupal.org/project/social/issues/3215978

## How to test
1. Go to /admin/people/permissions
2. Try to find the 'administer social_footer_block settings'
