### PR TITLE
Issue #3225518 by tBKoT: Allow SM to disable specific email notifications

### DIFF
--- a/modules/custom/activity_send/modules/activity_send_email/src/Plugin/EmailFrequency/None.php
+++ b/modules/custom/activity_send/modules/activity_send_email/src/Plugin/EmailFrequency/None.php
@@ -12,7 +12,7 @@ use Drupal\user\Entity\User;
  *
  * @EmailFrequency(
  *   id = "none",
- *   name = @Translation("- None -"),
+ *   name = @Translation("Never"),
  *   weight = 0,
  *   interval = 0
  * )

--- a/modules/social_features/social_swiftmail/src/Form/SocialSwiftmailSettingsForm.php
+++ b/modules/social_features/social_swiftmail/src/Form/SocialSwiftmailSettingsForm.php
@@ -120,9 +120,6 @@ class SocialSwiftmailSettingsForm extends ConfigFormBase {
     $email_frequencies = sort_email_frequency_options();
 
     $notification_options = [];
-    $never_option = $email_frequencies[3];
-    unset($email_frequencies[3]);
-    array_push($email_frequencies, $never_option);
     // Place the sorted data in an actual form option.
     foreach ($email_frequencies as $option) {
       $notification_options[$option['id']] = $option['name'];

--- a/modules/social_features/social_swiftmail/src/Form/SocialSwiftmailSettingsForm.php
+++ b/modules/social_features/social_swiftmail/src/Form/SocialSwiftmailSettingsForm.php
@@ -120,11 +120,12 @@ class SocialSwiftmailSettingsForm extends ConfigFormBase {
     $email_frequencies = sort_email_frequency_options();
 
     $notification_options = [];
+    $never_option = $email_frequencies[3];
+    unset($email_frequencies[3]);
+    array_push($email_frequencies, $never_option);
     // Place the sorted data in an actual form option.
     foreach ($email_frequencies as $option) {
-      if ($option['id'] !== 'none') {
-        $notification_options[$option['id']] = $option['name'];
-      }
+      $notification_options[$option['id']] = $option['name'];
     }
 
     $template_frequencies = $config->get('template_frequencies') ?: [];

--- a/tests/behat/features/bootstrap/EmailContext.php
+++ b/tests/behat/features/bootstrap/EmailContext.php
@@ -87,7 +87,7 @@ class EmailContext implements Context {
    *   The path where the spooled emails are stored.
    */
   protected function getSpoolDir() {
-    $path = '/var/www/html/profiles/contrib/social/tests/behat/features/swiftmailer-spool';
+    $path = drupal_get_path('profile', 'social') . '/tests/behat/features/swiftmailer-spool';
     if (!file_exists($path)) {
       mkdir($path, 0777, true);
     }

--- a/tests/behat/features/capabilities/notifications/notification-emails.feature
+++ b/tests/behat/features/capabilities/notifications/notification-emails.feature
@@ -144,3 +144,31 @@ Feature: Receive email notifications and choose frequency
     And I press "Delete"
     And I run cron
     And I check if queue items processed "activity_logger_message"
+
+  @email-spool @sm
+  Scenario: User should not receive notification as default
+    Given I set the configuration item "system.site" with key "name" to "Open Social"
+    And users:
+      | name  | mail                   | status | field_profile_first_name | field_profile_last_name |
+      | user1 | mail_user1@example.com | 1      | Christopher              | Conway                  |
+      | user2 | mail_user2@example.com | 1      | Cathy                    | Willis                  |
+    And I am logged in as an "sitemanager"
+    And I go to "/admin/config/opensocial/swiftmail"
+    And I click radio button "Never" with the id "edit-create-mention-post-none"
+    And I press "Save configuration"
+
+    Given I am logged in as "user1"
+    And I click the xth "0" element with the css ".navbar-nav .profile"
+    And I click "Settings"
+    And I click "Email notifications"
+    And I wait for "2" seconds
+    And I click "Message to me"
+    And I should see "Never" in the "select[name='email_notifications[message_to_me][create_mention_post]'] option[selected='selected']" element
+
+    Given I am logged in as "user2"
+    And I am on the homepage
+    And I fill in "Say something to the Community" with "You're not going to be notified of this [~user1]!"
+    And I press "Post"
+    And I press "Post"
+    And I wait for the queue to be empty
+    Then I should not have an email with subject "Notification from Open Social" and "Cathy Willis mentioned you" in the body

--- a/tests/behat/features/capabilities/notifications/notification-emails.feature
+++ b/tests/behat/features/capabilities/notifications/notification-emails.feature
@@ -145,7 +145,7 @@ Feature: Receive email notifications and choose frequency
     And I run cron
     And I check if queue items processed "activity_logger_message"
 
-  @email-spool @sm
+  @email-spool
   Scenario: User should not receive notification as default
     Given I set the configuration item "system.site" with key "name" to "Open Social"
     And users:
@@ -154,6 +154,7 @@ Feature: Receive email notifications and choose frequency
       | user2 | mail_user2@example.com | 1      | Cathy                    | Willis                  |
     And I am logged in as an "sitemanager"
     And I go to "/admin/config/opensocial/swiftmail"
+    And I press "Default email notification settings"
     And I click radio button "Never" with the id "edit-create-mention-post-none"
     And I press "Save configuration"
 


### PR DESCRIPTION
## Problem
Currently, as part of `/admin/config/opensocial/swiftmail`, we can already configure for each email notification if they are by default send as Immediately, Daily or Weekly.

We need to add the option for emails not to be sent.

## Solution
Add a `none`(Never) option for email notification frequency 

## Issue tracker
https://www.drupal.org/project/social/issues/3225518
https://getopensocial.atlassian.net/browse/YANG-6040

## How to test
- [ ] As an SM+
- [ ] Go to `/admin/config/opensocial/swiftmail`
- [ ] You should be able to set "Never" for email templates

## Screenshots
#### Before
Site settings
![зображення](https://user-images.githubusercontent.com/11648677/127191093-e46cdcdc-1652-4cd7-907f-20969d8a3ac5.png)
User settings
![image](https://user-images.githubusercontent.com/2241917/128485548-d4974066-49ec-4fe2-92dc-8ac78bbaf194.png)

#### After
Site settings
![image](https://user-images.githubusercontent.com/2241917/128485274-3204ac99-1f6f-4955-9f7b-cb616ecf3864.png)

User settings
![image](https://user-images.githubusercontent.com/2241917/128485375-47743779-bf2f-4a58-9e03-edf3459e65ba.png)



## Release notes
Now SM+ can select "Never" as a default email frequency option for email notifications.

## Change Record
N/A

## Translations
N/A
