### PR TITLE
Issue #3216884 by vnech: Improve translations for "Event" node type

### DIFF
--- a/modules/social_features/social_event/src/ContentTranslationDefaultsConfigOverride.php
+++ b/modules/social_features/social_event/src/ContentTranslationDefaultsConfigOverride.php
@@ -57,8 +57,7 @@ class ContentTranslationDefaultsConfigOverride extends ContentTranslationConfigO
         'use_operator' => FALSE,
         'operator' => '',
         'operator_limit_selection' => FALSE,
-        'operator_list' => [
-        ],
+        'operator_list' => [],
         'identifier' => '',
         'required' => FALSE,
         'remember' => FALSE,
@@ -78,10 +77,8 @@ class ContentTranslationDefaultsConfigOverride extends ContentTranslationConfigO
         'multiple' => FALSE,
         'remember' => FALSE,
         'default_group' => 'All',
-        'default_group_multiple' => [
-        ],
-        'group_items' => [
-        ],
+        'default_group_multiple' => [],
+        'group_items' => [],
       ],
       'entity_type' => 'node',
       'entity_field' => 'langcode',

--- a/modules/social_features/social_event/src/ContentTranslationDefaultsConfigOverride.php
+++ b/modules/social_features/social_event/src/ContentTranslationDefaultsConfigOverride.php
@@ -31,6 +31,75 @@ class ContentTranslationDefaultsConfigOverride extends ContentTranslationConfigO
    * {@inheritdoc}
    */
   protected function getTranslationOverrides() {
+    $views_plugin_content_translation_settings = [
+      'display_options' => [
+        'rendering_language' => '***LANGUAGE_language_interface***',
+      ],
+    ];
+
+    $langcode_filter_settings = [
+      'id' => 'langcode',
+      'table' => 'node_field_data',
+      'field' => 'langcode',
+      'relationship' => 'field_event',
+      'group_type' => 'group',
+      'admin_label' => '',
+      'operator' => 'in',
+      'value' => [
+        '***LANGUAGE_language_interface***' => '***LANGUAGE_language_interface***',
+      ],
+      'group' => 1,
+      'exposed' => FALSE,
+      'expose' => [
+        'operator_id' => '',
+        'label' => '',
+        'description' => '',
+        'use_operator' => FALSE,
+        'operator' => '',
+        'operator_limit_selection' => FALSE,
+        'operator_list' => [
+        ],
+        'identifier' => '',
+        'required' => FALSE,
+        'remember' => FALSE,
+        'multiple' => FALSE,
+        'remember_roles' => [
+          'authenticated' => 'authenticated',
+        ],
+        'reduce' => FALSE,
+      ],
+      'is_grouped' => FALSE,
+      'group_info' => [
+        'label' => '',
+        'description' => '',
+        'identifier' => '',
+        'optional' => TRUE,
+        'widget' => 'select',
+        'multiple' => FALSE,
+        'remember' => FALSE,
+        'default_group' => 'All',
+        'default_group_multiple' => [
+        ],
+        'group_items' => [
+        ],
+      ],
+      'entity_type' => 'node',
+      'entity_field' => 'langcode',
+      'plugin_id' => 'language',
+    ];
+
+    $default_display_langcode_filter_options = [
+      'display' => [
+        'default' => [
+          'display_options' => [
+            'filters' => [
+              'langcode' => $langcode_filter_settings,
+            ]
+          ],
+        ],
+      ],
+    ];
+
     return [
       'language.content_settings.node.event' => [
         'third_party_settings' => [
@@ -51,6 +120,12 @@ class ContentTranslationDefaultsConfigOverride extends ContentTranslationConfigO
       'field.field.node.event.body' => [
         'translatable' => TRUE,
       ],
+      'field.field.node.event.field_event_address' => [
+        'translatable' => TRUE,
+      ],
+      'field.field.node.event.field_files' => [
+        'translatable' => TRUE,
+      ],
       'field.field.node.event.field_event_image' => [
         'third_party_settings' => [
           'content_translation' => [
@@ -63,6 +138,31 @@ class ContentTranslationDefaultsConfigOverride extends ContentTranslationConfigO
         ],
         'translatable' => TRUE,
       ],
+      'views.view.upcoming_events' => [
+        'display' => [
+          'block_community_events' => $views_plugin_content_translation_settings,
+          'block_my_upcoming_events' => $views_plugin_content_translation_settings,
+          'page_community_events' => $views_plugin_content_translation_settings,
+          'upcoming_events_group' => $views_plugin_content_translation_settings,
+        ],
+      ],
+      'views.view.events' => [
+        'display' => [
+          'events_overview' => $views_plugin_content_translation_settings,
+          'block_events_on_profile' => $views_plugin_content_translation_settings,
+        ],
+      ],
+      'views.view.group_events' => [
+        'display' => [
+          'page_group_events' => $views_plugin_content_translation_settings,
+        ],
+      ],
+      'views.view.event_manage_enrollments' => $default_display_langcode_filter_options,
+      'views.view.user_event_invites' => $default_display_langcode_filter_options,
+      'views.view.event_enrollments' => $default_display_langcode_filter_options,
+      'views.view.manage_enrollments' => $default_display_langcode_filter_options,
+      'views.view.event_manage_enrollment_invites' => $default_display_langcode_filter_options,
+      'views.view.event_manage_enrollment_requests' => $default_display_langcode_filter_options,
     ];
   }
 

--- a/modules/social_features/social_event/src/ContentTranslationDefaultsConfigOverride.php
+++ b/modules/social_features/social_event/src/ContentTranslationDefaultsConfigOverride.php
@@ -120,6 +120,9 @@ class ContentTranslationDefaultsConfigOverride extends ContentTranslationConfigO
       'field.field.node.event.body' => [
         'translatable' => TRUE,
       ],
+      'field.field.node.event.field_event_location' => [
+        'translatable' => TRUE,
+      ],
       'field.field.node.event.field_event_address' => [
         'translatable' => TRUE,
       ],


### PR DESCRIPTION
## Problem
"Event" node type has fields unsuported translation: "Address" & "Attachements".
Also, there are a few views (displays events) that need to be adopted for translation support.
"Event Enrollment" should be also displayed according to current language.

## Solution
Add "Event" translation support to `modules/social_features/social_event/src/ContentTranslationDefaultsConfigOverride.php`

## Issue tracker
- https://www.drupal.org/project/social/issues/3216884
- https://getopensocial.atlassian.net/browse/YANG-5636
- https://getopensocial.atlassian.net/browse/YANG-5638
- https://getopensocial.atlassian.net/browse/YANG-5647

## How to test
- [ ] Login as an admin
- [ ] Make sure you have at least two languages installed
- [ ] Add an "Event" and attach it to any group
- [ ] Add translation for the created event
- [ ] Visit pages with the event

## Screenshots
*If this Pull Request makes visual changes then please include some screenshots that show what has changed here. A before and after screenshot helps the reviewer determine what changes were made.*

## Release notes
*Improve translation support for "Event" node type.*

## Change Record
Views affected:
- views.view.upcoming_events
- views.view.events
- views.view.group_events
- views.view.event_manage_enrollments
- views.view.user_event_invites
- views.view.event_enrollments
- views.view.manage_enrollments
- views.view.event_manage_enrollment_invites
- views.view.event_manage_enrollment_requests

