### PR TITLE
Issue #3258943 by tBKoT: Duplicated votes on the Votes page

### DIFF
--- a/modules/social_features/social_like/src/SocialLikeConfigOverride.php
+++ b/modules/social_features/social_like/src/SocialLikeConfigOverride.php
@@ -41,6 +41,65 @@ class SocialLikeConfigOverride implements ConfigFactoryOverrideInterface {
       }
     }
 
+    // Filter votes by translation language.
+    $config_name = 'views.view.votingapi_votes';
+    if (in_array($config_name, $names)) {
+      $overrides[$config_name] = [
+        'display' => [
+          'node_page' => [
+            'display_options' => [
+              'filters' => [
+                'default_langcode' => [
+                  'id' => 'default_langcode',
+                  'table' => 'node_field_data',
+                  'field' => 'default_langcode',
+                  'relationship' => 'entity_id',
+                  'group_type' => 'group',
+                  'admin_label' => '',
+                  'operator' => '=',
+                  'value' => '1',
+                  'group' => 1,
+                  'exposed' => FALSE,
+                  'expose' => [
+                    'operator_id' => '',
+                    'label' => '',
+                    'description' => '',
+                    'use_operator' => FALSE,
+                    'operator' => '',
+                    'operator_limit_selection' => FALSE,
+                    'operator_list' => [],
+                    'identifier' => '',
+                    'required' => FALSE,
+                    'remember' => FALSE,
+                    'multiple' => FALSE,
+                    'remember_roles' => [
+                      'authenticated' => 'authenticated',
+                    ],
+                  ],
+                  'is_grouped' => FALSE,
+                  'group_info' => [
+                    'label' => '',
+                    'description' => '',
+                    'identifier' => '',
+                    'optional' => TRUE,
+                    'widget' => 'select',
+                    'multiple' => FALSE,
+                    'remember' => FALSE,
+                    'default_group' => 'All',
+                    'default_group_multiple' => [],
+                    'group_items' => [],
+                  ],
+                  'entity_type' => 'node',
+                  'entity_field' => 'default_langcode',
+                  'plugin_id' => 'boolean',
+                ],
+              ],
+            ],
+          ],
+        ],
+      ];
+    }
+
     return $overrides;
   }
 


### PR DESCRIPTION
## Problem
When we liked the content or add other votes they show on the Votes page. But if we add a translation for that content all votes will be duplicated on this page.

## Solution
Add an additional filter for the Votes page to use only one language as we use for other views. As this view is provided by the `Votingapi` module, we should use config override.

## Issue tracker
- https://getopensocial.atlassian.net/browse/YANG-6909
- https://www.drupal.org/project/social/issues/3258943

## How to test
- [ ] the `Social like` module should be enabled
- [ ] Translations should be enabled
- [ ] Create a new Topic
- [ ] Add likes for it from different users
- [ ] Add translation(s) for this Topic
- [ ] Go to the Votes tab on the Topic page

## Screenshots
#### Topic with one like and with out translation
![зображення](https://user-images.githubusercontent.com/11648677/149781605-3887c04a-0fea-4854-8390-f9b62ee96c35.png)
#### Votes list
![зображення](https://user-images.githubusercontent.com/11648677/149781500-4b012c96-bc2d-40da-9cfc-d874927b12cf.png)
#### Added translation
![зображення](https://user-images.githubusercontent.com/11648677/149781863-63debdf7-0b53-4094-b3f2-89e47000ea4e.png)
#### Votes list after added translation
![зображення](https://user-images.githubusercontent.com/11648677/149782095-58a041d4-1631-4045-8611-a3ad6b2da0bc.png)


## Release notes
Now, votes are not duplicated for content with translations.

## Change Record
N/A

## Translations
N/A