### PR TITLE
Issue #3229425: Export CSV with only active group memberships

### DIFF
--- a/modules/social_features/social_group/src/SocialGroupHelperService.php
+++ b/modules/social_features/social_group/src/SocialGroupHelperService.php
@@ -194,7 +194,10 @@ class SocialGroupHelperService {
 
     // Get the memberships for the user if they aren't known yet.
     if (!isset($groups[$uid])) {
-      $group_content_types = GroupContentType::loadByEntityTypeId('user');
+      // We need to get all group memberships,
+      // GroupContentType::loadByEntityTypeId('user'); will also return
+      // requests and invites for a given user entity.
+      $group_content_types = GroupContentType::loadByContentPluginId('group_membership');
       $group_content_types = array_keys($group_content_types);
 
       $query = $this->database->select('group_content_field_data', 'gcfd');


### PR DESCRIPTION
## Problem
Currently: When I do a csv export of users who have pending requests to join a group, this group is listed in the group membership column in the csv.

## Solution
The problem is that we also get all the memberships based on Invites & Requests (which are not actual memberships yet)

## Issue tracker
https://www.drupal.org/project/social/issues/3229425

## How to test
- [ ] Login as GM, make sure LU can request to join a Group
- [ ] Invite a second LU
- [ ] Login as LU and request to join that group
- [ ] Login as SM and enable the social_user_export
- [ ] Export both LU's as CSV in the admin people overview
- [ ] See that for both LU's the Group you haven't joined yet but are invited or have requested to join are part of it
- [ ] Checkout this branch, and try again, see that now only active memberships are there.

## Screenshots
See that Chris Hall has requested to join a group with group id 5, but also joined a group with id 1.

![Screenshot 2021-08-23 at 13 49 26](https://user-images.githubusercontent.com/16667281/130443397-1ef17a9f-3084-4469-adad-10f9b80ce792.png)

The export now contains only the active group membership with group id 1, not with 5.
[export-users-d3fadc0704ca.csv](https://github.com/goalgorilla/open_social/files/7031619/export-users-d3fadc0704ca.csv)

## Release notes
When exporting users through the admin people overview, we now ensure in the Group Memberships column, only active memberships are shown.