### PR TITLE
Issue #3240794 by Ressinel: Fix error page when deleting users from a group or going to user profile within a group.

### DIFF
--- a/modules/social_features/social_group/src/Controller/GroupManagersController.php
+++ b/modules/social_features/social_group/src/Controller/GroupManagersController.php
@@ -7,6 +7,7 @@ use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Routing\RouteMatch;
 use Drupal\Core\Session\AccountInterface;
+use Drupal\group\Entity\GroupInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -68,7 +69,7 @@ class GroupManagersController extends ControllerBase {
     $group = _social_group_get_current_group();
 
     // Lets allow group managers as well.
-    if ($group->hasPermission('administer members', $account)) {
+    if ($group instanceof GroupInterface && $group->hasPermission('administer members', $account)) {
       return AccessResult::allowed();
     }
 


### PR DESCRIPTION
## Problem
Error page when deleting users from a group or going to user profile within a group.

It can be reproduced by going to a group → manage members → and clicking on a random profile.

The normal group member’s page is not affected by this problem, so this is related only to group and site managers.
Removing a member from a group through the "actions" button inside the 'manage group members' tab is not working as well.

![3240794-error](https://user-images.githubusercontent.com/10220937/136003657-a0daa18c-7cd5-46ce-b271-270702c05b3f.png)

## Solution
Make improvements in the `GroupManagersController`

## Issue tracker
- https://www.drupal.org/project/social/issues/3240794
- https://getopensocial.atlassian.net/browse/SUP-1551

## How to test
- [ ] Login as `Site Manager`
- [ ] Go to some group's `Manage members` page
- [ ] Try to click on a random profile and you shouldn't see any errors
- [ ] Try to remove some members and you should do that successfully

## Screenshots
See the `Problem` section above.

## Release notes
Was fixed error when deleting users from a group or going to user profile within a group.

## Change Record
N/A

## Translations
N/A
