### PR TITLE
Issue #3258541 by Irina Matusevich, navneet0693, tbsiqueira: Deprecat…

### DIFF
--- a/modules/social_features/social_user/src/Form/SocialUserPasswordForm.php
+++ b/modules/social_features/social_user/src/Form/SocialUserPasswordForm.php
@@ -6,6 +6,7 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Link;
 use Drupal\Core\Url;
 use Drupal\user\Form\UserPasswordForm;
+use Drupal\user\UserInterface;
 
 /**
  * Class SocialUserPasswordForm.
@@ -68,8 +69,14 @@ class SocialUserPasswordForm extends UserPasswordForm {
       // No success, try to load by name.
       $users = $this->userStorage->loadByProperties(['name' => $name]);
     }
+
+    /** @var \Drupal\user\UserInterface $account */
     $account = reset($users);
-    if ($account && $account->id() && $account->isActive()) {
+    if (
+      $account instanceof UserInterface &&
+      $account->id() &&
+      $account->isActive()
+    ) {
       $langcode = $this->languageManager->getCurrentLanguage()->getId();
 
       // Mail one time login URL and instructions using current language.
@@ -77,7 +84,7 @@ class SocialUserPasswordForm extends UserPasswordForm {
       if (!empty($mail)) {
         $this->logger('user')
           ->notice('Password reset instructions mailed to %name at %email.', [
-            '%name' => $account->getUsername(),
+            '%name' => $account->getAccountName(),
             '%email' => $account->getEmail(),
           ]);
       }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -19070,21 +19070,6 @@ parameters:
 			path: modules/social_features/social_user/src/Form/SocialUserNavigationSettingsForm.php
 
 		-
-			message: "#^Call to an undefined method Drupal\\\\Core\\\\Entity\\\\EntityInterface\\:\\:getEmail\\(\\)\\.$#"
-			count: 1
-			path: modules/social_features/social_user/src/Form/SocialUserPasswordForm.php
-
-		-
-			message: "#^Call to an undefined method Drupal\\\\Core\\\\Entity\\\\EntityInterface\\:\\:getUsername\\(\\)\\.$#"
-			count: 1
-			path: modules/social_features/social_user/src/Form/SocialUserPasswordForm.php
-
-		-
-			message: "#^Call to an undefined method Drupal\\\\Core\\\\Entity\\\\EntityInterface\\:\\:isActive\\(\\)\\.$#"
-			count: 1
-			path: modules/social_features/social_user/src/Form/SocialUserPasswordForm.php
-
-		-
 			message: "#^Class Drupal\\\\social_user\\\\Form\\\\SocialUserPasswordForm extends @internal class Drupal\\\\user\\\\Form\\\\UserPasswordForm\\.$#"
 			count: 1
 			path: modules/social_features/social_user/src/Form/SocialUserPasswordForm.php
@@ -19096,11 +19081,6 @@ parameters:
 
 		-
 			message: "#^Method Drupal\\\\social_user\\\\Form\\\\SocialUserPasswordForm\\:\\:validateForm\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: modules/social_features/social_user/src/Form/SocialUserPasswordForm.php
-
-		-
-			message: "#^Parameter \\#2 \\$account of function _user_mail_notify expects Drupal\\\\Core\\\\Session\\\\AccountInterface, Drupal\\\\Core\\\\Entity\\\\EntityInterface given\\.$#"
 			count: 1
 			path: modules/social_features/social_user/src/Form/SocialUserPasswordForm.php
 


### PR DESCRIPTION
## Problem
Password reset breaks due to deprecated function.

## Solution
Replace `$account->getAccountName` for `$account->getAccountName()` on `social_features/social_user/src/Form/SocialUserPasswordForm.php`

## Issue tracker
https://www.drupal.org/project/social/issues/3258541

## How to test
- [x] Go to [website]/user/password, type a valid user/email;
- [x] It should not break the form;


## Screenshots
N/A

## Release notes
N/A

## Change Record
N/A

## Translations
N/A
