### PR TITLE
Issue #3248383 by Ressinel: Open Social version 10.3.1 is not supported by PHP 7.3 - It works good with PHP 7.4

### DIFF
--- a/modules/social_features/social_activity/src/EmailTokenServices.php
+++ b/modules/social_features/social_activity/src/EmailTokenServices.php
@@ -31,21 +31,21 @@ class EmailTokenServices {
    *
    * @var \Drupal\Core\Entity\EntityTypeManager
    */
-  protected EntityTypeManager $entityTypeManager;
+  protected $entityTypeManager;
 
   /**
    * Date Formatter services.
    *
    * @var \Drupal\Core\Datetime\DateFormatter
    */
-  protected DateFormatter $dateFormatter;
+  protected $dateFormatter;
 
   /**
    * GroupStatistics services.
    *
    * @var \Drupal\social_group\GroupStatistics
    */
-  protected GroupStatistics $groupStatistics;
+  protected $groupStatistics;
 
   /**
    * Constructs a EmailTokenServices object.


### PR DESCRIPTION
## Problem
Updating the Open Social version to `10.3.1` with `PHP 7.3` cause error:

`ParseError: syntax error, unexpected 'EntityTypeManager' (T_STRING), expecting function (T_FUNCTION) or const (T_CONST) in Composer\Autoload\includeFile() (line 34 of /profiles/contrib/social/modules/social_features/social_activity/src/EmailTokenServices.php)`

## Solution
Remove type from properties.

## Issue tracker
- https://www.drupal.org/project/social/issues/3248383

## How to test
- [x] Checkout to this branch
- [x] Do a fresh installation with PHP 7.3.

## Screenshots
N/A

## Release notes
Fixed error related to typed properties on `PHP 7.3` in `modules/social_features/social_activity/src/EmailTokenServices.php`.

## Change Record
N/A

## Translations
N/A
