### PR TITLE
[Internal] Lock our phpstan rules and utilize dependabot to update the dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,3 +36,21 @@ updates:
       include: "scope"
     # Allow up to 5 open pull requests for Drupal dependencies as we have some to go.
     open-pull-requests-limit: 5  
+
+  # Maintain our test dependencies
+  - package-ecosystem: "composer"
+    directory: "/tests"
+    schedule:
+      interval: "daily"
+      time: "01:00"
+      timezone: "Europe/Amsterdam"
+    labels:
+      - "type: update"
+      - "team: nucleus"
+    # Let core team maintainers review it.
+    reviewers:
+      - "goalgorilla/maintainers"
+    # Prefix all commit messages and include a list of updated dependencies
+    commit-message:
+      prefix: "Updates test dependencies: "
+      include: "scope"

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -411,11 +411,6 @@ parameters:
 			path: modules/custom/activity_creator/src/ActivityAccessControlHandler.php
 
 		-
-			message: "#^Parameter \\#1 \\$condition of static method Drupal\\\\Core\\\\Access\\\\AccessResult\\:\\:allowedIf\\(\\) expects bool, bool\\|Drupal\\\\Core\\\\Access\\\\AccessResultInterface given\\.$#"
-			count: 1
-			path: modules/custom/activity_creator/src/ActivityAccessControlHandler.php
-
-		-
 			message: "#^Cannot call method fetchField\\(\\) on Drupal\\\\Core\\\\Database\\\\StatementInterface\\|null\\.$#"
 			count: 1
 			path: modules/custom/activity_creator/src/ActivityFactory.php
@@ -7556,12 +7551,11 @@ parameters:
 			path: modules/social_features/social_embed/src/SocialEmbedConfigOverride.php
 
 		-
-			message:
-				"""
-					#^Call to deprecated method assertEqual\\(\\) of class Drupal\\\\KernelTests\\\\KernelTestBase\\:
-					in drupal\\:8\\.0\\.0 and is removed from drupal\\:10\\.0\\.0\\. Use
-					  \\$this\\-\\>assertEquals\\(\\) instead\\.$#
-				"""
+			message: """
+				#^Call to deprecated method assertEqual\\(\\) of class Drupal\\\\KernelTests\\\\KernelTestBase\\:
+				in drupal\\:8\\.0\\.0 and is removed from drupal\\:10\\.0\\.0\\. Use
+				  \\$this\\-\\>assertEquals\\(\\) instead\\.$#
+			"""
 			count: 2
 			path: modules/social_features/social_embed/tests/src/Kernel/SocialUserEmbedTest.php
 
@@ -7986,11 +7980,6 @@ parameters:
 			path: modules/social_features/social_event/modules/social_event_an_enroll_enrolments_export/social_event_an_enroll_enrolments_export.module
 
 		-
-			message: "#^Cannot call method isAllowed\\(\\) on bool\\|Drupal\\\\Core\\\\Access\\\\AccessResultInterface\\.$#"
-			count: 1
-			path: modules/social_features/social_event/modules/social_event_an_enroll_enrolments_export/src/Plugin/Action/ExportAllEnrolments.php
-
-		-
 			message: "#^Method Drupal\\\\social_event_an_enroll_enrolments_export\\\\Plugin\\\\Action\\\\ExportAllEnrolments\\:\\:executeMultiple\\(\\) should return array but return statement is missing\\.$#"
 			count: 1
 			path: modules/social_features/social_event/modules/social_event_an_enroll_enrolments_export/src/Plugin/Action/ExportAllEnrolments.php
@@ -8029,11 +8018,6 @@ parameters:
 			message: "#^Parameter \\#2 \\$subject of function preg_match expects string, bool\\|string given\\.$#"
 			count: 1
 			path: modules/social_features/social_event/modules/social_event_enrolments_export/social_event_enrolments_export.module
-
-		-
-			message: "#^Cannot call method isAllowed\\(\\) on bool\\|Drupal\\\\Core\\\\Access\\\\AccessResultInterface\\.$#"
-			count: 1
-			path: modules/social_features/social_event/modules/social_event_enrolments_export/src/Plugin/Action/ExportEnrolments.php
 
 		-
 			message: "#^Method Drupal\\\\social_event_enrolments_export\\\\Plugin\\\\Action\\\\ExportEnrolments\\:\\:executeMultiple\\(\\) should return array but return statement is missing\\.$#"
@@ -8907,11 +8891,6 @@ parameters:
 
 		-
 			message: "#^Call to an undefined method Drupal\\\\social_event\\\\EventEnrollmentInterface\\:\\:getFieldValue\\(\\)\\.$#"
-			count: 1
-			path: modules/social_features/social_event/modules/social_event_managers/src/Plugin/Action/EventEnrollmentEntityDeleteAction.php
-
-		-
-			message: "#^Cannot call method isAllowed\\(\\) on bool\\|Drupal\\\\Core\\\\Access\\\\AccessResultInterface\\.$#"
 			count: 1
 			path: modules/social_features/social_event/modules/social_event_managers/src/Plugin/Action/EventEnrollmentEntityDeleteAction.php
 
@@ -11926,11 +11905,6 @@ parameters:
 			path: modules/social_features/social_group/modules/social_group_members_export/social_group_members_export.module
 
 		-
-			message: "#^Cannot call method isAllowed\\(\\) on bool\\|Drupal\\\\Core\\\\Access\\\\AccessResultInterface\\.$#"
-			count: 1
-			path: modules/social_features/social_group/modules/social_group_members_export/src/Plugin/Action/ExportMember.php
-
-		-
 			message: "#^Method Drupal\\\\social_group_members_export\\\\Plugin\\\\Action\\\\ExportMember\\:\\:executeMultiple\\(\\) should return array but return statement is missing\\.$#"
 			count: 1
 			path: modules/social_features/social_group/modules/social_group_members_export/src/Plugin/Action/ExportMember.php
@@ -13671,11 +13645,6 @@ parameters:
 			path: modules/social_features/social_group/src/Form/SocialGroupAddForm.php
 
 		-
-			message: "#^Cannot call method isAllowed\\(\\) on bool\\|Drupal\\\\Core\\\\Access\\\\AccessResultInterface\\.$#"
-			count: 1
-			path: modules/social_features/social_group/src/Form/SocialGroupAddForm.php
-
-		-
 			message: "#^Method Drupal\\\\social_group\\\\Form\\\\SocialGroupAddForm\\:\\:create\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: modules/social_features/social_group/src/Form/SocialGroupAddForm.php
@@ -13777,11 +13746,6 @@ parameters:
 
 		-
 			message: "#^Cannot call method getGroupType\\(\\) on Drupal\\\\Core\\\\Entity\\\\EntityInterface\\|null\\.$#"
-			count: 1
-			path: modules/social_features/social_group/src/Plugin/Action/ChangeGroupMembershipRole.php
-
-		-
-			message: "#^Cannot call method isAllowed\\(\\) on bool\\|Drupal\\\\Core\\\\Access\\\\AccessResultInterface\\.$#"
 			count: 1
 			path: modules/social_features/social_group/src/Plugin/Action/ChangeGroupMembershipRole.php
 
@@ -15731,12 +15695,12 @@ parameters:
 			path: modules/social_features/social_post/src/Plugin/Block/PostBlock.php
 
 		-
-			message: "#^Method Drupal\\\\social_post\\\\Plugin\\\\Block\\\\PostBlock\\:\\:blockAccess\\(\\) should return Drupal\\\\Core\\\\Access\\\\AccessResult but returns bool\\|Drupal\\\\Core\\\\Access\\\\AccessResultInterface\\.$#"
+			message: "#^Method Drupal\\\\social_post\\\\Plugin\\\\Block\\\\PostBlock\\:\\:blockAccess\\(\\) should return Drupal\\\\Core\\\\Access\\\\AccessResult but returns Drupal\\\\Core\\\\Access\\\\AccessResultInterface\\.$#"
 			count: 1
 			path: modules/social_features/social_post/src/Plugin/Block/PostBlock.php
 
 		-
-			message: "#^Method Drupal\\\\social_post\\\\Plugin\\\\Block\\\\PostGroupBlock\\:\\:blockAccess\\(\\) should return Drupal\\\\Core\\\\Access\\\\AccessResult but returns bool\\|Drupal\\\\Core\\\\Access\\\\AccessResultInterface\\.$#"
+			message: "#^Method Drupal\\\\social_post\\\\Plugin\\\\Block\\\\PostGroupBlock\\:\\:blockAccess\\(\\) should return Drupal\\\\Core\\\\Access\\\\AccessResult but returns Drupal\\\\Core\\\\Access\\\\AccessResultInterface\\.$#"
 			count: 1
 			path: modules/social_features/social_post/src/Plugin/Block/PostGroupBlock.php
 
@@ -19409,11 +19373,6 @@ parameters:
 			message: "#^Property Drupal\\\\social_user\\\\Plugin\\\\Action\\\\SocialAddRoleUser\\:\\:\\$currentUser \\(Drupal\\\\Core\\\\Session\\\\AccountProxyInterface\\) does not accept Drupal\\\\Core\\\\Session\\\\AccountInterface\\.$#"
 			count: 1
 			path: modules/social_features/social_user/src/Plugin/Action/SocialAddRoleUser.php
-
-		-
-			message: "#^Cannot call method andIf\\(\\) on bool\\|Drupal\\\\Core\\\\Access\\\\AccessResultInterface\\.$#"
-			count: 1
-			path: modules/social_features/social_user/src/Plugin/Action/SocialBlockUser.php
 
 		-
 			message: "#^Cannot call method hasPermission\\(\\) on Drupal\\\\Core\\\\Session\\\\AccountInterface\\|null\\.$#"

--- a/tests/composer.json
+++ b/tests/composer.json
@@ -11,7 +11,7 @@
         "drupal/core-dev": "~9.2.10",
         "drupal/devel": "^4.1",
         "dealerdirect/phpcodesniffer-composer-installer": "~0.7.1",
-        "mglaman/phpstan-drupal": "^1.0",
+        "mglaman/phpstan-drupal": "1.1.3",
         "mikey179/vfsstream": "^1.6",
         "phpspec/prophecy-phpunit": "^2.0",
         "phpstan/extension-installer": "^1.1",

--- a/tests/composer.json
+++ b/tests/composer.json
@@ -11,7 +11,7 @@
         "drupal/core-dev": "~9.2.10",
         "drupal/devel": "^4.1",
         "dealerdirect/phpcodesniffer-composer-installer": "~0.7.1",
-        "mglaman/phpstan-drupal": "1.1.3",
+        "mglaman/phpstan-drupal": "1.1.4",
         "mikey179/vfsstream": "^1.6",
         "phpspec/prophecy-phpunit": "^2.0",
         "phpstan/extension-installer": "^1.1",


### PR DESCRIPTION
## Problem
We noticed not locking our phpstan ruleset (phpstan-drupal) would mean whenever a patch or minor version was released all our PR's on top of main were breaking. Eventhough the information might be correct, we can't have such a breaking workflow.

## Solution
We have now locked the package and start utilizing Dependabot to update the actual package(s) in our `/tests/composer.json`, this should give us a nice PR showing the breaking changes that were introduced so we can immediately fix it in our pull requests.

## Issue tracker
Internal fix for workflow.

## How to test
See that PHPSTan now passes