### PR TITLE
Locked phpstan/phpstan library as it is not locked to a specific version in mglaman/phpstan-drupal.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -233,6 +233,7 @@
         "drupal/core-dev": "~9.2.10",
         "drupal/devel": "^4.1",
         "dealerdirect/phpcodesniffer-composer-installer": "~0.7.1",
+        "phpstan/phpstan": "1.3.3",
         "mglaman/phpstan-drupal": "1.1.4",
         "mikey179/vfsstream": "^1.6",
         "phpspec/prophecy-phpunit": "^2.0",

--- a/tests/composer.json
+++ b/tests/composer.json
@@ -11,6 +11,7 @@
         "drupal/core-dev": "~9.2.10",
         "drupal/devel": "^4.1",
         "dealerdirect/phpcodesniffer-composer-installer": "~0.7.1",
+        "phpstan/phpstan": "1.3.3",
         "mglaman/phpstan-drupal": "1.1.4",
         "mikey179/vfsstream": "^1.6",
         "phpspec/prophecy-phpunit": "^2.0",


### PR DESCRIPTION
## Problem
Lock PHPStan library version to avoid sudden PHPStan check failures. Recently, it was caused due to release of new phpstan library version https://github.com/phpstan/phpstan/releases/tag/1.4.1.

This was automatically updated as we require https://github.com/mglaman/phpstan-drupal and it has https://github.com/mglaman/phpstan-drupal/blob/main/composer.json#L15 which causes automatic updates.

See failures: https://github.com/goalgorilla/open_social/runs/4841468744?check_suite_focus=true#step:5:9

## Solution
Fix https://github.com/phpstan/phpstan to 1.3.3

## Issue tracker
[Internal]

## How to test
- [ ] PHPStan checks should pass.

## Screenshots
N.A

## Release notes
N.A

## Change Record
N.A

## Translations
N.A