### PR TITLE
Issue #3222538 by vnech: Allow "Content Manager" role to translate content

### DIFF
--- a/modules/custom/social_language/social_language.install
+++ b/modules/custom/social_language/social_language.install
@@ -44,13 +44,16 @@ function _social_language_set_permissions() {
  * Build the permissions.
  */
 function _social_language_get_permissions($role) {
-  // Site manager.
-  $permissions['sitemanager'] = [
+  // Content manager.
+  $permissions['contentmanager'] = [
     'create content translations',
     'delete content translations',
     'update content translations',
     'translate any entity',
   ];
+
+  // Site manager.
+  $permissions['sitemanager'] = $permissions['contentmanager'];
 
   return isset($permissions[$role]) ? $permissions[$role] : [];
 }
@@ -114,3 +117,12 @@ YAML;
     'translate topic_types taxonomy_term',
   ]);
 }
+
+/**
+ * Allow "Content Manager" role to manage translations.
+ */
+function social_language_update_10301() {
+  // The function grand permissions.
+  _social_language_set_permissions();
+}
+

--- a/modules/custom/social_language/social_language.install
+++ b/modules/custom/social_language/social_language.install
@@ -123,6 +123,10 @@ YAML;
  * Allow "Content Manager" role to manage translations.
  */
 function social_language_update_10301() {
-  // The function grand permissions.
-  _social_language_set_permissions();
+  $permissions = [
+    'create content translations',
+    'delete content translations',
+    'update content translations',
+  ];
+  user_role_grant_permissions('contentmanager', $permissions);
 }

--- a/modules/custom/social_language/social_language.install
+++ b/modules/custom/social_language/social_language.install
@@ -125,4 +125,3 @@ function social_language_update_10301() {
   // The function grand permissions.
   _social_language_set_permissions();
 }
-

--- a/modules/custom/social_language/social_language.install
+++ b/modules/custom/social_language/social_language.install
@@ -49,11 +49,12 @@ function _social_language_get_permissions($role) {
     'create content translations',
     'delete content translations',
     'update content translations',
-    'translate any entity',
   ];
 
   // Site manager.
-  $permissions['sitemanager'] = $permissions['contentmanager'];
+  $permissions['sitemanager'] = array_merge($permissions['contentmanager'], [
+    'translate any entity',
+  ]);
 
   return isset($permissions[$role]) ? $permissions[$role] : [];
 }

--- a/modules/custom/social_language/social_language.module
+++ b/modules/custom/social_language/social_language.module
@@ -5,6 +5,7 @@
  * Contains social_language.module.
  */
 
+use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Url;
 
@@ -56,7 +57,7 @@ function social_language_entity_operation_alter(array &$operations, EntityInterf
   // "Content Translations" module allows to add translations
   // to the entity that user can't edit...This cause displaying
   // the redundant operation "translate" in entity list pages.
-  /** @see content_translation_translate_access() */
+  /* @see content_translation_translate_access() */
   if (!empty($operations['translate'])) {
     // All checks are already done in social_language_entity_operation()
     // and we need only add the last one.

--- a/modules/custom/social_language/social_language.module
+++ b/modules/custom/social_language/social_language.module
@@ -48,3 +48,22 @@ function social_language_social_group_default_route_tabs_alter(&$tabs) {
   // Unset some tabs created by group.
   unset($tabs['content_translation.local_tasks:entity.group.content_translation_overview']);
 }
+
+/**
+ * Implements hook_entity_operation_alter().
+ */
+function social_language_entity_operation_alter(array &$operations, EntityInterface $entity): array {
+  // "Content Translations" module allows to add translations
+  // to the entity that user can't edit...This cause displaying
+  // the redundant operation "translate" in entity list pages.
+  /** @see content_translation_translate_access() */
+  if (!empty($operations['translate'])) {
+    // All checks are already done in social_language_entity_operation()
+    // and we need only add the last one.
+    if (!$entity->access('update')) {
+      // Remove the operation if user can't edit entity.
+      unset($operations['translate']);
+    }
+  }
+  return $operations;
+}

--- a/modules/custom/social_language/src/Routing/RouteSubscriber.php
+++ b/modules/custom/social_language/src/Routing/RouteSubscriber.php
@@ -52,7 +52,7 @@ class RouteSubscriber extends RouteSubscriberBase {
         }
       }
     }
-    
+
     // Restrict access to translations if user can't edit the original content.
     // @todo: make there restrictions more general (for custom entities, blocks, etc)
     $entity_types = ['node', 'group'];

--- a/modules/custom/social_language/src/Routing/RouteSubscriber.php
+++ b/modules/custom/social_language/src/Routing/RouteSubscriber.php
@@ -52,6 +52,23 @@ class RouteSubscriber extends RouteSubscriberBase {
         }
       }
     }
+    
+    // Restrict access to translations if user can't edit the original content.
+    // @todo: make there restrictions more general (for custom entities, blocks, etc)
+    $entity_types = ['node', 'group'];
+    foreach ($entity_types as $entity_type_id) {
+      $routes = [
+        "entity.{$entity_type_id}.content_translation_overview",
+        "entity.{$entity_type_id}.content_translation_add",
+        "entity.{$entity_type_id}.content_translation_edit",
+        "entity.{$entity_type_id}.content_translation_delete",
+      ];
+      foreach ($routes as $name) {
+        if ($route = $collection->get($name)) {
+          $route->setRequirement('_entity_access', "{$entity_type_id}.update");
+        }
+      }
+    }
 
   }
 

--- a/modules/social_features/social_book/social_book.install
+++ b/modules/social_features/social_book/social_book.install
@@ -85,6 +85,7 @@ function _social_book_get_permissions($role) {
     'edit any book content',
     'edit own book content',
     'view book revisions',
+    'translate book node',
   ]);
 
   // Site manager.
@@ -255,4 +256,13 @@ function social_book_update_8903() {
     'core.entity_view_display.node.book.small_teaser',
     $source->read('social_book_static_update_8903')
   );
+}
+
+/**
+ * Allow CM+ translate "Book Page" node type.
+ */
+function social_book_update_10301() {
+  foreach (['sitemanager', 'contentmanager'] as $role_id) {
+    user_role_grant_permissions($role_id, ['translate book node']);
+  }
 }

--- a/modules/social_features/social_event/social_event.install
+++ b/modules/social_features/social_event/social_event.install
@@ -70,6 +70,7 @@ function _social_event_get_permissions($role) {
 
   // Content manager.
   $permissions['contentmanager'] = array_merge($permissions['authenticated'], [
+    'translate event node',
     'delete any event content',
     'edit any event content',
     'revert event revisions',
@@ -1862,4 +1863,13 @@ function social_event_update_8919() {
 
   // Output logged messages to related channel of update execution.
   return $updateHelper->logger()->output();
+}
+
+/**
+ * Allow CM+ translate "Event" node type.
+ */
+function social_event_update_10301() {
+  foreach (['sitemanager', 'contentmanager'] as $role_id) {
+    user_role_grant_permissions($role_id, ['translate event node']);
+  }
 }

--- a/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.install
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.install
@@ -57,7 +57,9 @@ function _social_group_flexible_group_get_permissions($role) {
   ]);
 
   // Content manager.
-  $permissions['contentmanager'] = array_merge($permissions['authenticated'], []);
+  $permissions['contentmanager'] = array_merge($permissions['authenticated'], [
+    'translate flexible_group group',
+  ]);
 
   // Site manager.
   $permissions['sitemanager'] = array_merge($permissions['contentmanager'], []);
@@ -396,4 +398,13 @@ function social_group_flexible_group_update_8912() {
 
   // Output logged messages to related channel of update execution.
   return $updateHelper->logger()->output();
+}
+
+/**
+ * Allow CM+ translate "Flexible Group" group type.
+ */
+function social_group_flexible_update_10301() {
+  foreach (['sitemanager', 'contentmanager'] as $role_id) {
+    user_role_grant_permissions($role_id, ['translate flexible_group group']);
+  }
 }

--- a/modules/social_features/social_landing_page/social_landing_page.install
+++ b/modules/social_features/social_landing_page/social_landing_page.install
@@ -61,6 +61,7 @@ function _social_landing_page_get_permissions($role) {
     'delete own landing_page content',
     'edit any landing_page content',
     'edit own landing_page content',
+    'translate landing_page node',
     'view landing_page revisions',
     'delete landing_page revisions',
     'revert landing_page revisions',
@@ -692,4 +693,13 @@ function social_landing_page_update_8811() {
 
   // Output logged messages to related channel of update execution.
   return $updateHelper->logger()->output();
+}
+
+/**
+ * Allow CM+ translate "Landing Page" node type.
+ */
+function social_landing_page_update_10301() {
+  foreach (['sitemanager', 'contentmanager'] as $role_id) {
+    user_role_grant_permissions($role_id, ['translate landing_page node']);
+  }
 }

--- a/modules/social_features/social_page/social_page.install
+++ b/modules/social_features/social_page/social_page.install
@@ -58,6 +58,7 @@ function _social_page_get_permissions($role) {
     'delete own page content',
     'edit any page content',
     'edit own page content',
+    'translate page node',
     'view page revisions',
     'delete page revisions',
     'revert page revisions',
@@ -205,4 +206,13 @@ function social_page_update_8908() {
     'core.entity_view_display.node.page.small_teaser',
     $source->read('social_page_static_update_8908')
   );
+}
+
+/**
+ * Allow CM+ translate "Basic Page" node type.
+ */
+function social_page_update_10301() {
+  foreach (['sitemanager', 'contentmanager'] as $role_id) {
+    user_role_grant_permissions($role_id, ['translate page node']);
+  }
 }

--- a/modules/social_features/social_topic/social_topic.install
+++ b/modules/social_features/social_topic/social_topic.install
@@ -417,7 +417,7 @@ function social_topic_update_8909() {
 /**
  * Allow CM+ translate "Topic" node type.
  */
-function social_topic_update_10301() {
+function social_topic_update_10302() {
   foreach (['sitemanager', 'contentmanager'] as $role_id) {
     user_role_grant_permissions($role_id, ['translate topic node']);
   }

--- a/modules/social_features/social_topic/social_topic.install
+++ b/modules/social_features/social_topic/social_topic.install
@@ -94,6 +94,7 @@ function _social_topic_get_permissions($role) {
 
   // Content manager.
   $permissions['contentmanager'] = array_merge($permissions['authenticated'], [
+    'translate topic node',
     'delete any topic content',
     'edit any topic content',
     'revert topic revisions',
@@ -410,5 +411,14 @@ function social_topic_update_8909() {
 
       $config->setData($settings)->save(TRUE);
     }
+  }
+}
+
+/**
+ * Allow CM+ translate "Topic" node type.
+ */
+function social_topic_update_10301() {
+  foreach (['sitemanager', 'contentmanager'] as $role_id) {
+    user_role_grant_permissions($role_id, ['translate topic node']);
   }
 }


### PR DESCRIPTION
## Problem
In OS "Content manager" role doesn't have permissions to add/edit/delete translations but has permissions to manage most of the content.

## Solution
Grand "Content manager" role with permissions to translate content he has permissions to edit.

## Issue tracker
- https://www.drupal.org/project/social/issues/3222538
- https://getopensocial.atlassian.net/browse/YANG-5978
- https://getopensocial.atlassian.net/browse/YANG-5985

## How to test
- [ ] Make sure your site is multilingual
- [ ] Login as CM
- [ ] Create an Event
- [ ] Try to add a translation to the created event

## Release notes
*Allow "Content Manager" role to translate content.*
