### PR TITLE
Issue 3227098 by tBKoT: Redirect to the user's preferred language.

### DIFF
--- a/modules/custom/social_language/config/update/social_language_update_10201.yml
+++ b/modules/custom/social_language/config/update/social_language_update_10201.yml
@@ -1,0 +1,8 @@
+language.types:
+  expected_config: { }
+  update_actions:
+    delete:
+      negotiation:
+        language_interface:
+          enabled:
+            language-user: { }

--- a/modules/custom/social_language/social_language.install
+++ b/modules/custom/social_language/social_language.install
@@ -122,6 +122,20 @@ YAML;
 }
 
 /**
+ * Disable user language detection.
+ */
+function social_language_update_10201() {
+  /** @var \Drupal\update_helper\Updater $updateHelper */
+  $updateHelper = \Drupal::service('update_helper.updater');
+
+  // Execute configuration update definitions with logging of success.
+  $updateHelper->executeUpdate('social_language', 'social_language_update_10201');
+
+  // Output logged messages to related channel of update execution.
+  return $updateHelper->logger()->output();
+}
+
+/**
  * Allow "Content Manager" role to manage translations.
  */
 function social_language_update_10301() {

--- a/modules/custom/social_language/social_language.module
+++ b/modules/custom/social_language/social_language.module
@@ -7,8 +7,11 @@
 
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Language\LanguageInterface;
 use Drupal\Core\Render\Element;
 use Drupal\Core\Url;
+use Drupal\user\UserInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 
 /**
  * Implements hook_language_switch_links_alter().
@@ -51,12 +54,8 @@ function social_language_form_alter(&$form, FormStateInterface $form_state, $for
  * Implements hook_form_FORM_ID_alter().
  */
 function social_language_form_user_form_alter(&$form, FormStateInterface $form_state, $form_id) {
-  /** @var \Drupal\Core\Config\ImmutableConfig $language_types */
-  $language_negotiations = \Drupal::configFactory()->get('language.types')->get('negotiation');
-
-  // Show the preferred language field only when the user language negotiation
-  // is set to user and we have at least two languages.
-  if (isset($language_negotiations['language_interface']['enabled']['language-user']) && count(\Drupal::languageManager()->getLanguages()) > 1) {
+  // Show the preferred language field only when we have at least two languages.
+  if (count(\Drupal::languageManager()->getLanguages()) > 1) {
     $form['language']['#title'] = NULL;
     $form['language']['preferred_langcode']['#title'] = t('Interface language');
     $form['language']['preferred_langcode']['#description'] = t('Select the language you want to use this site in.');
@@ -101,4 +100,45 @@ function social_language_field_group_form_process_alter(array &$element, &$group
   // Prevent \Drupal\content_translation\ContentTranslationHandler::addTranslatabilityClue()
   // from adding an incorrect suffix to the field group title.
   $element['#multilingual'] = TRUE;
+}
+
+/**
+ * Implements hook_user_login().
+ */
+function social_language_user_login(UserInterface $account): void {
+  $active_theme = \Drupal::theme()->getActiveTheme()->getName();
+
+  /** @var \Drupal\block\BlockInterface $block */
+  $block = \Drupal::entityTypeManager()->getStorage('block')->load($active_theme . '_language_switcher_block');
+
+  // Skip if user does not have access to language switcher.
+  if (!$block->access('view', $account)) {
+    return;
+  }
+
+  $language_manager = \Drupal::languageManager();
+  $current_langcode = $language_manager->getCurrentLanguage(LanguageInterface::TYPE_URL)->getId();
+  $default_langcode = $language_manager->getDefaultLanguage()->getId();
+
+  // Skip if user changed interface language before.
+  if ($current_langcode !== $default_langcode) {
+    return;
+  }
+
+  $user_langcode = $account->getPreferredLangcode();
+  $langcode = $user_langcode ?: $current_langcode;
+
+  // Skip if user language is the same as current.
+  if ($langcode === $current_langcode) {
+    return;
+  }
+
+  $url = Url::fromRoute('<front>', [], [
+    'language' => $language_manager->getLanguage($langcode),
+  ]);
+
+  // Redirect with changed language.
+  // @phpstan-ignore-next-line
+  $response = new RedirectResponse($url->toString());
+  $response->send();
 }

--- a/tests/behat/features/capabilities/language/change-language.feature
+++ b/tests/behat/features/capabilities/language/change-language.feature
@@ -30,30 +30,26 @@ Feature: Multilingual Open Social
     And I translate "Settings" to "Instellingen" for "nl"
 
 
-    # Check language field not visible when User negotation is not turned on.
-    Given I go to "/admin/config/regional/language/detection"
-    And I uncheck the box "Enable user language detection method"
-    And I press "Save settings"
-    And I am logged in as an "authenticated user"
+    # Check language field visible when site has more than one language.
+    Given I am logged in as an "authenticated user"
     When I click the xth "0" element with the css ".navbar-nav .profile"
     And I click "Settings"
-    Then I should not see the text "Interface language"
-    And I should not see the text "Select the language you want to use this site in."
+    Then I should see the text "Interface language"
+    And I should see the text "Select the language you want to use this site in."
 
-    # Language field on user form should be visible when site has more than one
-    # language and the User language detection is enabled.
+    # Enable User language detection as main.
     Given I am logged in as an "administrator"
     When I go to "/admin/config/regional/language/detection"
     And I uncheck the box "Enable url language detection method"
     And I check the box "Enable user language detection method"
     And I press "Save settings"
-    And I am logged in as an "authenticated user"
+
+    # Switch user's preferred language to Dutch.
+    Given I am logged in as an "authenticated user"
     And I click the xth "0" element with the css ".navbar-nav .profile"
     And I click "Settings"
     Then I should see the text "Interface language"
     And I should see the text "Select the language you want to use this site in."
-
-    # Switch to Dutch.
     When I select "Dutch" from "Interface language"
     And I press "Save"
     Then I should see the text "Taalinstelling"


### PR DESCRIPTION
## Problem
This problem arises only then user's preferred language is different from the default language.
It's because when we use multiple language detections for the interface:
- by URL
- by preferred language

Url detection checks prefix in requested Uri and compares it with language prefixes in configuration, but default language does not have any prefix so Url negotiation returns false instead of language on all pages except the home page. In that case, Drupal goes to the next available negotiation and gets the user's preferred language. And sins it is not equal to default language we cannot switch back.
## Solution
Turn off the user language detection if it already was enabled.
Add redirection to the front page with the user's selected language.

## Issue tracker
https://www.drupal.org/project/social/issues/3227098
https://getopensocial.atlassian.net/browse/YANG-6094

## How to test
*For example*
- [ ] Enable the Social Language module
- [ ] Add any additional language
- [ ] Enable the User language detection
- [ ] Change your preferred language
- [ ] Go any page, except home
- [ ] Switch language to newly added and switch back to default

## Screenshots
#### Changed to Dutch
<img width="945" alt="зображення" src="https://user-images.githubusercontent.com/11648677/128515763-f380ab16-429c-45b0-85b3-e04a0c460bba.png">

#### Switch back to English
<img width="1044" alt="зображення" src="https://user-images.githubusercontent.com/11648677/128515942-ce014a80-a4eb-4b3f-942d-6a879b34cbd7.png">

## Release notes
Now the user is able to select a preferred language when the site has at least two languages, even if User language detection is not enabled.

## Change Record
N/A

## Translations
N/A
