### PR TITLE
Issue #3268520 by nkoporec: The destination param is missing when logging in via the social_magic_link and accepting the data policy.

### DIFF
--- a/modules/custom/social_magic_login/src/Controller/MagicLoginController.php
+++ b/modules/custom/social_magic_login/src/Controller/MagicLoginController.php
@@ -148,7 +148,7 @@ class MagicLoginController extends ControllerBase {
       if ($this->dataPolicyConsensus()) {
         // Set a different text when the user still needs to comply to
         // the data policy.
-        $link = Link::createFromRoute($this->t('here'), 'data_policy.data_policy.agreement');
+        $link = Link::createFromRoute($this->t('here'), 'data_policy.data_policy.agreement', [], ['query' => ["destination" => $destination]]);
         $message_set_password = $this->t('We published a new version of the data policy. You can review the data policy @url.', [
           '@url' => $link->toString(),
         ]);


### PR DESCRIPTION
## Problem
If you have a data policy and use the social magic link, then the 'destination' param is removed when going to the data policy agreement form.

## Solution
We need to pass the 'destination' query param when displaying the data policy message in social magic login controller.

## Issue tracker
https://www.drupal.org/project/social/issues/3268520

## How to test
1. Set up the data policy
2. Use social magic login link
3. Click the data policy message link
4. After the form submits, see if you get redirected to the correct page.

## Screenshots
*If this Pull Request makes visual changes then please include some screenshots that show what has changed here. A before and after screenshot helps the reviewer determine what changes were made.*

## Release notes
*A short summary of the changes that were made that can be included in release notes.*

## Change Record
*If this Pull Request changes the way that developers should do things or introduces a new API for developers then a change record to document this is needed. Please provide a draft for a change record or a link to an unpublished change record below. [Existing change records](https://www.drupal.org/list-changes/social) can be consulted as example.*

## Translations
*Translatable strings are always extracted from the latest development branch. To ensure translations remain available for platforms running older versions of Open Social the original string should be added to `translations.php` when it's changed or removed.*
- [ ] Changed or removed source strings are added to the `translations.php` file.
