### PR TITLE
Fix PHP warning when add user to group directly

### DIFF
--- a/modules/social_features/social_group/src/Element/SocialGroupEntityAutocomplete.php
+++ b/modules/social_features/social_group/src/Element/SocialGroupEntityAutocomplete.php
@@ -27,13 +27,11 @@ class SocialGroupEntityAutocomplete extends EntityAutocomplete {
     // Load the current Group so we can see if there are existing members.
     $group = _social_group_get_current_group();
 
-    // If we use the select 2 widget then we already got a nice array.
-    if ($select2 === TRUE) {
-      $input_values = $element['#value'];
+    if ($select2 !== TRUE) {
+      $input_values = Tags::explode($element['#value']);
     }
     else {
-      // Grab all the input values so we can get the ID's out of them.
-      $input_values = Tags::explode($element['#value']);
+      $input_values = $element['#value'];
     }
 
     foreach ($input_values as $input) {
@@ -68,7 +66,11 @@ class SocialGroupEntityAutocomplete extends EntityAutocomplete {
         if ($group->getMember($account)) {
           $duplicated_values[] = $account->getDisplayName();
         }
-
+        // We need set "validate_reference" for element to prevent
+        // receive notice Undefined index #validate_reference.
+        if (!isset($element['#validate_reference'])) {
+          $element['#validate_reference'] = FALSE;
+        }
         // Validate input for every single user. This way we make sure that
         // The element validates one, or more users added in the autocomplete.
         // This is because Group doesn't allow adding multiple users at once,


### PR DESCRIPTION
## Problem
After adding member to group through "Add directly" receive:
Notice: Undefined index: #validate_reference in Drupal\Core\Entity\Element\EntityAutocomplete::validateEntityAutocomplete() (line 242 of core/lib/Drupal/Core/Entity/Element/EntityAutocomplete.php).

Drupal\Core\Entity\Element\EntityAutocomplete::validateEntityAutocomplete(Array, Object, Array) (Line: 77)
Drupal\social_group\Element\SocialGroupEntityAutocomplete::validateEntityAutocomplete(Array, Object, Array, 1) (Line: 1024)
_social_group_unique_members(Array, Object, Array)
call_user_func_array('_social_group_unique_members', Array) (Line: 280)

## Solution
Make fixes in /modules/social_features/social_group/src/Element/SocialGroupEntityAutocomplete.php

## Issue tracker
https://www.drupal.org/project/social/issues/3216268

## How to test
- [x] Log in as SM or any other user
- [x] Create a group
- [x] Go to “Manage members" page
- [x] Add a new member to the group using “Add directly" option from “Add members" drop-down

## Screenshots
![grafik](https://user-images.githubusercontent.com/4402834/120012363-b0d08580-bfdf-11eb-81c3-e8c4d64ed293.png)


## Release notes
Fixed warnings after adding member through "Add directly" to group.

## Change Record
N/A

## Translations
N/A
