### PR TITLE
Issue #3233546 by agami4: Content on add new landing page translation has no wrapper

### DIFF
--- a/modules/social_features/social_landing_page/social_landing_page.module
+++ b/modules/social_features/social_landing_page/social_landing_page.module
@@ -175,7 +175,9 @@ function social_landing_page_preprocess_page(&$variables) {
     $variables['node'] instanceof NodeInterface &&
     $variables['node']->bundle() === 'landing_page'
   ) {
-    if (\Drupal::routeMatch()->getRouteName() === 'entity.node.edit_form') {
+    $route_name = \Drupal::routeMatch()->getRouteName();
+
+    if ($route_name === 'entity.node.edit_form' || $route_name === 'entity.node.content_translation_add') {
       $variables['attributes'] = new Attribute();
       $variables['attributes']->addClass('container');
     }


### PR DESCRIPTION
## Problem
Content expanded to full page width.

## Solution
Add route translation page to the condition.

## Issue tracker
https://www.drupal.org/project/social/issues/3233546
https://getopensocial.atlassian.net/browse/WAGGGGS-24

## How to test
*For example*
- [ ] Create a landing page
- [ ] Add translation to the created node on node translations page
- [ ] You will be redirected to (for example) /uk/node/id/translations/add/en/uk

## Screenshots
before:
![image-20210511-130507](https://user-images.githubusercontent.com/16086340/133634039-294f5ee9-e034-4784-9005-dc2da06e326d.png)

after:
<img width="1632" alt="Landing page en  ECI Demo 2021-09-16 17-42-26" src="https://user-images.githubusercontent.com/16086340/133633935-4b883a50-ff50-41fb-a3d3-09c262c929f9.png">

## Release notes
Landing page content on the page is in the wrapper and doesn’t expand to full page width

## Change Record
N/A

## Translations
N/A
