### PR TITLE
Issue #3232812 - Add core version requirements in all info.yml files of all modules in Open Social and remove the old core: key.

### DIFF
--- a/modules/custom/activity_send/modules/activity_send_email/activity_send_email.info.yml
+++ b/modules/custom/activity_send/modules/activity_send_email/activity_send_email.info.yml
@@ -1,7 +1,7 @@
 name: Activity Send Email
 type: module
 description: Used to send activity notifications by Email
-core: 8.x
+core_version_requirement: ^8.8 || ^9
 package: Social
 dependencies:
   - social:activity_send

--- a/modules/custom/activity_send/modules/activity_send_push_notification/activity_send_push_notification.info.yml
+++ b/modules/custom/activity_send/modules/activity_send_push_notification/activity_send_push_notification.info.yml
@@ -1,7 +1,7 @@
 name: Activity Send Push Notification
 type: module
 description: Used to send activity notifications by Push service
-core: 8.x
+core_version_requirement: ^8.8 || ^9
 package: Social
 dependencies:
   - social:activity_send

--- a/modules/custom/social_font/social_font.info.yml
+++ b/modules/custom/social_font/social_font.info.yml
@@ -1,4 +1,4 @@
 name: Social Font
 type: module
 description: Social font module
-core: 8.x
+core_version_requirement: ^8.8 || ^9

--- a/modules/custom/social_gdpr/social_gdpr.info.yml
+++ b/modules/custom/social_gdpr/social_gdpr.info.yml
@@ -1,7 +1,7 @@
 name: Social GDPR
 type: module
 description: Integrate Data Policy module.
-core: 8.x
+core_version_requirement: ^8.8 || ^9
 package: Social
 dependencies:
   - data_policy:data_policy

--- a/modules/custom/social_graphql/social_graphql.info.yml
+++ b/modules/custom/social_graphql/social_graphql.info.yml
@@ -1,8 +1,7 @@
 name: 'Social GraphQL'
 description: 'Enables GraphQL support for Open Social features.'
 type: module
-core: 8.x
-core_version_requirement: ^8 || ^9
+core_version_requirement: ^8.8 || ^9
 dependencies:
   - graphql:graphql
 package: Social (Experimental)

--- a/modules/custom/social_language/modules/social_content_translation/social_content_translation.info.yml
+++ b/modules/custom/social_language/modules/social_content_translation/social_content_translation.info.yml
@@ -1,7 +1,7 @@
 name: Social Language - Content Translation
 type: module
 description: Enables translation of static site content (such as Basic Pages, Landing Pages and Book Pages).
-core: 8.x
+core_version_requirement: ^8.8 || ^9
 package: Social (experimental)
 dependencies:
   - social:social_language

--- a/modules/custom/social_language/social_language.info.yml
+++ b/modules/custom/social_language/social_language.info.yml
@@ -1,7 +1,7 @@
 name: Social Language
 type: module
 description: Support for multilingual interface translations.
-core: 8.x
+core_version_requirement: ^8.8 || ^9
 package: Social
 dependencies:
   - drupal:config_translation

--- a/modules/custom/social_lazy_loading/social_lazy_loading_images/social_lazy_loading_images.info.yml
+++ b/modules/custom/social_lazy_loading/social_lazy_loading_images/social_lazy_loading_images.info.yml
@@ -1,7 +1,7 @@
 name: 'Social Lazy Loading Image'
 type: module
 description: 'Module for lazy loading images using the blazy library.'
-core: '8.x'
+core_version_requirement: ^8.8 || ^9
 package: Social
 dependencies:
   - drupal:lazy

--- a/modules/custom/social_lets_connect/modules/social_lets_connect_contact/social_lets_connect_contact.info.yml
+++ b/modules/custom/social_lets_connect/modules/social_lets_connect_contact/social_lets_connect_contact.info.yml
@@ -1,7 +1,7 @@
 name: 'Social Lets Connect Contact'
 type: module
 description: 'Contact the Open Social development team and help us improve the product.'
-core: 8.x
+core_version_requirement: ^8.8 || ^9
 package: 'Social Lets Connect'
 
 dependencies:

--- a/modules/custom/social_lets_connect/modules/social_lets_connect_usage/social_lets_connect_usage.info.yml
+++ b/modules/custom/social_lets_connect/modules/social_lets_connect_usage/social_lets_connect_usage.info.yml
@@ -1,7 +1,7 @@
 name: 'Social Lets Connect Usage'
 type: module
 description: 'Share usage data Open Social development team and help us improve the product.'
-core: 8.x
+core_version_requirement: ^8.8 || ^9
 package: 'Social Lets Connect'
 
 dependencies:

--- a/modules/social_features/social_activity/modules/social_activity_filter/social_activity_filter.info.yml
+++ b/modules/social_features/social_activity/modules/social_activity_filter/social_activity_filter.info.yml
@@ -1,7 +1,7 @@
 name: 'Social Activity Filter'
 description: 'Provides filters for activity streams used for example on landing pages, it allows you to filter by taxonomy terms.'
 type: module
-core: 8.x
+core_version_requirement: ^8.8 || ^9
 package: Social (experimental)
 configure: social_activity_filter.settings
 dependencies:

--- a/modules/social_features/social_album/social_album.info.yml
+++ b/modules/social_features/social_album/social_album.info.yml
@@ -1,7 +1,7 @@
 name: 'Social Album'
 description: 'Provides Album content type and related configuration.'
 type: module
-core: 8.x
+core_version_requirement: ^8.8 || ^9
 package: Social (experimental)
 dependencies:
   - social:social_event

--- a/modules/social_features/social_book/modules/social_book_featured/social_book_featured.info.yml
+++ b/modules/social_features/social_book/modules/social_book_featured/social_book_featured.info.yml
@@ -1,7 +1,7 @@
 name: 'Social Book on Landing pages'
 description: 'Provides a book featured view mode for use on landing pages.'
 type: module
-core: 8.x
+core_version_requirement: ^8.8 || ^9
 dependencies:
   - social:social_book
   - social:social_landing_page

--- a/modules/social_features/social_branding/social_branding.info.yml
+++ b/modules/social_features/social_branding/social_branding.info.yml
@@ -1,8 +1,7 @@
 name: 'Social Branding'
 description: 'Extends the GraphQL API with branding information for this Open Social platform.'
 type: module
-core: 8.x
-core_version_requirement: ^8 || ^9
+core_version_requirement: ^8.8 || ^9
 dependencies:
   # Remove this dependency when we have an accessible test environment.
   - social:social_graphql

--- a/modules/social_features/social_branding/tests/modules/social_branding_test/social_branding_test.info.yml
+++ b/modules/social_features/social_branding/tests/modules/social_branding_test/social_branding_test.info.yml
@@ -1,8 +1,7 @@
 name: 'Social Branding Test'
 description: 'Support module for module Social Branding for testing.'
 type: module
-core: 8.x
-core_version_requirement: ^8 || ^9
+core_version_requirement: ^8.8 || ^9
 dependencies:
   - social:social_branding
 package: Testing

--- a/modules/social_features/social_content_block/modules/social_book_content_block/social_book_content_block.info.yml
+++ b/modules/social_features/social_content_block/modules/social_book_content_block/social_book_content_block.info.yml
@@ -1,7 +1,7 @@
 name: 'Social Book Content Block'
 description: 'Provides a content block for books.'
 type: module
-core: 8.x
+core_version_requirement: ^8.8 || ^9
 dependencies:
   - social:social_content_block
   - social:social_book

--- a/modules/social_features/social_content_block/modules/social_content_block_landing_page/social_content_block_landing_page.info.yml
+++ b/modules/social_features/social_content_block/modules/social_content_block_landing_page/social_content_block_landing_page.info.yml
@@ -1,7 +1,7 @@
 name: 'Social Content Block on Landing pages'
 description: 'Provides "Custom content list block" paragraphs type for landing pages.'
 type: module
-core: 8.x
+core_version_requirement: ^8.8 || ^9
 dependencies:
   - social:social_content_block
   - social:social_landing_page

--- a/modules/social_features/social_content_block/modules/social_event_content_block/social_event_content_block.info.yml
+++ b/modules/social_features/social_content_block/modules/social_event_content_block/social_event_content_block.info.yml
@@ -1,7 +1,7 @@
 name: 'Social Event Content Block'
 description: 'Provides a content block for events.'
 type: module
-core: 8.x
+core_version_requirement: ^8.8 || ^9
 dependencies:
   - social:social_content_block
   - social:social_event

--- a/modules/social_features/social_content_block/modules/social_group_content_block/social_group_content_block.info.yml
+++ b/modules/social_features/social_content_block/modules/social_group_content_block/social_group_content_block.info.yml
@@ -1,7 +1,7 @@
 name: 'Social Group Content Block'
 description: 'Provides a content block for groups.'
 type: module
-core: 8.x
+core_version_requirement: ^8.8 || ^9
 dependencies:
   - social:social_content_block
   - social:social_group

--- a/modules/social_features/social_content_block/modules/social_page_content_block/social_page_content_block.info.yml
+++ b/modules/social_features/social_content_block/modules/social_page_content_block/social_page_content_block.info.yml
@@ -1,7 +1,7 @@
 name: 'Social Page Content Block'
 description: 'Provides a content block for pages.'
 type: module
-core: 8.x
+core_version_requirement: ^8.8 || ^9
 dependencies:
   - social:social_content_block
   - social:social_page

--- a/modules/social_features/social_content_report/config/install/views.view.report_overview.yml
+++ b/modules/social_features/social_content_report/config/install/views.view.report_overview.yml
@@ -25,7 +25,6 @@ description: ''
 tag: ''
 base_table: flagging
 base_field: id
-core: 8.x
 display:
   default:
     display_plugin: default

--- a/modules/social_features/social_editor/social_editor.info.yml
+++ b/modules/social_features/social_editor/social_editor.info.yml
@@ -1,7 +1,7 @@
 name: 'Social Editor'
 description: 'Provides site editor components.'
 type: module
-core: 8.x
+core_version_requirement: ^8.8 || ^9
 dependencies:
   - drupal:ckeditor
   - drupal:editor

--- a/modules/social_features/social_embed/social_embed.info.yml
+++ b/modules/social_features/social_embed/social_embed.info.yml
@@ -1,7 +1,7 @@
 name: Social Embed
 type: module
 description: Module for embedding social media links. Currently in an experimental stage. NOTE, This module is a work in progress and has some serious peformance issues still.
-core: '8.x'
+core_version_requirement: ^8.8 || ^9
 package: Social
 dependencies:
   - embed:embed

--- a/modules/social_features/social_event/modules/social_event_addtocal/social_event_addtocal.info.yml
+++ b/modules/social_features/social_event/modules/social_event_addtocal/social_event_addtocal.info.yml
@@ -1,7 +1,6 @@
 name: Social Event Add To Calendar
 description: Provides the ability to add Open Social events to the third party calendars
-core: 8.x
-core_version_requirement: ^8 || ^9
+core_version_requirement: ^8.8 || ^9
 type: module
 dependencies:
   - social:social_event

--- a/modules/social_features/social_event/modules/social_event_an_enroll/config/install/views.view.manage_enrollments.yml
+++ b/modules/social_features/social_event/modules/social_event_an_enroll/config/install/views.view.manage_enrollments.yml
@@ -15,7 +15,6 @@ description: ''
 tag: ''
 base_table: event_enrollment_field_data
 base_field: id
-core: 8.x
 display:
   default:
     display_plugin: default

--- a/modules/social_features/social_event/modules/social_event_an_enroll/social_event_an_enroll.info.yml
+++ b/modules/social_features/social_event/modules/social_event_an_enroll/social_event_an_enroll.info.yml
@@ -1,7 +1,7 @@
 name: 'Social Event Anonymous Enrolments'
 description: 'Provides ability to enroll to an event without having to create an account.'
 type: module
-core: 8.x
+core_version_requirement: ^8.8 || ^9
 package: Social
 dependencies:
   - social:social_editor

--- a/modules/social_features/social_event/modules/social_event_an_enroll_enrolments_export/social_event_an_enroll_enrolments_export.info.yml
+++ b/modules/social_features/social_event/modules/social_event_an_enroll_enrolments_export/social_event_an_enroll_enrolments_export.info.yml
@@ -1,7 +1,7 @@
 name: 'Social Event Anonymous Enrolments Export'
 description: 'Adds ability to export event enrolments (include guests) to a CSV.'
 type: module
-core: 8.x
+core_version_requirement: ^8.8 || ^9
 package: Social
 dependencies:
   - social:social_event_an_enroll

--- a/modules/social_features/social_event/modules/social_event_enrolments_export/social_event_enrolments_export.info.yml
+++ b/modules/social_features/social_event/modules/social_event_enrolments_export/social_event_enrolments_export.info.yml
@@ -1,7 +1,7 @@
 name: 'Social Event Enrolments Export'
 description: 'Adds ability to export event enrolments to a CSV.'
 type: module
-core: 8.x
+core_version_requirement: ^8.8 || ^9
 package: Social
 dependencies:
   - social:social_event

--- a/modules/social_features/social_event/modules/social_event_invite/social_event_invite.info.yml
+++ b/modules/social_features/social_event/modules/social_event_invite/social_event_invite.info.yml
@@ -1,7 +1,7 @@
 name: 'Social Event Invite Enrolments'
 description: 'Provides ability to invite enroll to an event.'
 type: module
-core: 8.x
+core_version_requirement: ^8.8 || ^9
 package: Social
 dependencies:
   - social:social_event

--- a/modules/social_features/social_event/modules/social_event_managers/config/install/views.view.managers.yml
+++ b/modules/social_features/social_event/modules/social_event_managers/config/install/views.view.managers.yml
@@ -16,7 +16,6 @@ description: ''
 tag: ''
 base_table: profile
 base_field: profile_id
-core: 8.x
 display:
   default:
     display_plugin: default

--- a/modules/social_features/social_event/modules/social_event_managers/social_event_managers.info.yml
+++ b/modules/social_features/social_event/modules/social_event_managers/social_event_managers.info.yml
@@ -1,7 +1,7 @@
 name: 'Social Event Organisers'
 type: module
 description: 'Social Event Organisers'
-core: 8.x
+core_version_requirement: ^8.8 || ^9
 package: Social
 dependencies:
   - drupal:block

--- a/modules/social_features/social_event/modules/social_event_max_enroll/social_event_max_enroll.info.yml
+++ b/modules/social_features/social_event/modules/social_event_max_enroll/social_event_max_enroll.info.yml
@@ -1,7 +1,7 @@
 name: 'Social Event Max Enroll'
 description: 'Allow setting the maximum participant number for events.'
 type: module
-core: 8.x
+core_version_requirement: ^8.8 || ^9
 configure: social_event_max_enroll.settings
 dependencies:
   - social:social_event

--- a/modules/social_features/social_event/modules/social_event_type/social_event_type.info.yml
+++ b/modules/social_features/social_event/modules/social_event_type/social_event_type.info.yml
@@ -1,7 +1,7 @@
 name: 'Social Event Type'
 description: 'Provides and event types taxonomy for the event content type.'
 type: module
-core: 8.x
+core_version_requirement: ^8.8 || ^9
 dependencies:
   - social:social_event
 package: Social

--- a/modules/social_features/social_event/social_event.info.yml
+++ b/modules/social_features/social_event/social_event.info.yml
@@ -1,7 +1,7 @@
 name: 'Social Event'
 description: 'Provides Event content type and related configuration. '
 type: module
-core: 8.x
+core_version_requirement: ^8.8 || ^9
 configure: social_event.settings
 dependencies:
   - address:address

--- a/modules/social_features/social_featured_content/config/install/views.view.featured_content_reference.yml
+++ b/modules/social_features/social_featured_content/config/install/views.view.featured_content_reference.yml
@@ -11,7 +11,6 @@ description: 'Custom selection handler for content that will be selected as feat
 tag: ''
 base_table: node_field_data
 base_field: nid
-core: 8.x
 display:
   default:
     display_plugin: default

--- a/modules/social_features/social_featured_content/config/install/views.view.featured_group_reference.yml
+++ b/modules/social_features/social_featured_content/config/install/views.view.featured_group_reference.yml
@@ -10,7 +10,6 @@ description: 'Custom selection handler for group that will be selected as featur
 tag: ''
 base_table: groups_field_data
 base_field: id
-core: 8.x
 display:
   default:
     display_plugin: default

--- a/modules/social_features/social_featured_content/config/install/views.view.featured_profile_reference.yml
+++ b/modules/social_features/social_featured_content/config/install/views.view.featured_profile_reference.yml
@@ -15,7 +15,6 @@ description: ''
 tag: ''
 base_table: profile
 base_field: profile_id
-core: 8.x
 display:
   default:
     display_plugin: default

--- a/modules/social_features/social_follow_taxonomy/modules/social_follow_landing_page/social_follow_landing_page.info.yml
+++ b/modules/social_features/social_follow_taxonomy/modules/social_follow_landing_page/social_follow_landing_page.info.yml
@@ -1,7 +1,7 @@
 name: 'Social Follow Landing Page'
 description: 'Provide the possibility to add the Follow tag block on the landing pages.'
 type: module
-core: 8.x
+core_version_requirement: ^8.8 || ^9
 dependencies:
   - social_follow_taxonomy:social_follow_taxonomy
   - social_tagging:social_tagging

--- a/modules/social_features/social_follow_taxonomy/modules/social_follow_tag/social_follow_tag.info.yml
+++ b/modules/social_features/social_follow_taxonomy/modules/social_follow_tag/social_follow_tag.info.yml
@@ -1,7 +1,7 @@
 name: 'Social Follow Tag'
 description: 'Provide follow functionality for the social_tagging vocabulary and create activities related to followed tag.'
 type: module
-core: 8.x
+core_version_requirement: ^8.8 || ^9
 dependencies:
   - social_follow_taxonomy:social_follow_taxonomy
   - social_tagging:social_tagging

--- a/modules/social_features/social_follow_taxonomy/social_follow_taxonomy.info.yml
+++ b/modules/social_features/social_follow_taxonomy/social_follow_taxonomy.info.yml
@@ -1,7 +1,7 @@
 name: 'Social Follow Taxonomy Term'
 description: 'Provides "Follow Term" flag type and related functionality.'
 type: module
-core: 8.x
+core_version_requirement: ^8.8 || ^9
 dependencies:
   - social:activity_logger
   - drupal:views

--- a/modules/social_features/social_footer/social_footer.info.yml
+++ b/modules/social_features/social_footer/social_footer.info.yml
@@ -1,7 +1,7 @@
 name: Social Footer
 type: module
 description: 'Provides block based on the "Powered by Drupal" block from Drupal core.'
-core: 8.x
+core_version_requirement: ^8.8 || ^9
 package: Social
 project: social_footer
 dependencies:

--- a/modules/social_features/social_group/modules/social_group_default_route/social_group_default_route.info.yml
+++ b/modules/social_features/social_group/modules/social_group_default_route/social_group_default_route.info.yml
@@ -1,7 +1,7 @@
 name: Social Group Default Route
 type: module
 description: This module allows group managers to set the default routes on a group for member and non-members.
-core: 8.x
+core_version_requirement: ^8.8 || ^9
 package: Social
 dependencies:
   - social:social_group

--- a/modules/social_features/social_group/modules/social_group_flexible_group/modules/social_flexible_group_featured/social_flexible_group_featured.info.yml
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/modules/social_flexible_group_featured/social_flexible_group_featured.info.yml
@@ -1,7 +1,7 @@
 name: 'Social Flexible Group on Landing pages'
 description: 'Provides a flexible Group featured view mode for use on landing pages.'
 type: module
-core: 8.x
+core_version_requirement: ^8.8 || ^9
 dependencies:
   - social:social_group_flexible_group
   - social:social_landing_page

--- a/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.info.yml
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.info.yml
@@ -1,7 +1,7 @@
 name: 'Social Flexible Group'
 description: 'Provides a flexible Group feature allowing members to configure the group to their liking.'
 type: module
-core: 8.x
+core_version_requirement: ^8.8 || ^9
 dependencies:
   - address
   - field

--- a/modules/social_features/social_group/modules/social_group_gvbo/social_group_gvbo.info.yml
+++ b/modules/social_features/social_group/modules/social_group_gvbo/social_group_gvbo.info.yml
@@ -1,7 +1,7 @@
 name: 'Social Group VBO integration with Groups and Open Social'
 description: 'Adds ability to act on Group Content.'
 type: module
-core: 8.x
+core_version_requirement: ^8.8 || ^9
 package: Social
 dependencies:
   - social:social_group

--- a/modules/social_features/social_group/modules/social_group_invite/social_group_invite.info.yml
+++ b/modules/social_features/social_group/modules/social_group_invite/social_group_invite.info.yml
@@ -1,7 +1,7 @@
 name: 'Social Group Invite'
 description: 'Provides Group Invite member feature.'
 type: module
-core: 8.x
+core_version_requirement: ^8.8 || ^9
 dependencies:
   - group:group
   - group:ginvite

--- a/modules/social_features/social_group/modules/social_group_members_export/social_group_members_export.info.yml
+++ b/modules/social_features/social_group/modules/social_group_members_export/social_group_members_export.info.yml
@@ -1,7 +1,7 @@
 name: 'Social Group Members Export'
 description: 'Adds ability to export group members to a CSV.'
 type: module
-core: 8.x
+core_version_requirement: ^8.8 || ^9
 package: Social
 dependencies:
   - social:social_group

--- a/modules/social_features/social_group/modules/social_group_quickjoin/social_group_quickjoin.info.yml
+++ b/modules/social_features/social_group/modules/social_group_quickjoin/social_group_quickjoin.info.yml
@@ -1,7 +1,7 @@
 name: 'Social Group Quickjoin'
 description: 'Allows users to skip confirmation when joining a group.'
 type: module
-core: 8.x
+core_version_requirement: ^8.8 || ^9
 dependencies:
 - social:social_group
 package: Social

--- a/modules/social_features/social_group/modules/social_group_request/social_group_request.info.yml
+++ b/modules/social_features/social_group/modules/social_group_request/social_group_request.info.yml
@@ -2,7 +2,7 @@ name: 'Social Group request'
 type: module
 description: 'Allows users to request access to Groups'
 package: Social
-core: 8.x
+core_version_requirement: ^8.8 || ^9
 dependencies:
   - group:group
   - grequest:grequest

--- a/modules/social_features/social_group/modules/social_group_secret/modules/social_secret_group_featured/social_secret_group_featured.info.yml
+++ b/modules/social_features/social_group/modules/social_group_secret/modules/social_secret_group_featured/social_secret_group_featured.info.yml
@@ -1,7 +1,7 @@
 name: 'Social Secret Group on Landing pages'
 description: 'Provides a Secret Group featured view mode for use on landing pages.'
 type: module
-core: 8.x
+core_version_requirement: ^8.8 || ^9
 dependencies:
   - social:social_group_secret
   - social:social_landing_page

--- a/modules/social_features/social_group/modules/social_group_secret/social_group_secret.info.yml
+++ b/modules/social_features/social_group/modules/social_group_secret/social_group_secret.info.yml
@@ -1,7 +1,7 @@
 name: 'Social Secret Group'
 description: 'Adds Secret Group as a group type.'
 type: module
-core: 8.x
+core_version_requirement: ^8.8 || ^9
 dependencies:
   - social:social_group
 package: Social

--- a/modules/social_features/social_group/modules/social_group_welcome_message/social_group_welcome_message.info.yml
+++ b/modules/social_features/social_group/modules/social_group_welcome_message/social_group_welcome_message.info.yml
@@ -1,7 +1,7 @@
 name: 'Social Group Welcome Message'
 description: 'Implements group welcome message functionality.'
 type: module
-core: 8.x
+core_version_requirement: ^8.8 || ^9
 dependencies:
   - social:social_editor
   - social:social_group

--- a/modules/social_features/social_landing_page/config/install/views.view.community_activities.yml
+++ b/modules/social_features/social_landing_page/config/install/views.view.community_activities.yml
@@ -13,7 +13,6 @@ description: ''
 tag: social_landing_page
 base_table: activity_field_data
 base_field: id
-core: 8.x
 display:
   default:
     display_plugin: default

--- a/modules/social_features/social_post/modules/social_post_album/social_post_album.info.yml
+++ b/modules/social_features/social_post/modules/social_post_album/social_post_album.info.yml
@@ -1,7 +1,7 @@
 name: 'Social Post Album'
 description: 'Provides the ability to use the Album feature in a post.'
 type: module
-core: 8.x
+core_version_requirement: ^8.8 || ^9
 dependencies:
   - social:social_post_photo
   - social:social_comment_upload

--- a/modules/social_features/social_post/modules/social_post_photo/social_post_photo.info.yml
+++ b/modules/social_features/social_post/modules/social_post_photo/social_post_photo.info.yml
@@ -1,7 +1,7 @@
 name: 'Social Post Photo'
 description: 'Provides an new post type bundle.'
 type: module
-core: 8.x
+core_version_requirement: ^8.8 || ^9
 dependencies:
   - drupal:comment
   - social:dropdown

--- a/modules/social_features/social_private_message/config/install/views.view.inbox.yml
+++ b/modules/social_features/social_private_message/config/install/views.view.inbox.yml
@@ -13,7 +13,6 @@ description: ''
 tag: ''
 base_table: private_message_threads
 base_field: id
-core: 8.x
 display:
   default:
     display_plugin: default

--- a/modules/social_features/social_profile/modules/social_profile_fields/social_profile_fields.info.yml
+++ b/modules/social_features/social_profile/modules/social_profile_fields/social_profile_fields.info.yml
@@ -1,7 +1,7 @@
 name: 'Social Profile Fields'
 description: 'Provides hiding fields on a per profile_type basis'
 type: module
-core: 8.x
+core_version_requirement: ^8.8 || ^9
 package: Social
 configure: social_profile_fields.settings
 dependencies:

--- a/modules/social_features/social_profile/modules/social_profile_manager_notes/social_profile_manager_notes.info.yml
+++ b/modules/social_features/social_profile/modules/social_profile_manager_notes/social_profile_manager_notes.info.yml
@@ -1,7 +1,7 @@
 name: 'Social Profile Manager Notes'
 description: 'Provides profile notes that can created by Managers'
 type: module
-core: 8.x
+core_version_requirement: ^8.8 || ^9
 package: Social (experimental)
 dependencies:
   - drupal:user

--- a/modules/social_features/social_profile/modules/social_profile_organization_tag/social_profile_organization_tag.info.yml
+++ b/modules/social_features/social_profile/modules/social_profile_organization_tag/social_profile_organization_tag.info.yml
@@ -1,7 +1,7 @@
 name: 'Social Profile Organization Tag'
 description: 'Provides Profile Organization Tag field and vocabulary'
 type: module
-core: 8.x
+core_version_requirement: ^8.8 || ^9
 package: Social
 dependencies:
   - social:social_profile

--- a/modules/social_features/social_profile/modules/social_profile_privacy/social_profile_privacy.info.yml
+++ b/modules/social_features/social_profile/modules/social_profile_privacy/social_profile_privacy.info.yml
@@ -1,7 +1,7 @@
 name: 'Social Profile Privacy'
 description: 'Provides ability to set visibility of profile fields'
 type: module
-core: 8.x
+core_version_requirement: ^8.8 || ^9
 package: Social
 configure: social_profile.settings
 dependencies:


### PR DESCRIPTION
## Problem
As per https://www.drupal.org/node/3070687

> The new `core_version_requirement` key in *.info.yml files for modules, themes, and profiles now supports semantic versioning as implemented by the Composer project. This allows modules, themes, and profiles to also specify that they are compatible with multiple major versions of Drupal core.

## Solution
Add the new `core_version_requirement` key in *.info.yml of all modules in Open Social and remove the old `core` key.

We can remove the core: key because we only accept Drupal ^8.8

> The core: is required here because Drupal Core versions before 8.7.7 do not recognize the core_version_requirement: key.

And we apply to this section

> Most modules however will have to remove deprecated code to be compatible with Drupal 9. Therefore they will not able to be compatible with all versions of Drupal 8.

For example a module that is compatible with Drupal 8 versions after Drupal 8.8.0 and also Drupal 9 will need a info.yml file like this:

```
name: My Module
type: module
core_version_requirement: ^8.8 || ^9
```

## Issue tracker
https://www.drupal.org/project/social/issues/3232812

## How to test
- [ ] Run the https://www.drupal.org/project/upgrade_status module to see that all warnings are removed.
- [ ] See that all modules are installed correctly on install & update.

## Release notes
Drupal 9 requirement: We have added the `core_version_requirements` to all our info.yml files of all our modules.
