### PR TITLE
Issue #3243539 by tBKoT: Remove the unused 'group_welcome_message' fieldgroup

### DIFF
--- a/modules/social_features/social_group/modules/social_group_welcome_message/social_group_welcome_message.install
+++ b/modules/social_features/social_group/modules/social_group_welcome_message/social_group_welcome_message.install
@@ -6,11 +6,14 @@
  */
 
 /**
- * Remove the not used fieldgroup 'group_welcome_message' from group forms.
+ * Remove the fieldgroup 'group_welcome_message' from group entity form config.
  *
  * Config override that adds the 'group_welcome_message' fieldgroup was removed
+ * in https://www.drupal.org/project/social/issues/3224631
  * but for some reason this field group still exist in group form configuration.
- * As we add a new wrapper in form alter we should remove it from configuration.
+ *
+ * @see https://www.drupal.org/project/social/issues/3243539
+ * @see social_group_welcome_message_form_alter
  */
 function social_group_welcome_message_update_10101(): void {
   $social_group_types = [


### PR DESCRIPTION
## Problem
After changes from this issue https://www.drupal.org/project/social/issues/3224631 the welcome message fields are disappeared on existing projects (UNDP, ECI). For some reason, the form display configuration already has a field group 'group_welcome_message' which is conflicts with newly added details.

## Solution
Update the groups form display to remove the unused field group.

## Issue tracker
https://www.drupal.org/project/social/issues/3243539
https://www.drupal.org/project/social/issues/3224631
https://getopensocial.atlassian.net/browse/YANG-6417

## How to test
- [ ] Go to the add/edit group form
- [ ] You should see welcome message settings

## Screenshots
![зображення](https://user-images.githubusercontent.com/11648677/137310667-3d3f9835-5b17-4565-806c-c8688f92169f.png)


## Release notes
N/A

## Change Record
N/A

## Translations
N/A
