### PR TITLE
Issue #3250345 by tBKoT: Changes the process of converting a term name to a machine-readable name

### DIFF
--- a/modules/social_features/social_tagging/social_tagging.module
+++ b/modules/social_features/social_tagging/social_tagging.module
@@ -563,10 +563,7 @@ function social_tagging_form_views_exposed_form_alter(&$form, FormStateInterface
  *   A machine name so it can be used pogrammatically.
  */
 function social_tagging_to_machine_name($text) {
-  $text = strtolower($text);
-  $text = str_replace(' ', '', $text);
-
-  return $text;
+  return preg_replace('@[^a-z0-9-]+@', '_', strtolower($text));
 }
 
 /**


### PR DESCRIPTION
## Problem
We can not use taxonomy terms with special characters as a filter field for a content search

## Solution
Change the function which converted term names to the field names to replace any of the special characters

## Issue tracker
https://www.drupal.org/project/social/issues/3250345
https://getopensocial.atlassian.net/browse/YANG-6663

## How to test
- [x] Enable `social_tagging` module
- [x] Make sure that the `Allow category split` option is enabled on the Tag settings page (`admin/config/opensocial/tagging-settings`)
- [x] Create parent tag in Content tags vocabulary with special character, for example `|`
- [x] Create child tag(s) for newly created parent tag
- [x] Add tags to new/existing content
- [x] Reindex content search index
- [x] Go to search content page
- [x] Try to filter by tag

## Screenshots
![зображення](https://user-images.githubusercontent.com/11648677/143014745-fb45b9d7-1e2a-4a91-8fb5-c97485956f55.png)
![зображення](https://user-images.githubusercontent.com/11648677/143015415-725a93aa-cb57-4b94-b9fe-e121fccbe278.png)


## Release notes
The process of replacing the term with machine-readable has changed. Now all non-alphanumeric characters are replaced with underscores

## Change Record
N/A

## Translations
N/A