### PR TITLE
Issue #3217219 by vnech: Set correct langcode when create a content in other then default language first

### DIFF
--- a/modules/custom/social_language/modules/social_content_translation/social_content_translation.module
+++ b/modules/custom/social_language/modules/social_content_translation/social_content_translation.module
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * @file
+ * Contains social_content_translation.module.
+ */
+
+use Drupal\Core\Entity\ContentEntityInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Render\Element;
+
+/**
+ * Implements hook_form_alter().
+ */
+function social_content_translation_form_alter(&$form, FormStateInterface $form_state) {
+  // We need to set correct default value for "langcode" as users can
+  // create content in different then default language.
+  if (method_exists($form_state->getFormObject(), 'getEntity')) {
+    $entity = $form_state->getFormObject()->getEntity();
+    if ($entity instanceof ContentEntityInterface) {
+      // We need to set "langcode" only to new values
+      // and if user doesn't set it manually with UI.
+      if ($entity->isNew()) {
+        if (!empty($form['langcode']) && !Element::isVisibleElement($form['langcode'])) {
+          if (isset($form['langcode']['widget'][0]['value']['#default_value'])) {
+            $language = \Drupal::languageManager()->getCurrentLanguage()->getId();
+            $form['langcode']['widget'][0]['value']['#default_value'] = $language;
+          }
+        }
+      }
+    }
+  }
+}

--- a/modules/custom/social_language/social_language.module
+++ b/modules/custom/social_language/social_language.module
@@ -5,9 +5,7 @@
  * Contains social_language.module.
  */
 
-use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Form\FormStateInterface;
-use Drupal\Core\Render\Element;
 use Drupal\Core\Url;
 
 /**

--- a/modules/custom/social_language/social_language.module
+++ b/modules/custom/social_language/social_language.module
@@ -5,7 +5,9 @@
  * Contains social_language.module.
  */
 
+use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Render\Element;
 use Drupal\Core\Url;
 
 /**
@@ -47,4 +49,27 @@ function social_language_form_user_form_alter(&$form, FormStateInterface $form_s
 function social_language_social_group_default_route_tabs_alter(&$tabs) {
   // Unset some tabs created by group.
   unset($tabs['content_translation.local_tasks:entity.group.content_translation_overview']);
+}
+
+/**
+ * Implements hook_form_alter().
+ */
+function social_language_form_alter(&$form, FormStateInterface $form_state) {
+  // We need to set correct default value for "langcode" as users can
+  // create content in different then default language.
+  if (method_exists($form_state->getFormObject(), 'getEntity')) {
+    $entity = $form_state->getFormObject()->getEntity();
+    if ($entity instanceof ContentEntityInterface) {
+      // We need to set "langcode" only to new values
+      // and if user doesn't set it manually with UI.
+      if ($entity->isNew()) {
+        if (!empty($form['langcode']) && !Element::isVisibleElement($form['langcode'])) {
+          if (isset($form['langcode']['widget'][0]['value']['#default_value'])) {
+            $language = \Drupal::languageManager()->getCurrentLanguage()->getId();
+            $form['langcode']['widget'][0]['value']['#default_value'] = $language;
+          }
+        }
+      }
+    }
+  }
 }

--- a/modules/custom/social_language/social_language.module
+++ b/modules/custom/social_language/social_language.module
@@ -50,26 +50,3 @@ function social_language_social_group_default_route_tabs_alter(&$tabs) {
   // Unset some tabs created by group.
   unset($tabs['content_translation.local_tasks:entity.group.content_translation_overview']);
 }
-
-/**
- * Implements hook_form_alter().
- */
-function social_language_form_alter(&$form, FormStateInterface $form_state) {
-  // We need to set correct default value for "langcode" as users can
-  // create content in different then default language.
-  if (method_exists($form_state->getFormObject(), 'getEntity')) {
-    $entity = $form_state->getFormObject()->getEntity();
-    if ($entity instanceof ContentEntityInterface) {
-      // We need to set "langcode" only to new values
-      // and if user doesn't set it manually with UI.
-      if ($entity->isNew()) {
-        if (!empty($form['langcode']) && !Element::isVisibleElement($form['langcode'])) {
-          if (isset($form['langcode']['widget'][0]['value']['#default_value'])) {
-            $language = \Drupal::languageManager()->getCurrentLanguage()->getId();
-            $form['langcode']['widget'][0]['value']['#default_value'] = $language;
-          }
-        }
-      }
-    }
-  }
-}


### PR DESCRIPTION
## Problem
There is an issue with the "langcode" field when creating entities in multilanguage OS.

For example, I have two languages installed - "English" (default) and "Ukrainian".
If I create a Topic in "Ukrainian" first the wrong "langcode" sets in the node (the field has "en" value instead of "uk")

## Solution
Set correct "langcode" on form alter for new entities.

## Issue tracker
- https://www.drupal.org/project/social/issues/3217219
- https://getopensocial.atlassian.net/browse/YANG-5782

## How to test
*For example*
- [ ] Login as admin
- [ ] Install additional language ("French", for example)
- [ ] Switch to "Franch" language and create a Topic
- [ ] Go to created topic translations page

## Release notes
Set correct langcode when creating content in different than default language

