### PR TITLE
Issue #3215464 by vnech: Missed translating support for "Book page" node type

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,8 @@
                 "Pagination does not work correctly for comment fields that are rendered using #lazy_builder": "https://www.drupal.org/files/issues/2020-12-22/pagination-does-not-work-with-lazy-builder-3189538-2.patch",
                 "Providing default route value for entity forms is not possible": "https://www.drupal.org/files/issues/2020-12-29/2921093-18.patch",
                 "Selecting the same day in a date between filter returns no results": "https://www.drupal.org/files/issues/2020-07-06/2842409-15.patch",
-                "Empty language (langcode) field wrapper inserted into contact form": "https://www.drupal.org/files/issues/2020-03-06/empty-langcode-field-wrapper-2842405-17.patch"
+                "Empty language (langcode) field wrapper inserted into contact form": "https://www.drupal.org/files/issues/2020-03-06/empty-langcode-field-wrapper-2842405-17.patch",
+                "Add Book page node type translation support": "https://www.drupal.org/files/issues/2020-12-16/2470896_237.patch"
             },
             "drupal/flag": {
                 "Add relationship to flagged entities when Flagging is base table": "https://www.drupal.org/files/issues/2723703_31.patch"
@@ -65,8 +66,7 @@
                 "Request membership feature": "https://www.drupal.org/files/issues/2019-07-04/group-request_membership_feature_grequest_module-2752603-110.patch",
                 "Rely on toUrl defaults for Entity url link": "https://www.drupal.org/files/issues/2019-12-04/group-3098675-2.patch",
                 "Group Invite": "https://www.drupal.org/files/issues/2020-03-26/ginvite_module_port-2801603-112.patch",
-                "Cache context update": "https://www.drupal.org/files/issues/2018-05-04/group-cache-context-2882102-2.patch",
-                "Add Book page node type translation support": "https://www.drupal.org/files/issues/2020-12-16/2470896_237.patch"
+                "Cache context update": "https://www.drupal.org/files/issues/2018-05-04/group-cache-context-2882102-2.patch"
             },
             "drupal/like_and_dislike": {
                 "Fix preview on node": "https://www.drupal.org/files/issues/2848080-2-preview-fails-on-node.patch"

--- a/composer.json
+++ b/composer.json
@@ -65,7 +65,8 @@
                 "Request membership feature": "https://www.drupal.org/files/issues/2019-07-04/group-request_membership_feature_grequest_module-2752603-110.patch",
                 "Rely on toUrl defaults for Entity url link": "https://www.drupal.org/files/issues/2019-12-04/group-3098675-2.patch",
                 "Group Invite": "https://www.drupal.org/files/issues/2020-03-26/ginvite_module_port-2801603-112.patch",
-                "Cache context update": "https://www.drupal.org/files/issues/2018-05-04/group-cache-context-2882102-2.patch"
+                "Cache context update": "https://www.drupal.org/files/issues/2018-05-04/group-cache-context-2882102-2.patch",
+                "Add Book page node type translation support": "https://www.drupal.org/files/issues/2020-12-16/2470896_237.patch"
             },
             "drupal/like_and_dislike": {
                 "Fix preview on node": "https://www.drupal.org/files/issues/2848080-2-preview-fails-on-node.patch"

--- a/modules/social_features/social_book/src/ContentTranslationDefaultsConfigOverride.php
+++ b/modules/social_features/social_book/src/ContentTranslationDefaultsConfigOverride.php
@@ -54,6 +54,9 @@ class ContentTranslationDefaultsConfigOverride extends ContentTranslationConfigO
       'field.field.node.book.body' => [
         'translatable' => TRUE,
       ],
+      'field.field.node.book.field_files' => [
+        'translatable' => TRUE,
+      ],
       'field.field.node.book.field_book_image' => [
         'third_party_settings' => [
           'content_translation' => [


### PR DESCRIPTION
## Problem
In "Open Social" there is missed translation support for "Book page" node type.

## Solution
Add related patch for Drupal core.

## Issue tracker
- https://www.drupal.org/project/social/issues/3216539
- https://getopensocial.atlassian.net/browse/YANG-5635

## How to test
- [ ] Login as an admin
- [ ] Add "Book page" (/node/add/book) at least with one translation
- [ ] Visit translated created book view page

## Release notes
Missed translating support for "Book page" node type

## Change Record
Patches:
- drupal/core
  -  "Add Book page node type translation support": "https://www.drupal.org/files/issues/2020-12-16/2470896_237.patch"
 
