### PR TITLE
Issue #3007303 by Ressinel: Fix issue with group post notifications.

### DIFF
--- a/modules/social_features/social_activity/src/Plugin/ActivityEntityCondition/GroupContentSingleActivityEntityCondition.php
+++ b/modules/social_features/social_activity/src/Plugin/ActivityEntityCondition/GroupContentSingleActivityEntityCondition.php
@@ -12,7 +12,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *
  * @ActivityEntityCondition(
  *  id = "group_content_node_single_group",
- *  label = @Translation("Node added in the first (single) group"),
+ *  label = @Translation("Entity exists in single group"),
  *  entities = {"group_content" = {}}
  * )
  */
@@ -58,7 +58,7 @@ class GroupContentSingleActivityEntityCondition extends ActivityEntityConditionB
    * {@inheritdoc}
    */
   public function isValidEntityCondition($entity) {
-    if ($entity->getEntityTypeId() === 'group_content') {
+    if (in_array($entity->getEntityTypeId(), ['group_content', 'post'])) {
       // If node is added only to one group then condition is valid.
       if (!$this->crossPostingService->nodeExistsInMultipleGroups($entity)) {
         return TRUE;


### PR DESCRIPTION
## Problem
Group post notifications don't work after https://github.com/goalgorilla/open_social/pull/2300 is merged.

## Solution
Fix it in `GroupContentSingleActivityEntityCondition.php`

## Issue tracker
- https://www.drupal.org/project/social/issues/3007303

## How to test
- [ ] Use exists a group with at least two members
- [ ] Create a post in a group by member
- [ ] Notification should be sent to all group members except post author (email, notifications centre)

## Screenshots
N/A

## Release notes
N/A

## Change Record
N/A

## Translations
N/A
