### PR TITLE
Issue #3240276 by agami4: Add icons to the items of the join method

### DIFF
--- a/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.module
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.module
@@ -383,6 +383,12 @@ function social_group_flexible_group_preprocess_form_element(&$variables) {
 
   if ($variables['element']['#type'] === 'radio' &&
     !empty($variables['name']) &&
+    $variables['name'] === 'field_group_allowed_join_method') {
+    $variables['label']['#render_icon'] = TRUE;
+    $variables['attributes']['class'][] = 'inline-item';
+  }
+  if ($variables['element']['#type'] === 'radio' &&
+    !empty($variables['name']) &&
     $variables['name'] === 'field_flexible_group_visibility') {
     $variables['label']['#render_icon'] = TRUE;
     $variables['attributes']['class'][] = 'inline-item';

--- a/modules/social_features/social_group/social_group.module
+++ b/modules/social_features/social_group/social_group.module
@@ -665,21 +665,27 @@ function social_group_allowed_join_method_description($key) {
 
   // Add explanatory descriptive text after the icon.
   switch ($key) {
-    case 'added':
-      $description = '<p><strong>' . t('Invite only')->render() . '</strong>';
-      $description .= ' - ' . t('users can only join this group if they are added/invited by group managers.')->render();
-      $description .= '</p>';
-      break;
-
     case 'direct':
-      $description = '<p><strong>' . t('Open to join')->render() . '</strong>';
+      $description = '<p>';
+      $description .= '<p><strong><svg class="icon-small"><use xlink:href="#icon-join_open"></use></svg></strong>';
+      $description .= '<strong>' . t('Open to join')->render() . '</strong>';
       $description .= ' - ' . t('users can join this group without approval.')->render();
       $description .= '</p>';
       break;
 
     case 'request':
-      $description = '<p><strong>' . t('Request to join')->render() . '</strong>';
+      $description = '<p>';
+      $description .= '<p><strong><svg class="icon-small"><use xlink:href="#icon-join_close"></use></svg></strong>';
+      $description .= '<strong>' . t('Request to join')->render() . '</strong>';
       $description .= ' - ' . t('users can "request to join" this group which group managers approve/decline.')->render();
+      $description .= '</p>';
+      break;
+
+    case 'added':
+      $description = '<p>';
+      $description .= '<p><strong><svg class="icon-small"><use xlink:href="#icon-invite"></use></svg></strong>';
+      $description .= '<strong>' . t('Invite only')->render() . '</strong>';
+      $description .= ' - ' . t('users can only join this group if they are added/invited by group managers.')->render();
       $description .= '</p>';
       break;
   }


### PR DESCRIPTION
## Problem
As a Group Manager I want to see configuration options for visibility and invite of group in a structured way

## Solution
1. Change the layout so elements would be better structured
2. Update the copy according to the design provided

## Issue tracker
https://getopensocial.atlassian.net/browse/OEC-54

## How to test
*For example*
- [ ] Go to the edit/add (group)page
- [ ] Check form elements of the `Access permissions`(visibility) section.

## Screenshots
![Groups – Figma 2021-10-04 13-57-00](https://user-images.githubusercontent.com/16086340/135839881-88ff42bd-41e1-4687-bcd1-3573c4fbda56.png)

## Release notes
The configuration options for visibility and invite of the group have a new layout structure.

## Change Record
N/A

## Translations
N/A
