### PR TITLE
fix: GroupRequestMembershipForm was using non-existing constant

### DIFF
--- a/modules/custom/grequest/src/Form/GroupRequestMembershipForm.php
+++ b/modules/custom/grequest/src/Form/GroupRequestMembershipForm.php
@@ -68,10 +68,10 @@ class GroupRequestMembershipForm extends ConfirmFormBase {
     ]);
     $result = $group_content->save();
     if ($result) {
-      $this->messenger()->addMessage($this->t("Your request is waiting for Group Administrator's approval"));
+      $this->messenger()->addStatus($this->t("Your request is waiting for Group Administrator's approval"));
     }
     else {
-      $this->messenger()->addMessage($this->t("Error creating request"), self::TYPE_ERROR);
+      $this->messenger()->addError($this->t("Error creating request"));
     }
   }
 


### PR DESCRIPTION
## Problem
`GroupRequestMembershipForm` class was using `self::TYPE_ERROR` which does not exist on Form classes. It should have been `MessengerInterface::TYPE_ERROR`.

## Solution
Use the messenger corresponding methods to display a Status or an Error.