### PR TITLE
Issue #3255823 by SV: Hide "Private message" button if user doesn't have "create private messages thread" permission.

### DIFF
--- a/modules/social_features/social_profile/social_profile.module
+++ b/modules/social_features/social_profile/social_profile.module
@@ -336,7 +336,13 @@ function social_profile_preprocess_profile(array &$variables) {
   // The actual label text should be changeable in the template.
   // Disable for the LU's own profile.
   $variables['profile_contact_label'] = 'profile_info';
-  if (\Drupal::moduleHandler()->moduleExists('social_private_message') && $current_user->id() != $profile->getOwnerId() && $current_user->hasPermission('use private messaging system') && User::load($profile->getOwnerId())->hasPermission('use private messaging system')) {
+  if (
+    \Drupal::moduleHandler()->moduleExists('social_private_message') &&
+    $current_user->id() != $profile->getOwnerId() &&
+    $current_user->hasPermission('use private messaging system') &&
+    $current_user->hasPermission('create private messages thread') &&
+    User::load($profile->getOwnerId())->hasPermission('use private messaging system')
+  ) {
     $variables['profile_contact_label'] = 'private_message';
     $variables['#cache']['contexts'][] = 'user';
   }


### PR DESCRIPTION
## Problem
Private messages are still visible on the page “All Members” and this allows everyone to send messages to everybody. The link “Private message” should not be visible for a normal user if they doesn't have "create private messages thread" permission.

## Solution
 Use addition check if the current user has `create private messages thread` permission.

## Issue tracker
- https://www.drupal.org/project/social/issues/3255823
- https://getopensocial.atlassian.net/browse/YANG-6625

## How to test
- [x] Using the latest version of Open Social with the social_private_message module enabled
- [x] As a LU I should not see the "private message" link on the "/all-members" page
- [x] As a SM I still should 
- [x] The expected result is attained when repeating the steps with this fix applied.

## Screenshots
<img width="895" alt="Screenshot 2021-12-23 at 14 51 27" src="https://user-images.githubusercontent.com/25609390/147262118-df323ba9-f1fa-44e2-9e36-91f01bbc1375.png">

## Release notes
Hide a "Private message" button if user doesn't have "create private messages thread" permission.