### PR TITLE
[Don't merge] Socialbase backwards compatibility check

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -109,6 +109,9 @@
             "drupal/dynamic_entity_reference": {
                 "Errors when new entity types are added (in certain cases)": "https://www.drupal.org/files/issues/2020-05-31/3099176-9.patch",
                 "Return the same content list after content type is changed": "https://www.drupal.org/files/issues/2021-08-27/dynamic_entity_reference-the_same_content_list-3230158-2.patch"
+            },
+            "drupal/socialbase": {
+                "Test profile updates": "https://www.drupal.org/files/issues/2021-10-29/socialbase-3246580-2-profile-theme-updates.patch"
             }
         }
     },


### PR DESCRIPTION
Checks whether the changes in profile are compatible with 11.0.0 or whether they must wait for 12.0.0