### PR TITLE
Issue #3257221 by navneet0693,ronaldtebrake,Ressinel: Broken search exposed form on search content and users.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -192,7 +192,7 @@
         "drupal/r4032login": "2.1.0",
         "drupal/redirect": "1.6.0",
         "drupal/role_delegation": "1.1",
-        "drupal/search_api": "1.21.0",
+        "drupal/search_api": "1.21",
         "drupal/select2": "1.13.0",
         "drupal/shariff": "1.7",
         "drupal/socialblue": "2.1.1",

--- a/composer.json
+++ b/composer.json
@@ -233,7 +233,7 @@
         "drupal/core-dev": "~9.2.10",
         "drupal/devel": "^4.1",
         "dealerdirect/phpcodesniffer-composer-installer": "~0.7.1",
-        "mglaman/phpstan-drupal": "^1.0",
+        "mglaman/phpstan-drupal": "1.1.4",
         "mikey179/vfsstream": "^1.6",
         "phpspec/prophecy-phpunit": "^2.0",
         "phpstan/extension-installer": "^1.1",

--- a/modules/social_features/social_profile/src/Plugin/views/filter/SocialSearchApiSplitProfileTerms.php
+++ b/modules/social_features/social_profile/src/Plugin/views/filter/SocialSearchApiSplitProfileTerms.php
@@ -65,7 +65,7 @@ class SocialSearchApiSplitProfileTerms extends SearchApiTerm {
     }
 
     // Render all value if split tag disabled.
-    if (!$this->profileTagService->allowSplit()) {
+    if (!$this->profileTagService->allowSplit() && !empty($element['#options'])) {
       $term_ids = [];
       $element['#type'] = 'select2';
       $options = &$element['#options'];

--- a/modules/social_features/social_search/social_search.module
+++ b/modules/social_features/social_search/social_search.module
@@ -44,8 +44,6 @@ function social_search_form_views_exposed_form_alter(&$form, FormStateInterface 
 }
 
 /**
- * Implements hook_form_FORM_ID_alter().
- *
  * Makes changes for the filter block on the user search page.
  */
 function social_search_alter_users_exposed_filter_block(&$form, FormStateInterface $form_state, $form_id) {
@@ -55,10 +53,12 @@ function social_search_alter_users_exposed_filter_block(&$form, FormStateInterfa
     }
   }
 
-  if (!empty($form['created']) && !empty($form['created_op'])) {
-    $form['settings']['created_op'] = $form['created_op'];
-    $form['settings']['created'] = $form['created'];
-    unset($form['created_op'], $form['created']);
+  if (!empty($form['created_wrapper']['created'])
+    && !empty($form['created_wrapper']['created_op'])) {
+    $form['settings']['created_op'] = $form['created_wrapper']['created_op'];
+    $form['settings']['created'] = $form['created_wrapper']['created'];
+    // $form['settings']['#attributes']['class'] = ['indent_filter'];
+    unset($form['created_wrapper']);
   }
 }
 
@@ -97,7 +97,8 @@ function social_search_alter_content_exposed_filter_block(&$form, FormStateInter
     $form['type']['#weight'] = '-100';
   }
 
-  if (!empty($form['field_event_date']) && !empty($form['field_event_date_op'])) {
+  if (!empty($form['field_event_date_wrapper']['field_event_date'])
+    && !empty($form['field_event_date_wrapper']['field_event_date_op'])) {
     if (!empty($form['settings'])) {
       $form['settings']['#states'] = [
         'visible' => [
@@ -106,13 +107,12 @@ function social_search_alter_content_exposed_filter_block(&$form, FormStateInter
           ],
         ],
       ];
-      $form['settings']['#weight'] = '-99';
-      $form['settings']['#attributes']['class'] = ['indent_filter'];
+
     }
 
-    $form['settings']['field_event_date_op'] = $form['field_event_date_op'];
-    $form['settings']['field_event_date'] = $form['field_event_date'];
-    unset($form['field_event_date'], $form['field_event_date_op']);
+    $form['settings']['field_event_date_op'] = $form['field_event_date_wrapper']['field_event_date_op'];
+    $form['settings']['field_event_date'] = $form['field_event_date_wrapper']['field_event_date'];
+    unset($form['field_event_date_wrapper']);
   }
 
   if (!empty($form['location_details'])) {
@@ -192,15 +192,6 @@ function social_search_views_data_alter(array &$data) {
       'field' => 'created',
     ],
   ];
-}
-
-/**
- * Implements hook_search_api_views_handler_mapping_alter().
- */
-function social_search_search_api_views_handler_mapping_alter(array &$mapping) {
-  // Override the Search API views filter connected to date with
-  // SocialDate.php (Extends current one limits options).
-  $mapping['date']['filter']['id'] = 'social_date_filter';
 }
 
 /**

--- a/modules/social_features/social_search/social_search.services.yml
+++ b/modules/social_features/social_search/social_search.services.yml
@@ -8,3 +8,9 @@ services:
     arguments: ['@current_route_match', '@current_user', '@config.factory', '@request_stack']
     tags:
       - { name: event_subscriber }
+
+  social_search.search_api_subscriber:
+    class: Drupal\social_search\EventSubscriber\SearchApiSubscriber
+    arguments: [ ]
+    tags:
+      - { name: event_subscriber }

--- a/modules/social_features/social_search/src/EventSubscriber/SearchApiSubscriber.php
+++ b/modules/social_features/social_search/src/EventSubscriber/SearchApiSubscriber.php
@@ -17,7 +17,7 @@ class SearchApiSubscriber implements EventSubscriberInterface {
    * @param \Drupal\search_api\Event\MappingViewsHandlersEvent $event
    *   The Search API event.
    */
-  public function onMappingViewsFilterHandlers(MappingViewsHandlersEvent $event) {
+  public function onMappingViewsFilterHandlers(MappingViewsHandlersEvent $event): void {
     $mapping = &$event->getHandlerMapping();
 
     // Override the Search API views filter connected to date with

--- a/modules/social_features/social_search/src/EventSubscriber/SearchApiSubscriber.php
+++ b/modules/social_features/social_search/src/EventSubscriber/SearchApiSubscriber.php
@@ -23,11 +23,9 @@ class SearchApiSubscriber implements EventSubscriberInterface {
     // Override the Search API views filter connected to date with
     // SocialDate.php (Extends current one limits options).
     // @see Drupal\social_search\Plugin\views\filter\SocialDate.
-    $mapping['date'] = [
-      'filter' => [
-        'id' => 'social_date_filter',
-      ],
-    ];
+    if (!empty($mapping['date']['filter']['id']) && $mapping['date']['filter']['id'] === 'search_api_date') {
+      $mapping['date']['filter']['id'] = 'social_date_filter';
+    }
   }
 
   /**

--- a/modules/social_features/social_search/src/EventSubscriber/SearchApiSubscriber.php
+++ b/modules/social_features/social_search/src/EventSubscriber/SearchApiSubscriber.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Drupal\social_search\EventSubscriber;
+
+use Drupal\search_api\Event\MappingViewsHandlersEvent;
+use Drupal\search_api\Event\SearchApiEvents;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Search API events subscriber.
+ */
+class SearchApiSubscriber implements EventSubscriberInterface {
+
+  /**
+   * Adds the mapping to replace date filter with social_date_filter.
+   *
+   * @param \Drupal\search_api\Event\MappingViewsHandlersEvent $event
+   *   The Search API event.
+   */
+  public function onMappingViewsFilterHandlers(MappingViewsHandlersEvent $event) {
+    $mapping = &$event->getHandlerMapping();
+
+    // Override the Search API views filter connected to date with
+    // SocialDate.php (Extends current one limits options).
+    // @see Drupal\social_search\Plugin\views\filter\SocialDate.
+    $mapping['date'] = [
+      'filter' => [
+        'id' => 'social_date_filter',
+      ],
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents(): array {
+    // Workaround to avoid a fatal error during site install in some cases.
+    // @see https://www.drupal.org/project/facets/issues/3199156
+    if (!class_exists('\Drupal\search_api\Event\SearchApiEvents', TRUE)) {
+      return [];
+    }
+
+    return [
+      SearchApiEvents::MAPPING_VIEWS_HANDLERS => 'onMappingViewsFilterHandlers',
+    ];
+
+  }
+
+}

--- a/modules/social_features/social_search/src/Plugin/views/filter/SocialDate.php
+++ b/modules/social_features/social_search/src/Plugin/views/filter/SocialDate.php
@@ -3,7 +3,7 @@
 namespace Drupal\social_search\Plugin\views\filter;
 
 use Drupal\Core\Form\FormStateInterface;
-use Drupal\search_api\Plugin\views\filter\SearchApiDate as DateTimeDate;
+use Drupal\search_api\Plugin\views\filter\SearchApiDate;
 
 /**
  * Defines a filter for filtering on dates.
@@ -12,7 +12,7 @@ use Drupal\search_api\Plugin\views\filter\SearchApiDate as DateTimeDate;
  *
  * @ViewsFilter("social_date_filter")
  */
-class SocialDate extends DateTimeDate {
+class SocialDate extends SearchApiDate {
 
   /**
    * {@inheritdoc}
@@ -104,20 +104,22 @@ class SocialDate extends DateTimeDate {
 
     // Key is form field name, value is title name.
     $form_keys = [
-      'field_event_date_op' => $this->t('Date of Event'),
-      'created_op' => $this->t('Registration Date'),
+      'field_event_date' => $this->t('Date of Event'),
+      'created' => $this->t('Registration Date'),
     ];
 
     // Update form values for the options.
     foreach ($form_keys as $key => $title) {
-      if (!empty($form[$key])) {
+      if (!empty($form[$key . '_wrapper'][$key . '_op'])) {
         $form['settings'] = [
           '#type' => 'details',
           '#title' => $title,
           '#attributes' => [
             'class' => [
               'filter',
+              'indent_filter',
             ],
+            '#weight' => '-99',
           ],
         ];
 
@@ -131,7 +133,6 @@ class SocialDate extends DateTimeDate {
           }
           if (!empty($form['value']['min'])) {
             $form['value']['min']['#type'] = 'date';
-            $form['value']['min']['#title'] = '';
           }
           if (!empty($form['value']['max'])) {
             $form['value']['max']['#type'] = 'date';

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -18010,11 +18010,6 @@ parameters:
 			path: modules/social_features/social_search/social_search.module
 
 		-
-			message: "#^Function social_search_search_api_views_handler_mapping_alter\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: modules/social_features/social_search/social_search.module
-
-		-
 			message: "#^Function social_search_views_data_alter\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: modules/social_features/social_search/social_search.module


### PR DESCRIPTION
## Problem
There is a broken date filter on Content/User search pages.

## Solution
1. Removed patch from https://www.drupal.org/project/search_api/issues/3248183#comment-14284072 as it was breaking event dispatching.
2. Added event subscriber to map our custom date views filter to search api date filter. This was done in favor of https://www.drupal.org/node/3059866.
3. Refactored code to make the form work again.

## Issue tracker
https://www.drupal.org/project/social/issues/3257221

## How to test
- [x] Install Open Social
- [x] Make sure search indexes are properly indexed
- [x] Go to content search
- [x] Make sure the "Date of event" filter is not there.
- [x] Choose Event from content type
- [x] Choose different operators (Before, After, Between)
- [x] Enter the date and check if the search results are there.
- [x] Go to user search
- [x] In the Registration date filter, please choose different operators and make sure the filter is working.

## Screenshots
**Before:**

![Screenshot 2022-01-05 at 5 56 18 PM](https://user-images.githubusercontent.com/8435994/148505464-e98a672b-81cf-4b90-9ebd-7c0bd6fc7f02.png)

**After:**

![Screenshot 2022-01-07 at 12 37 30 PM](https://user-images.githubusercontent.com/8435994/148505539-334ecf8b-2304-4d30-a266-5d40a612dd7a.png)


## Release notes
We have fixed a bug in exposed form on the Search content and user form which contain "Date of Event" and "Registration Date" filter respectively.

## Change Record
N.A

## Translations
N.A