### PR TITLE
Issue #3264208 by tBKoT: Do not send emails if related content does not exist

### DIFF
--- a/modules/custom/activity_send/modules/activity_send_email/src/Plugin/EmailFrequency/Immediately.php
+++ b/modules/custom/activity_send/modules/activity_send_email/src/Plugin/EmailFrequency/Immediately.php
@@ -2,12 +2,12 @@
 
 namespace Drupal\activity_send_email\Plugin\EmailFrequency;
 
-use Drupal\activity_creator\Entity\Activity;
+use Drupal\activity_creator\ActivityInterface;
 use Drupal\activity_send_email\EmailFrequencyBase;
 use Drupal\activity_send_email\Plugin\ActivityDestination\EmailActivityDestination;
 use Drupal\Core\Link;
 use Drupal\Core\Url;
-use Drupal\message\Entity\Message;
+use Drupal\message\MessageInterface;
 use Drupal\user\Entity\User;
 
 /**
@@ -25,9 +25,9 @@ class Immediately extends EmailFrequencyBase {
   /**
    * {@inheritdoc}
    */
-  public function processItem(Activity $activity, Message $message, User $target, $body_text = NULL) {
+  public function processItem(ActivityInterface $activity, MessageInterface $message, User $target, $body_text = NULL) {
     // If the user is blocked, we don't want to process this item further.
-    if ($target->isBlocked()) {
+    if ($target->isBlocked() || $activity->getRelatedEntity() === NULL) {
       return;
     }
 

--- a/modules/custom/activity_send/modules/activity_send_email/src/Plugin/QueueWorker/ActivityDigestWorker.php
+++ b/modules/custom/activity_send/modules/activity_send_email/src/Plugin/QueueWorker/ActivityDigestWorker.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\activity_send_email\Plugin\QueueWorker;
 
-use Drupal\activity_creator\Entity\Activity;
+use Drupal\activity_creator\ActivityInterface;
 use Drupal\activity_send\Plugin\QueueWorker\ActivitySendWorkerBase;
 use Drupal\activity_send_email\EmailFrequencyManager;
 use Drupal\activity_send_email\Plugin\ActivityDestination\EmailActivityDestination;
@@ -132,9 +132,9 @@ class ActivityDigestWorker extends ActivitySendWorkerBase implements ContainerFa
 
           // Only for users that have access to related content.
           if (
-            ($activity instanceof Activity) &&
-            ($activity->getRelatedEntity() !== NULL) &&
-            ($activity->getRelatedEntity()->access('view', $target) === FALSE)
+            !($activity instanceof ActivityInterface) ||
+            ($related_entity = $activity->getRelatedEntity()) === NULL ||
+            !$related_entity->access('view', $target)
           ) {
             continue;
           }


### PR DESCRIPTION
## Problem
When we send digest emails sometimes tokens are not replaced. The main reason that related content was deleted before we generate the email

## Solution
Check if a related entity still exists before creating the message for email.

## Issue tracker
- https://www.drupal.org/project/social/issues/3264208
- https://getopensocial.atlassian.net/browse/YANG-7105

## How to test
- [x] Go to the `admin/config/opensocial/swiftmail` page.
- [x] Set the `A person created a post, event or topic in a group I joined` setting  to `Daily` or `Weekly`
- [x] Create two topics in a group with members
- [x] Run cron to create data in the `user_activity_digest` table
- [x] Delete one of the created topics
- [x] Go to the `admin/config/system/cron/jobs` and run cron job in `Activity Send Email` module to generate queue for digest emails
- [x] If not generated update condition in https://github.com/goalgorilla/open_social/blob/bef2bafce837dbda54730a1bd3d9bbd5cbafe6f8/modules/custom/activity_send/modules/activity_send_email/activity_send_email.module#L47 and repeat steps.
- [x] Run cron to process all queue items
- [x] You should receive emails with broken tokens

## Screenshots
![Screen Shot 2022-02-08 at 9 40 51 AM](https://user-images.githubusercontent.com/11648677/154447421-50422e89-491b-4e75-980c-a94a1922eccc.png)

## Release notes
Users will not receive emails for activities where related content does not exist

## Change Record
N/A

## Translations
N/A
