### PR TITLE
Do not show the 'Profile tag' label on search if split disabled

### DIFF
--- a/modules/social_features/social_profile/src/Plugin/views/filter/SocialSearchApiSplitProfileTerms.php
+++ b/modules/social_features/social_profile/src/Plugin/views/filter/SocialSearchApiSplitProfileTerms.php
@@ -82,9 +82,7 @@ class SocialSearchApiSplitProfileTerms extends SearchApiTerm {
 
     // Wrapper.
     $element = [
-      '#type' => 'details',
-      '#open' => TRUE,
-      '#access' => FALSE,
+      '#type' => 'container',
     ];
 
     // Get the main categories.


### PR DESCRIPTION
## Problem
*Describe the problem you're trying to solve, this should motivate why the changes you're proposing are needed.*

## Solution
*Describe the solution you've created, elaborate on any technical choices you've made. Why is this the right solution and is a different solution not the right one?*

## Issue tracker
*Paste a link to the drupal.org issue queue item. If any other issue trackers were used, include links to those too.*

## How to test
*For example*
- [ ] Using version X.Y.Z of Open Social with the example module enabled
- [ ] As a sitemanager
- [ ] Try to enable the option B on screen c/d/e
- [ ] When saving I expect the result to be F but instead see G.
- [ ] The expected result F is attained when repeating the steps with this fix applied.

## Screenshots
*If this Pull Request makes visual changes then please include some screenshots that show what has changed here. A before and after screenshot helps the reviewer determine what changes were made.*

## Release notes
*A short summary of the changes that were made that can be included in release notes.*

## Change Record
*If this Pull Request changes the way that developers should do things or introduces a new API for developers then a change record to document this is needed. Please provide a draft for a change record or a link to an unpublished change record below. [Existing change records](https://www.drupal.org/list-changes/social) can be consulted as example.*

## Translations
*Translatable strings are always extracted from the latest development branch. To ensure translations remain available for platforms running older versions of Open Social the original string should be added to `translations.php` when it's changed or removed.*
- [ ] Changed or removed source strings are added to the `translations.php` file.
