### PR TITLE
INTERNAL | Update data_policy to 2.0.0 for Drupal 9.2 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -92,9 +92,6 @@
                 "Undefined property: stdClass::$region in field_group_form_process().": "https://www.drupal.org/files/issues/2020-06-15/3059614-37.patch",
                 "Remove dependency on jQuery UI Accordion for the accordion field group formatter": "https://www.drupal.org/files/issues/2021-10-16/3154304-2.patch"
             },
-            "drupal/data_policy": {
-                "9.2.x compatibility": "https://git.drupalcode.org/project/data_policy/-/merge_requests/12.diff"
-            },
             "drupal/flag": {
                 "Add relationship to flagged entities when Flagging is base table": "https://www.drupal.org/files/issues/2021-11-08/2723703-76.patch",
                 "3248173: Symfony 4.4 event dispatcher parameter order change": "https://www.drupal.org/files/issues/2021-11-08/symfony-4-4-event-dispatcher-parameter-order-change-3248173-2.patch"
@@ -171,7 +168,7 @@
         "drupal/crop": "2.1.0",
         "drupal/csv_serialization": "2.0",
         "drupal/ctools": "3.7",
-        "drupal/data_policy": "1.2",
+        "drupal/data_policy": "2.0.0-beta1",
         "drupal/dynamic_entity_reference": "1.12",
         "drupal/editor_advanced_link": "1.9",
         "drupal/entity": "1.2.0",


### PR DESCRIPTION
## Problem
Update data policy module to use the new beta version

## How to test
- [ ] Test the data policy module

## Screenshots
N/A

## Release notes
N/A

## Change Record
N/A

## Translations
N/A
