### PR TITLE
Issue #3179171 by agami4: Add autocomplete attr to the profile edit fields

### DIFF
--- a/modules/social_features/social_profile/social_profile.module
+++ b/modules/social_features/social_profile/social_profile.module
@@ -46,13 +46,35 @@ function social_profile_field_widget_form_alter(&$element, FormStateInterface $f
     case 'field_profile_phone_number':
       // @todo Remove this when rule for .form-tel elements will be added.
       $element['value']['#attributes']['class'][] = 'form-text';
+      $element['value']['#attributes']['autocomplete'][] = 'tel';
       break;
 
     case 'field_profile_address':
       // @todo Remove this when script for custom selects will be added.
       $element['country_code']['#attributes']['class'][] = 'browser-default';
       break;
+
+    case 'field_profile_nick_name':
+      $element['value']['#attributes']['autocomplete'][] = 'nickname';
+      break;
+
+    case 'field_profile_first_name':
+      $element['value']['#attributes']['autocomplete'][] = 'given-name';
+      break;
+
+    case 'field_profile_last_name':
+      $element['value']['#attributes']['autocomplete'][] = 'family-name';
+      break;
+
+    case 'field_profile_organization':
+      $element['value']['#attributes']['autocomplete'][] = 'organization';
+      break;
+
+    case 'field_profile_function':
+      $element['value']['#attributes']['autocomplete'][] = 'organization-title';
+      break;
   }
+
   // This replaces all user entity references with our EntityReferenceSelection.
   if ($field_definition->getType() === 'entity_reference') {
     if (


### PR DESCRIPTION
## Problem
The page contains input fields where personal information must be entered. The input fields such as first name and last name do not have a mechanism to automatically complete the input. This makes filling out forms easier for many users, especially those for whom text entry takes a long time, as this is done through special tools such as pointing out letters. The use of autocomplete with the correct value is mandatory, on page https://www.w3.org/TR/2018/REC-WCAG21-20180605/#input-purposes is a list of the values ​​to be used if applicable. There are more fields where the autocomplete attribute should be used, for example the field for the telephone number. In the list you can see which values ​​can be used for which fields.

## Solution
Properly use the following autocomplete values on the profile fields:
- given-name
- family-name
- nickname
- photo
- organization-title
- organization

## Issue tracker
https://www.drupal.org/project/social/issues/3179171

## How to test
*For example*
- [ ] Go to profile edit page
- [ ] Check if nickname, first/last name, organization, function fields have a autocomplete attr.

## Screenshots

## Release notes
The nickname, first/last name, organization, function fields have a autocomplete attr.

## Change Record

## Translations
