### PR TITLE
Issue #3255221 by vnech: Make possible to display notifications created in custom entities context

### DIFF
--- a/modules/custom/activity_viewer/src/Plugin/views/filter/ActivityNotificationVisibilityAccess.php
+++ b/modules/custom/activity_viewer/src/Plugin/views/filter/ActivityNotificationVisibilityAccess.php
@@ -231,6 +231,12 @@ class ActivityNotificationVisibilityAccess extends FilterPluginBase {
       $or->condition($membership_access);
     }
 
+    // Simple condition that allows to receive the notifications sent directly
+    // to the recipient.
+    if ($authenticated) {
+      $or->condition('activity__field_activity_recipient_user.field_activity_recipient_user_target_id', (string) $account->id());
+    }
+
     // Lets add all the or conditions to the Views query.
     $and_wrapper->condition($or);
     $this->query->addWhere('visibility', $and_wrapper);


### PR DESCRIPTION
## Problem
I created my own custom entity. Then I decided to create a new message template to send "notification" message to some users.
Sending works as should. Receivers get the correct numbers of new messages (at the "bell" sign).
But the "notifications" doesn't displaying on the _/notifications_ page...

The issue is that the page is built with views and the view display using the filter plugin with hardcoded access rules - [modules/custom/activity_viewer/src/Plugin/views/filter/ActivityNotificationVisibilityAccess.php](https://github.com/goalgorilla/open_social/blob/main/modules/custom/activity_viewer/src/Plugin/views/filter/ActivityNotificationVisibilityAccess.php)

## Solution
Add a general rule to the view filter plugin for accessing to activities by `field_activity_recipient_user` field

## Issue tracker
- https://www.drupal.org/project/social/issues/3255221
- https://getopensocial.atlassian.net/browse/YANG-6631

## How to test
- [ ] Create a custom entity
- [ ] Add a new message template with the parameters: 
<img width="811" alt="Screenshot 2021-12-20 at 12 53 18" src="https://user-images.githubusercontent.com/19921926/146756218-bff0b217-733d-4cd8-8282-d9ea6376d826.png">

- [ ] Create a custom entity
- [ ] Login as notification receiver
- [ ] Check if notification appears on _/notifications_ page

## Release notes
Make possible to display notifications created in custom entities context.