### PR TITLE
Issue #3245780 by tBKoT: Check if term to follow still exist in the system

### DIFF
--- a/modules/social_features/social_follow_taxonomy/modules/social_follow_landing_page/social_follow_landing_page.module
+++ b/modules/social_features/social_follow_taxonomy/modules/social_follow_landing_page/social_follow_landing_page.module
@@ -55,8 +55,9 @@ function social_follow_landing_page_preprocess_paragraph(&$variables) {
             /** @var \Drupal\Core\Field\EntityReferenceFieldItemListInterface $parent_field */
             $parent_field = $term->get('parent');
             if (!$parent_field->isEmpty()) {
+              $parents = $parent_field->referencedEntities();
               /** @var \Drupal\taxonomy\TermInterface $parent */
-              $parent = $parent_field->referencedEntities();
+              $parent = reset($parents);
               $category = $parent->getName();
               // Use the name of parent term as id of the filter parameter.
               $parameter = social_tagging_to_machine_name($category);


### PR DESCRIPTION
## Problem
There is an error when we add follow tag block and delete the added tag from the system
`Error: Call to a member function id() on null in social_follow_landing_page_preprocess_paragraph() (line 82 of /app/html/profiles/contrib/social/modules/social_features/social_follow_taxonomy/modules/social_follow_landing_page/social_follow_landing_page.module)`

## Solution
Add some checks if this term still exists in the system before we can get the ID.

## Issue tracker
https://www.drupal.org/project/social/issues/3245780
https://getopensocial.atlassian.net/browse/YANG-6499

## How to test
- [ ] Create the Landing page
- [ ] Add the `Tag` section with some tag
- [ ] Delete this tag from the system

## Screenshots
N/A

## Release notes
There was an error when we add follow tag block and delete the added tag from the system.
We add some checks if this term still exists in the system before we can get the ID.

## Change Record
N/A

## Translations
N/A
