### PR TITLE
Issue #3223639 by SV: Error after adding a parent of tag for translated nodes

### DIFF
--- a/modules/social_features/social_tagging/src/SocialTaggingService.php
+++ b/modules/social_features/social_tagging/src/SocialTaggingService.php
@@ -244,7 +244,8 @@ class SocialTaggingService {
         }
         // Or add the parent term itself if it connected to the content.
         else {
-          $category_label = $current_term->getTranslation($langcode)->getName();
+          $category_label = $current_term->hasTranslation($langcode) ? $current_term->getTranslation($langcode)
+            ->getName() : $current_term->getName();
           $parent = $current_term;
         }
         // Prepare the parameter;.


### PR DESCRIPTION
## Problem
When "Allow use a parent of category." option is enabled users can select a parent of tag and on saving translated node there is the following error:
![image-20210713-141736-png-1385×860- (1)](https://user-images.githubusercontent.com/25609390/125807462-6e26d1f1-8005-4b62-a779-e03e9daad70d.png)


## Solution
Need to add a check if there is a translation for a current term before call getTranslation()

## Issue tracker
- https://www.drupal.org/project/social/issues/3223639
- https://getopensocial.atlassian.net/browse/YANG-5883

## How to test
- [ ] Using the latest version of Open Social with the social_topic module enabled
- [ ] Login as an admin
- [ ] Make sure you enable all required modules (see screen bellow) and have at least two languages installed
- [ ] Add an "Topic" and attach it to any group
- [ ] Go to add translation tab for the created topic, select tag and his parent

## Screenshots
Following options are enabled on the tags settings page:
![Tag-settings-ECI-Demo (1)](https://user-images.githubusercontent.com/25609390/125808235-28ec093c-2e81-430a-8f77-467650bceb80.png)

Also, will need to enable all required translation modules:
![Screenshot from 2021-07-15 17-58-34](https://user-images.githubusercontent.com/25609390/125810054-70386d45-1444-4067-9d77-9014fb9c35e4.png)

Screen of translated node:
![Group-discussion-2-en-ECI-Demo](https://user-images.githubusercontent.com/25609390/125810672-fdde3f13-8a04-439c-934b-efbb08ec3f15.png)


## Release notes
Fixes issue with adding parent tags for translated nodes
