### PR TITLE
Issue #3223235: Social embed iframe display issues.

### DIFF
--- a/modules/social_features/social_embed/css/iframe.css
+++ b/modules/social_features/social_embed/css/iframe.css
@@ -1,0 +1,16 @@
+.iframe-wrapper {
+  position: relative;
+  overflow: hidden;
+  height: 0;
+  padding-bottom: 56.25%;
+}
+
+iframe {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
+  border-radius: .5rem;
+}

--- a/modules/social_features/social_embed/css/iframe.css
+++ b/modules/social_features/social_embed/css/iframe.css
@@ -10,7 +10,7 @@ iframe {
   top: 0;
   left: 0;
   width: 100%;
-  height: 100%;
+  height: 100% !important;
   max-width: 100%;
   border-radius: .5rem;
 }

--- a/modules/social_features/social_embed/social_embed.libraries.yml
+++ b/modules/social_features/social_embed/social_embed.libraries.yml
@@ -1,0 +1,4 @@
+iframe:
+  css:
+    theme:
+      css/iframe.css: {}

--- a/modules/social_features/social_embed/social_embed.module
+++ b/modules/social_features/social_embed/social_embed.module
@@ -41,3 +41,10 @@ function social_embed_create_media_button() {
   $button->save();
 
 }
+
+/**
+ * Implements hook_preprocess_HOOK() for node.html.twig.
+ */
+function social_embed_preprocess_node(&$variables) {
+  $variables['#attached']['library'][] = 'social_embed/iframe';
+}

--- a/modules/social_features/social_embed/src/Plugin/Filter/SocialEmbedIframeFilter.php
+++ b/modules/social_features/social_embed/src/Plugin/Filter/SocialEmbedIframeFilter.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Drupal\social_embed\Plugin\Filter;
+
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Component\Utility\Html;
+use Drupal\filter\FilterProcessResult;
+use Drupal\filter\Plugin\FilterBase;
+
+/**
+ * Provides a filter to wrap iframe items.
+ *
+ * @Filter(
+ *   id = "social_embed_iframe",
+ *   title = @Translation("Wrap iframe elements"),
+ *   description = @Translation("Wraps all iframe elements within a container."),
+ *   type = Drupal\filter\Plugin\FilterInterface::TYPE_TRANSFORM_REVERSIBLE,
+ * )
+ */
+class SocialEmbedIframeFilter extends FilterBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function settingsForm(array $form, FormStateInterface $form_state) {
+    return [];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function process($text, $langcode) {
+    $result = new FilterProcessResult($text);
+
+    if (stristr($text, '<iframe') === FALSE) {
+      return $result;
+    }
+
+    $dom = Html::load($text);
+
+    $new_div = $dom->createElement('div');
+    $new_div->setAttribute('class', 'iframe-wrapper');
+
+    $iframes = $dom->getElementsByTagName('iframe');
+
+    foreach ($iframes as $iframe) {
+      $new_div_clone = $new_div->cloneNode();
+      $iframe->parentNode->replaceChild($new_div_clone, $iframe);
+      $new_div_clone->appendChild($iframe);
+    }
+
+    $result->setProcessedText(Html::serialize($dom));
+
+    return $result;
+  }
+
+}

--- a/modules/social_features/social_embed/src/Plugin/Filter/SocialEmbedIframeFilter.php
+++ b/modules/social_features/social_embed/src/Plugin/Filter/SocialEmbedIframeFilter.php
@@ -38,15 +38,15 @@ class SocialEmbedIframeFilter extends FilterBase {
 
     $dom = Html::load($text);
 
-    $new_div = $dom->createElement('div');
-    $new_div->setAttribute('class', 'iframe-wrapper');
+    $wrapper = $dom->createElement('div');
+    $wrapper->setAttribute('class', 'iframe-wrapper');
 
     $iframes = $dom->getElementsByTagName('iframe');
 
     foreach ($iframes as $iframe) {
-      $new_div_clone = $new_div->cloneNode();
-      $iframe->parentNode->replaceChild($new_div_clone, $iframe);
-      $new_div_clone->appendChild($iframe);
+      $wrapperClone = $wrapper->cloneNode();
+      $iframe->parentNode->replaceChild($wrapperClone, $iframe);
+      $wrapperClone->appendChild($iframe);
     }
 
     $result->setProcessedText(Html::serialize($dom));

--- a/modules/social_features/social_embed/src/SocialEmbedConfigOverride.php
+++ b/modules/social_features/social_embed/src/SocialEmbedConfigOverride.php
@@ -96,6 +96,14 @@ class SocialEmbedConfigOverride implements ConfigFactoryOverrideInterface {
       'settings' => [],
     ];
 
+    $overrides[$config_name]['filters']['social_embed_iframe'] = [
+      'id' => 'social_embed_iframe',
+      'provider' => 'social_embed',
+      'status' => TRUE,
+      'weight' => 101,
+      'settings' => [],
+    ];
+
     if ($convert_url) {
       $overrides[$config_name]['filters']['social_embed_convert_url'] = [
         'id' => 'social_embed_convert_url',


### PR DESCRIPTION
## Problem
When embedding videos via CKeditor or adding a media URL to the stream, the video/embed is not displayed correctly.

This is similar to: https://github.com/goalgorilla/open_social/pull/2204, but it also fixes the issues with node pages and not just stream.

## Solution
I think the issue is with the html markup, when embedding videos, the iframe element is placed in the body, but this makes it very hard to theme it, so it can be responsive, because it does not have any wrapper/parent element. I think we should wrap all iframe elements within a div, so we can then style it easier.

## Issue tracker
https://www.drupal.org/project/social/issues/3223235

## How to test
1. Enable social_embed
2. Create a new node and embed a YouTube video.
3. See the video, notice it's not displayed correctly (width, height).
4. Switch to this branch and re-test it.
5. Also test out other embeds (Spotify, Instagram ...) and also test it on the /stream page.

## Screenshots

Basic page before:
![Screenshot from 2021-07-12 12-39-41](https://user-images.githubusercontent.com/35064680/125274604-6ba5b000-e30e-11eb-8341-225f84403b46.png)

Basic page after:
![Screenshot from 2021-07-12 12-37-26](https://user-images.githubusercontent.com/35064680/125274652-75c7ae80-e30e-11eb-96de-a76c941ae0dd.png)

Stream before:
![Screenshot from 2021-07-12 12-40-14](https://user-images.githubusercontent.com/35064680/125274680-7d875300-e30e-11eb-903b-9fa6bc1b9b1b.png)

Stream after:
![Screenshot from 2021-07-12 12-37-04](https://user-images.githubusercontent.com/35064680/125274720-85df8e00-e30e-11eb-829f-e34c3c013610.png)


## Release notes
1. Fixed an issue where embeds were not displayed correctly.

## Change Record

## Translations
