### PR TITLE
Issue #3240115 by vnech: Make possible to translate taxonomy terms (and vocabularies)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -108,8 +108,7 @@
                 "Group: Don't try to re-save deleted entities": "https://www.drupal.org/files/issues/2018-11-01/3010896-02.patch",
                 "Rely on toUrl defaults for Entity url link": "https://www.drupal.org/files/issues/2019-12-04/group-3098675-2.patch",
                 "Missing config schema for condition.plugin.group_type": "https://www.drupal.org/files/issues/2018-12-14/group-group_type_condition_plugin_config_schema-3020554-2.patch",
-                "gnode access checks revert for D9 so we dont cause major regression": "https://www.drupal.org/files/issues/2021-11-30/bring-back-node-access-grants-3162511-69.patch",
-                "Can't translate group roles": "https://www.drupal.org/files/issues/2020-07-07/group-3014651-9.patch"
+                "gnode access checks revert for D9 so we dont cause major regression": "https://www.drupal.org/files/issues/2021-11-30/bring-back-node-access-grants-3162511-69.patch"
             },
             "drupal/like_and_dislike": {
                 "As LU+ I can not like any content": "https://www.drupal.org/files/issues/2021-11-10/3247929-like_and_dislike-5.patch"

--- a/composer.json
+++ b/composer.json
@@ -108,7 +108,8 @@
                 "Group: Don't try to re-save deleted entities": "https://www.drupal.org/files/issues/2018-11-01/3010896-02.patch",
                 "Rely on toUrl defaults for Entity url link": "https://www.drupal.org/files/issues/2019-12-04/group-3098675-2.patch",
                 "Missing config schema for condition.plugin.group_type": "https://www.drupal.org/files/issues/2018-12-14/group-group_type_condition_plugin_config_schema-3020554-2.patch",
-                "gnode access checks revert for D9 so we dont cause major regression": "https://www.drupal.org/files/issues/2021-11-30/bring-back-node-access-grants-3162511-69.patch"
+                "gnode access checks revert for D9 so we dont cause major regression": "https://www.drupal.org/files/issues/2021-11-30/bring-back-node-access-grants-3162511-69.patch",
+                "Can't translate group roles": "https://www.drupal.org/files/issues/2020-07-07/group-3014651-9.patch"
             },
             "drupal/like_and_dislike": {
                 "As LU+ I can not like any content": "https://www.drupal.org/files/issues/2021-11-10/3247929-like_and_dislike-5.patch"

--- a/modules/social_features/social_content_report/config/optional/language.content_settings.taxonomy_term.report_reasons.yml
+++ b/modules/social_features/social_content_report/config/optional/language.content_settings.taxonomy_term.report_reasons.yml
@@ -1,0 +1,15 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.report_reasons
+  module:
+    - social_content_translation
+third_party_settings:
+  content_translation:
+    enabled: false
+id: taxonomy_term.report_reasons
+target_entity_type_id: taxonomy_term
+target_bundle: report_reasons
+default_langcode: site_default
+language_alterable: false

--- a/modules/social_features/social_content_report/config/static/language.content_settings.taxonomy_term.report_reasons_11201.yml
+++ b/modules/social_features/social_content_report/config/static/language.content_settings.taxonomy_term.report_reasons_11201.yml
@@ -1,0 +1,15 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.report_reasons
+  module:
+    - social_content_translation
+third_party_settings:
+  content_translation:
+    enabled: false
+id: taxonomy_term.report_reasons
+target_entity_type_id: taxonomy_term
+target_bundle: report_reasons
+default_langcode: site_default
+language_alterable: false

--- a/modules/social_features/social_content_report/social_content_report.install
+++ b/modules/social_features/social_content_report/social_content_report.install
@@ -5,6 +5,7 @@
  * Install hooks for Social Content Report.
  */
 
+use Drupal\Core\Config\FileStorage;
 use Drupal\Core\Entity\EntityStorageException;
 use Drupal\taxonomy\Entity\Term;
 use Symfony\Component\Yaml\Yaml;
@@ -98,4 +99,19 @@ function social_content_report_update_10301() {
       $config->setData($settings)->save(TRUE);
     }
   }
+}
+
+/**
+ * Make "Report Reasons" vocabulary translatable.
+ */
+function social_content_report_update_11201(): void {
+  if (!\Drupal::moduleHandler()->moduleExists('social_content_translation')) {
+    return;
+  }
+
+  $config_storage = \Drupal::service('config.storage');
+  $config_path = \Drupal::service('extension.list.module')->getPath('social_content_report') . '/config/static';
+  $source = new FileStorage($config_path);
+
+  $config_storage->write('language.content_settings.taxonomy_term.report_reasons', (array) $source->read('language.content_settings.taxonomy_term.report_reasons_11201'));
 }

--- a/modules/social_features/social_content_report/social_content_report.services.yml
+++ b/modules/social_features/social_content_report/social_content_report.services.yml
@@ -15,3 +15,8 @@ services:
     class: Drupal\social_content_report\Routing\RouteSubscriber
     tags:
       - { name: event_subscriber }
+  social_content_report.translation_defaults:
+    class: Drupal\social_content_report\ContentTranslationDefaultsConfigOverride
+    arguments: ['@module_handler']
+    tags:
+      - { name: config.factory.override, priority: 5 }

--- a/modules/social_features/social_content_report/src/ContentTranslationDefaultsConfigOverride.php
+++ b/modules/social_features/social_content_report/src/ContentTranslationDefaultsConfigOverride.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Drupal\social_content_report;
+
+use Drupal\Core\Cache\CacheableMetadata;
+use Drupal\Core\Config\ConfigFactoryOverrideInterface;
+use Drupal\Core\Config\StorableConfigBase;
+use Drupal\Core\Config\StorageInterface;
+use Drupal\Core\Extension\ModuleHandlerInterface;
+
+/**
+ * Provides content translation for the Social Content Report module.
+ *
+ * @package Drupal\social_content_report
+ */
+class ContentTranslationDefaultsConfigOverride implements ConfigFactoryOverrideInterface {
+
+  /**
+   * The module handler.
+   *
+   * @var \Drupal\Core\Extension\ModuleHandlerInterface
+   */
+  protected $moduleHandler;
+
+  /**
+   * ContentTranslationDefaultsConfigOverride constructor.
+   *
+   * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
+   *   The module handler service.
+   */
+  public function __construct(ModuleHandlerInterface $module_handler) {
+    $this->moduleHandler = $module_handler;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function loadOverrides($names): array {
+    $overrides = [];
+
+    // If the module "social_content_translation" is enabled let make
+    // translations enabled for content provided by the module by default.
+    if (!$this->moduleHandler->moduleExists('social_content_translation')) {
+      return $overrides;
+    }
+
+    // Translations for "Report Reasons" vocabulary.
+    $config_name = 'language.content_settings.taxonomy_term.report_reasons';
+
+    if (in_array($config_name, $names)) {
+      $overrides[$config_name] = [
+        'third_party_settings' => [
+          'content_translation' => [
+            'enabled' => TRUE,
+          ],
+        ],
+      ];
+    }
+
+    $config_names = [
+      'core.base_field_override.taxonomy_term.report_reasons.name',
+      'core.base_field_override.taxonomy_term.report_reasons.changed',
+      'core.base_field_override.taxonomy_term.report_reasons.description',
+    ];
+
+    foreach ($config_names as $config_name) {
+      if (in_array($config_name, $names)) {
+        $overrides[$config_name] = [
+          'translatable' => TRUE,
+        ];
+      }
+    }
+
+    return $overrides;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCacheSuffix(): string {
+    return 'social_content_report.content_translation_defaults_config_override';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCacheableMetadata($name): CacheableMetadata {
+    return new CacheableMetadata();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function createConfigObject($name, $collection = StorageInterface::DEFAULT_COLLECTION): ?StorableConfigBase {
+    return NULL;
+  }
+
+}

--- a/modules/social_features/social_event/modules/social_event_type/config/optional/language.content_settings.taxonomy_term.event_types.yml
+++ b/modules/social_features/social_event/modules/social_event_type/config/optional/language.content_settings.taxonomy_term.event_types.yml
@@ -1,0 +1,15 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.event_types
+  module:
+    - social_content_translation
+third_party_settings:
+  content_translation:
+    enabled: false
+id: taxonomy_term.event_types
+target_entity_type_id: taxonomy_term
+target_bundle: event_types
+default_langcode: site_default
+language_alterable: false

--- a/modules/social_features/social_event/modules/social_event_type/config/static/language.content_settings.taxonomy_term.event_types_11201.yml
+++ b/modules/social_features/social_event/modules/social_event_type/config/static/language.content_settings.taxonomy_term.event_types_11201.yml
@@ -1,0 +1,15 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.event_types
+  module:
+    - social_content_translation
+third_party_settings:
+  content_translation:
+    enabled: false
+id: taxonomy_term.event_types
+target_entity_type_id: taxonomy_term
+target_bundle: event_types
+default_langcode: site_default
+language_alterable: false

--- a/modules/social_features/social_event/modules/social_event_type/social_event_type.install
+++ b/modules/social_features/social_event/modules/social_event_type/social_event_type.install
@@ -6,6 +6,7 @@
  */
 
 use Drupal\field\Entity\FieldConfig;
+use Drupal\Core\Config\FileStorage;
 use Drupal\field\FieldConfigInterface;
 use Drupal\user\Entity\Role;
 use Symfony\Component\Yaml\Yaml;
@@ -127,4 +128,19 @@ function social_event_type_update_8902(&$sandbox) {
 
     $sandbox['#finished'] = $sandbox['current'] / $sandbox['total'];
   }
+}
+
+/**
+ * Make "Event Types" vocabulary translatable.
+ */
+function social_event_type_update_11201(): void {
+  if (!\Drupal::moduleHandler()->moduleExists('social_content_translation')) {
+    return;
+  }
+
+  $config_storage = \Drupal::service('config.storage');
+  $config_path = \Drupal::service('extension.list.module')->getPath('social_event_type') . '/config/static';
+  $source = new FileStorage($config_path);
+
+  $config_storage->write('language.content_settings.taxonomy_term.event_types', (array) $source->read('language.content_settings.taxonomy_term.event_types_11201'));
 }

--- a/modules/social_features/social_event/modules/social_event_type/social_event_type.services.yml
+++ b/modules/social_features/social_event/modules/social_event_type/social_event_type.services.yml
@@ -3,3 +3,8 @@ services:
     class: \Drupal\social_event_type\SocialEventTypeConfigOverride
     tags:
       - {name: config.factory.override, priority: 5}
+  social_event_type.translation_defaults:
+    class: Drupal\social_event_type\ContentTranslationDefaultsConfigOverride
+    arguments: ['@module_handler']
+    tags:
+      - { name: config.factory.override, priority: 5 }

--- a/modules/social_features/social_event/modules/social_event_type/src/ContentTranslationDefaultsConfigOverride.php
+++ b/modules/social_features/social_event/modules/social_event_type/src/ContentTranslationDefaultsConfigOverride.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Drupal\social_event_type;
+
+use Drupal\Core\Cache\CacheableMetadata;
+use Drupal\Core\Config\ConfigFactoryOverrideInterface;
+use Drupal\Core\Config\StorableConfigBase;
+use Drupal\Core\Config\StorageInterface;
+use Drupal\Core\Extension\ModuleHandlerInterface;
+
+/**
+ * Provides content translation for the Social Event Type module.
+ *
+ * @package Drupal\social_event_type
+ */
+class ContentTranslationDefaultsConfigOverride implements ConfigFactoryOverrideInterface {
+
+  /**
+   * The module handler.
+   *
+   * @var \Drupal\Core\Extension\ModuleHandlerInterface
+   */
+  protected $moduleHandler;
+
+  /**
+   * ContentTranslationDefaultsConfigOverride constructor.
+   *
+   * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
+   *   The module handler service.
+   */
+  public function __construct(ModuleHandlerInterface $module_handler) {
+    $this->moduleHandler = $module_handler;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function loadOverrides($names): array {
+    $overrides = [];
+
+    // If the module "social_content_translation" is enabled let make
+    // translations enabled for content provided by the module by default.
+    if (!$this->moduleHandler->moduleExists('social_content_translation')) {
+      return $overrides;
+    }
+
+    // Translations for "Event types" vocabulary.
+    $config_name = 'language.content_settings.taxonomy_term.event_types';
+
+    if (in_array($config_name, $names)) {
+      $overrides[$config_name] = [
+        'third_party_settings' => [
+          'content_translation' => [
+            'enabled' => TRUE,
+          ],
+        ],
+      ];
+    }
+
+    $config_names = [
+      'core.base_field_override.taxonomy_term.event_types.name',
+      'core.base_field_override.taxonomy_term.event_types.changed',
+      'core.base_field_override.taxonomy_term.event_types.description',
+    ];
+
+    foreach ($config_names as $config_name) {
+      if (in_array($config_name, $names)) {
+        $overrides[$config_name] = [
+          'translatable' => TRUE,
+        ];
+      }
+    }
+
+    return $overrides;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCacheSuffix(): string {
+    return 'social_event_type.content_translation_defaults_config_override';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCacheableMetadata($name): CacheableMetadata {
+    return new CacheableMetadata();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function createConfigObject($name, $collection = StorageInterface::DEFAULT_COLLECTION): ?StorableConfigBase {
+    return NULL;
+  }
+
+}

--- a/modules/social_features/social_group/modules/social_group_flexible_group/config/optional/language.content_settings.taxonomy_term.group_type.yml
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/config/optional/language.content_settings.taxonomy_term.group_type.yml
@@ -1,0 +1,15 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.group_type
+  module:
+    - social_content_translation
+third_party_settings:
+  content_translation:
+    enabled: false
+id: taxonomy_term.group_type
+target_entity_type_id: taxonomy_term
+target_bundle: group_type
+default_langcode: site_default
+language_alterable: false

--- a/modules/social_features/social_group/modules/social_group_flexible_group/config/static/language.content_settings.taxonomy_term.group_type_11203.yml
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/config/static/language.content_settings.taxonomy_term.group_type_11203.yml
@@ -1,0 +1,15 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.group_type
+  module:
+    - social_content_translation
+third_party_settings:
+  content_translation:
+    enabled: false
+id: taxonomy_term.group_type
+target_entity_type_id: taxonomy_term
+target_bundle: group_type
+default_langcode: site_default
+language_alterable: false

--- a/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.install
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.install
@@ -487,3 +487,18 @@ function social_group_flexible_group_update_11202(): string {
   // Output logged messages to related channel of update execution.
   return $updateHelper->logger()->output();
 }
+
+/**
+ * Make "Group Types" vocabulary translatable.
+ */
+function social_group_flexible_group_update_11203(): void {
+  if (!\Drupal::moduleHandler()->moduleExists('social_content_translation')) {
+    return;
+  }
+
+  $config_storage = \Drupal::service('config.storage');
+  $config_path = \Drupal::service('extension.list.module')->getPath('social_group_flexible_group') . '/config/static';
+  $source = new FileStorage($config_path);
+
+  $config_storage->write('language.content_settings.taxonomy_term.group_type', (array) $source->read('language.content_settings.taxonomy_term.group_type_11203'));
+}

--- a/modules/social_features/social_group/modules/social_group_flexible_group/src/ContentTranslationDefaultsConfigOverride.php
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/src/ContentTranslationDefaultsConfigOverride.php
@@ -4,6 +4,7 @@ namespace Drupal\social_group_flexible_group;
 
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\social_core\ContentTranslationConfigOverrideBase;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
 
 /**
  * Provides content translation defaults for the flexible group type.
@@ -17,14 +18,14 @@ class ContentTranslationDefaultsConfigOverride extends ContentTranslationConfigO
   /**
    * {@inheritdoc}
    */
-  protected function getModule() {
+  protected function getModule(): string {
     return 'social_group_flexible_group';
   }
 
   /**
    * {@inheritdoc}
    */
-  protected function getDisplayName() {
+  protected function getDisplayName(): TranslatableMarkup {
     // We can't use dependency injection here because it causes a circular
     // dependency for the configuration override.
     return $this->t('Flexible group');
@@ -33,8 +34,9 @@ class ContentTranslationDefaultsConfigOverride extends ContentTranslationConfigO
   /**
    * {@inheritdoc}
    */
-  protected function getTranslationOverrides() {
+  protected function getTranslationOverrides(): array {
     return [
+      // Translations for "Flexible Group" group type.
       'language.content_settings.group.flexible_group' => [
         'third_party_settings' => [
           'content_translation' => [
@@ -56,6 +58,24 @@ class ContentTranslationDefaultsConfigOverride extends ContentTranslationConfigO
             ],
           ],
         ],
+      ],
+
+      // Translations for "Group Type" vocabulary.
+      'language.content_settings.taxonomy_term.group_type' => [
+        'third_party_settings' => [
+          'content_translation' => [
+            'enabled' => TRUE,
+          ],
+        ],
+      ],
+      'core.base_field_override.taxonomy_term.group_type.name' => [
+        'translatable' => TRUE,
+      ],
+      'core.base_field_override.taxonomy_term.group_type.changed' => [
+        'translatable' => TRUE,
+      ],
+      'core.base_field_override.taxonomy_term.group_type.description' => [
+        'translatable' => TRUE,
       ],
     ];
   }

--- a/modules/social_features/social_profile/config/optional/language.content_settings.taxonomy_term.expertise.yml
+++ b/modules/social_features/social_profile/config/optional/language.content_settings.taxonomy_term.expertise.yml
@@ -1,0 +1,15 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.expertise
+  module:
+    - social_content_translation
+third_party_settings:
+  content_translation:
+    enabled: false
+id: taxonomy_term.expertise
+target_entity_type_id: taxonomy_term
+target_bundle: expertise
+default_langcode: site_default
+language_alterable: false

--- a/modules/social_features/social_profile/config/optional/language.content_settings.taxonomy_term.interests.yml
+++ b/modules/social_features/social_profile/config/optional/language.content_settings.taxonomy_term.interests.yml
@@ -1,0 +1,15 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.interests
+  module:
+    - social_content_translation
+third_party_settings:
+  content_translation:
+    enabled: false
+id: taxonomy_term.interests
+target_entity_type_id: taxonomy_term
+target_bundle: interests
+default_langcode: site_default
+language_alterable: false

--- a/modules/social_features/social_profile/config/optional/language.content_settings.taxonomy_term.profile_tag.yml
+++ b/modules/social_features/social_profile/config/optional/language.content_settings.taxonomy_term.profile_tag.yml
@@ -1,0 +1,15 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.profile_tag
+  module:
+    - social_content_translation
+third_party_settings:
+  content_translation:
+    enabled: false
+id: taxonomy_term.profile_tag
+target_entity_type_id: taxonomy_term
+target_bundle: profile_tag
+default_langcode: site_default
+language_alterable: false

--- a/modules/social_features/social_profile/config/static/language.content_settings.taxonomy_term.expertise_11203.yml
+++ b/modules/social_features/social_profile/config/static/language.content_settings.taxonomy_term.expertise_11203.yml
@@ -2,14 +2,14 @@ langcode: en
 status: true
 dependencies:
   config:
-    - taxonomy.vocabulary.topic_types
+    - taxonomy.vocabulary.expertise
   module:
-    - content_translation
+    - social_content_translation
 third_party_settings:
   content_translation:
-    enabled: true
-id: taxonomy_term.topic_types
+    enabled: false
+id: taxonomy_term.expertise
 target_entity_type_id: taxonomy_term
-target_bundle: topic_types
+target_bundle: expertise
 default_langcode: site_default
-language_alterable: true
+language_alterable: false

--- a/modules/social_features/social_profile/config/static/language.content_settings.taxonomy_term.interests_11203.yml
+++ b/modules/social_features/social_profile/config/static/language.content_settings.taxonomy_term.interests_11203.yml
@@ -1,0 +1,15 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.interests
+  module:
+    - social_content_translation
+third_party_settings:
+  content_translation:
+    enabled: false
+id: taxonomy_term.interests
+target_entity_type_id: taxonomy_term
+target_bundle: interests
+default_langcode: site_default
+language_alterable: false

--- a/modules/social_features/social_profile/config/static/language.content_settings.taxonomy_term.profile_tag_11203.yml
+++ b/modules/social_features/social_profile/config/static/language.content_settings.taxonomy_term.profile_tag_11203.yml
@@ -1,0 +1,15 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.profile_tag
+  module:
+    - social_content_translation
+third_party_settings:
+  content_translation:
+    enabled: false
+id: taxonomy_term.profile_tag
+target_entity_type_id: taxonomy_term
+target_bundle: profile_tag
+default_langcode: site_default
+language_alterable: false

--- a/modules/social_features/social_profile/modules/social_profile_fields/config/optional/language.content_settings.taxonomy_term.nationality.yml
+++ b/modules/social_features/social_profile/modules/social_profile_fields/config/optional/language.content_settings.taxonomy_term.nationality.yml
@@ -1,0 +1,15 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.nationality
+  module:
+    - social_content_translation
+third_party_settings:
+  content_translation:
+    enabled: false
+id: taxonomy_term.nationality
+target_entity_type_id: taxonomy_term
+target_bundle: nationality
+default_langcode: site_default
+language_alterable: false

--- a/modules/social_features/social_profile/modules/social_profile_fields/config/static/language.content_settings.taxonomy_term.nationality_11201.yml
+++ b/modules/social_features/social_profile/modules/social_profile_fields/config/static/language.content_settings.taxonomy_term.nationality_11201.yml
@@ -1,0 +1,15 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.nationality
+  module:
+    - social_content_translation
+third_party_settings:
+  content_translation:
+    enabled: false
+id: taxonomy_term.nationality
+target_entity_type_id: taxonomy_term
+target_bundle: nationality
+default_langcode: site_default
+language_alterable: false

--- a/modules/social_features/social_profile/modules/social_profile_fields/social_profile_fields.install
+++ b/modules/social_features/social_profile/modules/social_profile_fields/social_profile_fields.install
@@ -5,6 +5,7 @@
  * The social profile fields install file.
  */
 
+use Drupal\Core\Config\FileStorage;
 use Drupal\search_api\Entity\Index;
 use Drupal\user\Entity\User;
 use Symfony\Component\Yaml\Yaml;
@@ -116,4 +117,19 @@ function _social_profile_fields_nationalities() {
 
     $term->setName($nationality)->save();
   }
+}
+
+/**
+ * Make "Nationality" vocabulary translatable.
+ */
+function social_profile_fields_update_11201(): void {
+  if (!\Drupal::moduleHandler()->moduleExists('social_content_translation')) {
+    return;
+  }
+
+  $config_storage = \Drupal::service('config.storage');
+  $config_path = \Drupal::service('extension.list.module')->getPath('social_profile_fields') . '/config/static';
+  $source = new FileStorage($config_path);
+
+  $config_storage->write('language.content_settings.taxonomy_term.nationality', (array) $source->read('language.content_settings.taxonomy_term.nationality_11201'));
 }

--- a/modules/social_features/social_profile/modules/social_profile_fields/social_profile_fields.services.yml
+++ b/modules/social_features/social_profile/modules/social_profile_fields/social_profile_fields.services.yml
@@ -6,3 +6,8 @@ services:
   social_profile_fields.helper:
     class: Drupal\social_profile_fields\SocialProfileFieldsHelper
     arguments: ['@entity_type.manager', '@module_handler']
+  social_profile_fields.translation_defaults:
+    class: Drupal\social_profile_fields\ContentTranslationDefaultsConfigOverride
+    arguments: ['@module_handler']
+    tags:
+      - { name: config.factory.override, priority: 5 }

--- a/modules/social_features/social_profile/modules/social_profile_fields/src/ContentTranslationDefaultsConfigOverride.php
+++ b/modules/social_features/social_profile/modules/social_profile_fields/src/ContentTranslationDefaultsConfigOverride.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Drupal\social_profile_fields;
+
+use Drupal\Core\Cache\CacheableMetadata;
+use Drupal\Core\Config\ConfigFactoryOverrideInterface;
+use Drupal\Core\Config\StorableConfigBase;
+use Drupal\Core\Config\StorageInterface;
+use Drupal\Core\Extension\ModuleHandlerInterface;
+
+/**
+ * Provides content translation for the Social Profile Fields module.
+ *
+ * @package Drupal\social_profile_fields
+ */
+class ContentTranslationDefaultsConfigOverride implements ConfigFactoryOverrideInterface {
+
+  /**
+   * The module handler.
+   *
+   * @var \Drupal\Core\Extension\ModuleHandlerInterface
+   */
+  protected $moduleHandler;
+
+  /**
+   * ContentTranslationDefaultsConfigOverride constructor.
+   *
+   * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
+   *   The module handler service.
+   */
+  public function __construct(ModuleHandlerInterface $module_handler) {
+    $this->moduleHandler = $module_handler;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function loadOverrides($names): array {
+    $overrides = [];
+
+    // If the module "social_content_translation" is enabled let make
+    // translations enabled for content provided by the module by default.
+    if (!$this->moduleHandler->moduleExists('social_content_translation')) {
+      return $overrides;
+    }
+
+    // Translations for "Nationality" vocabulary.
+    $config_name = 'language.content_settings.taxonomy_term.nationality';
+
+    if (in_array($config_name, $names)) {
+      $overrides[$config_name] = [
+        'third_party_settings' => [
+          'content_translation' => [
+            'enabled' => TRUE,
+          ],
+        ],
+      ];
+    }
+
+    $config_names = [
+      'core.base_field_override.taxonomy_term.nationality.name',
+      'core.base_field_override.taxonomy_term.nationality.changed',
+      'core.base_field_override.taxonomy_term.nationality.description',
+    ];
+
+    foreach ($config_names as $config_name) {
+      if (in_array($config_name, $names)) {
+        $overrides[$config_name] = [
+          'translatable' => TRUE,
+        ];
+      }
+    }
+
+    return $overrides;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCacheSuffix(): string {
+    return 'social_profile_fields.content_translation_defaults_config_override';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCacheableMetadata($name): CacheableMetadata {
+    return new CacheableMetadata();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function createConfigObject($name, $collection = StorageInterface::DEFAULT_COLLECTION): ?StorableConfigBase {
+    return NULL;
+  }
+
+}

--- a/modules/social_features/social_profile/modules/social_profile_organization_tag/config/optional/language.content_settings.taxonomy_term.profile_organization_tag.yml
+++ b/modules/social_features/social_profile/modules/social_profile_organization_tag/config/optional/language.content_settings.taxonomy_term.profile_organization_tag.yml
@@ -1,0 +1,15 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.profile_organization_tag
+  module:
+    - social_content_translation
+third_party_settings:
+  content_translation:
+    enabled: false
+id: taxonomy_term.profile_organization_tag
+target_entity_type_id: taxonomy_term
+target_bundle: profile_organization_tag
+default_langcode: site_default
+language_alterable: false

--- a/modules/social_features/social_profile/modules/social_profile_organization_tag/config/static/language.content_settings.taxonomy_term.profile_organization_tag_11201.yml
+++ b/modules/social_features/social_profile/modules/social_profile_organization_tag/config/static/language.content_settings.taxonomy_term.profile_organization_tag_11201.yml
@@ -1,0 +1,15 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.profile_organization_tag
+  module:
+    - social_content_translation
+third_party_settings:
+  content_translation:
+    enabled: false
+id: taxonomy_term.profile_organization_tag
+target_entity_type_id: taxonomy_term
+target_bundle: profile_organization_tag
+default_langcode: site_default
+language_alterable: false

--- a/modules/social_features/social_profile/modules/social_profile_organization_tag/social_profile_organization_tag.install
+++ b/modules/social_features/social_profile/modules/social_profile_organization_tag/social_profile_organization_tag.install
@@ -5,6 +5,8 @@
  * Install and update functions for the social_profile_organization_tag module.
  */
 
+use Drupal\Core\Config\FileStorage;
+
 /**
  * Implements hook_install().
  */
@@ -29,4 +31,19 @@ function social_profile_organization_tag_install() {
   // Set the weight of this module to 1 so it is loaded after
   // the social_profile module.
   module_set_weight('social_profile_organization_tag', 1);
+}
+
+/**
+ * Make "Profile Organization Tag" vocabulary translatable.
+ */
+function social_profile_organization_tag_update_11201(): void {
+  if (!\Drupal::moduleHandler()->moduleExists('social_content_translation')) {
+    return;
+  }
+
+  $config_storage = \Drupal::service('config.storage');
+  $config_path = \Drupal::service('extension.list.module')->getPath('social_profile_organization_tag') . '/config/static';
+  $source = new FileStorage($config_path);
+
+  $config_storage->write('language.content_settings.taxonomy_term.profile_organization_tag', (array) $source->read('language.content_settings.taxonomy_term.profile_organization_tag_11201'));
 }

--- a/modules/social_features/social_profile/modules/social_profile_organization_tag/social_profile_organization_tag.services.yml
+++ b/modules/social_features/social_profile/modules/social_profile_organization_tag/social_profile_organization_tag.services.yml
@@ -3,3 +3,8 @@ services:
     class: \Drupal\social_profile_organization_tag\SocialProfileOrgTagConfigOverride
     tags:
       - {name: config.factory.override, priority: 5}
+  social_profile_organization_tag.translation_defaults:
+    class: Drupal\social_profile_organization_tag\ContentTranslationDefaultsConfigOverride
+    arguments: ['@module_handler']
+    tags:
+      - { name: config.factory.override, priority: 5 }

--- a/modules/social_features/social_profile/modules/social_profile_organization_tag/src/ContentTranslationDefaultsConfigOverride.php
+++ b/modules/social_features/social_profile/modules/social_profile_organization_tag/src/ContentTranslationDefaultsConfigOverride.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Drupal\social_profile_organization_tag;
+
+use Drupal\Core\Cache\CacheableMetadata;
+use Drupal\Core\Config\ConfigFactoryOverrideInterface;
+use Drupal\Core\Config\StorableConfigBase;
+use Drupal\Core\Config\StorageInterface;
+use Drupal\Core\Extension\ModuleHandlerInterface;
+
+/**
+ * Provides content translation for the Social Profile Organization tag module.
+ *
+ * @package Drupal\social_profile_organization_tag
+ */
+class ContentTranslationDefaultsConfigOverride implements ConfigFactoryOverrideInterface {
+
+  /**
+   * The module handler.
+   *
+   * @var \Drupal\Core\Extension\ModuleHandlerInterface
+   */
+  protected $moduleHandler;
+
+  /**
+   * ContentTranslationDefaultsConfigOverride constructor.
+   *
+   * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
+   *   The module handler service.
+   */
+  public function __construct(ModuleHandlerInterface $module_handler) {
+    $this->moduleHandler = $module_handler;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function loadOverrides($names): array {
+    $overrides = [];
+
+    // If the module "social_content_translation" is enabled let make
+    // translations enabled for content provided by the module by default.
+    if (!$this->moduleHandler->moduleExists('social_content_translation')) {
+      return $overrides;
+    }
+
+    // Translations for "Organization Tag" vocabulary.
+    $config_name = 'language.content_settings.taxonomy_term.profile_organization_tag';
+
+    if (in_array($config_name, $names)) {
+      $overrides[$config_name] = [
+        'third_party_settings' => [
+          'content_translation' => [
+            'enabled' => TRUE,
+          ],
+        ],
+      ];
+    }
+
+    $config_names = [
+      'core.base_field_override.taxonomy_term.profile_organization_tag.name',
+      'core.base_field_override.taxonomy_term.profile_organization_tag.changed',
+      'core.base_field_override.taxonomy_term.profile_organization_tag.description',
+    ];
+
+    foreach ($config_names as $config_name) {
+      if (in_array($config_name, $names)) {
+        $overrides[$config_name] = [
+          'translatable' => TRUE,
+        ];
+      }
+    }
+
+    return $overrides;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCacheSuffix(): string {
+    return 'social_profile_organization_tag.content_translation_defaults_config_override';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCacheableMetadata($name): CacheableMetadata {
+    return new CacheableMetadata();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function createConfigObject($name, $collection = StorageInterface::DEFAULT_COLLECTION): ?StorableConfigBase {
+    return NULL;
+  }
+
+}

--- a/modules/social_features/social_profile/social_profile.install
+++ b/modules/social_features/social_profile/social_profile.install
@@ -5,6 +5,7 @@
  * Install, update and uninstall functions for the social_profile module.
  */
 
+use Drupal\Core\Config\FileStorage;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityStorageException;
 use Drupal\Core\Field\BaseFieldDefinition;
@@ -660,4 +661,27 @@ function social_profile_update_11202(): string {
 
   // Output logged messages to related channel of update execution.
   return $update_helper->logger()->output();
+}
+
+/**
+ * Make profile related vocabularies translatable.
+ */
+function social_profile_update_11203(): void {
+  if (!\Drupal::moduleHandler()->moduleExists('social_content_translation')) {
+    return;
+  }
+
+  $config_storage = \Drupal::service('config.storage');
+  $config_path = \Drupal::service('extension.list.module')->getPath('social_profile') . '/config/static';
+  $source = new FileStorage($config_path);
+
+  $config_names = [
+    'language.content_settings.taxonomy_term.expertise' => 'language.content_settings.taxonomy_term.expertise_11203',
+    'language.content_settings.taxonomy_term.interests' => 'language.content_settings.taxonomy_term.interests_11203',
+    'language.content_settings.taxonomy_term.profile_tag' => 'language.content_settings.taxonomy_term.profile_tag_11203',
+  ];
+
+  foreach ($config_names as $name => $static) {
+    $config_storage->write($name, (array) $source->read($static));
+  }
 }

--- a/modules/social_features/social_profile/social_profile.services.yml
+++ b/modules/social_features/social_profile/social_profile.services.yml
@@ -14,3 +14,8 @@ services:
     arguments:
       - '@entity_type.manager'
       - '@module_handler'
+  social_profile.translation_defaults:
+    class: Drupal\social_profile\ContentTranslationDefaultsConfigOverride
+    arguments: ['@module_handler']
+    tags:
+      - { name: config.factory.override, priority: 5 }

--- a/modules/social_features/social_profile/src/ContentTranslationDefaultsConfigOverride.php
+++ b/modules/social_features/social_profile/src/ContentTranslationDefaultsConfigOverride.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Drupal\social_profile;
+
+use Drupal\Core\Cache\CacheableMetadata;
+use Drupal\Core\Config\ConfigFactoryOverrideInterface;
+use Drupal\Core\Config\StorableConfigBase;
+use Drupal\Core\Config\StorageInterface;
+use Drupal\Core\Extension\ModuleHandlerInterface;
+
+/**
+ * Provides content translation for the Social Profile module.
+ *
+ * @package Drupal\social_profile
+ */
+class ContentTranslationDefaultsConfigOverride implements ConfigFactoryOverrideInterface {
+
+  /**
+   * The module handler.
+   *
+   * @var \Drupal\Core\Extension\ModuleHandlerInterface
+   */
+  protected $moduleHandler;
+
+  /**
+   * ContentTranslationDefaultsConfigOverride constructor.
+   *
+   * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
+   *   The module handler service.
+   */
+  public function __construct(ModuleHandlerInterface $module_handler) {
+    $this->moduleHandler = $module_handler;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function loadOverrides($names): array {
+    $overrides = [];
+
+    // If the module "social_content_translation" is enabled let make
+    // translations enabled for content provided by the module by default.
+    if (!$this->moduleHandler->moduleExists('social_content_translation')) {
+      return $overrides;
+    }
+
+    // Translations for vocabularies: "Expertise", "Interests", "Profile Tag".
+    $vocabularies = [
+      'expertise',
+      'interests',
+      'profile_tag',
+    ];
+
+    foreach ($vocabularies as $vocabulary) {
+      $config_name = "language.content_settings.taxonomy_term.{$vocabulary}";
+
+      if (in_array($config_name, $names)) {
+        $overrides[$config_name] = [
+          'third_party_settings' => [
+            'content_translation' => [
+              'enabled' => TRUE,
+            ],
+          ],
+        ];
+      }
+
+      $config_names = [
+        "core.base_field_override.taxonomy_term.{$vocabulary}.name",
+        "core.base_field_override.taxonomy_term.{$vocabulary}.changed",
+        "core.base_field_override.taxonomy_term.{$vocabulary}.description",
+      ];
+
+      foreach ($config_names as $config_name) {
+        if (in_array($config_name, $names)) {
+          $overrides[$config_name] = [
+            'translatable' => TRUE,
+          ];
+        }
+      }
+    }
+
+    return $overrides;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCacheSuffix(): string {
+    return 'social_profile.content_translation_defaults_config_override';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCacheableMetadata($name): CacheableMetadata {
+    return new CacheableMetadata();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function createConfigObject($name, $collection = StorageInterface::DEFAULT_COLLECTION): ?StorableConfigBase {
+    return NULL;
+  }
+
+}

--- a/modules/social_features/social_tagging/config/optional/language.content_settings.taxonomy_term.social_tagging.yml
+++ b/modules/social_features/social_tagging/config/optional/language.content_settings.taxonomy_term.social_tagging.yml
@@ -1,0 +1,15 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.social_tagging
+  module:
+    - social_content_translation
+third_party_settings:
+  content_translation:
+    enabled: false
+id: taxonomy_term.social_tagging
+target_entity_type_id: taxonomy_term
+target_bundle: social_tagging
+default_langcode: site_default
+language_alterable: true

--- a/modules/social_features/social_tagging/config/static/language.content_settings.taxonomy_term.social_tagging_11201.yml
+++ b/modules/social_features/social_tagging/config/static/language.content_settings.taxonomy_term.social_tagging_11201.yml
@@ -1,0 +1,15 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.social_tagging
+  module:
+    - social_content_translation
+third_party_settings:
+  content_translation:
+    enabled: false
+id: taxonomy_term.social_tagging
+target_entity_type_id: taxonomy_term
+target_bundle: social_tagging
+default_langcode: site_default
+language_alterable: true

--- a/modules/social_features/social_tagging/social_tagging.install
+++ b/modules/social_features/social_tagging/social_tagging.install
@@ -5,6 +5,7 @@
  * Installation file for Social Tagging.
  */
 
+use Drupal\Core\Config\FileStorage;
 use Drupal\Core\Entity\EntityStorageException;
 use Drupal\Core\Field\BaseFieldDefinition;
 use Drupal\Core\Field\FieldStorageDefinitionInterface;
@@ -220,4 +221,19 @@ function social_tagging_update_8005(): void {
   catch (EntityStorageException $e) {
     \Drupal::logger('social_tagging')->info($e->getMessage());
   }
+}
+
+/**
+ * Make "Social Tagging" vocabulary translatable.
+ */
+function social_tagging_update_11201(): void {
+  if (!\Drupal::moduleHandler()->moduleExists('social_content_translation')) {
+    return;
+  }
+
+  $config_storage = \Drupal::service('config.storage');
+  $config_path = \Drupal::service('extension.list.module')->getPath('social_tagging') . '/config/static';
+  $source = new FileStorage($config_path);
+
+  $config_storage->write('language.content_settings.taxonomy_term.social_tagging', (array) $source->read('language.content_settings.taxonomy_term.social_tagging_11201'));
 }

--- a/modules/social_features/social_tagging/social_tagging.services.yml
+++ b/modules/social_features/social_tagging/social_tagging.services.yml
@@ -6,4 +6,9 @@ services:
     class: Drupal\social_tagging\SocialTaggingOverrides
     arguments: ['@config.factory']
     tags:
-      - {name: config.factory.override, priority: 5}
+      - { name: config.factory.override, priority: 5 }
+  social_tagging.translation_defaults:
+    class: Drupal\social_tagging\ContentTranslationDefaultsConfigOverride
+    arguments: ['@module_handler']
+    tags:
+      - { name: config.factory.override, priority: 5 }

--- a/modules/social_features/social_tagging/src/ContentTranslationDefaultsConfigOverride.php
+++ b/modules/social_features/social_tagging/src/ContentTranslationDefaultsConfigOverride.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Drupal\social_tagging;
+
+use Drupal\Core\Cache\CacheableMetadata;
+use Drupal\Core\Config\ConfigFactoryOverrideInterface;
+use Drupal\Core\Config\StorableConfigBase;
+use Drupal\Core\Config\StorageInterface;
+use Drupal\Core\Extension\ModuleHandlerInterface;
+
+/**
+ * Provides content translation for the Social Tagging module.
+ *
+ * @package Drupal\social_tagging
+ */
+class ContentTranslationDefaultsConfigOverride implements ConfigFactoryOverrideInterface {
+
+  /**
+   * The module handler.
+   *
+   * @var \Drupal\Core\Extension\ModuleHandlerInterface
+   */
+  protected $moduleHandler;
+
+  /**
+   * ContentTranslationDefaultsConfigOverride constructor.
+   *
+   * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
+   *   The module handler service.
+   */
+  public function __construct(ModuleHandlerInterface $module_handler) {
+    $this->moduleHandler = $module_handler;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function loadOverrides($names): array {
+    $overrides = [];
+
+    // If the module "social_content_translation" is enabled let make
+    // translations enabled for content provided by the module by default.
+    if (!$this->moduleHandler->moduleExists('social_content_translation')) {
+      return $overrides;
+    }
+
+    // Translations for "Content Tags" vocabulary.
+    $config_name = 'language.content_settings.taxonomy_term.social_tagging';
+
+    if (in_array($config_name, $names)) {
+      $overrides[$config_name] = [
+        'third_party_settings' => [
+          'content_translation' => [
+            'enabled' => TRUE,
+          ],
+        ],
+      ];
+    }
+
+    $config_names = [
+      'core.base_field_override.taxonomy_term.social_tagging.name',
+      'core.base_field_override.taxonomy_term.social_tagging.changed',
+      'core.base_field_override.taxonomy_term.social_tagging.description',
+    ];
+
+    foreach ($config_names as $config_name) {
+      if (in_array($config_name, $names)) {
+        $overrides[$config_name] = [
+          'translatable' => TRUE,
+        ];
+      }
+    }
+
+    return $overrides;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCacheSuffix(): string {
+    return 'social_tagging.content_translation_defaults_config_override';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCacheableMetadata($name): CacheableMetadata {
+    return new CacheableMetadata();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function createConfigObject($name, $collection = StorageInterface::DEFAULT_COLLECTION): ?StorableConfigBase {
+    return NULL;
+  }
+
+}

--- a/modules/social_features/social_topic/config/optional/language.content_settings.taxonomy_term.topic_types.yml
+++ b/modules/social_features/social_topic/config/optional/language.content_settings.taxonomy_term.topic_types.yml
@@ -1,0 +1,15 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.topic_types
+  module:
+    - social_content_translation
+third_party_settings:
+  content_translation:
+    enabled: false
+id: taxonomy_term.topic_types
+target_entity_type_id: taxonomy_term
+target_bundle: topic_types
+default_langcode: site_default
+language_alterable: false

--- a/modules/social_features/social_topic/config/static/language.content_settings.taxonomy_term.topic_types_11201.yml
+++ b/modules/social_features/social_topic/config/static/language.content_settings.taxonomy_term.topic_types_11201.yml
@@ -2,14 +2,14 @@ langcode: en
 status: true
 dependencies:
   config:
-    - taxonomy.vocabulary.profile_tag
+    - taxonomy.vocabulary.topic_types
   module:
-    - content_translation
+    - social_content_translation
 third_party_settings:
   content_translation:
-    enabled: true
-id: taxonomy_term.profile_tag
+    enabled: false
+id: taxonomy_term.topic_types
 target_entity_type_id: taxonomy_term
-target_bundle: profile_tag
+target_bundle: topic_types
 default_langcode: site_default
-language_alterable: true
+language_alterable: false

--- a/modules/social_features/social_topic/social_topic.install
+++ b/modules/social_features/social_topic/social_topic.install
@@ -5,6 +5,7 @@
  * Install, update and uninstall functions for the social_topic module.
  */
 
+use Drupal\Core\Config\FileStorage;
 use Drupal\field\Entity\FieldConfig;
 use Drupal\field\Entity\FieldStorageConfig;
 use Drupal\field\FieldConfigInterface;
@@ -483,4 +484,19 @@ function social_topic_update_11101(): void {
   /** @var \Drupal\field\FieldStorageConfigInterface $topic_type */
   $topic_type = $field_storage_config_storage->load('node.field_topic_type');
   $topic_type->setCardinality(FieldStorageConfig::CARDINALITY_UNLIMITED)->save();
+}
+
+/**
+ * Make "Topic Types" vocabulary translatable.
+ */
+function social_topic_update_11201(): void {
+  if (!\Drupal::moduleHandler()->moduleExists('social_content_translation')) {
+    return;
+  }
+
+  $config_storage = \Drupal::service('config.storage');
+  $config_path = \Drupal::service('extension.list.module')->getPath('social_topic') . '/config/static';
+  $source = new FileStorage($config_path);
+
+  $config_storage->write('language.content_settings.taxonomy_term.topic_types', (array) $source->read('language.content_settings.taxonomy_term.topic_types_11201'));
 }

--- a/modules/social_features/social_topic/src/ContentTranslationDefaultsConfigOverride.php
+++ b/modules/social_features/social_topic/src/ContentTranslationDefaultsConfigOverride.php
@@ -33,6 +33,7 @@ class ContentTranslationDefaultsConfigOverride extends ContentTranslationConfigO
    */
   protected function getTranslationOverrides() {
     return [
+      // Translations for "Topic" node type.
       'language.content_settings.node.topic' => [
         'third_party_settings' => [
           'content_translation' => [
@@ -53,6 +54,24 @@ class ContentTranslationDefaultsConfigOverride extends ContentTranslationConfigO
         'translatable' => TRUE,
       ],
       'core.base_field_override.node.topic.status' => [
+        'translatable' => TRUE,
+      ],
+
+      // Translations for "Topic Types" vocabulary.
+      'language.content_settings.taxonomy_term.topic_types' => [
+        'third_party_settings' => [
+          'content_translation' => [
+            'enabled' => TRUE,
+          ],
+        ],
+      ],
+      'core.base_field_override.taxonomy_term.topic_types.name' => [
+        'translatable' => TRUE,
+      ],
+      'core.base_field_override.taxonomy_term.topic_types.changed' => [
+        'translatable' => TRUE,
+      ],
+      'core.base_field_override.taxonomy_term.topic_types.description' => [
         'translatable' => TRUE,
       ],
     ];


### PR DESCRIPTION
## Problem
There are missed translations support for taxonomy terms (and vocabularies)

## Solution
Add `ContentTranslationDefaultsConfigOverride` allows apply translations after enabling `social_content_translation` module

Add the translations to the next taxonomy vocabularies:
- `Report Reasons`
- `Event types`
- `Topic types`
- `Group types`
- `Nationality`
- `Profile Organization Tag`
- `Expertise`
- `Interests`
- `Profile Tag`
- `Content tags`

## Issue tracker
- https://www.drupal.org/project/social/issues/3240115
- https://getopensocial.atlassian.net/browse/YANG-6124

## How to test
- [x] Install OS from scratch
- [x] Login as an admin
- [x] Add a few tags to any vocabulary listed in "Solution" section of the PR
- [x] Add at least one additional language (make the site multilingual)
- [x] Enable the module `social_content_translation`
- [x] Visit the taxonomy list page you added previously and try to translate any

## Screenshots
N/A

## Release notes
*Make it possible to translate taxonomy terms and vocabularies.*

## Change Record
N/A

## Translations
N/A
