### PR TITLE
Issue #3248421 by SV: As LU+ I can not like any content

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -110,7 +110,7 @@
                 "Return the same content list after content type is changed": "https://www.drupal.org/files/issues/2021-08-27/dynamic_entity_reference-the_same_content_list-3230158-2.patch"
             },
             "drupal/like_and_dislike": {
-                "As LU+ I can not like any content": "https://git.drupalcode.org/project/like_and_dislike/-/merge_requests/3.patch"
+                "As LU+ I can not like any content": "https://www.drupal.org/files/issues/2021-11-10/3247929-like_and_dislike-5.patch"
             }
         }
     },

--- a/composer.json
+++ b/composer.json
@@ -108,6 +108,9 @@
             "drupal/dynamic_entity_reference": {
                 "Errors when new entity types are added (in certain cases)": "https://www.drupal.org/files/issues/2020-05-31/3099176-9.patch",
                 "Return the same content list after content type is changed": "https://www.drupal.org/files/issues/2021-08-27/dynamic_entity_reference-the_same_content_list-3230158-2.patch"
+            },
+            "drupal/like_and_dislike": {
+                "As LU+ I can not like any content": "https://git.drupalcode.org/project/like_and_dislike/-/merge_requests/3.patch"
             }
         }
     },


### PR DESCRIPTION
## Problem
Since the last update of the like module, only Administrators can like the content.

## Solution
Looks like there is an issue in the like_and_dislike module and we should include a patch to fix the current issue for all projects

## Issue tracker
- https://www.drupal.org/project/social/issues/3248421
- https://www.drupal.org/project/like_and_dislike/issues/3247929
- https://getopensocial.atlassian.net/browse/YANG-6530

## How to test
- [ ] Using the latest version of Open Social with the social_likes module enabled
- [ ] As a sitemanager
- [ ] Go to any node where is an available likes widget
- [ ] When clicking "like" I expect that counter was increased but instead there are no actions
- [ ] The expected result is attained when repeating the steps with this fix applied.

## Screenshots
![Financial-update (1)](https://user-images.githubusercontent.com/25609390/140925892-49759ad1-1ca5-4087-8e1f-0877b0601044.png)

## Release notes
- Fixes the issue with "liking/disliking" a content
