### PR TITLE
Issue #3271758 by vnech: Fix fatal error on "social_profile_profile_view_alter()" function

### DIFF
--- a/modules/social_features/social_profile/social_profile.module
+++ b/modules/social_features/social_profile/social_profile.module
@@ -12,6 +12,7 @@ use Drupal\Core\Entity\Display\EntityViewDisplayInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Field\BaseFieldDefinition;
+use Drupal\Core\Field\FieldItemInterface;
 use Drupal\Core\Field\FieldStorageDefinitionInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Link;
@@ -20,7 +21,7 @@ use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\Session\AccountProxyInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\Core\Url;
-use Drupal\file\Entity\File;
+use Drupal\file\FileInterface;
 use Drupal\image\Entity\ImageStyle;
 use Drupal\node\Entity\Node;
 use Drupal\profile\Entity\Profile;
@@ -696,6 +697,12 @@ function social_profile_form_user_register_form_alter(&$form, FormStateInterface
  * Implements hook_ENTITY_TYPE_view_alter().
  */
 function social_profile_profile_view_alter(array &$build, EntityInterface $entity, EntityViewDisplayInterface $display) {
+  $image_item = $build['field_profile_image'][0]['#item'] ?? NULL;
+
+  // Image doesn't exists.
+  if (!($image_item instanceof FieldItemInterface)) {
+    return;
+  }
 
   /** @var \Drupal\Core\Session\AccountProxy $current_user */
   $current_user = \Drupal::currentUser();
@@ -704,27 +711,21 @@ function social_profile_profile_view_alter(array &$build, EntityInterface $entit
   // have access to the users profile.
   if (!$current_user->hasPermission('view any profile profile') && isset($display->get('content')['field_profile_image'])) {
     // Try to load the profile picture.
-    $fid = $entity->get('field_profile_image')->target_id;
+    $image = $entity->get('field_profile_image')->entity;
+
     // Must have a value and not be NULL.
-    if (!is_null($fid)) {
-      // Load the file.
-      $file = File::load($fid);
-      // Check if it's a real file.
-      if ($file instanceof File) {
-        // Potentially the file is in the private file system. In that case,
-        // anonymous user don't have access to it.
-        if (!$file->access('view', $current_user)) {
-          // Load default data.
-          $replacement_data = social_profile_get_default_image();
-          /** @var \Drupal\image\Plugin\Field\FieldType\ImageItem $imgitem */
-          $imgitem = $build['field_profile_image'][0]['#item'];
-          // Time to override the data that going to be rendered.
-          $imgitem->set('target_id', $replacement_data['id']);
-          $imgitem->set('width', $replacement_data['width']);
-          $imgitem->set('height', $replacement_data['height']);
-          // Put replacement data back in the object that's about to be built.
-          $build['field_profile_image'][0]['#item'] = $imgitem;
-        }
+    if ($image instanceof FileInterface) {
+      // Potentially the file is in the private file system. In that case,
+      // anonymous user don't have access to it.
+      if (!$image->access('view', $current_user)) {
+        // Load default data.
+        $replacement_data = social_profile_get_default_image();
+        // Time to override the data that going to be rendered.
+        $image_item->set('target_id', $replacement_data['id']);
+        $image_item->set('width', $replacement_data['width']);
+        $image_item->set('height', $replacement_data['height']);
+        // Put replacement data back in the object that's about to be built.
+        $build['field_profile_image'][0]['#item'] = $image_item;
       }
     }
   }


### PR DESCRIPTION
## Problem
We got a fatal error when displaying profile with empty field_profile_image field.

```php
The website encountered an unexpected error. Please try again later.
Error: Call to a member function set() on null in social_profile_profile_view_alter() (line 677 of profiles/contrib/social/modules/social_features/social_profile/social_profile.module).
social_profile_profile_view_alter(Array, Object, Object) (Line: 539)
Drupal\Core\Extension\ModuleHandler->alter('profile_view', Array, Object, Object) (Line: 316)
Drupal\Core\Entity\EntityViewBuilder->buildMultiple(Array) (Line: 250)
Drupal\Core\Entity\EntityViewBuilder->build(Array)
call_user_func_array(Array, Array) (Line: 100)
Drupal\Core\Render\Renderer->doTrustedCallback(Array, Array, 'Render #pre_render callbacks must be methods of a class that implements \Drupal\Core\Security\TrustedCallbackInterface or be an anonymous function. The callback was %s. Support for this callback implementation is deprecated in 8.8.0 and will be removed in Drupal 9.0.0. See https://www.drupal.org/node/2966725', 'silenced_deprecation', 'Drupal\Core\Render\Element\RenderCallbackInterface') (Line: 781)
Drupal\Core\Render\Renderer->doCallback('#pre_render', Array, Array) (Line: 372)
Drupal\Core\Render\Renderer->doRender(Array, ) (Line: 200)
Drupal\Core\Render\Renderer->render(Array) (Line: 501)
Drupal\Core\Template\TwigExtension->escapeFilter(Object, Array, 'html', NULL, 1) (Line: 41)
__TwigTemplate_ee957f55c17bc9db0aa7d9d4f9de1bc3354555bf923ab174673d3285c829fb2b->doDisplay(Array, Array) (Line: 453)
Twig\Template->displayWithErrorHandling(Array, Array) (Line: 420)
Twig\Template->display(Array) (Line: 432)
Twig\Template->render(Array) (Line: 64)
twig_render_template('modules/contrib/social_discussion/templates/comment--field-discussion-comments.html.twig', Array) (Line: 384)
Drupal\Core\Theme\ThemeManager->render('comment__field_discussion_comments', Array) (Line: 431)
Drupal\Core\Render\Renderer->doRender(Array) (Line: 444)
Drupal\Core\Render\Renderer->doRender(Array, 1) (Line: 200)
Drupal\Core\Render\Renderer->render(Array, 1) (Line: 156)
Drupal\Core\Render\Renderer->Drupal\Core\Render\{closure}() (Line: 573)
Drupal\Core\Render\Renderer->executeInRenderContext(Object, Object) (Line: 157)
Drupal\Core\Render\Renderer->renderPlain(Array) (Line: 171)
Drupal\Core\Render\Renderer->renderPlaceholder('callback=social_comment.lazy_renderer%3ArenderComments&amp;args%5B0%5D=node&amp;args%5B1%5D=78&amp;args%5B2%5D=1&amp;args%5B3%5D=field_discussion_comments&amp;args%5B4%5D=500&amp;args%5B5%5D=0&amp;token=RF8nY1_k49zXywWqkj5ao--8CxHZpayUVedLkJkp8WE', Array) (Line: 693)
Drupal\big_pipe\Render\BigPipe->renderPlaceholder('callback=social_comment.lazy_renderer%3ArenderComments&amp;args%5B0%5D=node&amp;args%5B1%5D=78&amp;args%5B2%5D=1&amp;args%5B3%5D=field_discussion_comments&amp;args%5B4%5D=500&amp;args%5B5%5D=0&amp;token=RF8nY1_k49zXywWqkj5ao--8CxHZpayUVedLkJkp8WE', Array) (Line: 547)
Drupal\big_pipe\Render\BigPipe->sendPlaceholders(Array, Array, Object) (Line: 305)
Drupal\big_pipe\Render\BigPipe->sendContent(Object) (Line: 112)
Drupal\big_pipe\Render\BigPipeResponse->sendContent() (Line: 374)
Symfony\Component\HttpFoundation\Response->send() (Line: 20)
```

## Solution
Refactor the function and fix fatal error.

## Issue tracker
- https://www.drupal.org/project/social/issues/3271758
- https://getopensocial.atlassian.net/browse/YANG-7364

## Theme issue tracker
N/A

## How to test
- [ ] Add a new authenticated user without profile image
- [ ] Login as LU
- [ ] Visit the page of created user

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] If applicable (I.E. new hook_updates) the update path from previous versions (major and minor versions) are tested
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
N/A

## Release notes
*Fix fatal error on "social_profile_profile_view_alter()" function.*

## Change Record
N/A

## Translations
N/A
