### PR TITLE
Issue #3222835 by mparker17,navneet0693: Removed layout_builder settings from small_teaser view mode for page.

### DIFF
--- a/modules/social_features/social_page/config/install/core.entity_view_display.node.page.small_teaser.yml
+++ b/modules/social_features/social_page/config/install/core.entity_view_display.node.page.small_teaser.yml
@@ -13,10 +13,7 @@ dependencies:
   module:
     - image
     - user
-third_party_settings:
-  layout_builder:
-    allow_custom: false
-    enabled: false
+third_party_settings: { }
 id: node.page.small_teaser
 targetEntityType: node
 bundle: page

--- a/modules/social_features/social_page/social_page.install
+++ b/modules/social_features/social_page/social_page.install
@@ -235,6 +235,6 @@ function social_page_update_10301() {
  * Remove layout_builder settings from small_teaser view mode for page.
  */
 function social_page_update_10302() {
- $config = \Drupal::configFactory()->getEditable('core.entity_view_display.node.page.small_teaser');
- $config->set('third_party_settings', [])->save();
+  $config = \Drupal::configFactory()->getEditable('core.entity_view_display.node.page.small_teaser');
+  $config->set('third_party_settings', [])->save();
 }

--- a/modules/social_features/social_page/social_page.install
+++ b/modules/social_features/social_page/social_page.install
@@ -230,3 +230,11 @@ function social_page_update_10301() {
     user_role_grant_permissions($role_id, ['translate page node']);
   }
 }
+
+/**
+ * Remove layout_builder settings from small_teaser view mode for page.
+ */
+function social_page_update_10302() {
+ $config = \Drupal::configFactory()->getEditable('core.entity_view_display.node.page.small_teaser');
+ $config->set('third_party_settings', [])->save();
+}


### PR DESCRIPTION
Follow up of #2407 

## Problem

After commit f11bf26e47c93af7bee59592e753f8380b9876a7 (whose commit message references [#3193302](https://www.drupal.org/project/social/issues/3193302)); `modules/social_features/social_page/config/install/core.entity_view_display.node.page.small_teaser.yml` contains layout_builder config in the third_party_settings section, which causes the following issue when you try to do a fresh site install without layout_builder enabled:

```
Drupal\Core\Config\ConfigImporterException: There were errors validating the config synchronization.
Configuration <em class="placeholder">core.entity_view_display.node.page.small_teaser</em> depends on the <em class="placeholder">Layout Builder</em> module that will not be installed after import. in
/app/web/core/lib/Drupal/Core/Config/ConfigImporter.php:755
Stack trace:
#0 /app/web/core/lib/Drupal/Core/Config/ConfigImporter.php(539): Drupal\Core\Config\ConfigImporter->validate()
#1 /app/web/core/lib/Drupal/Core/Config/ConfigImporter.php(485): Drupal\Core\Config\ConfigImporter->initialize()
#2 /app/web/modules/contrib/config_enforce/src/ConfigImporter.php(45): Drupal\Core\Config\ConfigImporter->import()
#3 /app/web/modules/contrib/config_enforce/src/ConfigEnforcer.php(100): Drupal\config_enforce\ConfigImporter->importConfig(Array)
#4 /app/web/modules/contrib/config_enforce/src/ConfigEnforcer.php(62): Drupal\config_enforce\ConfigEnforcer->readRegistriesFromDisk()
#5 /app/web/modules/contrib/config_enforce/config_enforce.module(38): Drupal\config_enforce\ConfigEnforcer->enforceConfigs()
#6 [internal function]: config_enforce_rebuild()
#7 /app/web/core/lib/Drupal/Core/Extension/ModuleHandler.php(403): call_user_func_array('config_enforce_...', Array)
#8 /app/web/core/includes/common.inc(1082): Drupal\Core\Extension\ModuleHandler->invokeAll('rebuild')
#9 /app/web/core/includes/utility.inc(55): drupal_flush_all_caches()
#10 /app/vendor/drush/drush/commands/core/cache.drush.inc(302): drupal_rebuild(Object(Composer\Autoload\ClassLoader), Object(Symfony\Component\HttpFoundation\Request))
#11 /app/vendor/drush/drush/includes/command.inc(422): drush_cache_rebuild()
#12 /app/vendor/drush/drush/includes/command.inc(231): _drush_invoke_hooks(Array, Array)
#13 /app/vendor/drush/drush/includes/command.inc(199): drush_command()
#14 /app/vendor/drush/drush/lib/Drush/Boot/BaseBoot.php(67): drush_dispatch(Array)
#15 /app/vendor/drush/drush/includes/preflight.inc(67): Drush\Boot\BaseBoot->bootstrap_and_dispatch()
#16 /app/vendor/drush/drush/drush.php(12): drush_main()
#17 {main}
```

## Solution

Empty the third_party_settings part of the config.

## Issue tracker

https://www.drupal.org/project/social/issues/3222835
