### PR TITLE
Issue #3228470 by Ressinel: Fix when event admin can't send email to his event attendees.

### DIFF
--- a/modules/social_features/social_event/modules/social_event_managers/src/Plugin/Action/SocialEventManagersSendEmail.php
+++ b/modules/social_features/social_event/modules/social_event_managers/src/Plugin/Action/SocialEventManagersSendEmail.php
@@ -102,6 +102,9 @@ class SocialEventManagersSendEmail extends SocialSendEmail {
       $event_id = $object->getFieldValue('field_event', 'target_id');
       $node = $this->entityTypeManager->getStorage('node')->load($event_id);
 
+      // Resets the social_event_manager_or_organizer caches.
+      drupal_static_reset('social_event_manager_or_organizer');
+
       // Also Event organizers can do this.
       if ($node instanceof NodeInterface && social_event_manager_or_organizer($node)) {
         $access = AccessResult::allowedIf($object instanceof EventEnrollmentInterface);


### PR DESCRIPTION
## Problem
Bulk emails are not sent to event attendees.

## Solution
The culprit seems to be in `social_event_managers/src/Plugin/Action/SocialEventManagersSendEmail.php`

## Issue tracker
- https://www.drupal.org/project/social/issues/3228470
- https://getopensocial.atlassian.net/browse/TB-5917

## How to test
- [ ] Create an event
- [ ] Add some enrollments
- [ ] Try to send emails to enrollments by bulk operation
- [ ] After cron run, emails have to be sent

## Screenshots
N/A

## Release notes
Fixed issue when event admin can't send email to his event attendees.

## Change Record
N/A

## Translations
N/A
