### PR TITLE
Issue #3247624 by nkoporec: Alternative frontpage is redirecting to AN page for user 1

### DIFF
--- a/modules/custom/alternative_frontpage/src/EventSubscriber/RedirectHomepageSubscriber.php
+++ b/modules/custom/alternative_frontpage/src/EventSubscriber/RedirectHomepageSubscriber.php
@@ -152,7 +152,7 @@ class RedirectHomepageSubscriber implements EventSubscriberInterface {
 
         // Always redirect if on root.
         if ($request_path == '/') {
-          $this->createRedirectResponse(['user.roles:anonymous'], $frontpage_lu)
+          $this->createRedirectResponse(['user.roles:anonymous'], $frontpage_lu);
           return;
         }
 

--- a/modules/custom/alternative_frontpage/src/EventSubscriber/RedirectHomepageSubscriber.php
+++ b/modules/custom/alternative_frontpage/src/EventSubscriber/RedirectHomepageSubscriber.php
@@ -150,10 +150,16 @@ class RedirectHomepageSubscriber implements EventSubscriberInterface {
           return;
         }
 
-        // Don't redirect site managers,content managers so they
-        // can preview the anonymous page.
+        // Always redirect if on root.
+        if ($request_path == '/') {
+          $this->createRedirectResponse(['user.roles:anonymous'], $frontpage_lu)
+          return;
+        }
+
+        // Don't redirect site managers,content managers when they are on
+        // an page so they can preview the page.
         $roles = ['sitemanager', 'contentmananger'];
-        if ($this->currentUser->id() == "1" || array_intersect($roles, $this->currentUser->getRoles()) && $request_path == $frontpage_an) {
+        if (($this->currentUser->id() == "1" || array_intersect($roles, $this->currentUser->getRoles())) && $request_path == $frontpage_an) {
           $this->messenger->addWarning($this->t(
             "This page is redirected to @url_link, but we deferred the redirect to give you an opportunity to edit the content.",
             [
@@ -174,10 +180,9 @@ class RedirectHomepageSubscriber implements EventSubscriberInterface {
           return;
         }
 
-        $cacheContext = ['user.roles:anonymous'];
         /** @var string $frontpage_lu */
         $event->setResponse(
-          $this->createRedirectResponse($cacheContext, $frontpage_lu)
+          $this->createRedirectResponse(['user.roles:anonymous'], $frontpage_lu)
         );
       }
     }

--- a/modules/custom/alternative_frontpage/src/EventSubscriber/RedirectHomepageSubscriber.php
+++ b/modules/custom/alternative_frontpage/src/EventSubscriber/RedirectHomepageSubscriber.php
@@ -150,17 +150,10 @@ class RedirectHomepageSubscriber implements EventSubscriberInterface {
           return;
         }
 
-        // Always redirect if on root.
-        if ($request_path == '/') {
-          /** @var string $frontpage_lu */
-          $this->createRedirectResponse(['user.roles:anonymous'], $frontpage_lu);
-          return;
-        }
-
         // Don't redirect site managers,content managers when they are on
         // an page so they can preview the page.
         $roles = ['sitemanager', 'contentmananger'];
-        if (($this->currentUser->id() == "1" || array_intersect($roles, $this->currentUser->getRoles())) && $request_path == $frontpage_an) {
+        if (($this->currentUser->id() == "1" || array_intersect($roles, $this->currentUser->getRoles())) && $request_path != '/' && $request_path == $frontpage_an) {
           $this->messenger->addWarning($this->t(
             "This page is redirected to @url_link, but we deferred the redirect to give you an opportunity to edit the content.",
             [

--- a/modules/custom/alternative_frontpage/src/EventSubscriber/RedirectHomepageSubscriber.php
+++ b/modules/custom/alternative_frontpage/src/EventSubscriber/RedirectHomepageSubscriber.php
@@ -152,6 +152,7 @@ class RedirectHomepageSubscriber implements EventSubscriberInterface {
 
         // Always redirect if on root.
         if ($request_path == '/') {
+          /** @var string $frontpage_lu */
           $this->createRedirectResponse(['user.roles:anonymous'], $frontpage_lu);
           return;
         }


### PR DESCRIPTION
## Problem

In https://www.drupal.org/project/social/issues/3214317 , we introduced the ability to preview the anonymous page but introduced a small bug, when user 1 visits the root domain (eq. https://my-site.local/) it will not redirect him to the LU page defined in the settings but instead it will defer the redirect and show the AN page.

## Solution

We should not defer the redirect if the url request is / .

## Issue tracker

https://www.drupal.org/project/social/issues/3247624

## How to test
1. Enable alternative_frontpage module
2. Set two different frontpages for AN and LU users
3. Visit the root url (apex domain) as admin (user 1)

## Screenshots

## Release notes
Fixed an issue with alternative frontpage module and the redirect defer when the administrator visits the root domain.

## Change Record

## Translations
