### PR TITLE
Issue #3226503 by robertragas: add an extra check to make sure we are…

### DIFF
--- a/modules/social_features/social_core/src/EventSubscriber/SocialInviteSubscriber.php
+++ b/modules/social_features/social_core/src/EventSubscriber/SocialInviteSubscriber.php
@@ -94,39 +94,43 @@ class SocialInviteSubscriber implements EventSubscriberInterface {
    *   The GetResponseEvent to process.
    */
   public function notifyAboutPendingInvitations(GetResponseEvent $event) {
-    $data = $this->inviteService->getInviteData();
-    /** @var \Symfony\Component\HttpFoundation\Request $request */
-    $request = $event->getRequest();
-    $request_path = $request->getPathInfo();
-    $route_name = $this->currentRoute->getRouteName();
-    $default_front = $this->siteSettings->get('page.front');
-    $frontpage_lu = $this->alternativeFrontpageSettings->get('frontpage_for_authenticated_user') ?: '';
+    // Only show this message when a user is logged in.
+    if($this->currentUser->isAuthenticated()) {
+      $data = $this->inviteService->getInviteData();
+      /** @var \Symfony\Component\HttpFoundation\Request $request */
+      $request = $event->getRequest();
+      $request_path = $request->getPathInfo();
+      $route_name = $this->currentRoute->getRouteName();
+      $default_front = $this->siteSettings->get('page.front');
+      $frontpage_lu = $this->alternativeFrontpageSettings->get('frontpage_for_authenticated_user') ?: '';
 
-    // Either allow on paths.
-    $paths_allowed = [
-      $default_front,
-      $frontpage_lu,
-      '/',
-    ];
-    // Or allow on route names.
-    $routes_allowed = [
-      'social_core.homepage',
-    ];
+      // Either allow on paths.
+      $paths_allowed = [
+        $default_front,
+        $frontpage_lu,
+        '/',
+      ];
+      // Or allow on route names.
+      $routes_allowed = [
+        'social_core.homepage',
+      ];
 
-    // We want to show this message either on:
-    // the default site front page
-    // the front page set for authenticated users
-    // or the stream being the social_core.homepage.
-    if (in_array($request_path, $paths_allowed) || in_array($route_name, $routes_allowed)) {
-      if (!empty($data['name']) && !empty($data['amount'])) {
-        $replacement_url = [
-          '@url' => Url::fromRoute($data['name'], ['user' => $this->currentUser->id()])->toString(),
-        ];
-        $message = $this->formatPlural($data['amount'],
-          'You have 1 pending invite <a href="@url">visit your invite overview</a> to see it.',
-          'You have @count pending invites <a href="@url">visit your invite overview</a> to see them.', $replacement_url);
+      // We want to show this message either on:
+      // the default site front page
+      // the front page set for authenticated users
+      // or the stream being the social_core.homepage.
+      if (in_array($request_path, $paths_allowed) || in_array($route_name, $routes_allowed)) {
+        if (!empty($data['name']) && !empty($data['amount'])) {
+          $replacement_url = [
+            '@url' => Url::fromRoute($data['name'], ['user' => $this->currentUser->id()])
+              ->toString(),
+          ];
+          $message = $this->formatPlural($data['amount'],
+            'You have 1 pending invite <a href="@url">visit your invite overview</a> to see it.',
+            'You have @count pending invites <a href="@url">visit your invite overview</a> to see them.', $replacement_url);
 
-        $this->messenger->addMessage($message, 'warning');
+          $this->messenger->addMessage($message, 'warning');
+        }
       }
     }
   }


### PR DESCRIPTION
… authenticated when we show pending invites

## Problem
In a former release of Open Social group/event invites got introduced. This can cause the situation where for anonymous it show a message with pending invites. Even though the link doesn't work and you get access denied, the message bar is still an disruptive experience.

## Solution
Make sure we don't show this message when a user isn't logged it.

## Issue tracker
https://www.drupal.org/project/social/issues/3226503

## How to test
- [ ] Create an event and allow anonymous to enroll
- [ ] Enroll as anonymous. If correct the table event_enrollment__field_account should have a field with account 0.
- [ ] Go as anonymous to the frontpage and see the header message that you have pending invites.
- [ ] Go to the branch and check if the message has disappeared.

## Screenshots
<img width="1166" alt="Screen Shot 2021-08-03 at 4 53 16 PM" src="https://user-images.githubusercontent.com/19951171/128039979-53749ab9-bfe4-4378-946d-4b662cb7eea9.png">

## Release notes
We have fixed an issue where the frontpage would show a message bar with pending invites as anonymous. This bar should now be gone