### PR TITLE
Issue #2880361: Add core patch for correct checking if post_update is hook_post_update_NAME() or hook_update_N().

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,8 @@
                 "Selecting the same day in a date between filter returns no results": "https://www.drupal.org/files/issues/2020-07-06/2842409-15.patch",
                 "Empty language (langcode) field wrapper inserted into contact form": "https://www.drupal.org/files/issues/2020-03-06/empty-langcode-field-wrapper-2842405-17.patch",
                 "Broken title in modal dialog when title is a render array": "https://www.drupal.org/files/issues/2019-10-21/2663316-76.drupal.Broken-title-in-modal-dialog-when-title-is-a-render-array.patch",
-                "PHPDocs with wrong parameters": "https://www.drupal.org/files/issues/2019-09-03/queryinterface-range-updated-phpdocs.patch"
+                "PHPDocs with wrong parameters": "https://www.drupal.org/files/issues/2019-09-03/queryinterface-range-updated-phpdocs.patch",
+                "Post update hook naming convention patch": "https://git.drupalcode.org/project/drupal/-/merge_requests/1215.patch"
             },
             "drupal/flag": {
                 "Add relationship to flagged entities when Flagging is base table": "https://www.drupal.org/files/issues/2723703_31.patch"


### PR DESCRIPTION
## Problem
As mentioned: https://www.drupal.org/project/drupal/issues/548470

> The underscore separator in the hook naming is very brittle. If a module invents the foo_bar hook and another invents the bar hook and you also have two modules called something_foo and something then all hell breaks lose. Also, it's impossible to see from a function name whether it's a hook implementation or not (and unless every non-hook implementation function name is carefully prefixed with an underscore, just with enabling another module suddenly it might become one).

We have found an issue with exactly this problem.

It has to do with the fact we have an install profile called `social` and a module called `social_post`
This means any regular update hooks (f.e. `hook_update_N()` or `hook_update_dependencies()`) used are considered as social module's `hook_post_update_NAME()`. instead of social_post module's `hook_update_%`

The same can be done with the standard install profile for example, by creating a standard_post module or any other module with the module_post name.

## Solution
For now we propose to at least fix this by adding some inspection in `DbUpdateController.php` to check if the `hook_post_update_NAME` function is coming from the correct file `module.post_update.php`
This aligns with what is indicated when the post update hook can't be found.

For example in our case:
`>  [warning] Post update function social_post_update_8801 not found in file social.post_update.php
`

## Issue tracker
In Open Social - 
https://www.drupal.org/project/social/issues/2880361

In Drupal - 
https://www.drupal.org/project/drupal/issues/3236316

## How to test
- [ ] See that `update.php/selection` does not show any `social_post` related update hooks.
- [ ] See that update path from an older version of Open Social is still accepted

## Release notes
Social post update hooks should now correctly not show up anymore when trying to update.

