### PR TITLE
Issue 3241569 by nachosalvador: Add setting to control magic login me…

### DIFF
--- a/modules/custom/social_magic_login/config/install/social_magic_login.settings.yml
+++ b/modules/custom/social_magic_login/config/install/social_magic_login.settings.yml
@@ -1,0 +1,1 @@
+show_used_message: false

--- a/modules/custom/social_magic_login/config/schema/social_magic_login.schema.yml
+++ b/modules/custom/social_magic_login/config/schema/social_magic_login.schema.yml
@@ -1,0 +1,7 @@
+social_magic_login.settings:
+  type: config_object
+  label: 'Social Magic Login Settings'
+  mapping:
+    show_used_message:
+      type: boolean
+      label: "Whether to show a message to the user when they've used a magic login link."

--- a/modules/custom/social_magic_login/social_magic_login.install
+++ b/modules/custom/social_magic_login/social_magic_login.install
@@ -1,0 +1,15 @@
+<?php
+
+/**
+ * @file
+ * Install, update and uninstall functions for the social_magic_login module.
+ */
+
+/**
+ * Preserve the functionality at the time the setting is introduced.
+ */
+function social_magic_login_update_11001() : void {
+  \Drupal::configFactory()->getEditable('social_magic_login.settings')
+    ->set('show_used_message', TRUE)
+    ->save();
+}


### PR DESCRIPTION
## Problem
Always magic login is used you receive a status message.

## Solution
Control it using a show_used_message setting.

## Issue tracker
https://www.drupal.org/project/social/issues/3241569

## How to test
*For example*
- [ ] Enable social_magic_login
- [ ] Do user login using the magic login: `drush php-eval "print_r(\Drupal::service('social_magic_login.create_url')->create(\Drupal\user\Entity\User::load(<user_uid>), 'all-groups', [])->toString());"`
- [ ] Check drupal status message doesn't appear
- [ ] Execute drush updb to enable the regarding setting
- [ ] Do user login using the magic login: `drush php-eval "print_r(\Drupal::service('social_magic_login.create_url')->create(\Drupal\user\Entity\User::load(<user_uid>), 'all-groups', [])->toString());"`
- [ ] Check drupal status message appears: "You have just used your one-time login link. It is no longer necessary to use this link to log in."

## Screenshots
None

## Release notes
None

## Change Record
None

## Translations
None
