### PR TITLE
Move Devel to require-dev dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -129,7 +129,6 @@
         "drupal/crop": "2.1.0",
         "drupal/csv_serialization": "2.0-beta1",
         "drupal/data_policy": "^1.0@RC",
-        "drupal/devel": "2.1",
         "drupal/dynamic_entity_reference": "1.7",
         "drupal/editor_advanced_link": "^1.8",
         "drupal/entity": "1.2.0",
@@ -197,6 +196,7 @@
     "require-dev": {
         "dealerdirect/phpcodesniffer-composer-installer": "~0.6 || ~0.7",
         "drupal/coder": "8.3.13",
+        "drupal/devel": "2.1",
         "mglaman/phpstan-drupal": "0.12",
         "mglaman/drupal-check": "^1.0"
     },


### PR DESCRIPTION
## Problem
As Devel is only used for development and should never be used in production it makes sense to move it to the `require-dev` section.

## Solution
Move Devel to the `require-dev` section.

I can imagine we need to move `social_demo` out of the distribution, but let's discuss that in the PR.

## Issue tracker
TBD

## How to test
- [ ] Run `composer install --no-dev`
- [ ] Observe that the Devel module is not installed
- [ ] Run `composer install`
- [ ] Observe that the Devel module is installed

## Screenshots
n/a

## Release notes
The Devel module is now part of Composer's `require-dev` section.

## Change Record
N/a

## Translations
N/a