### PR TITLE
Issue #3224828 by tBKoT: Fix profile save process when profile tagging is enabled

### DIFF
--- a/modules/social_features/social_profile/src/Plugin/Field/FieldWidget/SocialProfileTagSplitWidget.php
+++ b/modules/social_features/social_profile/src/Plugin/Field/FieldWidget/SocialProfileTagSplitWidget.php
@@ -141,6 +141,9 @@ class SocialProfileTagSplitWidget extends Select2EntityReferenceWidget {
       }
       $form_state->setValue($field_element, $field_value);
     }
+    else {
+      parent::validateElement($element, $form_state);
+    }
   }
 
 }


### PR DESCRIPTION
## Problem
The user receives an error when trying to save the profile with empty profile tags
```
The website encountered an unexpected error. Please try again later.
TypeError: Argument 1 passed to Drupal\Core\Field\WidgetBase::massageFormValues() must be of the type array, string given, called in /var/www/html/core/lib/Drupal/Core/Field/WidgetBase.php on line 390 in Drupal\Core\Field\WidgetBase->massageFormValues() (line 537 of core/lib/Drupal/Core/Field/WidgetBase.php).
Drupal\Core\Field\WidgetBase->massageFormValues('', Array, Object) (Line: 390)
Drupal\Core\Field\WidgetBase->extractFormValues(Object, Array, Object) (Line: 232)
Drupal\Core\Entity\Entity\EntityFormDisplay->extractFormValues(Object, Array, Object) (Line: 338)
Drupal\Core\Entity\ContentEntityForm->copyFormValuesToEntity(Object, Array, Object) (Line: 336)
Drupal\Core\Entity\EntityForm->buildEntity(Array, Object) (Line: 159)
Drupal\Core\Entity\ContentEntityForm->buildEntity(Array, Object) (Line: 190)
Drupal\Core\Entity\ContentEntityForm->validateForm(Array, Object)
call_user_func_array(Array, Array) (Line: 82)
Drupal\Core\Form\FormValidator->executeValidateHandlers(Array, Object) (Line: 273)
Drupal\Core\Form\FormValidator->doValidateForm(Array, Object, 'profile_profile_edit_form') (Line: 118)
Drupal\Core\Form\FormValidator->validateForm('profile_profile_edit_form', Array, Object) (Line: 589)
Drupal\Core\Form\FormBuilder->processForm('profile_profile_edit_form', Array, Object) (Line: 321)
Drupal\Core\Form\FormBuilder->buildForm(Object, Object) (Line: 61)
Drupal\Core\Entity\EntityFormBuilder->getForm(Object, 'edit') (Line: 107)
Drupal\profile\Controller\UserController->editForm(Object) (Line: 47)
Drupal\profile\Controller\UserController->singlePage(Object, Object)
call_user_func_array(Array, Array) (Line: 123)
Drupal\Core\EventSubscriber\EarlyRenderingControllerWrapperSubscriber->Drupal\Core\EventSubscriber\{closure}() (Line: 573)
Drupal\Core\Render\Renderer->executeInRenderContext(Object, Object) (Line: 124)
Drupal\Core\EventSubscriber\EarlyRenderingControllerWrapperSubscriber->wrapControllerExecutionInRenderContext(Array, Array) (Line: 97)
Drupal\Core\EventSubscriber\EarlyRenderingControllerWrapperSubscriber->Drupal\Core\EventSubscriber\{closure}() (Line: 151)
Symfony\Component\HttpKernel\HttpKernel->handleRaw(Object, 1) (Line: 68)
Symfony\Component\HttpKernel\HttpKernel->handle(Object, 1, 1) (Line: 57)
Drupal\Core\StackMiddleware\Session->handle(Object, 1, 1) (Line: 47)
Drupal\Core\StackMiddleware\KernelPreHandle->handle(Object, 1, 1) (Line: 106)
Drupal\page_cache\StackMiddleware\PageCache->pass(Object, 1, 1) (Line: 85)
Drupal\page_cache\StackMiddleware\PageCache->handle(Object, 1, 1) (Line: 47)
Drupal\Core\StackMiddleware\ReverseProxyMiddleware->handle(Object, 1, 1) (Line: 52)
Drupal\Core\StackMiddleware\NegotiationMiddleware->handle(Object, 1, 1) (Line: 23)
Stack\StackedHttpKernel->handle(Object, 1, 1) (Line: 708)
Drupal\Core\DrupalKernel->handle(Object) (Line: 19)
```

## Solution
Add parent validation to the `social_profile_tag_split` widget if the condition `$profile_tag_service->allowSplit()` is FALSE

## Issue tracker
https://www.drupal.org/project/social/issues/3224828
https://getopensocial.atlassian.net/browse/YANG-6037

## How to test
- [ ] Enable profile tagging and make sure that the `Allow category split` is off
- [ ] Go to user edit profile page
- [ ] Save profile with empty profile tags

## Screenshots
N/A

## Release notes
N/A

## Change Record
N/A

## Translations
N/A
