### PR TITLE
Issue #2528214 by epapaniko, ribel: Bump up restrict images patch to work with installations under a directory

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
             },
             "drupal/core": {
                 "Color module html preview optional": "https://www.drupal.org/files/issues/color-optional-html-preview-2844190-2.patch",
-                "Restrict images to this site blocks image style derivatives": "https://www.drupal.org/files/issues/2018-10-26/2528214-47.patch",
+                "Restrict images to this site blocks image style derivatives": "https://www.drupal.org/files/issues/2019-05-10/2528214-54.patch",
                 "Optimize getCommentedEntity()": "https://www.drupal.org/files/issues/2018-12-28/2580551-72.patch",
                 "#states cannot check/uncheck 'radios' and 'checkboxes' elements": "https://www.drupal.org/files/issues/drupal-994360-74-states-checkboxes-checked.patch",
                 "Multiple usages of FieldPluginBase::getEntity do not check for NULL, leading to WSOD": "https://www.drupal.org/files/issues/2019-11-14/3007424-68.patch",


### PR DESCRIPTION
## Problem
The current patch (47) does not work with private paths for installations under a directory, ie `http://example.com/drupal/folder` as mentioned in the definition of `base_path()`.

## Solution
Replace patch 47 with updated version 55:
> The only difference is that I removed the hard-coded leading slash of `$private_path` and replaced it with `$base_path`.

## Issue tracker
- https://www.drupal.org/project/drupal/issues/2528214#comment-13101537
- https://github.com/goalgorilla/open_social/pull/1110
- https://getopensocial.atlassian.net/browse/SUP-1880

## How to test
- [ ] Using version of Open Social with installations under a directory
- [ ] As a LU
- [ ] Try to create new content and upload image from CKEditor
- [ ] You will see the image in a small size with notice
- [ ] The expected result is an image in correct size when repeating the steps with this fix applied.

## Screenshots
![image](https://user-images.githubusercontent.com/2241917/144069869-01dac3ca-1a32-41bb-a4cf-181914bcf6ae.png)

## Release notes
Bump up restrict images patch to work with installations under a directory.

## Change Record
N/A

## Translations
N/A