### PR TITLE
Issue #3233038 - Social_event should set time field as optional for all day events

### DIFF
--- a/modules/social_features/social_event/social_event.module
+++ b/modules/social_features/social_event/social_event.module
@@ -768,14 +768,18 @@ function social_event_field_widget_form_alter(&$element, FormStateInterface $for
  * Add 'All day' checkbox to event datetime field.
  */
 function social_event_date_all_day_checkbox(&$element, FormStateInterface $form_state, $date) {
-  // Time field should disappear when 'All day' is checked.
-  $state = [
-    ':input[name="event_all_day"]' => [
-      'checked' => TRUE,
-    ],
-  ];
+  // Time field should disappear and optional when 'All day' is checked.
   $element['time']['#states'] = [
-    'invisible' => $state,
+    'invisible' => [
+      ':input[name="event_all_day"]' => [
+        'checked' => TRUE,
+      ],
+    ],
+    'required' => [
+      ':input[name="event_all_day"]' => [
+        'checked' => FALSE,
+      ],
+    ],
   ];
   $form_input = $form_state->getUserInput();
   $date = $element['#value']['object'];


### PR DESCRIPTION
## Problem/Motivation
When creating an event, if I flag "All Day", the time field disappears but remains required, and the browser refuses to submit the form.

## Steps to reproduce
Create a new event with "All Day" selected and try to submit the form.

## Proposed resolution
Add a state to set the time field as non-required when "All Day" is selected.

## Remaining tasks
Implement it.

## User interface changes
None.

## API changes
None.

## Data model changes
None.