### PR TITLE
Issue #3230205 by sjoerdvandervis: Make expertises and interests in profile clickable

### DIFF
--- a/modules/social_features/social_profile/social_profile.module
+++ b/modules/social_features/social_profile/social_profile.module
@@ -446,6 +446,16 @@ function social_profile_preprocess_profile(array &$variables) {
     $tags = $profile->get('field_profile_profile_tag')->getValue();
     $variables['profile_tagging_hierarchy'] = $tag_service->buildHierarchy($tags);
   }
+
+  if (!$profile->get('field_profile_expertise')->isEmpty()) {
+    $tags = $profile->get('field_profile_expertise')->getValue();
+    $variables['profile_expertise_hierarchy'] = $tag_service->buildHierarchy($tags, 'expertise');
+  }
+
+  if (!$profile->get('field_profile_interests')->isEmpty()) {
+    $tags = $profile->get('field_profile_interests')->getValue();
+    $variables['profile_interests_hierarchy'] = $tag_service->buildHierarchy($tags, 'interests');
+  }
 }
 
 /**

--- a/modules/social_features/social_profile/src/SocialProfileTagService.php
+++ b/modules/social_features/social_profile/src/SocialProfileTagService.php
@@ -186,7 +186,6 @@ class SocialProfileTagService implements SocialProfileTagServiceInterface {
         $route_parameters[$vocabulary] = $term->getName();
       }
 
-
       // Prepare the URL for the search by term.
       $url = Url::fromRoute($route, $route_parameters)->toString();
 

--- a/modules/social_features/social_profile/src/SocialProfileTagService.php
+++ b/modules/social_features/social_profile/src/SocialProfileTagService.php
@@ -154,7 +154,7 @@ class SocialProfileTagService implements SocialProfileTagServiceInterface {
   /**
    * {@inheritdoc}
    */
-  public function buildHierarchy(array $term_ids) {
+  public function buildHierarchy(array $term_ids, $vocabulary = 'profile_tag') {
     $tree = [];
     $terms = $this->taxonomyStorage->loadMultiple(array_column($term_ids, 'target_id'));
     if (empty($terms)) {
@@ -177,8 +177,15 @@ class SocialProfileTagService implements SocialProfileTagServiceInterface {
       $route = 'view.search_users.page_no_value';
       $route_parameters = [
         'created_op' => '<',
-        'profile_tag[]' => $term->id(),
       ];
+
+      if ($vocabulary === 'profile_tag') {
+        $route_parameters['profile_tag[]'] = $term->id();
+      }
+      else {
+        $route_parameters[$vocabulary] = $term->getName();
+      }
+
 
       // Prepare the URL for the search by term.
       $url = Url::fromRoute($route, $route_parameters)->toString();

--- a/modules/social_features/social_profile/src/SocialProfileTagService.php
+++ b/modules/social_features/social_profile/src/SocialProfileTagService.php
@@ -154,7 +154,7 @@ class SocialProfileTagService implements SocialProfileTagServiceInterface {
   /**
    * {@inheritdoc}
    */
-  public function buildHierarchy(array $term_ids, $vocabulary = 'profile_tag') {
+  public function buildHierarchy(array $term_ids, string $vocabulary = 'profile_tag') {
     $tree = [];
     $terms = $this->taxonomyStorage->loadMultiple(array_column($term_ids, 'target_id'));
     if (empty($terms)) {

--- a/modules/social_features/social_profile/src/SocialProfileTagServiceInterface.php
+++ b/modules/social_features/social_profile/src/SocialProfileTagServiceInterface.php
@@ -77,10 +77,13 @@ interface SocialProfileTagServiceInterface {
    * @param array $term_ids
    *   An array of items that are selected.
    *
+   * @param string $vocabulary
+   *   The vocabulary we are building the hierarchy for.
+   *
    * @return array
    *   An hierarchy array of items with their parent.
    */
-  public function buildHierarchy(array $term_ids);
+  public function buildHierarchy(array $term_ids, string $vocabulary);
 
   /**
    * Returns list of term names as option list.

--- a/modules/social_features/social_profile/src/SocialProfileTagServiceInterface.php
+++ b/modules/social_features/social_profile/src/SocialProfileTagServiceInterface.php
@@ -76,14 +76,13 @@ interface SocialProfileTagServiceInterface {
    *
    * @param array $term_ids
    *   An array of items that are selected.
-   *
    * @param string $vocabulary
    *   The vocabulary we are building the hierarchy for.
    *
    * @return array
    *   An hierarchy array of items with their parent.
    */
-  public function buildHierarchy(array $term_ids, string $vocabulary);
+  public function buildHierarchy(array $term_ids);
 
   /**
    * Returns list of term names as option list.

--- a/modules/social_features/social_profile/src/SocialProfileTagServiceInterface.php
+++ b/modules/social_features/social_profile/src/SocialProfileTagServiceInterface.php
@@ -76,11 +76,13 @@ interface SocialProfileTagServiceInterface {
    *
    * @param array $term_ids
    *   An array of items that are selected.
+   * @param string $vocabulary
+   *   The vocabulary name.
    *
    * @return array
    *   An hierarchy array of items with their parent.
    */
-  public function buildHierarchy(array $term_ids);
+  public function buildHierarchy(array $term_ids, string $vocabulary);
 
   /**
    * Returns list of term names as option list.

--- a/modules/social_features/social_profile/src/SocialProfileTagServiceInterface.php
+++ b/modules/social_features/social_profile/src/SocialProfileTagServiceInterface.php
@@ -76,8 +76,6 @@ interface SocialProfileTagServiceInterface {
    *
    * @param array $term_ids
    *   An array of items that are selected.
-   * @param string $vocabulary
-   *   The vocabulary we are building the hierarchy for.
    *
    * @return array
    *   An hierarchy array of items with their parent.


### PR DESCRIPTION
## Problem
When visiting a users profile with the sky flavour of socialblue enabled, all profile tags are clickable and send you to the users search page, with a filter for that profile tag. This does not work for interests and/or expertise though.

## Solution
Add a link to the expertises / interests that send the user to the search page, with a filter applied when landing on it. This should filter the users with the same expertise or interest.

## Issue tracker
- [ ] https://www.drupal.org/project/social/issues/3230205
- [ ] https://www.drupal.org/project/socialblue/issues/3230210

## How to test
- [ ] Check out this branch and also, check out the MR in https://www.drupal.org/project/socialblue/issues/3230210
- [ ] As a LU, add expertises and interests to your profile and save it
- [ ] See that the pills / badges now have changed to links and that these are clickable
- [ ] When clicking the expertise / interest, you will be sent to the user search page where the expertise / interest you've clicked is used as a filter.

## Release notes
We've made the interests and expertises clickable on a user's profile. With this change, expertises and interests can be clicked and used to find all users with the same expertise or interest.