### PR TITLE
Issue #3266096 by NickDaelemans, Ressinel, tbsiqueira, navneet0693: Adjusted update hooks in social_profile module to keep sync between Open Social 11.0.x and Open Social 11.1.x.

### DIFF
--- a/modules/social_features/social_profile/config/static/core.entity_view_display.profile.profile.name_11007.yml
+++ b/modules/social_features/social_profile/config/static/core.entity_view_display.profile.profile.name_11007.yml
@@ -1,0 +1,28 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.profile.name
+    - profile.type.profile
+id: profile.profile.name
+targetEntityType: profile
+bundle: profile
+mode: name
+content: { }
+hidden:
+  field_profile_address: true
+  field_profile_banner_image: true
+  field_profile_expertise: true
+  field_profile_first_name: true
+  field_profile_function: true
+  field_profile_image: true
+  field_profile_interests: true
+  field_profile_last_name: true
+  field_profile_nationality: true
+  field_profile_nick_name: true
+  field_profile_organization: true
+  field_profile_phone_number: true
+  field_profile_profile_tag: true
+  field_profile_self_introduction: true
+  field_profile_show_email: true
+  search_api_excerpt: true

--- a/modules/social_features/social_profile/config/static/core.entity_view_mode.profile.name_11007.yml
+++ b/modules/social_features/social_profile/config/static/core.entity_view_mode.profile.name_11007.yml
@@ -1,0 +1,9 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - profile
+id: profile.name
+label: Name
+targetEntityType: profile
+cache: true

--- a/modules/social_features/social_profile/social_profile.install
+++ b/modules/social_features/social_profile/social_profile.install
@@ -5,6 +5,8 @@
  * Install, update and uninstall functions for the social_profile module.
  */
 
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Entity\EntityStorageException;
 use Drupal\Core\Field\BaseFieldDefinition;
 use Drupal\Core\Field\FieldStorageDefinitionInterface;
 use Drupal\Core\File\FileSystemInterface;
@@ -552,16 +554,63 @@ function social_profile_update_11002(): string {
 }
 
 /**
- * Install 'name' view mode.
+ * Empty hook update.
+ *
+ * @see https://github.com/goalgorilla/open_social/pull/2783
+ */
+function social_profile_update_11003(array &$sandbox): void {
+  // This update hook was a part of release in Open Social 11.0.3.
+  // @see https://github.com/goalgorilla/open_social/blob/11.0.3/modules/social_features/social_profile/social_profile.install#L557
+  // But this update hook accidentally had hook number 11006 in
+  // Open Social 11.1.0-rc1, due to an accidental commit.
+  // @see https://github.com/goalgorilla/open_social/blob/11.1.0-rc1/modules/social_features/social_profile/social_profile.install#L557
+  // So, we removed code in update hook 11003 in favor of
+  // social_profile_update_11007().
+  // This is the reason why we don't have update hook number 11004 and 11005.
+}
+
+/**
+ * Empty hook update.
+ *
+ * @see https://github.com/goalgorilla/open_social/pull/2783
  */
 function social_profile_update_11006(array &$sandbox): void {
+  // We moved code to social_profile_update_11007().
+  // We had to rewrite this code in order to use 'static' or unchangeable
+  // representation of config file instead of file from config/install which
+  // could be changed in the future.
+}
+
+/**
+ * Install 'name' view mode on profile.
+ *
+ * @throws \Drupal\Core\Entity\EntityStorageException
+ */
+function social_profile_update_11007(array &$sandbox): void {
   $module_path = drupal_get_path('module', 'social_profile');
-  $content = file_get_contents($module_path . '/config/install/core.entity_view_mode.profile.name.yml');
-  if ($content) {
+  $view_mode = EntityViewMode::load('profile.name');
+
+  // Check if the view mode exists, so we don't try to create it again.
+  if ($view_mode) {
+    return;
+  }
+  $content = file_get_contents($module_path . '/config/static/core.entity_view_mode.profile.name_11007.yml');
+  if (is_string($content)) {
     $yml = Yaml::parse($content);
-    EntityViewMode::create($yml)->save();
-    $content = file_get_contents($module_path . '/config/install/core.entity_view_display.profile.profile.name.yml');
-    if ($content) {
+    try {
+      EntityViewMode::create($yml)->save();
+    }
+    catch (EntityStorageException $e) {
+      throw new EntityStorageException($e->getMessage());
+    }
+    $view_display = EntityViewDisplay::load('profile.profile.name');
+
+    // Check if the view display exists, so we don't try to create it again.
+    if ($view_display instanceof EntityInterface) {
+      return;
+    }
+    $content = file_get_contents($module_path . '/config/install/core.entity_view_display.profile.profile.name_11007.yml');
+    if (is_string($content)) {
       $yml = Yaml::parse($content);
       EntityViewDisplay::create($yml)->save();
     }

--- a/modules/social_features/social_profile/social_profile.install
+++ b/modules/social_features/social_profile/social_profile.install
@@ -587,7 +587,7 @@ function social_profile_update_11006(array &$sandbox): void {
  * @throws \Drupal\Core\Entity\EntityStorageException
  */
 function social_profile_update_11007(array &$sandbox): void {
-  $module_path = drupal_get_path('module', 'social_profile');
+  $module_path = \Drupal::service('extension.list.module')->getPath('social_profile');
   $view_mode = EntityViewMode::load('profile.name');
 
   // Check if the view mode exists, so we don't try to create it again.
@@ -599,20 +599,20 @@ function social_profile_update_11007(array &$sandbox): void {
     $yml = Yaml::parse($content);
     try {
       EntityViewMode::create($yml)->save();
+      $view_display = EntityViewDisplay::load('profile.profile.name');
+
+      // Check if the view display exists, so we don't try to create it again.
+      if ($view_display instanceof EntityInterface) {
+        return;
+      }
+      $content = file_get_contents($module_path . '/config/static/core.entity_view_display.profile.profile.name_11007.yml');
+      if (is_string($content)) {
+        $yml = Yaml::parse($content);
+        EntityViewDisplay::create($yml)->save();
+      }
     }
     catch (EntityStorageException $e) {
-      throw new EntityStorageException($e->getMessage());
-    }
-    $view_display = EntityViewDisplay::load('profile.profile.name');
-
-    // Check if the view display exists, so we don't try to create it again.
-    if ($view_display instanceof EntityInterface) {
-      return;
-    }
-    $content = file_get_contents($module_path . '/config/install/core.entity_view_display.profile.profile.name_11007.yml');
-    if (is_string($content)) {
-      $yml = Yaml::parse($content);
-      EntityViewDisplay::create($yml)->save();
+      \Drupal::logger('social_profile')->error($e->getMessage());
     }
   }
 }


### PR DESCRIPTION
## Problem
The hook update numbers in social_profile.install got out of sync in branches [11.0.x](https://github.com/goalgorilla/open_social/blob/11.0.3/modules/social_features/social_profile/social_profile.install#L557).x and [11.1.x](https://github.com/goalgorilla/open_social/blob/11.1.0-rc1/modules/social_features/social_profile/social_profile.install#L557)
 
There is a wrong update hook number on social_profile social_profile_update_11006 instead it should have been 11003. Also, this update is not working properly.

## Solution
Fix the update hook number, and sync it between releases, we currently have different update hooks for both 11.1.x and 11.0.x

## Issue tracker
https://www.drupal.org/project/social/issues/3266096

## How to test
- [ ] Run the update hooks
- [ ] If your project is already on 11006 it should do nothing
- [ ] If your project has any lower number, it should execute 3 dummy update hooks and the 11006 at last.

## Release notes
Fixed a hook update to add a new profile view mode called 'name' in Open Social 11 which was failing earlier.
