### PR TITLE
Issue #3256449 by navneet0693, tbsiqueira, skatheeth, andregp: Remove deprecated jQuery UI datepicker.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -125,6 +125,13 @@
             "drupal/r4032login": {
                 "3248175: Symfony 4.4 event dispatcher parameter order change": "https://www.drupal.org/files/issues/2021-11-08/symfony-4-4-event-dispatcher-parameter-order-change-3248175-2.patch"
             },
+            "drupal/socialbase": {
+                "[Internal] Add extra check for the file.": "https://git.drupalcode.org/project/socialbase/-/merge_requests/81.diff",
+                "OpenSocial 11.0.0-rc2 makes Datepicker and Timepicker not working": "https://git.drupalcode.org/project/socialbase/-/merge_requests/84.diff"
+            },
+            "drupal/socialblue": {
+                "Remove deprecated jQuery UI datepicker from socialblue": "https://git.drupalcode.org/project/socialblue/-/merge_requests/59.diff"
+            },
             "drupal/update_helper": {
                 "3248189: Symfony 4.4 event dispatcher parameter order change": "https://www.drupal.org/files/issues/2021-11-08/symfony-4-4-event-dispatcher-parameter-order-change-3248189-2.patch"
             },
@@ -142,9 +149,6 @@
             },
             "drupal/redirect": {
                 "Redirection issue when interface language is different from content language": "https://www.drupal.org/files/issues/2020-06-01/redirect-interface_language_different_from_content_language_2991423-13.patch"
-            },
-            "drupal/socialbase": {
-                "[Internal] Add extra check for the file.": "https://git.drupalcode.org/project/socialbase/-/merge_requests/81.diff"
             }
         }
     },
@@ -223,7 +227,6 @@
         "npm-asset/shariff": "^3.0.1",
         "npm-asset/slick-carousel": "~1.8.1",
         "npm-asset/tablesaw": "~3.1.0",
-        "npm-asset/timepicker": "~1.11.14",
         "oomphinc/composer-installers-extender": "~1.0 || ~2.0",
         "spatie/color": "^1.2",
         "swiftmailer/swiftmailer": "6.2.4",

--- a/composer.json
+++ b/composer.json
@@ -126,11 +126,7 @@
                 "3248175: Symfony 4.4 event dispatcher parameter order change": "https://www.drupal.org/files/issues/2021-11-08/symfony-4-4-event-dispatcher-parameter-order-change-3248175-2.patch"
             },
             "drupal/socialbase": {
-                "[Internal] Add extra check for the file.": "https://git.drupalcode.org/project/socialbase/-/merge_requests/81.diff",
-                "OpenSocial 11.0.0-rc2 makes Datepicker and Timepicker not working": "https://git.drupalcode.org/project/socialbase/-/merge_requests/84.diff"
-            },
-            "drupal/socialblue": {
-                "Remove deprecated jQuery UI datepicker from socialblue": "https://git.drupalcode.org/project/socialblue/-/merge_requests/59.diff"
+                "[Internal] Add extra check for the file.": "https://git.drupalcode.org/project/socialbase/-/merge_requests/81.diff"
             },
             "drupal/update_helper": {
                 "3248189: Symfony 4.4 event dispatcher parameter order change": "https://www.drupal.org/files/issues/2021-11-08/symfony-4-4-event-dispatcher-parameter-order-change-3248189-2.patch"
@@ -199,7 +195,7 @@
         "drupal/search_api": "1.21.0",
         "drupal/select2": "1.13.0",
         "drupal/shariff": "1.7",
-        "drupal/socialblue": "2.1.0",
+        "drupal/socialblue": "2.1.1",
         "drupal/swiftmailer": "2.0.0",
         "drupal/token": "1.9",
         "drupal/ultimate_cron": "2.0-alpha5",


### PR DESCRIPTION
## Problem
Remove support to datepicker on our date fields due to Drupal 9 removing JQueryUI datepicker because jQueryUI is no longer being supported.

The implication is that the datepicker will now be handled by browsers native support.

For more information, please take a look at the following links:

Deprecate and remove jQuery UI datepicker
jQuery UI datepicker deprecated and core usages removed
Most jQuery UI asset libraries are deprecated and moved to contrib modules

## Solution
Remove the library and let browsers handle date fields natively.

## Issue tracker
https://www.drupal.org/project/social/issues/3256449
https://www.drupal.org/project/socialblue/issues/3256450
https://www.drupal.org/project/socialbase/issues/3256388

## How to test
- [ ] Date and Time field should work normally.

## Screenshots
**Before:**

![Screenshot 2022-01-05 at 2 42 15 PM](https://user-images.githubusercontent.com/8435994/148191942-d3fd4c34-f52c-4b93-911d-5865e69c4c2b.png)

**After:**

![Screenshot 2022-01-05 at 2 42 24 PM](https://user-images.githubusercontent.com/8435994/148191974-7a1f8b2e-8d1c-4d7c-898a-7c29d70eda88.png)


## Release notes
We are removing deprecated date picker and time picker libraries due to removal from Durpal 9. Such inputs will now be dependent upon the browser's native support. You might experience different pickers on different browsers.

## Change Record
TBD

## Translations
N.A