### PR TITLE
Issue #3258954 by nkoporec: When on the group stream the local menu task is missing the active class

### DIFF
--- a/modules/social_features/social_group/social_group.module
+++ b/modules/social_features/social_group/social_group.module
@@ -1715,6 +1715,35 @@ function social_group_preprocess_views_view(&$variables) {
 }
 
 /**
+ * Implements theme_preprocess_menu_local_task().
+ *
+ * Sets an active class on stream tab when viewing group canonical page.
+ */
+function social_group_preprocess_menu_local_task(&$variables) {
+  $route_name = \Drupal::routeMatch()->getRouteName();
+  if ($route_name != 'entity.group.canonical') {
+    return;
+  }
+
+  /** @var array $link */
+  $link = $variables['link'] ?? NULL;
+  if (!$link) {
+    return;
+  }
+
+  /** @var \Drupal\Core\Url $menu_url */
+  $menu_url = $link['#url'] ?? NULL;
+  if (!$menu_url) {
+    return;
+  }
+
+  if ($menu_url->getRouteName() === 'social_group.stream') {
+    $variables['element']['#active'] = TRUE;
+    $variables['attributes']['class'][] = 'active';
+  }
+}
+
+/**
  * Implements hook_block_access().
  *
  * Check if the user is viewing a closed_group, check if the user is a member.


### PR DESCRIPTION
## Problem
When on the group page canonical URL, the 'Stream' tab does not have an 'active' class.

## Solution
Add the missing class.

## Issue tracker
https://www.drupal.org/project/social/issues/3258954

## How to test
1. Install Open Social
2. Disable the new 'Sky' styling
3. Go to the group stream page
4. See if the 'Stream' local task menu has an active class.

## Screenshots
Before:
![image](https://user-images.githubusercontent.com/35064680/149791015-1d1d5059-0d84-4128-af62-7f03e44564a3.png)

After:
![image](https://user-images.githubusercontent.com/35064680/149791077-4d9b40a9-2cef-416a-8a8a-07e1210c8352.png)


## Release notes
*A short summary of the changes that were made that can be included in release notes.*

## Change Record
*If this Pull Request changes the way that developers should do things or introduces a new API for developers then a change record to document this is needed. Please provide a draft for a change record or a link to an unpublished change record below. [Existing change records](https://www.drupal.org/list-changes/social) can be consulted as example.*

## Translations
*Translatable strings are always extracted from the latest development branch. To ensure translations remain available for platforms running older versions of Open Social the original string should be added to `translations.php` when it's changed or removed.*
- [ ] Changed or removed source strings are added to the `translations.php` file.
