### PR TITLE
Issue #3245155 by tbsiqueira: Remove dependency to deprecated core/jquery.ui.accordion library at Field Group module

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -97,7 +97,8 @@
                 "Fix display mode issue": "https://www.drupal.org/files/issues/2021-03-19/ajax_comments-ajax_not_working_when_using_non_default_view_mode-2896916-beta3.patch"
             },
             "drupal/field_group": {
-                "Undefined property: stdClass::$region in field_group_form_process().": "https://www.drupal.org/files/issues/2020-06-15/3059614-37.patch"
+                "Undefined property: stdClass::$region in field_group_form_process().": "https://www.drupal.org/files/issues/2020-06-15/3059614-37.patch",
+                "Remove dependency on jQuery UI Accordion for the accordion field group formatter": "https://www.drupal.org/files/issues/2021-10-16/3154304-2.patch"
             },
             "drupal/views_bulk_operations": {
                 "Make sure select all gets fired for socialbase theme": "https://www.drupal.org/files/issues/2019-09-19/3042494-trigger-vbo-action-on-jquery-checkbox-change-5.patch"
@@ -145,6 +146,7 @@
         "drupal/group": "1.0-rc5",
         "drupal/image_effects": "3.1",
         "drupal/image_widget_crop": "2.3.0",
+        "drupal/jquery_ui_accordion": "1.1",
         "drupal/lazy": "3.10",
         "drupal/like_and_dislike": "1.0-beta2",
         "drupal/message": "1.2",

--- a/modules/social_features/social_core/social_core.install
+++ b/modules/social_features/social_core/social_core.install
@@ -1488,3 +1488,15 @@ function social_core_update_11002(): void {
   );
   user_role_grant_permissions(RoleInterface::AUTHENTICATED_ID, $permissions);
 }
+
+/**
+ * Install jQuery UI Accordion module.
+ */
+function social_core_update_11003(): void {
+  // Check if jquery_ui_accordion module exists.
+  if (\Drupal::service('extension.list.module')
+    ->getName('jquery_ui_accordion')) {
+    \Drupal::service('module_installer')
+      ->install(['jquery_ui_accordion'], TRUE);
+  }
+}


### PR DESCRIPTION
## Problem
Field Group module required a deprecated library "core/jquery.ui.accordion" as part of https://www.drupal.org/project/field_group/issues/3154304

## Solution
Remove the library dependency form the Field Group Module.
Add the new module https://www.drupal.org/project/jquery_ui_accordion

## Issue tracker
https://www.drupal.org/project/social/issues/3245155

## How to test
- [ ] Edit any form, and use the accordion as field group formatter.

## Screenshots
N/A

## Release notes
Ensure accordions for fieldgroups still work

## Change Record
N/A

## Translations
N/A