### PR TITLE
Issue #3270714 by nkoporec: Don't allow setting the created date in the future

### DIFF
--- a/modules/social_features/social_core/social_core.module
+++ b/modules/social_features/social_core/social_core.module
@@ -991,7 +991,7 @@ function social_core_form_node_form_alter(&$form, FormStateInterface $form_state
  *
  * @throws \Drupal\Core\Entity\EntityStorageException
  */
-function _social_core_created_date_validation(array $form, FormStateInterface $form_state) {
+function _social_core_created_date_validation(array $form, FormStateInterface $form_state): void {
   $created = $form_state->getValue('created');
   if (!$created) {
     return;

--- a/modules/social_features/social_core/social_core.module
+++ b/modules/social_features/social_core/social_core.module
@@ -907,6 +907,9 @@ function social_core_form_node_form_alter(&$form, FormStateInterface $form_state
           unset($form['created']);
         }
 
+        // Add validation for created date.
+        array_unshift($form['#validate'], '_social_core_created_date_validation');
+
         $has_option_fields = FALSE;
 
         foreach (['promote', 'sticky'] as $field) {
@@ -975,6 +978,31 @@ function social_core_form_node_form_alter(&$form, FormStateInterface $form_state
         unset($form['actions']['preview']);
       }
     }
+  }
+}
+
+/**
+ * Custom form validation handler for validating created date.
+ *
+ * @param array $form
+ *   The form array.
+ * @param \Drupal\Core\Form\FormStateInterface $form_state
+ *   Form state.
+ *
+ * @throws \Drupal\Core\Entity\EntityStorageException
+ */
+function _social_core_created_date_validation(array $form, FormStateInterface $form_state) {
+  $created = $form_state->getValue('created');
+  if (!$created) {
+    return;
+  }
+
+  $date = end($created);
+  /** @var \Drupal\Core\Datetime\DrupalDateTime $date */
+  $date = $date['value'];
+
+  if ($date->getTimestamp() > time()) {
+    $form_state->setErrorByName('created', t('The created date cannot be in the future.'));
   }
 }
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -6851,11 +6851,6 @@ parameters:
 			path: modules/social_features/social_core/social_core.module
 
 		-
-			message: "#^Function _social_core_created_date_validation\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: modules/social_features/social_core/social_core.module
-
-		-
 			message: "#^Function social_core_filter_process_format\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: modules/social_features/social_core/social_core.module

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -6851,6 +6851,11 @@ parameters:
 			path: modules/social_features/social_core/social_core.module
 
 		-
+			message: "#^Function _social_core_created_date_validation\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: modules/social_features/social_core/social_core.module
+
+		-
 			message: "#^Function social_core_filter_process_format\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: modules/social_features/social_core/social_core.module


### PR DESCRIPTION
## Problem
Currently, users have the ability to set author information, inside of that fieldset, they also have the ability to change the created timestamp. We don't validate the date, so users can set the created date in the future, which is a problem, because this date is used in other parts of Open Social, for example, the activity entity is using it, and if the date is in the future then activity date will also be in the future, which means that on /stream page, it will always be on top.

## Solution
We need to add validation for that field, so users can't set the date in the future.


## Issue tracker
https://www.drupal.org/project/social/issues/3270714

## How to test
1. Create a topic
2. Under Author information set the authored on date in the future
3. Save the topic and run cron
4. Wait a couple of minutes and go to the /stream page

## Screenshots
![image](https://user-images.githubusercontent.com/35064680/159244225-4867d77b-c47a-424e-88cb-a9b78c091c45.png)


## Release notes
Users should not have the possibility to set the node created date in the future.


## Change Record
*If this Pull Request changes the way that developers should do things or introduces a new API for developers then a change record to document this is needed. Please provide a draft for a change record or a link to an unpublished change record below. [Existing change records](https://www.drupal.org/list-changes/social) can be consulted as example.*

## Translations
*Translatable strings are always extracted from the latest development branch. To ensure translations remain available for platforms running older versions of Open Social the original string should be added to `translations.php` when it's changed or removed.*
- [ ] Changed or removed source strings are added to the `translations.php` file.
