### PR TITLE
Issue #3247843 by nkoporec: Don't override the group types on search view if the filter is not active

### DIFF
--- a/modules/social_features/social_search/social_search.module
+++ b/modules/social_features/social_search/social_search.module
@@ -68,6 +68,10 @@ function social_search_alter_users_exposed_filter_block(&$form, FormStateInterfa
  * Makes changes for the filter block on the groups search page.
  */
 function social_search_alter_groups_exposed_filter_block(&$form, FormStateInterface $form_state, $form_id) {
+  if (!isset($form['type'])) {
+    return;
+  }
+
   $options = [
     'All' => t('- Any -'),
   ];


### PR DESCRIPTION
## Problem
When on /search/group page, the type filter will always display even if you go to the view settings and remove the filter. The reason for this is because we are programetically overriding it. This is a problem if you want to remove this filter, currently it is not possible and you can only do it via code.


## Solution
We need to check if the the form for this filter includes the 'type' element, if not then we should not override it.


## Issue tracker
https://www.drupal.org/project/social/issues/3247843

## How to test
1. Go to admin/structure/views/view/search_groups
2. Remove the 'Group datasource: Type (exposed)' filter and save it
3. Go to search/groups and see that the filter is still showing

## Screenshots
The type filter was removed from the view:
![2021-11-05_10-36](https://user-images.githubusercontent.com/35064680/140490321-d77fa0ce-ee49-443c-9928-3e77feadc785.png)


## Release notes
*A short summary of the changes that were made that can be included in release notes.*

## Change Record
*If this Pull Request changes the way that developers should do things or introduces a new API for developers then a change record to document this is needed. Please provide a draft for a change record or a link to an unpublished change record below. [Existing change records](https://www.drupal.org/list-changes/social) can be consulted as example.*

## Translations
*Translatable strings are always extracted from the latest development branch. To ensure translations remain available for platforms running older versions of Open Social the original string should be added to `translations.php` when it's changed or removed.*
- [ ] Changed or removed source strings are added to the `translations.php` file.
