### PR TITLE
Issue #3266003 by SV: Fix 'Notice: Undefined index: children in social_profile_privacy_private_fields_list()

### DIFF
--- a/modules/social_features/social_profile/modules/social_profile_privacy/social_profile_privacy.module
+++ b/modules/social_features/social_profile/modules/social_profile_privacy/social_profile_privacy.module
@@ -353,22 +353,25 @@ function social_profile_privacy_private_fields_list($uid) {
   $user_visibility = (array) $user_data->get('social_profile_privacy', $uid, 'fields');
 
   foreach ($display->getThirdPartySettings('field_group') as $field_group) {
-    foreach ($field_group['children'] as $field) {
-      if (!isset($global_visibility[$field])) {
-        continue;
-      }
 
-      $visibility = $global_visibility[$field];
+    if (isset($field_group['children'])) {
+      foreach ($field_group['children'] as $field) {
+        if (!isset($global_visibility[$field])) {
+          continue;
+        }
 
-      if (
-        $visibility === SocialProfilePrivacyHelperInterface::HIDE ||
-        (
-          $visibility === SocialProfilePrivacyHelperInterface::CONFIGURABLE &&
-          isset($user_visibility[$field]) &&
-          !$user_visibility[$field]
-        )
-      ) {
-        $fields[$uid][] = $field;
+        $visibility = $global_visibility[$field];
+
+        if (
+          $visibility === SocialProfilePrivacyHelperInterface::HIDE ||
+          (
+            $visibility === SocialProfilePrivacyHelperInterface::CONFIGURABLE &&
+            isset($user_visibility[$field]) &&
+            !$user_visibility[$field]
+          )
+        ) {
+          $fields[$uid][] = $field;
+        }
       }
     }
   }


### PR DESCRIPTION
## Problem
After update to 11.1.x & D9 displays a notice on the "/all-members" page:

`Notice: Undefined index: children in social_profile_privacy_private_fields_list() (line 356 of profiles/contrib/social/modules/social_features/social_profile/modules/social_profile_privacy/social_profile_privacy.module).
`
## Solution
Add a check to prevent the notice

## Issue tracker
- https://www.drupal.org/project/social/issues/3266003
- https://getopensocial.atlassian.net/browse/YANG-7178

## How to test
- [ ] Using version 11.1x of Open Social with the social_profile_privacy module enabled
- [ ] As a sitemanager
- [ ] Go to "/all-membres" page

## Screenshots
<img width="1063" alt="Screenshot 2022-02-23 at 00 32 12" src="https://user-images.githubusercontent.com/25609390/155233919-fec23311-200b-457f-b4b1-6d4962bb9c71.png">

## Release notes
 Fixes  'Notice: Undefined index: children in social_profile_privacy_private_fields_list()'