### PR TITLE
Issue #3265075 by Ressinel: Profile fields that are not available on the platform should also not be visible in the user settings.

### DIFF
--- a/modules/social_features/social_profile/modules/social_profile_privacy/social_profile_privacy.module
+++ b/modules/social_features/social_profile/modules/social_profile_privacy/social_profile_privacy.module
@@ -227,6 +227,15 @@ function social_profile_privacy_form_user_form_alter(&$form, FormStateInterface 
   $helper = \Drupal::service('social_profile_privacy.helper');
 
   foreach ($helper->getFieldOptions($account) as $field => $options) {
+    // If module social_profile_fields is enabled and the field is deselected in
+    // settings then we should not show it on profile settings.
+    if (
+      \Drupal::moduleHandler()->moduleExists('social_profile_fields') &&
+      !\Drupal::config('social_profile_fields.settings')->get("profile_profile_{$field}")
+    ) {
+      continue;
+    }
+
     $state = $global_states[$field] ?? SocialProfilePrivacyHelperInterface::SHOW;
     $value = $status = TRUE;
 


### PR DESCRIPTION
## Problem
In the backend, the **Site manager** can select which fields are available on the user profile. When a field is NOT selected, it does not show up on the user profile. But the unselected field still shows up in the Privacy settings of the users and this is confusing to see.

## Solution
Profile fields that are not available on the platform should also not be visible in the user settings.

## Issue tracker
- https://www.drupal.org/project/social/issues/3265075
- https://getopensocial.atlassian.net/browse/TB-6028

## How to test
- [ ] Unselect some field on profile fields page `/admin/config/opensocial/profile-fields`
- [ ] Go to the user settings page and you will be able to see unselected field the Privacy settings section

## Screenshots
N/A

## Release notes
Profile fields that are not available on the platform also not be visible in the user settings.

## Change Record
N/A

## Translations
N/A
