### PR TITLE
Issue #3243780 by Ressinel: 'GroupMuteNotify' The installation has encountered an error

### DIFF
--- a/modules/custom/activity_basics/src/Plugin/ActivityContext/ContentInMyGroupActivityContext.php
+++ b/modules/custom/activity_basics/src/Plugin/ActivityContext/ContentInMyGroupActivityContext.php
@@ -28,7 +28,7 @@ class ContentInMyGroupActivityContext extends ActivityContextBase {
    *
    * @var \Drupal\social_group\GroupMuteNotify
    */
-  protected GroupMuteNotify $groupMuteNotify;
+  protected $groupMuteNotify;
 
   /**
    * Constructs a GroupContentInMyGroupActivityContext object.

--- a/modules/custom/activity_basics/src/Plugin/ActivityContext/GroupContentInMyGroupActivityContext.php
+++ b/modules/custom/activity_basics/src/Plugin/ActivityContext/GroupContentInMyGroupActivityContext.php
@@ -33,7 +33,7 @@ class GroupContentInMyGroupActivityContext extends ActivityContextBase {
    *
    * @var \Drupal\social_group\GroupMuteNotify
    */
-  protected GroupMuteNotify $groupMuteNotify;
+  protected $groupMuteNotify;
 
   /**
    * Constructs a GroupContentInMyGroupActivityContext object.

--- a/modules/custom/activity_basics/src/Plugin/ActivityContext/OwnerActivityContext.php
+++ b/modules/custom/activity_basics/src/Plugin/ActivityContext/OwnerActivityContext.php
@@ -26,7 +26,7 @@ class OwnerActivityContext extends ActivityContextBase {
    *
    * @var \Drupal\social_group\GroupMuteNotify
    */
-  protected GroupMuteNotify $groupMuteNotify;
+  protected $groupMuteNotify;
 
   /**
    * Constructs a MentionActivityContext object.

--- a/modules/custom/activity_send/modules/activity_send_email/src/Plugin/QueueWorker/ActivitySendEmailWorker.php
+++ b/modules/custom/activity_send/modules/activity_send_email/src/Plugin/QueueWorker/ActivitySendEmailWorker.php
@@ -85,7 +85,7 @@ class ActivitySendEmailWorker extends ActivitySendWorkerBase implements Containe
    *
    * @var \Drupal\social_group\GroupMuteNotify
    */
-  protected GroupMuteNotify $groupMuteNotify;
+  protected $groupMuteNotify;
 
   /**
    * {@inheritdoc}

--- a/modules/social_features/social_follow_content/src/Plugin/ActivityContext/FollowContentActivityContext.php
+++ b/modules/social_features/social_follow_content/src/Plugin/ActivityContext/FollowContentActivityContext.php
@@ -28,7 +28,7 @@ class FollowContentActivityContext extends ActivityContextBase {
    *
    * @var \Drupal\social_group\GroupMuteNotify
    */
-  protected GroupMuteNotify $groupMuteNotify;
+  protected $groupMuteNotify;
 
   /**
    * Constructs a MentionActivityContext object.

--- a/modules/social_features/social_like/src/Plugin/ActivityContext/VoteActivityContext.php
+++ b/modules/social_features/social_like/src/Plugin/ActivityContext/VoteActivityContext.php
@@ -28,7 +28,7 @@ class VoteActivityContext extends ActivityContextBase {
    *
    * @var \Drupal\social_group\GroupMuteNotify
    */
-  protected GroupMuteNotify $groupMuteNotify;
+  protected $groupMuteNotify;
 
   /**
    * Constructs a MentionActivityContext object.

--- a/modules/social_features/social_mentions/src/Plugin/ActivityContext/MentionActivityContext.php
+++ b/modules/social_features/social_mentions/src/Plugin/ActivityContext/MentionActivityContext.php
@@ -26,7 +26,7 @@ class MentionActivityContext extends ActivityContextBase {
    *
    * @var \Drupal\social_group\GroupMuteNotify
    */
-  protected GroupMuteNotify $groupMuteNotify;
+  protected $groupMuteNotify;
 
   /**
    * Constructs a MentionActivityContext object.


### PR DESCRIPTION
## Problem
Installation fails just after the voting api component is installed.
I get the following error message:

```
An AJAX HTTP error occurred.
HTTP Result Code: 200
Debugging information follows.
Path: /core/install.php?rewrite=ok&profile=social&langcode=en&id=1&op=do_nojs&op=do
StatusText: OK
ResponseText: ParseError: syntax error, unexpected 'GroupMuteNotify' (T_STRING), expecting function (T_FUNCTION) or const (T_CONST) in Composer\Autoload\includeFile() (line 29 of C:\wamp64\www\opensocial\public_html\profiles\contrib\social\modules\custom\activity_basics\src\Plugin\ActivityContext\OwnerActivityContext.php).
```

Here is the error page message:

```
Error
The website encountered an unexpected error. Please try again later.
ParseError: syntax error, unexpected 'GroupMuteNotify' (T_STRING), expecting function (T_FUNCTION) or const (T_CONST) in Composer\Autoload\includeFile() (line 29 of profiles\contrib\social\modules\custom\activity_basics\src\Plugin\ActivityContext\OwnerActivityContext.php).
Composer\Autoload\includeFile('C:\wamp64\www\opensocial\public_html/profiles/contrib/social/modules/custom/activity_basics/src\Plugin\ActivityContext\OwnerActivityContext.php') (Line: 346)
Composer\Autoload\ClassLoader->loadClass('Drupal\activity_basics\Plugin\ActivityContext\OwnerActivityContext')
spl_autoload_call('Drupal\activity_basics\Plugin\ActivityContext\OwnerActivityContext')
class_exists('Drupal\activity_basics\Plugin\ActivityContext\OwnerActivityContext') (Line: 96)
Drupal\Component\Plugin\Factory\DefaultFactory::getPluginClass('owner_activity_context', Array, 'Drupal\activity_creator\Plugin\ActivityContextInterface') (Line: 17)
Drupal\Core\Plugin\Factory\ContainerFactory->createInstance('owner_activity_context', Array) (Line: 83)
Drupal\Component\Plugin\PluginManagerBase->createInstance('owner_activity_context') (Line: 180)
Drupal\activity_logger\Service\ActivityLoggerFactory->getMessageTypes('update_entity_action', Object) (Line: 82)
Drupal\activity_logger\Service\ActivityLoggerFactory->createMessages(Object, 'update_entity_action') (Line: 29)
Drupal\activity_creator\Plugin\ActivityActionBase->createMessage(Object) (Line: 18)
Drupal\activity_creator\Plugin\ActivityActionBase->create(Object) (Line: 56)
_activity_basics_entity_action(Object, 'update_entity_action') (Line: 23)
activity_basics_entity_update(Object)
call_user_func_array('activity_basics_entity_update', Array) (Line: 403)
Drupal\Core\Extension\ModuleHandler->invokeAll('entity_update', Array) (Line: 206)
Drupal\Core\Entity\EntityStorageBase->invokeHook('update', Object) (Line: 843)
Drupal\Core\Entity\ContentEntityStorageBase->invokeHook('update', Object) (Line: 535)
Drupal\Core\Entity\EntityStorageBase->doPostSave(Object, 1) (Line: 728)
Drupal\Core\Entity\ContentEntityStorageBase->doPostSave(Object, 1) (Line: 460)
Drupal\Core\Entity\EntityStorageBase->save(Object) (Line: 837)
Drupal\Core\Entity\Sql\SqlContentEntityStorage->save(Object) (Line: 395)
Drupal\Core\Entity\EntityBase->save() (Line: 26)
social_install()
call_user_func_array('social_install', Array) (Line: 392)
Drupal\Core\Extension\ModuleHandler->invoke('social', 'install', Array) (Line: 325)
Drupal\Core\Extension\ModuleInstaller->install(Array, ) (Line: 83)
Drupal\Core\ProxyClass\Extension\ModuleInstaller->install(Array, ) (Line: 1649)
install_install_profile(Array) (Line: 695)
install_run_task(Array, Array) (Line: 570)
install_run_tasks(Array, NULL) (Line: 118)
install_drupal(Object) (Line: 48)
```

## Solution
Remove type from `GroupMuteNotify` properties as this functionality can be used with `PHP 7.3`.

## Issue tracker
- https://www.drupal.org/project/social/issues/3243780

## How to test
- [x] Shouldn't be the typed properties errors (`PHP 7.3`)

## Screenshots
N/A

## Release notes
Fixed typed properties errors.

## Change Record
N/A

## Translations
N/A
