### PR TITLE
Issue #3244899 by tBKoT: Show mute/unmute group link only in hero or statistic displays

### DIFF
--- a/modules/social_features/social_group/social_group.module
+++ b/modules/social_features/social_group/social_group.module
@@ -252,7 +252,7 @@ function social_group_preprocess_group(array &$variables) {
   $account = \Drupal::currentUser();
 
   // Prevent access to mute group notifications if a user is not a group member.
-  if (!$group->getMember($account)) {
+  if (!in_array($variables['view_mode'], ['statistic', 'hero']) || !$group->getMember($account)) {
     unset($variables['content']['flag_mute_group_notifications']);
   }
   // Set joined to true for teaser when current logged in


### PR DESCRIPTION
## Problem
When a LU goes to the stream page of a  group he sees the Mute/Unmute link

## Solution


## Issue tracker
https://www.drupal.org/project/social/issues/3244899
https://getopensocial.atlassian.net/browse/YANG-6464

## How to test
- [x] Go to any group
- [x] Join to it
- [x] Go to the stream page
- [x] You should not see the Mute/Unmute link over the stream

## Screenshots
![зображення](https://user-images.githubusercontent.com/11648677/138105493-c2f41ac7-35ea-4735-9b61-461762b0d2c3.png)

## Release notes
N/A

## Change Record
N/A

## Translations
N/A
