### PR TITLE
Issue #3267357 by alex.ksis: Replace a patch for group for compatibility with D9.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -101,7 +101,7 @@
             },
             "drupal/group": {
                 "Add computed field for Group reference": "https://www.drupal.org/files/issues/2021-07-30/group-2718195-58-groups-computed-field.patch",
-                "Ability to use group tokens in node context": "https://www.drupal.org/files/issues/2018-12-19/group-2774827-41-gnode-tokens.patch",
+                "Ability to use group tokens in node context": "https://www.drupal.org/files/issues/2021-03-11/group-gnode_tokens-2774827-75.patch",
                 "Group: Don't try to re-save deleted entities": "https://www.drupal.org/files/issues/2018-11-01/3010896-02.patch",
                 "Rely on toUrl defaults for Entity url link": "https://www.drupal.org/files/issues/2019-12-04/group-3098675-2.patch",
                 "Missing config schema for condition.plugin.group_type": "https://www.drupal.org/files/issues/2018-12-14/group-group_type_condition_plugin_config_schema-3020554-2.patch",


### PR DESCRIPTION
## Problem
A fatal error occurred when creating content inside a group: **Call to undefined method Drupal\social_group\Entity\Group::urlInfo() in group_tokens**

## Solution
The OS uses a patch for the group module which uses urlInfo method. The error happened because of the urlInfo was deprecated and now does not exists.
There is an updated patch for the group module which solves the original issue but also compatible with D9.

## Issue tracker
https://www.drupal.org/project/social/issues/3267357

## How to test
- [ ] Try to create content (course_section in this case)
