### PR TITLE
Issue #3232278: Wrong image style for preview on group page when user tries to create post with images

### DIFF
--- a/modules/social_features/social_post/modules/social_post_album/src/SocialPostPhotoAlbumConfigOverride.php
+++ b/modules/social_features/social_post/modules/social_post_album/src/SocialPostPhotoAlbumConfigOverride.php
@@ -33,6 +33,13 @@ class SocialPostPhotoAlbumConfigOverride implements ConfigFactoryOverrideInterfa
       }
     }
 
+    // See https://www.drupal.org/project/social/issues/3232278
+    $config_name = 'core.entity_form_display.post.photo.group';
+
+    if (in_array($config_name, $names)) {
+      $overrides[$config_name]['content']['field_post_image']['settings']['preview_image_style'] = 'social_x_large';
+    }
+
     return $overrides;
   }
 


### PR DESCRIPTION
## Problem
When you create a post in a group, you can select multiple images for that post, and after you select, you may see the wrong preview image style.

## Solution
Override view module when the feature is enabled on `ConfigOverride` or `form_display_alter`.

## Issue tracker
- https://www.drupal.org/project/social/issues/3232278
- https://getopensocial.atlassian.net/browse/YANG-6222

## How to test
- [ ] Album feature should be enabled (`social_post_album`)
- [ ] Apply this change as a patch
- [ ] Go to some group stream page
- [ ] Add a few images to the post
- [ ] You should see nice preview image style

## Screenshots
![image](https://user-images.githubusercontent.com/50984627/132813001-95354a93-96d1-4e32-b959-bd1b13b73e7b.png)
![image](https://user-images.githubusercontent.com/50984627/132813045-ab70139f-695f-4e01-9d04-819fa0415fe6.png)

## Release notes
No changes in behaviour, only UI change.

## Change Record
Image style for the post in the group will be changed from the `social_post_photo` to `social_x_large`.

## Translations
No.
