### PR TITLE
Issue #3247237 by rolki: Custom content list block not working with Mysql 5.7 and ONLY_FULL_GROUP_BY

### DIFF
--- a/modules/social_features/social_content_block/src/ContentBuilder.php
+++ b/modules/social_features/social_content_block/src/ContentBuilder.php
@@ -634,8 +634,14 @@ class ContentBuilder implements ContentBuilderInterface, TrustedCallbackInterfac
       }
     }
 
-    if ($base_field) {
-      $query->groupBy($base_field);
+    $fields = $query->getFields();
+
+    foreach ($fields as $key => $field) {
+      $query->groupBy($key);
+    }
+
+    if (in_array($sort_by, ['created', 'changed'])) {
+      $query->groupBy($sorting_field);
     }
 
     $query->orderBy($sorting_field, $direction);


### PR DESCRIPTION
## Problem
When uses MySQL ^5.7 with ONLY_FULL_GROUP_BY sql_mode, then custom content list block does not fetch any element.

**Error message:**
`Drupal\Core\Database\DatabaseExceptionWrapper: SQLSTATE[42000]: Syntax error or access violation: 1055 Expression #1 of ORDER BY clause is not in GROUP BY clause and contains nonaggregated column 'opensocial.base_table.changed' which is not functionally dependent on columns in GROUP BY clause; this is incompatible with sql_mode=only_full_group_by: SELECT base_table.nid AS nid FROM {node_field_data} base_table WHERE base_table.type = :db_condition_placeholder_0 GROUP BY base_table.nid ORDER BY base_table.changed DESC LIMIT 5 OFFSET 0; Array ( [:db_condition_placeholder_0] => topic ) in Drupal\social_content_block\ContentBuilder->getEntities() (line 201 of /Users/rsalo/projects/e4c/web/profiles/contrib/social/modules/social_features/social_content_block/src/ContentBuilder.php).
`
## Solution
All selected fields should be `groupBy.`

There is a system variable "`ONLY_FULL_GROUP_BY`" in MySql engine.
From Mysql Version 5.7.5 : `ONLY_FULL_GROUP_BY` SQL mode is enabled by default

Before Version 5.7.5 : `ONLY_FULL_GROUP_BY` was not enabled by default.

If the ONLY_FULL_GROUP_BY SQL mode is enabled (which it is by default from version 5.7.5), MySQL rejects queries for which the select list, HAVING condition, or ORDER BY list refer to non-aggregated columns that are neither named in the GROUP BY clause nor are functionally dependent on them.

E.G. See https://stackoverflow.com/questions/41887460/select-list-is-not-in-group-by-clause-and-contains-nonaggregated-column-inc/41887524

## Issue tracker
- https://www.drupal.org/project/social/issues/3247237
- https://getopensocial.atlassian.net/browse/YANG-6544

## How to test
- [ ] Create a `Custom content list block`
- [ ] Place that block somewhere (dashboard, landing page, just block)
- [ ] And you will see empty results

## Screenshots
No.

## Release notes
Add `GroupBy` to all selected fields in the `Custom Content List Block` and it will fix the SQL Syntax error when enabling `ONLY_FULL_GROUP_BY` in MySQL.

## Change Record
No.

## Translations
No.
