### PR TITLE
Add description before preprocessing for files

### DIFF
--- a/modules/social_features/social_core/src/Plugin/Field/FieldFormatter/FileAndImageTableFormatter.php
+++ b/modules/social_features/social_core/src/Plugin/Field/FieldFormatter/FileAndImageTableFormatter.php
@@ -35,6 +35,7 @@ class FileAndImageTableFormatter extends ImageFormatter {
         $elements[$delta] = [
           '#theme' => 'file_link',
           '#file' => $file,
+          '#description' => $item->get('description')->getValue(),
           '#cache' => [
             'tags' => $file->getCacheTags(),
           ],


### PR DESCRIPTION
## Problem
When creating a node that has attachments, the file is shown with the title, even when the description is filled in.

## Solution
By altering the file_image_default field formatter we can add the description before it gets preprocess. Drupal will then pickup the description if it's filled in, instead of the title.

## Issue tracker
https://www.drupal.org/project/social/issues/3270782
https://getopensocial.atlassian.net/browse/TB-6704

## How to test
- [] Create a Topic with an attachment
- [] Fill a description for the file
- [] Save
- [] See that the file description is shown

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] If applicable (I.E. new hook_updates) the update path from previous versions (major and minor versions) are tested
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Release notes
We fixed a bug where the description of a file was not shown. If you provide a description for a file, it will be shown instead of the title.
