### PR TITLE
Issue #3222835 by curriedn, Ressinel: GroupRequestMembershipForm was using non-existing constant

### DIFF
--- a/modules/custom/grequest/src/Form/GroupRequestMembershipForm.php
+++ b/modules/custom/grequest/src/Form/GroupRequestMembershipForm.php
@@ -68,10 +68,10 @@ class GroupRequestMembershipForm extends ConfirmFormBase {
     ]);
     $result = $group_content->save();
     if ($result) {
-      $this->messenger()->addMessage($this->t("Your request is waiting for Group Administrator's approval"));
+      $this->messenger()->addStatus($this->t("Your request is waiting for Group Administrator's approval"));
     }
     else {
-      $this->messenger()->addMessage($this->t("Error creating request"), self::TYPE_ERROR);
+      $this->messenger()->addError($this->t('Error creating request'));
     }
   }
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2476,11 +2476,6 @@ parameters:
 			path: modules/custom/grequest/src/Controller/GrequestController.php
 
 		-
-			message: "#^Access to undefined constant Drupal\\\\grequest\\\\Form\\\\GroupRequestMembershipForm\\:\\:TYPE_ERROR\\.$#"
-			count: 1
-			path: modules/custom/grequest/src/Form/GroupRequestMembershipForm.php
-
-		-
 			message: "#^Method Drupal\\\\grequest\\\\Form\\\\GroupRequestMembershipForm\\:\\:submitForm\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: modules/custom/grequest/src/Form/GroupRequestMembershipForm.php


### PR DESCRIPTION
Follow up of #2669

## Problem
`GroupRequestMembershipForm` class was using `self::TYPE_ERROR` which does not exist on Form classes. It should have been `MessengerInterface::TYPE_ERROR`.

## Solution
Use the messenger corresponding methods to display a Status or an Error.

## Issue tracker
- https://www.drupal.org/project/social/issues/3256120

## How to test
N/A

## Screenshots
N/A

## Release notes
N/A

## Change Record
N/A

## Translations
N/A
