### PR TITLE
Feature/3238713 country field default value is no longer filled

### DIFF
--- a/modules/social_features/social_core/social_core.module
+++ b/modules/social_features/social_core/social_core.module
@@ -671,7 +671,7 @@ function social_core_block_access(Block $block, $operation, AccountInterface $ac
 function social_core_field_widget_form_alter(&$element, FormStateInterface $form_state, $context) {
   $field_definition = $context['items']->getFieldDefinition();
 
-  if ($field_definition->getType() == 'path') {
+  if ($field_definition->getType() === 'path') {
     $url = Url::fromRoute('<front>', [], [
       'absolute' => TRUE,
     ]);
@@ -706,6 +706,10 @@ function social_core_field_widget_form_alter(&$element, FormStateInterface $form
     }
 
     $element['#element_validate'] = ['social_core_path_validate'];
+  }
+  if ($field_definition->getType() === 'address') {
+    $default_country = \Drupal::config('system.date')->get('country.default');
+    $element['address']['#default_value']['country_code'] = $element['address']['#default_value']['country_code'] ?? $default_country;
   }
 }
 

--- a/modules/social_features/social_event/config/install/core.entity_form_display.node.event.default.yml
+++ b/modules/social_features/social_event/config/install/core.entity_form_display.node.event.default.yml
@@ -184,8 +184,7 @@ content:
     region: content
   field_event_address:
     weight: 14
-    settings:
-      default_country: site_default
+    settings: {  }
     third_party_settings: {  }
     type: address_default
     region: content

--- a/modules/social_features/social_group/config/install/core.entity_form_display.group.closed_group.default.yml
+++ b/modules/social_features/social_group/config/install/core.entity_form_display.group.closed_group.default.yml
@@ -64,8 +64,7 @@ mode: default
 content:
   field_group_address:
     weight: 33
-    settings:
-      default_country: site_default
+    settings: {  }
     third_party_settings: {  }
     type: address_default
     region: content

--- a/modules/social_features/social_group/config/install/core.entity_form_display.group.open_group.default.yml
+++ b/modules/social_features/social_group/config/install/core.entity_form_display.group.open_group.default.yml
@@ -64,8 +64,7 @@ mode: default
 content:
   field_group_address:
     weight: 33
-    settings:
-      default_country: site_default
+    settings: {  }
     third_party_settings: {  }
     type: address_default
     region: content

--- a/modules/social_features/social_group/config/install/core.entity_form_display.group.public_group.default.yml
+++ b/modules/social_features/social_group/config/install/core.entity_form_display.group.public_group.default.yml
@@ -64,8 +64,7 @@ mode: default
 content:
   field_group_address:
     weight: 33
-    settings:
-      default_country: null
+    settings: {  }
     third_party_settings: {  }
     type: address_default
     region: content

--- a/modules/social_features/social_group/modules/social_group_secret/config/install/core.entity_form_display.group.secret_group.default.yml
+++ b/modules/social_features/social_group/modules/social_group_secret/config/install/core.entity_form_display.group.secret_group.default.yml
@@ -65,8 +65,7 @@ mode: default
 content:
   field_group_address:
     weight: 33
-    settings:
-      default_country: site_default
+    settings: {  }
     third_party_settings: {  }
     type: address_default
     region: content

--- a/modules/social_features/social_profile/config/install/core.entity_form_display.profile.profile.default.yml
+++ b/modules/social_features/social_profile/config/install/core.entity_form_display.profile.profile.default.yml
@@ -88,8 +88,7 @@ mode: default
 content:
   field_profile_address:
     weight: 7
-    settings:
-      default_country: site_default
+    settings: {  }
     third_party_settings: {  }
     type: address_default
     region: content


### PR DESCRIPTION
## Problem
As part of [DS-4076](https://getopensocial.atlassian.net/browse/DS-4076) the functionality was added in Open Social to set the default value of country fields to the Platform's country.

The way this was implemented was removed in address 1.5/1.6 through [#2838457: Re-enable the default value functionality for Address fields](https://www.drupal.org/project/address/issues/2838457). The recommended method now is to provide a widget alter hook that provides the functionality.

Our current form_display config values are no longer valid. This would've been caught by schema validations of PHPUnit if those were in place.

This was instead discovered as part of work done on [#3230125: Refactor profile field management and visibility](https://www.drupal.org/project/social/issues/3230125)

## Solution
Implement the widget alter hook as proposed and clean up our existing configuration so that it conforms to the schema of the address module.

## Issue tracker
https://www.drupal.org/project/social/issues/3238713

## How to test
- [ ] Goto "/admin/config/regional/settings" and set the Default country.
- [ ] Create new event/group and scroll down to the Location fieldset, verify if Country field value matches with the Default country (set in the previous step).
- [ ] Set different country value than the default in a group or event.
- [ ] Save and check if the country value is stored properly.

## Screenshots
N/A

## Release notes
N/A

## Change Record
N/A

## Translations
N/A
