### PR TITLE
Issue #3254114 by tbsiqueira: Wrong UuidInterface instance on SocialEmbedHelper

### DIFF
--- a/modules/social_features/social_embed/src/Plugin/Filter/SocialEmbedUrlEmbedFilter.php
+++ b/modules/social_features/social_embed/src/Plugin/Filter/SocialEmbedUrlEmbedFilter.php
@@ -4,7 +4,7 @@ namespace Drupal\social_embed\Plugin\Filter;
 
 use Drupal\Component\Utility\Html;
 use Drupal\Component\Utility\UrlHelper;
-use Drupal\Component\Uuid\Php;
+use Drupal\Component\Uuid\UuidInterface;
 use Drupal\Core\Config\ConfigFactory;
 use Drupal\Core\Session\AccountProxyInterface;
 use Drupal\filter\FilterProcessResult;
@@ -29,9 +29,9 @@ class SocialEmbedUrlEmbedFilter extends UrlEmbedFilter {
   /**
    * Uuid services.
    *
-   * @var \Drupal\Component\Uuid\Php
+   * @var \Drupal\Component\Uuid\UuidInterface
    */
-  protected Php $uuid;
+  protected UuidInterface $uuid;
 
   /**
    * The config factory services.
@@ -65,7 +65,7 @@ class SocialEmbedUrlEmbedFilter extends UrlEmbedFilter {
    *   The plugin implementation definition.
    * @param \Drupal\url_embed\UrlEmbedInterface $url_embed
    *   The URL embed service.
-   * @param \Drupal\Component\Uuid\Php $uuid
+   * @param \Drupal\Component\Uuid\UuidInterface $uuid
    *   The uuid services.
    * @param \Drupal\Core\Config\ConfigFactory $config_factory
    *   The config factory services.
@@ -79,7 +79,7 @@ class SocialEmbedUrlEmbedFilter extends UrlEmbedFilter {
     $plugin_id,
     $plugin_definition,
     UrlEmbedInterface $url_embed,
-    Php $uuid,
+    UuidInterface $uuid,
     ConfigFactory $config_factory,
     SocialEmbedHelper $embed_helper,
     AccountProxyInterface $current_user

--- a/modules/social_features/social_embed/src/Service/SocialEmbedHelper.php
+++ b/modules/social_features/social_embed/src/Service/SocialEmbedHelper.php
@@ -5,7 +5,7 @@ namespace Drupal\social_embed\Service;
 use Drupal\Core\Render\Renderer;
 use Drupal\Core\Session\AccountProxyInterface;
 use Drupal\filter\FilterProcessResult;
-use Drupal\Component\Uuid\Php;
+use Drupal\Component\Uuid\UuidInterface;
 
 /**
  * Service class for Social Embed.
@@ -15,9 +15,9 @@ class SocialEmbedHelper {
   /**
    * Uuid generator.
    *
-   * @var \Drupal\Component\Uuid\Php
+   * @var \Drupal\Component\Uuid\UuidInterface
    */
-  protected Php $uuidGenerator;
+  protected UuidInterface $uuidGenerator;
 
   /**
    * Current user object.
@@ -36,14 +36,14 @@ class SocialEmbedHelper {
   /**
    * Constructor for SocialEmbedHelper.
    *
-   * @param \Drupal\Component\Uuid\Php $uuid_generator
+   * @param \Drupal\Component\Uuid\UuidInterface $uuid_generator
    *   The UUID generator.
    * @param \Drupal\Core\Session\AccountProxyInterface $current_user
    *   Current user object.
    * @param \Drupal\Core\Render\Renderer $renderer
    *   Renderer services.
    */
-  public function __construct(Php $uuid_generator, AccountProxyInterface $current_user, Renderer $renderer) {
+  public function __construct(UuidInterface $uuid_generator, AccountProxyInterface $current_user, Renderer $renderer) {
     $this->uuidGenerator = $uuid_generator;
     $this->currentUser = $current_user;
     $this->renderer = $renderer;


### PR DESCRIPTION
## Problem
Wrong instance passed to the constructor of **_SocialEmbedHelper_**.

`TypeError: Argument 1 passed to Drupal\social_embed\Service\SocialEmbedHelper::__construct() must be an instance of Drupal\Component\Uuid\Php, instance of Drupal\Component\Uuid\Pecl given in Drupal\social_embed\Service\SocialEmbedHelper->__construct()`

_**SocialEmbedHelper**_ expects `Drupal\Component\Uuid\Php` class because that is what core service _**uuid**_ offers.

Because of compatibility there is a service alter on CoreServiceProvider::alter that checks for existing functions and this can lead to a different class injection at SocialEmbedHelper

```
    $uuid_service = $container->getDefinition('uuid');
    // Debian/Ubuntu uses the (broken) OSSP extension as their UUID
    // implementation. The OSSP implementation is not compatible with the
    // PECL functions.
    if (function_exists('uuid_create') && !function_exists('uuid_make')) {
      $uuid_service->setClass('Drupal\Component\Uuid\Pecl');
    }
    // Try to use the COM implementation for Windows users.
    elseif (function_exists('com_create_guid')) {
      $uuid_service->setClass('Drupal\Component\Uuid\Com');
    }
```

## Solution
Change the expected class from `Drupal\Component\Uuid\Php` to _Drupal\Component\Uuid\UuidInterface_

## Issue tracker
https://www.drupal.org/project/social/issues/3254114

## How to test
- [ ] Enable and use Social Embed Helper.

## Screenshots
N/A

## Release notes
N/A

## Change Record
N/A

## Translations
N/A
