### PR TITLE
Issue #3226672 by nkoporec: Overwrite title field for blocks does not work in Landing Page form

### DIFF
--- a/modules/social_features/social_landing_page/social_landing_page.module
+++ b/modules/social_features/social_landing_page/social_landing_page.module
@@ -41,6 +41,72 @@ function social_landing_page_form_views_exposed_form_alter(&$form, FormStateInte
 }
 
 /**
+ * Implements hook_field_widget_WIDGET_TYPE_form_alter().
+ *
+ * When rendering the block form inside paragraphs, the #states will not
+ * work due to different name parameter, since it's nested inside the paragraph
+ * field. We need to alter the form, so that the #states will match the new
+ * html markup provided by paragraph. We only do this for
+ * 'Override title' field.
+ */
+function social_landing_page_field_widget_block_field_default_form_alter(&$element, &$form_state, $context) {
+  // Make sure we are inside a paragraph.
+  $form = $context['form'];
+  $entity_type = $form['#entity_type'];
+  if ($entity_type != 'paragraph') {
+    return;
+  }
+
+  // Make sure we only do this in field_landing_page_section.
+  $parents = $form['#parents'];
+  if (!in_array('field_landing_page_section', $parents)) {
+    return;
+  }
+
+  // Get block settings and label fields.
+  $block_settings = $element['settings'];
+  $views_label_checkbox = isset($block_settings['views_label_checkbox']) ? $block_settings['views_label_checkbox'] : FALSE;
+  $views_label_fieldset = isset($block_settings['views_label_fieldset']) ? $block_settings['views_label_fieldset'] : FALSE;
+  $views_label = isset($block_settings['views_label']) ? $block_settings['views_label'] : FALSE;
+
+  if (!$views_label_checkbox || !$views_label_fieldset || !$views_label) {
+    return;
+  }
+
+  // Grab the id.
+  $id = $block_settings['#attributes']['id'];
+  $items = explode('-', $id);
+
+  // Generate the new state name.
+  // We use block id, to get all the parent names
+  // and then add the checkbox element to it.
+  $state_name = $items[0];
+  unset($items[0]);
+  $items[] = 'views_label_checkbox';
+
+  foreach ($items as $name) {
+    $state_name .= '[' . $name . ']';
+  }
+
+  // Fields on which to alter the state.
+  $fields = [
+    'views_label_fieldset',
+    'views_label',
+  ];
+
+  $state = ':input[name="' . $state_name . '"]';
+  foreach ($fields as $field) {
+    // Remove old values and replace them with the new ones.
+    unset($element['settings'][$field]['#states']['visible']);
+    $element['settings'][$field]['#states']['visible'][0] = [
+      $state => [
+        'checked' => TRUE,
+      ],
+    ];
+  }
+}
+
+/**
  * Implements hook_theme().
  */
 function social_landing_page_theme() {


### PR DESCRIPTION
## Problem
When creating a new landing page and adding a new block in a section, the override title block field is not working correctly. The checkbox is enabled, but the actual field is not displayed, so currently you are not able to override the block title.

## Solution
The problem is with #states attribute. When rendering a form inside paragraphs, the '#name' attribute of fields are alternated since they are deeply nested within the paragraph fields. This means that the #states value of the original form(block settings form) is no longer correct, so we need to alter the form and set the correct #states attribute.

## Issue tracker
https://www.drupal.org/project/social/issues/3226672

## How to test

1. Enable social_landing_page module
2. Create a new landing page content type
3. Add a new section
4. Add a block reference
5. For 'Primary' field set 'Complete community activity stream'
6. Click the 'Override Title' checkbox and see that nothing happens (no additional field is displayed).

## Screenshots
Before:
![2021-08-04_12-12](https://user-images.githubusercontent.com/35064680/128164249-f8bbe47e-41be-45c5-9777-f9f25bd75334.png)

After:
![2021-08-04_12-13](https://user-images.githubusercontent.com/35064680/128164269-21217ffa-0f8e-4ca4-a1d8-0dc4c16459e5.png)


## Release notes
Fixed an issue where override title field would not work when rendered inside a paragraph of a landing page.
