### PR TITLE
Issue #3211565 by Ressinel: Sort users in Group view (improvements).

### DIFF
--- a/modules/social_features/social_profile/src/Plugin/views/field/ProfileEntitySortable.php
+++ b/modules/social_features/social_profile/src/Plugin/views/field/ProfileEntitySortable.php
@@ -125,8 +125,24 @@ class ProfileEntitySortable extends RenderedEntity {
           // We will have different expressions depending on is the Nickname
           // field provided or not.
           $field = in_array('field_profile_nick_name', $order_by_fields) ?
-            "CASE WHEN profile__field_profile_nick_name.field_profile_nick_name_value IS NULL THEN CONCAT(TRIM(profile__field_profile_first_name.field_profile_first_name_value), ' ', TRIM(profile__field_profile_last_name.field_profile_last_name_value)) ELSE TRIM(profile__field_profile_nick_name.field_profile_nick_name_value) END" :
-            "CONCAT(TRIM(profile__field_profile_first_name.field_profile_first_name_value), ' ', TRIM(profile__field_profile_last_name.field_profile_last_name_value))";
+            "CASE WHEN
+              profile__field_profile_nick_name.field_profile_nick_name_value IS NOT NULL
+            THEN
+              TRIM(profile__field_profile_nick_name.field_profile_nick_name_value)
+            WHEN
+              (profile__field_profile_nick_name.field_profile_nick_name_value IS NULL) AND ((profile__field_profile_first_name.field_profile_first_name_value IS NOT NULL) OR (profile__field_profile_last_name.field_profile_last_name_value IS NOT NULL))
+            THEN
+              CONCAT(TRIM(profile__field_profile_first_name.field_profile_first_name_value), ' ', TRIM(profile__field_profile_last_name.field_profile_last_name_value))
+            ELSE
+              TRIM(" . $this->view->relationship['profile']->tableAlias . ".name)
+            END" :
+            "CASE WHEN
+              ((profile__field_profile_first_name.field_profile_first_name_value IS NOT NULL) OR (profile__field_profile_last_name.field_profile_last_name_value IS NOT NULL))
+            THEN
+              CONCAT(TRIM(profile__field_profile_first_name.field_profile_first_name_value), ' ', TRIM(profile__field_profile_last_name.field_profile_last_name_value))
+            ELSE
+              TRIM(" . $this->view->relationship['profile']->tableAlias . ".name)
+            END";
           $query->addField(
             NULL,
             $field,

--- a/modules/social_features/social_profile/src/Plugin/views/field/ProfileEntitySortable.php
+++ b/modules/social_features/social_profile/src/Plugin/views/field/ProfileEntitySortable.php
@@ -124,6 +124,12 @@ class ProfileEntitySortable extends RenderedEntity {
           $this->field_alias = 'profile_full_name';
           // We will have different expressions depending on is the Nickname
           // field provided or not.
+          // Members will be sort by next queue:
+          // - Nickname
+          // - Firstname + Lastname (if Nickname is NULL)
+          // - Firstname (if Nickname and Lastname are NULL)
+          // - Lastname (if Nickname and Firstname are NULL)
+          // - Username (if all Name fields are NULL)
           $field = in_array('field_profile_nick_name', $order_by_fields) ?
             "CASE WHEN
               profile__field_profile_nick_name.field_profile_nick_name_value IS NOT NULL
@@ -132,14 +138,14 @@ class ProfileEntitySortable extends RenderedEntity {
             WHEN
               (profile__field_profile_nick_name.field_profile_nick_name_value IS NULL) AND ((profile__field_profile_first_name.field_profile_first_name_value IS NOT NULL) OR (profile__field_profile_last_name.field_profile_last_name_value IS NOT NULL))
             THEN
-              CONCAT(TRIM(profile__field_profile_first_name.field_profile_first_name_value), ' ', TRIM(profile__field_profile_last_name.field_profile_last_name_value))
+              CONCAT(TRIM(COALESCE(profile__field_profile_first_name.field_profile_first_name_value, '')), ' ', TRIM(COALESCE(profile__field_profile_last_name.field_profile_last_name_value, '')))
             ELSE
               TRIM(" . $this->view->relationship['profile']->tableAlias . ".name)
             END" :
             "CASE WHEN
               ((profile__field_profile_first_name.field_profile_first_name_value IS NOT NULL) OR (profile__field_profile_last_name.field_profile_last_name_value IS NOT NULL))
             THEN
-              CONCAT(TRIM(profile__field_profile_first_name.field_profile_first_name_value), ' ', TRIM(profile__field_profile_last_name.field_profile_last_name_value))
+              CONCAT(TRIM(COALESCE(profile__field_profile_first_name.field_profile_first_name_value, '')), ' ', TRIM(COALESCE(profile__field_profile_last_name.field_profile_last_name_value, '')))
             ELSE
               TRIM(" . $this->view->relationship['profile']->tableAlias . ".name)
             END";


### PR DESCRIPTION
## Problem
1. Update all profiles by post_update take a lot of time
2. Sorting for users which have permission to view hidden fields doesn't works properly.

## Solution
1. Add the Profile name field value directly by database insert to reduce the update time of a large number of profiles.
2. Try to improve sorting code.


## Issue tracker
- https://www.drupal.org/project/social/issues/3211565
- https://getopensocial.atlassian.net/browse/DS-7546

## How to test
- [ ] As GM goes to the group membership page
- [ ] You must be able to sort members taking into account all the limitations of the module Social Profile Privacy.

## Screenshots
N/A

## Release notes
Some improvements and fixes:
1. Reduce the update time of a large number of profiles.
2. Sort members in group view for users which have permission to view hidden fields works fixed and works properly now.

## Change Record
N/A

## Translations
N/A
