### PR TITLE
Add a flexible time slot for sending daily and weekly email notificat…

### DIFF
--- a/modules/custom/activity_send/modules/activity_send_email/activity_send_email.module
+++ b/modules/custom/activity_send/modules/activity_send_email/activity_send_email.module
@@ -52,9 +52,9 @@ function activity_send_email_cron() {
       if (!$timeslot_end) {
         $timeslot_end = 1435;
       }
-      $now = \Drupal::service('date.formatter')->format( time(), 'custom', 'H:i', Drupal::config('system.date')->get('timezone')['default']);
-      $start = \Drupal::service('date.formatter')->format( $timeslot_start * 60, 'custom', 'H:i', 'GMT');
-      $end = \Drupal::service('date.formatter')->format( $timeslot_end * 60, 'custom', 'H:i', 'GMT');
+      $now = \Drupal::service('date.formatter')->format(time(), 'custom', 'H:i', Drupal::config('system.date')->get('timezone')['default']);
+      $start = \Drupal::service('date.formatter')->format($timeslot_start * 60, 'custom', 'H:i', 'GMT');
+      $end = \Drupal::service('date.formatter')->format($timeslot_end * 60, 'custom', 'H:i', 'GMT');
       if ($now < $start || $now > $end) {
         $in_slot = FALSE;
       }

--- a/modules/custom/activity_send/modules/activity_send_email/activity_send_email.module
+++ b/modules/custom/activity_send/modules/activity_send_email/activity_send_email.module
@@ -42,9 +42,26 @@ function activity_send_email_cron() {
       $last_run = \Drupal::state()
         ->get('digest.' . $frequency['id'] . '.last_run', 0);
 
+      $in_slot = TRUE;
+      $interval = $interval - 300;
+      $timeslot_start = \Drupal::config('social_swiftmail.settings')->get('timeslot_start');
+      $timeslot_end = \Drupal::config('social_swiftmail.settings')->get('timeslot_end');
+      if (!$timeslot_start) {
+        $timeslot_start = 0;
+      }
+      if (!$timeslot_end) {
+        $timeslot_end = 1435;
+      }
+      $now = \Drupal::service('date.formatter')->format( time(), 'custom', 'H:i', Drupal::config('system.date')->get('timezone')['default']);
+      $start = \Drupal::service('date.formatter')->format( $timeslot_start * 60, 'custom', 'H:i', 'GMT');
+      $end = \Drupal::service('date.formatter')->format( $timeslot_end * 60, 'custom', 'H:i', 'GMT');
+      if ($now < $start || $now > $end) {
+        $in_slot = FALSE;
+      }
+
       // If interval of frequency passed since last time, try to create queue
       // items.
-      if ((time() - $last_run) > $interval) {
+      if ((time() - $last_run) > $interval && $in_slot) {
         // Query to get the data to process per user per frequency. And we make
         // sure to check only for items that need to be sent.
         $db = Database::getConnection();

--- a/modules/social_features/social_swiftmail/src/Form/SocialSwiftmailSettingsForm.php
+++ b/modules/social_features/social_swiftmail/src/Form/SocialSwiftmailSettingsForm.php
@@ -313,5 +313,5 @@ class SocialSwiftmailSettingsForm extends ConfigFormBase {
     }
     return $options;
   }
-  
+
 }

--- a/modules/social_features/social_swiftmail/src/Form/SocialSwiftmailSettingsForm.php
+++ b/modules/social_features/social_swiftmail/src/Form/SocialSwiftmailSettingsForm.php
@@ -2,7 +2,6 @@
 
 namespace Drupal\social_swiftmail\Form;
 
-use Drupal;
 use Drupal\activity_creator\Plugin\ActivityDestinationManager;
 use Drupal\Component\Utility\Html as HtmlUtility;
 use Drupal\Core\Batch\BatchBuilder;
@@ -189,7 +188,7 @@ class SocialSwiftmailSettingsForm extends ConfigFormBase {
       '#title' => $this->t("Send daily or weekly notifications after"),
       '#options' => $this->timeinterval(),
       '#default_value' => $config->get('timeslot_start') ? $config->get('timeslot_start') : 0,
-      '#description' => t('For reference, current server time is: @time', ['@time' => \Drupal::service('date.formatter')->format( time(), 'custom', 'H:i', Drupal::config('system.date')->get('timezone')['default'])]),
+      '#description' => t('For reference, current server time is: @time', ['@time' => \Drupal::service('date.formatter')->format(time(), 'custom', 'H:i', \Drupal::config('system.date')->get('timezone')['default'])]),
     ];
     $form['timeslot']['timeslot_end'] = [
       '#type' => 'select',
@@ -246,7 +245,7 @@ class SocialSwiftmailSettingsForm extends ConfigFormBase {
       }
     }
 
-    // Set the timeslot start and end time for sending daily or weekly notifications.
+    // Define the time slot for sending daily or weekly notifications.
     $config->set('timeslot_start', $form_state->getValue('timeslot_start'));
     $config->set('timeslot_end', $form_state->getValue('timeslot_end'));
 
@@ -307,11 +306,12 @@ class SocialSwiftmailSettingsForm extends ConfigFormBase {
   private function timeinterval() {
     $options = [];
     for ($x = 0; $x < 24; $x++) {
-      for ($y = 0; $y < 60; $y = $y +5) {
+      for ($y = 0; $y < 60; $y = $y + 5) {
         $key = $x * 60 + $y;
-        $options[$key] = ($x >= 10 ? $x: '0' . $x) . ":" . ($y >= 10 ? $y: '0' . $y);
+        $options[$key] = ($x >= 10 ? $x : '0' . $x) . ":" . ($y >= 10 ? $y : '0' . $y);
       }
     }
     return $options;
   }
+  
 }

--- a/modules/social_features/social_swiftmail/src/Form/SocialSwiftmailSettingsForm.php
+++ b/modules/social_features/social_swiftmail/src/Form/SocialSwiftmailSettingsForm.php
@@ -56,7 +56,7 @@ class SocialSwiftmailSettingsForm extends ConfigFormBase {
    *   The activity destination manager.
    * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
    *   The module handler.
-   * @param \Drupal\Core\Datetime\DateFormatter $date_formatter
+   * @param \Drupal\Core\Datetime\DateFormatterInterface $date_formatter
    *   The Date formatter.
    */
   public function __construct(


### PR DESCRIPTION
## Problem
The daily and weekly email notifications are send out more or less random over 24hours of day.
If they are send out during the night, users will maybe not take as much attention to it, when clean up there mailbox in the morning compared to an email send during "business"-hours.

## Solution
Define a time slot for sending out daily and weekly notifactions. Add an administer interface to "/admin/config/opensocial/swiftmail" which should be the best place for this setting. Allow admins to define a time slot for sending out email notifications.

## Issue tracker
[*Paste a link to the drupal.org issue queue item. If any other issue trackers were used, include links to those too.*](https://www.drupal.org/project/social/issues/3261031)

## How to test
*For example*
- [x] Using version 11 Open Social 
- [x] As a administrator
- [x] Define a bunch of activities as daily or weekly email notifiactions
- [x] Define a time slot at /admin/config/opensocial/swiftmail (if not emails are send out by default between 0:00 and 23:55)
- [x] Check that you receive the emails during the specified timeslot (maybe first on day 2)

## Screenshots
*If this Pull Request makes visual changes then please include some screenshots that show what has changed here. A before and after screenshot helps the reviewer determine what changes were made.*

## Release notes
*A short summary of the changes that were made that can be included in release notes.*

## Change Record
*If this Pull Request changes the way that developers should do things or introduces a new API for developers then a change record to document this is needed. Please provide a draft for a change record or a link to an unpublished change record below. [Existing change records](https://www.drupal.org/list-changes/social) can be consulted as example.*

## Translations
*Translatable strings are always extracted from the latest development branch. To ensure translations remain available for platforms running older versions of Open Social the original string should be added to `translations.php` when it's changed or removed.*
- [ ] Changed or removed source strings are added to the `translations.php` file.