### PR TITLE
Issue #3238766 by Kingdutch: Require at least PHP 7.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: trusty
+dist: focal
 sudo: required
 
 cache:
@@ -14,7 +14,7 @@ addons:
 language: php
 
 php:
-  - 7.3
+  - 7.4
 
 env:
   global:

--- a/composer.json
+++ b/composer.json
@@ -115,12 +115,10 @@
         }
     },
     "require": {
+        "php": "^7.4 || ^8",
         "bower-asset/lazysizes": "^5.3",
-        "cweagans/composer-patches": "^1.6.0",
         "composer/installers": "~1.0 || ~2.0",
-        "oomphinc/composer-installers-extender": "~1.0 || ~2.0",
-        "drupal/core": "8.8 - 9.1",
-        "drupal/core-composer-scaffold": "8.8 - 9.3",
+        "cweagans/composer-patches": "^1.6.0",
         "drupal/address": "1.9.0",
         "drupal/admin_toolbar": "3.0.3",
         "drupal/advancedqueue": "1.0-rc2",
@@ -128,8 +126,11 @@
         "drupal/better_exposed_filters": "5.0.0-beta3",
         "drupal/block_field": "1.0-rc1",
         "drupal/config_update": "1.7",
+        "drupal/core": "8.8 - 9.1",
+        "drupal/core-composer-scaffold": "8.8 - 9.3",
         "drupal/crop": "2.1.0",
         "drupal/csv_serialization": "2.0",
+        "drupal/ctools": "3.7",
         "drupal/data_policy": "1.0-rc3",
         "drupal/dynamic_entity_reference": "1.12",
         "drupal/editor_advanced_link": "1.9",
@@ -150,15 +151,17 @@
         "drupal/metatag": "1.16",
         "drupal/override_node_options": "2.6.0",
         "drupal/paragraphs": "1.12",
+        "drupal/pathauto": "1.8.0",
         "drupal/private_message": "1.3.0",
         "drupal/profile": "1.3",
         "drupal/r4032login": "2.1.0",
+        "drupal/redirect": "1.6.0",
         "drupal/role_delegation": "1.1",
         "drupal/search_api": "1.20.0",
+        "drupal/select2": "1.8",
         "drupal/shariff": "1.7",
         "drupal/socialblue": "1.3.2",
-        "drupal/swiftmailer" : "2.0-beta1",
-        "drupal/select2": "1.8",
+        "drupal/swiftmailer": "2.0-beta1",
         "drupal/token": "1.9",
         "drupal/ultimate_cron": "2.0-alpha5",
         "drupal/update_helper": "2.0.0",
@@ -166,11 +169,7 @@
         "drupal/views_bulk_operations": "3.4",
         "drupal/views_infinite_scroll": "1.8",
         "drupal/votingapi": "3.0.0-beta2",
-        "drupal/pathauto": "1.8.0",
-        "drupal/redirect": "1.6.0",
-        "drupal/ctools": "3.7",
         "league/csv": "^9.3",
-        "swiftmailer/swiftmailer" : "6.2.4",
         "npm-asset/autosize": "~4.0.2",
         "npm-asset/blazy": "~1.8.2",
         "npm-asset/bootstrap": "v3.4.1",
@@ -189,7 +188,9 @@
         "npm-asset/slick-carousel": "~1.8.1",
         "npm-asset/tablesaw": "~3.1.0",
         "npm-asset/timepicker": "~1.11.14",
+        "oomphinc/composer-installers-extender": "~1.0 || ~2.0",
         "spatie/color": "^1.2",
+        "swiftmailer/swiftmailer": "6.2.4",
         "webonyx/graphql-php": ">=14.5.0",
         "zaporylie/composer-drupal-optimizations": "^1.0"
     },
@@ -205,5 +206,8 @@
     },
     "replace": {
       "drupal/social": "self.version"
+    },
+    "config": {
+      "sort-packages": true
     }
 }


### PR DESCRIPTION
<h3 id="summary-problem-motivation">Problem/Motivation</h3>
As of Open Social 11.0.0 we want to use modern PHP features (like typed class properties). Additionally PHP 7.3 will no longer receive security updates after December 6th 2021.

<h3 id="summary-proposed-resolution">Proposed resolution</h3>
Indicate in <code>composer.json</code> that we have compatibility with PHP 7.4 or PHP 8. Do not yet include PHP 9 because we don't know what breaking changes it might have.


## Issue tracker
https://www.drupal.org/project/social/issues/3238766

## How to test
- [ ] Automated PR checks should be green.

## Screenshots
N/a

## Release notes
Open Social now requires at least PHP 7.4

## Change Record
https://www.drupal.org/node/3238767

## Translations
N/a
