### PR TITLE
Issue #3247896 by tBKoT: Fix errors with activity tokens when the related object does not exist

### DIFF
--- a/modules/custom/activity_creator/activity_creator.tokens.inc
+++ b/modules/custom/activity_creator/activity_creator.tokens.inc
@@ -48,7 +48,7 @@ function activity_creator_tokens($type, $tokens, array $data, array $options, Bu
 
           // Get the targeted user and its display name.
           if ($name === 'field_activity_recipient_user_display_name') {
-            if (!empty($message->get('field_message_related_object'))) {
+            if (!$message->get('field_message_related_object')->isEmpty()) {
               $target_type = $message->getFieldValue('field_message_related_object', 'target_type');
               $target_id = $message->getFieldValue('field_message_related_object', 'target_id');
               $entity = \Drupal::entityTypeManager()

--- a/modules/custom/activity_logger/activity_logger.tokens.inc
+++ b/modules/custom/activity_logger/activity_logger.tokens.inc
@@ -82,7 +82,7 @@ function activity_logger_tokens($type, $tokens, array $data, array $options, Bub
         case 'recipient-user-url':
         case 'pmt-url':
 
-          if ($message->hasField('field_message_related_object') && !empty($message->get('field_message_related_object'))) {
+          if ($message->hasField('field_message_related_object') && !$message->get('field_message_related_object')->isEmpty()) {
             $target_type = $message->getFieldValue('field_message_related_object', 'target_type');
             $target_id = $message->getFieldValue('field_message_related_object', 'target_id');
             $entity = \Drupal::entityTypeManager()

--- a/modules/social_features/social_activity/social_activity.tokens.inc
+++ b/modules/social_features/social_activity/social_activity.tokens.inc
@@ -52,7 +52,7 @@ function social_activity_tokens($type, $tokens, array $data, array $options, Bub
   if ($type === 'message' && !empty($data['message'])) {
     /** @var \Drupal\message\Entity\Message $message */
     $message = $data['message'];
-    if ($message->hasField('field_message_related_object') && !empty($message->get('field_message_related_object'))) {
+    if ($message->hasField('field_message_related_object') && !$message->get('field_message_related_object')->isEmpty()) {
       /** @var \Drupal\social_activity\EmailTokenServices $email_token_services */
       $email_token_services = \Drupal::service('social_activity.email_token_services');
 

--- a/modules/social_features/social_comment/social_comment.tokens.inc
+++ b/modules/social_features/social_comment/social_comment.tokens.inc
@@ -104,7 +104,7 @@ function social_comment_tokens($type, $tokens, array $data, array $options, Bubb
         case 'comment_text':
         case 'comment_reply_link_html':
 
-          if (!empty($message->get('field_message_related_object'))) {
+          if (!$message->get('field_message_related_object')->isEmpty()) {
             $target_type = $message->getFieldValue('field_message_related_object', 'target_type');
             $target_id = $message->getFieldValue('field_message_related_object', 'target_id');
 
@@ -190,7 +190,7 @@ function social_comment_tokens($type, $tokens, array $data, array $options, Bubb
         case 'commented_entity_link':
         case 'commented_entity_link_html':
 
-          if (!empty($message->get('field_message_related_object'))) {
+          if (!$message->get('field_message_related_object')->isEmpty()) {
             $target_type = $message->getFieldValue('field_message_related_object', 'target_type');
             $target_id = $message->getFieldValue('field_message_related_object', 'target_id');
 

--- a/modules/social_features/social_follow_taxonomy/social_follow_taxonomy.tokens.inc
+++ b/modules/social_features/social_follow_taxonomy/social_follow_taxonomy.tokens.inc
@@ -71,7 +71,7 @@ function social_follow_taxonomy_tokens($type, $tokens, array $data, array $optio
           /** @var \Drupal\message\Entity\Message $message */
           $message = $data['message'];
           // Get the related entity.
-          if (!empty($message->get('field_message_related_object'))) {
+          if (!$message->get('field_message_related_object')->isEmpty()) {
             $target_type = $message->getFieldValue('field_message_related_object', 'target_type');
             $target_id = $message->getFieldValue('field_message_related_object', 'target_id');
             $entity = \Drupal::entityTypeManager()

--- a/modules/social_features/social_group/social_group.tokens.inc
+++ b/modules/social_features/social_group/social_group.tokens.inc
@@ -63,7 +63,7 @@ function social_group_tokens($type, $tokens, array $data, array $options, Bubble
         case 'created_entity_link_html':
 
           // Get the related entity.
-          if (!empty($message->get('field_message_related_object'))) {
+          if (!$message->get('field_message_related_object')->isEmpty()) {
             $target_type = $message->getFieldValue('field_message_related_object', 'target_type');
             $target_id = $message->getFieldValue('field_message_related_object', 'target_id');
             $entity = \Drupal::entityTypeManager()

--- a/modules/social_features/social_like/social_like.tokens.inc
+++ b/modules/social_features/social_like/social_like.tokens.inc
@@ -11,6 +11,7 @@ use Drupal\node\NodeInterface;
 use Drupal\votingapi\Entity\Vote;
 use Drupal\Core\Render\Markup;
 use Drupal\node\Entity\Node;
+use Drupal\votingapi\VoteInterface;
 
 /**
  * Implements hook_token_info().
@@ -146,6 +147,9 @@ function social_like_tokens_alter(array &$replacements, array $context, Bubbleab
           /** @var \Drupal\social_activity\EmailTokenServices $email_token_services */
           $email_token_services = \Drupal::service('social_activity.email_token_services');
           $vote = $email_token_services->getRelatedObject($message);
+          if (!($vote instanceof VoteInterface)) {
+            return;
+          }
 
           /** @var \Drupal\votingapi\Entity\Vote $vote */
           $storage = \Drupal::entityTypeManager()

--- a/modules/social_features/social_mentions/social_mentions.tokens.inc
+++ b/modules/social_features/social_mentions/social_mentions.tokens.inc
@@ -86,7 +86,7 @@ function social_mentions_tokens($type, $tokens, array $data, array $options, Bub
         case 'mentioned_user':
 
           if ($name === 'mentioned_user') {
-            if (!empty($message->get('field_message_related_object'))) {
+            if (!$message->get('field_message_related_object')->isEmpty()) {
               $target_type = $message->getFieldValue('field_message_related_object', 'target_type');
               $target_id = $message->getFieldValue('field_message_related_object', 'target_id');
               $mention = \Drupal::entityTypeManager()
@@ -106,7 +106,7 @@ function social_mentions_tokens($type, $tokens, array $data, array $options, Bub
 
         case 'commented_entity_link_html':
 
-          if (!empty($message->get('field_message_related_object'))) {
+          if (!$message->get('field_message_related_object')->isEmpty()) {
             $target_type = $message->getFieldValue('field_message_related_object', 'target_type');
             $target_id = $message->getFieldValue('field_message_related_object', 'target_id');
             /** @var \Drupal\mentions\Entity\Mentions $mention */


### PR DESCRIPTION
## Problem
`Error: Call to a member function getVotedEntityType() on null in social_like_tokens_alter() (line 152 of profiles/contrib/social/modules/social_features/social_like/social_like.tokens.inc). `

Also, I've noticed that we do have a not correct condition to check if the field is empty here #2277 which could provide critical issues on the token replacement process.
`empty($entity->geet('<field_name>'))` will always return FALSE, so better to ALWAYS use already existing method `isEmpty()` for field values.

## Solution
Check if the like exists and we do not use the `NULL` value.

## Issue tracker
https://www.drupal.org/project/social/issues/3247896
https://getopensocial.atlassian.net/browse/YANG-6552

## How to test
- [x] Like some content
- [x] Generate activity (run cron)
- [x] Remove like
- [x] Check the last page of `/admin/content/message`

## Screenshots
N/A

## Release notes
N/A

## Change Record
N/A

## Translations
N/A