### PR TITLE
Issue #3224886 by tBKoT: Fix redirect for the group home route

### DIFF
--- a/modules/custom/social_path_manager/social_path_manager.module
+++ b/modules/custom/social_path_manager/social_path_manager.module
@@ -250,6 +250,12 @@ function _social_path_manager_update_alias(EntityInterface $entity, $op, $bulk =
             $suffix = _social_path_manager_get_path_suffix($entity, $route);
             $entity_language = $entity->language()->getId();
 
+            // Prevent adding alias for default tab.
+            $source_parts = explode('/', $path['source']);
+            if (end($source_parts) === $suffix) {
+              continue;
+            }
+
             // Get alias of the group tab.
             $grouptab_alias = $pam->getAliasByPath('/group/' . $entity->id() . '/' . $suffix);
 

--- a/modules/social_features/social_group/modules/social_group_default_route/social_group_default_route.services.yml
+++ b/modules/social_features/social_group/modules/social_group_default_route/social_group_default_route.services.yml
@@ -7,4 +7,4 @@ services:
   social_group_default_route.route_subscriber:
     class: Drupal\social_group_default_route\RouteSubscriber\RouteSubscriber
     tags:
-      - { name: event_subscriber }
+      - { name: event_subscriber, priority: 3 }

--- a/modules/social_features/social_group/modules/social_group_default_route/src/EventSubscriber/RedirectSubscriber.php
+++ b/modules/social_features/social_group/modules/social_group_default_route/src/EventSubscriber/RedirectSubscriber.php
@@ -69,7 +69,10 @@ class RedirectSubscriber implements EventSubscriberInterface {
     $routeMatch = $this->currentRoute->getRouteName();
 
     // Not group canonical, then we leave.
-    if ($routeMatch !== 'entity.group.canonical') {
+    if (
+      $routeMatch !== 'entity.group.canonical' &&
+      $routeMatch !== 'social_group_default.group_home'
+    ) {
       return;
     }
 

--- a/modules/social_features/social_group/modules/social_group_default_route/src/EventSubscriber/RedirectSubscriber.php
+++ b/modules/social_features/social_group/modules/social_group_default_route/src/EventSubscriber/RedirectSubscriber.php
@@ -68,8 +68,11 @@ class RedirectSubscriber implements EventSubscriberInterface {
     // First check if the current route is the group canonical.
     $routeMatch = $this->currentRoute->getRouteName();
 
-    // Not group canonical, then we leave.
-    if ($routeMatch !== 'entity.group.canonical') {
+    // Not group canonical or home, then we leave.
+    if (
+      $routeMatch !== 'entity.group.canonical' &&
+      $routeMatch !== 'social_group_default.group_home'
+    ) {
       return;
     }
 

--- a/modules/social_features/social_group/modules/social_group_default_route/src/EventSubscriber/RedirectSubscriber.php
+++ b/modules/social_features/social_group/modules/social_group_default_route/src/EventSubscriber/RedirectSubscriber.php
@@ -69,10 +69,7 @@ class RedirectSubscriber implements EventSubscriberInterface {
     $routeMatch = $this->currentRoute->getRouteName();
 
     // Not group canonical or home, then we leave.
-    if (
-      $routeMatch !== 'entity.group.canonical' &&
-      $routeMatch !== 'social_group_default.group_home'
-    ) {
+    if ($routeMatch !== 'entity.group.canonical') {
       return;
     }
 

--- a/modules/social_features/social_group/modules/social_group_default_route/src/EventSubscriber/RedirectSubscriber.php
+++ b/modules/social_features/social_group/modules/social_group_default_route/src/EventSubscriber/RedirectSubscriber.php
@@ -68,7 +68,7 @@ class RedirectSubscriber implements EventSubscriberInterface {
     // First check if the current route is the group canonical.
     $routeMatch = $this->currentRoute->getRouteName();
 
-    // Not group canonical or home, then we leave.
+    // Not group canonical, then we leave.
     if ($routeMatch !== 'entity.group.canonical') {
       return;
     }

--- a/modules/social_features/social_group/social_group.services.yml
+++ b/modules/social_features/social_group/social_group.services.yml
@@ -2,7 +2,7 @@ services:
   social_group.route_subscriber:
     class: Drupal\social_group\Routing\RouteSubscriber
     tags:
-      - { name: event_subscriber }
+      - { name: event_subscriber, priority: 2 }
   social_group.helper_service:
     class: Drupal\social_group\SocialGroupHelperService
     arguments: ['@database', '@module_handler']


### PR DESCRIPTION
## Problem
The `group/{group}/home` page is not used anywhere and it returns just a white page only with a title. That provides some issues with already existing aliases and users do not see any information on this page.

## Solution

- Add `group/{group}/home` route as needed to be redirected.
- Add priority for route subscribers to make them the same as the module weight to provide the correct order of execution.

## Issue tracker

- https://getopensocial.atlassian.net/browse/YANG-5837
- https://www.drupal.org/project/social/issues/3224886

## How to test
- [ ] As a LU set custom alias for a group
- [ ] When you go to that alias you should be redirected to the same page as `group/{group}/home` or `group/{group}`

## Screenshots
![зображення](https://user-images.githubusercontent.com/11648677/126641472-26603945-72eb-440f-9bf8-617bc2006f69.png)


## Release notes
Now all users that go to the group/{group_id}/home page will be redirected to the selected tab in group settings.

## Change Record
N/A

## Translations
N/A
