### PR TITLE
Issue #3272694 by chmez, agami4: As a User I want to see the short description on full size teasers

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -126,7 +126,8 @@
             },
             "drupal/socialbase": {
                 "As a LU I want to be able to see a preview of the user profile wherever I see a user": "https://www.drupal.org/files/issues/2022-03-28/preview-3267141-6.patch",
-                "Display 'Follow' button on user profile page": "https://www.drupal.org/files/issues/2022-04-08/socialbase-follow-button-3260424-8.patch"
+                "Display 'Follow' button on user profile page": "https://www.drupal.org/files/issues/2022-04-08/socialbase-follow-button-3260424-8.patch",
+                "Show the short description on full size teasers": "https://www.drupal.org/files/issues/2022-04-19/socialbase-teaser-description-3272691-7.patch"
             },
             "drupal/socialblue": {
                 "LU should be able to see the list of the users another user follow": "https://www.drupal.org/files/issues/2022-04-08/socialblue-user-follow-3272002-9.patch"

--- a/modules/social_features/social_profile/config/install/core.entity_view_display.profile.profile.teaser.yml
+++ b/modules/social_features/social_profile/config/install/core.entity_view_display.profile.profile.teaser.yml
@@ -21,7 +21,7 @@ dependencies:
     - profile.type.profile
   module:
     - image
-    - text
+    - social_profile
 id: profile.profile.teaser
 targetEntityType: profile
 bundle: profile
@@ -77,7 +77,7 @@ content:
     third_party_settings: {  }
     region: content
   field_profile_self_introduction:
-    type: text_trimmed
+    type: social_profile_text
     weight: 6
     region: content
     label: hidden

--- a/modules/social_features/social_profile/config/install/core.entity_view_display.profile.profile.teaser.yml
+++ b/modules/social_features/social_profile/config/install/core.entity_view_display.profile.profile.teaser.yml
@@ -21,6 +21,7 @@ dependencies:
     - profile.type.profile
   module:
     - image
+    - text
 id: profile.profile.teaser
 targetEntityType: profile
 bundle: profile
@@ -75,13 +76,27 @@ content:
       link: false
     third_party_settings: {  }
     region: content
+  field_profile_self_introduction:
+    type: text_trimmed
+    weight: 6
+    region: content
+    label: hidden
+    settings:
+      trim_length: 140
+    third_party_settings: {  }
+  field_profile_summary:
+    type: string
+    weight: 7
+    region: content
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
 hidden:
   field_profile_address: true
   field_profile_banner_image: true
   field_profile_expertise: true
   field_profile_interests: true
   field_profile_phone_number: true
-  field_profile_self_introduction: true
   field_profile_show_email: true
-  field_profile_summary: true
   search_api_excerpt: true

--- a/modules/social_features/social_profile/config/schema/social_profile.schema.yml
+++ b/modules/social_features/social_profile/config/schema/social_profile.schema.yml
@@ -2,6 +2,10 @@ field.formatter.settings.social_profile_avatar:
   type: field.formatter.settings.image
   label: 'Avatar settings'
 
+field.formatter.settings.social_profile_text:
+  type: field.formatter.settings.text_trimmed
+  label: 'Trimmed plain text display format settings'
+
 field.widget.settings.social_profile_string_textarea:
   type: field.widget.settings.string_textfield
   label: 'Text area display format settings'

--- a/modules/social_features/social_profile/config/update/social_profile_update_11301.yml
+++ b/modules/social_features/social_profile/config/update/social_profile_update_11301.yml
@@ -1,0 +1,28 @@
+core.entity_view_display.profile.profile.teaser:
+  expected_config:
+    hidden:
+      field_profile_self_introduction: true
+      field_profile_summary: true
+  update_actions:
+    delete:
+      hidden:
+        field_profile_self_introduction: true
+        field_profile_summary: true
+    add:
+      content:
+        field_profile_self_introduction:
+          type: text_trimmed
+          weight: 6
+          region: content
+          label: hidden
+          settings:
+            trim_length: 140
+          third_party_settings: {  }
+        field_profile_summary:
+          type: string
+          weight: 7
+          region: content
+          label: hidden
+          settings:
+            link_to_entity: false
+          third_party_settings: {  }

--- a/modules/social_features/social_profile/config/update/social_profile_update_11301.yml
+++ b/modules/social_features/social_profile/config/update/social_profile_update_11301.yml
@@ -11,7 +11,7 @@ core.entity_view_display.profile.profile.teaser:
     add:
       content:
         field_profile_self_introduction:
-          type: text_trimmed
+          type: social_profile_text
           weight: 6
           region: content
           label: hidden

--- a/modules/social_features/social_profile/social_profile.install
+++ b/modules/social_features/social_profile/social_profile.install
@@ -685,3 +685,17 @@ function social_profile_update_11203(): void {
     $config_storage->write($name, (array) $source->read($static));
   }
 }
+
+/**
+ * Add "Summary" and "Self introduction" fields to the profile teaser.
+ */
+function social_profile_update_11301(array &$sandbox): string {
+  /** @var \Drupal\update_helper\UpdaterInterface $update_helper */
+  $update_helper = \Drupal::service('update_helper.updater');
+
+  // Execute configuration update definitions with logging of success.
+  $update_helper->executeUpdate('social_profile', __FUNCTION__);
+
+  // Output logged messages to related channel of update execution.
+  return $update_helper->logger()->output();
+}

--- a/modules/social_features/social_profile/src/Plugin/Field/FieldFormatter/SocialProfileTextFormatter.php
+++ b/modules/social_features/social_profile/src/Plugin/Field/FieldFormatter/SocialProfileTextFormatter.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Drupal\social_profile\Plugin\Field\FieldFormatter;
+
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\text\Plugin\Field\FieldFormatter\TextTrimmedFormatter;
+
+/**
+ * Plugin implementation of the 'social_profile_text' formatter.
+ *
+ * @FieldFormatter(
+ *   id = "social_profile_text",
+ *   label = @Translation("Trimmed plain text"),
+ *   field_types = {
+ *     "text",
+ *     "text_long",
+ *     "text_with_summary",
+ *   },
+ *   quickedit = {
+ *     "editor" = "form",
+ *   },
+ * )
+ */
+class SocialProfileTextFormatter extends TextTrimmedFormatter {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function viewElements(FieldItemListInterface $items, $langcode) {
+    $elements = parent::viewElements($items, $langcode);
+
+    foreach ($items as $delta => $item) {
+      $elements[$delta]['#text'] = strip_tags($elements[$delta]['#text']);
+    }
+
+    return $elements;
+  }
+
+}


### PR DESCRIPTION
## Problem
As a User I want to see the short description on full size teasers.

## Solution
- Use the short description field instead of the full description
- if it not filled in fall back to the long description and cap it at 140 char
- if this is not filled in leave empty

## Issue tracker
- https://getopensocial.atlassian.net/browse/YANG-7266
- https://www.drupal.org/project/social/issues/3272694

## Theme issue tracker
- https://www.drupal.org/project/socialbase/issues/3272691

## How to test
- [ ] When the “Summary” field of a user profile is filled then you should see a text from this field instead of text from the “Self introduction” field in the profile teaser on the users' overview page.

## Screenhots
<img alt="Teaser description" src="https://user-images.githubusercontent.com/29273240/161044230-ee2e3074-681d-4297-85fd-8f3bc9cb36c8.png">

## Release notes
Display short description or trimmed full description in profile full teaser.