### PR TITLE
Issue #3247742 by tBKoT: Disallow to use unpublished content tags

### DIFF
--- a/modules/social_features/social_tagging/social_tagging.module
+++ b/modules/social_features/social_tagging/social_tagging.module
@@ -8,6 +8,7 @@
 use Drupal\Core\Entity\Display\EntityFormDisplayInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityTypeInterface;
+use Drupal\Core\Entity\FieldableEntityInterface;
 use Drupal\Core\Field\BaseFieldDefinition;
 use Drupal\Core\Field\FieldStorageDefinitionInterface;
 use Drupal\Core\Form\FormStateInterface;
@@ -384,14 +385,14 @@ function social_tagging_entity_delete(EntityInterface $entity) {
 /**
  * Build output on node view.
  *
- * @param \Drupal\Core\Entity\EntityInterface $entity
+ * @param \Drupal\Core\Entity\FieldableEntityInterface $entity
  *   A node.
  *
  * @return array
  *   Hierarchic presentation of the terms.
  */
-function social_tagging_process_tags(EntityInterface $entity) {
-  if (!($entity instanceof EntityInterface && $entity->hasField('social_tagging'))) {
+function social_tagging_process_tags(FieldableEntityInterface $entity): array {
+  if (!$entity->hasField('social_tagging')) {
     return [];
   }
 
@@ -404,9 +405,13 @@ function social_tagging_process_tags(EntityInterface $entity) {
   $terms = $entity->get('social_tagging')->getValue();
 
   if ($tag_service->allowSplit()) {
+    $taghierarchy = $tag_service->buildHierarchy($terms, $entity->getEntityTypeId());
+    if (empty($taghierarchy)) {
+      return [];
+    }
     $renderable = [
       '#theme' => 'social_tagging_split',
-      '#taghierarchy' => $tag_service->buildHierarchy($terms, $entity->getEntityTypeId()),
+      '#taghierarchy' => $taghierarchy,
     ];
   }
   else {
@@ -424,11 +429,18 @@ function social_tagging_process_tags(EntityInterface $entity) {
         'tag[]' => $term['target_id'],
       ]);
 
-      /** @var Drupal\taxonomy\Entity\Term $term */
-      $taxonomy_term = Term::load($term['target_id']);
-      $tarray[$taxonomy_term->getName()] = $url->toString();
+      /** @var \Drupal\taxonomy\TermInterface $taxonomy_term */
+      $taxonomy_term = \Drupal::entityTypeManager()
+        ->getStorage('taxonomy_term')
+        ->load($term['target_id']);
+      if ($taxonomy_term->isPublished()) {
+        $tarray[$taxonomy_term->getName()] = $url->toString();
+      }
     }
 
+    if (empty($tarray)) {
+      return [];
+    }
     $renderable = [
       '#theme' => 'social_tagging_nosplit',
       '#tagstitle' => t('Tags'),
@@ -438,7 +450,7 @@ function social_tagging_process_tags(EntityInterface $entity) {
 
   $renderable['#entity_type'] = $entity->getEntityTypeId();
 
-  return \Drupal::service('renderer')->render($renderable);
+  return $renderable;
 }
 
 /**

--- a/modules/social_features/social_tagging/src/Plugin/Block/SocialGroupTagsBlock.php
+++ b/modules/social_features/social_tagging/src/Plugin/Block/SocialGroupTagsBlock.php
@@ -136,6 +136,8 @@ class SocialGroupTagsBlock extends BlockBase implements ContainerFactoryPluginIn
       $contexts = Cache::mergeContexts($contexts, ['group']);
     }
 
+    $cache_tags[] = 'taxonomy_term_list:social_tagging';
+
     return $contexts;
   }
 
@@ -147,8 +149,14 @@ class SocialGroupTagsBlock extends BlockBase implements ContainerFactoryPluginIn
 
     $group = $this->routeMatch->getParameter('group');
 
+    $content = social_tagging_process_tags($group);
+
+    if (empty($content)) {
+      return [];
+    }
+
     if ($group instanceof GroupInterface) {
-      $build['content']['#markup'] = social_tagging_process_tags($group);
+      $build['content'] = $content;
     }
 
     return $build;

--- a/modules/social_features/social_tagging/src/Plugin/Block/SocialTagsBlock.php
+++ b/modules/social_features/social_tagging/src/Plugin/Block/SocialTagsBlock.php
@@ -118,6 +118,8 @@ class SocialTagsBlock extends BlockBase implements ContainerFactoryPluginInterfa
       $cache_tags[] = 'node:' . $node->id();
     }
 
+    $cache_tags[] = 'taxonomy_term_list:social_tagging';
+
     return $cache_tags;
   }
 
@@ -129,8 +131,14 @@ class SocialTagsBlock extends BlockBase implements ContainerFactoryPluginInterfa
 
     $node = $this->routeMatch->getParameter('node');
 
+    $content = social_tagging_process_tags($node);
+
+    if (empty($content)) {
+      return [];
+    }
+
     if ($node instanceof NodeInterface) {
-      $build['content']['#markup'] = social_tagging_process_tags($node);
+      $build['content'] = $content;
     }
 
     return $build;

--- a/modules/social_features/social_tagging/src/SocialTaggingService.php
+++ b/modules/social_features/social_tagging/src/SocialTaggingService.php
@@ -243,7 +243,10 @@ class SocialTaggingService {
       // Build the hierarchy.
       foreach ($terms as $current_term) {
         // Must be a valid Term.
-        if (!$current_term instanceof TermInterface) {
+        if (
+          !$current_term instanceof TermInterface ||
+          !$current_term->isPublished()
+        ) {
           continue;
         }
         // Get current terms parents.
@@ -296,7 +299,9 @@ class SocialTaggingService {
   private function prepareTermOptions(array $terms) {
     $options = [];
     foreach ($terms as $category) {
-      $options[$category->tid] = $category->name;
+      if ((bool) $category->status) {
+        $options[$category->tid] = $category->name;
+      }
     }
 
     return $options;

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -18861,11 +18861,6 @@ parameters:
 			path: modules/social_features/social_tagging/social_tagging.module
 
 		-
-			message: "#^Function social_tagging_process_tags\\(\\) should return array but returns Drupal\\\\Component\\\\Render\\\\MarkupInterface\\.$#"
-			count: 1
-			path: modules/social_features/social_tagging/social_tagging.module
-
-		-
 			message: "#^Function social_tagging_social_tagging_field_form_alter\\(\\) has no return typehint specified\\.$#"
 			count: 1
 			path: modules/social_features/social_tagging/social_tagging.module


### PR DESCRIPTION
## Problem
It's possible to add unpublished content tags to the content which is not logical.

## Solution
Change the process how we can taxonomy terms for the select options

## Issue tracker
https://www.drupal.org/project/social/issues/3247742
https://getopensocial.atlassian.net/browse/YANG-6546

## How to test
- [x] Create some aren't and child content tags
- [x] Created new content and tagged it with some tags
- [x] Go to Content Tags and un-published tag which we add to the content in the previous step
- [x] Edit content again
- [x] You are still able to add the unpublished tag

## Screenshots
#### When all tags published
![зображення](https://user-images.githubusercontent.com/11648677/140513064-d2e1889d-f8af-480d-9083-a7c498db12f7.png)
#### After unpublishing term
![зображення](https://user-images.githubusercontent.com/11648677/140513453-128bdae5-4ce2-4f93-99db-286b2f3c7c91.png)


## Release notes
Now content creators can not use unpublished Content tags for content tagging.

## Change Record
N/A

## Translations
N/A
