### PR TITLE
Issue #3270932 by alex.ksis: Do not recreate alternative frontpages if they exist.

### DIFF
--- a/modules/custom/alternative_frontpage/alternative_frontpage.install
+++ b/modules/custom/alternative_frontpage/alternative_frontpage.install
@@ -32,10 +32,11 @@ function alternative_frontpage_update_11101(): void {
   // Get the settings for authenticated users.
   $alternative_frontpage = \Drupal::configFactory()->get('alternative_frontpage.settings');
   $authenticated = $alternative_frontpage->get('frontpage_for_authenticated_user');
+  $storage = \Drupal::entityTypeManager()->getStorage('alternative_frontpage');
 
-  if (!empty($authenticated)) {
+  if (!empty($authenticated) && !$storage->load('authenticated')) {
     // Create the new entry.
-    $storage = \Drupal::entityTypeManager()->getStorage('alternative_frontpage')->create([
+    $storage = $storage->create([
       'id' => 'authenticated',
       'label' => 'Authenticated Users',
       'path' => $authenticated,
@@ -50,9 +51,9 @@ function alternative_frontpage_update_11101(): void {
   $site_config = \Drupal::configFactory()->get('system.site');
   $anonymous = $site_config->get('page.front');
 
-  if (!empty($anonymous)) {
+  if (!empty($anonymous) && !$storage->load('anonymous')) {
     // Create the new entry.
-    $storage = \Drupal::entityTypeManager()->getStorage('alternative_frontpage')->create([
+    $storage = $storage->create([
       'id' => 'anonymous',
       'label' => 'Anonymous Users',
       'path' => $anonymous,


### PR DESCRIPTION
## Problem
The alternative_frontpage_update_11101 hook is trying to create alternative frontpages even if they already exist.

## Solution
Check if entities with the given ids already exists.

## Issue tracker
https://www.drupal.org/project/social/issues/3270932

## How to test
- [ ] Run DB update

