### PR TITLE
Update the sociablue theme from 1.2.1 to 1.3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -162,7 +162,7 @@
         "drupal/role_delegation": "1.1",
         "drupal/search_api": "1.19",
         "drupal/shariff": "1.7",
-        "drupal/socialblue": "1.2.1",
+        "drupal/socialblue": "1.3.0",
         "drupal/swiftmailer" : "2.0-beta1",
         "drupal/select2": "1.8",
         "drupal/token": "1.9",


### PR DESCRIPTION
## Problem
We want to have all the latest code from our theme.

## Solution
Update from 1.2.1 to https://www.drupal.org/project/socialblue/releases/1.3.0

## Issue tracker
T.B.D.

## How to test
See that the bold text is fixed.

## Release notes
Socialblue has been updated to https://www.drupal.org/project/socialblue/releases/1.3.0