### PR TITLE
Issue #3248947: Added missing library for drupal/jquery_ui_touch_punch.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -178,6 +178,7 @@
         "npm-asset/diff": "^3.5",
         "npm-asset/highlight.js": "~9.15.6",
         "npm-asset/jquery.caret": "^0.3.1",
+        "npm-asset/jquery-ui-touch-punch": "^0.2.3",
         "npm-asset/morris.js06": "^0.6.6",
         "npm-asset/node-waves": "0.7.6",
         "npm-asset/photoswipe": "^4.1.2",


### PR DESCRIPTION
## Problem
The status report page shows an error of missing `jquery-ui-touch-punch/jquery.ui.touch-punch.min.js`  library.

## Solution
**drupal/jquery_ui_touch_punch needs library** is dependency of **"drupal/better_exposed_filters" which requires "furf/jquery-ui-touch-punch"** which is available in npm here: https://www.npmjs.com/package/jquery-ui-touch-punch

Add "npm-asset/jquery-ui-touch-punch": "^0.2.3 in composer.json

## Issue tracker
https://www.drupal.org/project/social/issues/3248947

## How to test
- [x] Install Open Social using this branch.
- [x] Go to the status page here: /admin/reports/status
- [x] Error reporting should not report this missing library.

## Screenshots
N.A

## Release notes
N.A

## Change Record
N.A

## Translations
N.A