### PR TITLE
Issue #3254684 by nachosalvador: Add featured view mode for flexible …

### DIFF
--- a/modules/social_features/social_featured_content/config/install/core.entity_view_display.group.flexible_group.featured.yml
+++ b/modules/social_features/social_featured_content/config/install/core.entity_view_display.group.flexible_group.featured.yml
@@ -1,0 +1,49 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.group.featured
+    - field.field.group.flexible_group.field_group_address
+    - field.field.group.flexible_group.field_group_description
+    - field.field.group.flexible_group.field_group_image
+    - field.field.group.flexible_group.field_group_location
+    - group.type.flexible_group
+    - image.style.social_featured
+  module:
+    - address
+    - image
+id: group.flexible_group.featured
+targetEntityType: group
+bundle: flexible_group
+mode: featured
+content:
+  field_group_address:
+    type: address_plain
+    weight: 1
+    region: content
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+  field_group_image:
+    type: image
+    weight: 0
+    region: content
+    label: hidden
+    settings:
+      image_style: social_featured
+      image_link: content
+    third_party_settings: {  }
+  field_group_location:
+    type: string
+    weight: 2
+    region: content
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+hidden:
+  changed: true
+  created: true
+  field_group_description: true
+  label: true
+  uid: true

--- a/modules/social_features/social_featured_content/config/static/core.entity_view_display.group.flexible_group.featured_11001.yml
+++ b/modules/social_features/social_featured_content/config/static/core.entity_view_display.group.flexible_group.featured_11001.yml
@@ -1,0 +1,49 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.group.featured
+    - field.field.group.flexible_group.field_group_address
+    - field.field.group.flexible_group.field_group_description
+    - field.field.group.flexible_group.field_group_image
+    - field.field.group.flexible_group.field_group_location
+    - group.type.flexible_group
+    - image.style.social_featured
+  module:
+    - address
+    - image
+id: group.flexible_group.featured
+targetEntityType: group
+bundle: flexible_group
+mode: featured
+content:
+  field_group_address:
+    type: address_plain
+    weight: 1
+    region: content
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+  field_group_image:
+    type: image
+    weight: 0
+    region: content
+    label: hidden
+    settings:
+      image_style: social_featured
+      image_link: content
+    third_party_settings: {  }
+  field_group_location:
+    type: string
+    weight: 2
+    region: content
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+hidden:
+  changed: true
+  created: true
+  field_group_description: true
+  label: true
+  uid: true

--- a/modules/social_features/social_featured_content/social_featured_content.install
+++ b/modules/social_features/social_featured_content/social_featured_content.install
@@ -5,6 +5,8 @@
  * Lifecycle functions for the social_featured_content module.
  */
 
+use Drupal\Core\Config\FileStorage;
+
 /**
  * Add translations support for "Featured Content" custom block fields.
  */
@@ -17,4 +19,21 @@ function social_featured_content_update_10300() {
 
   // Output logged messages to related channel of update execution.
   return $update_helper->logger()->output();
+}
+
+/**
+ * Import featured view display of flexible group.
+ */
+function social_featured_content_update_11001(): void {
+  $configs = [
+    'core.entity_view_display.group.flexible_group.featured' => 'core.entity_view_display.group.flexible_group.featured_11001',
+  ];
+
+  $config_storage = \Drupal::service('config.storage');
+  $config_path = drupal_get_path('module', 'social_featured_content') . '/config/static/';
+  $source = new FileStorage($config_path);
+
+  foreach ($configs as $origin_name => $update_name) {
+    $config_storage->write($origin_name, $source->read($update_name));
+  }
 }


### PR DESCRIPTION
## Problem
The images for the flexible group spaces displayed on the Social Featured Content are no longer showing up:

## Solution
Create featured view mode for flexible group type.

## Issue tracker
https://www.drupal.org/project/social/issues/3254684

## How to test

- [ ] Enable social_featured_content module
- [ ] Create flexible group and set a group image
- [ ] Create a featured content (from a dashboard for example) for the previous created flexible group

## Screenshots
**Before**
![Screenshot at 2021-12-15 18-07-48](https://user-images.githubusercontent.com/8913851/146328626-7449d577-896c-47c9-ae19-103c4dcc2341.png)

**After**
![Screenshot at 2021-12-15 19-14-41](https://user-images.githubusercontent.com/8913851/146328645-1246f082-e171-4366-b9ec-8c1f818c3258.png)

## Release notes
None

## Change Record
None

## Translations
None
