### PR TITLE
Issue #3248205 by nkoporec: Group managers should not be allowed to send invitations to users that are already part of the group

### DIFF
--- a/modules/social_features/social_group/modules/social_group_invite/src/Form/SocialBulkGroupInvitation.php
+++ b/modules/social_features/social_group/modules/social_group_invite/src/Form/SocialBulkGroupInvitation.php
@@ -21,6 +21,7 @@ use Drupal\user\UserInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Drupal\ginvite\Form\BulkGroupInvitation;
 use Symfony\Component\HttpFoundation\RedirectResponse;
+use Drupal\Component\Render\FormattableMarkup;
 
 /**
  * Class SocialBulkGroupInvitation.
@@ -395,6 +396,35 @@ class SocialBulkGroupInvitation extends BulkGroupInvitation {
     }
 
     return TRUE;
+  }
+
+  /**
+   * Prepares form error message if there is invalid emails.
+   *
+   * @param array $invalid_emails
+   *   List of invalid emails.
+   * @param string $message_singular
+   *   Error message for one invalid email.
+   * @param string $message_plural
+   *   Error message for multiple invalid emails.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The current state of the form.
+   */
+  public function displayErrorMessage(array $invalid_emails, $message_singular, $message_plural, FormStateInterface $form_state) {
+    $count = count($invalid_emails);
+
+    if ($count > 1) {
+      $error_message = '<ul>';
+      foreach ($invalid_emails as $line => $invalid_email) {
+        $error_message .= "<li>{$invalid_email} on line {$line}</li>";
+      }
+      $error_message .= '</ul>';
+      $form_state->setErrorByName('email_address', $this->formatPlural($count, $message_singular, $message_plural, ['@error_message' => new FormattableMarkup($error_message, [])]));
+    }
+    elseif ($count == 1) {
+      $error_message = reset($invalid_emails);
+      $form_state->setErrorByName('email_address', $this->formatPlural($count, $message_singular, $message_plural, ['@error_message' => $error_message]));
+    }
   }
 
   /**

--- a/modules/social_features/social_group/modules/social_group_invite/src/Form/SocialBulkGroupInvitation.php
+++ b/modules/social_features/social_group/modules/social_group_invite/src/Form/SocialBulkGroupInvitation.php
@@ -354,7 +354,7 @@ class SocialBulkGroupInvitation extends BulkGroupInvitation {
             $form_state->unsetValue(['users_fieldset', 'user', $user]);
             return;
           }
-          elseif (!empty($membership)) {
+          else {
             // Change the uservalue to email because the bulk invite for
             // groups can only handle emails.
             $form_state->setValue(['users_fieldset', 'user', $user], $account->getEmail());

--- a/modules/social_features/social_group/modules/social_group_invite/src/Form/SocialBulkGroupInvitation.php
+++ b/modules/social_features/social_group/modules/social_group_invite/src/Form/SocialBulkGroupInvitation.php
@@ -410,7 +410,7 @@ class SocialBulkGroupInvitation extends BulkGroupInvitation {
    * @param \Drupal\Core\Form\FormStateInterface $form_state
    *   The current state of the form.
    */
-  public function displayErrorMessage(array $invalid_emails, $message_singular, $message_plural, FormStateInterface $form_state) {
+  public function displayErrorMessage(array $invalid_emails, $message_singular, $message_plural, FormStateInterface $form_state) : void {
     $count = count($invalid_emails);
 
     if ($count > 1) {


### PR DESCRIPTION
## Problem
When group managers are inviting users to the group they currently can select existing members too. The invite batch will go through but no invites will actually be sent, but this is still a bad UX.

## Solution
If the user is already a member of the group an error should show up.

## Issue tracker
https://www.drupal.org/project/social/issues/3248205

## How to test
1. Create a group
2. Invite a user to the group and accept the invitation as that user
3. After the user is already a member of the group invite him again.
4. See that no error will show up

## Screenshots
![2021-11-08_14-23](https://user-images.githubusercontent.com/35064680/140749586-d4cdad30-65e9-417d-a164-25c6f05e3749.png)


## Release notes
*A short summary of the changes that were made that can be included in release notes.*

## Change Record
*If this Pull Request changes the way that developers should do things or introduces a new API for developers then a change record to document this is needed. Please provide a draft for a change record or a link to an unpublished change record below. [Existing change records](https://www.drupal.org/list-changes/social) can be consulted as example.*

## Translations
*Translatable strings are always extracted from the latest development branch. To ensure translations remain available for platforms running older versions of Open Social the original string should be added to `translations.php` when it's changed or removed.*
- [ ] Changed or removed source strings are added to the `translations.php` file.
