### PR TITLE
Issue #3228885 by vnech: Type filter doesn't work correctly on search groups page

### DIFF
--- a/modules/social_features/social_search/config/install/views.view.search_groups.yml
+++ b/modules/social_features/social_search/config/install/views.view.search_groups.yml
@@ -137,11 +137,8 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
-          operator: '='
-          value:
-            min: ''
-            max: ''
-            value: ''
+          operator: or
+          value: {  }
           group: 1
           exposed: true
           expose:
@@ -160,11 +157,7 @@ display:
               administrator: '0'
               contentmanager: '0'
               sitemanager: '0'
-            placeholder: ''
-            min_placeholder: ''
-            max_placeholder: ''
-            operator_limit_selection: false
-            operator_list: {  }
+            reduce: false
           is_grouped: false
           group_info:
             label: ''
@@ -177,7 +170,8 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          plugin_id: search_api_string
+          reduce_duplicates: false
+          plugin_id: search_api_options
         search_api_language:
           id: search_api_language
           table: search_api_index_social_groups
@@ -197,7 +191,7 @@ display:
             use_operator: false
             operator: ''
             operator_limit_selection: false
-            operator_list: { }
+            operator_list: {  }
             identifier: ''
             required: false
             remember: false
@@ -215,8 +209,8 @@ display:
             multiple: false
             remember: false
             default_group: All
-            default_group_multiple: { }
-            group_items: { }
+            default_group_multiple: {  }
+            group_items: {  }
           plugin_id: search_api_language
       sorts:
         search_api_relevance:
@@ -316,7 +310,8 @@ display:
         - url
         - url.query_args
         - user.permissions
-      tags: {  }
+      tags:
+        - 'config:search_api.index.social_groups'
   page:
     display_plugin: page
     id: page
@@ -333,7 +328,8 @@ display:
         - url
         - url.query_args
         - user.permissions
-      tags: {  }
+      tags:
+        - 'config:search_api.index.social_groups'
   page_no_value:
     display_plugin: page
     id: page_no_value
@@ -376,4 +372,5 @@ display:
         - url
         - url.query_args
         - user.permissions
-      tags: {  }
+      tags:
+        - 'config:search_api.index.social_groups'

--- a/modules/social_features/social_search/config/update/social_search_update_10302.yml
+++ b/modules/social_features/social_search/config/update/social_search_update_10302.yml
@@ -1,0 +1,51 @@
+views.view.search_groups:
+  expected_config: {  }
+  update_actions:
+    delete:
+      display:
+        default:
+          display_options:
+            filters:
+              type:
+                value:
+                  min:
+                  max:
+                  value:
+                expose:
+    change:
+      display:
+        default:
+          display_options:
+            filters:
+              type:
+                operator: or
+                plugin_id: search_api_options
+                exposed: true
+                expose:
+                  operator_id: type_op
+                  label: Type
+                  description: ''
+                  use_operator: false
+                  operator: type_op
+                  identifier: type
+                  required: false
+                  remember: false
+                  multiple: false
+                  remember_roles:
+                    authenticated: authenticated
+                    anonymous: '0'
+                    administrator: '0'
+                    contentmanager: '0'
+                    sitemanager: '0'
+                  reduce: false
+          cache_metadata:
+            tags:
+              - 'config:search_api.index.social_groups'
+        page:
+          cache_metadata:
+            tags:
+              - 'config:search_api.index.social_groups'
+        page_no_value:
+          cache_metadata:
+            tags:
+              - 'config:search_api.index.social_groups'

--- a/modules/social_features/social_search/social_search.install
+++ b/modules/social_features/social_search/social_search.install
@@ -255,3 +255,17 @@ function social_search_update_10301() {
   // Output logged messages to related channel of update execution.
   return $updateHelper->logger()->output();
 }
+
+/**
+ * Update the Search Groups "type" filter.
+ */
+function social_search_update_10302() {
+  /** @var \Drupal\update_helper\Updater $updateHelper */
+  $updateHelper = \Drupal::service('update_helper.updater');
+
+  // Execute configuration update definitions with logging of success.
+  $updateHelper->executeUpdate('social_search', __FUNCTION__);
+
+  // Output logged messages to related channel of update execution.
+  return $updateHelper->logger()->output();
+}

--- a/modules/social_features/social_search/social_search.module
+++ b/modules/social_features/social_search/social_search.module
@@ -74,7 +74,7 @@ function social_search_alter_users_exposed_filter_block(&$form, FormStateInterfa
  */
 function social_search_alter_groups_exposed_filter_block(&$form, FormStateInterface $form_state, $form_id) {
   $options = [
-    '' => t('- Any -'),
+    'All' => t('- Any -'),
   ];
   $group_types = GroupType::loadMultiple();
   /** @var \Drupal\group\Entity\GroupType $group_type */


### PR DESCRIPTION
## Problem
On groups search page (`/search/groups`) we have a filter "type" that allows filtering groups by type.
The issue is that the filter doesn't work properly (choosing group type doesn't give any effect). And even if we go to the view configuration page (`/admin/structure/views/view/search_groups`) and try to configure the filter we will see the error (see in screenshot section)


## Solution
- Change "type" filter plugin type from `search_api_string` to `search_api_options`

## Issue tracker
- https://www.drupal.org/project/social/issues/3228885
- https://getopensocial.atlassian.net/browse/YANG-6200

## How to test
- [ ] Login as an admin
- [ ] Go to the page `/search/groups`
- [ ] Make sure you have created groups with different group types
- [ ] Try to filter results by "Flexible Group"

## Screenshots
<img src="https://www.drupal.org/files/issues/2021-08-19/Screenshot%202021-08-19%20at%2012.03.10.png"/>

## Release notes
*Fix "type" filter on the Search Groups views page.*

## Change Record
N/A

## Translations
N/A
