### PR TITLE
Issue #3102720 by epapaniko, Ressinel: Search form submit redirects to the wrong path when the installation is under a subdirectory.

### DIFF
--- a/modules/social_features/social_search/src/EventSubscriber/RedirectSubscriber.php
+++ b/modules/social_features/social_search/src/EventSubscriber/RedirectSubscriber.php
@@ -105,13 +105,10 @@ class RedirectSubscriber implements EventSubscriberInterface {
     if (empty($query) || empty($query['created_op'])) {
       $query = ['created_op' => '<'];
       $parameters = $this->currentRoute->getParameters();
-      $currentUrl = Url::fromRoute($this->currentRoute->getRouteName());
-      if (!empty($parameters->get('keys'))) {
-        $currentUrl = Url::fromRoute($this->currentRoute->getRouteName(), ['keys' => $parameters->get('keys')]);
-      }
-      $redirect_path = $currentUrl->toString();
-      $redirect = Url::fromUserInput($redirect_path, ['query' => $query]);
-
+      $redirect_path = $this->currentRoute->getRouteName();
+      $options = ['query' => $query];
+      $route_parameters = ['keys' => $parameters->get('keys')];
+      $redirect = Url::fromRoute($redirect_path, $route_parameters, $options);
       $event->setResponse(new RedirectResponse($redirect->toString()));
     }
 

--- a/modules/social_features/social_search/src/Form/SearchContentForm.php
+++ b/modules/social_features/social_search/src/Form/SearchContentForm.php
@@ -80,22 +80,24 @@ class SearchContentForm extends FormBase implements ContainerInjectionInterface 
    */
   public function submitForm(array &$form, FormStateInterface $form_state) {
     $search_all_view = 'search_all';
+    $query = UrlHelper::filterQueryParameters($this->requestStack->getCurrentRequest()->query->all());
+    $options = ['query' => $query];
+    $parameters = [];
+
     if (empty($form_state->getValue('search_input_content'))) {
       // Redirect to the search content page with empty search values.
-      $search_content_page = Url::fromRoute("view.$search_all_view.page_no_value");
+      $page = "view.$search_all_view.page_no_value";
     }
     else {
       // Redirect to the search content page with filters in the GET parameters.
       $search_input = Xss::filter($form_state->getValue('search_input_content'));
       $search_input = preg_replace('/[\/]+/', ' ', $search_input);
       $search_input = str_replace('&amp;', '&', $search_input);
-      $search_content_page = Url::fromRoute("view.$search_all_view.page", ['keys' => $search_input]);
+      $parameters['keys'] = $search_input;
+      $page = "view.$search_all_view.page";
     }
-    $redirect_path = $search_content_page->toString();
 
-    $query = UrlHelper::filterQueryParameters($this->requestStack->getCurrentRequest()->query->all(), ['page']);
-
-    $redirect = Url::fromUserInput($redirect_path, ['query' => $query]);
+    $redirect = Url::fromRoute($page, $parameters, $options);
 
     $form_state->setRedirectUrl($redirect);
   }

--- a/modules/social_features/social_search/src/Form/SearchHeroForm.php
+++ b/modules/social_features/social_search/src/Form/SearchHeroForm.php
@@ -94,24 +94,26 @@ class SearchHeroForm extends FormBase implements ContainerInjectionInterface {
   public function submitForm(array &$form, FormStateInterface $form_state) {
     $current_route = $this->routeMatch->getRouteName();
     $route_parts = explode('.', $current_route);
+
+    $query = UrlHelper::filterQueryParameters($this->requestStack->getCurrentRequest()->query->all());
+    $options = ['query' => $query];
+    $parameters = [];
+
     if (empty($form_state->getValue('search_input'))) {
       // Redirect to the search page with empty search values.
       $new_route = "view.{$route_parts[1]}.page_no_value";
-      $search_group_page = Url::fromRoute($new_route);
     }
     else {
       // Redirect to the search page with filters in the GET parameters.
       $search_input = Xss::filter($form_state->getValue('search_input'));
       $search_input = preg_replace('/[\/]+/', ' ', $search_input);
       $search_input = str_replace('&amp;', '&', $search_input);
+      $parameters['keys'] = $search_input;
+
       $new_route = "view.{$route_parts[1]}.page";
-      $search_group_page = Url::fromRoute($new_route, ['keys' => $search_input]);
     }
-    $redirect_path = $search_group_page->toString();
 
-    $query = UrlHelper::filterQueryParameters($this->requestStack->getCurrentRequest()->query->all(), ['page']);
-
-    $redirect = Url::fromUserInput($redirect_path, ['query' => $query]);
+    $redirect = Url::fromRoute($new_route, $parameters, $options);
 
     $form_state->setRedirectUrl($redirect);
   }


### PR DESCRIPTION
## Problem
When Social is installed under a domain's directory, ex. http://www.example.com/social/, search forms and their exposed filters redirect to the wrong path once submitted.

Specifically, SearchContentForm and SearchHeroForm use Url::fromUserInput() which includes the base path resulting in a url like the following http://www.example.com/social/social/search/content/term.

The exposed filters of the form present the opposite problem; when submitting, they strip the base path from the url, so we end up with something like http://www.example.com/search/content/term?type=event

## Solution
N/A

## Issue tracker
- https://www.drupal.org/project/social/issues/3102720

## How to test
- [ ] Install **OpenSocial** in domain's directory e.g. http://www.example.com/social/
- [ ] Go to installed **OpenSocial** and click on the search icon
- [ ] Input text `I search this text` into the search field and press `Enter`
- [ ] You will be redirected to the page with the status `Page not found` http://www.example.com/social/social/search/all/I%2520search%2520this%2520text
- [ ] Checkout to this PR's branch
- [ ] Go to installed **OpenSocial** and click on the search icon
- [ ] Input text `I search this text` into the search field and press `Enter`
- [ ] You will be redirected to the right page http://www.example.com/social/search/all/I%20search%20this%20text

## Screenshots
N/A

## Release notes
Fix issue where search form submit redirects to the wrong path when the installation is under a subdirectory.

## Change Record
N/A

## Translations
N/A
