### PR TITLE
New email call to actions are not translatable

### DIFF
--- a/modules/social_features/social_activity/social_activity.tokens.inc
+++ b/modules/social_features/social_activity/social_activity.tokens.inc
@@ -6,6 +6,7 @@
  */
 
 use Drupal\Core\Render\BubbleableMetadata;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\group\Entity\GroupContentInterface;
 use Drupal\node\NodeInterface;
 
@@ -71,7 +72,7 @@ function social_activity_tokens($type, $tokens, array $data, array $options, Bub
           $preview_info = $email_token_services->getPostPreview($entity);
 
           // Prepare CTA button information.
-          $cta_button = $email_token_services->getCtaButton($link, 'Leave a comment');
+          $cta_button = $email_token_services->getCtaButton($link, new TranslatableMarkup('Leave a comment'));
 
           // This is for token deprecated token 'additional_information'.
           $additional_information = [
@@ -92,7 +93,7 @@ function social_activity_tokens($type, $tokens, array $data, array $options, Bub
             $link = $node->toUrl('canonical', ['absolute' => TRUE])->toString();
 
             // Prepare the CTA button markup.
-            $cta_button = $email_token_services->getCtaButton($link, 'Read more');
+            $cta_button = $email_token_services->getCtaButton($link, new TranslatableMarkup('Read more'));
 
             // This is for token deprecated token 'additional_information'.
             $additional_information = [

--- a/modules/social_features/social_activity/social_activity.tokens.inc
+++ b/modules/social_features/social_activity/social_activity.tokens.inc
@@ -66,7 +66,7 @@ function social_activity_tokens($type, $tokens, array $data, array $options, Bub
           /** @var \Drupal\social_post\Entity\Post $entity */
 
           // Prepare the link to post.
-          $link = $entity->toUrl('canonical', ['absolute' => TRUE])->toString();
+          $link = $entity->toUrl('canonical', ['absolute' => TRUE]);
 
           // Prepare the preview information.
           $preview_info = $email_token_services->getPostPreview($entity);
@@ -90,7 +90,7 @@ function social_activity_tokens($type, $tokens, array $data, array $options, Bub
             $preview_info = $email_token_services->getContentPreview($node);
 
             // Prepare the link to node.
-            $link = $node->toUrl('canonical', ['absolute' => TRUE])->toString();
+            $link = $node->toUrl('canonical', ['absolute' => TRUE]);
 
             // Prepare the CTA button markup.
             $cta_button = $email_token_services->getCtaButton($link, new TranslatableMarkup('Read more'));

--- a/modules/social_features/social_activity/src/EmailTokenServices.php
+++ b/modules/social_features/social_activity/src/EmailTokenServices.php
@@ -234,7 +234,7 @@ class EmailTokenServices {
   /**
    * Generates the renderable array for creation of a CTA button.
    *
-   * @param string $link
+   * @param \Drupal\Core\Url $url
    *   The href property for the button.
    * @param \Drupal\Core\StringTranslation\TranslatableMarkup $text
    *   The label of the button.
@@ -242,14 +242,10 @@ class EmailTokenServices {
    * @return array
    *   The renderable array.
    */
-  public function getCtaButton(string $link, TranslatableMarkup $text) {
-    if ($link === "") {
-      return [];
-    }
-
+  public function getCtaButton(Url $url, TranslatableMarkup $text) {
     return [
       '#theme' => 'message_cta_button',
-      '#link' => $link,
+      '#link' => $url,
       '#text' => $text,
     ];
   }

--- a/modules/social_features/social_activity/src/EmailTokenServices.php
+++ b/modules/social_features/social_activity/src/EmailTokenServices.php
@@ -6,6 +6,7 @@ use Drupal\comment\Entity\Comment;
 use Drupal\Core\Datetime\DateFormatter;
 use Drupal\Core\Entity\EntityTypeManager;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\Core\Url;
 use Drupal\file\Entity\File;
 use Drupal\group\Entity\Group;
@@ -231,28 +232,26 @@ class EmailTokenServices {
   }
 
   /**
-   * Generates the renderable array for creation of CTA button.
+   * Generates the renderable array for creation of a CTA button.
    *
    * @param string $link
-   *   The href property for button.
-   * @param string $text
-   *   The label of button.
+   *   The href property for the button.
+   * @param \Drupal\Core\StringTranslation\TranslatableMarkup $text
+   *   The label of the button.
    *
    * @return array
    *   The renderable array.
    */
-  public function getCtaButton(string $link, string $text) {
-    $cta_button = [];
-
-    if (!empty($text) && !empty($link)) {
-      $cta_button = [
-        '#theme' => 'message_cta_button',
-        '#link' => $link,
-        '#text' => $this->t($text),
-      ];
+  public function getCtaButton(string $link, TranslatableMarkup $text) {
+    if ($link === "") {
+      return [];
     }
 
-    return $cta_button;
+    return [
+      '#theme' => 'message_cta_button',
+      '#link' => $link,
+      '#text' => $text,
+    ];
   }
 
 }

--- a/modules/social_features/social_comment/social_comment.tokens.inc
+++ b/modules/social_features/social_comment/social_comment.tokens.inc
@@ -279,7 +279,7 @@ function social_comment_tokens_alter(array &$replacements, array $context, Bubbl
               // Replace the cta_button token value.
               if (isset($context['tokens']['cta_button'])) {
                 /** @var \Drupal\Core\Entity\EntityInterface $commented_entity */
-                $link = $commented_entity->toUrl('canonical', ['absolute' => TRUE])->toString() . '#comment-' . $comment->id();
+                $link = $commented_entity->toUrl('canonical', ['absolute' => TRUE, 'fragment' => 'comment-' . $comment->id()]);
 
                 $cta_button = $email_token_services->getCtaButton($link, new TranslatableMarkup('Reply to this comment'));
                 $replacements[$context['tokens']['cta_button']] = \Drupal::service('renderer')->renderPlain($cta_button);

--- a/modules/social_features/social_comment/social_comment.tokens.inc
+++ b/modules/social_features/social_comment/social_comment.tokens.inc
@@ -8,6 +8,7 @@
 use Drupal\comment\CommentInterface;
 use Drupal\Core\Render\BubbleableMetadata;
 use Drupal\Core\Render\Markup;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\Core\Url;
 use Drupal\node\NodeInterface;
 use Drupal\social_post\Entity\PostInterface;
@@ -280,7 +281,7 @@ function social_comment_tokens_alter(array &$replacements, array $context, Bubbl
                 /** @var \Drupal\Core\Entity\EntityInterface $commented_entity */
                 $link = $commented_entity->toUrl('canonical', ['absolute' => TRUE])->toString() . '#comment-' . $comment->id();
 
-                $cta_button = $email_token_services->getCtaButton($link, 'Reply to this comment');
+                $cta_button = $email_token_services->getCtaButton($link, new TranslatableMarkup('Reply to this comment'));
                 $replacements[$context['tokens']['cta_button']] = \Drupal::service('renderer')->renderPlain($cta_button);
               }
 

--- a/modules/social_features/social_content_report/social_content_report.tokens.inc
+++ b/modules/social_features/social_content_report/social_content_report.tokens.inc
@@ -94,7 +94,7 @@ function social_content_report_tokens_alter(array &$replacements, array $context
 
               // Replace the preview token.
               if (isset($context['tokens']['cta_button'])) {
-                $link = Url::fromRoute('view.report_overview.overview')->toString();
+                $link = Url::fromRoute('view.report_overview.overview');
                 $cta_button = $email_token_services->getCtaButton($link, new TranslatableMarkup('Check the reported contents'));
                 $replacements[$context['tokens']['cta_button']] = \Drupal::service('renderer')->renderPlain($cta_button);
               }

--- a/modules/social_features/social_content_report/social_content_report.tokens.inc
+++ b/modules/social_features/social_content_report/social_content_report.tokens.inc
@@ -6,6 +6,7 @@
  */
 
 use Drupal\Core\Render\BubbleableMetadata;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\Core\Url;
 use Drupal\node\NodeInterface;
 use Drupal\social_post\Entity\PostInterface;
@@ -94,7 +95,7 @@ function social_content_report_tokens_alter(array &$replacements, array $context
               // Replace the preview token.
               if (isset($context['tokens']['cta_button'])) {
                 $link = Url::fromRoute('view.report_overview.overview')->toString();
-                $cta_button = $email_token_services->getCtaButton($link, 'Check the reported contents');
+                $cta_button = $email_token_services->getCtaButton($link, new TranslatableMarkup('Check the reported contents'));
                 $replacements[$context['tokens']['cta_button']] = \Drupal::service('renderer')->renderPlain($cta_button);
               }
 

--- a/modules/social_features/social_event/social_event.tokens.inc
+++ b/modules/social_features/social_event/social_event.tokens.inc
@@ -8,6 +8,7 @@
 use Drupal\Core\Render\BubbleableMetadata;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\Core\Link;
+use Drupal\Core\Url;
 use Drupal\social_event\EventEnrollmentInterface;
 
 /**
@@ -106,40 +107,43 @@ function social_event_tokens_alter(array &$replacements, array $context, Bubblea
         $target_type = $message->getFieldValue('field_message_related_object', 'target_type');
 
         if ($target_type === 'event_enrollment' && $event_enrollment_id = $message->getFieldValue('field_message_related_object', 'target_id')) {
-          $link = _social_event_get_link_to_event_from_enrollment($event_enrollment_id, TRUE);
-          $message_template_id = $message->getTemplate()->id();
-          switch ($message_template_id) {
-            case 'activity_on_events_im_organizing':
-              if (isset($context['tokens']['cta_button'])) {
-                $cta_button = $email_token_services->getCtaButton($link . '/all-enrollments', new TranslatableMarkup('View enrollments'));
-                $replacements[$context['tokens']['cta_button']] = \Drupal::service('renderer')
-                  ->renderPlain($cta_button);
-              }
-              break;
+          if (isset($context['tokens']['cta_button'])) {
+            $event = _social_event_get_event_from_enrollment($event_enrollment_id);
+            if ($event !== NULL) {
+              $message_template_id = $message->getTemplate()->id();
+              switch ($message_template_id) {
+                case 'activity_on_events_im_organizing':
+                  $link = Url::fromRoute('view.event_manage_enrollments.page_manage_enrollments', ['node' => $event->id()]);
+                  $cta_button = $email_token_services->getCtaButton($link, new TranslatableMarkup('View enrollments'));
+                  $replacements[$context['tokens']['cta_button']] = \Drupal::service('renderer')
+                    ->renderPlain($cta_button);
+                  break;
 
-            case 'request_event_enrollment':
-              if (isset($context['tokens']['cta_button'])) {
-                $cta_button = $email_token_services->getCtaButton($link . '/all-enrollment-requests', new TranslatableMarkup('View enrollment requests'));
-                $replacements[$context['tokens']['cta_button']] = \Drupal::service('renderer')
-                  ->renderPlain($cta_button);
-              }
-              break;
+                case 'request_event_enrollment':
+                  $link = Url::fromRoute('view.event_manage_enrollment_requests.page_manage_enrollment_requests', ['node' => $event->id()]);
+                  $cta_button = $email_token_services->getCtaButton($link, new TranslatableMarkup('View enrollment requests'));
+                  $replacements[$context['tokens']['cta_button']] = \Drupal::service('renderer')
+                    ->renderPlain($cta_button);
+                  break;
 
-            case 'member_added_by_event_organiser':
-            case 'event_request_approved':
-              if (isset($context['tokens']['cta_button'])) {
-                $cta_button = $email_token_services->getCtaButton($link, new TranslatableMarkup('See the event'));
-                $replacements[$context['tokens']['cta_button']] = \Drupal::service('renderer')
-                  ->renderPlain($cta_button);
+                case 'member_added_by_event_organiser':
+                case 'event_request_approved':
+                  $link = $event->toUrl('canonical');
+                  $cta_button = $email_token_services->getCtaButton($link, new TranslatableMarkup('See the event'));
+                  $replacements[$context['tokens']['cta_button']] = \Drupal::service('renderer')
+                    ->renderPlain($cta_button);
+                  break;
               }
-              break;
+            }
           }
           // Replace the preview token.
           if (isset($context['tokens']['preview'])) {
-            if ($event = _social_event_get_event_from_enrollment($event_enrollment_id)) {
+            $event = _social_event_get_event_from_enrollment($event_enrollment_id);
+            if ($event !== NULL) {
               /** @var \Drupal\node\Entity\Node $event */
               $preview_info = $email_token_services->getContentPreview($event);
-              $replacements[$context['tokens']['preview']] = \Drupal::service('renderer')->renderPlain($preview_info);
+              $replacements[$context['tokens']['preview']] = \Drupal::service('renderer')
+                ->renderPlain($preview_info);
             }
           }
         }

--- a/modules/social_features/social_event/social_event.tokens.inc
+++ b/modules/social_features/social_event/social_event.tokens.inc
@@ -6,6 +6,7 @@
  */
 
 use Drupal\Core\Render\BubbleableMetadata;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\Core\Link;
 use Drupal\social_event\EventEnrollmentInterface;
 
@@ -110,7 +111,7 @@ function social_event_tokens_alter(array &$replacements, array $context, Bubblea
           switch ($message_template_id) {
             case 'activity_on_events_im_organizing':
               if (isset($context['tokens']['cta_button'])) {
-                $cta_button = $email_token_services->getCtaButton($link . '/all-enrollments', 'View enrollments');
+                $cta_button = $email_token_services->getCtaButton($link . '/all-enrollments', new TranslatableMarkup('View enrollments'));
                 $replacements[$context['tokens']['cta_button']] = \Drupal::service('renderer')
                   ->renderPlain($cta_button);
               }
@@ -118,7 +119,7 @@ function social_event_tokens_alter(array &$replacements, array $context, Bubblea
 
             case 'request_event_enrollment':
               if (isset($context['tokens']['cta_button'])) {
-                $cta_button = $email_token_services->getCtaButton($link . '/all-enrollment-requests', 'View enrollment requests');
+                $cta_button = $email_token_services->getCtaButton($link . '/all-enrollment-requests', new TranslatableMarkup('View enrollment requests'));
                 $replacements[$context['tokens']['cta_button']] = \Drupal::service('renderer')
                   ->renderPlain($cta_button);
               }
@@ -127,7 +128,7 @@ function social_event_tokens_alter(array &$replacements, array $context, Bubblea
             case 'member_added_by_event_organiser':
             case 'event_request_approved':
               if (isset($context['tokens']['cta_button'])) {
-                $cta_button = $email_token_services->getCtaButton($link, 'See the event');
+                $cta_button = $email_token_services->getCtaButton($link, new TranslatableMarkup('See the event'));
                 $replacements[$context['tokens']['cta_button']] = \Drupal::service('renderer')
                   ->renderPlain($cta_button);
               }

--- a/modules/social_features/social_follow_taxonomy/social_follow_taxonomy.tokens.inc
+++ b/modules/social_features/social_follow_taxonomy/social_follow_taxonomy.tokens.inc
@@ -202,7 +202,7 @@ function social_follow_taxonomy_tokens_alter(array &$replacements, array $contex
             case 'update_node_following_tag':
             case 'create_node_following_tag_stream':
               if (isset($context['tokens']['cta_button'])) {
-                $link = $entity->toUrl('canonical', ['absolute' => TRUE])->toString();
+                $link = $entity->toUrl('canonical', ['absolute' => TRUE]);
                 $cta_button = $email_token_services->getCtaButton($link, new TranslatableMarkup('Read more about it'));
                 $replacements[$context['tokens']['cta_button']] = \Drupal::service('renderer')
                   ->renderPlain($cta_button);

--- a/modules/social_features/social_follow_taxonomy/social_follow_taxonomy.tokens.inc
+++ b/modules/social_features/social_follow_taxonomy/social_follow_taxonomy.tokens.inc
@@ -6,6 +6,7 @@
  */
 
 use Drupal\Core\Render\BubbleableMetadata;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\Core\Url;
 use Drupal\node\NodeInterface;
 use Drupal\taxonomy\TermInterface;
@@ -202,7 +203,7 @@ function social_follow_taxonomy_tokens_alter(array &$replacements, array $contex
             case 'create_node_following_tag_stream':
               if (isset($context['tokens']['cta_button'])) {
                 $link = $entity->toUrl('canonical', ['absolute' => TRUE])->toString();
-                $cta_button = $email_token_services->getCtaButton($link, 'Read more about it');
+                $cta_button = $email_token_services->getCtaButton($link, new TranslatableMarkup('Read more about it'));
                 $replacements[$context['tokens']['cta_button']] = \Drupal::service('renderer')
                   ->renderPlain($cta_button);
               }

--- a/modules/social_features/social_group/modules/social_group_request/social_group_request.tokens.inc
+++ b/modules/social_features/social_group/modules/social_group_request/social_group_request.tokens.inc
@@ -95,7 +95,7 @@ function social_group_request_tokens_alter(array &$replacements, array $context,
               case 'request_to_join_a_group':
                 if (isset($context['tokens']['cta_button'])) {
                   $link = Url::fromRoute('view.group_pending_members.membership_requests', ['arg_0' => $group->id()],
-                    ['absolute' => TRUE])->toString();
+                    ['absolute' => TRUE]);
                   $cta_button = $email_token_services->getCtaButton($link, new TranslatableMarkup('View the requests'));
                   $replacements[$context['tokens']['cta_button']] = \Drupal::service('renderer')
                     ->renderPlain($cta_button);

--- a/modules/social_features/social_group/modules/social_group_request/social_group_request.tokens.inc
+++ b/modules/social_features/social_group/modules/social_group_request/social_group_request.tokens.inc
@@ -6,6 +6,7 @@
  */
 
 use Drupal\Core\Render\BubbleableMetadata;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\Core\Url;
 use Drupal\group\Entity\Group;
 use Drupal\user\UserInterface;
@@ -95,7 +96,7 @@ function social_group_request_tokens_alter(array &$replacements, array $context,
                 if (isset($context['tokens']['cta_button'])) {
                   $link = Url::fromRoute('view.group_pending_members.membership_requests', ['arg_0' => $group->id()],
                     ['absolute' => TRUE])->toString();
-                  $cta_button = $email_token_services->getCtaButton($link, 'View the requests');
+                  $cta_button = $email_token_services->getCtaButton($link, new TranslatableMarkup('View the requests'));
                   $replacements[$context['tokens']['cta_button']] = \Drupal::service('renderer')
                     ->renderPlain($cta_button);
                 }

--- a/modules/social_features/social_group/social_group.tokens.inc
+++ b/modules/social_features/social_group/social_group.tokens.inc
@@ -172,7 +172,7 @@ function social_group_tokens_alter(array &$replacements, array $context, Bubblea
           if ($group instanceof Group) {
             if ($group_content->getContentPlugin()->getPluginId() === 'group_membership') {
               $message_template_id = $message->getTemplate()->id();
-              $link = $group_content->getGroup()->toUrl()->toString();
+              $link = $group_content->getGroup()->toUrl();
               switch ($message_template_id) {
                 case 'approve_request_join_group':
                   if (isset($context['tokens']['cta_button'])) {
@@ -189,7 +189,7 @@ function social_group_tokens_alter(array &$replacements, array $context, Bubblea
 
                 case 'join_to_group':
                   if (isset($context['tokens']['cta_button'])) {
-                    $link = Url::fromRoute('view.group_members.page_group_members', ['group' => $group_content->getGroup()->id()])->toString();
+                    $link = Url::fromRoute('view.group_members.page_group_members', ['group' => $group_content->getGroup()->id()]);
                     $cta_button = $email_token_services->getCtaButton($link, new TranslatableMarkup('See all members'));
                     $replacements[$context['tokens']['cta_button']] = \Drupal::service('renderer')
                       ->renderPlain($cta_button);

--- a/modules/social_features/social_group/social_group.tokens.inc
+++ b/modules/social_features/social_group/social_group.tokens.inc
@@ -8,6 +8,7 @@
 use Drupal\group\Entity\Group;
 use Drupal\user\UserInterface;
 use Drupal\Core\Render\BubbleableMetadata;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\Core\Url;
 use Drupal\Core\Render\Markup;
 
@@ -175,7 +176,7 @@ function social_group_tokens_alter(array &$replacements, array $context, Bubblea
               switch ($message_template_id) {
                 case 'approve_request_join_group':
                   if (isset($context['tokens']['cta_button'])) {
-                    $cta_button = $email_token_services->getCtaButton($link, 'Explore the group');
+                    $cta_button = $email_token_services->getCtaButton($link, new TranslatableMarkup('Explore the group'));
                     $replacements[$context['tokens']['cta_button']] = \Drupal::service('renderer')
                       ->renderPlain($cta_button);
                   }
@@ -189,7 +190,7 @@ function social_group_tokens_alter(array &$replacements, array $context, Bubblea
                 case 'join_to_group':
                   if (isset($context['tokens']['cta_button'])) {
                     $link = Url::fromRoute('view.group_members.page_group_members', ['group' => $group_content->getGroup()->id()])->toString();
-                    $cta_button = $email_token_services->getCtaButton($link, 'See all members');
+                    $cta_button = $email_token_services->getCtaButton($link, new TranslatableMarkup('See all members'));
                     $replacements[$context['tokens']['cta_button']] = \Drupal::service('renderer')
                       ->renderPlain($cta_button);
                   }

--- a/modules/social_features/social_like/social_like.tokens.inc
+++ b/modules/social_features/social_like/social_like.tokens.inc
@@ -6,6 +6,7 @@
  */
 
 use Drupal\Core\Render\BubbleableMetadata;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\node\NodeInterface;
 use Drupal\votingapi\Entity\Vote;
 use Drupal\Core\Render\Markup;
@@ -169,7 +170,7 @@ function social_like_tokens_alter(array &$replacements, array $context, Bubbleab
                   $link = $commented_entity->toUrl('canonical', $url_options)
                     ->toString();
                 }
-                $cta_button = $email_token_services->getCtaButton($link, 'See all likes');
+                $cta_button = $email_token_services->getCtaButton($link, new TranslatableMarkup('See all likes'));
                 $replacements[$context['tokens']['cta_button']] = \Drupal::service('renderer')
                   ->renderPlain($cta_button);
               }

--- a/modules/social_features/social_like/social_like.tokens.inc
+++ b/modules/social_features/social_like/social_like.tokens.inc
@@ -161,14 +161,12 @@ function social_like_tokens_alter(array &$replacements, array $context, Bubbleab
               // Replace the cta_button token value.
               if (isset($context['tokens']['cta_button'])) {
                 $url_options = ['absolute' => TRUE];
-                $link = $voted_entity->toUrl('canonical', $url_options)
-                  ->toString();
+                $link = $voted_entity->toUrl('canonical', $url_options);
                 // We should only use the label of entities who have a label.
                 if ($content_type === 'comment') {
                   /** @var \Drupal\comment\Entity\Comment $voted_entity */
                   $commented_entity = $voted_entity->getCommentedEntity();
-                  $link = $commented_entity->toUrl('canonical', $url_options)
-                    ->toString();
+                  $link = $commented_entity->toUrl('canonical', $url_options);
                 }
                 $cta_button = $email_token_services->getCtaButton($link, new TranslatableMarkup('See all likes'));
                 $replacements[$context['tokens']['cta_button']] = \Drupal::service('renderer')

--- a/modules/social_features/social_mentions/social_mentions.tokens.inc
+++ b/modules/social_features/social_mentions/social_mentions.tokens.inc
@@ -7,6 +7,7 @@
 
 use Drupal\comment\CommentInterface;
 use Drupal\Core\Render\BubbleableMetadata;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\mentions\Entity\Mentions;
 use Drupal\user\Entity\User;
 use Drupal\Core\Render\Markup;
@@ -231,7 +232,7 @@ function social_mentions_tokens_alter(array &$replacements, array $context, Bubb
                 if ($comment instanceof CommentInterface) {
                   $link .= '#comment-' . $comment->id();
                 }
-                $cta_button = $email_token_services->getCtaButton($link, 'Reply to this comment');
+                $cta_button = $email_token_services->getCtaButton($link, new TranslatableMarkup('Reply to this comment'));
                 $replacements[$context['tokens']['cta_button']] = \Drupal::service('renderer')
                   ->renderPlain($cta_button);
               }

--- a/modules/social_features/social_mentions/social_mentions.tokens.inc
+++ b/modules/social_features/social_mentions/social_mentions.tokens.inc
@@ -227,11 +227,13 @@ function social_mentions_tokens_alter(array &$replacements, array $context, Bubb
 
               // Prepare the CTA button.
               if (isset($context['tokens']['cta_button'])) {
-                $link = $entity->toUrl('canonical', ['absolute' => TRUE])->toString();
+                $options = ['absolute' => TRUE];
                 // Append the comment reference in link.
                 if ($comment instanceof CommentInterface) {
-                  $link .= '#comment-' . $comment->id();
+                  $options['fragment'] = 'comment-' . $comment->id();
                 }
+
+                $link = $entity->toUrl('canonical', $options);
                 $cta_button = $email_token_services->getCtaButton($link, new TranslatableMarkup('Reply to this comment'));
                 $replacements[$context['tokens']['cta_button']] = \Drupal::service('renderer')
                   ->renderPlain($cta_button);

--- a/modules/social_features/social_private_message/social_private_message.tokens.inc
+++ b/modules/social_features/social_private_message/social_private_message.tokens.inc
@@ -42,7 +42,7 @@ function social_private_message_tokens_alter(array &$replacements, array $contex
                 $thread_url = Url::fromRoute('entity.private_message_thread.canonical',
                   ['private_message_thread' => $thread_id],
                   ['absolute' => TRUE]
-                )->toString();
+                );
                 $cta_button = $email_token_services->getCtaButton($thread_url, new TranslatableMarkup('Reply to this message'));
                 if (!empty($cta_button)) {
                   $replacements[$context['tokens']['cta_button']] = \Drupal::service('renderer')->renderPlain($cta_button);

--- a/modules/social_features/social_private_message/social_private_message.tokens.inc
+++ b/modules/social_features/social_private_message/social_private_message.tokens.inc
@@ -6,6 +6,7 @@
  */
 
 use Drupal\Core\Render\BubbleableMetadata;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\Core\Url;
 
 /**
@@ -42,7 +43,7 @@ function social_private_message_tokens_alter(array &$replacements, array $contex
                   ['private_message_thread' => $thread_id],
                   ['absolute' => TRUE]
                 )->toString();
-                $cta_button = $email_token_services->getCtaButton($thread_url, 'Reply to this message');
+                $cta_button = $email_token_services->getCtaButton($thread_url, new TranslatableMarkup('Reply to this message'));
                 if (!empty($cta_button)) {
                   $replacements[$context['tokens']['cta_button']] = \Drupal::service('renderer')->renderPlain($cta_button);
                 }


### PR DESCRIPTION
## Problem
In #2277 we created a new service that accepted strings in a `getCtaButton` method. Meanwhile Drupal has great types for the things that we are processing. Using string types caused two problems:

- Call to action texts are not translatable (since the string literals were not wrapped in a translatable class or function, static analysis can not find them)
- URLs may be empty or invalid. Since we were relying on path literals rather than Drupal routes, a change in paths could break emails being sent (e.g. because someone changes the path structure or because a language on the site requires a localised path).

## Solution
Switch over to using `Url` and `TranslatableMarkup` classes.

Looking at the goal of the function being called we should be able to go a step further and use `Link` classes, maybe even eliminating the service and template that were added. However, that'll take more time than is currently available and does not solve any pressing issues.

## Issue tracker
No issue created yet

## How to test

- [ ] Check that the upgrade from old version and install of this branch of Open Social is succesful.
- [ ] Trigger an activity which triggers an email on platform.
- [ ] See that the email received contains proper context, preview of the content in action and a CTA button which links to the entity.
- [ ] See that the back-compatibility is maintained.
- [ ] Check the message templates with destination notification and email are upgraded as per new pattern.

## Release notes
Unreleased change so the release notes of #2277 are sufficient.
