### PR TITLE
Issue #3219037 by vnech: Add permission for SM to edit Data Policy translations

### DIFF
--- a/modules/custom/social_gdpr/social_gdpr.install
+++ b/modules/custom/social_gdpr/social_gdpr.install
@@ -67,6 +67,7 @@ function _social_gdpr_get_permissions($role) {
     'overview inform and consent settings',
     'administer inform and consent settings',
     'change inform and consent setting status',
+    'translate data_policy',
   ]);
 
   if (isset($permissions[$role])) {
@@ -81,4 +82,11 @@ function _social_gdpr_get_permissions($role) {
  */
 function social_gdpr_update_8901() {
   user_role_grant_permissions('sitemanager', ['administer data policy entities']);
+}
+
+/**
+ * Add permissions for SM to add translations for Data Policy.
+ */
+function social_gdpr_update_8902() {
+  user_role_grant_permissions('sitemanager', ['translate data_policy']);
 }


### PR DESCRIPTION
## Problem
SM can't add/edit translations for Data Policy

## Solution
Add permission for "sitemanager" role

## Issue tracker
- https://www.drupal.org/project/social/issues/3219037
- https://getopensocial.atlassian.net/browse/YANG-5768

## How to test
- [ ] Login as SM
- [ ] Go to _/admin/config/people/data-policy/add_

## Release notes
*SM can add/edit Data Policy translations*
