### PR TITLE
Issue #3260835 by SV: User should be able to see a list with the content with the latest comments

### DIFF
--- a/modules/social_features/social_content_block/src/ContentBlockBase.php
+++ b/modules/social_features/social_content_block/src/ContentBlockBase.php
@@ -32,6 +32,10 @@ abstract class ContentBlockBase extends PluginBase implements ContentBlockPlugin
         'label' => 'Most commented',
         'description' => 'See posts with the most comments first.',
       ],
+      'last_commented' => [
+        'label' => 'Last commented',
+        'description' => 'See the last commented nodes first.',
+      ],
       'most_liked' => [
         'label' => 'Most liked',
         'description' => 'See posts with the most likes first.',

--- a/modules/social_features/social_content_block/src/ContentBuilder.php
+++ b/modules/social_features/social_content_block/src/ContentBuilder.php
@@ -475,6 +475,19 @@ class ContentBuilder implements ContentBuilderInterface {
         $sorting_field = $query->addExpression("COUNT($comment_alias.cid)", 'comment_count');
         break;
 
+      case 'last_commented':
+        if ($is_group) {
+          $post_alias = $query->leftJoin('post__field_recipient_group', 'pfrg', "$base_field = %alias.field_recipient_group_target_id");
+          $group_alias = $query->leftJoin('group_content_field_data', 'gfd', "$base_field = %alias.gid AND %alias.type LIKE '%-group_node-%'");
+          $comment_alias = $query->leftJoin('comment_field_data', 'cfd', "$post_alias.entity_id = %alias.entity_id AND %alias.entity_type = 'post' OR $group_alias.entity_id = %alias.entity_id AND %alias.entity_type = 'node'");
+        }
+        else {
+          $comment_alias = $query->leftJoin('comment_field_data', 'cfd', "$base_field = %alias.entity_id AND %alias.entity_type = :entity_type", $arguments);
+        }
+
+        $sorting_field = $query->addExpression("MAX($comment_alias.created)", 'comment_created');
+        break;
+
       // Creates a join to select the number of likes for a given entity in a
       // recent timeframe and use that for sorting.
       case 'most_liked':


### PR DESCRIPTION
## Problem
In the Custom content list block there are several sort options. None of them includes the last comments.

## Solution
Add new sorting option for custom content list block that will apply for all content types - last commented

## Issue tracker
- https://www.drupal.org/project/social/issues/3260835
- https://getopensocial.atlassian.net/browse/YANG-6628

## How to test
- [x] Using the latest version of Open Social with the social_content_block module enabled
- [x] As a sitemanager
- [x] Try to add a custom content block and there is no possibility to sort by last commented node
- [x] The expected result is attained when repeating the steps with this fix applied.

## Screenshots
![Edit-layout-for-Dashboard-1-Open-Social-11](https://user-images.githubusercontent.com/25609390/151356577-ccef9080-382a-47d1-940b-52cb4f31b71e.png)


## Release notes
Adds a new option of sorting - last commented in custom content block 

