### PR TITLE
DS-7613 - 1: Short-cut UserQuery for anonymous users

### DIFF
--- a/modules/custom/social_graphql/src/GraphQL/EmptyEntityConnection.php
+++ b/modules/custom/social_graphql/src/GraphQL/EmptyEntityConnection.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\social_graphql\GraphQL;
+
+use GraphQL\Deferred;
+use GraphQL\Executor\Promise\Adapter\SyncPromise;
+
+/**
+ * Provides an entity connection when it's known there are no results.
+ *
+ * @package Drupal\social_graphql\GraphQL
+ */
+class EmptyEntityConnection implements ConnectionInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setPagination(?int $first, ?string $after, ?int $last, ?string $before, bool $reverse): ConnectionInterface {
+    return $this;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function pageInfo(): SyncPromise {
+    return new Deferred(
+      fn () => [
+        'hasNextPage' => FALSE,
+        'hasPreviousPage' => FALSE,
+        'startCursor' => NULL,
+        'endCursor' => NULL,
+      ]
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function edges(): SyncPromise {
+    return new Deferred(fn () => []);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function nodes(): SyncPromise {
+    return new Deferred(fn () => []);
+  }
+
+}

--- a/modules/custom/social_graphql/src/Plugin/GraphQL/DataProducer/Connection/ConnectionEdges.php
+++ b/modules/custom/social_graphql/src/Plugin/GraphQL/DataProducer/Connection/ConnectionEdges.php
@@ -4,6 +4,7 @@ namespace Drupal\social_graphql\Plugin\GraphQL\DataProducer\Connection;
 
 use Drupal\graphql\Plugin\DataProducerPluginCachingInterface;
 use Drupal\graphql\Plugin\GraphQL\DataProducer\DataProducerPluginBase;
+use Drupal\social_graphql\GraphQL\ConnectionInterface;
 use Drupal\social_graphql\GraphQL\EntityConnection;
 
 /**
@@ -28,13 +29,13 @@ class ConnectionEdges extends DataProducerPluginBase implements DataProducerPlug
   /**
    * Resolves the request.
    *
-   * @param \Drupal\social_graphql\GraphQL\EntityConnection $connection
+   * @param \Drupal\social_graphql\GraphQL\ConnectionInterface $connection
    *   The connection to return the edges from.
    *
    * @return mixed
    *   The edges for the connection.
    */
-  public function resolve(EntityConnection $connection) {
+  public function resolve(ConnectionInterface $connection) {
     return $connection->edges();
   }
 

--- a/modules/custom/social_graphql/src/Plugin/GraphQL/DataProducer/Connection/ConnectionPageInfo.php
+++ b/modules/custom/social_graphql/src/Plugin/GraphQL/DataProducer/Connection/ConnectionPageInfo.php
@@ -4,6 +4,7 @@ namespace Drupal\social_graphql\Plugin\GraphQL\DataProducer\Connection;
 
 use Drupal\graphql\Plugin\DataProducerPluginCachingInterface;
 use Drupal\graphql\Plugin\GraphQL\DataProducer\DataProducerPluginBase;
+use Drupal\social_graphql\GraphQL\ConnectionInterface;
 use Drupal\social_graphql\GraphQL\EntityConnection;
 
 /**
@@ -28,13 +29,13 @@ class ConnectionPageInfo extends DataProducerPluginBase implements DataProducerP
   /**
    * Resolves the request.
    *
-   * @param \Drupal\social_graphql\GraphQL\EntityConnection $connection
+   * @param \Drupal\social_graphql\GraphQL\ConnectionInterface $connection
    *   The connection to return the page info for.
    *
    * @return mixed
    *   The page info for the connection.
    */
-  public function resolve(EntityConnection $connection) {
+  public function resolve(ConnectionInterface $connection) {
     return $connection->pageInfo();
   }
 

--- a/modules/social_features/social_user/src/Plugin/GraphQL/DataProducer/QueryUser.php
+++ b/modules/social_features/social_user/src/Plugin/GraphQL/DataProducer/QueryUser.php
@@ -3,9 +3,17 @@
 namespace Drupal\social_user\Plugin\GraphQL\DataProducer;
 
 use Drupal\Core\Cache\RefinableCacheableDependencyInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\graphql\GraphQL\Buffers\EntityBuffer;
+use Drupal\graphql\GraphQL\Buffers\EntityRevisionBuffer;
+use Drupal\graphql\GraphQL\Buffers\EntityUuidBuffer;
+use Drupal\social_graphql\GraphQL\EmptyEntityConnection;
 use Drupal\social_graphql\GraphQL\EntityConnection;
 use Drupal\social_graphql\Plugin\GraphQL\DataProducer\Entity\EntityDataProducerPluginBase;
 use Drupal\social_user\GraphQL\QueryHelper\UserQueryHelper;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Queries the users on the platform.
@@ -47,7 +55,68 @@ use Drupal\social_user\GraphQL\QueryHelper\UserQueryHelper;
  *   }
  * )
  */
-class QueryUser extends EntityDataProducerPluginBase {
+class QueryUser extends EntityDataProducerPluginBase implements ContainerFactoryPluginInterface {
+
+  /**
+   * The current user.
+   *
+   * @var \Drupal\Core\Session\AccountInterface
+   */
+  protected AccountInterface $currentUser;
+
+  /**
+   * {@inheritdoc}
+   *
+   * @codeCoverageIgnore
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('entity_type.manager'),
+      $container->get('graphql.buffer.entity'),
+      $container->get('graphql.buffer.entity_uuid'),
+      $container->get('graphql.buffer.entity_revision'),
+      $container->get('current_user')
+    );
+  }
+
+  /**
+   * EntityLoad constructor.
+   *
+   * @param array $configuration
+   *   The plugin configuration array.
+   * @param string $pluginId
+   *   The plugin id.
+   * @param array $pluginDefinition
+   *   The plugin definition array.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
+   *   The entity type manager service.
+   * @param \Drupal\graphql\GraphQL\Buffers\EntityBuffer $graphqlEntityBuffer
+   *   The GraphQL entity buffer.
+   * @param \Drupal\graphql\GraphQL\Buffers\EntityUuidBuffer $graphqlEntityUuidBuffer
+   *   The GraphQL entity uuid buffer.
+   * @param \Drupal\graphql\GraphQL\Buffers\EntityRevisionBuffer $graphqlEntityRevisionBuffer
+   *   The GraphQL entity revision buffer.
+   * @param \Drupal\Core\Session\AccountInterface $current_user
+   *   The current user.
+   *
+   * @codeCoverageIgnore
+   */
+  public function __construct(
+    array $configuration,
+    $pluginId,
+    array $pluginDefinition,
+    EntityTypeManagerInterface $entityTypeManager,
+    EntityBuffer $graphqlEntityBuffer,
+    EntityUuidBuffer $graphqlEntityUuidBuffer,
+    EntityRevisionBuffer $graphqlEntityRevisionBuffer,
+    AccountInterface $current_user
+  ) {
+    parent::__construct($configuration, $pluginId, $pluginDefinition, $entityTypeManager, $graphqlEntityBuffer, $graphqlEntityUuidBuffer, $graphqlEntityRevisionBuffer);
+    $this->currentUser = $current_user;
+  }
 
   /**
    * Resolves the request to the requested values.
@@ -74,6 +143,12 @@ class QueryUser extends EntityDataProducerPluginBase {
    * @todo https://www.drupal.org/project/social/issues/3191637
    */
   public function resolve(?int $first, ?string $after, ?int $last, ?string $before, bool $reverse, string $sortKey, RefinableCacheableDependencyInterface $metadata) {
+    // This is a quick fix due to an incorrect entity access layer for users
+    // do not copy this, but fix your access checks instead.
+    if ($this->currentUser->isAnonymous()) {
+      return new EmptyEntityConnection();
+    }
+
     $query_helper = new UserQueryHelper($sortKey, $this->entityTypeManager, $this->graphqlEntityBuffer);
     $metadata->addCacheableDependency($query_helper);
 

--- a/modules/social_features/social_user/tests/src/Kernel/GraphQL/GraphQLUsersEndpointTest.php
+++ b/modules/social_features/social_user/tests/src/Kernel/GraphQL/GraphQLUsersEndpointTest.php
@@ -29,21 +29,12 @@ class GraphQLUsersEndpointTest extends SocialGraphQLTestBase {
   ];
 
   /**
-   * An array of test users that serves as test data.
-   *
-   * @var \Drupal\user\Entity\User[]
+   * Test the filter for the users query.
    */
-  private $users = [];
-
-  /**
-   * {@inheritdoc}
-   */
-  protected function setUp() : void {
-    parent::setUp();
-
+  public function testUsersQueryFilter(): void {
     // Load the existing non-anonymous users as they're part of the dataset that
     // we want to verify test output against.
-    $this->users = array_values(
+    $users = array_values(
       array_filter(
         User::loadMultiple(),
         static function (User $u) {
@@ -54,30 +45,20 @@ class GraphQLUsersEndpointTest extends SocialGraphQLTestBase {
     // Create a set of 10 test users that we can query. The data of the users
     // shouldn't matter.
     for ($i = 0; $i < 10; ++$i) {
-      $this->users[] = $this->createUser();
+      $users[] = $this->createUser();
     }
-  }
 
-  /**
-   * Test the filter for the users query.
-   */
-  public function testUsersQueryFilter(): void {
     $this->assertEndpointSupportsPagination(
       'users',
-      array_map(static fn ($user) => $user->uuid(), $this->users)
+      array_map(static fn ($user) => $user->uuid(), $users)
     );
   }
 
   /**
    * Ensure that the fields for the user endpoint properly resolve.
-   *
-   * This test does not test the validity of the resolved data but merely that
-   * the API contract is adhered to.
    */
   public function testUserFieldsPresence() : void {
-    // Test as the admin users, this allows us to test all the fields that are
-    // available in an all-access scenario.
-    $this->setCurrentUser(User::load(1));
+    $this->setUpCurrentUser([], ['administer users']);
     $test_user = $this->createUser();
     $query = '
       query ($id: ID!) {
@@ -111,6 +92,62 @@ class GraphQLUsersEndpointTest extends SocialGraphQLTestBase {
       $this->defaultCacheMetaData()
         ->addCacheableDependency($test_user)
         // @todo It's unclear why this cache context is added.
+        ->addCacheContexts(['languages:language_interface'])
+    );
+  }
+
+  /**
+   * Test that permissions are needed to list all users on a platform.
+   *
+   * This limits access for pages like all-members to authenticated users.
+   */
+  public function testUsersNotEnumerableWithoutPermission() : void {
+    // Create some test users.
+    for ($i = 0; $i < 10; ++$i) {
+      $users[] = $this->createUser();
+    }
+
+    // Testing should be done with individual permissions rather than as
+    // anonymous user but the correct permissions don't exist yet.
+    // @todo Fix with DS-7613.
+    /** @var \Drupal\user\UserInterface $test_user */
+    $test_user = User::load(0);
+    $this->setCurrentUser($test_user);
+    $this->assertResults(
+      '
+        query {
+          users(last: 5) {
+            pageInfo {
+              hasNextPage
+              hasPreviousPage
+              startCursor
+              endCursor
+            }
+            edges {
+              node {
+                id
+              }
+            }
+            nodes {
+              id
+            }
+          }
+        }
+      ',
+      [],
+      [
+        'users' => [
+          'pageInfo' => [
+            'hasNextPage' => FALSE,
+            'hasPreviousPage' => FALSE,
+            'startCursor' => NULL,
+            'endCursor' => NULL,
+          ],
+          'edges' => [],
+          'nodes' => [],
+        ],
+      ],
+      $this->defaultCacheMetaData()
         ->addCacheContexts(['languages:language_interface'])
     );
   }


### PR DESCRIPTION
## Problem
We already know users are not allowed to list all users on a platform so we don't need to go querying at all.

## Solution
Short-cut the query for anonymous users.

## Issue tracker
Change on unsupported code, internal issue only: https://getopensocial.atlassian.net/browse/DS-7613

## How to test
- [ ] PHPUnit test should pass

## Screenshots
N/a

## Release notes
N/a

## Change Record
N/a

## Translations
N/a