### PR TITLE
Issue #3258883: (10.3.x) Revoke select account cancellation method permission for authenticate…

### DIFF
--- a/modules/social_features/social_user/social_user.install
+++ b/modules/social_features/social_user/social_user.install
@@ -161,7 +161,6 @@ function _social_user_get_permissions($role) {
     'access user profiles',
     'cancel account',
     'change own username',
-    'select account cancellation method',
   ]);
 
   // Content manager.
@@ -204,5 +203,14 @@ function social_user_update_8810() {
   // Grant the sitemanagers new permissions.
   user_role_grant_permissions('sitemanager', [
     'view blocked user',
+  ]);
+}
+
+/**
+ * Revoke the permission select account cancellation method.
+ */
+function social_user_update_8811() {
+  user_role_revoke_permissions(RoleInterface::AUTHENTICATED_ID, [
+    'select account cancellation method',
   ]);
 }


### PR DESCRIPTION
…d users.

## Problem
If I disable my account as an authenticated user I have to choose a cancellation method when cancelling my own account.

## Solution
We should skip this step by removing the permissions for authenticated users. The desired cancellation method can be selected from within the user settings.

## Issue tracker
https://www.drupal.org/project/social/issues/3258883
## How to test
- [ ] Log in as an authenticated user
- [ ] Cancel your account (Settings -> Cancel account)
- [ ] You should not be able to select a cancellation method.

## Release notes
By revoking the `select account cancellation method` authenticated users don't have to select a cancellation method anymore when cancelling their own account.
