### PR TITLE
Issue #3266302: Show no closed groups when you're not allowed to see them.

### DIFF
--- a/modules/custom/activity_basics/src/Plugin/ActivityContext/OwnerActivityContext.php
+++ b/modules/custom/activity_basics/src/Plugin/ActivityContext/OwnerActivityContext.php
@@ -146,12 +146,10 @@ class OwnerActivityContext extends ActivityContextBase {
       $group = $this->groupMuteNotify->getGroupByContent($entity);
       // Check if we have $group set which means that this content was
       // posted in a group.
-      if (!empty($group) && $group instanceof GroupInterface) {
-        // Skip the notification for users which have muted the group
-        // notification in which this content was posted.
-        if ($this->groupMuteNotify->groupNotifyIsMuted($group, $account)) {
-          return $recipients;
-        }
+      // Skip the notification for users which have muted the group
+      // notification in which this content was posted.
+      if ($this->groupMuteNotify->groupNotifyIsMuted($group, $account)) {
+        return $recipients;
       }
     }
 

--- a/modules/custom/activity_creator/src/ActivityFactory.php
+++ b/modules/custom/activity_creator/src/ActivityFactory.php
@@ -310,6 +310,7 @@ class ActivityFactory extends ControllerBase {
       if ($related_object['target_type'] === 'comment') {
         // Get commented entity.
         $comment_storage = $this->entityTypeManager->getStorage('comment');
+        /** @var \Drupal\social_comment\Entity\Comment $comment */
         $comment = $comment_storage->load($related_object['target_id']);
         $commented_entity = $comment->getCommentedEntity();
         // Get all comments of commented entity.

--- a/modules/custom/activity_send/modules/activity_send_email/src/Plugin/QueueWorker/ActivitySendEmailWorker.php
+++ b/modules/custom/activity_send/modules/activity_send_email/src/Plugin/QueueWorker/ActivitySendEmailWorker.php
@@ -292,12 +292,10 @@ class ActivitySendEmailWorker extends ActivitySendWorkerBase implements Containe
           }
           // Check if we have $group set which means that this content was
           // posted in a group.
-          if (!empty($group) && $group instanceof GroupInterface) {
-            // Skip the notification for users which have muted the group
-            // notification in which this content was posted.
-            if ($this->groupMuteNotify->groupNotifyIsMuted($group, $target_account)) {
-              continue;
-            }
+          // Skip the notification for users which have muted the group
+          // notification in which this content was posted.
+          if ($this->groupMuteNotify->groupNotifyIsMuted($group, $target_account)) {
+            continue;
           }
 
           // Only for users that have access to related content.

--- a/modules/custom/mentions/src/EventSubscriber/MentionsDelete.php
+++ b/modules/custom/mentions/src/EventSubscriber/MentionsDelete.php
@@ -65,9 +65,7 @@ class MentionsDelete implements EventSubscriberInterface {
     }
 
     $action_plugin = $action->getPlugin();
-    if (!empty($action_plugin)) {
-      $action_plugin->execute(FALSE);
-    }
+    $action_plugin->execute();
   }
 
 }

--- a/modules/custom/mentions/src/EventSubscriber/MentionsInsert.php
+++ b/modules/custom/mentions/src/EventSubscriber/MentionsInsert.php
@@ -64,10 +64,7 @@ class MentionsInsert implements EventSubscriberInterface {
     }
 
     $action_plugin = $action->getPlugin();
-
-    if (!empty($action_plugin)) {
-      $action_plugin->execute(FALSE);
-    }
+    $action_plugin->execute();
   }
 
 }

--- a/modules/custom/mentions/src/EventSubscriber/MentionsUpdate.php
+++ b/modules/custom/mentions/src/EventSubscriber/MentionsUpdate.php
@@ -65,10 +65,7 @@ class MentionsUpdate implements EventSubscriberInterface {
     }
 
     $action_plugin = $action->getPlugin();
-
-    if (!empty($action_plugin)) {
-      $action_plugin->execute(FALSE);
-    }
+    $action_plugin->execute();
   }
 
 }

--- a/modules/social_features/social_activity/modules/social_activity_filter/src/Form/FilterSettingsForm.php
+++ b/modules/social_features/social_activity/modules/social_activity_filter/src/Form/FilterSettingsForm.php
@@ -200,6 +200,7 @@ class FilterSettingsForm extends ConfigFormBase implements ContainerInjectionInt
    *   Mapped array of views displays.
    */
   public function getDisplayBlocks($views_id) {
+    /** @var \Drupal\views\Entity\View $view */
     $view = $this->entityTypeManager->getStorage('view')->load($views_id);
 
     $blocks = [];

--- a/modules/social_features/social_activity/src/SocialActivityLazyBuilder.php
+++ b/modules/social_features/social_activity/src/SocialActivityLazyBuilder.php
@@ -68,6 +68,7 @@ class SocialActivityLazyBuilder implements TrustedCallbackInterface {
    */
   public function viewsLazyBuild($view_id, $display_id, $node_type, $item_per_page, $vocabulary = NULL, ...$tags) {
     // Get view.
+    /** @var \Drupal\views\ViewEntityInterface $view_entity */
     $view_entity = $this->entityTypeManager->getStorage('view')->load($view_id);
     $view = $this->viewExecutable->get($view_entity);
     $view->setDisplay($display_id);

--- a/modules/social_features/social_event/modules/social_event_an_enroll/src/EventAnEnrollService.php
+++ b/modules/social_features/social_event/modules/social_event_an_enroll/src/EventAnEnrollService.php
@@ -114,7 +114,7 @@ class EventAnEnrollService {
     $node = $this->currentRouteMatch->getParameter('node');
 
     // If some data is missing we can already return FALSE.
-    if (!empty($token) || !empty($node)) {
+    if (!$token || !$node) {
       return FALSE;
     }
 

--- a/modules/social_features/social_follow_content/src/Plugin/ActivityContext/FollowContentActivityContext.php
+++ b/modules/social_features/social_follow_content/src/Plugin/ActivityContext/FollowContentActivityContext.php
@@ -150,12 +150,10 @@ class FollowContentActivityContext extends ActivityContextBase {
 
       // Check if we have $group set which means that this content was
       // posted in a group.
-      if (!empty($group) && $group instanceof GroupInterface) {
-        // Skip the notification for users which have muted the group
-        // notification in which this content was posted.
-        if ($this->groupMuteNotify->groupNotifyIsMuted($group, $recipient)) {
-          continue;
-        }
+      // Skip the notification for users which have muted the group
+      // notification in which this content was posted.
+      if ($this->groupMuteNotify->groupNotifyIsMuted($group, $recipient)) {
+        continue;
       }
 
       if ($recipient->id() !== $original_related_entity->getOwnerId() && $original_related_entity->access('view', $recipient)) {

--- a/modules/social_features/social_group/modules/social_group_invite/src/Plugin/Block/SocialGroupInviteNotificationBlock.php
+++ b/modules/social_features/social_group/modules/social_group_invite/src/Plugin/Block/SocialGroupInviteNotificationBlock.php
@@ -133,10 +133,9 @@ class SocialGroupInviteNotificationBlock extends BlockBase implements ContainerF
    * {@inheritdoc}
    */
   public function access(AccountInterface $account, $return_as_object = FALSE) {
-    $is_group_page = isset($this->group);
     $is_logged_in = $account->isAuthenticated();
 
-    return AccessResult::allowedIf($is_group_page && $is_logged_in);
+    return AccessResult::allowedIf($is_logged_in);
   }
 
   /**

--- a/modules/social_features/social_group/modules/social_group_request/src/Plugin/Block/SocialGroupRequestMembershipNotification.php
+++ b/modules/social_features/social_group/modules/social_group_request/src/Plugin/Block/SocialGroupRequestMembershipNotification.php
@@ -174,10 +174,9 @@ class SocialGroupRequestMembershipNotification extends BlockBase implements Cont
    * {@inheritdoc}
    */
   public function access(AccountInterface $account, $return_as_object = FALSE) {
-    $is_group_page = isset($this->group);
     if ($this->group instanceof Group) {
       $is_group_manager = $this->group->hasPermission('administer members', $account);
-      return AccessResult::allowedIf($is_group_page && $is_group_manager);
+      return AccessResult::allowedIf($is_group_manager);
     }
 
     return AccessResult::forbidden();

--- a/modules/social_features/social_group/social_group.install
+++ b/modules/social_features/social_group/social_group.install
@@ -313,6 +313,7 @@ function social_group_update_8004(&$sandbox) {
 
   // Update the field storage settings.
   $field_storage_id = "{$entity}.$field_name";
+  /** @var \Drupal\field\Entity\FieldStorageConfig $field_storage */
   $field_storage = \Drupal::entityTypeManager()->getStorage('field_storage_config')->load($field_storage_id);
 
   // Since the usual workflow for field storages do not allow changing the
@@ -329,6 +330,7 @@ function social_group_update_8004(&$sandbox) {
 
   // Update the field settings.
   $field_id = "{$entity}.{$bundle}.$field_name";
+  /** @var \Drupal\field\Entity\FieldConfig $field */
   $field = \Drupal::entityTypeManager()->getStorage('field_config')->load($field_id);
   $new_field = $field->toArray();
   $new_field['field_type'] = 'text_long';
@@ -340,6 +342,7 @@ function social_group_update_8004(&$sandbox) {
 
   // Update entity view display.
   $display_id = "{$entity}.{$bundle}.$display_mode";
+  /** @var \Drupal\Core\Entity\Entity\EntityViewDisplay $view_display */
   $view_display = \Drupal::service('entity_type.manager')->getStorage('entity_view_display')->load($display_id);
   if ($component = $view_display->getComponent($field_name)) {
     $view_display->setComponent($field_name, [
@@ -350,6 +353,7 @@ function social_group_update_8004(&$sandbox) {
 
   // Update entity form display.
   $form_display_name = 'group.open_group.default';
+  /** @var \Drupal\Core\Entity\Entity\EntityFormDisplay $form_display */
   $form_display = \Drupal::entityTypeManager()->getStorage('entity_form_display')->load($form_display_name);
   if (($component = $form_display->getComponent($field_name)) && $component['type'] == 'string_textarea') {
     $form_display->setComponent($field_name, [

--- a/modules/social_features/social_group/social_group.module
+++ b/modules/social_features/social_group/social_group.module
@@ -1751,7 +1751,7 @@ function social_group_preprocess_views_view(&$variables) {
  *
  * Sets an active class on stream tab when viewing group canonical page.
  */
-function social_group_preprocess_menu_local_task(&$variables) {
+function social_group_preprocess_menu_local_task(array &$variables): void {
   $route_name = \Drupal::routeMatch()->getRouteName();
   if ($route_name != 'entity.group.canonical') {
     return;
@@ -1765,9 +1765,6 @@ function social_group_preprocess_menu_local_task(&$variables) {
 
   /** @var \Drupal\Core\Url $menu_url */
   $menu_url = $link['#url'] ?? NULL;
-  if (!$menu_url) {
-    return;
-  }
 
   if ($menu_url->getRouteName() === 'social_group.stream') {
     $variables['element']['#active'] = TRUE;
@@ -2164,7 +2161,7 @@ function social_group_views_query_alter(ViewExecutable $view, QueryPluginBase $q
   $account = \Drupal::currentUser()->getAccount();
   if ($account->isAuthenticated()) {
     // Get all groups for LU.
-    /** @var \Drupal\social_group\SocialGroupHelperServiceInterface $group_helper */
+    /** @var \Drupal\social_group\SocialGroupHelperService $group_helper */
     $group_helper = \Drupal::service('social_group.helper_service');
     $my_groups = $group_helper->getAllGroupsForUser($account->id());
     // Get all hidden groups.

--- a/modules/social_features/social_group/social_group.module
+++ b/modules/social_features/social_group/social_group.module
@@ -2167,21 +2167,19 @@ function social_group_views_query_alter(ViewExecutable $view, QueryPluginBase $q
     /** @var \Drupal\social_group\SocialGroupHelperServiceInterface $group_helper */
     $group_helper = \Drupal::service('social_group.helper_service');
     $my_groups = $group_helper->getAllGroupsForUser($account->id());
-    if (!empty($my_groups)) {
-      // Get all hidden groups.
-      $hidden_groups = \Drupal::entityTypeManager()
-        ->getStorage('group')
-        ->loadByProperties([
-          'type' => 'closed_group',
-        ]);
+    // Get all hidden groups.
+    $hidden_groups = \Drupal::entityTypeManager()
+      ->getStorage('group')
+      ->loadByProperties([
+        'type' => 'closed_group',
+      ]);
 
-      // Get all hidden groups that the current user is not a member of
-      // and remove them from showing in the view.
-      $ids = array_diff(array_keys($hidden_groups), $my_groups);
-      if ($ids) {
-        /** @var \Drupal\views\Plugin\views\query\Sql $query */
-        $query->addWhere('group_membership', 'groups_field_data.id', $ids, 'NOT IN');
-      }
+    // Get all hidden groups that the current user is not a member of
+    // and remove them from showing in the view.
+    $ids = array_diff(array_keys($hidden_groups), $my_groups);
+    if ($ids) {
+      /** @var \Drupal\views\Plugin\views\query\Sql $query */
+      $query->addWhere('group_membership', 'groups_field_data.id', $ids, 'NOT IN');
     }
   }
 }

--- a/modules/social_features/social_group/src/Form/SocialGroupSettings.php
+++ b/modules/social_features/social_group/src/Form/SocialGroupSettings.php
@@ -299,6 +299,7 @@ class SocialGroupSettings extends ConfigFormBase {
     foreach ($content_types as $bundle) {
       $plugin_id = 'group_node:' . $bundle;
       if (in_array($plugin_id, $group_content_types)) {
+        /** @var \Drupal\node\Entity\NodeType $node_type */
         $node_type = $this->entityTypeManager->getStorage('node_type')->load($bundle);
         $options[$bundle] = $node_type->label();
       }

--- a/modules/social_features/social_group/src/SocialGroupHelperService.php
+++ b/modules/social_features/social_group/src/SocialGroupHelperService.php
@@ -84,6 +84,7 @@ class SocialGroupHelperService {
     // Special cases for comments.
     // Returns the entity to which the comment is attached.
     if ($entity['target_type'] === 'comment') {
+      /** @var \Drupal\social_comment\Entity\Comment $comment */
       $comment = \Drupal::entityTypeManager()
         ->getStorage('comment')
         ->load($entity['target_id']);

--- a/modules/social_features/social_like/social_like.tokens.inc
+++ b/modules/social_features/social_like/social_like.tokens.inc
@@ -79,10 +79,11 @@ function social_like_tokens($type, $tokens, array $data, array $options, Bubblea
             // Check if the content type is node.
             if ($content_type === 'node') {
               // Then get the bundle name.
-              $content_type_label = mb_strtolower(\Drupal::entityTypeManager()
+              /** @var \Drupal\node\Entity\NodeType $content_type_storage */
+              $content_type_storage = mb_strtolower(\Drupal::entityTypeManager()
                 ->getStorage('node_type')
-                ->load($entity->bundle())
-                ->label());
+                ->load($entity->bundle()));
+              $content_type_label = $content_type_storage->label();
             }
             if ($content_type === 'post' || $content_type === 'photo' || $content_type === 'comment') {
               $content_type_label = mb_strtolower($entity->getEntityType()->getLabel());

--- a/modules/social_features/social_like/src/Plugin/ActivityContext/VoteActivityContext.php
+++ b/modules/social_features/social_like/src/Plugin/ActivityContext/VoteActivityContext.php
@@ -104,12 +104,10 @@ class VoteActivityContext extends ActivityContextBase {
             $group = $this->groupMuteNotify->getGroupByContent($entity);
             // Check if we have $group set which means that this content was
             // posted in a group.
-            if (!empty($group) && $group instanceof GroupInterface) {
-              // Skip the notification for users which have muted the group
-              // notification in which this content was posted.
-              if ($this->groupMuteNotify->groupNotifyIsMuted($group, $account)) {
-                return $recipients;
-              }
+            // Skip the notification for users which have muted the group
+            // notification in which this content was posted.
+            if ($this->groupMuteNotify->groupNotifyIsMuted($group, $account)) {
+              return $recipients;
             }
           }
 

--- a/modules/social_features/social_mentions/social_mentions.tokens.inc
+++ b/modules/social_features/social_mentions/social_mentions.tokens.inc
@@ -130,10 +130,11 @@ function social_mentions_tokens($type, $tokens, array $data, array $options, Bub
               switch ($entity->getEntityTypeId()) {
                 case 'node':
                   // Then get the bundle name.
-                  $content_type_label = mb_strtolower(\Drupal::entityTypeManager()
+                  /** @var \Drupal\node\Entity\NodeType $content_type_storage */
+                  $content_type_storage = mb_strtolower(\Drupal::entityTypeManager()
                     ->getStorage('node_type')
-                    ->load($entity->bundle())
-                    ->label());
+                    ->load($entity->bundle()));
+                  $content_type_label = $content_type_storage->label();
                   break;
 
                 case 'post':

--- a/modules/social_features/social_mentions/src/Plugin/ActivityContext/MentionActivityContext.php
+++ b/modules/social_features/social_mentions/src/Plugin/ActivityContext/MentionActivityContext.php
@@ -118,14 +118,12 @@ class MentionActivityContext extends ActivityContextBase {
               $group = $this->groupMuteNotify->getGroupByContent($mentioned_entity);
               // Check if we have $group set which means that this content was
               // posted in a group.
-              if (!empty($group) && $group instanceof GroupInterface) {
-                // Skip the notification for users which have muted the group
-                // notification in which this content was posted.
-                if ($this->groupMuteNotify->groupNotifyIsMuted($group, $account)) {
-                  continue;
-                }
+              // Skip the notification for users which have muted the group
+              // notification in which this content was posted.
+              if ($this->groupMuteNotify->groupNotifyIsMuted($group, $account)) {
+                continue;
               }
-
+              
               $recipients[] = [
                 'target_type' => 'user',
                 'target_id' => $uid,

--- a/modules/social_features/social_private_message/src/Plugin/EntityReferenceSelection/UserSelection.php
+++ b/modules/social_features/social_private_message/src/Plugin/EntityReferenceSelection/UserSelection.php
@@ -22,7 +22,7 @@ class UserSelection extends UserSelectionBase {
    * {@inheritdoc}
    */
   protected function buildEntityQuery($match = NULL, $match_operator = 'CONTAINS', array $ids = []) {
-    /** @var \Drupal\user\RoleStorageInterface $r_storage */
+    /** @var \Drupal\user\RoleStorageInterface $role_storage */
     $role_storage = $this->entityTypeManager->getStorage('user_role');
 
     // Continue if authenticated users has permission to view private messages.

--- a/modules/social_features/social_profile/social_profile.module
+++ b/modules/social_features/social_profile/social_profile.module
@@ -612,10 +612,7 @@ function social_profile_form_user_form_alter(&$form, FormStateInterface $form_st
       }
     }
 
-    // Add Submit function only when the data is actually editable.
-    if (empty($global_value['social_profile_show_email']) || empty($global_value['social_profile_show_language'])) {
-      $form['actions']['submit']['#submit'][] = '_social_profile_form_user_form_submit';
-    }
+    $form['actions']['submit']['#submit'][] = '_social_profile_form_user_form_submit';
   }
 
   $form['#pre_render'][] = [SocialProfileUserFormAlter::class, 'preRender'];
@@ -743,6 +740,7 @@ function social_profile_get_default_image() {
     ->getStorage('file')
     ->loadByProperties(['uuid' => $default_image['uuid']]);
   // Pop it.
+  /** @var \Drupal\file\FileInterface $file */
   $file = array_pop($files);
   // Set in an array.
   $data = [

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -3041,6 +3041,11 @@ parameters:
 			path: modules/custom/mentions/src/Plugin/Filter/MentionsFilter.php
 
 		-
+			message: "#^Property Drupal\\\\mentions\\\\Plugin\\\\Filter\\\\MentionsFilter\\:\\:\\$inputSettings is never read, only written\\.$#"
+			count: 1
+			path: modules/custom/mentions/src/Plugin/Filter/MentionsFilter.php
+
+		-
 			message: "#^Offset 'entity_type' does not exist on array\\|string\\.$#"
 			count: 1
 			path: modules/custom/mentions/src/Plugin/Mentions/Entity.php


### PR DESCRIPTION
## Problem
When you have no closed groups, you will see all closed groups on the all-groups page, because there's a check that skips the condition if you don't have any secret groups

## Solution
Remove the check

## Issue tracker
https://www.drupal.org/project/social/issues/3266302

## How to test
- [ ] Make sure you are not a member of any closed group
- [ ] Go to the all-groups page.
- [ ] You should not be able to see any closed group

## Release notes
Users that don't have access to closed groups, can't see them anymore on the all-groups page.
