### PR TITLE
Issue #3259572 by tbsiqueira, navneet0693, ronaldtebrake: Backport Drupal 9.x SA-CORE-2022-001 to Open Social 10.x versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,8 @@
                 "Empty language (langcode) field wrapper inserted into contact form": "https://www.drupal.org/files/issues/2020-03-06/empty-langcode-field-wrapper-2842405-17.patch",
                 "Broken title in modal dialog when title is a render array": "https://www.drupal.org/files/issues/2019-10-21/2663316-76.drupal.Broken-title-in-modal-dialog-when-title-is-a-render-array.patch",
                 "PHPDocs with wrong parameters": "https://www.drupal.org/files/issues/2019-09-03/queryinterface-range-updated-phpdocs.patch",
-                "Post update hook naming convention patch": "https://git.drupalcode.org/project/drupal/-/merge_requests/1215.patch"
+                "Post update hook naming convention patch": "https://git.drupalcode.org/project/drupal/-/merge_requests/1215.patch",
+                "Backport Drupal 9.x SA-CORE-2022-001 to Open Social 10.x versions": "https://www.drupal.org/files/issues/2022-01-20/3259572-Backport-Drupal-9.x-SA-CORE-2022-001-1.patch"
             },
             "drupal/flag": {
                 "Add relationship to flagged entities when Flagging is base table": "https://www.drupal.org/files/issues/2723703_31.patch"


### PR DESCRIPTION
## Problem
Backport SA-CORE-2022-001 to still supported 10.x Open Social versions

## Solution
Backport SA-CORE-2022-001

## Issue tracker
https://www.drupal.org/project/social/issues/3259572

## How to test
- [ ] Use any date picker and make sure it works

## Screenshots
N/A

## Release notes
N/A

## Change Record
N/A

## Translations
N/A
