### PR TITLE
[GraphQL] Move addMutationResolver into trait for schema extension

### DIFF
--- a/modules/custom/social_graphql/src/GraphQL/ResolverRegistry.php
+++ b/modules/custom/social_graphql/src/GraphQL/ResolverRegistry.php
@@ -2,7 +2,6 @@
 
 namespace Drupal\social_graphql\GraphQL;
 
-use Drupal\graphql\GraphQL\ResolverBuilder;
 use Drupal\graphql\GraphQL\ResolverRegistry as ResolverRegistryBase;
 
 /**
@@ -14,47 +13,4 @@ use Drupal\graphql\GraphQL\ResolverRegistry as ResolverRegistryBase;
  * Previously included resolver inheritance which has been moved into the
  * GraphQL module.
  */
-class ResolverRegistry extends ResolverRegistryBase {
-
-  /**
-   * Add a field resolver for a mutation field.
-   *
-   * Calling this function is equivalent to writing out the following code
-   * manually:
-   *
-   * ```
-   * $field_name = camelCaseTOsnake_case($fieldName);
-   * $this->addFieldResolver('Mutation', $fieldName,
-   *   $builder->compose(
-   *     $builder->produce($field_name . "_input")
-   *       ->map('input', $builder->fromArgument('input')),
-   *     $builder->produce($field_name)
-   *       ->map('input', $builder->fromParent())
-   *   )
-   * );
-   * ```
-   *
-   * @param \Drupal\graphql\GraphQL\ResolverBuilder $builder
-   *   The resolver builder.
-   * @param string $field_name
-   *   A camelCased field name. This will be converted into snake_case for the
-   *   IDs of the used data producers.
-   */
-  public function addMutationResolver(ResolverBuilder $builder, string $field_name) : void {
-    $words = array_map(
-      'strtolower',
-      preg_split('/(?=[A-Z])/', $field_name, -1, PREG_SPLIT_NO_EMPTY)
-    );
-    $data_producer = implode("_", $words);
-
-    $this->addFieldResolver('Mutation', $field_name,
-      $builder->compose(
-        $builder->produce($data_producer . "_input")
-          ->map('input', $builder->fromArgument('input')),
-        $builder->produce($data_producer)
-          ->map('input', $builder->fromParent())
-      )
-    );
-  }
-
-}
+class ResolverRegistry extends ResolverRegistryBase {}

--- a/modules/custom/social_graphql/src/GraphQL/StandardisedMutationSchemaTrait.php
+++ b/modules/custom/social_graphql/src/GraphQL/StandardisedMutationSchemaTrait.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Drupal\social_graphql\GraphQL;
+
+use Drupal\graphql\GraphQL\ResolverBuilder;
+use Drupal\graphql\GraphQL\ResolverRegistryInterface;
+
+/**
+ * Provides a way for schemas to add mutations in a standardised format.
+ */
+trait StandardisedMutationSchemaTrait {
+
+  /**
+   * Add a field resolver for a mutation field.
+   *
+   * Calling this function is equivalent to writing out the following code
+   * manually:
+   *
+   * ```
+   * $field_name = camelCaseTOsnake_case($fieldName);
+   * $registry->addFieldResolver('Mutation', $fieldName,
+   *   $builder->compose(
+   *     $builder->produce($field_name . "_input")
+   *       ->map('input', $builder->fromArgument('input')),
+   *     $builder->produce($field_name)
+   *       ->map('input', $builder->fromParent())
+   *   )
+   * );
+   * ```
+   *
+   * @param \Drupal\graphql\GraphQL\ResolverRegistryInterface $registry
+   *   The registry in which to register the mutation.
+   * @param \Drupal\graphql\GraphQL\ResolverBuilder $builder
+   *   The resolver builder.
+   * @param string $field_name
+   *   A camelCased field name. This will be converted into snake_case for the
+   *   IDs of the used data producers.
+   */
+  protected function registerMutationResolver(ResolverRegistryInterface $registry, ResolverBuilder $builder, string $field_name) : void {
+    $words = array_map(
+      'strtolower',
+      preg_split('/(?=[A-Z])/', $field_name, -1, PREG_SPLIT_NO_EMPTY)
+    );
+    $data_producer = implode("_", $words);
+
+    $registry->addFieldResolver('Mutation', $field_name,
+      $builder->compose(
+        $builder->produce($data_producer . "_input")
+          ->map('input', $builder->fromArgument('input')),
+        $builder->produce($data_producer)
+          ->map('input', $builder->fromParent())
+      )
+    );
+  }
+
+}

--- a/modules/custom/social_graphql/src/Plugin/GraphQL/SchemaExtension/SchemaExtensionPluginBase.php
+++ b/modules/custom/social_graphql/src/Plugin/GraphQL/SchemaExtension/SchemaExtensionPluginBase.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Drupal\social_graphql\Plugin\GraphQL\SchemaExtension;
+
+use Drupal\graphql\Plugin\GraphQL\SchemaExtension\SdlSchemaExtensionPluginBase;
+use Drupal\social_graphql\GraphQL\StandardisedMutationSchemaTrait;
+
+/**
+ * Base class that can be used for Open Social schema extension plugins.
+ */
+abstract class SchemaExtensionPluginBase extends SdlSchemaExtensionPluginBase {
+
+  use StandardisedMutationSchemaTrait;
+
+}

--- a/modules/social_features/social_comment/src/Plugin/GraphQL/SchemaExtension/CommentSchemaExtension.php
+++ b/modules/social_features/social_comment/src/Plugin/GraphQL/SchemaExtension/CommentSchemaExtension.php
@@ -4,7 +4,7 @@ namespace Drupal\social_comment\Plugin\GraphQL\SchemaExtension;
 
 use Drupal\graphql\GraphQL\ResolverBuilder;
 use Drupal\graphql\GraphQL\ResolverRegistryInterface;
-use Drupal\graphql\Plugin\GraphQL\SchemaExtension\SdlSchemaExtensionPluginBase;
+use Drupal\social_graphql\Plugin\GraphQL\SchemaExtension\SchemaExtensionPluginBase;
 
 /**
  * Adds comment data to the Open Social GraphQL API.
@@ -16,7 +16,7 @@ use Drupal\graphql\Plugin\GraphQL\SchemaExtension\SdlSchemaExtensionPluginBase;
  *   schema = "open_social"
  * )
  */
-class CommentSchemaExtension extends SdlSchemaExtensionPluginBase {
+class CommentSchemaExtension extends SchemaExtensionPluginBase {
 
   /**
    * {@inheritdoc}

--- a/modules/social_features/social_profile/src/Plugin/GraphQL/SchemaExtension/ProfileSchemaExtension.php
+++ b/modules/social_features/social_profile/src/Plugin/GraphQL/SchemaExtension/ProfileSchemaExtension.php
@@ -4,7 +4,7 @@ namespace Drupal\social_profile\Plugin\GraphQL\SchemaExtension;
 
 use Drupal\graphql\GraphQL\ResolverBuilder;
 use Drupal\graphql\GraphQL\ResolverRegistryInterface;
-use Drupal\graphql\Plugin\GraphQL\SchemaExtension\SdlSchemaExtensionPluginBase;
+use Drupal\social_graphql\Plugin\GraphQL\SchemaExtension\SchemaExtensionPluginBase;
 
 /**
  * Adds user data to the Open Social GraphQL API.
@@ -16,7 +16,7 @@ use Drupal\graphql\Plugin\GraphQL\SchemaExtension\SdlSchemaExtensionPluginBase;
  *   schema = "open_social"
  * )
  */
-class ProfileSchemaExtension extends SdlSchemaExtensionPluginBase {
+class ProfileSchemaExtension extends SchemaExtensionPluginBase {
 
   /**
    * {@inheritdoc}

--- a/modules/social_features/social_user/src/Plugin/GraphQL/SchemaExtension/UserSchemaExtension.php
+++ b/modules/social_features/social_user/src/Plugin/GraphQL/SchemaExtension/UserSchemaExtension.php
@@ -4,7 +4,7 @@ namespace Drupal\social_user\Plugin\GraphQL\SchemaExtension;
 
 use Drupal\graphql\GraphQL\ResolverBuilder;
 use Drupal\graphql\GraphQL\ResolverRegistryInterface;
-use Drupal\graphql\Plugin\GraphQL\SchemaExtension\SdlSchemaExtensionPluginBase;
+use Drupal\social_graphql\Plugin\GraphQL\SchemaExtension\SchemaExtensionPluginBase;
 use Drupal\social_user\GraphQL\UserActorTypeResolver;
 
 /**
@@ -17,7 +17,7 @@ use Drupal\social_user\GraphQL\UserActorTypeResolver;
  *   schema = "open_social"
  * )
  */
-class UserSchemaExtension extends SdlSchemaExtensionPluginBase {
+class UserSchemaExtension extends SchemaExtensionPluginBase {
 
   /**
    * {@inheritdoc}


### PR DESCRIPTION
<h3 id="summary-problem-motivation">Problem/Motivation</h3>
Open Social creates its own ResolverRegistry so that it can make changes to the way the schema is built in case this is desirable. However, the actual schema extension plugins always expect a standardised ResolverRegistry as they must adhere to the schema extension interfaces. This means there's no easy way to call public methods from a schema extension on our custom resolver registry because it may lead to calling a non-existent function.

<h3 id="summary-proposed-resolution">Proposed resolution</h3>
Instead of trying to provide the functionality for our schema extensions in the registry we should just make the function easily available to the extensions directly. This can easily be done by providing a trait that can be reused by any schema extension that wants this functionality.

To standardise schema extensions created by Open Social itself we include the trait on a custom base class for schema extension plugins. Making it a trait allows other developers to use the specific function even if they don't want to use the custom base class.


__Changes in this PR are based on #2207 which should be merged first__

## Issue tracker
https://www.drupal.org/project/social/issues/3217376

## How to test
- [ ] PHPUnit tests should pass

## Screenshots
*If this Pull Request makes visual changes then please include some screenshots that show what has changed here. A before and after screenshot helps the reviewer determine what changes were made.*

## Release notes
`StandardisedMutationSchemaTrait` has been added which provides a standardised manner to handle GraphQL mutation input and processing.

## Change Record
N/a

## Translations
N/a