### PR TITLE
Issue #3223946 by vnech: Add missed content translation config for Flexible Group

### DIFF
--- a/modules/social_features/social_group/modules/social_group_flexible_group/config/optional/language.content_settings.group.flexible_group.yml
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/config/optional/language.content_settings.group.flexible_group.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - group.type.flexible_group
+  module:
+    - social_content_translation
+third_party_settings:
+  content_translation:
+    enabled: false
+    bundle_settings:
+      untranslatable_fields_hide: '0'
+id: group.flexible_group
+target_entity_type_id: group
+target_bundle: flexible_group
+default_langcode: site_default
+language_alterable: false


### PR DESCRIPTION
## Problem
If we have already a multi-language OS and then enable the module "Social Flexible Group" flexible groups can't be translated because of missed configuration `language.content_settings.group.flexible_group`

## Solution
Add missed content translation configuration for "Flexible Group" group type

## Issue tracker
- https://www.drupal.org/project/social/issues/3223946
- https://getopensocial.atlassian.net/browse/YANG-5702
- https://github.com/goalgorilla/open_social/pull/2369

## How to test
N/A

## Screenshots
N/A

## Release notes
*Add missed content translation configuration for "Flexible Group" group type.*

## Change Record
N/A

## Translations
N/A
