### PR TITLE
Issue #3219123 by Kingdutch: [GraphQL] Allow EntityConnectionQueryHelper to change sorting direction

### DIFF
--- a/modules/custom/social_graphql/src/GraphQL/ConnectionQueryHelperBase.php
+++ b/modules/custom/social_graphql/src/GraphQL/ConnectionQueryHelperBase.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Drupal\social_graphql\GraphQL;
+
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\graphql\GraphQL\Buffers\EntityBuffer;
+
+/**
+ * Base class for Connection Query Helpers.
+ *
+ * @see \Drupal\social_graphql\GraphQL\ConnectionQueryHelperInterface
+ */
+abstract class ConnectionQueryHelperBase implements ConnectionQueryHelperInterface {
+
+  /**
+   * The key that is used for sorting.
+   */
+  protected string $sortKey;
+
+  /**
+   * The Drupal entity type manager.
+   */
+  protected EntityTypeManagerInterface $entityTypeManager;
+
+  /**
+   * The GraphQL entity buffer.
+   */
+  protected EntityBuffer $graphqlEntityBuffer;
+
+  /**
+   * Create a new connection query helper.
+   *
+   * @param string $sort_key
+   *   The key that is used for sorting.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The Drupal entity type manager.
+   * @param \Drupal\graphql\GraphQL\Buffers\EntityBuffer $graphql_entity_buffer
+   *   The GraphQL entity buffer.
+   */
+  public function __construct(string $sort_key, EntityTypeManagerInterface $entity_type_manager, EntityBuffer $graphql_entity_buffer) {
+    $this->entityTypeManager = $entity_type_manager;
+    $this->graphqlEntityBuffer = $graphql_entity_buffer;
+    $this->sortKey = $sort_key;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getForwardSortDirection(): string {
+    return 'ASC';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getReverseSortDirection(): string {
+    return 'DESC';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getAggregateSortFunction() : ?string {
+    return NULL;
+  }
+
+}

--- a/modules/custom/social_graphql/src/GraphQL/ConnectionQueryHelperInterface.php
+++ b/modules/custom/social_graphql/src/GraphQL/ConnectionQueryHelperInterface.php
@@ -60,6 +60,22 @@ interface ConnectionQueryHelperInterface {
   public function getSortField() : string;
 
   /**
+   * Get the sort direction for normal searches.
+   *
+   * @return string
+   *   Either 'ASC' or 'DESC'.
+   */
+  public function getForwardSortDirection() : string;
+
+  /**
+   * Get the sort direction for reversed searches.
+   *
+   * @return string
+   *   Either 'ASC' or 'DESC'.
+   */
+  public function getReverseSortDirection() : string;
+
+  /**
    * The function to use for aggregate sorting.
    *
    * @return string|null

--- a/modules/custom/social_graphql/src/GraphQL/EntityConnection.php
+++ b/modules/custom/social_graphql/src/GraphQL/EntityConnection.php
@@ -234,7 +234,8 @@ class EntityConnection implements ConnectionInterface {
     // The order is descending if
     // - we want the first results in a reversed query
     // - we want the last results in a non reversed query.
-    $query_order = (!is_null($this->first) && !$this->reverse) || (!is_null($this->last) && $this->reverse) ? 'ASC' : 'DESC';
+    $field_query_order = (!is_null($this->first) && !$this->reverse) || (!is_null($this->last) && $this->reverse) ? $this->queryHelper->getForwardSortDirection() : $this->queryHelper->getReverseSortDirection();
+    $id_query_order = (!is_null($this->first) && !$this->reverse) || (!is_null($this->last) && $this->reverse) ? 'ASC' : 'DESC';
 
     // If a cursor is provided then we alter the condition to select the
     // elements on the correct side of the cursor.
@@ -274,13 +275,13 @@ class EntityConnection implements ConnectionInterface {
       $query->sortAggregate(
         $sort_field,
         $function,
-        $query_order
+        $field_query_order
       );
     }
     else {
       $query->sort(
         $sort_field,
-        $query_order
+        $field_query_order
       );
 
       // @todo https://www.drupal.org/project/social/issues/3191638
@@ -291,7 +292,7 @@ class EntityConnection implements ConnectionInterface {
       if ($sort_field !== $id_field) {
         $query->sort(
           $id_field,
-          $query_order
+          $id_query_order
         );
       }
     }

--- a/modules/social_features/social_comment/src/Plugin/GraphQL/DataProducer/QueryComments.php
+++ b/modules/social_features/social_comment/src/Plugin/GraphQL/DataProducer/QueryComments.php
@@ -83,7 +83,7 @@ class QueryComments extends EntityDataProducerPluginBase {
       $parent = reset($nodes);
     }
 
-    $query_helper = new CommentQueryHelper($parent, $this->entityTypeManager, $sortKey);
+    $query_helper = new CommentQueryHelper($sortKey, $this->entityTypeManager, $this->graphqlEntityBuffer, $parent);
     $metadata->addCacheableDependency($query_helper);
 
     $connection = new EntityConnection($query_helper);

--- a/modules/social_features/social_comment/src/Plugin/GraphQL/DataProducer/SocialCommentAttachments.php
+++ b/modules/social_features/social_comment/src/Plugin/GraphQL/DataProducer/SocialCommentAttachments.php
@@ -130,7 +130,7 @@ class SocialCommentAttachments extends EntityDataProducerPluginBase {
    *   An entity connection with results and data about the paginated results.
    */
   public function resolve(EntityInterface $parent, ?int $first, ?string $after, ?int $last, ?string $before, bool $reverse, string $sortKey, RefinableCacheableDependencyInterface $metadata) {
-    $query_helper = new CommentAttachmentsQueryHelper($parent, $this->entityTypeManager, $sortKey, $this->database);
+    $query_helper = new CommentAttachmentsQueryHelper($sortKey, $this->entityTypeManager, $this->graphqlEntityBuffer, $this->database, $parent);
     $metadata->addCacheableDependency($query_helper);
 
     $connection = new EntityConnection($query_helper);

--- a/modules/social_features/social_comment/src/Plugin/GraphQL/QueryHelper/CommentAttachmentsQueryHelper.php
+++ b/modules/social_features/social_comment/src/Plugin/GraphQL/QueryHelper/CommentAttachmentsQueryHelper.php
@@ -2,14 +2,13 @@
 
 namespace Drupal\social_comment\Plugin\GraphQL\QueryHelper;
 
-use Drupal\comment\Entity\Comment;
 use Drupal\Core\Database\Connection;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Entity\Query\QueryInterface;
 use Drupal\file\Entity\File;
-use Drupal\node\Entity\Node;
-use Drupal\social_graphql\GraphQL\ConnectionQueryHelperInterface;
+use Drupal\graphql\GraphQL\Buffers\EntityBuffer;
+use Drupal\social_graphql\GraphQL\ConnectionQueryHelperBase;
 use Drupal\social_graphql\Wrappers\Cursor;
 use Drupal\social_graphql\Wrappers\Edge;
 use GraphQL\Deferred;
@@ -18,7 +17,7 @@ use GraphQL\Executor\Promise\Adapter\SyncPromise;
 /**
  * Loads files.
  */
-class CommentAttachmentsQueryHelper implements ConnectionQueryHelperInterface {
+class CommentAttachmentsQueryHelper extends ConnectionQueryHelperBase {
 
   /**
    * The conversations for which participants are being fetched.
@@ -49,22 +48,23 @@ class CommentAttachmentsQueryHelper implements ConnectionQueryHelperInterface {
   protected $database;
 
   /**
-   * FileQueryHelper constructor.
+   * Create a new connection query helper.
    *
-   * @param \Drupal\Core\Entity\EntityInterface $entity
-   *   The conversations for which participants are being fetched.
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
-   *   The Drupal entity type manager.
    * @param string $sort_key
    *   The key that is used for sorting.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The Drupal entity type manager.
+   * @param \Drupal\graphql\GraphQL\Buffers\EntityBuffer $graphql_entity_buffer
+   *   The GraphQL entity buffer.
    * @param \Drupal\Core\Database\Connection $database
    *   Database Service Object.
+   * @param \Drupal\Core\Entity\EntityInterface $entity
+   *   The conversations for which participants are being fetched.
    */
-  public function __construct(EntityInterface $entity, EntityTypeManagerInterface $entity_type_manager, string $sort_key, Connection $database) {
-    $this->entity = $entity;
-    $this->entityTypeManager = $entity_type_manager;
-    $this->sortKey = $sort_key;
+  public function __construct(string $sort_key, EntityTypeManagerInterface $entity_type_manager, EntityBuffer $graphql_entity_buffer, Connection $database, EntityInterface $entity) {
+    parent::__construct($sort_key, $entity_type_manager, $graphql_entity_buffer);
     $this->database = $database;
+    $this->entity = $entity;
   }
 
   /**

--- a/modules/social_features/social_comment/src/Plugin/GraphQL/QueryHelper/CommentQueryHelper.php
+++ b/modules/social_features/social_comment/src/Plugin/GraphQL/QueryHelper/CommentQueryHelper.php
@@ -5,8 +5,9 @@ namespace Drupal\social_comment\Plugin\GraphQL\QueryHelper;
 use Drupal\comment\Entity\Comment;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Entity\Query\QueryInterface;
+use Drupal\graphql\GraphQL\Buffers\EntityBuffer;
 use Drupal\node\NodeInterface;
-use Drupal\social_graphql\GraphQL\ConnectionQueryHelperInterface;
+use Drupal\social_graphql\GraphQL\ConnectionQueryHelperBase;
 use Drupal\social_graphql\Wrappers\Cursor;
 use Drupal\social_graphql\Wrappers\Edge;
 use GraphQL\Deferred;
@@ -15,7 +16,7 @@ use GraphQL\Executor\Promise\Adapter\SyncPromise;
 /**
  * Loads comments.
  */
-class CommentQueryHelper implements ConnectionQueryHelperInterface {
+class CommentQueryHelper extends ConnectionQueryHelperBase {
 
   /**
    * The node for which comments are being fetched.
@@ -25,33 +26,20 @@ class CommentQueryHelper implements ConnectionQueryHelperInterface {
   protected ?NodeInterface $parent;
 
   /**
-   * The Drupal entity type manager.
-   *
-   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
-   */
-  protected EntityTypeManagerInterface $entityTypeManager;
-
-  /**
-   * The key that is used for sorting.
-   *
-   * @var string
-   */
-  protected string $sortKey;
-
-  /**
    * CommentQueryHelper constructor.
    *
-   * @param \Drupal\node\NodeInterface|null $parent
-   *   The node for which comments are being fetched.
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
-   *   The Drupal entity type manager.
    * @param string $sort_key
    *   The key that is used for sorting.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The Drupal entity type manager.
+   * @param \Drupal\graphql\GraphQL\Buffers\EntityBuffer $graphql_entity_buffer
+   *   The GraphQL entity buffer.
+   * @param \Drupal\node\NodeInterface|null $parent
+   *   The node for which comments are being fetched.
    */
-  public function __construct(?NodeInterface $parent, EntityTypeManagerInterface $entity_type_manager, string $sort_key) {
+  public function __construct(string $sort_key, EntityTypeManagerInterface $entity_type_manager, EntityBuffer $graphql_entity_buffer, ?NodeInterface $parent) {
+    parent::__construct($sort_key, $entity_type_manager, $graphql_entity_buffer);
     $this->parent = $parent;
-    $this->entityTypeManager = $entity_type_manager;
-    $this->sortKey = $sort_key;
   }
 
   /**
@@ -99,13 +87,6 @@ class CommentQueryHelper implements ConnectionQueryHelperInterface {
       default:
         throw new \InvalidArgumentException("Unsupported sortKey for sorting '{$this->sortKey}'");
     }
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function getAggregateSortFunction() : ?string {
-    return NULL;
   }
 
   /**

--- a/modules/social_features/social_user/src/GraphQL/QueryHelper/UserQueryHelper.php
+++ b/modules/social_features/social_user/src/GraphQL/QueryHelper/UserQueryHelper.php
@@ -2,10 +2,8 @@
 
 namespace Drupal\social_user\GraphQL\QueryHelper;
 
-use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Entity\Query\QueryInterface;
-use Drupal\graphql\GraphQL\Buffers\EntityBuffer;
-use Drupal\social_graphql\GraphQL\ConnectionQueryHelperInterface;
+use Drupal\social_graphql\GraphQL\ConnectionQueryHelperBase;
 use Drupal\social_graphql\Wrappers\Cursor;
 use Drupal\social_graphql\Wrappers\Edge;
 use Drupal\user\Entity\User;
@@ -16,44 +14,7 @@ use GraphQL\Executor\Promise\Adapter\SyncPromise;
 /**
  * Loads users.
  */
-class UserQueryHelper implements ConnectionQueryHelperInterface {
-
-  /**
-   * The Drupal entity type manager.
-   *
-   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
-   */
-  protected EntityTypeManagerInterface $entityTypeManager;
-
-  /**
-   * The GraphQL entity buffer.
-   *
-   * @var \Drupal\graphql\GraphQL\Buffers\EntityBuffer
-   */
-  protected EntityBuffer $graphqlEntityBuffer;
-
-  /**
-   * The key that is used for sorting.
-   *
-   * @var string
-   */
-  protected string $sortKey;
-
-  /**
-   * UserQueryHelper constructor.
-   *
-   * @param \Drupal\graphql\GraphQL\Buffers\EntityBuffer $graphql_entity_buffer
-   *   The GraphQL entity buffer.
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
-   *   The Drupal entity type manager.
-   * @param string $sort_key
-   *   The key that is used for sorting.
-   */
-  public function __construct(EntityBuffer $graphql_entity_buffer, EntityTypeManagerInterface $entity_type_manager, string $sort_key) {
-    $this->graphqlEntityBuffer = $graphql_entity_buffer;
-    $this->entityTypeManager = $entity_type_manager;
-    $this->sortKey = $sort_key;
-  }
+class UserQueryHelper extends ConnectionQueryHelperBase {
 
   /**
    * {@inheritdoc}
@@ -99,13 +60,6 @@ class UserQueryHelper implements ConnectionQueryHelperInterface {
       default:
         throw new \InvalidArgumentException("Unsupported sortKey for sorting '{$this->sortKey}'");
     }
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function getAggregateSortFunction() : ?string {
-    return NULL;
   }
 
   /**

--- a/modules/social_features/social_user/src/Plugin/GraphQL/DataProducer/QueryUser.php
+++ b/modules/social_features/social_user/src/Plugin/GraphQL/DataProducer/QueryUser.php
@@ -74,7 +74,7 @@ class QueryUser extends EntityDataProducerPluginBase {
    * @todo https://www.drupal.org/project/social/issues/3191637
    */
   public function resolve(?int $first, ?string $after, ?int $last, ?string $before, bool $reverse, string $sortKey, RefinableCacheableDependencyInterface $metadata) {
-    $query_helper = new UserQueryHelper($this->graphqlEntityBuffer, $this->entityTypeManager, $sortKey);
+    $query_helper = new UserQueryHelper($sortKey, $this->entityTypeManager, $this->graphqlEntityBuffer);
     $metadata->addCacheableDependency($query_helper);
 
     $connection = new EntityConnection($query_helper);


### PR DESCRIPTION
<h3 id="summary-problem-motivation">Problem/Motivation</h3>
In some cases the default sorting direction should not be ascending but instead descending. A possible scenario is for example sorting content by the number of likes.

Forward is currently always assumed to be "Ascending" and reversed is considered to be "Descending" with no way to change this.

<h3 id="summary-proposed-resolution">Proposed resolution</h3>
Update <code>ConnectionQueryHelperInterface</code> to add <code>getForwardSortDirection</code> and <code>getReverseSortDirection</code> which can be called instead of the current hardcoded 'ASC' and 'DESC' values.

Introduce <code>ConnectionQueryHelperBase</code> that contains these functions with their current default values to make upgrading easier.

## Issue tracker
https://www.drupal.org/project/social/issues/3219123

## How to test

- [x] GraphQL Tests should pass

## Screenshots
N/a

## Release notes
N/a unsupported internal change

## Change Record
N/a unsupported internal change

## Translations
N/a