### PR TITLE
Issue #3227326 by vnech: Add missed translation support for "Landing Page" content type

### DIFF
--- a/modules/social_features/social_landing_page/config/install/field.field.paragraph.accordion.field_accord_description.yml
+++ b/modules/social_features/social_landing_page/config/install/field.field.paragraph.accordion.field_accord_description.yml
@@ -13,7 +13,7 @@ bundle: accordion
 label: Description
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/modules/social_features/social_landing_page/config/install/field.field.paragraph.accordion.field_accord_title.yml
+++ b/modules/social_features/social_landing_page/config/install/field.field.paragraph.accordion.field_accord_title.yml
@@ -11,7 +11,7 @@ bundle: accordion
 label: Title
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/modules/social_features/social_landing_page/config/install/field.field.paragraph.accordion_item.field_accord_item_description.yml
+++ b/modules/social_features/social_landing_page/config/install/field.field.paragraph.accordion_item.field_accord_item_description.yml
@@ -13,7 +13,7 @@ bundle: accordion_item
 label: Description
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/modules/social_features/social_landing_page/config/install/field.field.paragraph.accordion_item.field_accord_item_title.yml
+++ b/modules/social_features/social_landing_page/config/install/field.field.paragraph.accordion_item.field_accord_item_title.yml
@@ -11,7 +11,7 @@ bundle: accordion_item
 label: Title
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/modules/social_features/social_landing_page/config/install/field.field.paragraph.block.field_block_link.yml
+++ b/modules/social_features/social_landing_page/config/install/field.field.paragraph.block.field_block_link.yml
@@ -13,7 +13,7 @@ bundle: block
 label: Link
 description: 'Optional link. Sometimes blocks already contain more link.'
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/modules/social_features/social_landing_page/config/install/field.field.paragraph.block.field_block_title.yml
+++ b/modules/social_features/social_landing_page/config/install/field.field.paragraph.block.field_block_title.yml
@@ -11,7 +11,7 @@ bundle: block
 label: Title
 description: 'Optional field, title can be printed from block or overridden here. Uncheck <em>Display title</em> if using this field'
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/modules/social_features/social_landing_page/config/install/field.field.paragraph.button.field_button_link_an.yml
+++ b/modules/social_features/social_landing_page/config/install/field.field.paragraph.button.field_button_link_an.yml
@@ -13,7 +13,7 @@ bundle: button
 label: 'Link for Anonymous User'
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/modules/social_features/social_landing_page/config/install/field.field.paragraph.button.field_button_link_lu.yml
+++ b/modules/social_features/social_landing_page/config/install/field.field.paragraph.button.field_button_link_lu.yml
@@ -13,7 +13,7 @@ bundle: button
 label: 'Link for Logged In User'
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/modules/social_features/social_landing_page/config/install/field.field.paragraph.hero.field_hero_image.yml
+++ b/modules/social_features/social_landing_page/config/install/field.field.paragraph.hero.field_hero_image.yml
@@ -13,7 +13,7 @@ bundle: hero
 label: Image
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/modules/social_features/social_landing_page/config/install/field.field.paragraph.hero.field_hero_subtitle.yml
+++ b/modules/social_features/social_landing_page/config/install/field.field.paragraph.hero.field_hero_subtitle.yml
@@ -11,7 +11,7 @@ bundle: hero
 label: Subtitle
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/modules/social_features/social_landing_page/config/install/field.field.paragraph.hero.field_hero_title.yml
+++ b/modules/social_features/social_landing_page/config/install/field.field.paragraph.hero.field_hero_title.yml
@@ -11,7 +11,7 @@ bundle: hero
 label: Title
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/modules/social_features/social_landing_page/config/install/field.field.paragraph.hero_small.field_hero_small_image.yml
+++ b/modules/social_features/social_landing_page/config/install/field.field.paragraph.hero_small.field_hero_small_image.yml
@@ -13,7 +13,7 @@ bundle: hero_small
 label: Image
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/modules/social_features/social_landing_page/config/install/field.field.paragraph.hero_small.field_hero_small_subtitle.yml
+++ b/modules/social_features/social_landing_page/config/install/field.field.paragraph.hero_small.field_hero_small_subtitle.yml
@@ -11,7 +11,7 @@ bundle: hero_small
 label: Subtitle
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/modules/social_features/social_landing_page/config/install/field.field.paragraph.hero_small.field_hero_small_title.yml
+++ b/modules/social_features/social_landing_page/config/install/field.field.paragraph.hero_small.field_hero_small_title.yml
@@ -11,7 +11,7 @@ bundle: hero_small
 label: Title
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/modules/social_features/social_landing_page/config/install/field.field.paragraph.introduction.field_introduction_link_an.yml
+++ b/modules/social_features/social_landing_page/config/install/field.field.paragraph.introduction.field_introduction_link_an.yml
@@ -13,7 +13,7 @@ bundle: introduction
 label: 'Link for Anonymous User'
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/modules/social_features/social_landing_page/config/install/field.field.paragraph.introduction.field_introduction_link_lu.yml
+++ b/modules/social_features/social_landing_page/config/install/field.field.paragraph.introduction.field_introduction_link_lu.yml
@@ -13,7 +13,7 @@ bundle: introduction
 label: 'Link for Logged In User'
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/modules/social_features/social_landing_page/config/install/field.field.paragraph.introduction.field_introduction_text.yml
+++ b/modules/social_features/social_landing_page/config/install/field.field.paragraph.introduction.field_introduction_text.yml
@@ -13,7 +13,7 @@ bundle: introduction
 label: Text
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/modules/social_features/social_landing_page/config/install/field.field.paragraph.introduction.field_introduction_title.yml
+++ b/modules/social_features/social_landing_page/config/install/field.field.paragraph.introduction.field_introduction_title.yml
@@ -11,7 +11,7 @@ bundle: introduction
 label: Title
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/modules/social_features/social_landing_page/config/optional/language.content_settings.paragraph.accordion.yml
+++ b/modules/social_features/social_landing_page/config/optional/language.content_settings.paragraph.accordion.yml
@@ -1,0 +1,15 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - paragraphs.paragraphs_type.accordion
+  module:
+    - social_content_translation
+third_party_settings:
+  content_translation:
+    enabled: true
+id: paragraph.accordion
+target_entity_type_id: paragraph
+target_bundle: accordion
+default_langcode: site_default
+language_alterable: true

--- a/modules/social_features/social_landing_page/config/optional/language.content_settings.paragraph.accordion_item.yml
+++ b/modules/social_features/social_landing_page/config/optional/language.content_settings.paragraph.accordion_item.yml
@@ -1,0 +1,15 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - paragraphs.paragraphs_type.accordion_item
+  module:
+    - social_content_translation
+third_party_settings:
+  content_translation:
+    enabled: true
+id: paragraph.accordion_item
+target_entity_type_id: paragraph
+target_bundle: accordion_item
+default_langcode: site_default
+language_alterable: true

--- a/modules/social_features/social_landing_page/config/optional/language.content_settings.paragraph.hero_small.yml
+++ b/modules/social_features/social_landing_page/config/optional/language.content_settings.paragraph.hero_small.yml
@@ -1,0 +1,15 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - paragraphs.paragraphs_type.hero_small
+  module:
+    - social_content_translation
+third_party_settings:
+  content_translation:
+    enabled: true
+id: paragraph.hero_small
+target_entity_type_id: paragraph
+target_bundle: hero_small
+default_langcode: site_default
+language_alterable: true

--- a/modules/social_features/social_landing_page/config/optional/language.content_settings.paragraph.section.yml
+++ b/modules/social_features/social_landing_page/config/optional/language.content_settings.paragraph.section.yml
@@ -1,0 +1,15 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - paragraphs.paragraphs_type.section
+  module:
+    - social_content_translation
+third_party_settings:
+  content_translation:
+    enabled: true
+id: paragraph.section
+target_entity_type_id: paragraph
+target_bundle: section
+default_langcode: site_default
+language_alterable: true

--- a/modules/social_features/social_landing_page/config/update/social_landing_page_update_10302.yml
+++ b/modules/social_features/social_landing_page/config/update/social_landing_page_update_10302.yml
@@ -1,0 +1,108 @@
+field.field.paragraph.block.field_block_title:
+  expected_config:
+    translatable: FALSE
+  update_actions:
+    change:
+      translatable: TRUE
+field.field.paragraph.block.field_block_link:
+  expected_config:
+    translatable: FALSE
+  update_actions:
+    change:
+      translatable: TRUE
+field.field.paragraph.button.field_button_link_an:
+  expected_config:
+    translatable: FALSE
+  update_actions:
+    change:
+      translatable: TRUE
+field.field.paragraph.button.field_button_link_lu:
+  expected_config:
+    translatable: FALSE
+  update_actions:
+    change:
+      translatable: TRUE
+field.field.paragraph.hero.field_hero_image:
+  expected_config:
+    translatable: FALSE
+  update_actions:
+    change:
+      translatable: TRUE
+field.field.paragraph.hero.field_hero_subtitle:
+  expected_config:
+    translatable: FALSE
+  update_actions:
+    change:
+      translatable: TRUE
+field.field.paragraph.hero.field_hero_title:
+  expected_config:
+    translatable: FALSE
+  update_actions:
+    change:
+      translatable: TRUE
+field.field.paragraph.hero_small.field_hero_small_image:
+  expected_config:
+    translatable: FALSE
+  update_actions:
+    change:
+      translatable: TRUE
+field.field.paragraph.hero_small.field_hero_small_subtitle:
+  expected_config:
+    translatable: FALSE
+  update_actions:
+    change:
+      translatable: TRUE
+field.field.paragraph.hero_small.field_hero_small_title:
+  expected_config:
+    translatable: FALSE
+  update_actions:
+    change:
+      translatable: TRUE
+field.field.paragraph.introduction.field_introduction_text:
+  expected_config:
+    translatable: FALSE
+  update_actions:
+    change:
+      translatable: TRUE
+field.field.paragraph.introduction.field_introduction_title:
+  expected_config:
+    translatable: FALSE
+  update_actions:
+    change:
+      translatable: TRUE
+field.field.paragraph.introduction.field_introduction_link_an:
+  expected_config:
+    translatable: FALSE
+  update_actions:
+    change:
+      translatable: TRUE
+field.field.paragraph.introduction.field_introduction_link_lu:
+  expected_config:
+    translatable: FALSE
+  update_actions:
+    change:
+      translatable: TRUE
+field.field.paragraph.accordion.field_accord_title:
+  expected_config:
+    translatable: FALSE
+  update_actions:
+    change:
+      translatable: TRUE
+field.field.paragraph.accordion.field_accord_description:
+  expected_config:
+    translatable: FALSE
+  update_actions:
+    change:
+      translatable: TRUE
+field.field.paragraph.accordion_item.field_accord_item_title:
+  expected_config:
+    translatable: FALSE
+  update_actions:
+    change:
+      translatable: TRUE
+field.field.paragraph.accordion_item.field_accord_item_description:
+  expected_config:
+    translatable: FALSE
+  update_actions:
+    change:
+      translatable: TRUE

--- a/modules/social_features/social_landing_page/social_landing_page.install
+++ b/modules/social_features/social_landing_page/social_landing_page.install
@@ -703,3 +703,17 @@ function social_landing_page_update_10301() {
     user_role_grant_permissions($role_id, ['translate landing_page node']);
   }
 }
+
+/**
+ * Make "Landing Page" translatable.
+ */
+function social_landing_page_update_10302() {
+  /** @var \Drupal\update_helper\Updater $updateHelper */
+  $updateHelper = \Drupal::service('update_helper.updater');
+
+  // Execute configuration update definitions with logging of success.
+  $updateHelper->executeUpdate('social_landing_page', __FUNCTION__);
+
+  // Output logged messages to related channel of update execution.
+  return $updateHelper->logger()->output();
+}

--- a/modules/social_features/social_landing_page/src/ContentTranslationDefaultsConfigOverride.php
+++ b/modules/social_features/social_landing_page/src/ContentTranslationDefaultsConfigOverride.php
@@ -32,6 +32,7 @@ class ContentTranslationDefaultsConfigOverride extends ContentTranslationConfigO
    */
   protected function getTranslationOverrides() {
     return [
+      // Translations for "Landing Page" node type.
       'language.content_settings.node.landing_page' => [
         'third_party_settings' => [
           'content_translation' => [
@@ -48,23 +49,29 @@ class ContentTranslationDefaultsConfigOverride extends ContentTranslationConfigO
       'core.base_field_override.node.landing_page.path' => [
         'translatable' => TRUE,
       ],
-      'field.field.node.landing_page.body' => [
-        'translatable' => TRUE,
+      // Translations for "Block" paragraph type.
+      'language.content_settings.paragraph.block' => [
+        'third_party_settings' => [
+          'content_translation' => [
+            'enabled' => TRUE,
+          ],
+        ],
       ],
-      'field.field.paragraph.block.field_block_title' => [
-        'translatable' => TRUE,
+      // Translations for "Button" paragraph type.
+      'language.content_settings.paragraph.button' => [
+        'third_party_settings' => [
+          'content_translation' => [
+            'enabled' => TRUE,
+          ],
+        ],
       ],
-      'field.field.paragraph.button.field_button_link_an' => [
-        'translatable' => TRUE,
-      ],
-      'field.field.paragraph.button.field_button_link_lu' => [
-        'translatable' => TRUE,
-      ],
-      'field.field.paragraph.featured.field_featured_description' => [
-        'translatable' => TRUE,
-      ],
-      'field.field.paragraph.featured.field_featured_title' => [
-        'translatable' => TRUE,
+      // Translations for "Hero" paragraph type.
+      'language.content_settings.paragraph.hero' => [
+        'third_party_settings' => [
+          'content_translation' => [
+            'enabled' => TRUE,
+          ],
+        ],
       ],
       'field.field.paragraph.hero.field_hero_image' => [
         'third_party_settings' => [
@@ -76,19 +83,49 @@ class ContentTranslationDefaultsConfigOverride extends ContentTranslationConfigO
             ],
           ],
         ],
-        'translatable' => TRUE,
       ],
-      'field.field.paragraph.hero.field_hero_subtitle' => [
-        'translatable' => TRUE,
+      // Translations for "Hero small" paragraph type.
+      'language.content_settings.paragraph.hero_small' => [
+        'third_party_settings' => [
+          'content_translation' => [
+            'enabled' => TRUE,
+          ],
+        ],
       ],
-      'field.field.paragraph.hero.field_hero_title' => [
-        'translatable' => TRUE,
+      'field.field.paragraph.hero_small.field_hero_small_image' => [
+        'third_party_settings' => [
+          'content_translation' => [
+            'translation_sync' => [
+              'file' => 'file',
+              'alt' => '0',
+              'title' => '0',
+            ],
+          ],
+        ],
       ],
-      'field.field.paragraph.introduction.field_introduction_text' => [
-        'translatable' => TRUE,
+      // Translations for "Introduction" paragraph type.
+      'language.content_settings.paragraph.introduction' => [
+        'third_party_settings' => [
+          'content_translation' => [
+            'enabled' => TRUE,
+          ],
+        ],
       ],
-      'field.field.paragraph.introduction.field_introduction_title' => [
-        'translatable' => TRUE,
+      // Translations for "Accordion" paragraph type.
+      'language.content_settings.paragraph.accordion' => [
+        'third_party_settings' => [
+          'content_translation' => [
+            'enabled' => TRUE,
+          ],
+        ],
+      ],
+      // Translations for "Accordion Item" paragraph type.
+      'language.content_settings.paragraph.accordion_item' => [
+        'third_party_settings' => [
+          'content_translation' => [
+            'enabled' => TRUE,
+          ],
+        ],
       ],
     ];
   }

--- a/modules/social_features/social_landing_page/src/ContentTranslationDefaultsConfigOverride.php
+++ b/modules/social_features/social_landing_page/src/ContentTranslationDefaultsConfigOverride.php
@@ -49,6 +49,14 @@ class ContentTranslationDefaultsConfigOverride extends ContentTranslationConfigO
       'core.base_field_override.node.landing_page.path' => [
         'translatable' => TRUE,
       ],
+      // Translations for "Section" paragraph type.
+      'language.content_settings.paragraph.section' => [
+        'third_party_settings' => [
+          'content_translation' => [
+            'enabled' => TRUE,
+          ],
+        ],
+      ],
       // Translations for "Block" paragraph type.
       'language.content_settings.paragraph.block' => [
         'third_party_settings' => [


### PR DESCRIPTION
## Problem
There are a few paragraph type in "Landing Page" node that don't support translations:
- Accordion
- Accordion Item
- Hero small

## Solution
- Make paragraphs translatable
- Make all fields used in "Landing Page" translatable by default

## Issue tracker
- https://www.drupal.org/project/social/issues/3227326
- https://getopensocial.atlassian.net/browse/YANG-6107

## How to test
*For example*
- [ ] Login as an admin
- [ ] Make sure the instance is multilingual
- [ ] Make sure the module "Social Content Translation" is enabled
- [ ] Add a "Landing Page"
- [ ] Translate created landing page

## Screenshots
N/A

## Release notes
*Make paragraphs in "Landing Page" translatable; Make fields in "Landing Page" translatable by default*

## Change Record
N/A

## Translations
N/A
