### PR TITLE
Issue #3268100 by nkoporec: Footer block image is not responsive

### DIFF
--- a/modules/social_features/social_footer/assets/css/social_footer.css
+++ b/modules/social_features/social_footer/assets/css/social_footer.css
@@ -13,6 +13,14 @@
 .block-social-footer-powered-by-block [block=block-socialblue-footer-powered] .footer-block--body > *:last-child {
   margin-bottom: 0;
 }
+@media (max-width: 500px) {
+  .block-social-footer-powered-by-block [block=block-socialblue-footer-powered] {
+    display: block;
+  }
+  .block-social-footer-powered-by-block [block=block-socialblue-footer-powered] img {
+    margin-bottom: 2rem;
+  }
+}
 
 #block-socialblue-footer-powered .block-title,
 .block-social-footer .block-title {

--- a/modules/social_features/social_footer/assets/css/social_footer.css.map
+++ b/modules/social_features/social_footer/assets/css/social_footer.css.map
@@ -1,1 +1,1 @@
-{"version":3,"sourceRoot":"","sources":["social_footer.scss"],"names":[],"mappings":"AACE;EACE;EACA;EACA;EACA;EACA;;AAEA;EACE;EACA;EACA;;AAIA;EACE;;;AAQN;AAAA;EACE;EACA;EACA","file":"social_footer.css"}
+{"version":3,"sourceRoot":"","sources":["social_footer.scss"],"names":[],"mappings":"AACE;EACE;EACA;EACA;EACA;EACA;;AAEA;EACE;EACA;EACA;;AAIA;EACE;;AAIP;EAnBC;IAoBA;;EAEA;IACC;;;;AASD;AAAA;EACE;EACA;EACA","file":"social_footer.css"}

--- a/modules/social_features/social_footer/assets/css/social_footer.scss
+++ b/modules/social_features/social_footer/assets/css/social_footer.scss
@@ -17,7 +17,16 @@
         margin-bottom: 0;
       }
     }
+
+	@media (max-width: 500px) {
+		display: block;
+
+		img {
+			margin-bottom: 2rem;
+		}
+	}
   }
+
 }
 
 #block-socialblue-footer-powered,


### PR DESCRIPTION
## Problem
If the image in the footer block is wide, then the text will expand beyond its parent.

## Solution
The wrapper that wraps the image should not have the flex display when the screen width is really small. We should make it a block, so that elements will stack on top of each other.

## Issue tracker
https://www.drupal.org/project/social/issues/3268100

## How to test
1. Add a wide image in the footer block
2. Add a couple paragraph of text
3. Check how it looks on mobile

## Screenshots
Before:
![2022-03-07_10-47](https://user-images.githubusercontent.com/35064680/157010128-7d3e6bd6-c9c5-4f08-b5da-049849612f3f.png)

After:
![2022-03-07_11-02](https://user-images.githubusercontent.com/35064680/157010158-aaf09b68-3ce7-420c-9f53-20ae46641bd1.png)



## Release notes
*A short summary of the changes that were made that can be included in release notes.*

## Change Record
*If this Pull Request changes the way that developers should do things or introduces a new API for developers then a change record to document this is needed. Please provide a draft for a change record or a link to an unpublished change record below. [Existing change records](https://www.drupal.org/list-changes/social) can be consulted as example.*

## Translations
*Translatable strings are always extracted from the latest development branch. To ensure translations remain available for platforms running older versions of Open Social the original string should be added to `translations.php` when it's changed or removed.*
- [ ] Changed or removed source strings are added to the `translations.php` file.
