### PR TITLE
Issue #3216240 by SV: Improve visibility of tags in content creation

### DIFF
--- a/modules/social_features/social_tagging/social_tagging.module
+++ b/modules/social_features/social_tagging/social_tagging.module
@@ -5,6 +5,7 @@
  * Contains social_tagging.module.
  */
 
+use Drupal\Core\Entity\Display\EntityFormDisplayInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Field\BaseFieldDefinition;
@@ -180,14 +181,14 @@ function social_tagging_social_tagging_field_form_alter(array &$form, FormStateI
       ];
 
       // We want to move the tagging field in new fieldset
-      // "Additional information". Only when the theme settings are updated.
+      // "Tags". Only when the theme settings are updated.
       $use_social_content_forms = theme_get_setting('content_entity_form_style');
-      if (isset($form['#fieldgroups']['group_attachments']) &&
+      if (isset($form['#fieldgroups']['group_social_tags']) &&
         $use_social_content_forms === 'open_social') {
         $form['tagging']['#type'] = 'details';
-        $form['tagging']['#title'] = t('Tags');
-        $form['#fieldgroups']['group_attachments']->children[] = 'tagging';
-        $form['#group_children']['tagging'] = 'group_attachments';
+        $form['tagging']['#title'] = '';
+        $form['#fieldgroups']['group_social_tags']->children[] = 'tagging';
+        $form['#group_children']['tagging'] = 'group_social_tags';
       }
 
       // Add Tags in flexible groups if enabled.
@@ -557,4 +558,34 @@ function social_tagging_preprocess_profile(array &$variables) {
       $variables['social_tagging_hierarchy'] = $tag_service->buildHierarchy($tags, 'profile');
     }
   }
+}
+
+/**
+ * Implements hook_entity_form_display_alter().
+ */
+function social_tagging_entity_form_display_alter(EntityFormDisplayInterface $form_display, array $context) {
+
+  // Creates a "Tags" fieldset for all existing content types. So, "Tags" fields
+  // will be attached in that section when a user enable tagging options.
+  if ($context['entity_type'] !== 'node' || !in_array($context['form_mode'], ['edit', 'default'])) {
+    return;
+  }
+
+  $settings = [
+    "children" => [],
+    "parent_name" => "",
+    "weight" => '1',
+    "label" => "Tags",
+    "format_type" => "fieldset",
+    "format_settings" => [
+      "required_fields" => TRUE,
+      "id" => "tags",
+      "classes" => "card",
+      "label" => "Tags",
+    ],
+    "region" => "hidden",
+  ];
+
+  $form_display->setThirdPartySetting('field_group', 'group_social_tags', $settings);
+  $form_display->save();
 }


### PR DESCRIPTION
## Problem
Tags are currently grouped together with other settings on the add/edit node pages. Also, these settings are collapsed by default, and as result users can miss them when creating or edit content.

## Solution
Move “Tags” from “Additional information” to a separate section on create/edit screen

## Issue tracker
- https://www.drupal.org/project/social/issues/3216240
- https://getopensocial.atlassian.net/browse/YANG-5649

## How to test
- [ ] Using the latest version of Open Social with the social_tagging module enabled
- [ ] As a sitemanager
- [ ] On creating or edit content page try to find the “Tags” field
- [ ] When creating/editing I expect the “Tags” field displayed in the separate section.
- [ ] The expected result is attained when repeating the steps with this fix applied.

## Screenshots
**Before** 
is collapsed:
![Screenshot from 2021-05-28 15-09-17](https://user-images.githubusercontent.com/25609390/119985341-30a02500-bfcb-11eb-8b42-76c536916d17.png)

is mixed with other fields:
![Screenshot from 2021-05-28 15-44-42](https://user-images.githubusercontent.com/25609390/119985717-b0c68a80-bfcb-11eb-8178-020ebd55e288.png)


**After:** 
displays in separate fieldset
![Screenshot-from-2021-05-28-15-11-13-png-777×786-](https://user-images.githubusercontent.com/25609390/119985481-5a594c00-bfcb-11eb-8819-c3e85f285217.png)


## Release notes
Now, "Tags" is much more visible and displays in the new separate fieldset 

