### PR TITLE
Issue #3230885 by vnech: Automate translation fields definitions updates

### DIFF
--- a/modules/custom/social_language/social_language.module
+++ b/modules/custom/social_language/social_language.module
@@ -102,3 +102,29 @@ function social_language_field_group_form_process_alter(array &$element, &$group
   // from adding an incorrect suffix to the field group title.
   $element['#multilingual'] = TRUE;
 }
+
+/**
+ * Implements hook_modules_installed().
+ */
+function social_language_modules_installed($modules) {
+  // When "Content Translation" module enabled, it provides few additional
+  // fields for translated entities. After fields are added, Drupal requires
+  // these fields definitions to be updated. Technically this is proceeded
+  // after submit this form "/admin/config/regional/content-language".
+  // But in OS this approach doesn't work as SM doesn't have access to the page.
+  // So, here we track any module installation and check if there are updates for
+  // translations fields and run updates.
+  $change_list = \Drupal::entityDefinitionUpdateManager()->getChangeList();
+
+  if ($change_list) {
+    foreach ($change_list as $entity_type_id => $changes) {
+      // We check only "content_translation_source"
+      // as this field should exist everytime.
+      if (!empty($changes['field_storage_definitions']['content_translation_source'])) {
+        if (function_exists('_content_translation_install_field_storage_definitions')) {
+          _content_translation_install_field_storage_definitions($entity_type_id);
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Problem
When we enable translations support for any entity in OS "Content Translation" module add to the entity a few new fields (like `content_translation_source`, `content_translation_status` etc). After this Drupal require this fields definition updates on status report page:
<img src="https://www.drupal.org/files/issues/2021-09-01/Screenshot%202021-09-01%20at%2018.18.07.png"/>

## Solution
Add a hook function that listens to any module installation and runs updates for translations field definitions if exist.

## Issue tracker
- https://www.drupal.org/project/social/issues/3230885
- https://getopensocial.atlassian.net/browse/YANG-6064

## How to test
- [ ] Install fresh OS
- [ ] Login as an admin
- [ ] Enable module social_content_translation
- [ ] Visit status report page

## Screenshots
N/A

## Release notes
*Automate translation fields definitions updates.*

## Change Record
N/A

## Translations
N/A
