### PR TITLE
Update social medium image style configuration to use crop small type

### DIFF
--- a/modules/social_features/social_core/config/update/social_core_update_11005.yml
+++ b/modules/social_features/social_core/config/update/social_core_update_11005.yml
@@ -1,0 +1,20 @@
+image.style.social_medium:
+  expected_config:
+    effects:
+      151b526b-cb42-4553-a9ab-9c2407ee4134:
+        uuid: 151b526b-cb42-4553-a9ab-9c2407ee4134
+        id: crop_crop
+        weight: 1
+        data:
+          crop_type: profile_medium
+          automatic_crop_provider: null
+  update_actions:
+    change:
+      effects:
+        151b526b-cb42-4553-a9ab-9c2407ee4134:
+          uuid: 151b526b-cb42-4553-a9ab-9c2407ee4134
+          id: crop_crop
+          weight: 1
+          data:
+            crop_type: teaser
+            automatic_crop_provider: null

--- a/modules/social_features/social_core/social_core.install
+++ b/modules/social_features/social_core/social_core.install
@@ -1512,3 +1512,17 @@ function social_core_update_11004(): void {
     \Drupal::configFactory()->getEditable('social_core.settings')->delete();
   }
 }
+
+/**
+ * Update image style of social medium.
+ */
+function social_core_update_11005(): string {
+  /** @var \Drupal\update_helper\Updater $updateHelper */
+  $updateHelper = \Drupal::service('update_helper.updater');
+
+  // Execute configuration update definitions with logging of success.
+  $updateHelper->executeUpdate('social_core', 'social_core_update_11005');
+
+  // Output logged messages to related channel of update execution.
+  return $updateHelper->logger()->output();
+}


### PR DESCRIPTION
## Problem
The social medium image style doesn't show correctly the cropped image.

## Solution
Change the image style for the “Social medium” to use the small crop type.

## Issue tracker
https://www.drupal.org/project/social/issues/3251038

## How to test
*For example*

1. Create an event adding an image and crop it:
![Screenshot at 2021-11-24 11-20-26](https://user-images.githubusercontent.com/8913851/143268508-ab18b0ab-0fb2-4e65-b671-82b7f16fc8df.png)

2. Check the small cropped image on homepage on the Upcoming events block:
![Screenshot at 2021-11-24 11-20-31](https://user-images.githubusercontent.com/8913851/143268533-19022f75-71d0-4a53-9f75-822a6e3bc814.png)

## Screenshots
**Before**
![Screenshot at 2021-11-24 11-20-31](https://user-images.githubusercontent.com/8913851/143268664-21961e42-30d1-48df-a06c-3be0a2c0928a.png)
**After**
![Screenshot at 2021-11-24 16-30-48](https://user-images.githubusercontent.com/8913851/143268767-5c2078e5-556d-428e-bf61-64d27c519dfa.png)

## Release notes
None

## Change Record
None

## Translations
None
