### PR TITLE
Add script that can be run as pre-commit hook

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,4 @@
+# Open Social - Scripts
+
+These scripts exist to aid in the development of the Open Social distribution. 
+They serve no purpose outside of it.

--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+###############################################
+# Executes all checks that are also run by CI #
+###############################################
+
+# Abort on any error
+set -e
+
+# Store the script and Open Social directory.
+# Script should be in <os_dir>/scripts
+SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+OS_DIR="$SCRIPT_DIR/.."
+
+# Execute from the Open Social directory.
+cd $OS_DIR
+
+# Find the vendor directory and core directory.
+# We need this for some of the tools we use.
+while [[ `pwd` != '/' ]]; do
+  if [ -d "core" ]; then
+    CORE_DIR="`pwd`/core"
+  fi
+
+  if [ -d "vendor" ]; then
+    VENDOR_DIR="`pwd`/vendor"
+  fi
+
+  cd ..
+done
+
+if [ -z $CORE_DIR ] || [ -z $VENDOR_DIR ]; then
+  echo "Could not find core ('$CORE_DIR') or vendor ('$VENDOR_DIR') directory."
+  exit 1
+fi
+
+# We run our coding checks from the Open Social directory.
+cd $OS_DIR
+
+# Perform coding standards check.
+echo "└ Executing '$VENDOR_DIR/bin/phpcs'"
+$VENDOR_DIR/bin/phpcs
+
+# Perform PHPStan check.
+echo "└ Executing '$VENDOR_DIR/bin/phpstan'"
+$VENDOR_DIR/bin/phpstan
+
+# Run PHPUnit tests.
+echo "└ Executing '$VENDOR_DIR/bin/phpunit'"
+$VENDOR_DIR/bin/phpunit


### PR DESCRIPTION
## Problem
We have a lot of "Fix coding standards" commits that are really annoying in a git history because they tell you nothing about the change.

## Solution
The script makes it easy to execute all the things that we also run in
our GitHub workflows. This makes it easier to check those things
locally.

It can also easily be used in `git bisect` or `git rebase --exec` to
find a broken commit or verify that each commit is working.

For example `git rebase --exec scripts/pre-commit.sh --reschedule-failed-exec main` will go through each commit in your current branch as it's placing it onto `main` and run PHPCS, PHPStan and PHPUnit. If any of those errors the rebase will halt and you can clean up the errors. When you use `git rebase --continue` the checks will automatically be applied again (thanks to `--reschedule-failed-exec`).

## Issue tracker
Internal developer change, no issue.

## How to test

- [ ] Run the script locally
- [ ] Follow the instructions for a rebase under "solution"

## Screenshots
![image](https://user-images.githubusercontent.com/327697/135301646-1d343052-1ec1-4057-be7e-e02810402fea.png)

## Release notes
N/a

## Change Record
N/a
