### PR TITLE
Issue #3258123 by hitesh-jain, tbsiqueira: VBO actions on Group membership not working

### DIFF
--- a/modules/social_features/social_group/src/Plugin/views/field/SocialGroupViewsBulkOperationsBulkForm.php
+++ b/modules/social_features/social_group/src/Plugin/views/field/SocialGroupViewsBulkOperationsBulkForm.php
@@ -199,25 +199,32 @@ class SocialGroupViewsBulkOperationsBulkForm extends ViewsBulkOperationsBulkForm
     if ($this->view->id() === 'group_manage_members') {
       $user_input = $form_state->getUserInput();
       $available_options = $this->getBulkOptions();
+
+      $selected_actions = array_combine(
+        array_keys($this->options['selected_actions']),
+        array_column($this->options['selected_actions'], 'action_id')
+      );
+
       // Grab all the actions that are available.
       foreach (Element::children($this->actions) as $action) {
-        // If the option is not in our selected options, next.
-        if (($action_key = array_search($action, array_column($this->options['selected_actions'], 'action_id'))) === FALSE) {
-          continue;
-        }
+        // Check if we have the command.
+        if (
+          is_array($selected_actions) &&
+          ($action_key = array_search($action, $selected_actions)) !== FALSE
+        ) {
+          /** @var \Drupal\Core\StringTranslation\TranslatableMarkup $label */
+          $label = $available_options[$action_key];
 
-        /** @var \Drupal\Core\StringTranslation\TranslatableMarkup $label */
-        $label = $available_options[$action_key];
-
-        // Match the Users action from our custom dropdown.
-        // Find the action from the VBO selection.
-        // And set that as the chosen action in the form_state.
-        if (strip_tags($label->render()) === $user_input['op']) {
-          $user_input['action'] = $action_key;
-          $form_state->setUserInput($user_input);
-          $form_state->setValue('action', $action_key);
-          $form_state->setTriggeringElement($this->actions[$action]);
-          break;
+          // Match the Users action from our custom dropdown.
+          // Find the action from the VBO selection.
+          // And set that as the chosen action in the form_state.
+          if (strip_tags($label->render()) === $user_input['op']) {
+            $user_input['action'] = $action_key;
+            $form_state->setUserInput($user_input);
+            $form_state->setValue('action', $action_key);
+            $form_state->setTriggeringElement($this->actions[$action]);
+            break;
+          }
         }
       }
     }


### PR DESCRIPTION
## Problem
VBO action on Group membership page throws error when you select any custom actions defined for Group membership view

<img src="https://www.drupal.org/files/issues/2022-01-12/screenshot-pcpos11new.lndo_.site-2022.01.12-09_22_19.png" alt="error">

## Solution
Error was caused due to incorrect key being used to fetch Selected action label and as it was invalid key to fetch Label it was empty and hence calling `render` function on empty label caused above error.

## Issue tracker
https://www.drupal.org/project/social/issues/3258123

## How to test
N/A

## Screenshots
N/A

## Release notes
N/A

## Change Record
N/A

## Translations
N/A
