### PR TITLE
Issue #3244876 by tBKoT: Fix issue with disappeared filters in Custom content list blocks

### DIFF
--- a/modules/social_features/social_content_block/src/ContentBlockManager.php
+++ b/modules/social_features/social_content_block/src/ContentBlockManager.php
@@ -63,7 +63,7 @@ class ContentBlockManager extends DefaultPluginManager implements ContentBlockMa
     $parents = array_merge($this->fieldParents, [$field_name]);
 
     if ($column) {
-      $parents = array_merge($this->fieldParents, [0, $column]);
+      $parents = array_merge($parents, [0, $column]);
     }
 
     return $parents;


### PR DESCRIPTION
## Problem
Custom content lists filters have disappeared.

## Solution
Update selector for the form states.

## Issue tracker
https://www.drupal.org/project/social/issues/3244876
https://getopensocial.atlassian.net/browse/SUP-1688

## How to test
- [x] Create/edit dashboard
- [x] Try to add a new Custom content list block 
- [x] You should see specific filters for every type of content

## Screenshots
#### 10.2.5
![зображення](https://user-images.githubusercontent.com/11648677/138091573-2ac49578-ff32-42cb-a4cd-5d86b5ea5420.png)
#### 10.3
![зображення](https://user-images.githubusercontent.com/11648677/138091680-ccb1f8bd-83b1-4abf-ad23-c2390c8a48fb.png)


## Release notes
N/A

## Change Record
N/A

## Translations
N/A
