### PR TITLE
Issue #3268097: Update social blue theme to the latest version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -187,7 +187,7 @@
         "drupal/search_api": "1.23.0",
         "drupal/select2": "1.13.0",
         "drupal/shariff": "1.7",
-        "drupal/socialblue": "2.1.1",
+        "drupal/socialblue": "2.1.3",
         "drupal/swiftmailer": "2.2.0",
         "drupal/token": "1.10.0",
         "drupal/ultimate_cron": "2.0-alpha5",


### PR DESCRIPTION
## Problem
Update Social Blue theme to the latest 2.1.3 version

## Solution
Update Social Blue theme to the latest 2.1.3 version

## Issue tracker
https://www.drupal.org/project/social/issues/3268097

## How to test
- [ ] Check if Open Social is using the latest 2.1.3 social blue theme

## Screenshots
N/A

## Release notes
N/A

## Change Record
N/A

## Translations
N/A
