### PR TITLE
Issue #3246398 by tbsiqueira: Social Tag Settings not working on a new installation

### DIFF
--- a/modules/social_features/social_tagging/config/install/social_tagging.settings.yml
+++ b/modules/social_features/social_tagging/config/install/social_tagging.settings.yml
@@ -2,4 +2,8 @@ enable_content_tagging: true
 allow_category_split: true
 use_category_parent: true
 use_and_condition: false
+tag_node_type_book: true
+tag_node_type_event: true
 tag_node_type_landing_page: false
+tag_node_type_page: true
+tag_node_type_topic: true

--- a/modules/social_features/social_tagging/config/install/social_tagging.settings.yml
+++ b/modules/social_features/social_tagging/config/install/social_tagging.settings.yml
@@ -2,7 +2,7 @@ enable_content_tagging: true
 allow_category_split: true
 use_category_parent: true
 use_and_condition: false
-tag_node_type_book: true
+tag_node_type_book: false
 tag_node_type_event: true
 tag_node_type_landing_page: false
 tag_node_type_page: true

--- a/modules/social_features/social_tagging/config/schema/social_tagging.schema.yml
+++ b/modules/social_features/social_tagging/config/schema/social_tagging.schema.yml
@@ -11,6 +11,18 @@ social_tagging.settings:
     use_category_parent:
       type: boolean
       label: 'Determine if the parent of categories will be used with children tags.'
+    tag_node_type_book:
+      type: boolean
+      label: 'Determines whether the book node type has tagging enabled.'
+    tag_node_type_event:
+      type: boolean
+      label: 'Determines whether the event node type has tagging enabled.'
     tag_node_type_landing_page:
       type: boolean
       label: 'Determines whether the landing page node type has tagging enabled.'
+    tag_node_type_page:
+      type: boolean
+      label: 'Determines whether the page node type has tagging enabled.'
+    tag_node_type_topic:
+      type: boolean
+      label: 'Determines whether the topic node type has tagging enabled.'

--- a/modules/social_features/social_tagging/social_tagging.install
+++ b/modules/social_features/social_tagging/social_tagging.install
@@ -121,3 +121,22 @@ function social_tagging_update_8004() {
     \Drupal::logger('social_tagging')->info($e->getMessage());
   }
 }
+
+/**
+ * Create, if not set, default settings to enable tagging on content.
+ */
+function social_tagging_update_11001(): void {
+  // Get the editable social tagging configuration.
+  $tag_settings = \Drupal::getContainer()->get('config.factory')->getEditable('social_tagging.settings');
+
+  // Get the multiple types of nodes.
+  /** @var \Drupal\node\NodeTypeInterface[] $node_types */
+  $node_types = \Drupal::service('entity_type.manager')->getStorage('node_type')->loadMultiple();
+  foreach ($node_types as $node_type) {
+    $config_name = 'tag_node_type_' . $node_type->id();
+    // Foreach node type, check if there isn't a configuration in place.
+    if ($tag_settings->get($config_name) === NULL) {
+      $tag_settings->set($config_name, TRUE)->save();
+    }
+  }
+}

--- a/modules/social_features/social_tagging/social_tagging.install
+++ b/modules/social_features/social_tagging/social_tagging.install
@@ -121,22 +121,3 @@ function social_tagging_update_8004() {
     \Drupal::logger('social_tagging')->info($e->getMessage());
   }
 }
-
-/**
- * Create, if not set, default settings to enable tagging on content.
- */
-function social_tagging_update_11001(): void {
-  // Get the editable social tagging configuration.
-  $tag_settings = \Drupal::getContainer()->get('config.factory')->getEditable('social_tagging.settings');
-
-  // Get the multiple types of nodes.
-  /** @var \Drupal\node\NodeTypeInterface[] $node_types */
-  $node_types = \Drupal::service('entity_type.manager')->getStorage('node_type')->loadMultiple();
-  foreach ($node_types as $node_type) {
-    $config_name = 'tag_node_type_' . $node_type->id();
-    // Foreach node type, check if there isn't a configuration in place.
-    if ($tag_settings->get($config_name) === NULL) {
-      $tag_settings->set($config_name, TRUE)->save();
-    }
-  }
-}


### PR DESCRIPTION
Initially the content types didn't have a default settings, this caused an issue where on a clean installation, users would need to re-save the social tagging in order to work. Also added a hook update to enable it by default on all already installed content types, since this is the expected behaviour

## Problem
On a clean installation, user should be able to create and add tags to the following content types as a default behaviour:

- Book page
- Event
- Basic page
- Topic

## Solution
- Enable tags by default for the following content types: Book page, event, basic page, topic
- Add a hook update to social_tag to enable tags on all installed content types as default true

## Issue tracker
https://www.drupal.org/project/social/issues/3246398

## How to test
- [ ] Fresh install Open Social
- [ ] Go to "admin/structure/taxonomy/manage/social_tagging/overview" and add a couple of tags with a parent a child
- [ ] Go to "/node/add/event" and look for the field set "Tags"
- [ ] You should see the option to add tags

## Screenshots
N/A

## Release notes
N/A

## Change Record
N/A

## Translations
N/A