### PR TITLE
Issue #3258139 by CurriedN, hitesh-jain, tbsiqueira: Invalid user name/password on login screen throws website error

### DIFF
--- a/modules/social_features/social_user/src/Form/SocialUserLoginForm.php
+++ b/modules/social_features/social_user/src/Form/SocialUserLoginForm.php
@@ -263,7 +263,7 @@ class SocialUserLoginForm extends UserLoginForm {
           <li>Too many failed login attempts from your computer (IP address). This IP address is temporarily blocked. </li>
         </ul>
         <p>To solve the issue, try using different login information, try again later, or <a href=":url">request a new password</a></p>',
-      ['%name_or_email' => $form_state->getValue('name_or_mail'), ':url' => Url::fromRoute('user.pass')]));
+      ['%name_or_email' => $form_state->getValue('name_or_mail'), ':url' => Url::fromRoute('user.pass')->toString()]));
   }
 
 }


### PR DESCRIPTION
## Problem
With PHP 8.0 version when the user tries to submit with Invalid username/password it throws below website encounter error.

<img src="https://www.drupal.org/files/issues/2022-01-12/screenshot-pcpos11new.lndo_.site-2022.01.12-13_14_57.png"/>

## Solution
This error is due to PHP 8.0 version causing TypeError exception with error message passed to form element.

## Issue tracker
https://www.drupal.org/project/social/issues/3258139

## How to test
- [ ] Use php 8.0
- [ ] Log in to the website with an invalid username/password

## Screenshots
N/A

## Release notes
N/A

## Change Record
N/A

## Translations
N/A
