### PR TITLE
Issue #3220157 by navneet0693: Update search indexes after search_api module update to v1.19.

### DIFF
--- a/modules/social_features/social_search/config/static/search_api.index.social_all_10301.yml
+++ b/modules/social_features/social_search/config/static/search_api.index.social_all_10301.yml
@@ -1,0 +1,377 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - group
+    - profile
+    - user
+    - search_api
+    - entity_access_by_field
+    - social_search
+  config:
+    - field.storage.group.field_group_description
+    - field.storage.group.field_group_location
+    - field.storage.profile.field_profile_expertise
+    - field.storage.profile.field_profile_first_name
+    - field.storage.profile.field_profile_interests
+    - field.storage.profile.field_profile_last_name
+    - field.storage.profile.field_profile_profile_tag
+    - search_api.server.social_database
+    - core.entity_view_mode.group.teaser
+    - core.entity_view_mode.node.search_index
+    - core.entity_view_mode.profile.search_index
+id: social_all
+name: 'Social all'
+description: 'All content index created for the Social distribution.'
+read_only: false
+field_settings:
+  created:
+    label: 'Authored on'
+    datasource_id: 'entity:node'
+    property_path: created
+    type: date
+    dependencies:
+      module:
+        - node
+  created_1:
+    label: 'Created on'
+    datasource_id: 'entity:group'
+    property_path: created
+    type: date
+    dependencies:
+      module:
+        - group
+  field_group_description:
+    label: Description
+    datasource_id: 'entity:group'
+    property_path: field_group_description
+    type: text
+    dependencies:
+      config:
+        - field.storage.group.field_group_description
+  field_group_location:
+    label: 'Location name'
+    datasource_id: 'entity:group'
+    property_path: field_group_location
+    type: string
+    dependencies:
+      config:
+        - field.storage.group.field_group_location
+  field_profile_expertise:
+    label: Expertise
+    datasource_id: 'entity:profile'
+    property_path: field_profile_expertise
+    type: integer
+    dependencies:
+      config:
+        - field.storage.profile.field_profile_expertise
+  field_profile_first_name:
+    label: 'First name'
+    datasource_id: 'entity:profile'
+    property_path: field_profile_first_name
+    type: text
+    boost: !!float 2
+    dependencies:
+      config:
+        - field.storage.profile.field_profile_first_name
+  field_profile_interests:
+    label: Interests
+    datasource_id: 'entity:profile'
+    property_path: field_profile_interests
+    type: integer
+    dependencies:
+      config:
+        - field.storage.profile.field_profile_interests
+  field_profile_last_name:
+    label: 'Last name'
+    datasource_id: 'entity:profile'
+    property_path: field_profile_last_name
+    type: text
+    boost: !!float 2
+    dependencies:
+      config:
+        - field.storage.profile.field_profile_last_name
+  field_profile_profile_tag:
+    label: 'Profile tag'
+    datasource_id: 'entity:profile'
+    property_path: field_profile_profile_tag
+    type: integer
+    dependencies:
+      config:
+        - field.storage.profile.field_profile_profile_tag
+  label:
+    label: Title
+    datasource_id: 'entity:group'
+    property_path: label
+    type: text
+    boost: !!float 21
+    dependencies:
+      module:
+        - group
+  name:
+    label: 'Owner » User » Name'
+    datasource_id: 'entity:profile'
+    property_path: 'uid:entity:name'
+    type: text
+    boost: !!float 2
+    dependencies:
+      module:
+        - profile
+        - user
+  node_grants:
+    label: 'Node access information'
+    property_path: search_api_node_grants
+    type: string
+    indexed_locked: true
+    type_locked: true
+    hidden: true
+  rendered_item:
+    label: 'Rendered HTML output'
+    property_path: rendered_item
+    type: text
+    configuration:
+      roles:
+        anonymous: anonymous
+      view_mode:
+        'entity:group':
+          closed_group: teaser
+          open_group: teaser
+          public_group: ''
+        'entity:node':
+          event: search_index
+          page: search_index
+          topic: search_index
+        'entity:profile':
+          profile: search_index
+  status:
+    label: 'Publishing status'
+    datasource_id: 'entity:node'
+    property_path: status
+    type: boolean
+    indexed_locked: true
+    type_locked: true
+    dependencies:
+      module:
+        - node
+  title:
+    label: Title
+    datasource_id: 'entity:node'
+    property_path: title
+    type: text
+    boost: !!float 21
+    dependencies:
+      module:
+        - node
+  type:
+    label: 'Content type'
+    datasource_id: 'entity:node'
+    property_path: type
+    type: string
+    dependencies:
+      module:
+        - node
+  type_1:
+    label: 'Content type'
+    datasource_id: 'entity:node'
+    property_path: type
+    type: text
+    boost: !!float 13
+    dependencies:
+      module:
+        - node
+  uid:
+    label: 'Authored by'
+    datasource_id: 'entity:node'
+    property_path: uid
+    type: integer
+    indexed_locked: true
+    type_locked: true
+    dependencies:
+      module:
+        - node
+  uid_1:
+    label: 'Group creator'
+    datasource_id: 'entity:group'
+    property_path: uid
+    type: integer
+    dependencies:
+      module:
+        - group
+  uid_2:
+    label: Owner
+    datasource_id: 'entity:profile'
+    property_path: uid
+    type: integer
+    dependencies:
+      module:
+        - profile
+  user_status:
+    label: 'Owner » User » User status'
+    datasource_id: 'entity:profile'
+    property_path: 'uid:entity:status'
+    type: boolean
+    dependencies:
+      module:
+        - profile
+        - user
+datasource_settings:
+  'entity:group':
+    bundles:
+      default: true
+      selected: {  }
+    languages:
+      default: true
+      selected: {  }
+  'entity:node':
+    bundles:
+      default: true
+      selected: {  }
+    languages:
+      default: true
+      selected: {  }
+  'entity:profile':
+    bundles:
+      default: true
+      selected: {  }
+processor_settings:
+  entity_access_by_field:
+    weights:
+      preprocess_query: -30
+  ignorecase:
+    all_fields: true
+    fields:
+      - field_group_description
+      - field_group_location
+      - field_profile_first_name
+      - field_profile_last_name
+      - label
+      - name
+      - rendered_item
+      - title
+      - type
+      - type_1
+    weights:
+      preprocess_index: -20
+      preprocess_query: -20
+  content_access:
+    weights:
+      preprocess_query: -30
+  language_with_fallback: {  }
+  stopwords:
+    all_fields: false
+    fields:
+      - field_group_description
+      - rendered_item
+    stopwords:
+      - a
+      - an
+      - and
+      - are
+      - as
+      - at
+      - be
+      - but
+      - by
+      - for
+      - if
+      - in
+      - into
+      - is
+      - it
+      - 'no'
+      - not
+      - of
+      - 'on'
+      - or
+      - s
+      - such
+      - t
+      - that
+      - the
+      - their
+      - then
+      - there
+      - these
+      - they
+      - this
+      - to
+      - was
+      - will
+      - with
+    weights:
+      preprocess_index: -5
+      preprocess_query: -2
+  html_filter:
+    all_fields: false
+    fields:
+      - field_group_description
+      - field_group_location
+      - label
+      - name
+      - rendered_item
+      - title
+      - type
+    title: true
+    alt: true
+    tags:
+      b: 2
+      em: 1
+      h1: 5
+      h2: 3
+      h3: 2
+      strong: 2
+      u: 1
+    weights:
+      preprocess_index: -25
+      preprocess_query: -15
+  transliteration:
+    all_fields: true
+    fields:
+      - field_group_description
+      - field_group_location
+      - field_profile_first_name
+      - field_profile_last_name
+      - label
+      - name
+      - rendered_item
+      - title
+      - type
+      - type_1
+    weights:
+      preprocess_index: -20
+      preprocess_query: -20
+  rendered_item: {  }
+  add_url: {  }
+  aggregated_field: {  }
+  tokenizer:
+    all_fields: true
+    fields:
+      - field_group_description
+      - field_profile_first_name
+      - field_profile_last_name
+      - label
+      - name
+      - rendered_item
+      - title
+      - type_1
+    spaces: ''
+    overlap_cjk: 1
+    minimum_word_size: '3'
+    weights:
+      preprocess_index: -6
+      preprocess_query: -6
+    ignored: ._-
+  blocked_users:
+    weights:
+      preprocess_query: -30
+  super_user:
+    weights:
+      preprocess_query: 30
+tracker_settings:
+  default:
+    indexing_order: fifo
+options:
+  index_directly: false
+  cron_limit: 50
+server: social_database

--- a/modules/social_features/social_search/config/static/search_api.index.social_content_10301.yml
+++ b/modules/social_features/social_search/config/static/search_api.index.social_content_10301.yml
@@ -1,0 +1,235 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - search_api
+    - entity_access_by_field
+  config:
+    - field.storage.node.field_event_date
+    - field.storage.node.field_event_date_end
+    - search_api.server.social_database
+    - core.entity_view_mode.node.search_index
+id: social_content
+name: 'Social Content'
+description: 'Default content index created for the Social distribution.'
+read_only: false
+field_settings:
+  created:
+    label: 'Authored on'
+    datasource_id: 'entity:node'
+    property_path: created
+    type: date
+    dependencies:
+      module:
+        - node
+  field_event_date:
+    label: Start
+    datasource_id: 'entity:node'
+    property_path: field_event_date
+    type: date
+    dependencies:
+      config:
+        - field.storage.node.field_event_date
+  field_event_date_end:
+    label: End
+    datasource_id: 'entity:node'
+    property_path: field_event_date_end
+    type: date
+    dependencies:
+      config:
+        - field.storage.node.field_event_date_end
+  node_grants:
+    label: 'Node access information'
+    property_path: search_api_node_grants
+    type: string
+    indexed_locked: true
+    type_locked: true
+    hidden: true
+  rendered_item:
+    label: 'Rendered HTML output'
+    property_path: rendered_item
+    type: text
+    configuration:
+      roles:
+        anonymous: anonymous
+      view_mode:
+        'entity:node':
+          book: search_index
+          event: search_index
+          page: search_index
+          topic: search_index
+  status:
+    label: 'Publishing status'
+    datasource_id: 'entity:node'
+    property_path: status
+    type: boolean
+    indexed_locked: true
+    type_locked: true
+    dependencies:
+      module:
+        - node
+  title:
+    label: Title
+    datasource_id: 'entity:node'
+    property_path: title
+    type: text
+    boost: !!float 21
+    dependencies:
+      module:
+        - node
+  type:
+    label: Type
+    datasource_id: 'entity:node'
+    property_path: type
+    type: text
+    boost: !!float 13
+    dependencies:
+      module:
+        - node
+  uid:
+    label: 'Authored by'
+    datasource_id: 'entity:node'
+    property_path: uid
+    type: integer
+    indexed_locked: true
+    type_locked: true
+    dependencies:
+      module:
+        - node
+datasource_settings:
+  'entity:node':
+    plugin_id: 'entity:node'
+    bundles:
+      default: true
+      selected: {  }
+    languages:
+      default: true
+      selected: {  }
+processor_settings:
+  entity_access_by_field:
+    weights:
+      preprocess_query: -30
+  ignorecase:
+    plugin_id: ignorecase
+    all_fields: true
+    fields:
+      - rendered_item
+      - title
+      - type
+    weights:
+      preprocess_index: -10
+      preprocess_query: -10
+  content_access:
+    plugin_id: content_access
+    weights:
+      preprocess_index: -10
+      preprocess_query: -10
+  language_with_fallback: {  }
+  stopwords:
+    plugin_id: stopwords
+    all_fields: false
+    fields:
+      - rendered_item
+      - title
+    stopwords:
+      - a
+      - an
+      - and
+      - are
+      - as
+      - at
+      - be
+      - but
+      - by
+      - for
+      - if
+      - in
+      - into
+      - is
+      - it
+      - 'no'
+      - not
+      - of
+      - 'on'
+      - or
+      - s
+      - such
+      - t
+      - that
+      - the
+      - their
+      - then
+      - there
+      - these
+      - they
+      - this
+      - to
+      - was
+      - will
+      - with
+    weights:
+      preprocess_index: -5
+      preprocess_query: -2
+  html_filter:
+    plugin_id: html_filter
+    all_fields: false
+    fields:
+      - rendered_item
+    title: true
+    alt: true
+    tags:
+      b: 2
+      em: 1
+      h1: 5
+      h2: 3
+      h3: 2
+      strong: 2
+      u: 1
+    weights:
+      preprocess_index: -15
+      preprocess_query: -10
+  transliteration:
+    plugin_id: transliteration
+    all_fields: true
+    fields:
+      - rendered_item
+      - title
+      - type
+    weights:
+      preprocess_index: -10
+      preprocess_query: -10
+  rendered_item:
+    plugin_id: rendered_item
+    weights:
+      add_properties: 0
+      pre_index_save: -10
+  add_url:
+    plugin_id: add_url
+    weights:
+      preprocess_index: -30
+  aggregated_field:
+    plugin_id: aggregated_field
+    weights:
+      add_properties: 20
+  tokenizer:
+    plugin_id: tokenizer
+    all_fields: true
+    fields:
+      - rendered_item
+      - title
+      - type
+    spaces: ''
+    overlap_cjk: 1
+    minimum_word_size: '3'
+    weights:
+      preprocess_index: -6
+      preprocess_query: -6
+    ignored: ._-
+tracker_settings:
+  default:
+    indexing_order: fifo
+options:
+  index_directly: false
+  cron_limit: 50
+server: social_database

--- a/modules/social_features/social_search/config/static/search_api.index.social_groups_10301.yml
+++ b/modules/social_features/social_search/config/static/search_api.index.social_groups_10301.yml
@@ -1,0 +1,243 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - group
+    - user
+    - search_api
+  config:
+    - field.storage.group.field_group_allowed_join_method
+    - field.storage.group.field_group_description
+    - search_api.server.social_database
+    - core.entity_view_mode.group.teaser
+id: social_groups
+name: 'Social Groups'
+description: 'Default group index created for the Social distribution.'
+read_only: false
+field_settings:
+  created:
+    label: 'Created on'
+    datasource_id: 'entity:group'
+    property_path: created
+    type: date
+    dependencies:
+      module:
+        - group
+  field_group_allowed_join_method:
+    label: 'Allowed join method'
+    datasource_id: 'entity:group'
+    property_path: field_group_allowed_join_method
+    type: string
+    dependencies:
+      config:
+        - field.storage.group.field_group_allowed_join_method
+  field_group_description:
+    label: Description
+    datasource_id: 'entity:group'
+    property_path: field_group_description
+    type: text
+    dependencies:
+      config:
+        - field.storage.group.field_group_description
+  label:
+    label: Title
+    datasource_id: 'entity:group'
+    property_path: label
+    type: text
+    boost: !!float 21
+    dependencies:
+      module:
+        - group
+  name:
+    label: 'Group creator » User » Name'
+    datasource_id: 'entity:group'
+    property_path: 'uid:entity:name'
+    type: string
+    dependencies:
+      module:
+        - group
+        - user
+  rendered_item:
+    label: 'Rendered HTML output'
+    property_path: rendered_item
+    type: text
+    configuration:
+      roles:
+        anonymous: anonymous
+      view_mode:
+        'entity:group':
+          closed_group: teaser
+          open_group: teaser
+          secret_group: teaser
+  type:
+    label: Type
+    datasource_id: 'entity:group'
+    property_path: type
+    type: string
+    dependencies:
+      module:
+        - group
+datasource_settings:
+  'entity:group':
+    plugin_id: 'entity:group'
+    bundles:
+      default: true
+      selected: {  }
+    languages:
+      default: true
+      selected: {  }
+processor_settings:
+  ignorecase:
+    plugin_id: ignorecase
+    all_fields: true
+    fields:
+      - field_group_allowed_join_method
+      - field_group_description
+      - label
+      - name
+      - rendered_item
+      - type
+    weights:
+      preprocess_index: -10
+      preprocess_query: -10
+  language_with_fallback: {  }
+  stopwords:
+    plugin_id: stopwords
+    all_fields: false
+    fields:
+      - field_group_description
+      - rendered_item
+    stopwords:
+      - a
+      - an
+      - and
+      - are
+      - as
+      - at
+      - be
+      - but
+      - by
+      - for
+      - if
+      - in
+      - into
+      - is
+      - it
+      - 'no'
+      - not
+      - of
+      - 'on'
+      - or
+      - s
+      - such
+      - t
+      - that
+      - the
+      - their
+      - then
+      - there
+      - these
+      - they
+      - this
+      - to
+      - was
+      - will
+      - with
+    weights:
+      preprocess_index: -5
+      preprocess_query: -2
+  html_filter:
+    plugin_id: html_filter
+    all_fields: false
+    fields:
+      - field_group_description
+      - rendered_item
+    title: true
+    alt: true
+    tags:
+      b: 2
+      em: 1
+      h1: 5
+      h2: 3
+      h3: 2
+      strong: 2
+      u: 1
+    weights:
+      preprocess_index: -15
+      preprocess_query: -10
+  ignore_character:
+    plugin_id: ignore_character
+    all_fields: false
+    fields:
+      - field_group_description
+      - label
+      - name
+      - type
+    ignorable: '[''¿¡!?,.:;]'
+    strip:
+      character_sets:
+        Pc: Pc
+        Pd: Pd
+        Pe: Pe
+        Pf: Pf
+        Pi: Pi
+        Po: Po
+        Ps: Ps
+    weights:
+      preprocess_index: -10
+      preprocess_query: -10
+    ignorable_classes:
+      - Pc
+      - Pd
+      - Pe
+      - Pf
+      - Pi
+      - Po
+      - Ps
+  transliteration:
+    plugin_id: transliteration
+    all_fields: true
+    fields:
+      - field_group_allowed_join_method
+      - field_group_description
+      - label
+      - name
+      - rendered_item
+      - type
+    weights:
+      preprocess_index: -10
+      preprocess_query: -10
+  rendered_item:
+    plugin_id: rendered_item
+    weights:
+      add_properties: 0
+      pre_index_save: -10
+  add_url:
+    plugin_id: add_url
+    weights:
+      preprocess_index: -30
+  aggregated_field:
+    plugin_id: aggregated_field
+    weights:
+      add_properties: 20
+  tokenizer:
+    plugin_id: tokenizer
+    all_fields: true
+    fields:
+      - field_group_description
+      - label
+      - rendered_item
+    spaces: ''
+    overlap_cjk: 1
+    minimum_word_size: '3'
+    weights:
+      preprocess_index: -6
+      preprocess_query: -6
+    ignored: ._-
+tracker_settings:
+  default:
+    indexing_order: fifo
+options:
+  index_directly: false
+  cron_limit: 50
+server: social_database

--- a/modules/social_features/social_search/config/static/search_api.index.social_users_10301.yml
+++ b/modules/social_features/social_search/config/static/search_api.index.social_users_10301.yml
@@ -1,0 +1,272 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.profile.field_profile_expertise
+    - field.storage.profile.field_profile_first_name
+    - field.storage.profile.field_profile_interests
+    - field.storage.profile.field_profile_last_name
+    - field.storage.profile.field_profile_profile_tag
+    - search_api.server.social_database
+    - core.entity_view_mode.profile.search_index
+  module:
+    - taxonomy
+    - profile
+    - user
+    - search_api
+    - social_search
+id: social_users
+name: 'Social Users'
+description: 'Default users index created for the Social distribution.'
+read_only: false
+field_settings:
+  created:
+    label: 'Owner » User » Created'
+    datasource_id: 'entity:profile'
+    property_path: 'uid:entity:created'
+    type: date
+    dependencies:
+      module:
+        - profile
+        - user
+  field_profile_expertise:
+    label: Expertise
+    datasource_id: 'entity:profile'
+    property_path: field_profile_expertise
+    type: integer
+    dependencies:
+      config:
+        - field.storage.profile.field_profile_expertise
+  field_profile_expertise_name:
+    label: 'Expertise » Taxonomy term » Name'
+    datasource_id: 'entity:profile'
+    property_path: 'field_profile_expertise:entity:name'
+    type: text
+    dependencies:
+      config:
+        - field.storage.profile.field_profile_expertise
+      module:
+        - taxonomy
+  field_profile_first_name:
+    label: 'First name'
+    datasource_id: 'entity:profile'
+    property_path: field_profile_first_name
+    type: text
+    boost: !!float 2
+    dependencies:
+      config:
+        - field.storage.profile.field_profile_first_name
+  field_profile_interests:
+    label: Interests
+    datasource_id: 'entity:profile'
+    property_path: field_profile_interests
+    type: integer
+    dependencies:
+      config:
+        - field.storage.profile.field_profile_interests
+  field_profile_interests_name:
+    label: 'Interests » Taxonomy term » Name'
+    datasource_id: 'entity:profile'
+    property_path: 'field_profile_interests:entity:name'
+    type: text
+    dependencies:
+      config:
+        - field.storage.profile.field_profile_interests
+      module:
+        - taxonomy
+  field_profile_last_name:
+    label: 'Last name'
+    datasource_id: 'entity:profile'
+    property_path: field_profile_last_name
+    type: text
+    boost: !!float 2
+    dependencies:
+      config:
+        - field.storage.profile.field_profile_last_name
+  field_profile_profile_tag:
+    label: 'Profile tag'
+    datasource_id: 'entity:profile'
+    property_path: field_profile_profile_tag
+    type: integer
+    dependencies:
+      config:
+        - field.storage.profile.field_profile_profile_tag
+  name:
+    label: 'Owner » User » Name'
+    datasource_id: 'entity:profile'
+    property_path: 'uid:entity:name'
+    type: text
+    boost: !!float 2
+    dependencies:
+      module:
+        - profile
+        - user
+  rendered_item:
+    label: 'Rendered HTML output'
+    property_path: rendered_item
+    type: text
+    configuration:
+      roles:
+        authenticated: authenticated
+      view_mode:
+        'entity:profile':
+          main: ''
+          profile: search_index
+  uid:
+    label: Owner
+    datasource_id: 'entity:profile'
+    property_path: uid
+    type: integer
+    dependencies:
+      module:
+        - profile
+  user_status:
+    label: 'Owner » User » User status'
+    datasource_id: 'entity:profile'
+    property_path: 'uid:entity:status'
+    type: boolean
+    dependencies:
+      module:
+        - profile
+        - user
+datasource_settings:
+  'entity:profile':
+    plugin_id: 'entity:profile'
+    bundles:
+      default: true
+      selected: {  }
+processor_settings:
+  ignorecase:
+    plugin_id: ignorecase
+    all_fields: true
+    fields:
+      - field_profile_expertise_name
+      - field_profile_first_name
+      - field_profile_interests_name
+      - field_profile_last_name
+      - name
+      - rendered_item
+    weights:
+      preprocess_index: -10
+      preprocess_query: -10
+  language_with_fallback: {  }
+  stopwords:
+    plugin_id: stopwords
+    all_fields: false
+    fields:
+      - name
+      - rendered_item
+    stopwords:
+      - a
+      - an
+      - and
+      - are
+      - as
+      - at
+      - be
+      - but
+      - by
+      - for
+      - if
+      - in
+      - into
+      - is
+      - it
+      - 'no'
+      - not
+      - of
+      - 'on'
+      - or
+      - s
+      - such
+      - t
+      - that
+      - the
+      - their
+      - then
+      - there
+      - these
+      - they
+      - this
+      - to
+      - was
+      - will
+      - with
+    weights:
+      preprocess_index: -5
+      preprocess_query: -2
+  html_filter:
+    plugin_id: html_filter
+    all_fields: false
+    fields:
+      - name
+      - rendered_item
+    title: true
+    alt: true
+    tags:
+      b: 2
+      em: 1
+      h1: 5
+      h2: 3
+      h3: 2
+      strong: 2
+      u: 1
+    weights:
+      preprocess_index: -15
+      preprocess_query: -10
+  transliteration:
+    plugin_id: transliteration
+    all_fields: true
+    fields:
+      - field_profile_expertise_name
+      - field_profile_first_name
+      - field_profile_interests_name
+      - field_profile_last_name
+      - name
+      - rendered_item
+    weights:
+      preprocess_index: -10
+      preprocess_query: -10
+  rendered_item:
+    plugin_id: rendered_item
+    weights:
+      add_properties: 0
+      pre_index_save: -10
+  add_url:
+    plugin_id: add_url
+    weights:
+      preprocess_index: -30
+  aggregated_field:
+    plugin_id: aggregated_field
+    weights:
+      add_properties: 20
+  tokenizer:
+    plugin_id: tokenizer
+    all_fields: true
+    fields:
+      - field_profile_expertise_name
+      - field_profile_first_name
+      - field_profile_interests_name
+      - field_profile_last_name
+      - name
+      - rendered_item
+    spaces: ''
+    overlap_cjk: 1
+    minimum_word_size: '3'
+    weights:
+      preprocess_index: -6
+      preprocess_query: -6
+    ignored: ._-
+  blocked_users:
+    weights:
+      preprocess_query: -30
+  super_user:
+    weights:
+      preprocess_query: 30
+tracker_settings:
+  default:
+    indexing_order: fifo
+options:
+  index_directly: false
+  cron_limit: 50
+server: social_database

--- a/modules/social_features/social_search/social_search.install
+++ b/modules/social_features/social_search/social_search.install
@@ -9,6 +9,7 @@ use Drupal\Core\Entity\EntityStorageException;
 use Drupal\Core\Site\Settings;
 use Drupal\search_api\Entity\Index;
 use Drupal\user\Entity\Role;
+use Symfony\Component\Yaml\Yaml;
 
 /**
  * Implements hook_update_dependencies().
@@ -225,5 +226,39 @@ function social_search_update_10002() {
   }
   catch (EntityStorageException $e) {
     \Drupal::logger('social_search')->info($e->getMessage());
+  }
+}
+
+/**
+ * Update following search indexes after search_api module v1.19 update.
+ *
+ * 1. Social All
+ * 2. Social Content
+ * 3. Social Groups
+ * 4. Social Users.
+ */
+function social_search_update_10301() {
+  // Prepare the path.
+  $social_search_path = drupal_get_path('module', 'social_search') . '/config/static/';
+
+  $message_templates = [
+    'search_api.index.social_all' => $social_search_path . 'search_api.index.social_all_10301.yml',
+    'search_api.index.social_content' => $social_search_path . 'search_api.index.social_content_10301.yml',
+    'search_api.index.social_groups' => $social_search_path . 'search_api.index.social_groups_10301.yml',
+    'search_api.index.social_users' => $social_search_path . 'search_api.index.social_users_10301.yml',
+  ];
+
+  // Retrieves the configuration factory.
+  $config_factory = \Drupal::configFactory();
+
+  // Update each template file.
+  foreach ($message_templates as $key => $config_file) {
+    if (is_file($config_file)) {
+      $settings = Yaml::parse(file_get_contents($config_file));
+      if (is_array($settings)) {
+        $config = $config_factory->getEditable($key);
+        $config->setData($settings)->save();
+      }
+    }
   }
 }


### PR DESCRIPTION
## Problem
Follow up of #2307. 

As @Kingdutch wrote in https://www.drupal.org/project/social/issues/3171966#comment-14090657.

**8.x-1.16** https://www.drupal.org/project/search_api/releases/8.x-1.16
Due to #3111635: Duplicate dependencies, new index exports will differ substantially from earlier versions after this release. It is advised to re-export all exported search indexes, stored in any config directory or the like, after updating to this release, to avoid confusion when actual changes are later made.

This means we will need to re-create our social*.index.*.yml files. Doing this only for the install folder should be fine. Search API will update the in-database config for us.

## Solution
Re-import all search indexes provided by Open Social social_search module.

## Issue tracker
https://www.drupal.org/project/social/issues/3220157

## How to test
- [ ] Run the update
- [ ] Re-index search server.
- [ ] Check that search performs normally.

## Screenshots
N.A

## Release notes
N.A

## Change Record
N.A

## Translations
N.A