### PR TITLE
Issue #3244274 by tBKoT: Update get value process to avoid errors on the event view/edit page

### DIFF
--- a/modules/social_features/social_event/src/Service/SocialEventEnrollService.php
+++ b/modules/social_features/social_event/src/Service/SocialEventEnrollService.php
@@ -38,19 +38,19 @@ class SocialEventEnrollService implements SocialEventEnrollServiceInterface {
       $this->eventSettings->get('disable_event_enroll') ||
       $node->bundle() !== 'event' ||
       !$node->hasField('field_event_enroll') ||
-      (!$node->get('field_event_enroll')->isEmpty() && !(bool) $node->get('field_event_enroll')->first()->getValue()['value'])
+      (!$node->get('field_event_enroll')->isEmpty() && !(bool) $node->get('field_event_enroll')->getString())
     ) {
       return FALSE;
     }
 
     $was_not_changed = $node->get('field_event_enroll')->isEmpty();
-    $is_enabled = $node->get('field_event_enroll')->first()->getValue()['value'];
+    $is_enabled = (bool) $node->get('field_event_enroll')->getString();
 
     // Make an exception for the invite enroll method.
     // This doesn't allow people to enroll themselves, but get invited.
     if (
       !$node->get('field_enroll_method')->isEmpty() &&
-      (int) $node->get('field_enroll_method')->first()->getValue()['value'] === EventEnrollmentInterface::ENROLL_METHOD_INVITE
+      (int) $node->get('field_enroll_method')->getString() === EventEnrollmentInterface::ENROLL_METHOD_INVITE
     ) {
       $is_enabled = TRUE;
     }


### PR DESCRIPTION
## Problem
After changes in this issue https://www.drupal.org/project/social/issues/3232719 (#2489) some old event returns an error on the edit/view page.
```
The website encountered an unexpected error. Please try again later.
Error: Call to a member function getValue() on null in Drupal\social_event\Service\SocialEventEnrollService->isEnabled() (line 47 of profiles/contrib/social/modules/social_features/social_event/src/Service/SocialEventEnrollService.php).
```

## Solution
Use another method to get value.

## Issue tracker
https://www.drupal.org/project/social/issues/3244274
https://getopensocial.atlassian.net/browse/YANG-6443


## Screenshots
N/A

## Release notes
N/A

## Change Record
N/A

## Translations
N/A
