### PR TITLE
Issue #3220809 by vnech: Refactor "Social Content Translation" module

### DIFF
--- a/modules/custom/social_language/modules/social_content_translation/config/install/social_content_translation.settings.yml
+++ b/modules/custom/social_language/modules/social_content_translation/config/install/social_content_translation.settings.yml
@@ -1,6 +1,0 @@
-# TODO: Overrides to these settings are currently unusable (See ContentTranslationDefaultsConfigOverride).
-social_book: true
-social_landing_page: true
-social_page: true
-social_event: true
-social_group_flexible_group: true

--- a/modules/custom/social_language/modules/social_content_translation/social_content_translation.install
+++ b/modules/custom/social_language/modules/social_content_translation/social_content_translation.install
@@ -90,4 +90,3 @@ function social_content_translation_update_8002() {
     ->getEditable('social_content_translation.settings')
     ->delete();
 }
-

--- a/modules/custom/social_language/modules/social_content_translation/social_content_translation.install
+++ b/modules/custom/social_language/modules/social_content_translation/social_content_translation.install
@@ -78,14 +78,16 @@ function social_content_translation_disable_field_translations() {
  * Add support translations for entities.
  */
 function social_content_translation_update_8001() {
-  $module_names = [
-    'social_group_flexible_group',
-  ];
-
-  $config = \Drupal::configFactory()->getEditable('social_content_translation.settings');
-
-  foreach ($module_names as $module_name) {
-    $config->set($module_name, TRUE);
-    $config->save(TRUE);
-  }
+  // Don't do anything.
 }
+
+/**
+ * Delete redundant configuration settings.
+ */
+function social_content_translation_update_8002() {
+  // Delete redundant settings.
+  \Drupal::configFactory()
+    ->getEditable('social_content_translation.settings')
+    ->delete();
+}
+

--- a/modules/custom/social_language/modules/social_content_translation/social_content_translation.install
+++ b/modules/custom/social_language/modules/social_content_translation/social_content_translation.install
@@ -84,7 +84,7 @@ function social_content_translation_update_8001() {
 /**
  * Delete redundant configuration settings.
  */
-function social_content_translation_update_8002() {
+function social_content_translation_update_10301() {
   // Delete redundant settings.
   \Drupal::configFactory()
     ->getEditable('social_content_translation.settings')

--- a/modules/custom/social_language/modules/social_content_translation/src/ContentTranslationConfigOverrideBase.php
+++ b/modules/custom/social_language/modules/social_content_translation/src/ContentTranslationConfigOverrideBase.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Drupal\social_core;
+namespace Drupal\social_content_translation;
 
 use Drupal\Core\Cache\CacheableMetadata;
 use Drupal\Core\Config\ConfigFactoryOverrideInterface;
@@ -9,7 +9,7 @@ use Drupal\Core\Config\StorageInterface;
 /**
  * Provides a base class for configurable content translation config overrides.
  *
- * @package Drupal\social_core
+ * @package Drupal\social_content_translation
  */
 abstract class ContentTranslationConfigOverrideBase implements ConfigFactoryOverrideInterface {
 

--- a/modules/social_features/social_book/src/ContentTranslationDefaultsConfigOverride.php
+++ b/modules/social_features/social_book/src/ContentTranslationDefaultsConfigOverride.php
@@ -2,7 +2,6 @@
 
 namespace Drupal\social_book;
 
-use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\social_core\ContentTranslationConfigOverrideBase;
 
 /**
@@ -12,22 +11,11 @@ use Drupal\social_core\ContentTranslationConfigOverrideBase;
  */
 class ContentTranslationDefaultsConfigOverride extends ContentTranslationConfigOverrideBase {
 
-  use StringTranslationTrait;
-
   /**
    * {@inheritdoc}
    */
   protected function getModule() {
     return 'social_book';
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  protected function getDisplayName() {
-    // We can't use dependency injection here because it causes a circular
-    // dependency for the configuration override.
-    return $this->t('Book Pages');
   }
 
   /**

--- a/modules/social_features/social_book/src/ContentTranslationDefaultsConfigOverride.php
+++ b/modules/social_features/social_book/src/ContentTranslationDefaultsConfigOverride.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\social_book;
 
-use Drupal\social_core\ContentTranslationConfigOverrideBase;
+use Drupal\social_content_translation\ContentTranslationConfigOverrideBase;
 
 /**
  * Provides content translation defaults for the book content type.

--- a/modules/social_features/social_book/src/ContentTranslationDefaultsConfigOverride.php
+++ b/modules/social_features/social_book/src/ContentTranslationDefaultsConfigOverride.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\social_book;
 
-use Drupal\social_content_translation\ContentTranslationConfigOverrideBase;
+use Drupal\social_core\ContentTranslationConfigOverrideBase;
 
 /**
  * Provides content translation defaults for the book content type.

--- a/modules/social_features/social_core/src/ContentTranslationConfigOverrideBase.php
+++ b/modules/social_features/social_core/src/ContentTranslationConfigOverrideBase.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Drupal\social_content_translation;
+namespace Drupal\social_core;
 
 use Drupal\Core\Cache\CacheableMetadata;
 use Drupal\Core\Config\ConfigFactoryOverrideInterface;
@@ -9,7 +9,7 @@ use Drupal\Core\Config\StorageInterface;
 /**
  * Provides a base class for configurable content translation config overrides.
  *
- * @package Drupal\social_content_translation
+ * @package Drupal\social_core
  */
 abstract class ContentTranslationConfigOverrideBase implements ConfigFactoryOverrideInterface {
 

--- a/modules/social_features/social_core/src/ContentTranslationConfigOverrideBase.php
+++ b/modules/social_features/social_core/src/ContentTranslationConfigOverrideBase.php
@@ -28,25 +28,12 @@ abstract class ContentTranslationConfigOverrideBase implements ConfigFactoryOver
   /**
    * Returns the module that provides the overrides.
    *
-   * This is used as the social_contant_translation.settings configuration key
-   * as well as in the cache suffix for the overrides.
+   * This is used as the cache suffix for the overrides.
    *
    * @return string
    *   The module name providing the overrides.
    */
   abstract protected function getModule();
-
-  /**
-   * Returns the display name for this set of configuration overrides.
-   *
-   * This can be used in a user interface to let sitemanagers determine which
-   * parts of Open Social should be translatable. For consistency when
-   * displaying this should always be a plural string.
-   *
-   * @return \Drupal\Core\StringTranslation\TranslatableMarkup|string
-   *   The (translatable) string that can be shown to the user.
-   */
-  abstract protected function getDisplayName();
 
   /**
    * {@inheritdoc}
@@ -56,10 +43,9 @@ abstract class ContentTranslationConfigOverrideBase implements ConfigFactoryOver
 
     // This setting can't be changed in an override because that would create
     // and endless loop in trying to apply the override.
-    $settings = \Drupal::configFactory()->getEditable('social_content_translation.settings');
-    $is_enabled = $settings->getOriginal($this->getModule(), FALSE);
+    $is_content_translations_enabled = \Drupal::moduleHandler()->getModule('social_content_translation');
 
-    if ($is_enabled) {
+    if ($is_content_translations_enabled) {
       $translation_overrides = $this->getTranslationOverrides();
 
       foreach ($translation_overrides as $name => $override) {
@@ -93,11 +79,7 @@ abstract class ContentTranslationConfigOverrideBase implements ConfigFactoryOver
    * {@inheritdoc}
    */
   public function getCacheableMetadata($name) {
-    $metadata = new CacheableMetadata();
-    if (in_array($name, $this->getOverriddenConfigurations())) {
-      $metadata->addCacheTags(['config:social_content_translation.settings']);
-    }
-    return $metadata;
+    return new CacheableMetadata();
   }
 
   /**

--- a/modules/social_features/social_core/src/ContentTranslationConfigOverrideBase.php
+++ b/modules/social_features/social_core/src/ContentTranslationConfigOverrideBase.php
@@ -43,7 +43,7 @@ abstract class ContentTranslationConfigOverrideBase implements ConfigFactoryOver
 
     // This setting can't be changed in an override because that would create
     // and endless loop in trying to apply the override.
-    $is_content_translations_enabled = \Drupal::moduleHandler()->getModule('social_content_translation');
+    $is_content_translations_enabled = \Drupal::moduleHandler()->moduleExists('social_content_translation');
 
     if ($is_content_translations_enabled) {
       $translation_overrides = $this->getTranslationOverrides();

--- a/modules/social_features/social_event/src/ContentTranslationDefaultsConfigOverride.php
+++ b/modules/social_features/social_event/src/ContentTranslationDefaultsConfigOverride.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\social_event;
 
-use Drupal\social_core\ContentTranslationConfigOverrideBase;
+use Drupal\social_content_translation\ContentTranslationConfigOverrideBase;
 
 /**
  * Provides content translation defaults for the event content type.

--- a/modules/social_features/social_event/src/ContentTranslationDefaultsConfigOverride.php
+++ b/modules/social_features/social_event/src/ContentTranslationDefaultsConfigOverride.php
@@ -3,7 +3,6 @@
 namespace Drupal\social_event;
 
 use Drupal\social_core\ContentTranslationConfigOverrideBase;
-use Drupal\Core\StringTranslation\StringTranslationTrait;
 
 /**
  * Provides content translation defaults for the event content type.
@@ -12,22 +11,11 @@ use Drupal\Core\StringTranslation\StringTranslationTrait;
  */
 class ContentTranslationDefaultsConfigOverride extends ContentTranslationConfigOverrideBase {
 
-  use StringTranslationTrait;
-
   /**
    * {@inheritdoc}
    */
   protected function getModule() {
     return 'social_event';
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  protected function getDisplayName() {
-    // We can't use dependency injection here because it causes a circular
-    // dependency for the configuration override.
-    return $this->t('Events');
   }
 
   /**

--- a/modules/social_features/social_event/src/ContentTranslationDefaultsConfigOverride.php
+++ b/modules/social_features/social_event/src/ContentTranslationDefaultsConfigOverride.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\social_event;
 
-use Drupal\social_content_translation\ContentTranslationConfigOverrideBase;
+use Drupal\social_core\ContentTranslationConfigOverrideBase;
 
 /**
  * Provides content translation defaults for the event content type.

--- a/modules/social_features/social_group/modules/social_group_flexible_group/src/ContentTranslationDefaultsConfigOverride.php
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/src/ContentTranslationDefaultsConfigOverride.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\social_group_flexible_group;
 
-use Drupal\social_content_translation\ContentTranslationConfigOverrideBase;
+use Drupal\social_core\ContentTranslationConfigOverrideBase;
 
 /**
  * Provides content translation defaults for the flexible group type.

--- a/modules/social_features/social_group/modules/social_group_flexible_group/src/ContentTranslationDefaultsConfigOverride.php
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/src/ContentTranslationDefaultsConfigOverride.php
@@ -2,7 +2,6 @@
 
 namespace Drupal\social_group_flexible_group;
 
-use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\social_core\ContentTranslationConfigOverrideBase;
 
 /**
@@ -12,22 +11,11 @@ use Drupal\social_core\ContentTranslationConfigOverrideBase;
  */
 class ContentTranslationDefaultsConfigOverride extends ContentTranslationConfigOverrideBase {
 
-  use StringTranslationTrait;
-
   /**
    * {@inheritdoc}
    */
   protected function getModule() {
     return 'social_group_flexible_group';
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  protected function getDisplayName() {
-    // We can't use dependency injection here because it causes a circular
-    // dependency for the configuration override.
-    return $this->t('Flexible group');
   }
 
   /**

--- a/modules/social_features/social_group/modules/social_group_flexible_group/src/ContentTranslationDefaultsConfigOverride.php
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/src/ContentTranslationDefaultsConfigOverride.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\social_group_flexible_group;
 
-use Drupal\social_core\ContentTranslationConfigOverrideBase;
+use Drupal\social_content_translation\ContentTranslationConfigOverrideBase;
 
 /**
  * Provides content translation defaults for the flexible group type.

--- a/modules/social_features/social_landing_page/src/ContentTranslationDefaultsConfigOverride.php
+++ b/modules/social_features/social_landing_page/src/ContentTranslationDefaultsConfigOverride.php
@@ -21,15 +21,6 @@ class ContentTranslationDefaultsConfigOverride extends ContentTranslationConfigO
   /**
    * {@inheritdoc}
    */
-  protected function getDisplayName() {
-    // We can't use dependency injection here because it causes a circular
-    // dependency for the configuration override.
-    return \Drupal::translation()->translate('Landing Pages');
-  }
-
-  /**
-   * {@inheritdoc}
-   */
   protected function getTranslationOverrides() {
     return [
       'language.content_settings.node.landing_page' => [

--- a/modules/social_features/social_landing_page/src/ContentTranslationDefaultsConfigOverride.php
+++ b/modules/social_features/social_landing_page/src/ContentTranslationDefaultsConfigOverride.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\social_landing_page;
 
-use Drupal\social_content_translation\ContentTranslationConfigOverrideBase;
+use Drupal\social_core\ContentTranslationConfigOverrideBase;
 
 /**
  * Provides content translation defaults for the landing page content type.

--- a/modules/social_features/social_landing_page/src/ContentTranslationDefaultsConfigOverride.php
+++ b/modules/social_features/social_landing_page/src/ContentTranslationDefaultsConfigOverride.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\social_landing_page;
 
-use Drupal\social_core\ContentTranslationConfigOverrideBase;
+use Drupal\social_content_translation\ContentTranslationConfigOverrideBase;
 
 /**
  * Provides content translation defaults for the landing page content type.

--- a/modules/social_features/social_page/src/ContentTranslationDefaultsConfigOverride.php
+++ b/modules/social_features/social_page/src/ContentTranslationDefaultsConfigOverride.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\social_page;
 
-use Drupal\social_content_translation\ContentTranslationConfigOverrideBase;
+use Drupal\social_core\ContentTranslationConfigOverrideBase;
 
 /**
  * Provides content translation defaults for the basic page content type.

--- a/modules/social_features/social_page/src/ContentTranslationDefaultsConfigOverride.php
+++ b/modules/social_features/social_page/src/ContentTranslationDefaultsConfigOverride.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\social_page;
 
-use Drupal\social_core\ContentTranslationConfigOverrideBase;
+use Drupal\social_content_translation\ContentTranslationConfigOverrideBase;
 
 /**
  * Provides content translation defaults for the basic page content type.

--- a/modules/social_features/social_page/src/ContentTranslationDefaultsConfigOverride.php
+++ b/modules/social_features/social_page/src/ContentTranslationDefaultsConfigOverride.php
@@ -21,15 +21,6 @@ class ContentTranslationDefaultsConfigOverride extends ContentTranslationConfigO
   /**
    * {@inheritdoc}
    */
-  protected function getDisplayName() {
-    // We can't use dependency injection here because it causes a circular
-    // dependency for the configuration override.
-    return \Drupal::translation()->translate('Pages');
-  }
-
-  /**
-   * {@inheritdoc}
-   */
   protected function getTranslationOverrides() {
     return [
       'language.content_settings.node.page' => [

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2301,7 +2301,7 @@ parameters:
 			path: modules/custom/social_language/modules/social_content_translation/src/ContentTranslationConfigOverrideBase.php
 
 		-
-			message: "#^Method Drupal\\\\social_core\\\\ContentTranslationConfigOverrideBase\\:\\:createConfigObject\\(\\) should return Drupal\\\\Core\\\\Config\\\\StorableConfigBase but returns null\\.$#"
+			message: "#^Method Drupal\\\\social_content_translation\\\\ContentTranslationConfigOverrideBase\\:\\:createConfigObject\\(\\) should return Drupal\\\\Core\\\\Config\\\\StorableConfigBase but returns null\\.$#"
 			count: 1
 			path: modules/custom/social_language/modules/social_content_translation/src/ContentTranslationConfigOverrideBase.php
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2298,12 +2298,12 @@ parameters:
 		-
 			message: "#^\\\\Drupal calls should be avoided in classes, use dependency injection instead$#"
 			count: 1
-			path: modules/social_features/social_content_translation/src/ContentTranslationConfigOverrideBase.php
+			path: modules/custom/social_language/modules/social_content_translation/src/ContentTranslationConfigOverrideBase.php
 
 		-
 			message: "#^Method Drupal\\\\social_core\\\\ContentTranslationConfigOverrideBase\\:\\:createConfigObject\\(\\) should return Drupal\\\\Core\\\\Config\\\\StorableConfigBase but returns null\\.$#"
 			count: 1
-			path: modules/social_features/social_content_translation/src/ContentTranslationConfigOverrideBase.php
+			path: modules/custom/social_language/modules/social_content_translation/src/ContentTranslationConfigOverrideBase.php
 
 		-
 			message: "#^\\\\Drupal calls should be avoided in classes, use dependency injection instead$#"

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2298,12 +2298,12 @@ parameters:
 		-
 			message: "#^\\\\Drupal calls should be avoided in classes, use dependency injection instead$#"
 			count: 1
-			path: modules/social_features/social_core/src/ContentTranslationConfigOverrideBase.php
+			path: modules/social_features/social_content_translation/src/ContentTranslationConfigOverrideBase.php
 
 		-
 			message: "#^Method Drupal\\\\social_core\\\\ContentTranslationConfigOverrideBase\\:\\:createConfigObject\\(\\) should return Drupal\\\\Core\\\\Config\\\\StorableConfigBase but returns null\\.$#"
 			count: 1
-			path: modules/social_features/social_core/src/ContentTranslationConfigOverrideBase.php
+			path: modules/social_features/social_content_translation/src/ContentTranslationConfigOverrideBase.php
 
 		-
 			message: "#^\\\\Drupal calls should be avoided in classes, use dependency injection instead$#"

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2298,12 +2298,12 @@ parameters:
 		-
 			message: "#^\\\\Drupal calls should be avoided in classes, use dependency injection instead$#"
 			count: 1
-			path: modules/custom/social_language/modules/social_content_translation/src/ContentTranslationConfigOverrideBase.php
+			path: modules/social_features/social_core/src/ContentTranslationConfigOverrideBase.php
 
 		-
-			message: "#^Method Drupal\\\\social_content_translation\\\\ContentTranslationConfigOverrideBase\\:\\:createConfigObject\\(\\) should return Drupal\\\\Core\\\\Config\\\\StorableConfigBase but returns null\\.$#"
+			message: "#^Method Drupal\\\\social_core\\\\ContentTranslationConfigOverrideBase\\:\\:createConfigObject\\(\\) should return Drupal\\\\Core\\\\Config\\\\StorableConfigBase but returns null\\.$#"
 			count: 1
-			path: modules/custom/social_language/modules/social_content_translation/src/ContentTranslationConfigOverrideBase.php
+			path: modules/social_features/social_core/src/ContentTranslationConfigOverrideBase.php
 
 		-
 			message: "#^\\\\Drupal calls should be avoided in classes, use dependency injection instead$#"

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -5079,8 +5079,3 @@ parameters:
 			message: "#^Negated boolean expression is always false\\.$#"
 			count: 1
 			path: src/Installer/OptionalModuleManager.php
-
-		-
-			message: "#^If condition is always true\\.$#"
-			count: 1
-			path: modules/social_features/social_core/src/ContentTranslationConfigOverrideBase.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -5080,3 +5080,7 @@ parameters:
 			count: 1
 			path: src/Installer/OptionalModuleManager.php
 
+		-
+			message: "#^If condition is always true\\.$#"
+			count: 1
+			path: modules/social_features/social_core/src/ContentTranslationConfigOverrideBase.php


### PR DESCRIPTION
## Problem
We have the module "Social Language - Content Translation"(`social_content_translation`) module responsible for enabling content translations support in Distro. 

In general, this module has a settings `social_content_translation.settings` with a list of modules for what we enable loading special config overrides classes extended from abstract class `Drupal\social_core\ContentTranslationConfigOverrideBase`
We don't have any page where we can configure these settings. Seems this configuration is redundant as just enough to enable the module `social_content_translation` for loading all translations.


## Solution
Delete redundant config `social_content_translation.settings` and make translation support depending only from enabling/disabling the module `social_content_translation`.

## Issue tracker
- https://www.drupal.org/project/social/issues/3220809
- https://getopensocial.atlassian.net/browse/YANG-5904

## How to test
- [ ] Login as an admin
- [ ] Enable an extention "Social Language - Content Translation"
- [ ] Add a Flexible group
- [ ] Add a translation for created flexible group

## Release notes
*Make translations support depending only from enabling/disabling the module `social_content_translation`*

## Change Record
- Delete `social_content_translation.settings` configuration
