### PR TITLE
Issue #3254196 by ribel: Fix mention link output to work with the installation under a subdirectory

### DIFF
--- a/modules/custom/mentions/src/Plugin/Filter/MentionsFilter.php
+++ b/modules/custom/mentions/src/Plugin/Filter/MentionsFilter.php
@@ -272,7 +272,7 @@ class MentionsFilter extends FilterBase implements ContainerFactoryPluginInterfa
         $build = [
           '#theme' => 'mention_link',
           '#mention_id' => $match['target']['entity_id'],
-          '#link' => $output['link'],
+          '#link' => base_path() . $output['link'],
           '#render_link' => $output_settings['renderlink'],
           '#render_value' => $output['value'],
         ];

--- a/modules/custom/mentions/templates/mention-link.html.twig
+++ b/modules/custom/mentions/templates/mention-link.html.twig
@@ -1,1 +1,1 @@
-{% if render_link == true %}<a href="/{{ link }}" class="mentions mentions-{{ mention_id }}">{{ render_value|raw }}</a>{% else %}{{ link }}{% endif %}
+{% if render_link == true %}<a href="{{ link }}" class="mentions mentions-{{ mention_id }}">{{ render_value|raw }}</a>{% else %}{{ link }}{% endif %}


### PR DESCRIPTION
## Problem
There is an issue for sites installed in the subfolder and the domain looks like: https://example.com/community.

When mention you're redirected to a non-existent page (e.g. https://example.com/user/9/information) because the /community URL section is missing (the right URL would be, for instance, https://example.com/community/user/9/information).

## Solution
Replace hardcoded `/` in template with `base_path()` function in the preprocess.

## Issue tracker
- https://www.drupal.org/project/social/issues/3254196
- https://getopensocial.atlassian.net/browse/YANG-6760

## How to test
- [ ] Using version 10.x of Open Social with the Mentions module enabled
- [ ] As a LU mention another user
- [ ] Click on mention link
- [ ] You should be redirected to user profile

## Release notes
Fix mention link output to work with the sites installed under a subdirectory.

## Change Record
N/A

## Translations
N/A
