### PR TITLE
Issue #3263595 by Ressinel: Fix wrong token for the og_street_address.

### DIFF
--- a/modules/custom/social_metatag/config/install/metatag.metatag_defaults.group_content__closed_group-group_node-event.yml
+++ b/modules/custom/social_metatag/config/install/metatag.metatag_defaults.group_content__closed_group-group_node-event.yml
@@ -11,5 +11,5 @@ tags:
   og_locality: '[node:field_event_address:locality]'
   og_postal_code: '[node:field_event_address:postal_code]'
   og_site_name: '[site:name]'
-  og_street_address: '[node:field_event_addressaddress_line1]'
+  og_street_address: '[node:field_event_address:address_line1]'
   og_title: '[current-page:title]'

--- a/modules/custom/social_metatag/config/install/metatag.metatag_defaults.node__event.yml
+++ b/modules/custom/social_metatag/config/install/metatag.metatag_defaults.node__event.yml
@@ -11,5 +11,5 @@ tags:
   og_locality: '[node:field_event_address:locality]'
   og_postal_code: '[node:field_event_address:postal_code]'
   og_site_name: '[site:name]'
-  og_street_address: '[node:field_event_addressaddress_line1]'
+  og_street_address: '[node:field_event_address:address_line1]'
   og_title: '[current-page:title]'

--- a/modules/custom/social_metatag/config/update/social_metatag_update_11001.yml
+++ b/modules/custom/social_metatag/config/update/social_metatag_update_11001.yml
@@ -1,0 +1,12 @@
+metatag.metatag_defaults.group_content__closed_group-group_node-event:
+  expected_config: {  }
+  update_actions:
+    change:
+      tags:
+        og_street_address: '[node:field_event_address:address_line1]'
+metatag.metatag_defaults.node__event:
+  expected_config: {  }
+  update_actions:
+    change:
+      tags:
+        og_street_address: '[node:field_event_address:address_line1]'

--- a/modules/custom/social_metatag/social_metatag.install
+++ b/modules/custom/social_metatag/social_metatag.install
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * @file
+ * Install, update and uninstall functions for the social_metatag module.
+ */
+
+/**
+ * Update event metatags.
+ */
+function social_metatag_update_11001(): string {
+  /** @var \Drupal\update_helper\Updater $updateHelper */
+  $updateHelper = \Drupal::service('update_helper.updater');
+
+  // Execute configuration update definitions with logging of success.
+  $updateHelper->executeUpdate('social_metatag', __FUNCTION__);
+
+  // Output logged messages to related channel of update execution.
+  return $updateHelper->logger()->output();
+}


### PR DESCRIPTION
## Problem
Value for metatag og_street_address doesn't show for events.

## Solution
Fix wrong token for the og_street_address:
`node:field_event_addressaddress_line1` --> `node:field_event_address:address_line1`

## Issue tracker
- https://www.drupal.org/project/social/issues/3263595

## How to test
- [ ] Enable social_metatag
- [ ] Create an event in a group or separately from any group
- [ ] Fill street address field
- [ ] You won't see `og_street_address` in the event source code
- [ ] Apply changes from this PR
- [ ] You will be able to see `og_street_address` in the event source code

## Screenshots
N/A

## Release notes
TBD

## Change Record
N/A

## Translations
N/A
