### PR TITLE
Issue #3217339 by vnech: Hide "Group type" field on group edit page

### DIFF
--- a/modules/social_features/social_group/social_group.module
+++ b/modules/social_features/social_group/social_group.module
@@ -1024,18 +1024,9 @@ function social_group_form_alter(&$form, FormStateInterface $form_state, $form_i
   }
 
   if (!empty($form['#entity_type']) && $form['#entity_type'] === 'group') {
-    // Modify "Group type" field widget.
-    if (!empty($form['group_type']) && !empty($form['group_type']['widget']['#default_value'])) {
-      $default_value = $form['group_type']['widget']['#default_value'];
-      // User should see only the current group type and can't change it.
-      foreach ($form['group_type']['widget']['#options'] as $type => $label) {
-        if ($type !== $default_value) {
-          unset($form['group_type']['widget']['#options'][$type]);
-          $form['group_type']['widget'][$type] = [
-            '#disabled' => TRUE,
-          ];
-        }
-      }
+    // Hide "Group type" field widget.
+    if (!empty($form['group_type'])) {
+      $form['group_type']['#access'] = FALSE;
     }
   }
 }

--- a/modules/social_features/social_group/social_group.module
+++ b/modules/social_features/social_group/social_group.module
@@ -1022,6 +1022,22 @@ function social_group_form_alter(&$form, FormStateInterface $form_state, $form_i
       }
     }
   }
+
+  if (!empty($form['#entity_type']) && $form['#entity_type'] === 'group') {
+    // Modify "Group type" field widget.
+    if (!empty($form['group_type']) && !empty($form['group_type']['widget']['#default_value'])) {
+      $default_value = $form['group_type']['widget']['#default_value'];
+      // User should see only the current group type and can't change it.
+      foreach ($form['group_type']['widget']['#options'] as $type => $label) {
+        if ($type !== $default_value) {
+          unset($form['group_type']['widget']['#options'][$type]);
+          $form['group_type']['widget'][$type] = [
+            '#disabled' => TRUE,
+          ];
+        }
+      }
+    }
+  }
 }
 
 /**


### PR DESCRIPTION
## Problem
We should hide "Group type" on the group edit page as users aren't allowed to change it.

## Issue tracker
- https://www.drupal.org/project/social/issues/3217339
- https://getopensocial.atlassian.net/browse/ECI-1163

## How to test
- [ ] Login as SM
- [ ] Go to any of Public, Open, Closed group edit pages

## Release notes
*Hide "Group type" field on group edit pages*
