### PR TITLE
Issue #3261513 by nkoporec: Error: Call to undefined method Drupal\data_policy\DataPolicyConsentManager::hasGivenConsent()

### DIFF
--- a/modules/custom/social_magic_login/src/Controller/MagicLoginController.php
+++ b/modules/custom/social_magic_login/src/Controller/MagicLoginController.php
@@ -191,7 +191,7 @@ class MagicLoginController extends ControllerBase {
       // When it's enabled, load the data policy manager service and check
       // if consent is (still) needed.
       $data_policy_manager = \Drupal::service('data_policy.manager');
-      return $data_policy_manager->hasGivenConsent();
+      return $data_policy_manager->needConstent();
     }
 
     return TRUE;

--- a/modules/custom/social_magic_login/src/Controller/MagicLoginController.php
+++ b/modules/custom/social_magic_login/src/Controller/MagicLoginController.php
@@ -191,7 +191,7 @@ class MagicLoginController extends ControllerBase {
       // When it's enabled, load the data policy manager service and check
       // if consent is (still) needed.
       $data_policy_manager = \Drupal::service('data_policy.manager');
-      return $data_policy_manager->needConstent();
+      return $data_policy_manager->needConsent();
     }
 
     return TRUE;

--- a/modules/custom/social_magic_login/src/Controller/MagicLoginController.php
+++ b/modules/custom/social_magic_login/src/Controller/MagicLoginController.php
@@ -6,6 +6,7 @@ use Drupal\Component\Utility\Crypt;
 use Drupal\Core\Config\ConfigFactory;
 use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\Extension\ModuleHandler;
+use Drupal\Core\Link;
 use Drupal\Core\Url;
 use Drupal\user\UserStorageInterface;
 use Psr\Log\LoggerInterface;
@@ -144,10 +145,13 @@ class MagicLoginController extends ControllerBase {
     // registered through social login possibilities.
     if (NULL === $user->getPassword()) {
       $message_set_password = $this->t('You need to set your password in order to log in.');
-      if ($this->dataPolicyConsensus() === FALSE) {
+      if ($this->dataPolicyConsensus()) {
         // Set a different text when the user still needs to comply to
         // the data policy.
-        $message_set_password = $this->t('Before you can log in and set your password, you need to agree to the data policy.');
+        $link = Link::createFromRoute($this->t('here'), 'data_policy.data_policy.agreement');
+        $message_set_password = $this->t('We published a new version of the data policy. You can review the data policy @url.', [
+          '@url' => $link->toString(),
+        ]);
       }
       $this->messenger()->addStatus($message_set_password);
       $this->logger->notice('User %name used magic login link at time %timestamp but needs to set a password.', ['%name' => $user->getDisplayName(), '%timestamp' => $timestamp]);
@@ -194,7 +198,7 @@ class MagicLoginController extends ControllerBase {
       return $data_policy_manager->needConsent();
     }
 
-    return TRUE;
+    return FALSE;
   }
 
 }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -3856,11 +3856,6 @@ parameters:
 			path: modules/custom/social_magic_login/social_magic_login.module
 
 		-
-			message: "#^Call to an undefined method Drupal\\\\data_policy\\\\DataPolicyConsentManager\\:\\:needConsent\\(\\)\\.$#"
-			count: 1
-			path: modules/custom/social_magic_login/src/Controller/MagicLoginController.php
-
-		-
 			message: "#^Method Drupal\\\\social_magic_login\\\\Controller\\\\MagicLoginController\\:\\:create\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: modules/custom/social_magic_login/src/Controller/MagicLoginController.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -3856,7 +3856,7 @@ parameters:
 			path: modules/custom/social_magic_login/social_magic_login.module
 
 		-
-			message: "#^Call to an undefined method Drupal\\\\data_policy\\\\DataPolicyConsentManager\\:\\:hasGivenConsent\\(\\)\\.$#"
+			message: "#^Call to an undefined method Drupal\\\\data_policy\\\\DataPolicyConsentManager\\:\\:needConsent\\(\\)\\.$#"
 			count: 1
 			path: modules/custom/social_magic_login/src/Controller/MagicLoginController.php
 


### PR DESCRIPTION
## Problem
When trying to login with social_magic_link, certain users receive this error:
`Error: Call to undefined method Drupal\data_policy\DataPolicyConsentManager::hasGivenConsent()`

## Solution
The hasGivenConsent() method no longer exists in data_policy, so we need to update it.

## Issue tracker
https://www.drupal.org/project/social/issues/3261513

## How to test
1. Create a new user, but don't login yet
2. Make sure data_policy module is enabled
2. Create a magic login link using social_magic_link module
3. Visit the magic link

## Screenshots
*If this Pull Request makes visual changes then please include some screenshots that show what has changed here. A before and after screenshot helps the reviewer determine what changes were made.*

## Release notes
*A short summary of the changes that were made that can be included in release notes.*

## Change Record
*If this Pull Request changes the way that developers should do things or introduces a new API for developers then a change record to document this is needed. Please provide a draft for a change record or a link to an unpublished change record below. [Existing change records](https://www.drupal.org/list-changes/social) can be consulted as example.*

## Translations
*Translatable strings are always extracted from the latest development branch. To ensure translations remain available for platforms running older versions of Open Social the original string should be added to `translations.php` when it's changed or removed.*
- [ ] Changed or removed source strings are added to the `translations.php` file.
