### PR TITLE
Move drupal/devel from require to require-dev.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -125,7 +125,6 @@
         "drupal/crop": "2.1.0",
         "drupal/csv_serialization": "2.0-beta1",
         "drupal/data_policy": "^1.0@RC",
-        "drupal/devel": "2.1",
         "drupal/dynamic_entity_reference": "1.7",
         "drupal/editor_advanced_link": "^1.8",
         "drupal/entity": "1.2.0",
@@ -193,6 +192,7 @@
     "require-dev": {
         "dealerdirect/phpcodesniffer-composer-installer": "~0.6 || ~0.7",
         "drupal/coder": "8.3.13",
+        "drupal/devel": "2.1",
         "mglaman/phpstan-drupal": "0.12",
         "mglaman/drupal-check": "^1.0"
     },


### PR DESCRIPTION
## Problem
The devel module is a 'dev' module. At this time the module lives under 'require' in composer.json.

## Solution
Move drupal/devel to require-dev.

## Issue tracker

## How to test

## Screenshots

## Release notes
Moved drupal/devel to the require-dev section in composer.json.

## Change Record

## Translations
