### PR TITLE
Issue #3246407 by tBKoT: Check if parent term exist on the Follow Tag on the Landing Page

### DIFF
--- a/modules/social_features/social_follow_taxonomy/modules/social_follow_landing_page/social_follow_landing_page.module
+++ b/modules/social_features/social_follow_taxonomy/modules/social_follow_landing_page/social_follow_landing_page.module
@@ -54,8 +54,8 @@ function social_follow_landing_page_preprocess_paragraph(&$variables) {
           if ($tag_service->allowSplit()) {
             /** @var \Drupal\Core\Field\EntityReferenceFieldItemListInterface $parent_field */
             $parent_field = $term->get('parent');
-            if (!$parent_field->isEmpty()) {
-              $parents = $parent_field->referencedEntities();
+            $parents = $parent_field->referencedEntities();
+            if (!empty($parents)) {
               /** @var \Drupal\taxonomy\TermInterface $parent */
               $parent = reset($parents);
               $category = $parent->getName();


### PR DESCRIPTION
## Problem
In this [PR](https://github.com/goalgorilla/open_social/pull/2566) I've missed one critical thing. If we add parent term to the following block on the Landing page then we get an error:
`Error: Call to a member function getName() on bool in social_follow_landing_page_preprocess_paragraph() (line 61 of profiles/contrib/social/modules/social_features/social_follow_taxonomy/modules/ social_follow_landing_page/social_follow_landing_page.module)`

## Solution
As even first level tags have a parent with a "0" id we need to check if the term does not have any "real" parent terms.

## Issue tracker
https://www.drupal.org/project/social/issues/3246407
https://getopensocial.atlassian.net/browse/YANG-6521

## How to test
- [x] Make sure that the "Allow category split." option is enabled
- [x] Create/edit Landing Page
- [x] Add tag section with first level tag
- [x] Save Landing Page

## Screenshots
N/A

## Release notes
N/A

## Change Record
N/A

## Translations
N/A
