### PR TITLE
Fix PHPCS configuration

### DIFF
--- a/.github/workflows/drupalCodingStandards.yml
+++ b/.github/workflows/drupalCodingStandards.yml
@@ -21,3 +21,4 @@ jobs:
         uses: chekalsky/phpcs-action@v1
         with:
           phpcs_bin_path: './vendor/bin/phpcs'
+          enable_warnings: true

--- a/modules/social_features/social_group/social_group.install
+++ b/modules/social_features/social_group/social_group.install
@@ -9,7 +9,6 @@ use Drupal\menu_link_content\Entity\MenuLinkContent;
 use Drupal\field\Entity\FieldConfig;
 use Drupal\field\Entity\FieldStorageConfig;
 use Drupal\Core\Database\Database;
-use Drupal\social_core\Service\ConfigurationsService;
 use Drupal\user\Entity\Role;
 use Drupal\social_post\Entity\Post;
 use Drupal\node\Entity\Node;

--- a/modules/social_features/social_user/tests/src/Kernel/GraphQL/GraphQLUsersEndpointTest.php
+++ b/modules/social_features/social_user/tests/src/Kernel/GraphQL/GraphQLUsersEndpointTest.php
@@ -3,7 +3,6 @@
 namespace Drupal\Tests\social_user\Kernel\GraphQL;
 
 use Drupal\Tests\social_graphql\Kernel\SocialGraphQLTestBase;
-use Drupal\user\Entity\User;
 use Drupal\user\UserInterface;
 
 /**

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -5,8 +5,6 @@
     <file>./modules/social_features</file>
     <file>./social.profile</file>
     <file>./social.install</file>
-    <file>./themes/socialbase</file>
-    <file>./themes/socialblue</file>
     <config name="ignore_errors_on_exit" value="0"/>
     <config name="ignore_warnings_on_exit" value="0"/>
     <config name="default_standard" value="Drupal"/>


### PR DESCRIPTION
## Problem
Our PHPCS configuration and CI set-up has a few bugs.

Specifically running PHPCS on the entire `social` folder no longer works because the themes are no longer included. This is not noticed in PRs because PHPCS only runs against changed files (that aren't removed).

Additionally our PHPCS workflow doesn't catch warnings which means that we aren't alerted of using variables in Drupal translation functions, e.g.: https://github.com/goalgorilla/open_social/commit/d29174775d9a52f5afc7b7372b5d28df7de9e835#diff-8830e9f8d111250aa50db10f31d5d9e4c66990800cc26adb86686dbb3c6fa911R251

## Solution
- Remove themes
- Enable warnings in the GitHub workflow.

## Issue tracker
CI change, no issue

## How to test
- [ ] PHPCS should pass

## Release notes
CI change, n/a
