### PR TITLE
Issue #3225297 by vnech: Remove "all languages" suffix from field group labels

### DIFF
--- a/modules/custom/social_language/social_language.module
+++ b/modules/custom/social_language/social_language.module
@@ -68,3 +68,12 @@ function social_language_entity_operation_alter(array &$operations, EntityInterf
   }
   return $operations;
 }
+
+/**
+ * Implements hook_field_group_form_process_alter().
+ */
+function social_language_field_group_form_process_alter(array &$element, &$group, &$complete_form) {
+  // Prevent \Drupal\content_translation\ContentTranslationHandler::addTranslatabilityClue()
+  // from adding an incorrect suffix to the field group title.
+    $element['#multilingual'] = TRUE;
+}

--- a/modules/custom/social_language/social_language.module
+++ b/modules/custom/social_language/social_language.module
@@ -75,5 +75,5 @@ function social_language_entity_operation_alter(array &$operations, EntityInterf
 function social_language_field_group_form_process_alter(array &$element, &$group, &$complete_form) {
   // Prevent \Drupal\content_translation\ContentTranslationHandler::addTranslatabilityClue()
   // from adding an incorrect suffix to the field group title.
-    $element['#multilingual'] = TRUE;
+  $element['#multilingual'] = TRUE;
 }


### PR DESCRIPTION
## Problem
After enabling content translations we got confusing suffix on field groups labels "all languages" even if all fields in the field group are translatable.

## Solution
Remove suffix "all languages" on multilingual sites.

## Issue tracker
- https://www.drupal.org/project/social/issues/3225297
- https://getopensocial.atlassian.net/browse/YANG-5843

## How to test
- [ ] Login as an admin
- [ ] Enable "Content Translation" module
- [ ] Go to add/edit Topic page

## Screenshots
![image](https://user-images.githubusercontent.com/2241917/127019739-1520fca2-5e1a-4435-a904-ea750045af7c.png)

## Release notes
*Remove suffix "all languages" on multilingual sites.*

## Change Record
N/A

## Translations
N/A
