### PR TITLE
Issue #3247222 by ribel: Fix fatal error in activity tokens when related object doesn't exist

### DIFF
--- a/modules/custom/activity_logger/activity_logger.tokens.inc
+++ b/modules/custom/activity_logger/activity_logger.tokens.inc
@@ -82,7 +82,7 @@ function activity_logger_tokens($type, $tokens, array $data, array $options, Bub
         case 'recipient-user-url':
         case 'pmt-url':
 
-          if (!empty($message->get('field_message_related_object'))) {
+        if ($message->hasField('field_message_related_object') && !empty($message->get('field_message_related_object'))) {
             $target_type = $message->getFieldValue('field_message_related_object', 'target_type');
             $target_id = $message->getFieldValue('field_message_related_object', 'target_id');
             $entity = \Drupal::entityTypeManager()

--- a/modules/custom/activity_logger/activity_logger.tokens.inc
+++ b/modules/custom/activity_logger/activity_logger.tokens.inc
@@ -82,7 +82,7 @@ function activity_logger_tokens($type, $tokens, array $data, array $options, Bub
         case 'recipient-user-url':
         case 'pmt-url':
 
-        if ($message->hasField('field_message_related_object') && !empty($message->get('field_message_related_object'))) {
+          if ($message->hasField('field_message_related_object') && !empty($message->get('field_message_related_object'))) {
             $target_type = $message->getFieldValue('field_message_related_object', 'target_type');
             $target_id = $message->getFieldValue('field_message_related_object', 'target_id');
             $entity = \Drupal::entityTypeManager()

--- a/modules/social_features/social_activity/social_activity.tokens.inc
+++ b/modules/social_features/social_activity/social_activity.tokens.inc
@@ -52,7 +52,7 @@ function social_activity_tokens($type, $tokens, array $data, array $options, Bub
   if ($type === 'message' && !empty($data['message'])) {
     /** @var \Drupal\message\Entity\Message $message */
     $message = $data['message'];
-    if (!empty($message->get('field_message_related_object'))) {
+    if ($message->hasField('field_message_related_object') && !empty($message->get('field_message_related_object'))) {
       /** @var \Drupal\social_activity\EmailTokenServices $email_token_services */
       $email_token_services = \Drupal::service('social_activity.email_token_services');
 


### PR DESCRIPTION
## Problem
After the Open Social update to 10.3, we noticed fatal errors on activity streams. They were related to missing `field_message_related_object` during token generations.

## Solution
Add additional check if $messaage actually has related object field:
```
$message->hasField('field_message_related_object') && !empty($message->get('field_message_related_object')
```

## Issue tracker
https://www.drupal.org/project/social/issues/3247222

## How to test
*For example*
- [x] Update site with existing activities from 10.2.x to 10.3.x
- [x] Go to activity streams or `admin/content/message`
- [ ] You see fatal errors
- [ ] Apply this patch
- [ ] You should not see fatal errors


## Release notes
Add additional check if $messaage actually has related object field t prevent fatal errors during activity tokens genrations.

## Change Record
No 

## Translations
No
