### PR TITLE
Issue #3264434 by nickmans: Set timestamp to 0 when timestamp is empty

### DIFF
--- a/modules/custom/social_language/social_language.module
+++ b/modules/custom/social_language/social_language.module
@@ -128,3 +128,14 @@ function social_language_modules_installed($modules) {
     }
   }
 }
+
+/**
+ * Implements hook_preprocess_HOOK().
+ */
+function social_language_preprocess_locale_translation_update_info(array &$variables): void {
+  foreach ($variables['updates'] as &$update) {
+    if (!is_int($update['timestamp'])) {
+      $update['timestamp'] = 0;
+    }
+  }
+}


### PR DESCRIPTION
## Problem
For some platforms the Translations report at /admin/reports/translations may crash when the provided timestamp is NULL and the template tries to create a time from it for the report.

## Solution
By preprocessing the template file we can set all empty timestamp to 0, that way the report will keep working.

## Issue tracker
https://www.drupal.org/project/social/issues/3264434

## How to test
- [ ] Go to /admin/reports/translations
- [ ] See the report without any issues
- [ ] Note: the date for some modules may be set to 1970, because of the 0 use for the timestamps that were previously empty

## Release notes
The translation report has been fixed and should work for all platforms. 