### PR TITLE
Issue #3270885 by vnech: Add ability to sort events by date (DESC & ASC) in content list block

### DIFF
--- a/modules/social_features/social_content_block/modules/social_event_content_block/src/Plugin/ContentBlock/EventContentBlock.php
+++ b/modules/social_features/social_content_block/modules/social_event_content_block/src/Plugin/ContentBlock/EventContentBlock.php
@@ -178,8 +178,14 @@ class EventContentBlock extends ContentBlockBase implements ContainerFactoryPlug
    */
   public function supportedSortOptions(): array {
     return parent::supportedSortOptions() + [
+      // Sort in "ASC" order.
       'event_date' => [
-        'label' => $this->t('Event date'),
+        'label' => $this->t('Oldest -> Newest'),
+        'limit' => FALSE,
+      ],
+      // Sort in "DESC" order.
+      'event_date_desc' => [
+        'label' => $this->t('Newest -> Oldest'),
         'limit' => FALSE,
       ],
     ];

--- a/modules/social_features/social_content_block/src/ContentBuilder.php
+++ b/modules/social_features/social_content_block/src/ContentBuilder.php
@@ -558,10 +558,16 @@ class ContentBuilder implements ContentBuilderInterface {
         break;
 
       case 'event_date':
+      case 'event_date_desc':
         $sorting_field = $query->leftJoin('node__field_event_date', 'nfed', "$base_field = %alias.entity_id");
         $sorting_field .= '.field_event_date_value';
         $direction = 'ASC';
         $base_field = NULL;
+
+        // Change sort order for "event_date_desc".
+        if ($sort_by === 'event_date_desc') {
+          $direction = 'DESC';
+        }
         break;
     }
 


### PR DESCRIPTION
## Problem
Currently it is possible to create a large range of custom content list but the way we display results is hardcoded.
For example, when we show a list of events in the past, and sort them by event date, they are automatically ordered by oldest to newest.
It would be adding a lot of value if we could add an extra option to choose from ascending and descending.
In this way we would literally double our range of options.

## Solution
- Rename "Event Date" sort order option to "Oldest -> Newest"
- Add a new option - "Newest -> Oldest" - to sort events in DESC order

## Issue tracker
- https://www.drupal.org/project/social/issues/3270885
- https://getopensocial.atlassian.net/browse/YANG-7095

## Theme issue tracker
N/A

## How to test
- [ ] Login as SM
- [ ] Add a dashboard
- [ ] Go to dashboard layout and add custom content list with events 
- [ ] In the block use (Newest → Oldest)
- [ ] In the block use (Oldest → Newest)

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] If applicable (I.E. new hook_updates) the update path from previous versions (major and minor versions) are tested
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
N/A

## Release notes
*Add ability to sort events by date (DESC & ASC) in content list block.*

## Change Record
N/A

## Translations
N/A