### PR TITLE
Issue #3261093 by Kingdutch: Fix out of the box swiftmailer config

### DIFF
--- a/modules/social_features/social_swiftmail/social_swiftmail.install
+++ b/modules/social_features/social_swiftmail/social_swiftmail.install
@@ -11,18 +11,20 @@
  * Perform actions related to the installation of social_swiftmail.
  */
 function social_swiftmail_install() {
-  // Get swift and mailsystem config.
-  $swift_settings = \Drupal::configFactory()->getEditable('swiftmailer.message');
-  $mailsystem_settings = \Drupal::configFactory()->getEditable('mailsystem.settings');
+  $config_factory = \Drupal::configFactory();
   // Alter swift settings.
-  $swift_settings->set('format', 'text/html')->save();
-  $swift_settings->set('respect_format', FALSE)->save();
+  $config_factory->getEditable('swiftmailer.message')
+    ->set('format', 'text/html')
+    ->set('respect_format', FALSE)
+    ->save();
   // Alter mailsystem settings.
-  $mailsystem_settings->set('theme', 'default')->save();
-  $mailsystem_settings->set('defaults.sender', 'social_swiftmailer')->save();
-  $mailsystem_settings->set('defaults.formatter', 'social_swiftmailer')->save();
-  $mailsystem_settings->set('modules.swiftmailer.none.sender', 'social_swiftmailer')->save();
-  $mailsystem_settings->set('modules.swiftmailer.none.formatter', 'social_swiftmailer')->save();
+  $config_factory->getEditable('mailsystem.settings')
+    ->set('theme', 'default')
+    ->set('defaults.sender', 'social_swiftmailer')
+    ->set('defaults.formatter', 'social_swiftmailer')
+    ->set('modules.swiftmailer.none.sender', 'social_swiftmailer')
+    ->set('modules.swiftmailer.none.formatter', 'social_swiftmailer')
+    ->save();
 
   // Grant the default permissions for this feature.
   user_role_grant_permissions(

--- a/modules/social_features/social_swiftmail/social_swiftmail.install
+++ b/modules/social_features/social_swiftmail/social_swiftmail.install
@@ -26,6 +26,13 @@ function social_swiftmail_install() {
     ->set('modules.swiftmailer.none.formatter', 'social_swiftmailer')
     ->save();
 
+  // Ensure the sendmail mode matches the PHP.ini configuration.
+  $sendmail_path = ini_get('sendmail_path');
+  $sendmail_mode = ($sendmail_path !== FALSE && str_contains($sendmail_path, '-bs')) ? 'bs' : 't';
+  $config_factory->getEditable('swiftmailer.transport')
+    ->set('sendmail_mode', $sendmail_mode)
+    ->save();
+
   // Grant the default permissions for this feature.
   user_role_grant_permissions(
     'verified',


### PR DESCRIPTION
<h3 id="summary-problem-motivation">Problem/Motivation</h3>
The default swiftmailer config is to use sendmail with the <code>bs</code> option.

<blockquote>Stand-alone SMTP server mode. Read SMTP commands from standard input, and write responses to standard output.  In stand-alone SMTP server mode, mail relaying and other access
controls are disabled by default. To enable them, run the process as the mail_owner user.
This mode of operation is implemented by running the smtpd(8) daemon.
</blockquote>

The issue is that this mode isn't allowed on some more secure hosting providers (such as Platform.sh). Instead they will have their PHP settings configured to use the <code>t</code> option.

<blockquote>
Extract recipients from message headers. These are added to any recipients specified on the command line.<
</blockquote>

This is also indicated in an issue open for Swiftmailer itself which will probably not get fixed: https://www.drupal.org/project/swiftmailer/issues/3174215#comment-13845855

<h3 id="summary-proposed-resolution">Proposed resolution</h3>
Adjust the <code>social_swiftmail_install</code> hook to update the <code>sendmail_mode</code> in the <code>swiftmailer.transport</code> config based on the PHP settings. This ensures that the <code>t</code> mode is properly used on supported platforms so that emailing in Open Social works out of the box.

## Issue tracker
https://www.drupal.org/project/social/issues/3261093

## How to test
*For example*
- [ ] Install Open Social on a server that has <code>sendmail_path</code> configured to <code>/usr/sbin/sendmail -t -i</code> in their php.ini and try to send an email.

## Release notes
The swiftmail_transport will now be set to `t` during installation if PHP is configured to use `sendmail` in that mode.

