### PR TITLE
Issue #3259297: Computed fields added to content type are deleting group content entity

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -101,7 +101,7 @@
                 "Symfony 4.4 event dispatcher parameter order change #1252": "https://patch-diff.githubusercontent.com/raw/drupal-graphql/graphql/pull/1252.diff"
             },
             "drupal/group": {
-                "Add computed field for Group reference": "https://www.drupal.org/files/issues/2021-07-30/group-2718195-58-groups-computed-field.patch",
+                "Add computed field for Group reference": "https://www.drupal.org/files/issues/2022-01-19/group-computedfields-2718195-60.patch",
                 "Ability to use group tokens in node context": "https://www.drupal.org/files/issues/2018-12-19/group-2774827-41-gnode-tokens.patch",
                 "Group: Don't try to re-save deleted entities": "https://www.drupal.org/files/issues/2018-11-01/3010896-02.patch",
                 "Rely on toUrl defaults for Entity url link": "https://www.drupal.org/files/issues/2019-12-04/group-3098675-2.patch",


### PR DESCRIPTION
## Problem

Computed fields that are added to get the groups related to entity is deleting group content if one of the computed fields for specific group type attached to content type don't have value for that field.

## Solution
Apply updated patch https://www.drupal.org/files/issues/2022-01-19/group-computedfields-2718... from Groups module issue https://www.drupal.org/project/group/issues/2718195#comment-14378528 to open social

## Issue tracker
https://www.drupal.org/project/social/issues/3259297

## How to test
NA

## Screenshots
NA

## Release notes
NA

## Change Record
NA

## Translations
NA
