### PR TITLE
Issue #3272386 by Ressinel: Patch for instaclick/php-webdriver is not longer being applied

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "enable-patching": true,
         "patches": {
             "instaclick/php-webdriver": {
-                "Curl_exec errors on behat (1.4.10)": "https://www.drupal.org/files/issues/2021-10-17/social-instaclick-webdriver-3226058-8.patch"
+                "Curl_exec errors on behat (1.4.11)": "https://www.drupal.org/files/issues/2022-03-30/social-instaclick-webdriver-3272386-2.patch"
             },
             "embed/embed": {
                 "Issue #3110341: Embedded Vimeo videos are sometimes blocked when hosted on cloud hosting": "https://www.drupal.org/files/issues/2020-01-31/3110341-vendor-fix-vimeo-adapter.patch"


### PR DESCRIPTION
## Problem
We are using a patch that is no longer able to be applied:
- https://www.drupal.org/files/issues/2021-10-17/social-instaclick-webdriver-3226058-8.patch

## Solution
The file changed on version 1.4.11 we need to re-roll the patch.
- https://github.com/instaclick/php-webdriver/blob/1.4.11/lib/WebDriver/AbstractWebDriver.php

## Issue tracker
- https://www.drupal.org/project/social/issues/3272386

## Theme issue tracker
N/A

## How to test
- [ ] Run `composer install` on the latest Open Social Profile and patch won't apply
- [ ] Get changes from current PR and patch will be successfully apply

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] If applicable (I.E. new hook_updates) the update path from previous versions (major and minor versions) are tested
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
N/A

## Release notes
N/A

## Change Record
N/A

## Translations
N/A
