### PR TITLE
Issue #3260860 by navneet0693,tbsiqueira: Remove PHP 8 support from Open Social 11.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -149,7 +149,7 @@
         }
     },
     "require": {
-        "php": "^7.4 || ^8",
+        "php": "^7.4",
         "bower-asset/lazysizes": "^5.3",
         "composer/installers": "~1.0 || ~2.0",
         "cweagans/composer-patches": "^1.6.0",


### PR DESCRIPTION
## Problem
Our composer.json allows PHP 8, since Open Social is not fully tested, therefore supported, we need to remove it from Open Social 11

## Solution
Remove PHP 8 from composer.json

## Issue tracker
https://www.drupal.org/project/social/issues/3260860

## How to test
- [ ] All checks should pass.

## Screenshots
N.A

## Release notes
N.A

## Change Record
N.A

## Translations
N.A