### PR TITLE
[Internal] - Update phpstan-baseline.neon

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -8637,7 +8637,7 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$input of static method Symfony\\\\Component\\\\Yaml\\\\Yaml\\:\\:parse\\(\\) expects string, string\\|false given\\.$#"
-			count: 1
+			count: 2
 			path: modules/social_features/social_event/modules/social_event_managers/social_event_managers.install
 
 		-


### PR DESCRIPTION
## Problem
New PHPStan errors appear.

## Solution
Update `phpstan-baseline.neon` after `mglaman/phpstan-drupal` new version was released.

## Issue tracker
N/A

## How to test
- [ ] PHPStan passes

## Screenshots
N/A

## Release notes
N/A

## Change Record
N/A

## Translations
N/A