### PR TITLE
Issue #3249894 by navneet0693: Added patch on redirect module for allowing redirection when the interface language is different from content language.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -111,6 +111,9 @@
             },
             "drupal/like_and_dislike": {
                 "As LU+ I can not like any content": "https://www.drupal.org/files/issues/2021-11-10/3247929-like_and_dislike-5.patch"
+            },
+            "drupal/redirect": {
+                "Redirection issue when interface language is different from content language": "https://www.drupal.org/files/issues/2020-06-01/redirect-interface_language_different_from_content_language_2991423-13.patch"
             }
         }
     },


### PR DESCRIPTION
## Problem
On a multilingual website, when a user creates content in one language and then moves it to a group, a redirect is registered for that path in the language of the user. But when a user from a different language tries to access the old link the content is not found as the redirect is not registered for that language.

## Solution
Add patch from https://www.drupal.org/project/redirect/issues/2991423#comment-13657465

## Issue tracker
https://www.drupal.org/project/social/issues/3249894
https://getopensocial.atlassian.net/browse/TB-5925

## How to test
- [x] Using version 10.2.6 of Open Social with the redirect module enabled and multiple languages configured.
- [x] Make sure you have "social_path_manager" module enabled.
- [x] As a user of language A, create content and create a group.
- [x] Save the link to the content. Move the content to that group.
- [x] As a user of language B, try to access the old URL of the content.
- [x] You should get "content not found" error.
- [x] Install the patch given.
- [x] Clear the cache
- [x] Repeat step 5 now.
- [x] You should be able to access.

## Screenshots
N.A

## Release notes
We fixed a redirection issue where when the content of one language is moved within a group, it cannot be accessed by its old URL by a user of another language.

## Change Record
N.A

## Translations
N.A