### PR TITLE
[Internal] - Travis update after drupal_social versioning.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,6 +49,7 @@ before_install:
   # Lets set-up our helper repository with all the docker config and use correct version in composer.json.
   - git clone https://github.com/goalgorilla/drupal_social.git install
   - cd install
+  - git checkout 1.0.0
   - export PR=https://api.github.com/repos/$TRAVIS_REPO_SLUG/pulls/$TRAVIS_PULL_REQUEST
   - export BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_BRANCH; else echo $TRAVIS_PULL_REQUEST_BRANCH; fi)
   - export COMMIT=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_COMMIT; else echo $TRAVIS_PULL_REQUEST_SHA; fi)

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,9 +47,8 @@ before_install:
   - if [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TEST_SUITE" = "accessibility" ]; then exit 0; fi
   - phpenv config-rm xdebug.ini
   # Lets set-up our helper repository with all the docker config and use correct version in composer.json.
-  - git clone https://github.com/goalgorilla/drupal_social.git install
+  - git clone -b 1.0.0 https://github.com/goalgorilla/drupal_social.git install
   - cd install
-  - git checkout 1.0.0
   - export PR=https://api.github.com/repos/$TRAVIS_REPO_SLUG/pulls/$TRAVIS_PULL_REQUEST
   - export BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_BRANCH; else echo $TRAVIS_PULL_REQUEST_BRANCH; fi)
   - export COMMIT=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_COMMIT; else echo $TRAVIS_PULL_REQUEST_SHA; fi)


### PR DESCRIPTION
## Problem
We are in a process to use Drupal 9 and ship with Drush 10 and a lot more goodies in our `goalgorilla/drupal_social` development repository.

For that we have had to use versioning so we can use Drupal 8.9.x and Drush 8 next to Drupal 9 and Drush 10.

## Solution
Make sure we use the correct version in our travis.yml file.
You can see the differences here:
https://github.com/goalgorilla/drupal_social/pull/361/files
https://github.com/goalgorilla/open_social_scripts/compare/1.0.0...2.0.0

## Issue tracker
Internal

## How to test
Let test pass. 

