### PR TITLE
Issue #3262896 by tBKoT: Make entity_access_by_field type more usefull

### DIFF
--- a/modules/custom/entity_access_by_field/entity_access_by_field.module
+++ b/modules/custom/entity_access_by_field/entity_access_by_field.module
@@ -8,15 +8,16 @@
  * @todo Add support for multiple entity types.
  */
 
-use Drupal\entity_access_by_field\EntityAccessHelper;
-use Drupal\node\NodeInterface;
-use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\Cache\Cache;
-use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Entity\EntityFormInterface;
 use Drupal\Core\Entity\EntityInterface;
-use Drupal\social_post\Entity\PostInterface;
+use Drupal\Core\Field\BaseFieldDefinition;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\entity_access_by_field\EntityAccessHelper;
 use Drupal\field\Entity\FieldConfig;
+use Drupal\node\NodeInterface;
+use Drupal\social_post\Entity\PostInterface;
 
 /**
  * Here we define a constant for our node access grant ID.
@@ -180,14 +181,17 @@ function entity_access_by_field_post_presave(PostInterface $post) {
 function entity_access_by_field_field_widget_form_alter(&$element, FormStateInterface $form_state, $context) {
   $field_definition = $context['items']->getFieldDefinition();
 
-  if ($field_definition->getType() != 'entity_access_field' && $field_definition->getName() != 'field_visibility') {
+  if ($field_definition->getType() !== 'entity_access_field' && $field_definition->getName() !== 'field_visibility') {
+    return;
+  }
+
+  if ($field_definition instanceof BaseFieldDefinition && $field_definition->isMultiple()) {
     return;
   }
 
   $form_object = $form_state->getFormObject();
 
   if (!$form_object instanceof EntityFormInterface) {
-
     return;
   }
 

--- a/modules/custom/entity_access_by_field/src/EntityAccessHelper.php
+++ b/modules/custom/entity_access_by_field/src/EntityAccessHelper.php
@@ -72,7 +72,7 @@ class EntityAccessHelper {
                   return EntityAccessHelper::NEUTRAL;
                 }
 
-                $permission_label = $field_definition->id() . ':' . $field_value['value'];
+                $permission_label = "node.{$node->bundle()}.{$field_definition->getName()}:{$field_value['value']}";
 
                 // When content is posted in a group and the account does not
                 // have permission we return Access::ignore.

--- a/modules/custom/entity_access_by_field/tests/src/Unit/EntityAccessTest.php
+++ b/modules/custom/entity_access_by_field/tests/src/Unit/EntityAccessTest.php
@@ -78,8 +78,8 @@ class EntityAccessTest extends UnitTestCase {
    * Tests the EntityAccessHelper::nodeAccessCheck for Forbidden Access.
    */
   public function testForbiddenAccess() {
-
     $node = $this->prophesize(NodeInterface::class);
+    $node->bundle()->willReturn('article');
 
     $this->fieldValue = 'public';
     $this->fieldType = 'entity_access_field';
@@ -88,9 +88,9 @@ class EntityAccessTest extends UnitTestCase {
     $fieldDefinitionInterface->expects($this->once())
       ->method('getType')
       ->willReturn($this->fieldType);
-    $fieldDefinitionInterface->expects($this->any())
-      ->method('id')
-      ->willReturn('node.article.field_content_visibility');
+    $fieldDefinitionInterface->expects($this->once())
+      ->method('getName')
+      ->willReturn('field_content_visibility');
 
     $fieldItemListInterface = $this->createMock('Drupal\Core\Field\FieldItemListInterface');
     $fieldItemListInterface->expects($this->any())
@@ -121,8 +121,8 @@ class EntityAccessTest extends UnitTestCase {
    * Tests the EntityAccessHelper::nodeAccessCheck for Allowed Access.
    */
   public function testAllowedAccess() {
-
     $node = $this->prophesize(NodeInterface::class);
+    $node->bundle()->willReturn('article');
 
     $this->fieldId = 'node.article.field_content_visibility';
     $this->fieldValue = 'public';
@@ -134,9 +134,9 @@ class EntityAccessTest extends UnitTestCase {
     $fieldDefinitionInterface->expects($this->once())
       ->method('getType')
       ->willReturn($this->fieldType);
-    $fieldDefinitionInterface->expects($this->any())
-      ->method('id')
-      ->willReturn($this->fieldId);
+    $fieldDefinitionInterface->expects($this->once())
+      ->method('getName')
+      ->willReturn('field_content_visibility');
 
     $fieldItemListInterface = $this->createMock('Drupal\Core\Field\FieldItemListInterface');
     $fieldItemListInterface->expects($this->any())
@@ -167,8 +167,8 @@ class EntityAccessTest extends UnitTestCase {
    * Tests the EntityAccessHelper::nodeAccessCheck for Author Access Allowed.
    */
   public function testAuthorAccessAllowed() {
-
     $node = $this->prophesize(NodeInterface::class);
+    $node->bundle()->willReturn('article');
 
     $this->fieldValue = 'nonexistant';
     $this->fieldType = 'entity_access_field';
@@ -178,9 +178,9 @@ class EntityAccessTest extends UnitTestCase {
     $fieldDefinitionInterface->expects($this->once())
       ->method('getType')
       ->willReturn($this->fieldType);
-    $fieldDefinitionInterface->expects($this->any())
-      ->method('id')
-      ->willReturn($this->fieldId);
+    $fieldDefinitionInterface->expects($this->once())
+      ->method('getName')
+      ->willReturn('field_content_visibility');
 
     $fieldItemListInterface = $this->createMock('Drupal\Core\Field\FieldItemListInterface');
     $fieldItemListInterface->expects($this->any())

--- a/modules/social_features/social_group/social_group.module
+++ b/modules/social_features/social_group/social_group.module
@@ -1328,16 +1328,19 @@ function social_group_field_widget_form_alter(&$element, FormStateInterface $for
   $field_definition = $context['items']->getFieldDefinition();
 
   // Unset the visibility field options which are not enabled.
-  if ($field_definition->getType() == 'entity_access_field') {
+  if ($field_definition->getType() === 'entity_access_field') {
     $default_value = $context['items']->getValue();
-    if (isset($default_value[0]['value'])) {
-      $element['#default_value'] = $default_value[0]['value'];
-    }
-    else {
-      $default_visibility = \Drupal::configFactory()
-        ->get('entity_access_by_field.settings')
-        ->get('default_visibility');
-      $element['#default_value'] = $default_visibility;
+    $field_cardinality = $field_definition->getFieldStorageDefinition()->getCardinality();
+    if ($field_cardinality === 1) {
+      if (isset($default_value[0]['value'])) {
+        $element['#default_value'] = $default_value[0]['value'];
+      }
+      else {
+        $default_visibility = \Drupal::configFactory()
+          ->get('entity_access_by_field.settings')
+          ->get('default_visibility');
+        $element['#default_value'] = $default_visibility;
+      }
     }
     $entity = $form_state->getFormObject()->getEntity();
 
@@ -1345,9 +1348,9 @@ function social_group_field_widget_form_alter(&$element, FormStateInterface $for
     if (!empty($current_group)) {
       $group_type = $current_group->getGroupType();
       $group_type_id = $group_type->id();
-      // If it's an existing entity we dont need to set the default
+      // If it's an existing entity we don't need to set the default
       // rather follow the saved one.
-      if (!$entity->id()) {
+      if (!$entity->id() && $field_cardinality === 1) {
         $element['#default_value'] = \Drupal::service('social_group.helper_service')
           ->getDefaultGroupVisibility($group_type_id);
       }
@@ -2074,45 +2077,43 @@ function social_group_get_allowed_visibility_options_per_group_type($group_type_
       $visibility_options['group'] = TRUE;
       break;
 
-    case 'flexible_group':
+    default:
       if (empty($group)) {
         $group = _social_group_get_current_group();
       }
-      if ($group !== NULL) {
+      if ($group !== NULL && $group->hasField('field_group_allowed_visibility')) {
         $visibility_options['public'] = FALSE;
         $visibility_options['community'] = FALSE;
         $visibility_options['group'] = FALSE;
         // Try to retrieve allowed options from Group directly.
-        $allowed_options = $group->get('field_group_allowed_visibility')
-          ->getValue();
+        $allowed_options = $group->get('field_group_allowed_visibility')->getValue();
         foreach ($allowed_options as $option) {
           $value = $option['value'];
           $visibility_options[$value] = TRUE;
         }
       }
-      break;
-
-    default:
-      $config = \Drupal::config('entity_access_by_field.settings');
-      $visibility_options['public'] = TRUE;
-      if ($config->get('disable_public_visibility') === 1 && !$account->hasPermission('override disabled public visibility')) {
-        // This is a new entity.
-        if (!$entity) {
-          $visibility_options['public'] = FALSE;
-        }
-        else {
-          /** @var \Drupal\node\Entity\Node $entity */
-          if ($entity->hasField('field_content_visibility')) {
-            $current_visibility = $entity->get('field_content_visibility')
-              ->getString();
-            if ($current_visibility !== 'public') {
-              $visibility_options['public'] = FALSE;
+      else {
+        $config = \Drupal::config('entity_access_by_field.settings');
+        $visibility_options['public'] = TRUE;
+        if ($config->get('disable_public_visibility') === 1 && !$account->hasPermission('override disabled public visibility')) {
+          // This is a new entity.
+          if (!$entity) {
+            $visibility_options['public'] = FALSE;
+          }
+          else {
+            /** @var \Drupal\node\Entity\Node $entity */
+            if ($entity->hasField('field_content_visibility')) {
+              $current_visibility = $entity->get('field_content_visibility')
+                ->getString();
+              if ($current_visibility !== 'public') {
+                $visibility_options['public'] = FALSE;
+              }
             }
           }
         }
+        $visibility_options['community'] = TRUE;
+        $visibility_options['group'] = FALSE;
       }
-      $visibility_options['community'] = TRUE;
-      $visibility_options['group'] = FALSE;
       break;
   }
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2081,6 +2081,11 @@ parameters:
 			path: modules/custom/entity_access_by_field/tests/src/Unit/EntityAccessTest.php
 
 		-
+		  message: "#^Call to an undefined method Prophecy\\\\Prophecy\\\\ObjectProphecy\\:\\:bundle\\(\\)\\.$#"
+		  count: 3
+		  path: modules/custom/entity_access_by_field/tests/src/Unit/EntityAccessTest.php
+
+		-
 			message: "#^Method Drupal\\\\entity_access_by_field\\\\Tests\\\\EntityAccessTest\\:\\:testAllowedAccess\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: modules/custom/entity_access_by_field/tests/src/Unit/EntityAccessTest.php


### PR DESCRIPTION
## Problem
For now, if we wanna use the 'entity_access_field' type for the base fields in entity types it is not possible because of some methods that do not exist in that kind of field definition. Also, widgets with multiple values do not support default values and we cannot use the "allowed_values_function".

## Solution
- Use the `getName` method to generate permission labels.
- Check allowed values by using `allowed_values_function` if it exists, use same process as in the `options.module`
- Update default value in the `social_group_field_widget_form_alter` to make it possible use multiple values.

## Issue tracker
- https://www.drupal.org/project/social/issues/3262896
- https://getopensocial.atlassian.net/browse/YANG-6191

## How to test
N/A

## Screenshots
N/A

## Release notes
Now the `entity_access_field` field type could be used for the base field definitions and for multiple values.

## Change Record
N/A

## Translations
N/A
