### PR TITLE
Issue #3228303 by tBKoT: Use event type label instead of 'Event'

### DIFF
--- a/modules/social_features/social_event/modules/social_event_type/social_event_type.module
+++ b/modules/social_features/social_event/modules/social_event_type/social_event_type.module
@@ -13,7 +13,7 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Link;
 use Drupal\Core\Url;
 use Drupal\field\Entity\FieldStorageConfig;
-use Drupal\node\Entity\Node;
+use Drupal\taxonomy\TermInterface;
 
 /**
  * Implements hook_form_FORM_ID_alter().
@@ -63,47 +63,42 @@ function social_event_type_widget_alter(array &$form) {
  * @param array $variables
  *   Array with variables of a node.
  */
-function social_event_type_preprocess_node(array &$variables) {
-  /** @var \Drupal\node\Entity\NodeInterface $node */
+function social_event_type_preprocess_node(array &$variables): void {
+  /** @var \Drupal\node\NodeInterface $node */
   $node = $variables['node'];
 
   if ($node->getType() === 'event') {
-    $event_type = $node->get('field_event_type');
-    $event_type_entities = $event_type->referencedEntities();
-    if (count($event_type_entities) === 1) {
-      /** @var \Drupal\node\Entity\Node $event */
-      foreach ($event_type_entities as $event) {
-        if ($event instanceof Node) {
-          $variables['metadata'] = t('in @event', ['@event' => $event->toLink()->toString()]);
-          // Set event type link.
-          $now = strtotime("now");
-          $end = strtotime($node->get('field_event_date_end')->getString());
-          // 1 are upcoming events.
-          // 2 are ones that have started or are finished.
-          $datetype = ($now > $end) ? 2 : 1;
-
-          $event_type_url = Url::fromRoute('view.upcoming_events.page_community_events', [
-            'field_event_date_value' => $datetype,
-            'event_type_id' => $event->id(),
-          ]);
-          $event_type_link = Link::fromTextAndUrl($event->label(), $event_type_url)
-            ->toString();
-          $variables['event_type'] = $event_type_link;
-        }
-
-        if (
-          $event->hasField('field_event_type_icon') &&
-          !$event->get('field_event_type_icon')->isEmpty()
-        ) {
-          $variables['event_type_icon'] = $event->get('field_event_type_icon')->value;
-        }
-
-        $variables['#cache']['tags'][] = $event->getEntityTypeId() . ':' . $event->id();
+    /** @var \Drupal\Core\Field\EntityReferenceFieldItemListInterface $event_type_field */
+    $event_type_field = $node->get('field_event_type');
+    $event_types = $event_type_field->referencedEntities();
+    $variables['metadata'] = NULL;
+    $variables['event_type'] = NULL;
+    $event_type = empty($event_types) ? NULL : reset($event_types);
+    if ($event_type instanceof TermInterface) {
+      $variables['metadata'] = t('in @event', [
+        '@event' => $event_type->toLink()
+          ->toString(),
+      ]);
+      // Set event type link.
+      $now = strtotime("now");
+      $end = strtotime($node->get('field_event_date_end')->getString());
+      // 1 are upcoming events.
+      // 2 are ones that have started or are finished.
+      $datetype = ($now > $end) ? 2 : 1;
+      $event_type_url = Url::fromRoute('view.upcoming_events.page_community_events', [
+        'field_event_date_value' => $datetype,
+        'event_type_id' => $event_type->id(),
+      ]);
+      $event_type_link = Link::fromTextAndUrl($event_type->label() ?? '', $event_type_url)
+        ->toString();
+      $variables['event_type'] = $event_type_link;
+      if (
+        $event_type->hasField('field_event_type_icon') &&
+        !$event_type->get('field_event_type_icon')->isEmpty()
+      ) {
+        $variables['event_type_icon'] = $event_type->get('field_event_type_icon')->getString();
       }
-    }
-    else {
-      $variables['metadata'] = NULL;
-      $variables['event_type'] = NULL;
+      $variables['#cache']['tags'][] = $event_type->getEntityTypeId() . ':' . $event_type->id();
     }
   }
 }

--- a/tests/behat/features/capabilities/event/event-create.feature
+++ b/tests/behat/features/capabilities/event/event-create.feature
@@ -78,5 +78,5 @@ Feature: Create Event
     And I fill in the "edit-body-0-value" WYSIWYG editor with "Body description text."
     And I press "Create event"
     Then I should see the link "Online Event" in the "Hero block" region
-    Then I set the configuration item "socialblue.settings" with key "style" to "default"
+    Then I set the configuration item "socialblue.settings" with key "style" to ""
     And the cache has been cleared

--- a/tests/behat/features/capabilities/event/event-create.feature
+++ b/tests/behat/features/capabilities/event/event-create.feature
@@ -57,3 +57,26 @@ Feature: Create Event
     Then I should see "Access denied"
       And I should see "You are not authorized to access this page."
       And I enable that the registered users to be verified immediately
+
+  @event-types
+  Scenario: Create event with event type
+    Given I enable the module "social_event_type"
+    And I set the configuration item "socialblue.settings" with key "style" to "sky"
+    And "event_types" terms:
+      | name         |
+      | Online Event |
+    And the cache has been cleared
+
+    Given I am logged in as an "authenticated user"
+    And I go to "node/add/event"
+    Then I should see "Online Event"
+    Then I click radio button "Online Event"
+    And I fill in the following:
+      | Title                                  | This is a test event |
+      | edit-field-event-date-0-value-date     | 2025-01-01           |
+      | edit-field-event-date-end-0-value-date | 2025-01-01           |
+    And I fill in the "edit-body-0-value" WYSIWYG editor with "Body description text."
+    And I press "Create event"
+    Then I should see the link "Online Event" in the "Hero block" region
+    Then I set the configuration item "socialblue.settings" with key "style" to "default"
+    And the cache has been cleared

--- a/tests/behat/features/capabilities/event/event-create.feature
+++ b/tests/behat/features/capabilities/event/event-create.feature
@@ -57,26 +57,3 @@ Feature: Create Event
     Then I should see "Access denied"
       And I should see "You are not authorized to access this page."
       And I enable that the registered users to be verified immediately
-
-  @event-types
-  Scenario: Create event with event type
-    Given I enable the module "social_event_type"
-    And I set the configuration item "socialblue.settings" with key "style" to "sky"
-    And "event_types" terms:
-      | name         |
-      | Online Event |
-    And the cache has been cleared
-
-    Given I am logged in as an "authenticated user"
-    And I go to "node/add/event"
-    Then I should see "Online Event"
-    Then I click radio button "Online Event"
-    And I fill in the following:
-      | Title                                  | This is a test event |
-      | edit-field-event-date-0-value-date     | 2025-01-01           |
-      | edit-field-event-date-end-0-value-date | 2025-01-01           |
-    And I fill in the "edit-body-0-value" WYSIWYG editor with "Body description text."
-    And I press "Create event"
-    Then I should see the link "Online Event" in the "Hero block" region
-    Then I set the configuration item "socialblue.settings" with key "style" to ""
-    And the cache has been cleared


### PR DESCRIPTION
## Problem
When we use the event types then it should be shown instead of the `Event` label above the title.

## Solution
Fix incorrect condition in the `social_event_type.module`.
Add test or scenario to check changes.

## Issue tracker
https://www.drupal.org/project/social/issues/3228303
https://getopensocial.atlassian.net/browse/YANG-6161

## How to test
*For example*
- [ ] Enable the `social_event_type` module
- [ ] Enable `Sky` style
- [ ] Add some event types terms
- [ ] Create an event with a provided term
- [ ] You should see the event type over the title but is not

## Screenshots
![зображення](https://user-images.githubusercontent.com/11648677/129557765-cf39178e-9aaf-4e85-81bc-acebc58b827e.png)
![зображення](https://user-images.githubusercontent.com/11648677/129558245-f0f44d8e-566e-4dcf-81a4-b6883d240881.png)


## Release notes
N/A

## Change Record
N/A

## Translations
 N/A