### PR TITLE
Issue #3247272 by rolki: It is not possible to get heroImage URL via GraphQL for any type

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,8 @@
                 "Empty language (langcode) field wrapper inserted into contact form": "https://www.drupal.org/files/issues/2020-03-06/empty-langcode-field-wrapper-2842405-17.patch",
                 "Broken title in modal dialog when title is a render array": "https://www.drupal.org/files/issues/2019-10-21/2663316-76.drupal.Broken-title-in-modal-dialog-when-title-is-a-render-array.patch",
                 "PHPDocs with wrong parameters": "https://www.drupal.org/files/issues/2019-09-03/queryinterface-range-updated-phpdocs.patch",
-                "Post update hook naming convention patch": "https://git.drupalcode.org/project/drupal/-/merge_requests/1215.patch"
+                "Post update hook naming convention patch": "https://git.drupalcode.org/project/drupal/-/merge_requests/1215.patch",
+                "Exception in EarlyRenderingControllerWrapperSubscriber is a DX nightmare, remove it": "https://www.drupal.org/files/issues/2020-09-10/2638686-43.patch"
             },
             "drupal/coder": {
                 "Allow class property types instead of @var comments": "https://www.drupal.org/files/issues/2021-09-21/coder-3123282-3.patch"


### PR DESCRIPTION
## Problem
When I'm trying to get heroImage url for topics or events I have got an error, see:
`LogicException: The controller result claims to be providing relevant cache metadata, but leaked metadata was detected. Please ensure you are not rendering content too early. Returned object class: Drupal\Core\Cache\CacheableJsonResponse. in Drupal\Core\EventSubscriber\EarlyRenderingControllerWrapperSubscriber->wrapControllerExecutionInRenderContext() (line 154 of /app/html/core/lib/Drupal/Core/EventSubscriber/EarlyRenderingControllerWrapperSubscriber.php)
`
## Solution
Apply Drupal core patch if needed or investigate problem.

## Issue tracker
https://www.drupal.org/project/social/issues/3247272

## How to test
Just run the query to get topics and heroImage URL for that topic, E.G.:
```
query {
  
  topics(first: 5) {
    nodes {
      title
      heroImage {
        url
      }
    }
  }

}

```

## Screenshots
![image (2)](https://user-images.githubusercontent.com/50984627/139879358-e2623d65-888c-42ab-a71c-9fc91a28b5b9.png)
<img width="1608" alt="Screenshot 2021-10-04 at 11 45 35" src="https://user-images.githubusercontent.com/50984627/139879370-3c645a06-9151-413f-b50c-860aef6a45ca.png">
![image](https://user-images.githubusercontent.com/50984627/139879378-f1f407d8-ab37-49f8-98c1-f1c4b0a952ab.png)

## Release notes
It will be possible to get `heroImage` URL via `GraphQL` query.

## Change Record
No.

## Translations
No.
