### PR TITLE
Issue #3250368 by rolki: Add the ability to alter conditions in CommentQueryAccessHandler class

### DIFF
--- a/modules/social_features/social_comment/social_comment.api.php
+++ b/modules/social_features/social_comment/social_comment.api.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * @file
+ * Hooks provided by the Social Comment module.
+ */
+
+/**
+ * @addtogroup hooks
+ * @{
+ */
+
+use Drupal\Core\Entity\EntityTypeInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\entity\QueryAccess\ConditionGroup;
+
+/**
+ * Provides a method to alter query access conditions for comments.
+ *
+ * @param \Drupal\Core\Session\AccountInterface $account
+ *   The account to check access for.
+ * @param \Drupal\Core\Entity\EntityTypeInterface $entity_type
+ *   The entity type.
+ * @param \Drupal\entity\QueryAccess\ConditionGroup|null $conditions
+ *   The access conditions or NULL.
+ *
+ * @ingroup social_comment_api
+ */
+function hook_social_comment_query_access_alter(AccountInterface $account, EntityTypeInterface $entity_type, ConditionGroup &$conditions = NULL) {
+  $conditions = new ConditionGroup('OR');
+  $conditions->addCacheContexts(['user.permissions']);
+  $conditions->alwaysFalse();
+}
+
+/**
+ * @} End of "addtogroup hooks".
+ */

--- a/modules/social_features/social_comment/social_comment.api.php
+++ b/modules/social_features/social_comment/social_comment.api.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @file
  * Hooks provided by the Social Comment module.

--- a/modules/social_features/social_comment/src/Entity/Access/CommentQueryAccessHandler.php
+++ b/modules/social_features/social_comment/src/Entity/Access/CommentQueryAccessHandler.php
@@ -3,10 +3,12 @@
 namespace Drupal\social_comment\Entity\Access;
 
 use Drupal\Core\Entity\EntityPublishedInterface;
+use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\entity\QueryAccess\ConditionGroup;
 use Drupal\entity\QueryAccess\QueryAccessHandlerBase;
 use Drupal\user\EntityOwnerInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Controls query access for comment entities.
@@ -14,6 +16,23 @@ use Drupal\user\EntityOwnerInterface;
  * @see \Drupal\entity\QueryAccess\QueryAccessHandler
  */
 class CommentQueryAccessHandler extends QueryAccessHandlerBase {
+
+  /**
+   * The Module Handler.
+   *
+   * @var \Drupal\Core\Extension\ModuleHandlerInterface
+   */
+  protected $moduleHandler;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function createInstance(ContainerInterface $container, EntityTypeInterface $entity_type) {
+    $instance = parent::createInstance($container, $entity_type);
+    $instance->moduleHandler = $container->get('module_handler');
+
+    return $instance;
+  }
 
   /**
    * {@inheritdoc}
@@ -64,6 +83,8 @@ class CommentQueryAccessHandler extends QueryAccessHandlerBase {
     else {
       $conditions = $entity_conditions;
     }
+
+    $this->moduleHandler->alter('social_comment_query_access', $account,$this->entityType, $conditions);
 
     if (!$conditions) {
       // The user doesn't have access to any entities.

--- a/modules/social_features/social_comment/src/Entity/Access/CommentQueryAccessHandler.php
+++ b/modules/social_features/social_comment/src/Entity/Access/CommentQueryAccessHandler.php
@@ -84,7 +84,7 @@ class CommentQueryAccessHandler extends QueryAccessHandlerBase {
       $conditions = $entity_conditions;
     }
 
-    $this->moduleHandler->alter('social_comment_query_access', $account,$this->entityType, $conditions);
+    $this->moduleHandler->alter('social_comment_query_access', $account, $this->entityType, $conditions);
 
     if (!$conditions) {
       // The user doesn't have access to any entities.


### PR DESCRIPTION
## Problem
We have `CommentQueryAccessHandler` class that is implement `query_access` for comment entity type, and there's no way to alter `$conditions` for that class.

E.G. Drupal has a few modules to extend permission system (or custom one). And in case if we have custom permissions to display comments for anonymous users e.g. for only one node bundle, then we have to add specific conditions to `query_access` (if current user has some custom permission).

Also it can affect out `GraphQL API`, in case if we have case as I said before, when we have custom permission to display comments e.g. only for topics for anonymous users and accordingly we have check access method then sure anonymous user will see comments for topics, but when we will try to get comments for topics via `GraphQL`, also under anonymous request then we will have empty result because of `query_access`.

## Solution
Add the ability to alter conditions in CommentQueryAccessHandler class.

See an example how this change can be used: 
* https://bitbucket.org/goalgorilla/comment_permission/pull-requests/6/yang-6671-fix-issue-with-wrong-permissions
* https://bitbucket.org/goalgorilla/social_discussion/pull-requests/111/yang-6671-alter-conditions-for-comment

## Issue tracker
- https://www.drupal.org/project/social/issues/3250368
- https://getopensocial.atlassian.net/browse/YANG-6671

## How to test
- [ ] Create custom permission to display comments for anonymous users
- [ ] Assign that permission to anonymous role
- [ ] You should have check access method
- [ ] Go to the node with comments
- [ ] You should see comments
- [ ] You should not see comments via GraphQL API

## Screenshots
No.

## Release notes
It will be possible to alter conditions in `CommentQueryAccessHandler` class.

## Change Record
No.

## Translations
No.
