### PR TITLE
Issue #3246384 by vnech: Move unapplied code from Album config override

### DIFF
--- a/modules/social_features/social_post/modules/social_post_album/social_post_album.module
+++ b/modules/social_features/social_post/modules/social_post_album/social_post_album.module
@@ -6,6 +6,7 @@
  */
 
 use Drupal\Component\Serialization\Json;
+use Drupal\Core\Entity\Display\EntityFormDisplayInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Url;
 use Drupal\social_post\Entity\PostInterface;
@@ -206,6 +207,23 @@ function social_post_album_comment_redirect($form, FormStateInterface $form_stat
       $post = $comment->getCommentedEntity();
 
       $form_state->setRedirect('entity.post.canonical', ['post' => $post->id()], ['fragment' => 'comment-' . $comment->id()]);
+    }
+  }
+}
+
+/**
+ * Implements hook_entity_form_display_alter().
+ */
+function social_post_album_entity_form_display_alter(EntityFormDisplayInterface $form_display, array $context): void {
+  if ($context['entity_type'] === 'post'
+    && $context['bundle'] === 'photo'
+    && $form_display->getMode() === 'default') {
+    // We want to change the image style for the post view page.
+    if (\Drupal::routeMatch()->getRouteName() === 'entity.post.canonical') {
+      if ($component = (array) $form_display->getComponent('field_post_image')) {
+        $component['settings']['image_style'] = 'social_x_large';
+        $form_display->setComponent('field_post_image', $component);
+      }
     }
   }
 }

--- a/modules/social_features/social_post/modules/social_post_album/social_post_album.module
+++ b/modules/social_features/social_post/modules/social_post_album/social_post_album.module
@@ -6,7 +6,7 @@
  */
 
 use Drupal\Component\Serialization\Json;
-use Drupal\Core\Entity\Display\EntityFormDisplayInterface;
+use Drupal\Core\Entity\Display\EntityViewDisplayInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Url;
 use Drupal\social_post\Entity\PostInterface;
@@ -212,17 +212,17 @@ function social_post_album_comment_redirect($form, FormStateInterface $form_stat
 }
 
 /**
- * Implements hook_entity_form_display_alter().
+ * Implements hook_entity_view_display_alter().
  */
-function social_post_album_entity_form_display_alter(EntityFormDisplayInterface $form_display, array $context): void {
+function social_post_album_entity_view_display_alter(EntityViewDisplayInterface $display, array $context): void {
   if ($context['entity_type'] === 'post'
     && $context['bundle'] === 'photo'
-    && $form_display->getMode() === 'default') {
+    && $display->getMode() === 'default') {
     // We want to change the image style for the post view page.
     if (\Drupal::routeMatch()->getRouteName() === 'entity.post.canonical') {
-      if ($component = (array) $form_display->getComponent('field_post_image')) {
+      if ($component = (array) $display->getComponent('field_post_image')) {
         $component['settings']['image_style'] = 'social_x_large';
-        $form_display->setComponent('field_post_image', $component);
+        $display->setComponent('field_post_image', $component);
       }
     }
   }

--- a/modules/social_features/social_post/modules/social_post_album/social_post_album.services.yml
+++ b/modules/social_features/social_post/modules/social_post_album/social_post_album.services.yml
@@ -14,7 +14,6 @@ services:
 
   social_post_album.override:
     class: Drupal\social_post_album\SocialPostPhotoAlbumConfigOverride
-    arguments: ['@current_route_match']
     tags:
       - { name: config.factory.override, priority: 5 }
 

--- a/modules/social_features/social_post/modules/social_post_album/src/SocialPostPhotoAlbumConfigOverride.php
+++ b/modules/social_features/social_post/modules/social_post_album/src/SocialPostPhotoAlbumConfigOverride.php
@@ -5,7 +5,6 @@ namespace Drupal\social_post_album;
 use Drupal\Core\Cache\CacheableMetadata;
 use Drupal\Core\Config\ConfigFactoryOverrideInterface;
 use Drupal\Core\Config\StorageInterface;
-use Drupal\Core\Routing\RouteMatchInterface;
 
 /**
  * Provides an overridden elements.
@@ -13,23 +12,6 @@ use Drupal\Core\Routing\RouteMatchInterface;
  * @package Drupal\social_post_album
  */
 class SocialPostPhotoAlbumConfigOverride implements ConfigFactoryOverrideInterface {
-
-  /**
-   * The route match.
-   *
-   * @var \Drupal\Core\Routing\RouteMatchInterface
-   */
-  protected $routeMatch;
-
-  /**
-   * Constructs the configuration override.
-   *
-   * @param \Drupal\Core\Routing\RouteMatchInterface $route_match
-   *   The current route match.
-   */
-  public function __construct(RouteMatchInterface $route_match) {
-    $this->routeMatch = $route_match;
-  }
 
   /**
    * Field widget or formatter type per configuration.
@@ -56,15 +38,6 @@ class SocialPostPhotoAlbumConfigOverride implements ConfigFactoryOverrideInterfa
 
     if (in_array($config_name, $names)) {
       $overrides[$config_name]['content']['field_post_image']['settings']['preview_image_style'] = 'social_x_large';
-    }
-
-    // We want to change the image style for the post view page.
-    if ($this->routeMatch->getRouteName() === 'entity.post.canonical') {
-      $config_name = 'core.entity_view_display.post.photo.default';
-
-      if (in_array($config_name, $names)) {
-        $overrides[$config_name]['content']['field_post_image']['settings']['image_style'] = 'social_x_large';
-      }
     }
 
     return $overrides;


### PR DESCRIPTION
## Problem
In the config overrides exists code that never applied:
- `modules/social_features/social_post/modules/social_post_album/src/SocialPostPhotoAlbumConfigOverride.php`

Also,  during updating OS to 10.3 a run time error is rising (see screenshot).

## Solution
- Move unapplied code from config overrides to appropriate hooks etc.

## Issue tracker
- https://www.drupal.org/project/social/issues/3246384

## How to test
- [x] Login as SM
- [x] Create "photo" post
- [x] Go to canonical post page
- [ ] Make sure the images in post using `social_x_large` image style

## Screenshots
![image](https://user-images.githubusercontent.com/19921926/139246368-c6938cd6-00f9-4e2f-af4b-b5edf1544bd9.png)

## Release notes
*Move unapplied code from config overrides to appropriate hooks etc.*

## Change Record
N/A

## Translations
N/A
