### PR TITLE
Issue #3256341 by nkoporec: When deleting an event, delete the event invites too

### DIFF
--- a/modules/social_features/social_event/modules/social_event_invite/social_event_invite.module
+++ b/modules/social_features/social_event/modules/social_event_invite/social_event_invite.module
@@ -252,7 +252,7 @@ function social_event_invite_user_insert(UserInterface $entity) {
 /**
  * Implements hook_ENTITY_TYPE_delete().
  */
-function social_event_invite_node_delete(NodeInterface $node) {
+function social_event_invite_node_delete(NodeInterface $node): void {
   $type = $node->getType();
   if ($type != "event") {
     return;

--- a/modules/social_features/social_event/modules/social_event_invite/social_event_invite.module
+++ b/modules/social_features/social_event/modules/social_event_invite/social_event_invite.module
@@ -12,6 +12,7 @@ use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Url;
 use Drupal\node\Entity\Node;
+use Drupal\node\NodeInterface;
 use Drupal\social_event\EventEnrollmentInterface;
 use Drupal\user\UserInterface;
 
@@ -246,6 +247,37 @@ function social_event_invite_user_insert(UserInterface $entity) {
     $enrollment->set('user_id', $entity->id());
     $enrollment->save();
   }
+}
+
+/**
+ * Implements hook_ENTITY_TYPE_delete().
+ */
+function social_event_invite_node_delete(NodeInterface $node) {
+  $type = $node->getType();
+  if ($type != "event") {
+    return;
+  }
+
+  $conditions = [
+    'field_event' => $node->id(),
+  ];
+
+  /** @var \Drupal\social_event\EventEnrollmentInterface[] $enrollments */
+  $enrollments = \Drupal::entityTypeManager()
+    ->getStorage('event_enrollment')
+    ->loadByProperties($conditions);
+
+  $tags = [];
+  foreach ($enrollments as $enrollment) {
+    $enrollment->delete();
+
+    $tags[] = 'enrollment:' . $enrollment->field_event->value . '-' . $enrollment->user_id->target_id;
+    $tags[] = 'event_content_list:entity:' . $enrollment->field_event->value;
+    $tags[] = 'event_content_list:user:' . $enrollment->user_id->value;
+    $tags[] = 'event_enrollment_view';
+  }
+
+  Cache::invalidateTags($tags);
 }
 
 /**


### PR DESCRIPTION
## Problem
If you delete an event, the co-responding event invites are not deleted. This means that if a user has a pending invite and the event gets deleted, the user will keep seeing the pending invite notification even though the event no longer exists.

## Solution
When deleting an event, we should also delete all invites for that event.

## Issue tracker
https://www.drupal.org/project/social/issues/3256341

## How to test
1. Create an event
2. Invite an authenticated user to the event
3. Log in as that user and see your pending invites
4. As admin delete this event
5. Login back as authenticated user and see you pending invites.

## Screenshots
![2021-12-29_15-24](https://user-images.githubusercontent.com/35064680/147672004-b87ff781-923b-48c5-a9b5-374801c6e202.png)


## Release notes
When deleting an event make sure that all invites gets deleted as well.

## Change Record
*If this Pull Request changes the way that developers should do things or introduces a new API for developers then a change record to document this is needed. Please provide a draft for a change record or a link to an unpublished change record below. [Existing change records](https://www.drupal.org/list-changes/social) can be consulted as example.*

## Translations
*Translatable strings are always extracted from the latest development branch. To ensure translations remain available for platforms running older versions of Open Social the original string should be added to `translations.php` when it's changed or removed.*
- [ ] Changed or removed source strings are added to the `translations.php` file.
