### PR TITLE
Issue #3272432 by robertragas: Only add the social tagging field to the search index if it's not there yet

### DIFF
--- a/modules/social_features/social_tagging/social_tagging.install
+++ b/modules/social_features/social_tagging/social_tagging.install
@@ -80,14 +80,17 @@ function _social_tagging_add_fields_search_api(): void {
     /** @var \Drupal\search_api\IndexInterface $index */
     $index = $index_storage->load($index);
 
-    $field_intro = new Field($index, 'social_tagging');
-    $field_intro->setType('integer');
-    $field_intro->setPropertyPath('social_tagging');
-    $field_intro->setDatasourceId('entity:' . $type);
-    $field_intro->setLabel('Social Tagging');
-    $index->addField($field_intro);
+    // Only add the field if it doesn't exist yet.
+    if (!$index->getField('social_tagging')) {
+      $field_intro = new Field($index, 'social_tagging');
+      $field_intro->setType('integer');
+      $field_intro->setPropertyPath('social_tagging');
+      $field_intro->setDatasourceId('entity:' . $type);
+      $field_intro->setLabel('Social Tagging');
+      $index->addField($field_intro);
 
-    $index->save();
+      $index->save();
+    }
   }
 }
 


### PR DESCRIPTION
## Problem
In 11.0.8 we introduced https://github.com/goalgorilla/open_social/pull/2527 which added social_tagging to the search indexes because sometimes they were not added correctly as it was using an override.

It seems that in some cases the field social_tagging already exists within the search indexes. In this case it will crash the update hook.

## Solution
Make sure we double check if the field already exists in the search indexes before we add it.

## Issue tracker
https://www.drupal.org/project/social/issues/3272432

## How to test
- [x] Manually add social_tagging to one of the search indexes
- [x] Try to execute hook social_tagging_8805 and see it fails
- [x] Check out to the branch and see the update hook will succeed
- [x] Also try to execute it without the field social_tagging and see it will still get added if not there yet

## Definition of done
### Before merge
- [x] Code/peer review is completed
- [x] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [x] All automated tests are green
- [x] Functional/manual tests of the acceptance criteria are approved
- [x] All acceptance criteria were met
- [x] If applicable (I.E. new hook_updates) the update path from previous versions (major and minor versions) are tested
- [x] This pull request has all required labels (team/type/priority)
- [x] This pull request has a milestone
- [x] This pull request has an assignee (if applicable)
- [x] Any front end changes are tested on all major browsers
- [x] New UI elements, or changes on UI elements are approved by the design team
- [x] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Release notes
In our last release 11.0.8 we introduced a fix for being able to use content tags in the search pages, but didn't correctly check if the field was already present. This caused the update process to get stuck. This now has been solved.
