### PR TITLE
Issue 3229797 by nachosalvador: Fix Inbox link disappears from the us…

### DIFF
--- a/modules/social_features/social_private_message/social_private_message.module
+++ b/modules/social_features/social_private_message/social_private_message.module
@@ -526,7 +526,7 @@ function social_private_message_social_user_account_header_items(array $context)
  * Adds the mobile indicator for private messages under the profile icon menu.
  */
 function social_private_message_social_user_account_header_account_links(array $context) {
-  if (\Drupal::config('social_user.navigation.settings')->get('display_social_private_message_icon') !== 1) {
+  if (\Drupal::config('social_user.navigation.settings')->get('display_social_private_message_icon') !== TRUE) {
     return [];
   }
 
@@ -574,7 +574,7 @@ function social_private_message_social_user_account_header_account_links(array $
  * Adds an indicator to the user account menu on mobile.
  */
 function social_private_message_social_user_account_header_items_alter(array &$menu_links, array $context) {
-  if (\Drupal::config('social_user.navigation.settings')->get('display_social_private_message_icon') !== 1) {
+  if (\Drupal::config('social_user.navigation.settings')->get('display_social_private_message_icon') !== TRUE) {
     return;
   }
 


### PR DESCRIPTION
…er menu on mobile screens.

## Problem
On mobile I cannot see the Inbox link in the user menu.

## Solution
Modify condition to check the configuration settings.

## Issue tracker
https://www.drupal.org/project/social/issues/3229797

## How to test

- [ ] Enable social_private_message module
- [ ] Enable "Display the Social Private Message (envelope) icon." from navigation settings /admin/config/opensocial/navigation-settings
- [ ] Check from mobile view the menu link for Inbox doesn't appear

## Screenshots
Before:
![Screenshot at 2021-08-25 13-45-30](https://user-images.githubusercontent.com/8913851/130785211-ec31697d-538e-4b96-9424-ef574700cc20.png)

After:
![Screenshot at 2021-08-25 13-46-07](https://user-images.githubusercontent.com/8913851/130785220-8debc02f-90bc-4807-82e9-c5449e66c34a.png)
