### PR TITLE
Issue #3231551 by Kingdutch, ronaldtebrake: Do not install `page_cache` by default

### DIFF
--- a/social.installer_options_list.yml
+++ b/social.installer_options_list.yml
@@ -8,7 +8,6 @@ inline_form_errors:
 page_cache:
   name: Anonymous page cache (recommended)
   description: Cache page for anonymous users. Enable this if you do not have a web server to do this for you.
-  default: true
 dynamic_page_cache:
   name: Dynamic page cache (recommended)
   description: Caches parts of the page dynamically for any user.


### PR DESCRIPTION
## Problem
Most hosting providers these days provide their own static page caching.
This means that Drupal's page_cache provides only overhead but no 
actual benefit. We've found such a set-up in some cases to cause issues.


## Solution

To fix this we no longer enable the page_cache by default but require site
builders to manually enable this module when it makes sense for their 
hosting set-up.

## Issue tracker
https://www.drupal.org/project/social/issues/3231551

## How to test
*For example*
- [ ] Perform a site install using the UI or Drush without changing any settings
- [ ] Check the extensions page and see that page_cache is not enabled

## Screenshots
N/a

## Release notes
The `page_cache` module is no longer enabled for new site installs by default. When your hosting provider does not over a static page cache you should enable this yourselves.

## Change Record
https://www.drupal.org/node/3231552

## Translations
N/a
