### PR TITLE
Added social_private_message_update_11002() to be executed after group_update_8002().

### DIFF
--- a/modules/social_features/social_private_message/social_private_message.install
+++ b/modules/social_features/social_private_message/social_private_message.install
@@ -79,6 +79,14 @@ function social_private_message_update_dependencies() {
     'social_private_message' => 11008,
   ];
 
+  // > [notice] Update started: social_private_message_update_11002
+  // > [error]  The "VariationCache" module is not installed.
+  // Please run the update script to install it properly.
+  // > [error]  Update failed: social_private_message_update_11002
+  $dependencies['social_private_message'][11002] = [
+    'group' => 8020,
+  ];
+
   return $dependencies;
 }
 


### PR DESCRIPTION
## Problem
Updated hook social_private_message_update_11002 was throwing error when updating from Open Social 10.2.x

```
>  [notice] Update started: social_private_message_update_11002
>  [error]  The "VariationCache" module is not installed. Please run the update script to install it properly. 
>  [error]  Update failed: social_private_message_update_11002 

```
## Solution
The enabling of variationcache is necessary in order to enable this module due to changes in groups module in https://www.drupal.org/project/group/issues/3135757.

## Issue tracker
https://www.drupal.org/project/social/issues/3264287

## How to test
- [ ] Upgrade from Open Social 10 to Open Social 11. It will break if we don't have message notify enabled.
- [ ] Apply current PR changes.
- [ ] You should not have the error anymore for the first step.

## Screenshots
N.A

## Release notes
N.A

## Change Record
N.A

## Translations
N.A