### PR TITLE
Warning when failing to login

### DIFF
--- a/modules/social_features/social_user/src/Form/SocialUserLoginForm.php
+++ b/modules/social_features/social_user/src/Form/SocialUserLoginForm.php
@@ -263,7 +263,7 @@ class SocialUserLoginForm extends UserLoginForm {
           <li>Too many failed login attempts from your computer (IP address). This IP address is temporarily blocked. </li>
         </ul>
         <p>To solve the issue, try using different login information, try again later, or <a href=":url">request a new password</a></p>',
-      ['%name_or_email' => $form_state->getValue('name_or_mail'), ':url' => Url::fromRoute('user.pass')]));
+      ['%name_or_email' => $form_state->getValue('name_or_mail'), ':url' => Url::fromRoute('user.pass')->toString()]));
   }
 
 }


### PR DESCRIPTION
## Problem
When failing to login (with wrong username or password) we walk into this warning:
```bash
Warning: strpos() expects parameter 1 to be string, object given in Drupal\Component\Utility\UrlHelper::stripDangerousProtocols() (line 359 of core/lib/Drupal/Component/Utility/UrlHelper.php).
```

It cames from `\Drupal\social_user\Form\SocialUserLoginForm::setGeneralErrorMessage` where we try to pass directly an `\Drupal\Core\Url\Url` object.

## Solution
Cast `\Drupal\Core\Url\Url` to string.

## How to test
- [ ] Try to login with wrong username or password
- [ ] The warning should no longer appear
