### PR TITLE
 Issue #3232648 by nkoporec: Social footer inline images are deleted after a certain time

### DIFF
--- a/modules/social_features/social_footer/src/Form/FooterSettingsForm.php
+++ b/modules/social_features/social_footer/src/Form/FooterSettingsForm.php
@@ -174,7 +174,7 @@ class FooterSettingsForm extends FormBase {
 
       $file->setPermanent();
       $file->save();
-      $this->fileUsage->add($file, 'editor', 'file', $file->id());
+      $this->fileUsage->add($file, 'social_footer', 'file', $file->id());
     }
   }
 

--- a/modules/social_features/social_footer/src/Form/FooterSettingsForm.php
+++ b/modules/social_features/social_footer/src/Form/FooterSettingsForm.php
@@ -2,9 +2,11 @@
 
 namespace Drupal\social_footer\Form;
 
+use Drupal\Core\Entity\EntityRepositoryInterface;
 use Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\file\FileStorageInterface;
+use Drupal\file\FileUsage\FileUsageInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -20,13 +22,33 @@ class FooterSettingsForm extends FormBase {
   protected $fileStorage;
 
   /**
+   * The entity repository.
+   *
+   * @var \Drupal\Core\Entity\EntityRepositoryInterface
+   */
+  protected $entityRepository;
+
+  /**
+   * The file usage service.
+   *
+   * @var \Drupal\file\FileUsage\FileUsageInterface
+   */
+  protected $fileUsage;
+
+  /**
    * Creates a FooterSettingsForm instance.
    *
    * @param \Drupal\file\FileStorageInterface $file_storage
    *   The file storage.
+   * @param \Drupal\Core\Entity\EntityRepositoryInterface $entity_repository
+   *   The entity repository service.
+   * @param \Drupal\file\FileUsage\FileUsageInterface $file_usage
+   *   The file usage service.
    */
-  public function __construct(FileStorageInterface $file_storage) {
+  public function __construct(FileStorageInterface $file_storage, EntityRepositoryInterface $entity_repository, FileUsageInterface $file_usage) {
     $this->fileStorage = $file_storage;
+    $this->entityRepository = $entity_repository;
+    $this->fileUsage = $file_usage;
   }
 
   /**
@@ -34,7 +56,9 @@ class FooterSettingsForm extends FormBase {
    */
   public static function create(ContainerInterface $container) {
     return new static(
-      $container->get('entity_type.manager')->getStorage('file')
+      $container->get('entity_type.manager')->getStorage('file'),
+      $container->get('entity.repository'),
+      $container->get('file.usage')
     );
   }
 
@@ -49,12 +73,12 @@ class FooterSettingsForm extends FormBase {
    * {@inheritDoc}
    */
   public function buildForm(array $form, FormStateInterface $form_state) {
-    $block = self::configFactory()->get('block.block.socialblue_footer_powered');
-    if ($block) {
+    $block = $this->configFactory()->get('block.block.socialblue_footer_powered');
+    if (!empty($block)) {
       $settings = $block->get('settings');
     }
 
-    $default_scheme = self::config('system.file')->get('default_scheme');
+    $default_scheme = $this->config('system.file')->get('default_scheme');
 
     $form['logo'] = [
       '#type' => 'managed_file',
@@ -114,8 +138,13 @@ class FooterSettingsForm extends FormBase {
       $file->setPermanent();
       $file->save();
     }
-    $block = self::configFactory()->getEditable('block.block.socialblue_footer_powered');
-    if ($block) {
+
+    // Set all images used within the ckeditor to have permanent status.
+    $text = $form_state->getValue('text')['value'];
+    $this->setInlineImagesAsPermanent($text);
+
+    $block = $this->configFactory()->getEditable('block.block.socialblue_footer_powered');
+    if (!empty($block)) {
       $settings = $block->get('settings');
       $settings['logo'] = $logo;
       $settings['text'] = $values['text'];
@@ -123,7 +152,30 @@ class FooterSettingsForm extends FormBase {
       $settings['link']['title'] = $values['title'];
       $block->set('settings', $settings)->save();
     }
-    $this->messenger()->addStatus(t('Your footer settings have been updated'));
+
+    $this->messenger()->addStatus($this->t('Your footer settings have been updated'));
+  }
+
+  /**
+   * Set the inline images status to permanent.
+   *
+   * @param string $text
+   *   Text editor value.
+   */
+  public function setInlineImagesAsPermanent($text) {
+    $uuids = _editor_parse_file_uuids($text);
+    foreach ($uuids as $uuid) {
+      $file = $this->entityRepository->loadEntityByUuid('file', $uuid);
+
+      /** @var \Drupal\file\FileInterface $file */
+      if (empty($file) || !$file->isTemporary()) {
+        continue;
+      }
+
+      $file->setPermanent();
+      $file->save();
+      $this->fileUsage->add($file, 'editor', 'file', $file->id());
+    }
   }
 
 }


### PR DESCRIPTION
## Problem
When adding inline images (using ckeditor upload widget) to the social footer block at /admin/config/opensocial/footer-block the images gets deleted after certain time. The problem is that this images are set as temporary, this means that on cron run Drupal will delete all temporary images. 

## Solution
We need to set the images to have the permanent status and add them to the file usage table.

## Issue tracker
https://www.drupal.org/project/social/issues/3232648

## How to test
1. Go to /admin/config/opensocial/footer-block
2. Upload and embed the image via Ckeditor
3. Save the form.
4. Go to admin/content/files and see the image status.

## Release notes
We have fixed an issue where images embedded with ckeditor on social footer settings page would get deleted after a certain time.
