### PR TITLE
Issue #3217678 by vnech: Remove group admins as recipient for sending message when a new member is added

### DIFF
--- a/modules/social_features/social_group/modules/social_group_welcome_message/social_group_welcome_message.module
+++ b/modules/social_features/social_group/modules/social_group_welcome_message/social_group_welcome_message.module
@@ -132,14 +132,6 @@ function social_group_welcome_message_group_content_insert(GroupContentInterface
       return;
     }
 
-    // Get group admins entities.
-    $g_admins = $group->getMembers($g_type_id . '-group_admin');
-    $g_admins_users = [];
-    /** @var \Drupal\group\GroupMembership $member */
-    foreach ($g_admins as $key => $member) {
-      $g_admins_users[$key] = $member->getUser();
-    }
-
     // Get group managers entities.
     $g_managers = $group->getMembers($g_type_id . '-group_manager');
     $g_managers_users = [];
@@ -149,10 +141,7 @@ function social_group_welcome_message_group_content_insert(GroupContentInterface
     }
 
     // Set sender (owner) of the pm.
-    if (count($g_admins_users) === 1) {
-      list($owner) = $g_admins_users;
-    }
-    elseif (count($g_managers_users) > 0) {
+    if (count($g_managers_users) > 0) {
       list($owner) = $g_managers_users;
     }
     else {
@@ -168,7 +157,7 @@ function social_group_welcome_message_group_content_insert(GroupContentInterface
     }
 
     // Merge all managers of the group to recipients array.
-    $recipients = array_merge($g_admins_users, $g_managers_users);
+    $recipients = $g_managers_users;
 
     // Add the joined user to the already existing recipients array.
     $recipients[] = $account;


### PR DESCRIPTION
## Problem
Don't send a message to group admins when a new member is added as this produces a lot of similar messages.

## Issue tracker
- https://www.drupal.org/project/social/issues/3217678
- https://getopensocial.atlassian.net/browse/YANG-4990

## How to test
- [ ] Login as SM
- [ ] Enable Welcome Message on some group
- [ ] Join this group as a "Group Admin"
- [ ] Add a new member to this group
- [ ] Member should receive Welcome message only from Group Managers, but not from Group Admin
