### PR TITLE
Issue #3255928 by tBKoT: Fix enity autocomplete when views is using

### DIFF
--- a/modules/social_features/social_core/src/Entity/EntityAutocompleteMatcher.php
+++ b/modules/social_features/social_core/src/Entity/EntityAutocompleteMatcher.php
@@ -19,7 +19,7 @@ class EntityAutocompleteMatcher extends EntityAutocompleteMatcherBase {
   public function getMatches($target_type, $selection_handler, $selection_settings, $string = '') {
     $matches = [];
 
-    $options = [
+    $options = $selection_settings + [
       'target_type' => $target_type,
       'handler' => $selection_handler,
       'handler_settings' => $selection_settings,

--- a/modules/social_features/social_core/src/Entity/EntityAutocompleteMatcher.php
+++ b/modules/social_features/social_core/src/Entity/EntityAutocompleteMatcher.php
@@ -22,7 +22,6 @@ class EntityAutocompleteMatcher extends EntityAutocompleteMatcherBase {
     $options = $selection_settings + [
       'target_type' => $target_type,
       'handler' => $selection_handler,
-      'handler_settings' => $selection_settings,
     ];
     $handler = $this->selectionManager->getInstance($options);
 


### PR DESCRIPTION
## Problem
Now, the `entity autocomplete` fields that use the view as a handler returns nothing because views cannot be found.
I've noticed that problem in `EntityAutocompleteMatcher`, it has incorrect the `$options` array for instances. For example, I can not find any field in the distro, only in extensions.

## Solution
Make the `$options` array be like in extended class.

## Issue tracker
- https://www.drupal.org/project/social/issues/3255928

## How to test

## Screenshots
#### Notice
![зображення](https://user-images.githubusercontent.com/11648677/147350630-a73238b6-2338-4dcf-8e5f-f5031c2de78f.png)

#### Before changes(empty list)
![зображення](https://user-images.githubusercontent.com/11648677/147350679-370dfc77-220a-4b77-9999-6079e23df563.png)

#### After changes
![зображення](https://user-images.githubusercontent.com/11648677/147350572-0df1e581-f635-4e78-85bc-6a35eb977bde.png)


## Release notes
Entity autocomplete works as expected.

## Change Record
N/A

## Translations
N/A
