### PR TITLE
Issue #3264667 by alex.ksis: Display username as plain text in mentions for anonymous users.

### DIFF
--- a/modules/custom/mentions/mentions.module
+++ b/modules/custom/mentions/mentions.module
@@ -36,6 +36,7 @@ function mentions_theme() {
         'link' => NULL,
         'render_link' => FALSE,
         'render_value' => '',
+        'render_plain' => FALSE,
       ],
     ],
   ];

--- a/modules/custom/mentions/src/Plugin/Filter/MentionsFilter.php
+++ b/modules/custom/mentions/src/Plugin/Filter/MentionsFilter.php
@@ -264,6 +264,7 @@ class MentionsFilter extends FilterBase implements ContainerFactoryPluginInterfa
           '#link' => base_path() . $output['link'],
           '#render_link' => $output_settings['renderlink'],
           '#render_value' => $output['value'],
+          '#render_plain' => $output['render_plain'] ?? FALSE,
         ];
         $mentions = $this->renderer->render($build);
         $text = str_replace($match['source']['string'], $mentions, $text);

--- a/modules/custom/mentions/src/Plugin/Mentions/Entity.php
+++ b/modules/custom/mentions/src/Plugin/Mentions/Entity.php
@@ -63,6 +63,7 @@ class Entity implements MentionsPluginInterface {
       ->load($mention['target']['entity_id']);
     $output = [];
     $output['value'] = $this->tokenService->replace($settings['value'], [$mention['target']['entity_type'] => $entity]);
+    $output['render_plain'] = !$entity->access('view');
     if ($settings['renderlink']) {
       $output['link'] = $this->tokenService->replace($settings['rendertextbox'], [$mention['target']['entity_type'] => $entity]);
     }
@@ -76,6 +77,7 @@ class Entity implements MentionsPluginInterface {
     $entity_type = $settings['entity_type'];
     $input_value = $settings['value'];
     $query = $this->entityTypeManager->getStorage($entity_type)->getQuery();
+    $query->accessCheck(FALSE);
     $result = $query->condition($input_value, $value)->execute();
 
     if (!empty($result)) {

--- a/modules/custom/mentions/templates/mention-link.html.twig
+++ b/modules/custom/mentions/templates/mention-link.html.twig
@@ -1,1 +1,1 @@
-{% if render_link == true %}<a href="{{ link }}" class="mentions mentions-{{ mention_id }}">{{ render_value|raw }}</a>{% else %}{{ link }}{% endif %}
+{% if render_link == true and render_plain == false %}<a href="{{ link }}" class="mentions mentions-{{ mention_id }}">{{ render_value|raw }}</a>{% elseif render_plain == true %}{{ render_value|raw }}{% else %}{{ link }}{% endif %}

--- a/tests/behat/features/capabilities/mention/mention-comment.feature
+++ b/tests/behat/features/capabilities/mention/mention-comment.feature
@@ -11,7 +11,10 @@ Feature: Create Mention in a Comment
       | user_2   | mail_2@example.com | 1      | Isaac                    | Newton                  | verified |
       | user_3   | mail_3@example.com | 1      | Stephen                  | Hawking                 | verified |
     And I am logged in as "user_1"
-    And I am viewing a "topic" with the title "Mention in a comment test topic 2"
+    And I am viewing my topic:
+      | title                    | Mention in a comment test topic 2 |
+      | status                   | 1                                 |
+      | field_content_visibility | public                            |
     When I fill in the following:
       | Add a comment | [~user_2], [~user_3], see my comment. |
     And I press "Comment"
@@ -19,5 +22,11 @@ Feature: Create Mention in a Comment
     And I should see the link "user_2"
     When I click "user_3"
     Then I should see "Stephen Hawking"
+    Then I logout
+    And I am on "/all-topics"
+    And I click "Mention in a comment test topic 2"
+    And I should not see the link "user_2"
+    And I should not see the link "user_3"
+    And I should see "user_2, user_3, see my comment." in the "Main content"
 #    Then I should see "Albert Einstein mentioned Stephen Hawking in a comment"
 #    And I should see "user_2, user_3, see my comment."

--- a/tests/behat/features/capabilities/mention/mention-post.feature
+++ b/tests/behat/features/capabilities/mention/mention-post.feature
@@ -13,6 +13,7 @@ Feature: Create Mention in a Post
     And I am logged in as "user_1"
     And I am on the homepage
     And I fill in "Say something to the Community" with "Hello [~user_2], [~user_3]!"
+    And I select post visibility "Public"
     And I press "Post"
     Then I should see "Albert Einstein posted"
     And I should see "Hello user_2, user_3!"
@@ -25,3 +26,9 @@ Feature: Create Mention in a Post
     And I wait for the queue to be empty
     And I am at "notifications"
     Then I should see text matching "Albert Einstein mentioned you in a post"
+
+    When I logout
+    And I am on the homepage
+    And I should not see the link "user_2"
+    And I should not see the link "user_3"
+    Then I should see "Hello user_2, user_3!"


### PR DESCRIPTION
## Problem
Mentions sources are displayed instead of user name for anonymous users

## Solution
Display user name as plain text instead of a link for the users who does not have permissions to view user profiles.

## Issue tracker
[*Paste a link to the drupal.org issue queue item. If any other issue trackers were used, include links to those too.*](https://www.drupal.org/project/social/issues/3264667)

## How to test
- [ ] Post a comment with mentions in a public post/node.
- [ ] Open your just created content as anonymous.
- [ ] Make sure mentions displayed correctly (username instead of mention source like [~10]).

