### PR TITLE
Issue #3248515 by SV: Comments do not load when there is unpublished item in the thread

### DIFF
--- a/modules/social_features/social_like/social_like.module
+++ b/modules/social_features/social_like/social_like.module
@@ -83,10 +83,10 @@ function social_like_preprocess_like_and_dislike_icons(&$variables) {
 
     // If the entity is unpublished and of type comment disable voting.
     if (!$entity->isPublished() && $entity->getEntityTypeId() === 'comment') {
-      $variables['like_attributes']->addClass('disable-status');
-      $variables['dislike_attributes']->addClass('disable-status');
+      foreach (['like', 'dislike'] as $item) {
+        $variables['icons'][$item]['attributes']->addClass('disable-status');
+      }
     }
-
   }
   $variables['modal_title'] = t('Members who liked this @content', ['@content' => $bundle]);
 }


### PR DESCRIPTION
## Problem
I'm logged in as admin. If I try to see the comments under the discussions, they don't load.

![screen](https://user-images.githubusercontent.com/25609390/140967727-70458208-b920-4f25-94e2-54e78cc2981a.png)


## Solution
Looks like after upgrading like_and_dislike module hasn't changed inherited functionality:

In the **8.x-1.0-alpha2** version there is the following:

>    $build['icons'] = [
      '#theme' => 'like_and_dislike_icons',
      '#attached' => ['library' => ['like_and_dislike/icons']],
      '#entity_id' => $entity_id,
      '#entity_type' => $entity_type_id,
      '#likes' => $likes,
      '#dislikes' => $dislikes,
      '#like_attributes' => $like_attributes,
      '#dislike_attributes' => $dislike_attributes,
    ];

and it was changed in **8.x-1.0-beta2** to:

>    $like_attributes = new Attribute([
        'title' => $this->t('Like'),
        'data-entity-id' => $entity_id,
        'data-entity-type' => $entity_type_id,
      ]);
     ...................................
>      $icons['like'] = [
        'count' => $likes,
        'label' => $this->t('Like'),
        'attributes' => $like_attributes,
      ];
     ...................................
    $build['icons'] = [
      '#theme' => 'like_and_dislike_icons',
      '#attached' => ['library' => ['like_and_dislike/icons']],
      '#entity_id' => $entity_id,
      '#entity_type' => $entity_type_id,
      '#icons' => $icons,
    ];

**So, in the social_likes it should be changed as well, from:**

>    $variables['like_attributes']->addClass('disable-status');
      $variables['dislike_attributes']->addClass('disable-status');

**to the following:**

>    foreach (['like', 'dislike'] as $item) {
        $variables['icons'][$item]['attributes']->addClass('disable-status');
      }

## Issue tracker
- https://www.drupal.org/project/social/issues/3248515
- https://getopensocial.atlassian.net/browse/YANG-6528

## How to test
- [x] Using the latest version of Open Social with the social_like, AJAX Comments modules enabled
- [x] As an administrator
- [x] Go to any nodes where enabled comments and like/dislike functionality
- [x] Try to add the unpublished comment
- [x] When saving I expect the result to see the added comment but instead see a loading indicator.
- [x] The expected result is attained when repeating the steps with this fix applied.

## Release notes
Fixes issue with displaying comments when there is unpublished item in the thread.