### PR TITLE
Issuue #3251356 by yaroslav-shandra: Change type field widget from autocomplete to select list

### DIFF
--- a/modules/social_features/social_content_block/src/SocialContentBlockOverride.php
+++ b/modules/social_features/social_content_block/src/SocialContentBlockOverride.php
@@ -106,18 +106,39 @@ class SocialContentBlockOverride implements ConfigFactoryOverrideInterface {
             $dependencies[] = $field_config;
             $group[] = $field;
 
-            $fields[$field] = [
-              'weight' => $weight++,
-              'settings' => [
-                'match_operator' => 'CONTAINS',
-                'size' => 60,
-                'placeholder' => '',
-                'match_limit' => 10,
-              ],
-              'third_party_settings' => [],
-              'type' => 'entity_reference_autocomplete_tags',
-              'region' => 'content',
+            $fields_select_types = [
+              'field_event_type',
+              'field_group_type',
+              'field_topic_type'
             ];
+
+            if (in_array($field, $fields_select_types)) {
+              $fields[$field] = [
+                'weight' => $weight++,
+                'settings' => [
+                  'autocomplete' => false,
+                  'match_operator' => 'CONTAINS',
+                  'match_limit' => 10,
+                ],
+                'third_party_settings' => [],
+                'type' => 'select2_entity_reference',
+                'region' => 'content',
+              ];
+            }
+            else {
+              $fields[$field] = [
+                'weight' => $weight++,
+                'settings' => [
+                  'match_operator' => 'CONTAINS',
+                  'size' => 60,
+                  'placeholder' => '',
+                  'match_limit' => 10,
+                ],
+                'third_party_settings' => [],
+                'type' => 'entity_reference_autocomplete_tags',
+                'region' => 'content',
+              ];
+            }
           }
         }
       }

--- a/modules/social_features/social_content_block/src/SocialContentBlockOverride.php
+++ b/modules/social_features/social_content_block/src/SocialContentBlockOverride.php
@@ -109,14 +109,14 @@ class SocialContentBlockOverride implements ConfigFactoryOverrideInterface {
             $fields_select_types = [
               'field_event_type',
               'field_group_type',
-              'field_topic_type'
+              'field_topic_type',
             ];
 
             if (in_array($field, $fields_select_types)) {
               $fields[$field] = [
                 'weight' => $weight++,
                 'settings' => [
-                  'autocomplete' => false,
+                  'autocomplete' => FALSE,
                   'match_operator' => 'CONTAINS',
                   'match_limit' => 10,
                 ],


### PR DESCRIPTION
## Problem
Fields Event types, Group types and Topic type in the custom content list block is not friendly for users which work with content. Now fields have type of autocomplete and users should keep in mind ​what values they want to type.

## Solution
Change widget for fields from autocomplete to select list (select2_entity_reference).

## Issue tracker
https://www.drupal.org/project/social/issues/3251356
https://getopensocial.atlassian.net/browse/MAIN-311

## How to test
1. Turn on the modules: Social Content Block, Social Event Content Block, Social Group Content Block
2. Make terms in vocabularies (Topic type,  Event types)
3. Add block custom content list (/block/add/custom_content_list?destination=/admin/structure/block/block-content)
4. Select type of content (Event, Group, Topic)
5. Start type in field (Event types, Group types, Topic type)

## Screenshots
before:
![Screenshot from 2021-12-01 11-59-46](https://user-images.githubusercontent.com/80881183/144213441-a46cc37d-1358-4a3a-b8a1-9d93143dabf5.png)

after:

![Screenshot from 2021-12-01 13-35-25](https://user-images.githubusercontent.com/80881183/144227746-efcdc5c6-c426-43d5-be96-868a0aacd0e6.png)

## Release notes
Change widget for Fields Event types, Group types and Topic type from autocomplete to select list (select2_entity_reference) at  in custom content list block on the Dashboard

## Change Record
n/a

## Translations
n/a
