### PR TITLE
Issue #3243511 by Ressinel: Empty social_landing_page_update_10303 hook.

### DIFF
--- a/modules/social_features/social_landing_page/social_landing_page.install
+++ b/modules/social_features/social_landing_page/social_landing_page.install
@@ -732,17 +732,11 @@ function social_landing_page_update_10302() {
 }
 
 /**
- * Update configuration for the types of the block_field field.
+ * Moved to OS 11.0.0.
  */
 function social_landing_page_update_10303() {
-  /** @var \Drupal\update_helper\Updater $updateHelper */
-  $updateHelper = \Drupal::service('update_helper.updater');
-
-  // Execute configuration update definitions with logging of success.
-  $updateHelper->executeUpdate('social_landing_page', __FUNCTION__);
-
-  // Output logged messages to related channel of update execution.
-  return $updateHelper->logger()->output();
+  // Removed in OS 10.3.1 and moved to OS 11.0.0.
+  // @see https://www.drupal.org/project/social/issues/3243511
 }
 
 /**


### PR DESCRIPTION
## Problem
Related PRs:
- https://github.com/goalgorilla/open_social/pull/2548
- https://github.com/goalgorilla/open_social/pull/2421

`10.3.0` now contains the update hook itself but not the file it’s trying to use as source for the update helper.

The following commit https://github.com/goalgorilla/open_social/commit/859771a8cd9cd70f69dfb3... cherry picks social_landing_page_update_10303

The update hook was introduced in https://github.com/goalgorilla/open_social/pull/2421 and scheduled for 11.0.0

## Solution
Empty `social_landing_page_update_10303` hook in OpenSocial `10.3`

## Issue tracker
- https://www.drupal.org/project/social/issues/3243511

## How to test
- [x] Test Open Social install and update from old versions.
- [x] `drush updb` shouldn't have errors

## Screenshots
N/A

## Release notes
Fixed error during updating database.

## Change Record
N/A

## Translations
N/A
