### PR TITLE
Add validation for users don't have the right roles

### DIFF
--- a/modules/social_features/social_group/src/Element/SocialGroupEntityAutocomplete.php
+++ b/modules/social_features/social_group/src/Element/SocialGroupEntityAutocomplete.php
@@ -68,6 +68,7 @@ class SocialGroupEntityAutocomplete extends EntityAutocomplete {
           foreach($group_visibilities as $group_visibility){
             if($account->hasRole($group_visibility['value'])){
               $user_has_role = TRUE;
+              break;
             }
           }
           // Add error if user doesn't have required role.

--- a/modules/social_features/social_group/src/Element/SocialGroupEntityAutocomplete.php
+++ b/modules/social_features/social_group/src/Element/SocialGroupEntityAutocomplete.php
@@ -61,18 +61,19 @@ class SocialGroupEntityAutocomplete extends EntityAutocomplete {
         ];
 
         $account = User::load($match);
-        if($group->hasField('field_flexible_group_visibility')){
-          $group_visibilities = $group->get('field_flexible_group_visibility')->getValue();
+        if ($group->hasField('field_flexible_group_visibility')) {
+          $group_visibilities = $group->get('field_flexible_group_visibility')
+            ->getValue();
           $user_has_role = FALSE;
           // Loop through group visibility and check if user has that role.
-          foreach($group_visibilities as $group_visibility){
-            if($account->hasRole($group_visibility['value'])){
+          foreach ($group_visibilities as $group_visibility) {
+            if ($account->hasRole($group_visibility['value'])) {
               $user_has_role = TRUE;
               break;
             }
           }
           // Add error if user doesn't have required role.
-          if(!$user_has_role){
+          if (!$user_has_role) {
             $message = \Drupal::translation()->translate(
               "@username doesn't have the required role. You can't add them. Please contact your community manager.",
               ['@username' => $account->getDisplayName()]

--- a/modules/social_features/social_group/src/Element/SocialGroupEntityAutocomplete.php
+++ b/modules/social_features/social_group/src/Element/SocialGroupEntityAutocomplete.php
@@ -61,19 +61,19 @@ class SocialGroupEntityAutocomplete extends EntityAutocomplete {
         ];
 
         $account = User::load($match);
-        if ($group->hasField('field_flexible_group_visibility')) {
+        if ($group !== NULL && $group->hasField('field_flexible_group_visibility')) {
           $group_visibilities = $group->get('field_flexible_group_visibility')
             ->getValue();
           $user_has_role = FALSE;
           // Loop through group visibility and check if user has that role.
           foreach ($group_visibilities as $group_visibility) {
-            if ($account->hasRole($group_visibility['value'])) {
+            if ($account !== NULL && $account->hasRole($group_visibility['value'])) {
               $user_has_role = TRUE;
               break;
             }
           }
           // Add error if user doesn't have required role.
-          if (!$user_has_role) {
+          if ($account !== NULL && !$user_has_role) {
             $message = \Drupal::translation()->translate(
               "@username doesn't have the required role. You can't add them. Please contact your community manager.",
               ['@username' => $account->getDisplayName()]
@@ -84,7 +84,7 @@ class SocialGroupEntityAutocomplete extends EntityAutocomplete {
         }
         // User is already a member, add it to an array for the Form element
         // to render an error after all checks are gone.
-        if ($group->getMember($account)) {
+        if ($group !== NULL && $group->getMember($account)) {
           $duplicated_values[] = $account->getDisplayName();
         }
         // We need set "validate_reference" for element to prevent

--- a/modules/social_features/social_group/src/Element/SocialGroupEntityAutocomplete.php
+++ b/modules/social_features/social_group/src/Element/SocialGroupEntityAutocomplete.php
@@ -77,9 +77,6 @@ class SocialGroupEntityAutocomplete extends EntityAutocomplete {
               "@username doesn't have the required role. You can't add them. Please contact your community manager.",
               ['@username' => $account->getDisplayName()]
             );
-            // We have to kick in a form set error here, or else the
-            // GroupContentCardinalityValidator will kick in and show a faulty
-            // error message. Alter this later when Group supports multiple members.
             $form_state->setError($element, $message);
             return;
           }

--- a/translations.php
+++ b/translations.php
@@ -32,6 +32,8 @@ new TranslatableMarkup('
         - There has been more than one failed login attempt for this account. It is temporarily blocked. <br>
         - Too many failed login attempts from your computer (IP address). This IP address is temporarily blocked. <br> <br>
         To solve the issue, try using different login information, try again later, or <a href=":url">request a new password</a>');
+new TranslatableMarkup("@username doesn't have the required role. You can't add them. Please contact your community manager.");
+
 
 // Change in version 8.3.
 new TranslatableMarkup("Set wether event types field is required or not.");

--- a/translations.php
+++ b/translations.php
@@ -34,7 +34,6 @@ new TranslatableMarkup('
         To solve the issue, try using different login information, try again later, or <a href=":url">request a new password</a>');
 new TranslatableMarkup("@username doesn't have the required role. You can't add them. Please contact your community manager.");
 
-
 // Change in version 8.3.
 new TranslatableMarkup("Set wether event types field is required or not.");
 new TranslatableMarkup("Determine wether users can upload documents to comments.");


### PR DESCRIPTION
## Problem
When adding people to a flexible group that is restricted to specific roles, people without the right role could be added to that group.
## Solution
Added an extra validation that checks if the selected users have the right roles. If they don't, an error is thrown.

## Issue tracker
https://www.drupal.org/project/social/issues/3250886
## How to test

1. Create a flexible group that is restricted on role.
2. Try to add a user (Add directly) to that newly created group that doesn't have the role.
3. You should get an error message, that you are not allowed to add the user, since he hasn't got the right role.

## Translations
*Translatable strings are always extracted from the latest development branch. To ensure translations remain available for platforms running older versions of Open Social the original string should be added to `translations.php` when it's changed or removed.*
- [ ] Changed or removed source strings are added to the `translations.php` file.`
