### PR TITLE
Issue #3252054 by Ressinel: Search all results should show correct information.

### DIFF
--- a/modules/social_features/social_book/src/SocialBookConfigOverride.php
+++ b/modules/social_features/social_book/src/SocialBookConfigOverride.php
@@ -59,7 +59,7 @@ class SocialBookConfigOverride implements ConfigFactoryOverrideInterface {
     ];
     foreach ($config_names as $config_name) {
       if (in_array($config_name, $names)) {
-        $overrides[$config_name]['field_settings']['rendered_item']['configuration']['view_mode']['book'] = 'search_index';
+        $overrides[$config_name]['field_settings']['rendered_item']['configuration']['view_mode']['entity:node']['book'] = 'search_index';
       }
     }
 


### PR DESCRIPTION
## Problem
### Scenario 1:
For example on Share Square - if I search the term MDR. the All page shows 4 results, only the ones with MDR in the title, while the Content page show 19 results where MDR is also mentioned in the description of the nodes. So seems the All page does not index the content of the nodes, while Content does. is that something that can possibly be fixed?

### Scenario 2:
I just searched "extensions" on Community Talks. and it seems that the All page also does not index the content of the Book page, but it does index the content of Topics & Events. So it might only be so for book pages? Or different settings per content type.

## Solution
Update `modules/social_features/social_book/src/SocialBookConfigOverride.php`

## Issue tracker
- https://www.drupal.org/project/social/issues/3252054

## How to test
- [x] Enable module `social_book`;
- [x] Create **Book** content with **Description** field value `qwerty`;
- [x] Make sure that the **Search all** index is reindexed;
- [x] Go to `/search/all/qwerty`;
- [x] You should see created book content.

## Screenshots
### Before:

![before](https://user-images.githubusercontent.com/10220937/144255038-17209cb5-b34b-4cb3-ab59-d00348f3b9b7.png)


### After:

![after](https://user-images.githubusercontent.com/10220937/144255072-cf83c7b4-d227-4dbc-a30d-209fc3c10e71.png)


## Release notes
Fixed issue for the search all when book content cannot find by description text.

## Change Record
N/A

## Translations
N/A