### PR TITLE
Internal - Fix PHPStan error

### DIFF
--- a/modules/social_features/social_core/src/InviteService.php
+++ b/modules/social_features/social_core/src/InviteService.php
@@ -104,10 +104,10 @@ class InviteService {
 
     // Return specific data.
     if ($specific === 'name') {
-      return $route['name'];
+      return (string) $route['name'];
     }
     if ($specific === 'amount') {
-      return $route['amount'];
+      return (string) $route['amount'];
     }
 
     return $route;


### PR DESCRIPTION
## Problem
We have PHPStan error:
`Method Drupal\social_core\InviteService::getInviteData() should return array|string but returns int<0, max>.`

## Solution
Ensure that `Drupal\social_core\InviteService::getInviteData()` returns `array|string`.

## Issue tracker
N/A

## How to test
- [ ] PHPStan have to be green on this branch

## Screenshots
N/A

## Release notes
N/A

## Change Record
N/A

## Translations
N/A