### PR TITLE
Issue #3216202 by nkoporec: Missing translations for access permissions on flexible groups form

### DIFF
--- a/translations.php
+++ b/translations.php
@@ -102,6 +102,12 @@ new TranslatableMarkup("Manage Enrollments");
 new TranslatableMarkup("Collaboration Settings");
 new TranslatableMarkup("Reply-to");
 new TranslatableMarkup("Selected @count entities:");
+new TranslatableMarkup("Group visibility");
+new TranslatableMarkup("Who can see the group.");
+new TranslatableMarkup("Group content visibility options");
+new TranslatableMarkup("Choose the visibility options allowed for the group content.");
+new TranslatableMarkup("Join methods");
+new TranslatableMarkup("How can people join this group. Group managers can always add members directly, regardless of the chosen join method.");
 // Following plural strings are not translatable due to the @todo in
 // _social_event_managers_action_batch_finish().
 new PluralTranslatableMarkup(0, '1 selected enrollee has been exported successfully', '@count selected enrollees have been exported successfully');


### PR DESCRIPTION
## Problem
Currently the access permission tab is not fully translated.

## Solution
Add the missing translation strings to translations.php so it gets pickup by POTX tool.

## Issue tracker
https://www.drupal.org/project/social/issues/3216202

## How to test
1. Enable translations
2. Go to edit group form
3. See the 'Access permission' tab

## Screenshots
![Screenshot from 2021-05-28 10-33-32](https://user-images.githubusercontent.com/35064680/119955765-a9d65280-bfa0-11eb-88d6-4ec37d5b35f4.png)


## Translations
- Added new source strings to the `translations.php` file.
