### PR TITLE
Issue #3225482 by Ressinel: Update the Like & Dislike module from 1.0-alpha2 to 1.0-beta2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -65,9 +65,6 @@
                 "Cache context update": "https://www.drupal.org/files/issues/2018-05-04/group-cache-context-2882102-2.patch",
                 "Missing config schema for condition.plugin.group_type": "https://www.drupal.org/files/issues/2018-12-14/group-group_type_condition_plugin_config_schema-3020554-2.patch"
             },
-            "drupal/like_and_dislike": {
-                "Fix preview on node": "https://www.drupal.org/files/issues/2848080-2-preview-fails-on-node.patch"
-            },
             "drupal/paragraphs": {
                 "Integrity constraint violation: 1048 Column 'langcode' cannot be null": "https://www.drupal.org/files/issues/2019-07-10/paragraphs-set_langcode_widgets-2901390-29.patch"
             },
@@ -145,7 +142,7 @@
         "drupal/image_effects": "3.1",
         "drupal/image_widget_crop": "2.3.0",
         "drupal/lazy": "2.0",
-        "drupal/like_and_dislike": "1.0-alpha2",
+        "drupal/like_and_dislike": "1.0-beta2",
         "drupal/link_css": "1.x-dev",
         "drupal/message": "1.0",
         "drupal/metatag": "1.11",


### PR DESCRIPTION
## Problem
Update the Like & Dislike module to have compatibility with Drupal 9

## Solution
Update to the latest version.

## Issue tracker
- https://www.drupal.org/project/social/issues/3225482

## How to test
- [ ] Since the Like & Dislike template was changed firstly apply the patch for Social Base theme (TBA)
- [ ] Try like/unlike any comment
- [ ] Functionality must work properly

## Screenshots
N/A

## Release notes
The Like & Dislike module has been updated to 1.0-beta2. Please view the release notes from [1.0-alpha3](https://www.drupal.org/project/like_and_dislike/releases/8.x-1.0-alpha3), [1.0-beta1](https://www.drupal.org/project/like_and_dislike/releases/8.x-1.0-beta1), and [1.0-beta2](https://www.drupal.org/project/like_and_dislike/releases/8.x-1.0-beta2) of that module for the changes.

Important: Social Base theme must be updated to version TBA.

## Change Record
N/A

## Translations
N/A
