### PR TITLE
Use own copy of `GraphQLTestBase` in tests

### DIFF
--- a/modules/custom/social_graphql/tests/src/Kernel/GraphQLTestBase.php
+++ b/modules/custom/social_graphql/tests/src/Kernel/GraphQLTestBase.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace Drupal\Tests\social_graphql\Kernel;
+
+use Drupal\Core\Cache\Cache;
+use Drupal\graphql\GraphQL\ResolverBuilder;
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\Tests\graphql\Traits\DataProducerExecutionTrait;
+use Drupal\Tests\graphql\Traits\MockingTrait;
+use Drupal\Tests\graphql\Traits\HttpRequestTrait;
+use Drupal\Tests\graphql\Traits\QueryFileTrait;
+use Drupal\Tests\graphql\Traits\QueryResultAssertionTrait;
+use Drupal\Tests\graphql\Traits\SchemaPrinterTrait;
+use Drupal\Tests\user\Traits\UserCreationTrait;
+
+/**
+ * Modified version of graphql's GraphQLTestBase class.
+ *
+ * For GraphQL tests in Open Social use `SocialGraphQLTestBase` instead.
+ *
+ * This version of the class removes the language and user creation from the
+ * setUp step. This allows code in Open Social to rely on its own configuration.
+ *
+ * In the previous version of the class it could happen that a module was
+ * installed causing its hooks to be invoked but its configuration was not yet
+ * present, causing errors. This is not a scenario that would occur in an actual
+ * Drupal installation since config is installed when the module is enabled
+ * (before content is created).
+ *
+ * With the exception of the above outlined modification, this class should be
+ * kept in sync with the grahpql module's version of this class.
+ *
+ * @internal
+ */
+abstract class GraphQLTestBase extends KernelTestBase {
+  use DataProducerExecutionTrait;
+  use HttpRequestTrait;
+  use QueryFileTrait;
+  use QueryResultAssertionTrait;
+  use SchemaPrinterTrait;
+  use MockingTrait;
+  use UserCreationTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'user',
+    'language',
+    'node',
+    'graphql',
+    'content_translation',
+    'entity_reference_test',
+    'field',
+    'menu_link_content',
+    'link',
+    'typed_data',
+  ];
+
+  /**
+   * The resolver builder used for our server's schema.
+   *
+   * @var \Drupal\graphql\GraphQL\ResolverBuilder
+   */
+  protected $builder;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $this->installConfig('system');
+    $this->installConfig('graphql');
+    $this->installEntitySchema('node');
+    $this->installEntitySchema('user');
+    $this->installSchema('node', ['node_access']);
+    $this->installSchema('user', ['users_data']);
+    $this->installEntitySchema('graphql_server');
+    $this->installEntitySchema('configurable_language');
+    $this->installConfig(['language']);
+
+    // Since `setupCurrentUser` is not called, extending tests may call
+    // `createUser` before calling `setupCurrentUser`. That function doesn't
+    // install the sequences table automatically causing failing tests, so we do
+    // it here.
+    $this->installSchema('system', ['sequences']);
+
+    $this->builder = new ResolverBuilder();
+  }
+
+  /**
+   * Returns the default cache maximum age for the test.
+   */
+  protected function defaultCacheMaxAge(): int {
+    return Cache::PERMANENT;
+  }
+
+  /**
+   * Returns the default cache tags used in assertions for this test.
+   *
+   * @return string[]
+   *   The list of cache tags.
+   */
+  protected function defaultCacheTags(): array {
+    $tags = ['graphql_response'];
+    if (isset($this->server)) {
+      array_push($tags, "config:graphql.graphql_servers.{$this->server->id()}");
+    }
+
+    return $tags;
+  }
+
+  /**
+   * Returns the default cache contexts used in assertions for this test.
+   *
+   * @return string[]
+   *   The list of cache contexts.
+   */
+  protected function defaultCacheContexts(): array {
+    return ['user.permissions'];
+  }
+
+  /**
+   * Provides the user permissions that the test user is set up with.
+   *
+   * @return string[]
+   *   List of user permissions.
+   */
+  protected function userPermissions(): array {
+    return ['access content', 'bypass graphql access'];
+  }
+
+}

--- a/modules/custom/social_graphql/tests/src/Kernel/GraphQLTestBase.php
+++ b/modules/custom/social_graphql/tests/src/Kernel/GraphQLTestBase.php
@@ -42,7 +42,16 @@ abstract class GraphQLTestBase extends KernelTestBase {
   use UserCreationTrait;
 
   /**
-   * {@inheritdoc}
+   * Modules to enable.
+   *
+   * The test runner will merge the $modules lists from this class, the class
+   * it extends, and so on up the class hierarchy. It is not necessary to
+   * include modules in your list that a parent class has already declared.
+   *
+   * @see \Drupal\Tests\KernelTestBase::enableModules()
+   * @see \Drupal\Tests\KernelTestBase::bootKernel()
+   *
+   * @var string[]
    */
   protected static $modules = [
     'system',

--- a/modules/custom/social_graphql/tests/src/Kernel/GraphQLTestBase.php
+++ b/modules/custom/social_graphql/tests/src/Kernel/GraphQLTestBase.php
@@ -48,10 +48,10 @@ abstract class GraphQLTestBase extends KernelTestBase {
    * it extends, and so on up the class hierarchy. It is not necessary to
    * include modules in your list that a parent class has already declared.
    *
+   * @var string[]
+   *
    * @see \Drupal\Tests\KernelTestBase::enableModules()
    * @see \Drupal\Tests\KernelTestBase::bootKernel()
-   *
-   * @var string[]
    */
   protected static $modules = [
     'system',

--- a/modules/custom/social_graphql/tests/src/Kernel/SocialGraphQLTestBase.php
+++ b/modules/custom/social_graphql/tests/src/Kernel/SocialGraphQLTestBase.php
@@ -4,11 +4,10 @@ namespace Drupal\Tests\social_graphql\Kernel;
 
 use Drupal\Component\Utility\NestedArray;
 use Drupal\graphql\Entity\Server;
-use Drupal\Tests\graphql\Kernel\GraphQLTestBase;
 use GraphQL\Server\OperationParams;
 
 /**
- * Bass class for Open Social GraphQL tests.
+ * Base class for Open Social GraphQL tests.
  *
  * Provides utility methods for testing Open Social GraphQL endpoints. Ensures
  * the Open Social GraphQL server is loaded and configured.

--- a/modules/custom/social_graphql/tests/src/Kernel/SocialGraphQLTestBase.php
+++ b/modules/custom/social_graphql/tests/src/Kernel/SocialGraphQLTestBase.php
@@ -4,6 +4,7 @@ namespace Drupal\Tests\social_graphql\Kernel;
 
 use Drupal\Component\Utility\NestedArray;
 use Drupal\graphql\Entity\Server;
+use Drupal\graphql\Entity\ServerInterface;
 use GraphQL\Server\OperationParams;
 
 /**
@@ -43,7 +44,9 @@ abstract class SocialGraphQLTestBase extends GraphQLTestBase {
     $this->installConfig("social_graphql");
 
     // Set up the schema and use the Open Social GraphQL server in queries.
-    $this->server = Server::load("open_social_graphql");
+    $server = Server::load("open_social_graphql");
+    self::assertInstanceOf(ServerInterface::class, $server, "Test set-up failed: 'open_social_graphql' server is not installed.");
+    $this->server = $server;
 
     // Manually enable query_access checks, until `use_entity_access_api` is no
     // longer a setting. This is done in the social_graphql_install hook but

--- a/modules/social_features/social_profile/tests/src/Kernel/GraphQLUsersEndpointTest.php
+++ b/modules/social_features/social_profile/tests/src/Kernel/GraphQLUsersEndpointTest.php
@@ -99,7 +99,7 @@ class GraphQLUsersEndpointTest extends SocialGraphQLTestBase {
   public function testUserProfileFieldsPresence() : void {
     // Test as the admin users, this allows us to test all the fields that are
     // available in an all-access scenario.
-    $this->setCurrentUser(User::load(1));
+    $this->setUpCurrentUser([], [], TRUE);
     $test_user = $this->createUser();
     $profile = $this->ensureTestProfile($test_user, 'profile');
     $query = "

--- a/modules/social_features/social_profile/tests/src/Kernel/GraphQLUsersEndpointTest.php
+++ b/modules/social_features/social_profile/tests/src/Kernel/GraphQLUsersEndpointTest.php
@@ -24,6 +24,8 @@ class GraphQLUsersEndpointTest extends SocialGraphQLTestBase {
     "role_delegation",
     // Profile is needed for the profile storage.
     "profile",
+    // Required for third party config schema.
+    "field_group",
     // Modules needed for profile fields.
     "file",
     "image",
@@ -31,10 +33,12 @@ class GraphQLUsersEndpointTest extends SocialGraphQLTestBase {
     "taxonomy",
     "telephone",
     "text",
+    "options",
     "filter",
     "lazy",
     "image_widget_crop",
     "crop",
+    // The actual module under test.
     "social_profile",
   ];
 
@@ -42,9 +46,7 @@ class GraphQLUsersEndpointTest extends SocialGraphQLTestBase {
    * {@inheritdoc}
    */
   protected static $configSchemaCheckerExclusions = [
-    // The third party settings in this config fail and since the lazy module
-    // doesn't have a schema we can't fix this either.
-    "core.entity_view_display.profile.profile.medium_teaser",
+    // @todo when https://www.drupal.org/project/social/issues/3238713 is fixed.
     "core.entity_form_display.profile.profile.default",
     // We don't need views in the GraphQL API so no sense in enabling the views
     // module or validating the schema.

--- a/modules/social_features/social_user/tests/src/Kernel/GraphQL/GraphQLUsersEndpointTest.php
+++ b/modules/social_features/social_user/tests/src/Kernel/GraphQL/GraphQLUsersEndpointTest.php
@@ -4,6 +4,7 @@ namespace Drupal\Tests\social_user\Kernel\GraphQL;
 
 use Drupal\Tests\social_graphql\Kernel\SocialGraphQLTestBase;
 use Drupal\user\Entity\User;
+use Drupal\user\UserInterface;
 
 /**
  * Tests the users endpoint added to the Open Social schema by this module.
@@ -32,25 +33,18 @@ class GraphQLUsersEndpointTest extends SocialGraphQLTestBase {
    * Test the filter for the users query.
    */
   public function testUsersQueryFilter(): void {
-    // Load the existing non-anonymous users as they're part of the dataset that
-    // we want to verify test output against.
-    $users = array_values(
-      array_filter(
-        User::loadMultiple(),
-        static function (User $u) {
-          return !$u->isAnonymous();
-        }
-      )
-    );
     // Create a set of 10 test users that we can query. The data of the users
     // shouldn't matter.
     for ($i = 0; $i < 10; ++$i) {
       $users[] = $this->createUser();
     }
 
+    // We must include the current user in the test data because it'll also be
+    // listed.
+    $users[] = $this->setUpCurrentUser([], ['administer users', 'access content', 'bypass graphql access']);
     $this->assertEndpointSupportsPagination(
       'users',
-      array_map(static fn ($user) => $user->uuid(), $users)
+      array_map(static fn (UserInterface $user) => $user->uuid(), $users)
     );
   }
 
@@ -110,9 +104,11 @@ class GraphQLUsersEndpointTest extends SocialGraphQLTestBase {
     // Testing should be done with individual permissions rather than as
     // anonymous user but the correct permissions don't exist yet.
     // @todo Fix with DS-7613.
-    /** @var \Drupal\user\UserInterface $test_user */
-    $test_user = User::load(0);
-    $this->setCurrentUser($test_user);
+    $this->setUpCurrentUser([
+      'uid' => 0,
+      'status' => 0,
+      'name' => '',
+    ]);
     $this->assertResults(
       '
         query {

--- a/modules/social_features/social_user/tests/src/Kernel/GraphQL/GraphQLViewerEndpointTest.php
+++ b/modules/social_features/social_user/tests/src/Kernel/GraphQL/GraphQLViewerEndpointTest.php
@@ -3,6 +3,7 @@
 namespace Drupal\Tests\social_user\Kernel\GraphQL;
 
 use Drupal\Tests\social_graphql\Kernel\SocialGraphQLTestBase;
+use Drupal\user\UserInterface;
 
 /**
  * Tests the root viewer endpoint.
@@ -25,8 +26,8 @@ class GraphQLViewerEndpointTest extends SocialGraphQLTestBase {
    * It loads the current user.
    */
   public function testViewerLoadsCurrentUser() : void {
-    $user = $this->createUser();
-    $this->setCurrentUser($user);
+    $user = $this->setUpCurrentUser();
+    self::assertInstanceOf(UserInterface::class, $user, "Test setup failure: could not create test user.");
 
     $this->assertResults(
       "

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -3206,11 +3206,6 @@ parameters:
 			path: modules/custom/social_graphql/src/Wrappers/EdgeInterface.php
 
 		-
-			message: "#^Method Drupal\\\\Tests\\\\social_graphql\\\\Kernel\\\\FieldDataProducerAccessTest\\:\\:testFieldDataProducerAccessCheck\\(\\) has no return typehint specified\\.$#"
-			count: 1
-			path: modules/custom/social_graphql/tests/src/Kernel/FieldDataProducerAccessTest.php
-
-		-
 			message: "#^Access to an undefined property Drupal\\\\Core\\\\Field\\\\FieldItemListInterface\\:\\:\\$alt\\.$#"
 			count: 1
 			path: modules/custom/social_graphql/tests/src/Kernel/MediaBridgeFileTest.php
@@ -3294,11 +3289,6 @@ parameters:
 			message: "#^Method Drupal\\\\Tests\\\\social_graphql\\\\Kernel\\\\MediaBridgeMediaTest\\:\\:testMediaSource\\(\\) has no return typehint specified\\.$#"
 			count: 1
 			path: modules/custom/social_graphql/tests/src/Kernel/MediaBridgeMediaTest.php
-
-		-
-			message: "#^Property Drupal\\\\Tests\\\\graphql\\\\Kernel\\\\GraphQLTestBase\\:\\:\\$server \\(Drupal\\\\graphql\\\\Entity\\\\ServerInterface\\) does not accept Drupal\\\\graphql\\\\Entity\\\\Server\\|null\\.$#"
-			count: 1
-			path: modules/custom/social_graphql/tests/src/Kernel/SocialGraphQLTestBase.php
 
 		-
 			message: "#^Cannot call method getKey\\(\\) on Drupal\\\\Core\\\\Entity\\\\EntityTypeInterface\\|null\\.$#"
@@ -18076,11 +18066,6 @@ parameters:
 			path: modules/social_features/social_profile/tests/src/Kernel/GraphQLUsersEndpointTest.php
 
 		-
-			message: "#^Parameter \\#1 \\$account of method Drupal\\\\Tests\\\\graphql\\\\Kernel\\\\GraphQLTestBase\\:\\:setCurrentUser\\(\\) expects Drupal\\\\Core\\\\Session\\\\AccountInterface, Drupal\\\\user\\\\Entity\\\\User\\|null given\\.$#"
-			count: 1
-			path: modules/social_features/social_profile/tests/src/Kernel/GraphQLUsersEndpointTest.php
-
-		-
 			message: "#^Parameter \\#1 \\$json of function json_decode expects string, string\\|false given\\.$#"
 			count: 1
 			path: modules/social_features/social_profile/tests/src/Kernel/GraphQLUsersEndpointTest.php
@@ -19924,21 +19909,6 @@ parameters:
 			message: "#^Parameter \\#1 \\$other_object of method Drupal\\\\Core\\\\Cache\\\\CacheableMetadata\\:\\:addCacheableDependency\\(\\) expects object, Drupal\\\\user\\\\Entity\\\\User\\|false given\\.$#"
 			count: 1
 			path: modules/social_features/social_user/tests/src/Kernel/GraphQL/GraphQLUsersEndpointTest.php
-
-		-
-			message: "#^Cannot call method uuid\\(\\) on Drupal\\\\user\\\\Entity\\\\User\\|false\\.$#"
-			count: 1
-			path: modules/social_features/social_user/tests/src/Kernel/GraphQL/GraphQLViewerEndpointTest.php
-
-		-
-			message: "#^Parameter \\#1 \\$account of method Drupal\\\\Tests\\\\graphql\\\\Kernel\\\\GraphQLTestBase\\:\\:setCurrentUser\\(\\) expects Drupal\\\\Core\\\\Session\\\\AccountInterface, Drupal\\\\user\\\\Entity\\\\User\\|false given\\.$#"
-			count: 1
-			path: modules/social_features/social_user/tests/src/Kernel/GraphQL/GraphQLViewerEndpointTest.php
-
-		-
-			message: "#^Parameter \\#1 \\$other_object of method Drupal\\\\Core\\\\Cache\\\\CacheableMetadata\\:\\:addCacheableDependency\\(\\) expects object, Drupal\\\\user\\\\Entity\\\\User\\|false given\\.$#"
-			count: 1
-			path: modules/social_features/social_user/tests/src/Kernel/GraphQL/GraphQLViewerEndpointTest.php
 
 		-
 			message: "#^Method Drupal\\\\social_user\\\\Tests\\\\SocialUserNameConstraintTest\\:\\:itemsMock\\(\\) has no return typehint specified\\.$#"


### PR DESCRIPTION
## Problem
The `GraphQLTestBase` of the graphql module creates a user during set-up
and installs languages. This may be problematic in case we have a module
that acts on this (e.g. through hook_user_insert) and then relies on
their own configuration that may not yet be installed. This happens
because all modules are installed before `setUp` is called (enabling
their hooks) but the GraphQL module's `setUp` is called before some of
our own config is installed (to ensure dependent config is installed in
the proper order).

## Solution
The easiest way to solve this is to duplicate everything we need but
remove the offending lines. We already expected tests to be explicit
about setting up their test user in the class. We choose to keep a
separate class so that it's clear what is part of the `graphql` module's
dependencies and what is needed for Open Social's added functionality.
This should also help keep the class up-to-date during module updates.

## Issue tracker
No ticket, unsupported internal testing change.

## How to test

- [ ] PHPCS should pass
- [ ] PHPStan should pass
- [ ] Travis should pass

## Screenshots
N/a

## Release notes
N/a, unsupported internal testing change.

## Change Record
N/a

## Translations
N/a