### PR TITLE
Issue #3251664 by SV: Intro text of the "followed" items is not translatable on the stream

### DIFF
--- a/modules/social_features/social_follow_taxonomy/templates/activity--followed.html.twig
+++ b/modules/social_features/social_follow_taxonomy/templates/activity--followed.html.twig
@@ -35,7 +35,7 @@ post and not published ? 'post-unpublished',
     <div class="card__block">
       {% if followed_tags %}
         <div class="card__activity-followed">
-          <span>{{ content_type }} related to tag(s) you follow:</span>
+          <span>{{ content_type }} {% trans %} related to tag(s) you follow: {% endtrans %}</span>
           {% for tag in followed_tags %}
             <div class="activity-followed">
               <p class="tag__name">{{ tag.name }}</p>

--- a/modules/social_features/social_follow_taxonomy/templates/activity--node--followed.html.twig
+++ b/modules/social_features/social_follow_taxonomy/templates/activity--node--followed.html.twig
@@ -35,7 +35,7 @@ post and not published ? 'post-unpublished',
     <div class="card__block">
       {% if followed_tags %}
         <div class="card__activity-followed">
-          <span>{{ content_type }} related to tag(s) you follow:</span>
+          <span>{{ content_type }} {% trans %} related to tag(s) you follow: {% endtrans %}</span>
           {% for tag in followed_tags %}
             <div class="activity-followed">
               <p class="tag__name">{{ tag.name }}</p>


### PR DESCRIPTION
## Problem
Text **"related to tag(s) you follow"** intro text of the "followed" items is not translatable on the stream.

## Solution
Replace:  `<span>{{ content_type }} related to tag(s) you follow:</span> ` in the  related twig template
With following:   `<span>{{ content_type }} {% trans %} related to tag(s) you follow: {% endtrans %}</span>` 


## Issue tracker
- https://www.drupal.org/project/social/issues/3251664
- https://getopensocial.atlassian.net/browse/YANG-6597

## How to test
- [ ] Using the latest version of Open Social with the example module enabled
- [ ] As a sitemanager check his followed tags and set NL language in the user settings
- [ ] As login user try to update topic/event with a tag which sitemanager followed
- [ ] Next, switch back to the sitemanager 
- [ ] When I opened the stream I expect to see that intro text of followed items are translated but instead, I see a string on English
- [ ] The expected result is attained when repeating the steps with this fix applied.

## Screenshots
![Screenshot 2021-11-29 at 11 00 14](https://user-images.githubusercontent.com/25609390/143873925-b3873f4b-daeb-4d50-8349-9b8768aaeb63.png)

## Release notes
Make intro text of the followed items translatable on the stream page