### PR TITLE
Issue #3185497 by rolki: Implement basic event querying in the Graph

### DIFF
--- a/modules/social_features/social_event/graphql/social_event_schema_extension.base.graphqls
+++ b/modules/social_features/social_event/graphql/social_event_schema_extension.base.graphqls
@@ -1,0 +1,114 @@
+"""
+A type of content on Open Social which allows users to organize, discuss topics, and join activities.
+"""
+type Event implements Node & Commentable {
+  """
+  The unique identifier for the event.
+  """
+  id: ID!
+  """
+  The display title of the event.
+  """
+  title: String!
+  """
+  The author of the event.
+  """
+  author: Actor
+  """
+  A hero image for the event.
+  """
+  heroImage: Image
+  """
+  The message of the event as rendered HTML.
+  """
+  bodyHtml: Html!
+  """
+  The formatted start date of the event.
+  """
+  startDate: DateTime!
+  """
+  The formatted end date of the event.
+
+  When a event is not limited to a specific time period the end date may be NULL.
+  """
+  endDate: DateTime
+  """
+  The location of the event as plain text.
+  """
+  location: String
+  """
+  List of event managers.
+
+  Managers are people who have the rights to edit the event itself.
+  """
+  managers(
+    """Returns the elements that come after the specified cursor."""
+    after: Cursor
+    """Returns the elements that come before the specified cursor."""
+    before: Cursor
+    """Returns up to the first `n` elements from the list."""
+    first: Int
+    """Returns up to the last `n` elements from the list."""
+    last: Int
+    """Reverse the order of the underlying list."""
+    reverse: Boolean = false
+  ): EventManagerConnection!
+  """
+  List of event comments.
+  """
+  comments(
+    """Returns the elements that come after the specified cursor."""
+    after: Cursor
+    """Returns the elements that come before the specified cursor."""
+    before: Cursor
+    """Returns up to the first `n` elements from the list."""
+    first: Int
+    """Returns up to the last `n` elements from the list."""
+    last: Int
+    """Reverse the order of the underlying list."""
+    reverse: Boolean = false
+    """Sort the underlying list by the given key."""
+    sortKey: CommentSortKeys = CREATED_AT
+  ): CommentConnection!
+  """
+  The url to the event.
+  """
+  url: Url!
+  """
+  When the event was created.
+  """
+  created: DateTime!
+}
+
+type EventEdge implements Edge {
+  cursor: Cursor!
+  node: Event!
+}
+
+type EventConnection implements Connection {
+  edges: [EventEdge!]!
+  nodes: [Event!]!
+  pageInfo: PageInfo!
+}
+
+"""
+The set of valid sort keys for the event query.
+"""
+enum EventSortKeys {
+  """Sort by event creation date"""
+  CREATED_AT
+}
+
+type EventManagerEdge implements Edge {
+  cursor: Cursor!
+  node: User!
+}
+
+"""
+Pagination info for moderators of a discussion.
+"""
+type EventManagerConnection implements Connection {
+  edges: [EventManagerEdge!]!
+  nodes: [User!]!
+  pageInfo: PageInfo!
+}

--- a/modules/social_features/social_event/graphql/social_event_schema_extension.extension.graphqls
+++ b/modules/social_features/social_event/graphql/social_event_schema_extension.extension.graphqls
@@ -1,0 +1,31 @@
+extend type Query {
+  """
+  List of all events on the platform.
+
+  Results are limited to what the current viewer has access to.
+  """
+  events(
+    """Returns the elements that come after the specified cursor."""
+    after: Cursor
+    """Returns the elements that come before the specified cursor."""
+    before: Cursor
+    """Returns up to the first `n` elements from the list."""
+    first: Int
+    """Returns up to the last `n` elements from the list."""
+    last: Int
+    """Reverse the order of the underlying list."""
+    reverse: Boolean = false
+    """Sort the underlying list by the given key."""
+    sortKey: EventSortKeys = CREATED_AT
+  ): EventConnection!
+
+  """
+  Fetch data for a specific event.
+  """
+  event(
+    """
+    The id of the event to load.
+    """
+    id: ID!
+  ): Event
+}

--- a/modules/social_features/social_event/src/Plugin/GraphQL/DataProducer/EventManagers.php
+++ b/modules/social_features/social_event/src/Plugin/GraphQL/DataProducer/EventManagers.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Drupal\social_event\Plugin\GraphQL\DataProducer;
+
+use Drupal\Core\Cache\RefinableCacheableDependencyInterface;
+use Drupal\Core\Database\Connection;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\graphql\GraphQL\Buffers\EntityBuffer;
+use Drupal\graphql\GraphQL\Buffers\EntityRevisionBuffer;
+use Drupal\graphql\GraphQL\Buffers\EntityUuidBuffer;
+use Drupal\node\NodeInterface;
+use Drupal\social_event\Plugin\GraphQL\QueryHelper\EventManagersQueryHelper;
+use Drupal\social_graphql\GraphQL\EntityConnection;
+use Drupal\social_graphql\Plugin\GraphQL\DataProducer\Entity\EntityDataProducerPluginBase;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Queries the managers of the event on the platform.
+ *
+ * @DataProducer(
+ *   id = "event_managers",
+ *   name = @Translation("Event managers"),
+ *   description = @Translation("Loads the managers for a event."),
+ *   produces = @ContextDefinition("any",
+ *     label = @Translation("EntityConnection")
+ *   ),
+ *   consumes = {
+ *     "event" = @ContextDefinition("entity:node:event",
+ *       label = @Translation("Event"),
+ *       required = TRUE
+ *     ),
+ *     "first" = @ContextDefinition("integer",
+ *       label = @Translation("First"),
+ *       required = FALSE
+ *     ),
+ *     "after" = @ContextDefinition("string",
+ *       label = @Translation("After"),
+ *       required = FALSE
+ *     ),
+ *     "last" = @ContextDefinition("integer",
+ *       label = @Translation("Last"),
+ *       required = FALSE
+ *     ),
+ *     "before" = @ContextDefinition("string",
+ *       label = @Translation("Before"),
+ *       required = FALSE
+ *     ),
+ *     "reverse" = @ContextDefinition("boolean",
+ *       label = @Translation("Reverse"),
+ *       required = FALSE,
+ *       default_value = FALSE
+ *     ),
+ *     "sortKey" = @ContextDefinition("string",
+ *       label = @Translation("Sort key"),
+ *       required = FALSE,
+ *       default_value = "CREATED_AT"
+ *     )
+ *   }
+ * )
+ */
+class EventManagers extends EntityDataProducerPluginBase {
+
+  /**
+   * Resolves the request to the requested values.
+   *
+   * @param \Drupal\node\NodeInterface $event
+   *   The conversation to fetch participants for.
+   * @param int|null $first
+   *   Fetch the first X results.
+   * @param string|null $after
+   *   Cursor to fetch results after.
+   * @param int|null $last
+   *   Fetch the last X results.
+   * @param string|null $before
+   *   Cursor to fetch results before.
+   * @param bool $reverse
+   *   Reverses the order of the data.
+   * @param string $sortKey
+   *   Key to sort by.
+   * @param \Drupal\Core\Cache\RefinableCacheableDependencyInterface $metadata
+   *   Cacheability metadata for this request.
+   *
+   * @return \Drupal\social_graphql\GraphQL\ConnectionInterface
+   *   An entity connection with results and data about the paginated results.
+   */
+  public function resolve(NodeInterface $event, ?int $first, ?string $after, ?int $last, ?string $before, bool $reverse, string $sortKey, RefinableCacheableDependencyInterface $metadata) {
+    $query_helper = new EventManagersQueryHelper($sortKey, $this->entityTypeManager, $this->graphqlEntityBuffer, $event);
+    $metadata->addCacheableDependency($query_helper);
+
+    $connection = new EntityConnection($query_helper);
+    $connection->setPagination($first, $after, $last, $before, $reverse);
+    return $connection;
+  }
+
+}

--- a/modules/social_features/social_event/src/Plugin/GraphQL/DataProducer/Field/DateToTimestamp.php
+++ b/modules/social_features/social_event/src/Plugin/GraphQL/DataProducer/Field/DateToTimestamp.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Drupal\social_event\Plugin\GraphQL\DataProducer\Field;
+
+use Drupal\datetime\Plugin\Field\FieldType\DateTimeFieldItemList;
+use Drupal\datetime\Plugin\Field\FieldType\DateTimeItem;
+use Drupal\graphql\Plugin\GraphQL\DataProducer\DataProducerPluginBase;
+
+/**
+ * Get the date range as a timestamp.
+ *
+ * @DataProducer(
+ *   id = "date_to_timestamp",
+ *   name = @Translation("Date to timestamp"),
+ *   description = @Translation("Convert date field object to timestamp."),
+ *   produces = @ContextDefinition("int",
+ *     label = @Translation("Timestamp")
+ *   ),
+ *   consumes = {
+ *     "field" = @ContextDefinition("any",
+ *       label = @Translation("The date field")
+ *     )
+ *   }
+ * )
+ */
+class DateToTimestamp extends DataProducerPluginBase {
+
+  /**
+   * Resolves the request to the requested values.
+   *
+   * @param \Drupal\datetime\Plugin\Field\FieldType\DateTimeFieldItemList $field
+   *   The date field object.
+   *
+   * @return int|null
+   *   An event start or end day timestamp.
+   */
+  public function resolve(DateTimeFieldItemList $field) {
+    if ($field->isEmpty()) {
+      return NULL;
+    }
+
+    return $field->{DateTimeItem::DATETIME_TYPE_DATE}->getTimestamp();
+  }
+
+}

--- a/modules/social_features/social_event/src/Plugin/GraphQL/DataProducer/QueryEvent.php
+++ b/modules/social_features/social_event/src/Plugin/GraphQL/DataProducer/QueryEvent.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Drupal\social_event\Plugin\GraphQL\DataProducer;
+
+use Drupal\Core\Cache\RefinableCacheableDependencyInterface;
+use Drupal\social_event\Plugin\GraphQL\QueryHelper\EventQueryHelper;
+use Drupal\social_graphql\GraphQL\EntityConnection;
+use Drupal\social_graphql\Plugin\GraphQL\DataProducer\Entity\EntityDataProducerPluginBase;
+
+/**
+ * Queries the events on the platform.
+ *
+ * @DataProducer(
+ *   id = "query_event",
+ *   name = @Translation("Query a list of events"),
+ *   description = @Translation("Loads the events."),
+ *   produces = @ContextDefinition("any",
+ *     label = @Translation("EntityConnection")
+ *   ),
+ *   consumes = {
+ *     "first" = @ContextDefinition("integer",
+ *       label = @Translation("First"),
+ *       required = FALSE
+ *     ),
+ *     "after" = @ContextDefinition("string",
+ *       label = @Translation("After"),
+ *       required = FALSE
+ *     ),
+ *     "last" = @ContextDefinition("integer",
+ *       label = @Translation("Last"),
+ *       required = FALSE
+ *     ),
+ *     "before" = @ContextDefinition("string",
+ *       label = @Translation("Before"),
+ *       required = FALSE
+ *     ),
+ *     "reverse" = @ContextDefinition("boolean",
+ *       label = @Translation("Reverse"),
+ *       required = FALSE,
+ *       default_value = FALSE
+ *     ),
+ *     "sortKey" = @ContextDefinition("string",
+ *       label = @Translation("Sort key"),
+ *       required = FALSE,
+ *       default_value = "CREATED_AT"
+ *     ),
+ *   }
+ * )
+ */
+class QueryEvent extends EntityDataProducerPluginBase {
+
+  /**
+   * Resolves the request to the requested values.
+   *
+   * @param int|null $first
+   *   Fetch the first X results.
+   * @param string|null $after
+   *   Cursor to fetch results after.
+   * @param int|null $last
+   *   Fetch the last X results.
+   * @param string|null $before
+   *   Cursor to fetch results before.
+   * @param bool $reverse
+   *   Reverses the order of the data.
+   * @param string $sortKey
+   *   Key to sort by.
+   * @param \Drupal\Core\Cache\RefinableCacheableDependencyInterface $metadata
+   *   Cacheability metadata for this request.
+   *
+   * @return \Drupal\social_graphql\GraphQL\ConnectionInterface
+   *   An entity connection with results and data about the paginated results.
+   */
+  public function resolve(?int $first, ?string $after, ?int $last, ?string $before, bool $reverse, string $sortKey, RefinableCacheableDependencyInterface $metadata) {
+    $query_helper = new EventQueryHelper($sortKey, $this->entityTypeManager, $this->graphqlEntityBuffer);
+    $metadata->addCacheableDependency($query_helper);
+
+    $connection = new EntityConnection($query_helper);
+    $connection->setPagination($first, $after, $last, $before, $reverse);
+    return $connection;
+  }
+
+}

--- a/modules/social_features/social_event/src/Plugin/GraphQL/QueryHelper/EventManagersQueryHelper.php
+++ b/modules/social_features/social_event/src/Plugin/GraphQL/QueryHelper/EventManagersQueryHelper.php
@@ -1,0 +1,170 @@
+<?php
+
+namespace Drupal\social_event\Plugin\GraphQL\QueryHelper;
+
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Entity\Query\QueryInterface;
+use Drupal\graphql\GraphQL\Buffers\EntityBuffer;
+use Drupal\node\NodeInterface;
+use Drupal\social_graphql\GraphQL\ConnectionQueryHelperBase;
+use Drupal\social_graphql\Wrappers\Cursor;
+use Drupal\social_graphql\Wrappers\Edge;
+use Drupal\user\UserInterface;
+use GraphQL\Deferred;
+use GraphQL\Executor\Promise\Adapter\SyncPromise;
+
+/**
+ * Loads event managers.
+ */
+class EventManagersQueryHelper extends ConnectionQueryHelperBase {
+
+  /**
+   * The event for which managers are being fetched.
+   *
+   * @var \Drupal\node\NodeInterface
+   */
+  protected NodeInterface $event;
+
+  /**
+   * EventManagersQueryHelper constructor.
+   *
+   * @param string $sort_key
+   *   The key that is used for sorting.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The Drupal entity type manager.
+   * @param \Drupal\graphql\GraphQL\Buffers\EntityBuffer $graphql_entity_buffer
+   *   The GraphQL entity buffer.
+   * @param \Drupal\node\NodeInterface $event
+   *   The event.
+   */
+  public function __construct(
+    string $sort_key,
+    EntityTypeManagerInterface $entity_type_manager,
+    EntityBuffer $graphql_entity_buffer,
+    NodeInterface $event
+  ) {
+    parent::__construct($sort_key, $entity_type_manager, $graphql_entity_buffer);
+
+    $this->event = $event;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getQuery() : QueryInterface {
+    // This slightly inefficiently loads all referenced entities. Unfortunately
+    // we want to load user entities and Drupal core does not support joining
+    // other entity types in entity queries. The below can be optimised with a
+    // more efficient direct database query to load the event manager user ids
+    // but this requires properly getting all the table names (taking database
+    // prefixes into account). That's more effort than it's worth for a field
+    // that realistically will not have more than a handful values usually.
+    // The upside is that any users we match in the eventual query will probably
+    // need to be loaded since a GraphQL query is likely to want more data for a
+    // user. So optimisation may not win you a lot.
+    // The filter is added since entity reference fields may be configured to
+    // reference other values than users, but this is something we don't (yet)
+    // support.
+    $users = $this->event->field_event_managers->referencedEntities();
+    $uids = array_map(
+      fn (UserInterface $user) => $user->id(),
+      array_filter(
+        $users,
+        fn (EntityInterface $entity) => $entity instanceof UserInterface
+      )
+    );
+
+    return $this->entityTypeManager->getStorage('user')
+      ->getQuery()
+      ->accessCheck(TRUE)
+      ->condition('uid', $uids ?: NULL, 'IN');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCursorObject(string $cursor) : ?Cursor {
+    $cursor_object = Cursor::fromCursorString($cursor);
+
+    return !is_null($cursor_object) && $cursor_object->isValidFor($this->sortKey, 'node')
+      ? $cursor_object
+      : NULL;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getIdField() : string {
+    return 'uid';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getSortField() : string {
+    switch ($this->sortKey) {
+      case 'CREATED_AT':
+        return 'created';
+
+      default:
+        throw new \InvalidArgumentException("Unsupported sortKey for sorting '{$this->sortKey}'");
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getAggregateSortFunction() : ?string {
+    return NULL;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getLoaderPromise(array $result) : SyncPromise {
+    // In case of no results we create a callback the returns an empty array.
+    if (empty($result)) {
+      $callback = static fn () => [];
+    }
+    // Otherwise we create a callback that uses the GraphQL entity buffer to
+    // ensure the entities for this query are only loaded once. Even if the
+    // results are used multiple times.
+    else {
+      $buffer = \Drupal::service('graphql.buffer.entity');
+      $callback = $buffer->add('user', array_values($result));
+    }
+
+    return new Deferred(
+      function () use ($callback) {
+        return array_map(
+          fn (UserInterface $entity) => new Edge(
+            $entity,
+            new Cursor('user', $entity->id(), $this->sortKey, $this->getSortValue($entity))
+          ),
+          $callback()
+        );
+      }
+    );
+  }
+
+  /**
+   * Get the value for an entity based on the sort key for this connection.
+   *
+   * @param \Drupal\user\UserInterface $user
+   *   The moderator entity for the user in this conversation.
+   *
+   * @return mixed
+   *   The sort value.
+   */
+  protected function getSortValue(UserInterface $user) {
+    switch ($this->sortKey) {
+      case 'CREATED_AT':
+        return $user->getCreatedTime();
+
+      default:
+        throw new \InvalidArgumentException("Unsupported sortKey for pagination '{$this->sortKey}'");
+    }
+  }
+
+}

--- a/modules/social_features/social_event/src/Plugin/GraphQL/QueryHelper/EventQueryHelper.php
+++ b/modules/social_features/social_event/src/Plugin/GraphQL/QueryHelper/EventQueryHelper.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace Drupal\social_event\Plugin\GraphQL\QueryHelper;
+
+use Drupal\Core\Entity\Query\QueryInterface;
+use Drupal\node\Entity\Node;
+use Drupal\social_graphql\GraphQL\ConnectionQueryHelperBase;
+use Drupal\social_graphql\Wrappers\Cursor;
+use Drupal\social_graphql\Wrappers\Edge;
+use GraphQL\Deferred;
+use GraphQL\Executor\Promise\Adapter\SyncPromise;
+
+/**
+ * Loads events.
+ */
+class EventQueryHelper extends ConnectionQueryHelperBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getQuery() : QueryInterface {
+    return $this->entityTypeManager->getStorage('node')
+      ->getQuery()
+      ->currentRevision()
+      ->accessCheck(TRUE)
+      ->condition('type', 'event');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCursorObject(string $cursor) : ?Cursor {
+    $cursor_object = Cursor::fromCursorString($cursor);
+
+    return !is_null($cursor_object) && $cursor_object->isValidFor($this->sortKey, 'node')
+      ? $cursor_object
+      : NULL;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getIdField() : string {
+    return 'nid';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getSortField() : string {
+    switch ($this->sortKey) {
+      case 'CREATED_AT':
+        return 'created';
+
+      default:
+        throw new \InvalidArgumentException("Unsupported sortKey for sorting '{$this->sortKey}'");
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getAggregateSortFunction() : ?string {
+    return NULL;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getLoaderPromise(array $result) : SyncPromise {
+    // In case of no results we create a callback the returns an empty array.
+    if (empty($result)) {
+      $callback = static fn () => [];
+    }
+    // Otherwise we create a callback that uses the GraphQL entity buffer to
+    // ensure the entities for this query are only loaded once. Even if the
+    // results are used multiple times.
+    else {
+      $buffer = \Drupal::service('graphql.buffer.entity');
+      $callback = $buffer->add('node', array_values($result));
+    }
+
+    return new Deferred(
+      function () use ($callback) {
+        return array_map(
+          fn (Node $entity) => new Edge(
+            $entity,
+            new Cursor('node', $entity->id(), $this->sortKey, $this->getSortValue($entity))
+          ),
+          $callback()
+        );
+      }
+    );
+  }
+
+  /**
+   * Get the value for an entity based on the sort key for this connection.
+   *
+   * @param \Drupal\node\Entity\Node $node
+   *   The participant entity for the user in this conversation.
+   *
+   * @return mixed
+   *   The sort value.
+   */
+  protected function getSortValue(Node $node) {
+    switch ($this->sortKey) {
+      case 'CREATED_AT':
+        return $node->getCreatedTime();
+
+      default:
+        throw new \InvalidArgumentException("Unsupported sortKey for pagination '{$this->sortKey}'");
+    }
+  }
+
+}

--- a/modules/social_features/social_event/src/Plugin/GraphQL/SchemaExtension/EventSchemaExtension.php
+++ b/modules/social_features/social_event/src/Plugin/GraphQL/SchemaExtension/EventSchemaExtension.php
@@ -1,0 +1,162 @@
+<?php
+
+namespace Drupal\social_event\Plugin\GraphQL\SchemaExtension;
+
+use Drupal\graphql\GraphQL\ResolverBuilder;
+use Drupal\graphql\GraphQL\ResolverRegistryInterface;
+use Drupal\graphql\Plugin\GraphQL\SchemaExtension\SdlSchemaExtensionPluginBase;
+
+/**
+ * Adds event data to the Open Social GraphQL API.
+ *
+ * @SchemaExtension(
+ *   id = "social_event_schema_extension",
+ *   name = "Open Social - Event Schema Extension",
+ *   description = "GraphQL schema extension for Open Social event data.",
+ *   schema = "open_social"
+ * )
+ */
+class EventSchemaExtension extends SdlSchemaExtensionPluginBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function registerResolvers(ResolverRegistryInterface $registry) {
+    $builder = new ResolverBuilder();
+
+    $this->addQueryFields($registry, $builder);
+    $this->addEventFields($registry, $builder);
+  }
+
+  /**
+   * Registers type and field resolvers in the shared registry.
+   *
+   * @param \Drupal\graphql\GraphQL\ResolverRegistryInterface $registry
+   *   The resolver registry.
+   * @param \Drupal\graphql\GraphQL\ResolverBuilder $builder
+   *   The resolver builder.
+   */
+  protected function addEventFields(ResolverRegistryInterface $registry, ResolverBuilder $builder) {
+    $registry->addFieldResolver('Event', 'id',
+      $builder->produce('entity_uuid')
+        ->map('entity', $builder->fromParent())
+    );
+
+    $registry->addFieldResolver('Event', 'title',
+      $builder->produce('entity_label')
+        ->map('entity', $builder->fromParent())
+    );
+
+    $registry->addFieldResolver('Event', 'author',
+      $builder->produce('entity_owner')
+        ->map('entity', $builder->fromParent())
+    );
+
+    $registry->addFieldResolver('Event', 'bodyHtml',
+      $builder->compose(
+        $builder->produce('field')
+          ->map('entity', $builder->fromParent())
+          ->map('field', $builder->fromValue('body')),
+        $builder->produce('field_renderer')
+          ->map('field', $builder->fromParent())
+      )
+    );
+
+    $registry->addFieldResolver('Event', 'heroImage',
+      $builder->produce('field')
+        ->map('entity', $builder->fromParent())
+        ->map('field', $builder->fromValue('field_event_image'))
+    );
+
+    $registry->addFieldResolver('Event', 'comments',
+      $builder->produce('query_comments')
+        ->map('parent', $builder->fromParent())
+        ->map('bundle', $builder->fromValue('comment'))
+        ->map('after', $builder->fromArgument('after'))
+        ->map('before', $builder->fromArgument('before'))
+        ->map('first', $builder->fromArgument('first'))
+        ->map('last', $builder->fromArgument('last'))
+        ->map('reverse', $builder->fromArgument('reverse'))
+        ->map('sortKey', $builder->fromArgument('sortKey'))
+    );
+
+    $registry->addFieldResolver('Event', 'startDate',
+      $builder->compose(
+        $builder->produce('field')
+          ->map('entity', $builder->fromParent())
+          ->map('field', $builder->fromValue('field_event_date')),
+        $builder->produce('date_to_timestamp')
+          ->map('field', $builder->fromParent())
+      )
+    );
+
+    $registry->addFieldResolver('Event', 'endDate',
+      $builder->compose(
+        $builder->produce('field')
+          ->map('entity', $builder->fromParent())
+          ->map('field', $builder->fromValue('field_event_date_end')),
+        $builder->produce('date_to_timestamp')
+          ->map('field', $builder->fromParent())
+          ->map('type', $builder->fromValue('end_date'))
+      )
+    );
+
+    $registry->addFieldResolver('Event', 'location',
+      $builder->fromPath('entity:node', 'field_event_location.value')
+    );
+
+    $registry->addFieldResolver('Event', 'url',
+      $builder->compose(
+        $builder->produce('social_entity_url')
+          ->map('entity', $builder->fromParent())
+          ->map('options', $builder->fromValue(['absolute' => TRUE])),
+        $builder->produce('url_path')
+          ->map('url', $builder->fromParent())
+      )
+    );
+
+    $registry->addFieldResolver('Event', 'created',
+      $builder->produce('entity_created')
+        ->map('entity', $builder->fromParent())
+        ->map('format', $builder->fromValue('U'))
+    );
+
+    $registry->addFieldResolver('Event', 'managers',
+      $builder->produce('event_managers')
+        ->map('event', $builder->fromParent())
+        ->map('after', $builder->fromArgument('after'))
+        ->map('before', $builder->fromArgument('before'))
+        ->map('first', $builder->fromArgument('first'))
+        ->map('last', $builder->fromArgument('last'))
+        ->map('reverse', $builder->fromArgument('reverse'))
+    );
+  }
+
+  /**
+   * Registers type and field resolvers in the query type.
+   *
+   * @param \Drupal\graphql\GraphQL\ResolverRegistryInterface $registry
+   *   The resolver registry.
+   * @param \Drupal\graphql\GraphQL\ResolverBuilder $builder
+   *   The resolver builder.
+   */
+  protected function addQueryFields(ResolverRegistryInterface $registry, ResolverBuilder $builder) {
+    $registry->addFieldResolver('Query', 'events',
+      $builder->produce('query_event')
+        ->map('after', $builder->fromArgument('after'))
+        ->map('before', $builder->fromArgument('before'))
+        ->map('first', $builder->fromArgument('first'))
+        ->map('last', $builder->fromArgument('last'))
+        ->map('reverse', $builder->fromArgument('reverse'))
+        ->map('sortKey', $builder->fromArgument('sortKey'))
+    );
+
+    $registry->addFieldResolver('Query', 'event',
+      $builder->produce('entity_load_by_uuid')
+        ->map('type', $builder->fromValue('node'))
+        ->map('bundles', $builder->fromValue(['event']))
+        ->map('uuid', $builder->fromArgument('id'))
+    );
+  }
+
+}

--- a/modules/social_features/social_event/tests/src/Kernel/GraphQL/QueryEventTest.php
+++ b/modules/social_features/social_event/tests/src/Kernel/GraphQL/QueryEventTest.php
@@ -1,0 +1,250 @@
+<?php
+
+namespace Drupal\Tests\social_event\Kernel\GraphQL;
+
+use Drupal\comment\Entity\Comment;
+use Drupal\file\Entity\File;
+use Drupal\node\NodeInterface;
+use Drupal\Tests\node\Traits\NodeCreationTrait;
+use Drupal\Tests\social_graphql\Kernel\SocialGraphQLTestBase;
+use Drupal\Tests\user\Traits\UserCreationTrait;
+
+/**
+ * Tests the event field on the Query type.
+ *
+ * @group social_graphql
+ * @group social_event
+ */
+class QueryEventTest extends SocialGraphQLTestBase {
+
+  use NodeCreationTrait;
+  use UserCreationTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static $modules = [
+    'social_event',
+    'entity',
+    // For the event author and viewer.
+    'social_user',
+    'user',
+    // User creation in social_user requires a service in role_delegation.
+    "role_delegation",
+    // social_comment configures events for nodes.
+    'node',
+    // The default event config contains a body text field.
+    'field',
+    'text',
+    'filter',
+    'file',
+    'image',
+    // For the comment functionality.
+    'social_comment',
+    'comment',
+    'menu_ui',
+    'entity_access_by_field',
+    'options',
+    'taxonomy',
+    'path',
+    'image_widget_crop',
+    'crop',
+    'field_group',
+    'social_node',
+    'social_core',
+    'block',
+    'block_content',
+    'image_effects',
+    'file_mdm',
+    'group_core_comments',
+    'views',
+    'group',
+    'datetime',
+    'address',
+    'profile',
+    'social_profile',
+    'social_event_managers',
+    'views_bulk_operations',
+    // @deprecated added since we use social_entity_url producer in the
+    // EventSchemaExtension, but social_entity_url marked as deprecated so,
+    // social_topic should be removed from $modules when
+    // https://github.com/drupal-graphql/graphql/pull/1220 is merged.
+    'social_topic',
+  ];
+
+  /**
+   * An array of config object names that are excluded from schema checking.
+   *
+   * @var string[]
+   */
+  protected static $configSchemaCheckerExclusions = [
+    'social_event_managers.settings',
+    'views.view.event_manage_enrollments',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp() : void {
+    parent::setUp();
+
+    $this->installEntitySchema('node');
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('comment');
+    $this->installEntitySchema('file');
+    $this->installEntitySchema('profile');
+
+    $this->installSchema('comment', 'comment_entity_statistics');
+    $this->installSchema('file', ['file_usage']);
+    $this->installConfig([
+      'node',
+      'social_core',
+      'social_node',
+      'social_event',
+      'social_event_managers',
+      'filter',
+      'comment',
+      'social_comment',
+    ]);
+  }
+
+  /**
+   * Test that the fields provided by the module can be queried.
+   */
+  public function testSupportsFieldsIncludedInModule() : void {
+    $raw_event_body = "This is a link test: https://social.localhost";
+    $html_event_body = "<div><p>This is a link test: <a href=\"https://social.localhost\">https://social.localhost</a></p>\n</div>";
+
+    $event_image = File::create();
+    $event_image->setFileUri('core/misc/druplicon.png');
+    $event_image->setFilename(\Drupal::service('file_system')->basename($event_image->getFileUri()));
+    $event_image->save();
+
+    $event_manager = $this->createUser();
+
+    $event = $this->createNode([
+      'type' => 'event',
+      'field_content_visibility' => 'public',
+      'field_event_image' => $event_image->id(),
+      'field_event_managers' => [$event_manager->id()],
+      'status' => NodeInterface::PUBLISHED,
+      'body' => $raw_event_body,
+    ]);
+
+    // Set up a user that can view public events and create a published
+    // comment and view it.
+    $this->setUpCurrentUser([], array_merge([
+      'skip comment approval',
+      'access comments',
+      'view node.event.field_content_visibility:public content',
+    ], $this->userPermissions()));
+
+    $comment = Comment::create([
+      'entity_id' => $event->id(),
+      'entity_type' => $event->getEntityTypeId(),
+      'comment_type' => 'comment',
+      'field_name' => 'comments',
+    ]);
+    $comment->save();
+
+    $query = '
+      query ($id: ID!) {
+        event(id: $id) {
+          id
+          title
+          author {
+            id
+            displayName
+          }
+          bodyHtml
+          comments(first: 1) {
+            nodes {
+              id
+            }
+          }
+          url
+          created {
+            timestamp
+          }
+          heroImage {
+            url
+          }
+          managers(first: 1) {
+            nodes {
+              id
+            }
+          }
+        }
+      }
+    ';
+
+    $this->assertResults(
+      $query,
+      ['id' => $event->uuid()],
+      [
+        'event' => [
+          'id' => $event->uuid(),
+          'title' => $event->label(),
+          'author' => [
+            'id' => $event->getOwner()->uuid(),
+            'displayName' => $event->getOwner()->getDisplayName(),
+          ],
+          'bodyHtml' => $html_event_body,
+          'comments' => [
+            'nodes' => [
+              ['id' => $comment->uuid()],
+            ],
+          ],
+          'url' => $event->toUrl('canonical', ['absolute' => TRUE])->toString(),
+          'created' => [
+            'timestamp' => $event->getCreatedTime(),
+          ],
+          'heroImage' => [
+            'url' => file_create_url($event_image->getFileUri()),
+          ],
+          'managers' => [
+            'nodes' => [
+              ['id' => $event_manager->uuid()],
+            ],
+          ],
+        ],
+      ],
+      $this->defaultCacheMetaData()
+        ->setCacheMaxAge(0)
+        ->addCacheableDependency($event)
+        ->addCacheableDependency($event->getOwner())
+        ->addCacheableDependency($event_manager)
+        ->addCacheTags(['config:filter.format.plain_text', 'config:filter.settings', 'comment:1'])
+        ->addCacheContexts(['languages:language_interface', 'user.node_grants:view', 'url.site'])
+    );
+  }
+
+  /**
+   * Test that it respects the access events permission.
+   */
+  public function testRequiresAccessEventsPermission() {
+    $topic = $this->createNode([
+      'type' => 'event',
+      'field_content_visibility' => 'public',
+      'status' => NodeInterface::PUBLISHED,
+    ]);
+
+    // Create a user that is not allowed to view public topics and comments.
+    $this->setUpCurrentUser();
+
+    $this->assertResults('
+        query ($id: ID!) {
+          event(id: $id) {
+            id
+          }
+        }
+      ',
+      ['id' => $topic->uuid()],
+      ['event' => NULL],
+      $this->defaultCacheMetaData()
+        ->addCacheableDependency($topic)
+        ->addCacheContexts(['languages:language_interface'])
+    );
+  }
+
+}

--- a/modules/social_features/social_event/tests/src/Kernel/GraphQL/QueryEventsTest.php
+++ b/modules/social_features/social_event/tests/src/Kernel/GraphQL/QueryEventsTest.php
@@ -1,0 +1,243 @@
+<?php
+
+namespace Drupal\Tests\social_event\Kernel\GraphQL;
+
+use Drupal\node\NodeInterface;
+use Drupal\Tests\node\Traits\NodeCreationTrait;
+use Drupal\Tests\social_graphql\Kernel\SocialGraphQLTestBase;
+use Drupal\Tests\user\Traits\UserCreationTrait;
+
+/**
+ * Tests the events field on the Query type.
+ *
+ * @group social_graphql
+ * @group social_event
+ */
+class QueryEventsTest extends SocialGraphQLTestBase {
+
+  use NodeCreationTrait;
+  use UserCreationTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static $modules = [
+    'social_event',
+    'entity',
+    // For the event author and viewer.
+    'social_user',
+    'user',
+    // User creation in social_user requires a service in role_delegation.
+    "role_delegation",
+    // social_comment configures events for nodes.
+    'node',
+    // The default event config contains a body text field.
+    'field',
+    'text',
+    'filter',
+    'file',
+    'image',
+    // For the comment functionality.
+    'social_comment',
+    'comment',
+    'menu_ui',
+    'entity_access_by_field',
+    'options',
+    'taxonomy',
+    'path',
+    'image_widget_crop',
+    'crop',
+    'field_group',
+    'social_node',
+    'social_core',
+    'block',
+    'block_content',
+    'image_effects',
+    'file_mdm',
+    'group_core_comments',
+    'views',
+    'group',
+    'datetime',
+    'address',
+    'profile',
+    'social_profile',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $this->installEntitySchema('node');
+    $this->installEntitySchema('user');
+
+    $this->installSchema('comment', 'comment_entity_statistics');
+    $this->installConfig([
+      'node',
+      'social_core',
+      'social_node',
+      'social_event',
+      'filter',
+    ]);
+  }
+
+  /**
+   * Test that platform events can be fetched using platform pagination.
+   */
+  public function testSupportsRelayPagination(): void {
+    $this->setUpCurrentUser([], ['view node.event.field_content_visibility:public content']);
+
+    for ($i = 0; $i < 10; ++$i) {
+      $events[] = $this->createNode([
+        'type' => 'event',
+        'field_content_visibility' => 'public',
+        'status' => NodeInterface::PUBLISHED,
+      ]);
+    }
+
+    $event_uuids = array_map(
+      static fn($event) => $event->uuid(),
+      $events ?? []
+    );
+
+    $this->assertEndpointSupportsPagination(
+      'events',
+      $event_uuids
+    );
+  }
+
+  /**
+   * Test that a anonymous user can only see public events.
+   */
+  public function testAnonymousUserCanViewOnlyPublicEvents() {
+    $public_event = $this->createNode([
+      'type' => 'event',
+      'field_content_visibility' => 'public',
+      'status' => NodeInterface::PUBLISHED,
+    ]);
+    $this->createNode([
+      'type' => 'event',
+      'field_content_visibility' => 'community',
+      'status' => NodeInterface::PUBLISHED,
+    ]);
+    $this->createNode([
+      'type' => 'event',
+      'field_content_visibility' => 'group',
+      'status' => NodeInterface::PUBLISHED,
+    ]);
+
+    $this->setUpCurrentUser([], ['view node.event.field_content_visibility:public content']);
+
+    $this->assertResults('
+          query {
+            events(last: 3) {
+              pageInfo {
+                hasNextPage
+                hasPreviousPage
+              }
+              nodes {
+                id
+              }
+            }
+          }
+        ',
+      [],
+      [
+        'events' => [
+          'pageInfo' => [
+            'hasNextPage' => FALSE,
+            'hasPreviousPage' => FALSE,
+          ],
+          'nodes' => [
+            ['id' => $public_event->uuid()],
+          ],
+        ],
+      ],
+      $this->defaultCacheMetaData()
+        ->setCacheMaxAge(0)
+        ->addCacheableDependency($public_event)
+        ->addCacheContexts(['languages:language_interface'])
+    );
+  }
+
+  /**
+   * Test that a anonymous user can not see unpublished events.
+   */
+  public function testAnonymousUserCanNotViewUnpublishedEvents() {
+    $this->createNode([
+      'type' => 'event',
+      'field_content_visibility' => 'public',
+      'status' => NodeInterface::NOT_PUBLISHED,
+    ]);
+    $published_event = $this->createNode([
+      'type' => 'event',
+      'field_content_visibility' => 'public',
+      'status' => NodeInterface::PUBLISHED,
+    ]);
+
+    $this->setUpCurrentUser([], ['view node.event.field_content_visibility:public content']);
+
+    $this->assertResults('
+          query {
+            events(last: 3) {
+              nodes {
+                id
+              }
+            }
+          }
+        ',
+      [],
+      [
+        'events' => [
+          'nodes' => [
+            ['id' => $published_event->uuid()],
+          ],
+        ],
+      ],
+      $this->defaultCacheMetaData()
+        ->setCacheMaxAge(0)
+        ->addCacheableDependency($published_event)
+        ->addCacheContexts(['languages:language_interface'])
+    );
+  }
+
+  /**
+   * Test that a user without permission can not see any events.
+   */
+  public function testAnonymousUserCanNotViewEventsWithoutPermission() {
+    $this->createNode([
+      'type' => 'event',
+      'field_content_visibility' => 'public',
+      'status' => NodeInterface::NOT_PUBLISHED,
+    ]);
+    $this->createNode([
+      'type' => 'event',
+      'field_content_visibility' => 'public',
+      'status' => NodeInterface::PUBLISHED,
+    ]);
+
+    $this->setUpCurrentUser();
+
+    $this->assertResults('
+          query {
+            events(last: 2) {
+              nodes {
+                id
+              }
+            }
+          }
+        ',
+      [],
+      [
+        'events' => [
+          'nodes' => [],
+        ],
+      ],
+      $this->defaultCacheMetaData()
+        ->setCacheMaxAge(0)
+        ->addCacheContexts(['languages:language_interface'])
+    );
+  }
+
+}


### PR DESCRIPTION
## Problem
Events play a big part in a community. To open this data up towards external consumers can aid in engagement and enrollees.

It should be possible to
- Select an event by its UUID
- Find an event by a specific property of its node data, or specific event-related data (No need for additions like geolocation just yet)
- Search for an event in a similar manner as on /search/content
- Paginate through results according to the Relay connection specification

Querying and searching for data should respect existing privacy measures (such as public content is available for AN, community to LU, etc) according to platform configuration.

## Solution
Implement the required GraphQL Schema and DataProducer plugins in `social_event` that extend the schema defined on `social_graphql`

## Issue tracker
- https://getopensocial.atlassian.net/browse/YANG-5685
- https://www.drupal.org/project/social/issues/3185497

## How to test
- [ ] Enable `social_graphql` module
- [ ] Apply https://github.com/goalgorilla/open_social/pull/2400 as a patch
- [ ] Use `Altair` or some similar tool to send a request
- [ ] Create some events on the platform
- [ ] Send request, like:
```
  events(first: 2) {
    nodes {
      id
      title
    }
  }
```

## Screenshots
None.

## Release notes
The following GraphQL Query endpoints become available.
```
query {
  events(...PaginationFilter!, ...?)
  event(uuid: ID!)
}
```

## Change Record
None.

## Translations
None.
