### PR TITLE
Issue #3250333 by yaroslav-shandra: The count of enrolled users is not displayed correctly after disabling checkbox ''Allow users to enroll to this event without an account'' at event

### DIFF
--- a/modules/social_features/social_event/modules/social_event_an_enroll/social_event_an_enroll.module
+++ b/modules/social_features/social_event/modules/social_event_an_enroll/social_event_an_enroll.module
@@ -132,36 +132,33 @@ function social_event_an_enroll_preprocess_node(array &$variables) {
  */
 function social_event_an_enroll_views_post_render(ViewExecutable $view, &$output, CachePluginBase $cache) {
   if ($view->id() == 'event_enrollments' && $view->current_display == 'event_enrollments') {
-    if (isset($output['#rows'])) {
-      if (!empty($view->args[0])) {
-        $nid = $view->args[0];
-        $node = Node::load($nid);
-        $an_count = \Drupal::service('social_event_an_enroll.service')->enrollmentCount($nid);
-        if (social_event_an_enroll_is_enabled($node) && $an_count && $an_count > 0) {
-          // Fix counter in block title.
-          $view->total_rows += $an_count;
-          // Add default avatar image with counter.
-          if (empty($output['#rows'])) {
-            $output['#rows'][0]['#theme'] = $output['#theme'];
-            $output['#rows'][0]['#view'] = $output['#view'];
-            $output['#rows'][0]['#grouping_level'] = 0;
-            $output['#rows'][0]['#title'] = '';
-          }
-          // Get default profile image uri.
-          $default_image = social_profile_get_default_image();
-          if (!empty($default_image['id'])) {
-            $file = File::load($default_image['id']);
-            $uri = $file->getFileUri();
-            $output['#rows'][0]['#rows'][] = [
-              '#prefix' => '<div class="avatar">',
-              '#theme' => 'image_style',
-              '#style_name' => 'social_medium',
-              '#uri' => $uri,
-              '#suffix' => '<span class="badge badge--pill">' . $an_count . '</span></div>',
-            ];
-          }
-          $output['#attached']['library'][] = 'social_event_an_enroll/event_an_enroll';
+    if (isset($output['#rows']) && !empty($view->args[0])) {
+      $nid = $view->args[0];
+      $an_count = \Drupal::service('social_event_an_enroll.service')->enrollmentCount($nid);
+      if ($an_count && $an_count > 0) {
+        // Fix counter in block title.
+        $view->total_rows += $an_count;
+        // Add default avatar image with counter.
+        if (empty($output['#rows'])) {
+          $output['#rows'][0]['#theme'] = $output['#theme'];
+          $output['#rows'][0]['#view'] = $output['#view'];
+          $output['#rows'][0]['#grouping_level'] = 0;
+          $output['#rows'][0]['#title'] = '';
         }
+        // Get default profile image uri.
+        $default_image = social_profile_get_default_image();
+        if (!empty($default_image['id'])) {
+          $file = File::load($default_image['id']);
+          $uri = $file->getFileUri();
+          $output['#rows'][0]['#rows'][] = [
+            '#prefix' => '<div class="avatar">',
+            '#theme' => 'image_style',
+            '#style_name' => 'social_medium',
+            '#uri' => $uri,
+            '#suffix' => '<span class="badge badge--pill">' . $an_count . '</span></div>',
+          ];
+        }
+        $output['#attached']['library'][] = 'social_event_an_enroll/event_an_enroll';
       }
     }
   }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -7535,11 +7535,6 @@ parameters:
 			path: modules/social_features/social_event/modules/social_event_an_enroll/social_event_an_enroll.module
 
 		-
-			message: "#^Parameter \\#1 \\$node of function social_event_an_enroll_is_enabled expects Drupal\\\\node\\\\Entity\\\\Node, Drupal\\\\node\\\\Entity\\\\Node\\|null given\\.$#"
-			count: 1
-			path: modules/social_features/social_event/modules/social_event_an_enroll/social_event_an_enroll.module
-
-		-
 			message: "#^Function social_event_an_enroll_token_info\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: modules/social_features/social_event/modules/social_event_an_enroll/social_event_an_enroll.tokens.inc


### PR DESCRIPTION
## Problem
When disable checkbox ''Allow users to enroll to this event without an account'' at event.
![Screenshot from 2021-11-19 13-37-39](https://user-images.githubusercontent.com/80881183/142623780-4635b26e-c1ae-45cd-924e-c9fc4545ee42.png)
And users enrolled in this event without an account (guests).
The count of enrolled users is not displayed correctly on the event preview page at enrollments block.
![Screenshot from 2021-11-19 13-35-07](https://user-images.githubusercontent.com/80881183/142623734-d18d9c2a-36f4-47d8-9cb9-6b2707f8b515.png)

## Issue tracker
- https://www.drupal.org/project/social/issues/3250333

## How to test
- [x] Create event with selected ''Allow users to enroll to this event without an account'' checkbox.
- [x] Enroll to event in incognito window as guest.
- [x] Disable checkbox ''Allow users to enroll to this event without an account'' at event.