### PR TITLE
[Internal] - Remove Social Base theme patch since those changes were released in last theme version.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -121,9 +121,6 @@
             "drupal/r4032login": {
                 "3248175: Symfony 4.4 event dispatcher parameter order change": "https://www.drupal.org/files/issues/2021-11-08/symfony-4-4-event-dispatcher-parameter-order-change-3248175-2.patch"
             },
-            "drupal/socialbase": {
-                "[Internal] Add extra check for the file.": "https://git.drupalcode.org/project/socialbase/-/merge_requests/81.diff"
-            },
             "drupal/update_helper": {
                 "3248189: Symfony 4.4 event dispatcher parameter order change": "https://www.drupal.org/files/issues/2021-11-08/symfony-4-4-event-dispatcher-parameter-order-change-3248189-2.patch"
             },

--- a/composer.json
+++ b/composer.json
@@ -122,7 +122,8 @@
                 "3248175: Symfony 4.4 event dispatcher parameter order change": "https://www.drupal.org/files/issues/2021-11-08/symfony-4-4-event-dispatcher-parameter-order-change-3248175-2.patch"
             },
             "drupal/socialbase": {
-                "Socialbase 2.1.5 - WSOD - A template that extends another one cannot include content outside Twig blocks.": "https://git.drupalcode.org/project/socialbase/-/merge_requests/107.diff"
+                "Socialbase 2.1.5 - WSOD - A template that extends another one cannot include content outside Twig blocks.": "https://git.drupalcode.org/project/socialbase/-/merge_requests/107.diff",
+                "Issue #3269600: Empty private message text in Inbox page": "https://git.drupalcode.org/project/socialbase/-/merge_requests/108.diff"
             },
             "drupal/update_helper": {
                 "3248189: Symfony 4.4 event dispatcher parameter order change": "https://www.drupal.org/files/issues/2021-11-08/symfony-4-4-event-dispatcher-parameter-order-change-3248189-2.patch"

--- a/composer.json
+++ b/composer.json
@@ -121,6 +121,9 @@
             "drupal/r4032login": {
                 "3248175: Symfony 4.4 event dispatcher parameter order change": "https://www.drupal.org/files/issues/2021-11-08/symfony-4-4-event-dispatcher-parameter-order-change-3248175-2.patch"
             },
+            "drupal/socialbase": {
+                "Socialbase 2.1.5 - WSOD - A template that extends another one cannot include content outside Twig blocks.": "https://git.drupalcode.org/project/socialbase/-/merge_requests/107.diff"
+            },
             "drupal/update_helper": {
                 "3248189: Symfony 4.4 event dispatcher parameter order change": "https://www.drupal.org/files/issues/2021-11-08/symfony-4-4-event-dispatcher-parameter-order-change-3248189-2.patch"
             },


### PR DESCRIPTION
## Problem
The **Social Base** theme patch is not applying.

## Solution
Remove **Social Base** theme patch since those changes were released in the last theme version:
- Release https://www.drupal.org/project/socialbase/releases/2.1.5
- MR https://git.drupalcode.org/project/socialbase/-/merge_requests/81

## Issue tracker
N/A

## How to test
- [ ] All checks should be green.

## Screenshots
N/A

## Release notes
N/A

## Change Record
N/A

## Translations
N/A
