### PR TITLE
Issue #3270158 by tBKoT: Remove useless fields

### DIFF
--- a/modules/social_features/social_group/social_group.module
+++ b/modules/social_features/social_group/social_group.module
@@ -1925,6 +1925,18 @@ function social_group_entity_base_field_info_alter(&$fields, EntityTypeInterface
         'weight' => 16,
       ])
       ->setDisplayConfigurable('form', TRUE);
+
+    // Remove 'group_type_<group_type>' fields from the node and user entities
+    // as these fields providing issues with cross posting and translations.
+    // Also, we do not use these fields in Open Social, so we can disable them.
+    $entity_types = ['node', 'user'];
+    if (in_array($entity_type->id(), $entity_types)) {
+      /** @var \Drupal\group\Entity\GroupType $group_type */
+      foreach (\Drupal::service('entity_type.manager')->getStorage('group_type')->loadMultiple() as $group_type) {
+        $field_name = 'groups_type_' . $group_type->id();
+        unset($fields[$field_name]);
+      }
+    }
   }
 }
 


### PR DESCRIPTION
## Problem
When we add the translation of the content inside the group we lose their connection. It's happening because of using useless fields in this [patch](https://www.drupal.org/files/issues/2021-07-30/group-2718195-58-groups-computed-field.patch). It contains additional fields for every group type which we do not use. These fields check the values before the node saves and deletes the `group_content` entities.

## Solution
Remove all useless `group_type` fields.

## Issue tracker
https://www.drupal.org/project/social/issues/3270158

## How to test
- [x] Using version 11.x of Open Social with the` social_content_translation` module enabled
- [x] Add additional language
- [x] Create a group
- [x] Add any content to the group
- [x] Add translation to the created content

## Screenshots
#### Topic in a group
![зображення](https://user-images.githubusercontent.com/11648677/158850254-92b8a4e2-4573-4edf-a100-e70a05135f09.png)

#### Group field on the add translation form
![зображення](https://user-images.githubusercontent.com/11648677/158850345-353caacc-41db-4b9d-b749-f9922a71cbdd.png)

#### Topic after adding translation
![зображення](https://user-images.githubusercontent.com/11648677/158850740-731d2abd-46e2-49af-94eb-09fa3f2bc003.png)

## Release notes
Fixed bug with closed connection between content and group

## Change Record
N/A

## Translations
N/A
