### PR TITLE
Issue #3223299 by tBKoT: Add Office 365 support for Add to calendar

### DIFF
--- a/modules/social_features/social_event/modules/social_event_addtocal/src/Plugin/SocialAddToCalendar/AddToICal.php
+++ b/modules/social_features/social_event/modules/social_event_addtocal/src/Plugin/SocialAddToCalendar/AddToICal.php
@@ -7,7 +7,7 @@ use Drupal\node\NodeInterface;
 use Drupal\social_event_addtocal\Plugin\SocialAddToCalendarBase;
 
 /**
- * Provides add to Google calendar plugin.
+ * Provides add to iCal calendar plugin.
  *
  * @SocialAddToCalendar(
  *   id = "ical",

--- a/modules/social_features/social_event/modules/social_event_addtocal/src/Plugin/SocialAddToCalendar/AddToOffice365.php
+++ b/modules/social_features/social_event/modules/social_event_addtocal/src/Plugin/SocialAddToCalendar/AddToOffice365.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Drupal\social_event_addtocal\Plugin\SocialAddToCalendar;
+
+/**
+ * Provides add to Office 365 calendar plugin.
+ *
+ * @SocialAddToCalendar(
+ *   id = "office_365",
+ *   label = @Translation("Office 365"),
+ *   url = "https://outlook.office.com/calendar/0/deeplink/compose",
+ *   allDayFormat = "Y-m-d",
+ *   dateFormat = "Y-m-d\TH:i:s",
+ *   utcDateFormat = "Y-m-d\TH:i:s\Z"
+ * )
+ */
+class AddToOffice365 extends AddToOutlook {
+
+}

--- a/modules/social_features/social_event/modules/social_event_addtocal/src/Plugin/SocialAddToCalendar/AddToOutlook.php
+++ b/modules/social_features/social_event/modules/social_event_addtocal/src/Plugin/SocialAddToCalendar/AddToOutlook.php
@@ -7,7 +7,7 @@ use Drupal\node\NodeInterface;
 use Drupal\social_event_addtocal\Plugin\SocialAddToCalendarBase;
 
 /**
- * Provides add to Google calendar plugin.
+ * Provides add to Outlook calendar plugin.
  *
  * @SocialAddToCalendar(
  *   id = "outlook",

--- a/modules/social_features/social_event/modules/social_event_addtocal/src/Plugin/SocialAddToCalendar/AddToYahoo.php
+++ b/modules/social_features/social_event/modules/social_event_addtocal/src/Plugin/SocialAddToCalendar/AddToYahoo.php
@@ -7,7 +7,7 @@ use Drupal\node\NodeInterface;
 use Drupal\social_event_addtocal\Plugin\SocialAddToCalendarBase;
 
 /**
- * Provides add to Google calendar plugin.
+ * Provides add to Yahoo calendar plugin.
  *
  * @SocialAddToCalendar(
  *   id = "yahoo",


### PR DESCRIPTION
## Problem
`Add to calendar` functionality for outlook does not work properly. It redirects members to general Outlook login, and after login does not provide an option to add the event to the calendar. It happens when trying to add an event to the calendar of accounts that are connected to Office 365.

## Solution
Create a new option for the `Add to calendar` to provide the possibility to add events in Office 365 accounts. It's needed because Outlook and Office 365 used different links to add events in the calendar.

## Issue tracker
https://www.drupal.org/project/social/issues/3223299
https://getopensocial.atlassian.net/browse/YANG-5106

## How to test
- [ ] Using the latest version of Open Social with the `social_event_addtocal` module enabled
- [ ] Enable the `Add to calendar` feature and `Outlook` option
- [ ] Go to any event as LU
- [ ] Try the `Add to calendar` and select `Outlook`
- [ ] Log in to Outlook with the account connected to Office 365
- [ ] It is not possible to add events to the calendar

## Screenshots
N/A

## Release notes
Now we have one more option for the `Add to calendar` feature which allows us to add events in Office 365 account's calendar

## Change Record
N/A

## Translations
N/A
