### PR TITLE
(10.3.x) Issue #3260572: Filter groups on access on all-groups page.

### DIFF
--- a/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.module
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.module
@@ -667,17 +667,15 @@ function social_group_flexible_group_views_query_alter(ViewExecutable $view, Que
   // Get all hidden groups that the current user is not a member of
   // and remove them from showing in the view.
   $ids = array_diff(array_keys($hidden_groups), $my_groups);
-  if ($ids) {
-    // Anonymous user should only see 'public' groups.
-    if ($account->isAnonymous()) {
-      $community_groups = \Drupal::entityTypeManager()->getStorage('group')->loadByProperties([
-        'field_flexible_group_visibility' => 'community',
-      ]);
-      $ids = array_merge($ids, array_keys($community_groups));
+  // Anonymous user should only see 'public' groups.
+  if ($account->isAnonymous()) {
+    $community_groups = \Drupal::entityTypeManager()->getStorage('group')->loadByProperties([
+      'field_flexible_group_visibility' => 'community',
+    ]);
+    $ids = array_merge($ids, array_keys($community_groups));
 
-      // Add context so for AN it will have a different cache.
-      $view->element['#cache']['contexts'][] = 'user.roles:anonymous';
-    }
+    // Add context so for AN it will have a different cache.
+    $view->element['#cache']['contexts'][] = 'user.roles:anonymous';
 
     $query->addWhere($new_where, 'groups_field_data.id', $ids, 'NOT IN');
   }

--- a/modules/social_features/social_group/social_group.module
+++ b/modules/social_features/social_group/social_group.module
@@ -2184,21 +2184,19 @@ function social_group_views_query_alter(ViewExecutable $view, QueryPluginBase $q
     /** @var \Drupal\social_group\SocialGroupHelperServiceInterface $group_helper */
     $group_helper = \Drupal::service('social_group.helper_service');
     $my_groups = $group_helper->getAllGroupsForUser($account->id());
-    if (!empty($my_groups)) {
-      // Get all hidden groups.
-      $hidden_groups = \Drupal::entityTypeManager()
-        ->getStorage('group')
-        ->loadByProperties([
-          'type' => 'closed_group',
-        ]);
+    // Get all hidden groups.
+    $hidden_groups = \Drupal::entityTypeManager()
+      ->getStorage('group')
+      ->loadByProperties([
+        'type' => 'closed_group',
+      ]);
 
-      // Get all hidden groups that the current user is not a member of
-      // and remove them from showing in the view.
-      $ids = array_diff(array_keys($hidden_groups), $my_groups);
-      if ($ids) {
-        /** @var \Drupal\views\Plugin\views\query\Sql $query */
-        $query->addWhere('group_membership', 'groups_field_data.id', $ids, 'NOT IN');
-      }
+    // Get all hidden groups that the current user is not a member of
+    // and remove them from showing in the view.
+    $ids = array_diff(array_keys($hidden_groups), $my_groups);
+    if ($ids) {
+      /** @var \Drupal\views\Plugin\views\query\Sql $query */
+      $query->addWhere('group_membership', 'groups_field_data.id', $ids, 'NOT IN');
     }
   }
 }

--- a/modules/social_features/social_group/social_group.module
+++ b/modules/social_features/social_group/social_group.module
@@ -105,8 +105,7 @@ function social_group_group_type_permission_check() {
   // Check if we have a default visibility, if we don't it must be a custom
   // group type, we need to have a visibility in order to update group content.
   // please see hook_social_group_default_visibility_alter.
-  if (\Drupal::service('social_group.helper_service')
-      ->getDefaultGroupVisibility($group->getGroupType()->id()) === NULL) {
+  if (\Drupal::service('social_group.helper_service')->getDefaultGroupVisibility($group->getGroupType()->id()) === NULL) {
     return FALSE;
   }
 
@@ -125,8 +124,7 @@ function _social_group_get_overview_route(GroupInterface $group) {
     'name' => 'view.groups.page_user_groups',
     'parameters' => ['user' => \Drupal::currentUser()->id()],
   ];
-  \Drupal::moduleHandler()
-    ->alter('social_group_overview_route', $route, $group);
+  \Drupal::moduleHandler()->alter('social_group_overview_route', $route, $group);
   return $route;
 }
 
@@ -195,9 +193,7 @@ function _social_group_visibility_settings_submit(array $form, FormStateInterfac
 function _social_group_get_group_labels() {
 
   // Load the entity label from the group content being handled.
-  $group_content = \Drupal::routeMatch()
-    ->getParameter('group_content')
-    ->label();
+  $group_content = \Drupal::routeMatch()->getParameter('group_content')->label();
 
   // Load group name.
   $group = \Drupal::routeMatch()->getParameter('group')->label();
@@ -244,24 +240,19 @@ function social_group_preprocess_group(array &$variables) {
   if (in_array($group_type_id, $group_types)
     && $group->hasField('field_group_type')
     && !empty($term = $group->get('field_group_type')->entity)
-    && \Drupal::config('social_group.settings')
-      ->get('social_group_type_required')) {
+    && \Drupal::config('social_group.settings')->get('social_group_type_required')) {
     $variables['group_type'] = $term->getName();
     $variables['group_type_icon'] = $term->get('field_group_type_icon')->value;
   }
 
   // Render the group settings help, gear icon with popover.
   $group_settings_help = _social_group_render_group_settings_hero($group);
-  $variables['group_settings_help'] = \Drupal::service('renderer')
-    ->renderPlain($group_settings_help);
+  $variables['group_settings_help'] = \Drupal::service('renderer')->renderPlain($group_settings_help);
 
   $account = \Drupal::currentUser();
 
   // Prevent access to mute group notifications if a user is not a group member.
-  if (!in_array($variables['view_mode'], [
-      'statistic',
-      'hero',
-    ]) || !$group->getMember($account)) {
+  if (!in_array($variables['view_mode'], ['statistic', 'hero']) || !$group->getMember($account)) {
     unset($variables['content']['flag_mute_group_notifications']);
   }
   // Set joined to true for teaser when current logged in
@@ -296,8 +287,8 @@ function social_group_preprocess_group(array &$variables) {
   if (
     $account->isAnonymous() &&
     (in_array($group_type_id, $group_types) &&
-      social_group_flexible_group_can_join_directly($group) ||
-      in_array($group_type_id, ['public_group']))
+    social_group_flexible_group_can_join_directly($group) ||
+    in_array($group_type_id, ['public_group']))
   ) {
     $variables['group_operations_url'] = Url::fromRoute('entity.group.join', ['group' => $group->id()]);
   }
@@ -312,9 +303,7 @@ function social_group_preprocess_group(array &$variables) {
 
       $variables['group_hero_styled_image_url'] = $image_style->buildUrl($group->get('field_group_image')->entity->getFileUri());
       // Check if this style is considered small.
-      $overridden_image_style = Drupal::getContainer()
-        ->get('social_group.hero_image')
-        ->getGroupHeroImageStyle();
+      $overridden_image_style = Drupal::getContainer()->get('social_group.hero_image')->getGroupHeroImageStyle();
 
       if ($overridden_image_style !== $original_image_style) {
         $variables['group_hero_styled_image_url'] = ImageStyle::load($overridden_image_style)
@@ -365,19 +354,17 @@ function social_group_preprocess_group(array &$variables) {
     $variables['about_url'] = $about_url;
     if ($group->getGroupType()->hasContentPlugin('group_node:event')) {
       $variables['group_events'] = $group_statistics->getGroupNodeCount($group, 'event');
-      $variables['group_events_label'] = \Drupal::translation()
-        ->formatPlural($variables['group_events'],
-          'event',
-          'events'
-        );
+      $variables['group_events_label'] = \Drupal::translation()->formatPlural($variables['group_events'],
+        'event',
+        'events'
+      );
     }
     if ($group->getGroupType()->hasContentPlugin('group_node:topic')) {
       $variables['group_topics'] = $group_statistics->getGroupNodeCount($group, 'topic');
-      $variables['group_topics_label'] = \Drupal::translation()
-        ->formatPlural($variables['group_topics'],
-          'topic',
-          'topics'
-        );
+      $variables['group_topics_label'] = \Drupal::translation()->formatPlural($variables['group_topics'],
+        'topic',
+        'topics'
+      );
     }
   }
 }
@@ -402,8 +389,7 @@ function social_group_preprocess_group__hero(array &$variables) {
 
   // Render the group settings help, gear icon with popover.
   $group_settings_help = _social_group_render_group_settings_hero($group);
-  $variables['group_settings_help'] = \Drupal::service('renderer')
-    ->renderPlain($group_settings_help);
+  $variables['group_settings_help'] = \Drupal::service('renderer')->renderPlain($group_settings_help);
 }
 
 /**
@@ -471,8 +457,7 @@ function _social_group_get_join_methods(GroupInterface $group) {
   if (in_array($group_type_id, $group_types)) {
     // Try to retrieve join methods from Group directly.
     if ($group->hasField('field_group_allowed_join_method')) {
-      $allowed_options = $group->get('field_group_allowed_join_method')
-        ->getValue();
+      $allowed_options = $group->get('field_group_allowed_join_method')->getValue();
       foreach ($allowed_options as $option) {
         // Lets grab the value from the selected radio item.
         if (!empty($option['value']) && is_string($option['value'])) {
@@ -521,8 +506,7 @@ function _social_group_get_group_visibility(GroupInterface $group, $field_name =
   if (in_array($group_type_id, $group_types)) {
     // By default we ship with the below field, lets grab its value(s).
     if ($group->hasField('field_flexible_group_visibility')) {
-      $visibility_values = $group->get('field_flexible_group_visibility')
-        ->getValue();
+      $visibility_values = $group->get('field_flexible_group_visibility')->getValue();
       // Lets grab the rendered description for the group visibility.
       if (!empty($visibility_values)) {
         foreach ($visibility_values as $visibility_value) {
@@ -657,8 +641,7 @@ function social_group_group_visibility_description($key) {
 
   // Allow modules to provide their own markup for a given key in the
   // group_visibility #options array.
-  \Drupal::moduleHandler()
-    ->alter('social_group_group_visibility_description', $key, $description);
+  \Drupal::moduleHandler()->alter('social_group_group_visibility_description', $key, $description);
 
   return $description;
 }
@@ -709,8 +692,7 @@ function social_group_allowed_join_method_description($key) {
 
   // Allow modules to provide their own markup for a given key in the
   // join method #options array.
-  \Drupal::moduleHandler()
-    ->alter('social_group_allowed_join_method_description', $key, $description);
+  \Drupal::moduleHandler()->alter('social_group_allowed_join_method_description', $key, $description);
 
   return $description;
 }
@@ -821,8 +803,7 @@ function social_group_form_alter(&$form, FormStateInterface $form_state, $form_i
     $form['actions']['submit']['#submit'][] = '_social_group_action_form_submit';
   }
 
-  if (in_array($form_id, $membership_forms) && Drupal::currentUser()
-      ->id() != 1) {
+  if (in_array($form_id, $membership_forms) && Drupal::currentUser()->id() != 1) {
     // Change titles on membership forms.
     $form['entity_id']['widget'][0]['target_id']['#title'] = t('Find people by name');
     $form['group_roles']['widget']['#title'] = t('Group roles');
@@ -830,8 +811,7 @@ function social_group_form_alter(&$form, FormStateInterface $form_state, $form_i
   }
 
   // Change the form when adding members directly in groups.
-  if (in_array($form_id, $membership_add_forms, TRUE) && \Drupal::routeMatch()
-      ->getRouteName() !== 'grequest.group_request_membership_approve') {
+  if (in_array($form_id, $membership_add_forms, TRUE) && \Drupal::routeMatch()->getRouteName() !== 'grequest.group_request_membership_approve') {
     // Lets add the new select 2 widget to add members to a group.
     $form['entity_id']['widget'][0]['target_id'] = [
       '#title' => t('Find people by name or email address'),
@@ -902,8 +882,7 @@ function social_group_form_alter(&$form, FormStateInterface $form_state, $form_i
       // Get the current group.
       $group = _social_group_get_current_group();
       // Set the default value in the form.
-      $group_type_element['widget']['#default_value'] = $group->getGroupType()
-        ->id();
+      $group_type_element['widget']['#default_value'] = $group->getGroupType()->id();
 
       // If user doesn't have permission to change group types disable it.
       // Or if group types can't be edited due to visibility issues.
@@ -924,8 +903,7 @@ function social_group_form_alter(&$form, FormStateInterface $form_state, $form_i
       // Disable all group types that can't be edited. Because they don't have
       // a visibility.
       foreach (array_keys($form['group_type']['widget']['#options']) as $type) {
-        if (\Drupal::service('social_group.helper_service')
-            ->getDefaultGroupVisibility($type) === NULL) {
+        if (\Drupal::service('social_group.helper_service')->getDefaultGroupVisibility($type) === NULL) {
           $form['group_type']['widget'][$type] = [
             '#disabled' => TRUE,
           ];
@@ -983,8 +961,8 @@ function social_group_form_alter(&$form, FormStateInterface $form_state, $form_i
 
   // Exposed Filter block on the all-groups overview.
   if ($form['#id'] === 'views-exposed-form-newest-groups-page-all-groups' ||
-    $form['#id'] === 'views-exposed-form-search-groups-page-no-value' ||
-    $form['#id'] === 'views-exposed-form-search-groups-page') {
+  $form['#id'] === 'views-exposed-form-search-groups-page-no-value' ||
+  $form['#id'] === 'views-exposed-form-search-groups-page') {
     $account = \Drupal::currentUser();
     if (!empty($form['type']['#options'])) {
       foreach ($form['type']['#options'] as $type => $label) {
@@ -1074,8 +1052,7 @@ function _social_group_type_edit_submit($form, FormStateInterface $form_state) {
   if (
     $group instanceof GroupInterface &&
     !empty($form['group_type']) &&
-    (\Drupal::service('social_group.helper_service')
-        ->getDefaultGroupVisibility($group->getGroupType()->id()) != NULL)
+    (\Drupal::service('social_group.helper_service')->getDefaultGroupVisibility($group->getGroupType()->id()) != NULL)
   ) {
     $default_type = $form['group_type']['widget']['#default_value'];
     $new_type = $form_state->getValue('group_type')[0]['value'];
@@ -1153,8 +1130,7 @@ function _social_group_action_form_submit($form, FormStateInterface $form_state)
 
         // Add nice messages.
         if (!empty($count)) {
-          $message = \Drupal::translation()
-            ->formatPlural($count, '@count new member joined the group.', '@count new members joined the group.');
+          $message = \Drupal::translation()->formatPlural($count, '@count new member joined the group.', '@count new members joined the group.');
           \Drupal::messenger()->addMessage($message, 'status');
         }
 
@@ -1221,10 +1197,8 @@ function _social_group_grant_admin_role($uid, $gid) {
  */
 function social_group_group_content_insert(GroupContentInterface $group_content) {
   if ($group_content->getEntity()->getEntityTypeId() == 'user') {
-    if ($group_content->bundle() == $group_content->getGroup()
-        ->bundle() . '-group_membership') {
-      _social_group_grant_admin_role($group_content->getEntity()
-        ->id(), $group_content->getGroup()->id());
+    if ($group_content->bundle() == $group_content->getGroup()->bundle() . '-group_membership') {
+      _social_group_grant_admin_role($group_content->getEntity()->id(), $group_content->getGroup()->id());
     }
   }
 }
@@ -1338,8 +1312,7 @@ function social_group_field_widget_form_alter(&$element, FormStateInterface $for
       $element['#default_value'] = $default_value[0]['value'];
     }
     else {
-      $default_visibility = \Drupal::configFactory()
-        ->get('entity_access_by_field.settings')
+      $default_visibility = \Drupal::configFactory()->get('entity_access_by_field.settings')
         ->get('default_visibility');
       $element['#default_value'] = $default_visibility;
     }
@@ -1352,8 +1325,7 @@ function social_group_field_widget_form_alter(&$element, FormStateInterface $for
       // If it's an existing entity we dont need to set the default
       // rather follow the saved one.
       if (!$entity->id()) {
-        $element['#default_value'] = \Drupal::service('social_group.helper_service')
-          ->getDefaultGroupVisibility($group_type_id);
+        $element['#default_value'] = \Drupal::service('social_group.helper_service')->getDefaultGroupVisibility($group_type_id);
       }
     }
     else {
@@ -1603,15 +1575,13 @@ function _social_group_get_current_group($node = NULL) {
       ->load($group);
   }
   else {
-    $node = is_object($node) ? $node : \Drupal::routeMatch()
-      ->getParameter('node');
+    $node = is_object($node) ? $node : \Drupal::routeMatch()->getParameter('node');
     if (is_object($node)) {
       $node_entity = [
         'target_type' => 'node',
         'target_id' => $node->id(),
       ];
-      $gid_from_entity = \Drupal::service('social_group.helper_service')
-        ->getGroupFromEntity($node_entity);
+      $gid_from_entity = \Drupal::service('social_group.helper_service')->getGroupFromEntity($node_entity);
       if ($gid_from_entity !== NULL) {
         $group = \Drupal::entityTypeManager()
           ->getStorage('group')
@@ -1676,7 +1646,7 @@ function social_group_block_view_local_tasks_block_alter(array &$build, BlockPlu
 function social_group_block_build_alter(array &$build, BlockPluginInterface $block) {
   if (!empty($block->getPluginId()) &&
     ($block->getPluginId() === 'views_exposed_filter_block:newest_groups-page_all_groups' ||
-      $block->getPluginId() === 'views_exposed_filter_block:search_groups-page')) {
+    $block->getPluginId() === 'views_exposed_filter_block:search_groups-page')) {
     // The Group Type filter has to listen to changes in
     // group type role permissions. Using the role list ensures
     // it's cleared correctly.
@@ -1792,8 +1762,7 @@ function social_group_block_access(Block $block, $operation, AccountInterface $a
   $group = _social_group_get_current_group();
   $user = Drupal::currentUser();
   // Check if there is a group set and if its an closed group.
-  if ($group && $group->getGroupType()
-      ->id() == 'closed_group' && $account->id() != 1) {
+  if ($group && $group->getGroupType()->id() == 'closed_group' && $account->id() != 1) {
     if ($account->hasPermission('manage all groups')) {
       return AccessResult::neutral();
     }
@@ -2132,8 +2101,7 @@ function social_group_get_allowed_visibility_options_per_group_type($group_type_
         $visibility_options['community'] = FALSE;
         $visibility_options['group'] = FALSE;
         // Try to retrieve allowed options from Group directly.
-        $allowed_options = $group->get('field_group_allowed_visibility')
-          ->getValue();
+        $allowed_options = $group->get('field_group_allowed_visibility')->getValue();
         foreach ($allowed_options as $option) {
           $value = $option['value'];
           $visibility_options[$value] = TRUE;
@@ -2152,8 +2120,7 @@ function social_group_get_allowed_visibility_options_per_group_type($group_type_
         else {
           /** @var \Drupal\node\Entity\Node $entity */
           if ($entity->hasField('field_content_visibility')) {
-            $current_visibility = $entity->get('field_content_visibility')
-              ->getString();
+            $current_visibility = $entity->get('field_content_visibility')->getString();
             if ($current_visibility !== 'public') {
               $visibility_options['public'] = FALSE;
             }
@@ -2165,8 +2132,7 @@ function social_group_get_allowed_visibility_options_per_group_type($group_type_
       break;
   }
 
-  \Drupal::moduleHandler()
-    ->alter('social_group_allowed_visibilities', $visibility_options, $group_type_id);
+  \Drupal::moduleHandler()->alter('social_group_allowed_visibilities', $visibility_options, $group_type_id);
 
   return $visibility_options;
 }
@@ -2175,28 +2141,61 @@ function social_group_get_allowed_visibility_options_per_group_type($group_type_
  * Implements hook_views_query_alter().
  */
 function social_group_views_query_alter(ViewExecutable $view, QueryPluginBase $query) {
+  if (\Drupal::currentUser()->isAuthenticated()) {
+    return;
+  }
+
   if (empty($view->rowPlugin) || !($view->rowPlugin instanceof EntityRow) || $view->rowPlugin->getEntityTypeId() != 'group') {
     return;
   }
-  $account = \Drupal::currentUser()->getAccount();
-  if ($account->isAuthenticated()) {
-    // Get all groups for LU.
-    /** @var \Drupal\social_group\SocialGroupHelperServiceInterface $group_helper */
-    $group_helper = \Drupal::service('social_group.helper_service');
-    $my_groups = $group_helper->getAllGroupsForUser($account->id());
-    // Get all hidden groups.
-    $hidden_groups = \Drupal::entityTypeManager()
-      ->getStorage('group')
-      ->loadByProperties([
-        'type' => 'closed_group',
-      ]);
 
-    // Get all hidden groups that the current user is not a member of
-    // and remove them from showing in the view.
-    $ids = array_diff(array_keys($hidden_groups), $my_groups);
-    if ($ids) {
-      /** @var \Drupal\views\Plugin\views\query\Sql $query */
-      $query->addWhere('group_membership', 'groups_field_data.id', $ids, 'NOT IN');
+  $found = FALSE;
+
+  foreach ($query->where as &$conditions) {
+    foreach ($conditions['conditions'] as &$condition) {
+      if ($condition['field'] == 'groups_field_data.type') {
+        $found = TRUE;
+        break 2;
+      }
+    }
+  }
+
+  if (!$found) {
+    unset($condition);
+
+    $condition = [
+      'field' => 'groups_field_data.type',
+      'value' => [],
+      'operator' => 'not in',
+    ];
+  }
+
+  $hiddens = $condition['operator'] == 'not in';
+
+  // Define the variable as array otherwise it can be interpreted as string
+  // And breaking the code below.
+  $condition['value'] = [];
+
+  /** @var \Drupal\group\Entity\GroupTypeInterface $group_type */
+  foreach (GroupType::loadMultiple() as $group_type) {
+    $new = !in_array($group_type->id(), $condition['value']);
+    $permissions = $group_type->getAnonymousRole()->getPermissions();
+    $hidden = !in_array('view group', $permissions);
+
+    if ($new && $hiddens == $hidden) {
+      $condition['value'][] = $group_type->id();
+    }
+  }
+
+  if (!$found) {
+    if (isset($conditions)) {
+      $conditions['conditions'][] = $condition;
+    }
+    else {
+      $query->where[] = [
+        'conditions' => [$condition],
+        'type' => 'AND',
+      ];
     }
   }
 }
@@ -2226,18 +2225,18 @@ function social_group_social_user_account_header_create_links($context) {
     /** @var \Drupal\Core\Session\AccountInterface $user */
     $account = $context['user'];
     $route_add_group = \Drupal::service('social_group.helper_service')
-        ->getGroupsToAddUrl($account) ?? $route_add_group;
+      ->getGroupsToAddUrl($account) ?? $route_add_group;
   }
 
   return [
     'add_group' => [
-        '#type' => 'link',
-        '#attributes' => [
-          'title' => new TranslatableMarkup('Create New Group'),
-        ],
-        '#title' => new TranslatableMarkup('New Group'),
-        '#weight' => 500,
-      ] + $route_add_group->toRenderArray(),
+      '#type' => 'link',
+      '#attributes' => [
+        'title' => new TranslatableMarkup('Create New Group'),
+      ],
+      '#title' => new TranslatableMarkup('New Group'),
+      '#weight' => 500,
+    ] + $route_add_group->toRenderArray(),
   ];
 }
 
@@ -2248,8 +2247,7 @@ function social_group_social_user_account_header_create_links($context) {
  * site manager.
  */
 function social_group_social_user_account_header_items(array $context) {
-  if (\Drupal::config('social_user.navigation.settings')
-      ->get('display_my_groups_icon') !== TRUE) {
+  if (\Drupal::config('social_user.navigation.settings')->get('display_my_groups_icon') !== TRUE) {
     return [];
   }
 
@@ -2287,15 +2285,15 @@ function social_group_social_user_account_header_account_links(array $context) {
 
   return [
     'my_groups' => [
-        '#type' => 'link',
-        '#attributes' => [
-          'title' => new TranslatableMarkup('View my groups'),
-        ],
-        '#title' => new TranslatableMarkup('My groups'),
-        '#weight' => 800,
-      ] + Url::fromRoute('view.groups.page_user_groups', [
-        'user' => $context['user']->id(),
-      ])->toRenderArray(),
+      '#type' => 'link',
+      '#attributes' => [
+        'title' => new TranslatableMarkup('View my groups'),
+      ],
+      '#title' => new TranslatableMarkup('My groups'),
+      '#weight' => 800,
+    ] + Url::fromRoute('view.groups.page_user_groups', [
+      'user' => $context['user']->id(),
+    ])->toRenderArray(),
   ];
 }
 
@@ -2310,7 +2308,7 @@ function social_group_social_user_account_header_account_links(array $context) {
  * @return bool
  *   Whether the user is allowed to view groups of the given type.
  */
-function social_group_can_view_groups_of_type(string $type, AccountInterface $account): bool {
+function social_group_can_view_groups_of_type(string $type, AccountInterface $account) : bool {
   $group_type = GroupType::load($type);
 
   // If the group type doesn't exist then the user can't see the group type.
@@ -2517,8 +2515,7 @@ function _social_group_action_batch_finish($success, array $results, array $oper
       }
 
       if ($fields === 2) {
-        $message = \Drupal::translation()
-          ->formatPlural($results_count, $messages['singular'], $messages['plural']);
+        $message = \Drupal::translation()->formatPlural($results_count, $messages['singular'], $messages['plural']);
         $type = $success ? MessengerInterface::TYPE_STATUS : MessengerInterface::TYPE_WARNING;
         \Drupal::messenger()->addMessage($message, $type);
       }
@@ -2795,8 +2792,7 @@ function social_group_allowed_visibility_description($key) {
 
   // Allow modules to provide their own markup for a given key in the
   // group_visibility #options array.
-  \Drupal::moduleHandler()
-    ->alter('social_group_content_visibility_description', $key, $description);
+  \Drupal::moduleHandler()->alter('social_group_content_visibility_description', $key, $description);
 
   return $description;
 }

--- a/modules/social_features/social_group/social_group.module
+++ b/modules/social_features/social_group/social_group.module
@@ -105,7 +105,8 @@ function social_group_group_type_permission_check() {
   // Check if we have a default visibility, if we don't it must be a custom
   // group type, we need to have a visibility in order to update group content.
   // please see hook_social_group_default_visibility_alter.
-  if (\Drupal::service('social_group.helper_service')->getDefaultGroupVisibility($group->getGroupType()->id()) === NULL) {
+  if (\Drupal::service('social_group.helper_service')
+      ->getDefaultGroupVisibility($group->getGroupType()->id()) === NULL) {
     return FALSE;
   }
 
@@ -124,7 +125,8 @@ function _social_group_get_overview_route(GroupInterface $group) {
     'name' => 'view.groups.page_user_groups',
     'parameters' => ['user' => \Drupal::currentUser()->id()],
   ];
-  \Drupal::moduleHandler()->alter('social_group_overview_route', $route, $group);
+  \Drupal::moduleHandler()
+    ->alter('social_group_overview_route', $route, $group);
   return $route;
 }
 
@@ -193,7 +195,9 @@ function _social_group_visibility_settings_submit(array $form, FormStateInterfac
 function _social_group_get_group_labels() {
 
   // Load the entity label from the group content being handled.
-  $group_content = \Drupal::routeMatch()->getParameter('group_content')->label();
+  $group_content = \Drupal::routeMatch()
+    ->getParameter('group_content')
+    ->label();
 
   // Load group name.
   $group = \Drupal::routeMatch()->getParameter('group')->label();
@@ -240,19 +244,24 @@ function social_group_preprocess_group(array &$variables) {
   if (in_array($group_type_id, $group_types)
     && $group->hasField('field_group_type')
     && !empty($term = $group->get('field_group_type')->entity)
-    && \Drupal::config('social_group.settings')->get('social_group_type_required')) {
+    && \Drupal::config('social_group.settings')
+      ->get('social_group_type_required')) {
     $variables['group_type'] = $term->getName();
     $variables['group_type_icon'] = $term->get('field_group_type_icon')->value;
   }
 
   // Render the group settings help, gear icon with popover.
   $group_settings_help = _social_group_render_group_settings_hero($group);
-  $variables['group_settings_help'] = \Drupal::service('renderer')->renderPlain($group_settings_help);
+  $variables['group_settings_help'] = \Drupal::service('renderer')
+    ->renderPlain($group_settings_help);
 
   $account = \Drupal::currentUser();
 
   // Prevent access to mute group notifications if a user is not a group member.
-  if (!in_array($variables['view_mode'], ['statistic', 'hero']) || !$group->getMember($account)) {
+  if (!in_array($variables['view_mode'], [
+      'statistic',
+      'hero',
+    ]) || !$group->getMember($account)) {
     unset($variables['content']['flag_mute_group_notifications']);
   }
   // Set joined to true for teaser when current logged in
@@ -287,8 +296,8 @@ function social_group_preprocess_group(array &$variables) {
   if (
     $account->isAnonymous() &&
     (in_array($group_type_id, $group_types) &&
-    social_group_flexible_group_can_join_directly($group) ||
-    in_array($group_type_id, ['public_group']))
+      social_group_flexible_group_can_join_directly($group) ||
+      in_array($group_type_id, ['public_group']))
   ) {
     $variables['group_operations_url'] = Url::fromRoute('entity.group.join', ['group' => $group->id()]);
   }
@@ -303,7 +312,9 @@ function social_group_preprocess_group(array &$variables) {
 
       $variables['group_hero_styled_image_url'] = $image_style->buildUrl($group->get('field_group_image')->entity->getFileUri());
       // Check if this style is considered small.
-      $overridden_image_style = Drupal::getContainer()->get('social_group.hero_image')->getGroupHeroImageStyle();
+      $overridden_image_style = Drupal::getContainer()
+        ->get('social_group.hero_image')
+        ->getGroupHeroImageStyle();
 
       if ($overridden_image_style !== $original_image_style) {
         $variables['group_hero_styled_image_url'] = ImageStyle::load($overridden_image_style)
@@ -354,17 +365,19 @@ function social_group_preprocess_group(array &$variables) {
     $variables['about_url'] = $about_url;
     if ($group->getGroupType()->hasContentPlugin('group_node:event')) {
       $variables['group_events'] = $group_statistics->getGroupNodeCount($group, 'event');
-      $variables['group_events_label'] = \Drupal::translation()->formatPlural($variables['group_events'],
-        'event',
-        'events'
-      );
+      $variables['group_events_label'] = \Drupal::translation()
+        ->formatPlural($variables['group_events'],
+          'event',
+          'events'
+        );
     }
     if ($group->getGroupType()->hasContentPlugin('group_node:topic')) {
       $variables['group_topics'] = $group_statistics->getGroupNodeCount($group, 'topic');
-      $variables['group_topics_label'] = \Drupal::translation()->formatPlural($variables['group_topics'],
-        'topic',
-        'topics'
-      );
+      $variables['group_topics_label'] = \Drupal::translation()
+        ->formatPlural($variables['group_topics'],
+          'topic',
+          'topics'
+        );
     }
   }
 }
@@ -389,7 +402,8 @@ function social_group_preprocess_group__hero(array &$variables) {
 
   // Render the group settings help, gear icon with popover.
   $group_settings_help = _social_group_render_group_settings_hero($group);
-  $variables['group_settings_help'] = \Drupal::service('renderer')->renderPlain($group_settings_help);
+  $variables['group_settings_help'] = \Drupal::service('renderer')
+    ->renderPlain($group_settings_help);
 }
 
 /**
@@ -457,7 +471,8 @@ function _social_group_get_join_methods(GroupInterface $group) {
   if (in_array($group_type_id, $group_types)) {
     // Try to retrieve join methods from Group directly.
     if ($group->hasField('field_group_allowed_join_method')) {
-      $allowed_options = $group->get('field_group_allowed_join_method')->getValue();
+      $allowed_options = $group->get('field_group_allowed_join_method')
+        ->getValue();
       foreach ($allowed_options as $option) {
         // Lets grab the value from the selected radio item.
         if (!empty($option['value']) && is_string($option['value'])) {
@@ -506,7 +521,8 @@ function _social_group_get_group_visibility(GroupInterface $group, $field_name =
   if (in_array($group_type_id, $group_types)) {
     // By default we ship with the below field, lets grab its value(s).
     if ($group->hasField('field_flexible_group_visibility')) {
-      $visibility_values = $group->get('field_flexible_group_visibility')->getValue();
+      $visibility_values = $group->get('field_flexible_group_visibility')
+        ->getValue();
       // Lets grab the rendered description for the group visibility.
       if (!empty($visibility_values)) {
         foreach ($visibility_values as $visibility_value) {
@@ -641,7 +657,8 @@ function social_group_group_visibility_description($key) {
 
   // Allow modules to provide their own markup for a given key in the
   // group_visibility #options array.
-  \Drupal::moduleHandler()->alter('social_group_group_visibility_description', $key, $description);
+  \Drupal::moduleHandler()
+    ->alter('social_group_group_visibility_description', $key, $description);
 
   return $description;
 }
@@ -692,7 +709,8 @@ function social_group_allowed_join_method_description($key) {
 
   // Allow modules to provide their own markup for a given key in the
   // join method #options array.
-  \Drupal::moduleHandler()->alter('social_group_allowed_join_method_description', $key, $description);
+  \Drupal::moduleHandler()
+    ->alter('social_group_allowed_join_method_description', $key, $description);
 
   return $description;
 }
@@ -803,7 +821,8 @@ function social_group_form_alter(&$form, FormStateInterface $form_state, $form_i
     $form['actions']['submit']['#submit'][] = '_social_group_action_form_submit';
   }
 
-  if (in_array($form_id, $membership_forms) && Drupal::currentUser()->id() != 1) {
+  if (in_array($form_id, $membership_forms) && Drupal::currentUser()
+      ->id() != 1) {
     // Change titles on membership forms.
     $form['entity_id']['widget'][0]['target_id']['#title'] = t('Find people by name');
     $form['group_roles']['widget']['#title'] = t('Group roles');
@@ -811,7 +830,8 @@ function social_group_form_alter(&$form, FormStateInterface $form_state, $form_i
   }
 
   // Change the form when adding members directly in groups.
-  if (in_array($form_id, $membership_add_forms, TRUE) && \Drupal::routeMatch()->getRouteName() !== 'grequest.group_request_membership_approve') {
+  if (in_array($form_id, $membership_add_forms, TRUE) && \Drupal::routeMatch()
+      ->getRouteName() !== 'grequest.group_request_membership_approve') {
     // Lets add the new select 2 widget to add members to a group.
     $form['entity_id']['widget'][0]['target_id'] = [
       '#title' => t('Find people by name or email address'),
@@ -882,7 +902,8 @@ function social_group_form_alter(&$form, FormStateInterface $form_state, $form_i
       // Get the current group.
       $group = _social_group_get_current_group();
       // Set the default value in the form.
-      $group_type_element['widget']['#default_value'] = $group->getGroupType()->id();
+      $group_type_element['widget']['#default_value'] = $group->getGroupType()
+        ->id();
 
       // If user doesn't have permission to change group types disable it.
       // Or if group types can't be edited due to visibility issues.
@@ -903,7 +924,8 @@ function social_group_form_alter(&$form, FormStateInterface $form_state, $form_i
       // Disable all group types that can't be edited. Because they don't have
       // a visibility.
       foreach (array_keys($form['group_type']['widget']['#options']) as $type) {
-        if (\Drupal::service('social_group.helper_service')->getDefaultGroupVisibility($type) === NULL) {
+        if (\Drupal::service('social_group.helper_service')
+            ->getDefaultGroupVisibility($type) === NULL) {
           $form['group_type']['widget'][$type] = [
             '#disabled' => TRUE,
           ];
@@ -961,8 +983,8 @@ function social_group_form_alter(&$form, FormStateInterface $form_state, $form_i
 
   // Exposed Filter block on the all-groups overview.
   if ($form['#id'] === 'views-exposed-form-newest-groups-page-all-groups' ||
-  $form['#id'] === 'views-exposed-form-search-groups-page-no-value' ||
-  $form['#id'] === 'views-exposed-form-search-groups-page') {
+    $form['#id'] === 'views-exposed-form-search-groups-page-no-value' ||
+    $form['#id'] === 'views-exposed-form-search-groups-page') {
     $account = \Drupal::currentUser();
     if (!empty($form['type']['#options'])) {
       foreach ($form['type']['#options'] as $type => $label) {
@@ -1052,7 +1074,8 @@ function _social_group_type_edit_submit($form, FormStateInterface $form_state) {
   if (
     $group instanceof GroupInterface &&
     !empty($form['group_type']) &&
-    (\Drupal::service('social_group.helper_service')->getDefaultGroupVisibility($group->getGroupType()->id()) != NULL)
+    (\Drupal::service('social_group.helper_service')
+        ->getDefaultGroupVisibility($group->getGroupType()->id()) != NULL)
   ) {
     $default_type = $form['group_type']['widget']['#default_value'];
     $new_type = $form_state->getValue('group_type')[0]['value'];
@@ -1130,7 +1153,8 @@ function _social_group_action_form_submit($form, FormStateInterface $form_state)
 
         // Add nice messages.
         if (!empty($count)) {
-          $message = \Drupal::translation()->formatPlural($count, '@count new member joined the group.', '@count new members joined the group.');
+          $message = \Drupal::translation()
+            ->formatPlural($count, '@count new member joined the group.', '@count new members joined the group.');
           \Drupal::messenger()->addMessage($message, 'status');
         }
 
@@ -1197,8 +1221,10 @@ function _social_group_grant_admin_role($uid, $gid) {
  */
 function social_group_group_content_insert(GroupContentInterface $group_content) {
   if ($group_content->getEntity()->getEntityTypeId() == 'user') {
-    if ($group_content->bundle() == $group_content->getGroup()->bundle() . '-group_membership') {
-      _social_group_grant_admin_role($group_content->getEntity()->id(), $group_content->getGroup()->id());
+    if ($group_content->bundle() == $group_content->getGroup()
+        ->bundle() . '-group_membership') {
+      _social_group_grant_admin_role($group_content->getEntity()
+        ->id(), $group_content->getGroup()->id());
     }
   }
 }
@@ -1312,7 +1338,8 @@ function social_group_field_widget_form_alter(&$element, FormStateInterface $for
       $element['#default_value'] = $default_value[0]['value'];
     }
     else {
-      $default_visibility = \Drupal::configFactory()->get('entity_access_by_field.settings')
+      $default_visibility = \Drupal::configFactory()
+        ->get('entity_access_by_field.settings')
         ->get('default_visibility');
       $element['#default_value'] = $default_visibility;
     }
@@ -1325,7 +1352,8 @@ function social_group_field_widget_form_alter(&$element, FormStateInterface $for
       // If it's an existing entity we dont need to set the default
       // rather follow the saved one.
       if (!$entity->id()) {
-        $element['#default_value'] = \Drupal::service('social_group.helper_service')->getDefaultGroupVisibility($group_type_id);
+        $element['#default_value'] = \Drupal::service('social_group.helper_service')
+          ->getDefaultGroupVisibility($group_type_id);
       }
     }
     else {
@@ -1575,13 +1603,15 @@ function _social_group_get_current_group($node = NULL) {
       ->load($group);
   }
   else {
-    $node = is_object($node) ? $node : \Drupal::routeMatch()->getParameter('node');
+    $node = is_object($node) ? $node : \Drupal::routeMatch()
+      ->getParameter('node');
     if (is_object($node)) {
       $node_entity = [
         'target_type' => 'node',
         'target_id' => $node->id(),
       ];
-      $gid_from_entity = \Drupal::service('social_group.helper_service')->getGroupFromEntity($node_entity);
+      $gid_from_entity = \Drupal::service('social_group.helper_service')
+        ->getGroupFromEntity($node_entity);
       if ($gid_from_entity !== NULL) {
         $group = \Drupal::entityTypeManager()
           ->getStorage('group')
@@ -1646,7 +1676,7 @@ function social_group_block_view_local_tasks_block_alter(array &$build, BlockPlu
 function social_group_block_build_alter(array &$build, BlockPluginInterface $block) {
   if (!empty($block->getPluginId()) &&
     ($block->getPluginId() === 'views_exposed_filter_block:newest_groups-page_all_groups' ||
-    $block->getPluginId() === 'views_exposed_filter_block:search_groups-page')) {
+      $block->getPluginId() === 'views_exposed_filter_block:search_groups-page')) {
     // The Group Type filter has to listen to changes in
     // group type role permissions. Using the role list ensures
     // it's cleared correctly.
@@ -1762,7 +1792,8 @@ function social_group_block_access(Block $block, $operation, AccountInterface $a
   $group = _social_group_get_current_group();
   $user = Drupal::currentUser();
   // Check if there is a group set and if its an closed group.
-  if ($group && $group->getGroupType()->id() == 'closed_group' && $account->id() != 1) {
+  if ($group && $group->getGroupType()
+      ->id() == 'closed_group' && $account->id() != 1) {
     if ($account->hasPermission('manage all groups')) {
       return AccessResult::neutral();
     }
@@ -2101,7 +2132,8 @@ function social_group_get_allowed_visibility_options_per_group_type($group_type_
         $visibility_options['community'] = FALSE;
         $visibility_options['group'] = FALSE;
         // Try to retrieve allowed options from Group directly.
-        $allowed_options = $group->get('field_group_allowed_visibility')->getValue();
+        $allowed_options = $group->get('field_group_allowed_visibility')
+          ->getValue();
         foreach ($allowed_options as $option) {
           $value = $option['value'];
           $visibility_options[$value] = TRUE;
@@ -2120,7 +2152,8 @@ function social_group_get_allowed_visibility_options_per_group_type($group_type_
         else {
           /** @var \Drupal\node\Entity\Node $entity */
           if ($entity->hasField('field_content_visibility')) {
-            $current_visibility = $entity->get('field_content_visibility')->getString();
+            $current_visibility = $entity->get('field_content_visibility')
+              ->getString();
             if ($current_visibility !== 'public') {
               $visibility_options['public'] = FALSE;
             }
@@ -2132,7 +2165,8 @@ function social_group_get_allowed_visibility_options_per_group_type($group_type_
       break;
   }
 
-  \Drupal::moduleHandler()->alter('social_group_allowed_visibilities', $visibility_options, $group_type_id);
+  \Drupal::moduleHandler()
+    ->alter('social_group_allowed_visibilities', $visibility_options, $group_type_id);
 
   return $visibility_options;
 }
@@ -2141,61 +2175,30 @@ function social_group_get_allowed_visibility_options_per_group_type($group_type_
  * Implements hook_views_query_alter().
  */
 function social_group_views_query_alter(ViewExecutable $view, QueryPluginBase $query) {
-  if (\Drupal::currentUser()->isAuthenticated()) {
-    return;
-  }
-
   if (empty($view->rowPlugin) || !($view->rowPlugin instanceof EntityRow) || $view->rowPlugin->getEntityTypeId() != 'group') {
     return;
   }
+  $account = \Drupal::currentUser()->getAccount();
+  if ($account->isAuthenticated()) {
+    // Get all groups for LU.
+    /** @var \Drupal\social_group\SocialGroupHelperServiceInterface $group_helper */
+    $group_helper = \Drupal::service('social_group.helper_service');
+    $my_groups = $group_helper->getAllGroupsForUser($account->id());
+    if (!empty($my_groups)) {
+      // Get all hidden groups.
+      $hidden_groups = \Drupal::entityTypeManager()
+        ->getStorage('group')
+        ->loadByProperties([
+          'type' => 'closed_group',
+        ]);
 
-  $found = FALSE;
-
-  foreach ($query->where as &$conditions) {
-    foreach ($conditions['conditions'] as &$condition) {
-      if ($condition['field'] == 'groups_field_data.type') {
-        $found = TRUE;
-        break 2;
+      // Get all hidden groups that the current user is not a member of
+      // and remove them from showing in the view.
+      $ids = array_diff(array_keys($hidden_groups), $my_groups);
+      if ($ids) {
+        /** @var \Drupal\views\Plugin\views\query\Sql $query */
+        $query->addWhere('group_membership', 'groups_field_data.id', $ids, 'NOT IN');
       }
-    }
-  }
-
-  if (!$found) {
-    unset($condition);
-
-    $condition = [
-      'field' => 'groups_field_data.type',
-      'value' => [],
-      'operator' => 'not in',
-    ];
-  }
-
-  $hiddens = $condition['operator'] == 'not in';
-
-  // Define the variable as array otherwise it can be interpreted as string
-  // And breaking the code below.
-  $condition['value'] = [];
-
-  /** @var \Drupal\group\Entity\GroupTypeInterface $group_type */
-  foreach (GroupType::loadMultiple() as $group_type) {
-    $new = !in_array($group_type->id(), $condition['value']);
-    $permissions = $group_type->getAnonymousRole()->getPermissions();
-    $hidden = !in_array('view group', $permissions);
-
-    if ($new && $hiddens == $hidden) {
-      $condition['value'][] = $group_type->id();
-    }
-  }
-
-  if (!$found) {
-    if (isset($conditions)) {
-      $conditions['conditions'][] = $condition;
-    }
-    else {
-      $query->where[] = [
-        'conditions' => [$condition],
-        'type' => 'AND',
-      ];
     }
   }
 }
@@ -2225,18 +2228,18 @@ function social_group_social_user_account_header_create_links($context) {
     /** @var \Drupal\Core\Session\AccountInterface $user */
     $account = $context['user'];
     $route_add_group = \Drupal::service('social_group.helper_service')
-      ->getGroupsToAddUrl($account) ?? $route_add_group;
+        ->getGroupsToAddUrl($account) ?? $route_add_group;
   }
 
   return [
     'add_group' => [
-      '#type' => 'link',
-      '#attributes' => [
-        'title' => new TranslatableMarkup('Create New Group'),
-      ],
-      '#title' => new TranslatableMarkup('New Group'),
-      '#weight' => 500,
-    ] + $route_add_group->toRenderArray(),
+        '#type' => 'link',
+        '#attributes' => [
+          'title' => new TranslatableMarkup('Create New Group'),
+        ],
+        '#title' => new TranslatableMarkup('New Group'),
+        '#weight' => 500,
+      ] + $route_add_group->toRenderArray(),
   ];
 }
 
@@ -2247,7 +2250,8 @@ function social_group_social_user_account_header_create_links($context) {
  * site manager.
  */
 function social_group_social_user_account_header_items(array $context) {
-  if (\Drupal::config('social_user.navigation.settings')->get('display_my_groups_icon') !== TRUE) {
+  if (\Drupal::config('social_user.navigation.settings')
+      ->get('display_my_groups_icon') !== TRUE) {
     return [];
   }
 
@@ -2285,15 +2289,15 @@ function social_group_social_user_account_header_account_links(array $context) {
 
   return [
     'my_groups' => [
-      '#type' => 'link',
-      '#attributes' => [
-        'title' => new TranslatableMarkup('View my groups'),
-      ],
-      '#title' => new TranslatableMarkup('My groups'),
-      '#weight' => 800,
-    ] + Url::fromRoute('view.groups.page_user_groups', [
-      'user' => $context['user']->id(),
-    ])->toRenderArray(),
+        '#type' => 'link',
+        '#attributes' => [
+          'title' => new TranslatableMarkup('View my groups'),
+        ],
+        '#title' => new TranslatableMarkup('My groups'),
+        '#weight' => 800,
+      ] + Url::fromRoute('view.groups.page_user_groups', [
+        'user' => $context['user']->id(),
+      ])->toRenderArray(),
   ];
 }
 
@@ -2308,7 +2312,7 @@ function social_group_social_user_account_header_account_links(array $context) {
  * @return bool
  *   Whether the user is allowed to view groups of the given type.
  */
-function social_group_can_view_groups_of_type(string $type, AccountInterface $account) : bool {
+function social_group_can_view_groups_of_type(string $type, AccountInterface $account): bool {
   $group_type = GroupType::load($type);
 
   // If the group type doesn't exist then the user can't see the group type.
@@ -2515,7 +2519,8 @@ function _social_group_action_batch_finish($success, array $results, array $oper
       }
 
       if ($fields === 2) {
-        $message = \Drupal::translation()->formatPlural($results_count, $messages['singular'], $messages['plural']);
+        $message = \Drupal::translation()
+          ->formatPlural($results_count, $messages['singular'], $messages['plural']);
         $type = $success ? MessengerInterface::TYPE_STATUS : MessengerInterface::TYPE_WARNING;
         \Drupal::messenger()->addMessage($message, $type);
       }
@@ -2792,7 +2797,8 @@ function social_group_allowed_visibility_description($key) {
 
   // Allow modules to provide their own markup for a given key in the
   // group_visibility #options array.
-  \Drupal::moduleHandler()->alter('social_group_content_visibility_description', $key, $description);
+  \Drupal::moduleHandler()
+    ->alter('social_group_content_visibility_description', $key, $description);
 
   return $description;
 }

--- a/modules/social_features/social_group/social_group.module
+++ b/modules/social_features/social_group/social_group.module
@@ -2194,8 +2194,10 @@ function social_group_views_query_alter(ViewExecutable $view, QueryPluginBase $q
     // Get all hidden groups that the current user is not a member of
     // and remove them from showing in the view.
     $ids = array_diff(array_keys($hidden_groups), $my_groups);
-    /** @var \Drupal\views\Plugin\views\query\Sql $query */
-    $query->addWhere('group_membership', 'groups_field_data.id', $ids, 'NOT IN');
+    if ($ids) {
+      /** @var \Drupal\views\Plugin\views\query\Sql $query */
+      $query->addWhere('group_membership', 'groups_field_data.id', $ids, 'NOT IN');
+    }
   }
 }
 

--- a/modules/social_features/social_group/social_group.module
+++ b/modules/social_features/social_group/social_group.module
@@ -2194,10 +2194,8 @@ function social_group_views_query_alter(ViewExecutable $view, QueryPluginBase $q
     // Get all hidden groups that the current user is not a member of
     // and remove them from showing in the view.
     $ids = array_diff(array_keys($hidden_groups), $my_groups);
-    if ($ids) {
-      /** @var \Drupal\views\Plugin\views\query\Sql $query */
-      $query->addWhere('group_membership', 'groups_field_data.id', $ids, 'NOT IN');
-    }
+    /** @var \Drupal\views\Plugin\views\query\Sql $query */
+    $query->addWhere('group_membership', 'groups_field_data.id', $ids, 'NOT IN');
   }
 }
 


### PR DESCRIPTION
## Problem
When you look at the 'All Groups' overview (/all-groups) you can also see community groups. The view is not filters sufficiently on group access.

## Solution
Adding a ViewsFilter and applying it using config override class should solve this issue.

## Issue tracker
https://getopensocial.atlassian.net/browse/SUP-2034
https://www.drupal.org/project/social/issues/3260572

## How to test
- [ ] Create a community group (open_group or flexible with right visibility)
- [ ] Go to /all-groups as anonymous user
- [ ] You are not able to see that new group (since you don't have access to it)
- [ ] Feel free to also check this with closed_group or flexible (member groups).

## Release notes
Groups are now filtered on right access when viewing the all-groups page. You will not be able to see closed or community groups when being anonymous or not in the right group.