### PR TITLE
Issue #3224647 by nkoporec: Event enrollments bulk operations should not be visible to users that don't have the correct permissions

### DIFF
--- a/modules/social_features/social_event/modules/social_event_managers/src/Plugin/views/field/SocialEventManagersViewsBulkOperationsBulkForm.php
+++ b/modules/social_features/social_event/modules/social_event_managers/src/Plugin/views/field/SocialEventManagersViewsBulkOperationsBulkForm.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\social_event_managers\Plugin\views\field;
 
+use Drupal\Core\Action\ActionManager;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\FormStateInterface;
@@ -34,6 +35,13 @@ class SocialEventManagersViewsBulkOperationsBulkForm extends ViewsBulkOperations
   protected $entityTypeManager;
 
   /**
+   * The action plugin manager.
+   *
+   * @var \Drupal\Core\Action\ActionManager
+   */
+  protected $actionManager;
+
+  /**
    * Constructs a new SocialEventManagersViewsBulkOperationsBulkForm object.
    *
    * @param array $configuration
@@ -56,6 +64,8 @@ class SocialEventManagersViewsBulkOperationsBulkForm extends ViewsBulkOperations
    *   The request stack.
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
    *   The entity type manager.
+   * @param \Drupal\Core\Action\ActionManager $pluginActionManager
+   *   The action manager.
    */
   public function __construct(
     array $configuration,
@@ -67,11 +77,13 @@ class SocialEventManagersViewsBulkOperationsBulkForm extends ViewsBulkOperations
     PrivateTempStoreFactory $tempStoreFactory,
     AccountInterface $currentUser,
     RequestStack $requestStack,
-    EntityTypeManagerInterface $entity_type_manager
+    EntityTypeManagerInterface $entity_type_manager,
+    ActionManager $pluginActionManager
   ) {
     parent::__construct($configuration, $plugin_id, $plugin_definition, $viewData, $actionManager, $actionProcessor, $tempStoreFactory, $currentUser, $requestStack);
 
     $this->entityTypeManager = $entity_type_manager;
+    $this->actionManager = $pluginActionManager;
   }
 
   /**
@@ -88,7 +100,8 @@ class SocialEventManagersViewsBulkOperationsBulkForm extends ViewsBulkOperations
       $container->get('tempstore.private'),
       $container->get('current_user'),
       $container->get('request_stack'),
-      $container->get('entity_type.manager')
+      $container->get('entity_type.manager'),
+      $container->get('plugin.manager.action')
     );
   }
 
@@ -101,6 +114,9 @@ class SocialEventManagersViewsBulkOperationsBulkForm extends ViewsBulkOperations
     if ($this->view->id() !== 'event_manage_enrollments') {
       return $bulk_options;
     }
+
+    // Check access.
+    $bulk_options = $this->bulkOptionAccess($bulk_options);
 
     foreach ($bulk_options as $id => &$label) {
       if (!empty($this->options['preconfiguration'][$id]['label_override'])) {
@@ -375,6 +391,51 @@ class SocialEventManagersViewsBulkOperationsBulkForm extends ViewsBulkOperations
     }
 
     return $data;
+  }
+
+  /**
+   * Removes all bulk options that user don't have access to it.
+   *
+   * @param array $bulkOptions
+   *   Array of bulk options.
+   *
+   * @return array
+   *   Returns array of bulk options.
+   */
+  protected function bulkOptionAccess(array $bulkOptions) {
+    /** @var \Drupal\node\NodeInterface $event */
+    $event = social_event_get_current_event();
+    $isEventOrganizer = social_event_manager_or_organizer($event);
+
+    // Event organizers have all permissions.
+    if ($isEventOrganizer) {
+      return $bulkOptions;
+    }
+
+    // Get the user enrollment.
+    $eventEnrollment = $this->entityTypeManager->getStorage('event_enrollment')->loadByProperties([
+      'user_id' => $this->currentUser()->id(),
+      'field_event' => $event->id(),
+    ]);
+    $eventEnrollment = end($eventEnrollment);
+    if (!$eventEnrollment) {
+      return $bulkOptions;
+    }
+
+    // Load each action and check the access.
+    foreach ($bulkOptions as $id => $name) {
+      // Create plugin instance.
+      $action = $this->entityTypeManager->getStorage('action')->load($id);
+      $action = $this->actionManager->createInstance($id);
+
+      // Check the access.
+      $access = $action->access($eventEnrollment, $this->currentUser);
+      if (!$access) {
+        unset($bulkOptions[$id]);
+      }
+    }
+
+    return $bulkOptions;
   }
 
 }


### PR DESCRIPTION
## Problem
Currently when a LU visits an event page and switch to the 'Enrollments' tab, they can see the VBO operations block and can execute VBO operations on users that enrolled, they never complete due to missing access (the batch goes into a loop).

## Solution
We need to remove all VBO actions that the current user does not have access to perform. If there is no actions to perform, then we should hide the VBO block and only show the list of users that enrolled to the event.

## Issue tracker
https://www.drupal.org/project/social/issues/3224647

## How to test
1. Create an event
2. Log in as a authenticated user
3. Go to the event and the enrollments tab.
4. See the VBO operations block, with the ability to delete and email enrollees.

## Screenshots
As a LU, before:
![2021-07-21_12-21](https://user-images.githubusercontent.com/35064680/126476122-b76a5ca2-9766-4d77-ad86-b0948810fa19.png)

As a LU, after:
![2021-07-21_12-20](https://user-images.githubusercontent.com/35064680/126476140-22d31f81-d962-4778-95d2-b4367d2f680d.png)


## Release notes
Fixed an issue with VBO event enrollments, which enabled an authenticated users to perform VBO operations without the correct access.

## Change Record

## Translations
