### PR TITLE
Issue #3254503 by nkoporec: iCal is not importing to Calendar (Mac OSX) if the event contains emojis

### DIFF
--- a/modules/social_features/social_event/modules/social_event_addtocal/src/Controller/AddToCalendarIcsController.php
+++ b/modules/social_features/social_event/modules/social_event_addtocal/src/Controller/AddToCalendarIcsController.php
@@ -100,6 +100,7 @@ class AddToCalendarIcsController extends ControllerBase {
       }
 
       // Set end of file.
+      $file_data[] = 'TRANSP:OPAQUE';
       $file_data[] = 'END:VEVENT';
       $file_data[] = 'END:VCALENDAR';
 


### PR DESCRIPTION
## Problem

The default Calendar app on Mac OS or on an iPhone is not importing the events exported using the iCal add to calendar feature. On the desktop the Calendar app imports the event but it is not shown after, on an iPhone a parsing error is shown during the import.

## Solution
After investigating, the emojis are supported in Calendar app on OSX, so I checked the file that Open Social export and the file that the Calendar app exports and I found out that it is adding the 'TRANSP' property to the VEVENT which is missing in the Open Social export file.

## Issue tracker
https://www.drupal.org/project/social/issues/3254503

## How to test
1. Enable the social_event_addtocal module
2. Under module settings enable the iCal export
3. Create an event with emojis in title and body
4. Click the Add to calendar button and select the iCal
5. Try to import it to the Calendar app.


## Screenshots
*If this Pull Request makes visual changes then please include some screenshots that show what has changed here. A before and after screenshot helps the reviewer determine what changes were made.*

## Release notes
Fixed an issue with calendar imports on Mac OSX systems.

## Change Record
*If this Pull Request changes the way that developers should do things or introduces a new API for developers then a change record to document this is needed. Please provide a draft for a change record or a link to an unpublished change record below. [Existing change records](https://www.drupal.org/list-changes/social) can be consulted as example.*

## Translations
*Translatable strings are always extracted from the latest development branch. To ensure translations remain available for platforms running older versions of Open Social the original string should be added to `translations.php` when it's changed or removed.*
- [ ] Changed or removed source strings are added to the `translations.php` file.
