### PR TITLE
Issue #3263114 by Ressinel: Events maximum for enrollee's has been exceeded.

### DIFF
--- a/modules/social_features/social_event/modules/social_event_invite/src/Controller/UserEnrollInviteController.php
+++ b/modules/social_features/social_event/modules/social_event_invite/src/Controller/UserEnrollInviteController.php
@@ -20,7 +20,7 @@ class UserEnrollInviteController extends CancelEnrollInviteController {
   /**
    * {@inheritdoc}
    */
-  public function updateEnrollmentInvite(EventEnrollmentInterface $event_enrollment, $accept_decline) {
+  public function updateEnrollmentInvite(EventEnrollmentInterface $event_enrollment, string $accept_decline) {
     // Just some sanity checks.
     if (!empty($event_enrollment)) {
       // When the user accepted the invite,

--- a/modules/social_features/social_event/modules/social_event_invite/src/Form/EnrollInviteEmailForm.php
+++ b/modules/social_features/social_event/modules/social_event_invite/src/Form/EnrollInviteEmailForm.php
@@ -210,16 +210,13 @@ class EnrollInviteEmailForm extends InviteEmailBaseForm {
 
       if (
         $node instanceof NodeInterface &&
-        $event_max_enroll_service->isEnabled($node)
+        $event_max_enroll_service->isEnabled($node) &&
+        $event_max_enroll_service->getEnrollmentsLeft($node) === 0
       ) {
-        // If there are no spots left, disable button and add the button title
-        // with appropriate notice.
-        if ($event_max_enroll_service->getEnrollmentsLeft($node) === 0) {
-          $form['actions']['submit']['#attributes'] = [
-            'disabled' => 'disabled',
-            'title' => $this->t('There are no spots left'),
-          ];
-        }
+        $form['actions']['submit']['#attributes'] = [
+          'disabled' => 'disabled',
+          'title' => $this->t('There are no spots left'),
+        ];
       }
     }
 

--- a/modules/social_features/social_event/modules/social_event_invite/src/Form/EnrollInviteEmailForm.php
+++ b/modules/social_features/social_event/modules/social_event_invite/src/Form/EnrollInviteEmailForm.php
@@ -5,6 +5,7 @@ namespace Drupal\social_event_invite\Form;
 use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Logger\LoggerChannelFactoryInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
@@ -16,6 +17,7 @@ use Drupal\social_core\Form\InviteEmailBaseForm;
 use Drupal\social_event\EventEnrollmentInterface;
 use Drupal\Core\Entity\EntityStorageInterface;
 use Drupal\social_event\Service\SocialEventEnrollServiceInterface;
+use Drupal\social_event_max_enroll\Service\EventMaxEnrollService;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -28,14 +30,14 @@ class EnrollInviteEmailForm extends InviteEmailBaseForm {
    *
    * @var \Drupal\Core\entity\EntityStorageInterface
    */
-  protected $entityStorage;
+  protected EntityStorageInterface $entityStorage;
 
   /**
    * Drupal\Core\TempStore\PrivateTempStoreFactory definition.
    *
    * @var \Drupal\Core\TempStore\PrivateTempStoreFactory
    */
-  private $tempStoreFactory;
+  private PrivateTempStoreFactory $tempStoreFactory;
 
   /**
    * The Config factory.
@@ -49,14 +51,28 @@ class EnrollInviteEmailForm extends InviteEmailBaseForm {
    *
    * @var \Drupal\Core\Utility\Token
    */
-  protected $token;
+  protected Token $token;
 
   /**
    * The social event enroll.
    *
    * @var \Drupal\social_event\Service\SocialEventEnrollServiceInterface
    */
-  protected $eventEnrollService;
+  protected SocialEventEnrollServiceInterface $eventEnrollService;
+
+  /**
+   * The module handler service.
+   *
+   * @var \Drupal\Core\Extension\ModuleHandlerInterface
+   */
+  protected $moduleHandler;
+
+  /**
+   * The event maximum enroll service.
+   *
+   * @var \Drupal\social_event_max_enroll\Service\EventMaxEnrollService
+   */
+  protected EventMaxEnrollService $eventMaxEnrollService;
 
   /**
    * {@inheritdoc}
@@ -76,7 +92,9 @@ class EnrollInviteEmailForm extends InviteEmailBaseForm {
     PrivateTempStoreFactory $tempStoreFactory,
     ConfigFactoryInterface $config_factory,
     Token $token,
-    SocialEventEnrollServiceInterface $event_enroll_service
+    SocialEventEnrollServiceInterface $event_enroll_service,
+    ModuleHandlerInterface $module_handler,
+    EventMaxEnrollService $eventMaxEnrollService
   ) {
     parent::__construct($route_match, $entity_type_manager, $logger_factory);
     $this->entityStorage = $entity_storage;
@@ -84,6 +102,8 @@ class EnrollInviteEmailForm extends InviteEmailBaseForm {
     $this->configFactory = $config_factory;
     $this->token = $token;
     $this->eventEnrollService = $event_enroll_service;
+    $this->moduleHandler = $module_handler;
+    $this->eventMaxEnrollService = $eventMaxEnrollService;
   }
 
   /**
@@ -98,7 +118,9 @@ class EnrollInviteEmailForm extends InviteEmailBaseForm {
       $container->get('tempstore.private'),
       $container->get('config.factory'),
       $container->get('token'),
-      $container->get('social_event.enroll')
+      $container->get('social_event.enroll'),
+      $container->get('module_handler'),
+      $container->get('social_event_max_enroll.service')
     );
   }
 
@@ -110,9 +132,12 @@ class EnrollInviteEmailForm extends InviteEmailBaseForm {
 
     $form['#attributes']['class'][] = 'form--default';
 
+    /** @var \Drupal\node\Entity\Node $node */
+    $node = $this->routeMatch->getParameter('node');
+
     $params = [
       'user' => $this->currentUser(),
-      'node' => $this->routeMatch->getParameter('node'),
+      'node' => $node,
     ];
 
     // Load event invite configuration.
@@ -177,6 +202,26 @@ class EnrollInviteEmailForm extends InviteEmailBaseForm {
       '#submit' => [[$this, 'cancelForm']],
       '#limit_validation_errors' => [],
     ];
+
+    // We should prevent invite enrollments if social_event_max_enroll is
+    // enabled and there are no left spots.
+    if ($this->moduleHandler->moduleExists('social_event_max_enroll')) {
+      $event_max_enroll_service = $this->eventMaxEnrollService;
+
+      if (
+        $node instanceof NodeInterface &&
+        $event_max_enroll_service->isEnabled($node)
+      ) {
+        // If there are no spots left, disable button and add the button title
+        // with appropriate notice.
+        if ($event_max_enroll_service->getEnrollmentsLeft($node) === 0) {
+          $form['actions']['submit']['#attributes'] = [
+            'disabled' => 'disabled',
+            'title' => $this->t('There are no spots left'),
+          ];
+        }
+      }
+    }
 
     return $form;
   }

--- a/modules/social_features/social_event/modules/social_event_managers/src/Plugin/views/field/SocialEventManagersViewsBulkOperationsBulkForm.php
+++ b/modules/social_features/social_event/modules/social_event_managers/src/Plugin/views/field/SocialEventManagersViewsBulkOperationsBulkForm.php
@@ -279,8 +279,18 @@ class SocialEventManagersViewsBulkOperationsBulkForm extends ViewsBulkOperations
       $selected_actions = $this->options['selected_actions'];
       // Grab all the actions that are available.
       foreach (Element::children($this->actions) as $action) {
+
+        // Combine both arrays elements.
+        $array_combine = (array) array_combine(
+          array_keys($selected_actions),
+          array_column($selected_actions, 'action_id')
+        );
+
+        // Get the action key.
+        $action_key = array_search($action, array_filter($array_combine));
+
         // If the option is not in our selected options, next.
-        if (($action_key = array_search($action, array_filter((array) array_combine(array_keys($selected_actions), array_column($selected_actions, 'action_id'))))) === FALSE) {
+        if ($action_key === FALSE) {
           continue;
         }
 

--- a/modules/social_features/social_event/modules/social_event_managers/src/Plugin/views/field/SocialEventManagersViewsBulkOperationsBulkForm.php
+++ b/modules/social_features/social_event/modules/social_event_managers/src/Plugin/views/field/SocialEventManagersViewsBulkOperationsBulkForm.php
@@ -6,6 +6,7 @@ use Drupal\Core\Action\ActionManager;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Render\Element;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\Url;
 use Drupal\Core\TempStore\PrivateTempStoreFactory;
@@ -275,8 +276,14 @@ class SocialEventManagersViewsBulkOperationsBulkForm extends ViewsBulkOperations
     if ($this->view->id() === 'event_manage_enrollments') {
       $user_input = $form_state->getUserInput();
       $available_options = $this->getBulkOptions();
+      $selected_actions = $this->options['selected_actions'];
       // Grab all the actions that are available.
-      foreach ($this->options['selected_actions'] as $action_key => $action) {
+      foreach (Element::children($this->actions) as $action) {
+        // If the option is not in our selected options, next.
+        if (($action_key = array_search($action, array_filter((array) array_combine(array_keys($selected_actions), array_column($selected_actions, 'action_id'))))) === FALSE) {
+          continue;
+        }
+
         /** @var \Drupal\Core\StringTranslation\TranslatableMarkup $label */
         $label = $available_options[$action_key];
 

--- a/modules/social_features/social_event/modules/social_event_max_enroll/config/install/field.field.node.event.field_event_max_enroll_num.yml
+++ b/modules/social_features/social_event/modules/social_event_max_enroll/config/install/field.field.node.event.field_event_max_enroll_num.yml
@@ -15,7 +15,7 @@ translatable: false
 default_value: {  }
 default_value_callback: ''
 settings:
-  min: 0
+  min: 1
   max: 100000
   prefix: ''
   suffix: ''

--- a/modules/social_features/social_event/modules/social_event_max_enroll/config/update/social_event_max_enroll_update_11001.yml
+++ b/modules/social_features/social_event/modules/social_event_max_enroll/config/update/social_event_max_enroll_update_11001.yml
@@ -1,0 +1,8 @@
+field.field.node.event.field_event_max_enroll_num:
+  expected_config:
+    settings:
+      min: 0
+  update_actions:
+    change:
+      settings:
+        min: 1

--- a/modules/social_features/social_event/modules/social_event_max_enroll/social_event_max_enroll.install
+++ b/modules/social_features/social_event/modules/social_event_max_enroll/social_event_max_enroll.install
@@ -28,3 +28,17 @@ function social_event_max_enroll_update_8001() {
   // Output logged messages to related channel of update execution.
   return $updateHelper->logger()->output();
 }
+
+/**
+ * Update min value in the field_event_max_enroll_num.
+ */
+function social_event_max_enroll_update_11001(): string {
+  /** @var \Drupal\update_helper\Updater $updateHelper */
+  $updateHelper = \Drupal::service('update_helper.updater');
+
+  // Execute configuration update definitions with logging of success.
+  $updateHelper->executeUpdate('social_event_max_enroll', __FUNCTION__);
+
+  // Output logged messages to related channel of update execution.
+  return $updateHelper->logger()->output();
+}

--- a/modules/social_features/social_event/modules/social_event_max_enroll/social_event_max_enroll.module
+++ b/modules/social_features/social_event/modules/social_event_max_enroll/social_event_max_enroll.module
@@ -106,6 +106,14 @@ function social_event_max_enroll_form_alter(&$form, FormStateInterface $form_sta
       $event_max_enroll_service = \Drupal::service('social_event_max_enroll.service');
       $node = \Drupal::routeMatch()->getParameter('node');
 
+      // If there is node ID instead of an object then load node with NID.
+      if (!$node instanceof NodeInterface && !is_null($node)) {
+        /** @var \Drupal\node\NodeStorageInterface $node_storage */
+        $node_storage = \Drupal::entityTypeManager()->getStorage('node');
+        /** @var \Drupal\node\NodeInterface $node */
+        $node = $node_storage->load((int) $node);
+      }
+
       if ($node instanceof NodeInterface && $event_max_enroll_service->isEnabled($node)) {
         // Count how many spots are left.
         $left = $event_max_enroll_service->getEnrollmentsLeft($node);

--- a/modules/social_features/social_event/modules/social_event_max_enroll/social_event_max_enroll.module
+++ b/modules/social_features/social_event/modules/social_event_max_enroll/social_event_max_enroll.module
@@ -112,10 +112,7 @@ function social_event_max_enroll_form_alter(&$form, FormStateInterface $form_sta
       $node = \Drupal::routeMatch()->getParameter('node');
 
       // If there is node ID instead of an object then load node with NID.
-      if (
-        !($node instanceof NodeInterface) &&
-        !is_null($node)
-      ) {
+      if (!is_object($node) && $node !== NULL) {
         /** @var \Drupal\node\NodeStorageInterface $node_storage */
         $node_storage = \Drupal::entityTypeManager()->getStorage('node');
         /** @var \Drupal\node\NodeInterface $node */

--- a/modules/social_features/social_event/modules/social_event_max_enroll/social_event_max_enroll.module
+++ b/modules/social_features/social_event/modules/social_event_max_enroll/social_event_max_enroll.module
@@ -112,7 +112,10 @@ function social_event_max_enroll_form_alter(&$form, FormStateInterface $form_sta
       $node = \Drupal::routeMatch()->getParameter('node');
 
       // If there is node ID instead of an object then load node with NID.
-      if (!$node instanceof NodeInterface && !is_null($node)) {
+      if (
+        !($node instanceof NodeInterface) &&
+        !is_null($node)
+      ) {
         /** @var \Drupal\node\NodeStorageInterface $node_storage */
         $node_storage = \Drupal::entityTypeManager()->getStorage('node');
         /** @var \Drupal\node\NodeInterface $node */
@@ -221,5 +224,52 @@ function social_event_max_enroll_preprocess_page_hero_data(array &$variables) {
           '@spots_left' => $spots_left,
         ]
       );
+  }
+}
+
+/**
+ * Implements hook_entity_operation_alter().
+ */
+function social_event_max_enroll_entity_operation_alter(array &$operations, EntityInterface $entity): void {
+  // Do nothing if module social_event_invite is not enabled.
+  if (!\Drupal::moduleHandler()->moduleExists('social_event_invite')) {
+    return;
+  }
+
+  // Check if the entity type is event_enrollment.
+  if ($entity->getEntityTypeId() !== 'event_enrollment') {
+    return;
+  }
+
+  // Get the route name.
+  $route_name = \Drupal::routeMatch()->getRouteName();
+
+  // Check if we're on the correct view and appropriate operation exists.
+  // Otherwise, it would update all actions across the platform.
+  if (
+    $route_name === 'view.user_event_invites.page_user_event_invites' &&
+    !empty($operations['accept'])
+  ) {
+    $event_max_enroll_service = \Drupal::service('social_event_max_enroll.service');
+
+    /** @var \Drupal\social_event\Entity\EventEnrollment $entity */
+    $event_id = $entity->getFieldValue('field_event', 'target_id');
+
+    /** @var \Drupal\node\NodeInterface $node */
+    $node = \Drupal::entityTypeManager()->getStorage('node')->load($event_id);
+
+    if (
+      $node instanceof NodeInterface &&
+      $event_max_enroll_service->isEnabled($node)
+    ) {
+      // If there are no spots left, disable the Accept invite button and add
+      // the button title with appropriate notice.
+      if ($event_max_enroll_service->getEnrollmentsLeft($node) === 0) {
+        $operations['accept']['attributes'] = [
+          'disabled' => 'disabled',
+          'title' => t('No spots left'),
+        ];
+      }
+    }
   }
 }

--- a/modules/social_features/social_event/modules/social_event_max_enroll/social_event_max_enroll.module
+++ b/modules/social_features/social_event/modules/social_event_max_enroll/social_event_max_enroll.module
@@ -17,7 +17,12 @@ use Drupal\views\ViewExecutable;
  * Alter "Event enrollments" views. Add number of spots left.
  */
 function social_event_max_enroll_views_post_render(ViewExecutable $view, &$output, CachePluginBase $cache) {
-  if ($view->current_display === 'event_enrollments' && $view->id() === 'event_enrollments' && isset($output['#rows']) && !empty($view->args[0])) {
+  if (
+    $view->current_display === 'event_enrollments' &&
+    $view->id() === 'event_enrollments' &&
+    isset($output['#rows']) &&
+    !empty($view->args[0])
+  ) {
     $nid = $view->args[0];
     $node = \Drupal::entityTypeManager()->getStorage('node')->load($nid);
     $event_max_enroll_service = \Drupal::service('social_event_max_enroll.service');
@@ -71,7 +76,7 @@ function social_event_max_enroll_form_alter(&$form, FormStateInterface $form_sta
           ];
         }
 
-        // Add an details element to status.
+        // Add a details element to status.
         // Also hide checkbox if feature is disabled globally.
         $form['field_event_max_enroll_wrapper'] = [
           '#type' => 'details',

--- a/modules/social_features/social_event/modules/social_event_max_enroll/social_event_max_enroll.services.yml
+++ b/modules/social_features/social_event/modules/social_event_max_enroll/social_event_max_enroll.services.yml
@@ -10,3 +10,7 @@ services:
       - '@entity_type.manager'
       - '@config.factory'
       - '@social_event.enroll'
+  social_event_invite.route_subscriber:
+    class: Drupal\social_event_max_enroll\Routing\RouteSubscriber
+    tags:
+      - { name: event_subscriber }

--- a/modules/social_features/social_event/modules/social_event_max_enroll/src/Controller/UserEnrollInviteControllerAlter.php
+++ b/modules/social_features/social_event/modules/social_event_max_enroll/src/Controller/UserEnrollInviteControllerAlter.php
@@ -4,7 +4,6 @@ namespace Drupal\social_event_max_enroll\Controller;
 
 use Drupal\Core\Session\AccountProxyInterface;
 use Drupal\Core\Url;
-use Drupal\node\NodeInterface;
 use Drupal\social_event\EventEnrollmentInterface;
 use Drupal\social_event_invite\Controller\UserEnrollInviteController;
 use Drupal\social_event_max_enroll\Service\EventMaxEnrollService;
@@ -63,7 +62,7 @@ class UserEnrollInviteControllerAlter extends UserEnrollInviteController {
       $node = $this->entityTypeManager()->getStorage('node')->load($event_id);
 
       if (
-        $node instanceof NodeInterface &&
+        $node !== NULL &&
         $this->eventMaxEnrollService->isEnabled($node)
       ) {
         // If there are no spots left then we should prevent approving

--- a/modules/social_features/social_event/modules/social_event_max_enroll/src/Controller/UserEnrollInviteControllerAlter.php
+++ b/modules/social_features/social_event/modules/social_event_max_enroll/src/Controller/UserEnrollInviteControllerAlter.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Drupal\social_event_max_enroll\Controller;
+
+use Drupal\Core\Session\AccountProxyInterface;
+use Drupal\Core\Url;
+use Drupal\node\NodeInterface;
+use Drupal\social_event\EventEnrollmentInterface;
+use Drupal\social_event_invite\Controller\UserEnrollInviteController;
+use Drupal\social_event_max_enroll\Service\EventMaxEnrollService;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/**
+ * Accepts or declines an event enrollment invite.
+ *
+ * @package Drupal\social_event_max_enroll\Controller
+ */
+class UserEnrollInviteControllerAlter extends UserEnrollInviteController {
+
+  /**
+   * The event maximum enroll service.
+   *
+   * @var \Drupal\social_event_max_enroll\Service\EventMaxEnrollService
+   */
+  protected EventMaxEnrollService $eventMaxEnrollService;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct(
+    RequestStack $requestStack,
+    AccountProxyInterface $currentUser,
+    EventMaxEnrollService $eventMaxEnrollService
+  ) {
+    parent::__construct($requestStack, $currentUser);
+
+    $this->eventMaxEnrollService = $eventMaxEnrollService;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container): self {
+    return new static(
+      $container->get('request_stack'),
+      $container->get('current_user'),
+      $container->get('social_event_max_enroll.service')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function updateEnrollmentInvite(EventEnrollmentInterface $event_enrollment, string $accept_decline): RedirectResponse {
+    // We should move forward only when the user is accepting the invite.
+    if ($accept_decline === '1') {
+      // Retrieve event ID.
+      $event_id = $event_enrollment->field_event->target_id;
+
+      /** @var \Drupal\node\NodeInterface $node */
+      $node = $this->entityTypeManager()->getStorage('node')->load($event_id);
+
+      if (
+        $node instanceof NodeInterface &&
+        $this->eventMaxEnrollService->isEnabled($node)
+      ) {
+        // If there are no spots left then we should prevent approving
+        // invite.
+        if ($this->eventMaxEnrollService->getEnrollmentsLeft($node) === 0) {
+          // Let's delete all messages to keep the messages clean.
+          $this->messenger()->deleteAll();
+          $this->messenger()->addWarning($this->t('No spots left.'));
+
+          // Get the redirect destination we're given in the request for the
+          // response.
+          $destination = Url::fromRoute('view.user_event_invites.page_user_event_invites', ['user' => $this->currentUser->id()])->toString();
+
+          return new RedirectResponse($destination);
+        }
+      }
+    }
+
+    // If there are spots left in the event, do nothing and let the original
+    // controller do what it should.
+    return parent::updateEnrollmentInvite($event_enrollment, $accept_decline);
+  }
+
+}

--- a/modules/social_features/social_event/modules/social_event_max_enroll/src/EventMaxEnrollOverride.php
+++ b/modules/social_features/social_event/modules/social_event_max_enroll/src/EventMaxEnrollOverride.php
@@ -53,7 +53,7 @@ class EventMaxEnrollOverride implements ConfigFactoryOverrideInterface {
   public function loadOverrides($names) {
     $overrides = [];
 
-    // Add field_event_max_enroll to event form.
+    // Add field_event_max_enroll to the event form.
     $config_name = 'core.entity_form_display.node.event.default';
     if (in_array($config_name, $names)) {
       if ($this->socialEventAnEnrollOverrider instanceof ConfigFactoryOverrideInterface) {

--- a/modules/social_features/social_event/modules/social_event_max_enroll/src/Routing/RouteSubscriber.php
+++ b/modules/social_features/social_event/modules/social_event_max_enroll/src/Routing/RouteSubscriber.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Drupal\social_event_max_enroll\Routing;
+
+use Drupal\Core\Routing\RouteSubscriberBase;
+use Symfony\Component\Routing\RouteCollection;
+
+/**
+ * Class RouteSubscriber listens to the dynamic route events.
+ *
+ * We need it to alter social_event_invite controller where we need to prevent
+ * users accept the invite if an event has no spots left.
+ *
+ * @package Drupal\social_event_max_enroll\Routing
+ */
+class RouteSubscriber extends RouteSubscriberBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function alterRoutes(RouteCollection $collection): void {
+    if ($route = $collection->get('social_event_invite.update_enrollment_invite')) {
+      $route->setDefaults([
+        '_controller' => '\Drupal\social_event_max_enroll\Controller\UserEnrollInviteControllerAlter::updateEnrollmentInvite',
+      ]);
+    }
+  }
+
+}

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -8185,11 +8185,6 @@ parameters:
 			path: modules/social_features/social_event/modules/social_event_invite/src/Controller/UserEnrollInviteController.php
 
 		-
-			message: "#^Method Drupal\\\\social_event_invite\\\\Controller\\\\UserEnrollInviteController\\:\\:updateEnrollmentInvite\\(\\) has parameter \\$accept_decline with no type specified\\.$#"
-			count: 1
-			path: modules/social_features/social_event/modules/social_event_invite/src/Controller/UserEnrollInviteController.php
-
-		-
 			message: "#^Property Drupal\\\\Core\\\\Field\\\\FieldItemListInterface\\:\\:\\$value \\(string\\) does not accept int\\.$#"
 			count: 2
 			path: modules/social_features/social_event/modules/social_event_invite/src/Controller/UserEnrollInviteController.php


### PR DESCRIPTION
## Problem
**Should**: when users set a maximum of enrollees for their events, this maximum should not be exceeded.
**Is**: in a particular event, the organizers have set a maximum of 28 enrollees, however, it is able to enroll as the 30th user.

## Solution
- Make sure that we always have the node object when we want to disable the **Enroll** button.
- Make sure that users can't accept invites if there are no spots left in an event.

## Issue tracker
- https://www.drupal.org/project/social/issues/3263114
- https://getopensocial.atlassian.net/browse/TB-5626

## How to test
#### Reproduce issue:
- [x] Create an event with set the **Enrollment limit**;
- [x] Add participants to have the maximum possible number of enrollments;
- [x] Log in by user that is not enrolled in the event;
- [x] Go to created event;
- [x] On the **Details** page you will see that you cannot enroll and will be seen **No spots left** button;
- [x] Go to any other tabs like **Organisers** or **Enrollments** and you will be able to enroll even no spots are left;
- [x] Send an invite to some user and try to accept it from him and you will be able to enroll even no spots are left.
#### Fixes:
- [x] Apply changes from current PR;
- [x] You won't be able to enroll on any tabs if an event has no spots left and you will be seen **No spots left** button;
- [x] Send an invite to some user and try to accept it from him and you will not be able to enroll since no spots are left.

## Screenshots
Limit of enrollees is **3**.
#### Before:
Details page:
![before1](https://user-images.githubusercontent.com/10220937/153018616-92db67a8-6445-488e-9244-0391f529c586.png)
Enrollments page:
![before2](https://user-images.githubusercontent.com/10220937/153018622-161fa77c-b775-4444-8142-8dbfb09b8498.png)
The event invites page:
![invites-before](https://user-images.githubusercontent.com/10220937/153220271-4820baa0-18d7-4086-b57d-87447594187c.png)

#### After:
Details page:
![before1](https://user-images.githubusercontent.com/10220937/153018616-92db67a8-6445-488e-9244-0391f529c586.png)
Enrollments page:
![after1](https://user-images.githubusercontent.com/10220937/153018625-ea7968fa-f726-4680-9fc6-0236679afa51.png)
The event invites page:
![invites-after](https://user-images.githubusercontent.com/10220937/153220304-b940de5a-ebe4-4372-bcdd-f7f6c240d77c.png)

## Release notes
Fixed event issue where a user was able to exceed the limit of enrollees.

## Change Record
N/A

## Translations
N/A
