### PR TITLE
Issue #3266990 by alex.ksis: Update config override to be compatible with lazy 3.11

### DIFF
--- a/modules/custom/social_lazy_loading/src/SocialLazyLoadingTextFormatOverride.php
+++ b/modules/custom/social_lazy_loading/src/SocialLazyLoadingTextFormatOverride.php
@@ -54,14 +54,6 @@ class SocialLazyLoadingTextFormatOverride implements ConfigFactoryOverrideInterf
       }
     }
 
-    // Set lazy loading settings.
-    if (in_array('lazy.settings', $names, FALSE)) {
-      $overrides['lazy.settings']['alter_tag'] = [
-        'img' => 'img',
-        'iframe' => 'iframe',
-      ];
-    }
-
     return $overrides;
   }
 
@@ -85,7 +77,10 @@ class SocialLazyLoadingTextFormatOverride implements ConfigFactoryOverrideInterf
         'provider' => 'lazy',
         'status' => TRUE,
         'weight' => 999,
-        'settings' => [],
+        'settings' => [
+          'image' => TRUE,
+          'iframe' => TRUE,
+        ],
       ];
     }
   }


### PR DESCRIPTION
## Problem
"Lazy-loading is not enabled...." message always is shown.

## Solution
Update SocialLazyLoadingTextFormatOverride so that it would be compatible with lazy:3.10

## Issue tracker
https://www.drupal.org/project/social/issues/3266990

## How to test
- [ ] Open any page with a wysiwyg editor.
- [ ] Make sure there is no message about lazy-loading is not enabled.

## Screenshots
<img width="844" alt="image" src="https://user-images.githubusercontent.com/4526828/156036760-b81ed7f4-b4d0-49c7-9e4d-e736c0e77ad5.png">

