### PR TITLE
Issue #3217353 by Ressinel: Zero permission user role.

### DIFF
--- a/modules/social_features/social_core/config/install/user.role.verified.yml
+++ b/modules/social_features/social_core/config/install/user.role.verified.yml
@@ -1,0 +1,8 @@
+langcode: en
+status: true
+dependencies: {  }
+id: verified
+label: 'Verified user'
+weight: 5
+is_admin: null
+permissions: {  }

--- a/modules/social_features/social_user/config/install/social_user.settings.yml
+++ b/modules/social_features/social_user/config/install/social_user.settings.yml
@@ -2,5 +2,4 @@ langcode: en
 signup_help: 'A welcome message with further instructions will be sent to your email address after you successfully enter your email address and a username.'
 login_help: ''
 social_user_profile_landingpage: social_user.stream
-_core:
-  default_config_hash: olu0qGxeLmRSDeYDtBxZveqpc2LNmlKiirZf9300v0A
+verified_immediately: true

--- a/modules/social_features/social_user/config/schema/social_user.schema.yml
+++ b/modules/social_features/social_user/config/schema/social_user.schema.yml
@@ -8,6 +8,9 @@ social_user.settings:
     login_help:
       type: text
       label: "Log in Help Text"
+    verified_immediately:
+      type: boolean
+      label: "Verified immediately"
     social_user_profile_landingpage:
       type: string
       label: "A valid route name that is used as default user profile page"

--- a/modules/social_features/social_user/social_user.module
+++ b/modules/social_features/social_user/social_user.module
@@ -18,6 +18,7 @@ use Drupal\social_user\Plugin\Action\SocialAddRoleUser;
 use Drupal\social_user\Plugin\Action\SocialBlockUser;
 use Drupal\social_user\Plugin\Action\SocialRemoveRoleUser;
 use Drupal\user\Plugin\Action\BlockUser;
+use Drupal\user\UserInterface;
 use Drupal\views\ViewExecutable;
 use Drupal\social_user\SocialUserSearchContentBlockAlter;
 
@@ -663,6 +664,14 @@ function social_user_form_user_admin_settings_alter(&$form, FormStateInterface $
     '#weight' => 20,
   ];
 
+  $form['registration_cancellation']['verified_immediately'] = [
+    '#type' => 'checkbox',
+    '#title' => new TranslatableMarkup('Registered users are verified immediately'),
+    '#description' => new TranslatableMarkup('New registered users get the "verified user & authenticated" role when they are registered. With this setting disabled, new registered users get the "authenticated" role when they are registered.'),
+    '#default_value' => $config->get('verified_immediately'),
+    '#weight' => -10,
+  ];
+
   $form['#submit'][] = 'social_user_form_user_admin_settings_submit';
 }
 
@@ -674,6 +683,7 @@ function social_user_form_user_admin_settings_submit($form, FormStateInterface $
     ->getEditable('social_user.settings');
   $config->set('signup_help', $form_state->getValue("signup_help"));
   $config->set('login_help', $form_state->getValue("login_help"));
+  $config->set('verified_immediately', $form_state->getValue("verified_immediately"));
   $config->save();
 }
 
@@ -799,5 +809,22 @@ function social_user_module_implements_alter(&$implementations, $hook) {
     $social_user = $implementations['social_user'];
     unset($implementations['social_user']);
     $implementations['social_user'] = $social_user;
+  }
+}
+
+/**
+ * Implements hook_ENTITY_TYPE_insert().
+ *
+ * @throws \Drupal\Core\Entity\EntityStorageException
+ */
+function social_user_user_insert(UserInterface $user) {
+  // If site setting "Registered users are verified immediately" is enabled:
+  // new registered users get the "verified user & authenticated" role when they
+  // are registered.
+  $config = \Drupal::config('social_user.settings');
+  $verified_immediately = $config->get('verified_immediately');
+  if ($verified_immediately) {
+    $user->addRole('verified');
+    $user->save();
   }
 }


### PR DESCRIPTION
## Problem
Currently, whenever a user signs up they get the authenticated user role by default, which comes with a lot of permissions. Permissions to create content, actively engage with the community and also show up as a new member immediately.
If we allow to change this we can achieve:

- Spam prevention: New spam accounts are not verified by default and cant create content.
- Monitization: Registered users, without payment, can't actively engage with the entiry community yet. Custom roles & permissions can be built on top of this open up parts of the system by payment (e.g. you get the event enrollment role which allows to enroll to an event only after payment)
- Information density: New unverified users, without an up to date profile, can be filtered out of overviews.

## Solution
How to achieve this?

- The idea is that a SM can decide, on site level if Users who registered are verified by default
- For existing platforms this is set, so nothing changes there
- The current authenticated user role permissions are moved to the new role called "verified user"
- Existing users need to get the verified user role immediately, so they don't lose permissions
- Authenticated users get the same permissions as AN, and potentially some more (e.g. edit/create profile)
- Users without the verified user role are filtered out of overviews/search/blocks

## Issue tracker

- https://getopensocial.atlassian.net/browse/DS-7601
- https://www.drupal.org/project/social/issues/3217353

## How to test
TBA

## Screenshots
N/A
## Release notes
Added new user role "verified".

## Change Record
N/A

## Translations
N/A
