### PR TITLE
[Internal] Updated commit message prefix for dependabot as limit is 15 characters.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
       day: "saturday"
     labels:
       - "type: update"
-      - "team: nucleus"  
+      - "team: nucleus"
 
   # Maintain dependencies for Composer.
   - package-ecosystem: "composer"
@@ -24,7 +24,7 @@ updates:
     # Let core team maintainers review it.
     reviewers:
       - "goalgorilla/maintainers"
-    # Allow updates for all Drupal modules, lets leave the rest for now.  
+    # Allow updates for all Drupal modules, lets leave the rest for now.
     allow:
       - dependency-name: "drupal*"
     ignore:
@@ -35,7 +35,7 @@ updates:
       prefix: "Updates: "
       include: "scope"
     # Allow up to 5 open pull requests for Drupal dependencies as we have some to go.
-    open-pull-requests-limit: 5  
+    open-pull-requests-limit: 5
 
   # Maintain our test dependencies
   - package-ecosystem: "composer"
@@ -52,5 +52,5 @@ updates:
       - "goalgorilla/maintainers"
     # Prefix all commit messages and include a list of updated dependencies
     commit-message:
-      prefix: "Updates test dependencies: "
+      prefix: "Updates deps: "
       include: "scope"


### PR DESCRIPTION
## Problem
Your .github/dependabot.yml contained invalid details

https://github.com/goalgorilla/open_social/pull/2676/checks?check_run_id=4703238785

## Solution
Shorten the prefix of commit message.

## Issue tracker
N.A

## How to test
- [ ] Checks should be green

## Screenshots
N.A

## Release notes
N.A

## Change Record
N.A

## Translations
N.A