### PR TITLE
Issue #3263649 by Corn696, Ressinel: Fix wrong profile name for event enrollment decline request messages.

### DIFF
--- a/modules/social_features/social_profile/src/SocialProfileNameService.php
+++ b/modules/social_features/social_profile/src/SocialProfileNameService.php
@@ -102,7 +102,7 @@ class SocialProfileNameService {
    * @param \Drupal\profile\Entity\ProfileInterface|null $profile
    *   The profile.
    *
-   * @return string|void
+   * @return string
    *   The generated profile name value.
    *
    * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
@@ -110,7 +110,7 @@ class SocialProfileNameService {
    */
   public function getProfileName(ProfileInterface $profile = NULL) {
     // Do nothing if no profile.
-    if ($profile == NULL) {
+    if ($profile === NULL) {
       return '';
     }
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -10061,7 +10061,7 @@ parameters:
 
 		-
 			message: "#^Property Drupal\\\\social_event\\\\Form\\\\EnrollRequestDeclineForm\\:\\:\\$eventEnrollment \\(Drupal\\\\social_event\\\\Entity\\\\EventEnrollment\\) in empty\\(\\) is not falsy\\.$#"
-			count: 2
+			count: 1
 			path: modules/social_features/social_event/src/Form/EnrollRequestDeclineForm.php
 
 		-


### PR DESCRIPTION
## Problem
If the user id is out of sync with the profile id the wrong name is displayed in the in the decline request confirmation and the success message. The reason is that the profile entity is loaded directly with the user id of the user.

## Solution
Instead of loading the profile directly by id use EntityTypeManagerInterface loadByProperties to get the profile for the specific user.

## Issue tracker
- https://www.drupal.org/project/social/issues/3263649

## How to test
TBD

## Screenshots
N/A

## Release notes
TBD

## Change Record
N/A

## Translations
N/A
