### PR TITLE
Remove check so it also works when you have no groups.

### DIFF
--- a/modules/social_features/social_group/social_group.module
+++ b/modules/social_features/social_group/social_group.module
@@ -2136,21 +2136,19 @@ function social_group_views_query_alter(ViewExecutable $view, QueryPluginBase $q
     /** @var \Drupal\social_group\SocialGroupHelperServiceInterface $group_helper */
     $group_helper = \Drupal::service('social_group.helper_service');
     $my_groups = $group_helper->getAllGroupsForUser($account->id());
-    if (!empty($my_groups)) {
-      // Get all hidden groups.
-      $hidden_groups = \Drupal::entityTypeManager()
-        ->getStorage('group')
-        ->loadByProperties([
-          'type' => 'closed_group',
-        ]);
+    // Get all hidden groups.
+    $hidden_groups = \Drupal::entityTypeManager()
+      ->getStorage('group')
+      ->loadByProperties([
+        'type' => 'closed_group',
+      ]);
 
-      // Get all hidden groups that the current user is not a member of
-      // and remove them from showing in the view.
-      $ids = array_diff(array_keys($hidden_groups), $my_groups);
-      if ($ids) {
-        /** @var \Drupal\views\Plugin\views\query\Sql $query */
-        $query->addWhere('group_membership', 'groups_field_data.id', $ids, 'NOT IN');
-      }
+    // Get all hidden groups that the current user is not a member of
+    // and remove them from showing in the view.
+    $ids = array_diff(array_keys($hidden_groups), $my_groups);
+    if ($ids) {
+      /** @var \Drupal\views\Plugin\views\query\Sql $query */
+      $query->addWhere('group_membership', 'groups_field_data.id', $ids, 'NOT IN');
     }
   }
 }


### PR DESCRIPTION
## Problem
When you have no closed groups, you will see all closed groups on the all-groups page, because there's a check that skips the condition if you don't have any secret groups

## Solution
Remove the check

## Issue tracker
https://www.drupal.org/project/social/issues/3266302

## How to test
- [ ] Make sure you are not a member of any closed group
- [ ] Go to the all-groups page.
- [ ] You should not be able to see any closed group

## Release notes
Users that don't have access to closed groups, can't see them anymore on the all-groups page.
