### PR TITLE
fix: check if flexible_group bundle is used before importing config

### DIFF
--- a/modules/social_features/social_group/modules/social_group_invite/social_group_invite.install
+++ b/modules/social_features/social_group/modules/social_group_invite/social_group_invite.install
@@ -118,6 +118,14 @@ function social_group_invite_update_8007() {
  * Add a new field to the flexible group.
  */
 function social_group_invite_update_11001(): void {
+  /** @var \Drupal\Core\Entity\EntityTypeBundleInfoInterface $entityTypeBundleInfo */
+  $entityTypeBundleInfo = \Drupal::service('entity_type.bundle.info');
+  $availableGroupBundles = $entityTypeBundleInfo->getBundleInfo('group');
+  $flexibleGroup = $availableGroupBundles['flexible_group'] ?? NULL;
+  if (NULL === $flexibleGroup) {
+    return;
+  }
+
   $config_path = drupal_get_path('module', 'social_group_invite') . '/config/static';
   $source = new FileStorage($config_path);
   $entity_type_manager = \Drupal::entityTypeManager();


### PR DESCRIPTION
## Problem
When updating my Open social from 11.0.7 to 11.1.0 and running the update `social_group_invite_update_11001` I got the following error:
> Missing bundle entity, entity type group_type, entity id flexible_group.

## Solution
Check if `flexible_group` bundle is available before running the update `social_group_invite_update_11001`. If it does not exit, do nothing, if it does then import the expected config.

## Issue tracker
[*[Required] Paste a link to the drupal.org issue queue item. If any other issue trackers were used, include links to those too.*
](https://www.drupal.org/project/social/issues/3272437)

## How to test
- [ ] Update to Open Social 11.1.0 without using `flexible_group` bundle

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] If applicable (I.E. new hook_updates) the update path from previous versions (major and minor versions) are tested
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

