### PR TITLE
Issue #3245748 by tBKoT: Update condition for a comments on content without group

### DIFF
--- a/modules/custom/activity_basics/src/Plugin/ActivityContext/GroupActivityContext.php
+++ b/modules/custom/activity_basics/src/Plugin/ActivityContext/GroupActivityContext.php
@@ -104,7 +104,12 @@ class GroupActivityContext extends ActivityContextBase {
   public function isValidEntity(EntityInterface $entity) {
     // Special cases for comments.
     if ($entity->getEntityTypeId() === 'comment') {
-      return (bool) $entity->getCommentedEntity();
+      /** @var \Drupal\comment\CommentInterface $comment */
+      $comment = $entity;
+      $entity = $comment->getCommentedEntity();
+      if (!($entity instanceof EntityInterface)) {
+        return FALSE;
+      }
     }
 
     if ($entity->getEntityTypeId() === 'group_content') {
@@ -112,7 +117,9 @@ class GroupActivityContext extends ActivityContextBase {
     }
 
     if ($entity->getEntityTypeId() === 'post') {
-      if ($entity->hasField('field_recipient_group') && !$entity->get('field_recipient_group')->isEmpty()) {
+      /** @var \Drupal\social_post\Entity\PostInterface $post */
+      $post = $entity;
+      if ($post->hasField('field_recipient_group') && !$post->get('field_recipient_group')->isEmpty()) {
         return TRUE;
       }
     }


### PR DESCRIPTION
## Problem
When someone comments on content that is not in the group we receive activity with a message that contains a not converted token of the group title because the group does not exist for this message.

## Solution
Update conditions for comments in the `isValidEntity` method in the "GroupActivityContext" to make sure it returns true only if the commented content has a group.

## Issue tracker
https://www.drupal.org/project/social/issues/3245748
https://getopensocial.atlassian.net/browse/YANG-6491

## How to test
- [ ] Create content without group
- [ ] Add comment to it as another user
- [ ] Run cron
- [ ] Check activity stream

## Screenshots
![зображення](https://user-images.githubusercontent.com/11648677/138708516-d54864ad-6133-47ca-b665-26b1034c8c80.png)

## Release notes
N/A

## Change Record
N/A

## Translations
N/A
