### PR TITLE
Uninstall `social_demo` in Tugboat after setup

### DIFF
--- a/.tugboat/config.yml
+++ b/.tugboat/config.yml
@@ -62,6 +62,11 @@ services:
         # Allow site managers to enable modules so developers can change the
         # set-up during testing.
         ../vendor/bin/drush role:add:perm --yes 'sitemanager' 'administer modules'
+        # Uninstall the social_demo module since demo content has been 
+        # installed and the module silences useful status messages.
+        ../vendor/bin/drush \
+          --yes \
+          pmu social_demo
         # Change file owner again because of the way demo content is copied.
         chown -R www-data:www-data $DOCROOT
       build: |


### PR DESCRIPTION


## Problem
The social_demo module silences status messages in 
`Drupal\social_demo\Messenger` to ensure that the environment isn't
spammed while creating the demo content. However, this also removes 
useful status messages when working on the platform.

## Solution
Disable the social_demo module after demo content setup.

## Issue tracker
Untracked CI change.

## How to test

- [ ] On the new Tugboat environment create a user
- [ ] see the "User created" status message

## Screenshots
N/a

## Release notes
N/a

## Change Record
N/a

## Translations
N/a