### PR TITLE
Issue #3236250 by agami4: Add "data-copyright" to the hero section

### DIFF
--- a/modules/social_features/social_landing_page/templates/paragraph--hero--default.html.twig
+++ b/modules/social_features/social_landing_page/templates/paragraph--hero--default.html.twig
@@ -52,7 +52,7 @@
   ]
 %}
 
-<div{{ attributes.addClass(cover_classes) }} {% if hero_styled_image_url %} style="background-image: url('{{ hero_styled_image_url }}');" {% endif %}>
+<div{{ attributes.addClass(cover_classes) }} {% if hero_styled_image_url %} style="background-image: url('{{ hero_styled_image_url }}');" data-copyright="{{ data_copyright }}"{% endif %}>
   <div class="hero__bgimage-overlay"></div>
   {% if node_edit_url %}
     <div class="hero-action-button">

--- a/modules/social_features/social_landing_page/templates/paragraph--hero-small--default.html.twig
+++ b/modules/social_features/social_landing_page/templates/paragraph--hero-small--default.html.twig
@@ -52,7 +52,7 @@
 ]
 %}
 
-<div{{ attributes.addClass(cover_classes) }} {% if hero_small_styled_image_url %} style="background-image: url('{{ hero_small_styled_image_url }}');" {% endif %}>
+<div{{ attributes.addClass(cover_classes) }} {% if hero_small_styled_image_url %} style="background-image: url('{{ hero_small_styled_image_url }}');" data-copyright="{{ data_copyright }}"{% endif %}>
   <div class="hero-small__bgimage-overlay"></div>
   {% if node_edit_url %}
     <div class="hero-small-action-button">


### PR DESCRIPTION
## Problem
The copyright is not shown correctly on the nodes in the Sky theme.

## Solution
1. Add new `data_copyright` variable.
2. Set a new variable on the `hero` templates.

## Issue tracker
https://www.drupal.org/project/social/issues/3236250

## How to test
*For example*
- [ ] Enable `social_advanced_image` module.
- [ ] Go to/Create topic/group page.
- [ ] Add banner image and fill `Copyright text` filed.
- [ ] Save page.
- [ ] When you hover on the banner image you can see the text of the copyright block.

## Screenshots
before:
<img width="951" alt="Copyright close" src="https://user-images.githubusercontent.com/16086340/133772962-feab2278-f784-4ef6-8c1f-f0ea478001d1.png">
<img width="315" alt="Copyright covered" src="https://user-images.githubusercontent.com/16086340/133772970-8d50b823-5576-4722-923d-f3793e78167f.png">

after:
![Even community upcoming - request to enroll 2021-09-17 14-08-59](https://user-images.githubusercontent.com/16086340/133773185-0bd16b95-26c8-4473-a1e8-2a45469cdc6e.png)

## Release notes
Copyright image is shown correctly.

## Change Record
N/A

## Translations
N/A
