### PR TITLE
Issue #3221056 by nkoporec: Don't cache the number of event enrollments

### DIFF
--- a/modules/social_features/social_event/social_event.module
+++ b/modules/social_features/social_event/social_event.module
@@ -285,6 +285,9 @@ function social_event_node_view_alter(array &$build, EntityInterface $entity, En
     $build['enrollments_count'] = [
       '#type' => '#text_field',
       '#markup' => $enrollments_count,
+      '#cache' => [
+        'max-age' => 0,
+      ],
     ];
 
     // Check if ongoing.

--- a/modules/social_features/social_event/social_event.module
+++ b/modules/social_features/social_event/social_event.module
@@ -285,9 +285,6 @@ function social_event_node_view_alter(array &$build, EntityInterface $entity, En
     $build['enrollments_count'] = [
       '#type' => '#text_field',
       '#markup' => $enrollments_count,
-      '#cache' => [
-        'max-age' => 0,
-      ],
     ];
 
     // Check if ongoing.

--- a/modules/social_features/social_event/src/Form/EnrollActionForm.php
+++ b/modules/social_features/social_event/src/Form/EnrollActionForm.php
@@ -435,8 +435,9 @@ class EnrollActionForm extends FormBase implements ContainerInjectionInterface {
 
     // Invalidate cache for our enrollment cache tag in
     // social_event_node_view_alter().
-    $cache_tag = 'enrollment:' . $nid . '-' . $uid;
-    Cache::invalidateTags([$cache_tag]);
+    $cache_tags[] = 'enrollment:' . $nid . '-' . $uid;
+    $cache_tags[] = 'node:' . $nid;
+    Cache::invalidateTags($cache_tags);
 
     if ($enrollment = array_pop($enrollments)) {
       $current_enrollment_status = $enrollment->field_enrollment_status->value;


### PR DESCRIPTION
## Problem
When viewing the event enrollments on /group/*/events the number of enrollments is cached. This means that if after your first page load an additional members joins the event then the enrollment number will not be correct until the render cache is cleared.

## Solution
Don't cache the number.

## Issue tracker
https://www.drupal.org/project/social/issues/3221056

## How to test
*For example*
1. Find a group with an event
2. Go to /group/*/events and check the number of enrollments
3. Go to incognito as a different user and enroll into that event
4. As a previous user reload the /group/*/events page and check the enrollment count ( it will still be the same, even though a new user enrolled)

