### PR TITLE
Issue #3222350 by navneet0693: Locked gin_toolbar version to 1.0-beta17.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -138,7 +138,7 @@
         "drupal/field_group": "3.1",
         "drupal/flag": "4.0-alpha3",
         "drupal/gin": "3.0.0-alpha34",
-        "drupal/gin_toolbar": "^1.0@beta",
+        "drupal/gin_toolbar": "1.0-beta17",
         "drupal/graphql": "^4.1",
         "drupal/group": "1.0-rc5",
         "drupal/image_effects": "3.1",


### PR DESCRIPTION
## Problem
Gin toolbar 1.0-beta18 makes toolbar disappear even for the superuser (UID 1)

## Solution
Lock gin_toolbar to 1.0-beta17.

## Issue tracker
https://www.drupal.org/project/social/issues/3222350

## How to test
- [ ] Install OpenSocial
- [ ] Check toolbar works fine.

## Screenshots
N.A

## Release notes
Gin toolbar version is locked to 1.0-beta17

## Change Record
N.A

## Translations
N.A