### PR TITLE
[Internal] - Make sure we run our tests on the old theme.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -114,6 +114,9 @@
             },
             "drupal/redirect": {
                 "Redirection issue when interface language is different from content language": "https://www.drupal.org/files/issues/2020-06-01/redirect-interface_language_different_from_content_language_2991423-13.patch"
+            },
+            "drupal/socialblue": {
+                "Sky theme by default": "https://git.drupalcode.org/project/socialblue/-/merge_requests/52.diff"
             }
         }
     },

--- a/tests/behat/features/bootstrap/FeatureContext.php
+++ b/tests/behat/features/bootstrap/FeatureContext.php
@@ -54,8 +54,15 @@ class FeatureContext extends RawMinkContext implements Context
         $this->getSession()->start();
       }
 
+      $config_factory = \Drupal::configFactory();
+
       // Let's disable the tour module for all tests by default.
-      \Drupal::configFactory()->getEditable('social_tour.settings')->set('social_tour_enabled', 0)->save();
+      $config_factory->getEditable('social_tour.settings')->set('social_tour_enabled', 0)->save();
+
+      // Since we enable Sky theme by default we should make sure we run our
+      // tests on the old theme. In another case, it will break all our tests.
+      // @see https://www.drupal.org/project/socialblue/issues/3251299
+      $config_factory->getEditable('socialblue.settings')->set('style', '')->save();
 
       /** @var \Behat\Testwork\Environment\Environment $environment */
       $environment = $scope->getEnvironment();


### PR DESCRIPTION
## Problem
Whenever we update our theme to “sky” by default for new installs (not for existing customers), it also means our Behat tests will be running on Sky because behat is running on both new install / updates in our Distribution
So that will break all our tests if we don’t fix it.

## Solution
Making sure we run our tests on the old theme.

## Issue tracker
- https://www.drupal.org/project/socialblue/issues/3251299

## How to test
- [x] Checkout to this branch
- [x] Make sure that patch is applied
- [x] Install OS from scratch
- [x] Run behat tests and they should pass without errors

## Screenshots
N/A

## Release notes
N/A

## Change Record
N/A

## Translations
N/A
