### PR TITLE
Issue #3225336 by vnech: Move "Translations" fieldset to "Settings" fields group

### DIFF
--- a/modules/custom/social_language/social_language.install
+++ b/modules/custom/social_language/social_language.install
@@ -16,7 +16,7 @@ use Drupal\user\Entity\Role;
 function social_language_install() {
   // Make sure the module has more weight then "Content Translation" module.
   module_set_weight('social_language', 11);
-  
+
   // Set some default permissions.
   _social_language_set_permissions();
 

--- a/modules/custom/social_language/social_language.install
+++ b/modules/custom/social_language/social_language.install
@@ -14,7 +14,9 @@ use Drupal\user\Entity\Role;
  * Perform actions related to the installation of social_language.
  */
 function social_language_install() {
-
+  // Make sure the module has more weight then "Content Translation" module.
+  module_set_weight('social_language', 11);
+  
   // Set some default permissions.
   _social_language_set_permissions();
 
@@ -129,4 +131,12 @@ function social_language_update_10301() {
     'update content translations',
   ];
   user_role_grant_permissions('contentmanager', $permissions);
+}
+
+/**
+ * Change the weight for the module "Social Language".
+ */
+function social_language_update_10302() {
+  // Make sure the module has more weight then "Content Translation" module.
+  module_set_weight('social_language', 11);
 }

--- a/modules/custom/social_language/social_language.module
+++ b/modules/custom/social_language/social_language.module
@@ -35,21 +35,14 @@ function social_language_form_alter(&$form, FormStateInterface $form_state, $for
     if (isset($form['content_translation']) && Element::isVisibleElement($form['content_translation'])) {
       // Change element type for "content_translation" to be consistent
       // with general approach in OS.
-      $form['content_translation']['#type'] = 'fieldset';
       $form['#fieldgroups']['group_settings']->children[] = 'content_translation';
       $form['content_translation']['#group'] = 'group_settings';
     }
 
     if (isset($form['source_langcode']) && Element::isVisibleElement($form['source_langcode'])) {
-      // Move "source_langcode" form element to translations fieldset.
-      if (!empty($form['content_translation'])) {
-        $form['source_langcode']['#group'] = 'content_translation';
-      }
-      else {
-        // Otherwise to general settings fieldset.
-        $form['#fieldgroups']['group_settings']->children[] = 'source_langcode';
-        $form['source_langcode']['#group'] = 'group_settings';
-      }
+      // Move "source_langcode" form element to general settings fieldset.
+      $form['#fieldgroups']['group_settings']->children[] = 'source_langcode';
+      $form['source_langcode']['#group'] = 'group_settings';
     }
   }
 }

--- a/modules/custom/social_language/social_language.module
+++ b/modules/custom/social_language/social_language.module
@@ -29,7 +29,7 @@ function social_language_language_switch_links_alter(array &$links, $type, Url $
 function social_language_form_alter(&$form, FormStateInterface $form_state, $form_id) {
   // Move the fields to group_settings.
   if (isset($form['#fieldgroups']['group_settings'])) {
-    // As translation form fields are added directly to forms bypassing 
+    // As translation form fields are added directly to forms bypassing
     // entity form display we can't have both approaches (OS and user own)
     // for field managing (@see social_core_form_node_form_alter()).
     if (isset($form['content_translation']) && Element::isVisibleElement($form['content_translation'])) {
@@ -39,7 +39,7 @@ function social_language_form_alter(&$form, FormStateInterface $form_state, $for
       $form['#fieldgroups']['group_settings']->children[] = 'content_translation';
       $form['content_translation']['#group'] = 'group_settings';
     }
-    
+
     if (isset($form['source_langcode']) && Element::isVisibleElement($form['source_langcode'])) {
       // Move "source_langcode" form element to translations fieldset.
       if (!empty($form['content_translation'])) {

--- a/modules/custom/social_language/social_language.module
+++ b/modules/custom/social_language/social_language.module
@@ -7,6 +7,7 @@
 
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Render\Element;
 use Drupal\Core\Url;
 
 /**
@@ -19,6 +20,37 @@ function social_language_language_switch_links_alter(array &$links, $type, Url $
     $link['attributes']['title'] = $link['title'];
     $link['title'] .= " (${langcode})";
     $link['attributes']['class'][] = $langcode === $currentLangcode ? 'active' : NULL;
+  }
+}
+
+/**
+ * Implements hook_form_alter().
+ */
+function social_language_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+  // Move the fields to group_settings.
+  if (isset($form['#fieldgroups']['group_settings'])) {
+    // As translation form fields are added directly to forms bypassing 
+    // entity form display we can't have both approaches (OS and user own)
+    // for field managing (@see social_core_form_node_form_alter()).
+    if (isset($form['content_translation']) && Element::isVisibleElement($form['content_translation'])) {
+      // Change element type for "content_translation" to be consistent
+      // with general approach in OS.
+      $form['content_translation']['#type'] = 'fieldset';
+      $form['#fieldgroups']['group_settings']->children[] = 'content_translation';
+      $form['content_translation']['#group'] = 'group_settings';
+    }
+    
+    if (isset($form['source_langcode']) && Element::isVisibleElement($form['source_langcode'])) {
+      // Move "source_langcode" form element to translations fieldset.
+      if (!empty($form['content_translation'])) {
+        $form['source_langcode']['#group'] = 'content_translation';
+      }
+      else {
+        // Otherwise to general settings fieldset.
+        $form['#fieldgroups']['group_settings']->children[] = 'source_langcode';
+        $form['source_langcode']['#group'] = 'group_settings';
+      }
+    }
   }
 }
 


### PR DESCRIPTION
## Problem
When translations are enabled on node (groups or other entities) forms appear fieldset "Translations" and this broke a common form design (see screenshot below).

## Solution
Move "Translations" fieldset to the "Settings" field group.

## Issue tracker
- https://www.drupal.org/project/social/issues/3225336
- https://getopensocial.atlassian.net/browse/YANG-5842

## How to test
- [ ] Login as an admin
- [ ] Enable "Social Language - Content Translation"
- [ ] Make sure you have installed at least two languages in OS
- [ ] Create a Topic
- [ ] Add a translation to the created Topic

## Screenshots
<img src="https://www.drupal.org/files/issues/2021-07-26/Screenshot%202021-07-26%20at%2016.19.47.png" />

## Release notes
*Move "Translations" fieldset to the "Settings" field group.*

## Change Record
N/A

## Translations
N/A
