### PR TITLE
Issue #3251371 by SV: Token [social_taxonomy:content_type] is not translatable

### DIFF
--- a/modules/social_features/social_follow_taxonomy/social_follow_taxonomy.tokens.inc
+++ b/modules/social_features/social_follow_taxonomy/social_follow_taxonomy.tokens.inc
@@ -83,8 +83,12 @@ function social_follow_taxonomy_tokens($type, $tokens, array $data, array $optio
                 case 'node':
                   /** @var \Drupal\node\Entity\Node $entity */
                   if ($entity instanceof NodeInterface) {
-                    // Get the name of the content.
-                    $display_name = strtolower($entity->getType());
+                    /** @var \Drupal\node\NodeTypeInterface $node_type */
+                    $node_type = \Drupal::entityTypeManager()
+                      ->getStorage('node_type')
+                      ->load($entity->bundle());
+                    // Get the label of the content type.
+                    $display_name = mb_strtolower((string) $node_type->label());
 
                     // Get the names of terms related to the content.
                     $term_ids = social_follow_taxonomy_terms_list($entity);


### PR DESCRIPTION
## Problem
Notification messages about tagging content use the [social_taxonomy:content_type] token which is not translatable

## Solution
Use label instead of machine name of the content type in the token replacement

## Issue tracker
- https://www.drupal.org/project/social/issues/3251371
- https://getopensocial.atlassian.net/browse/YANG-6597

## How to test
*For example*
- [ ] Using the latest version of Open Social with the social_follow_taxonomy module enabled
- [ ] As an administrator, try to add NL(or any other) translation of the name of some content type,
- [ ] Switch to another user and update topic/event with a tag which admin followed
- [ ] Next, switch back to the admin and select & save that language
- [ ] After, I expect that in the stream page/notifications/email a message displays a translated string but instead, I see a default name of content type (EN)
- [ ] The expected result is attained when repeating the steps with this fix applied.

## Screenshots
*If this Pull Request makes visual changes then please include some screenshots that show what has changed here. A before and after screenshot helps the reviewer determine what changes were made.*

## Release notes
Fixes a translation issue for [social_taxonomy:content_type] token in the notification messages

