### PR TITLE
Issue #3272707 by tBKoT: Allows GMs to decide if group members can leave a post

### DIFF
--- a/modules/social_features/social_group/modules/social_group_flexible_group/config/install/core.entity_form_display.group.flexible_group.default.yml
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/config/install/core.entity_form_display.group.flexible_group.default.yml
@@ -10,6 +10,7 @@ dependencies:
     - field.field.group.flexible_group.field_group_image
     - field.field.group.flexible_group.field_group_location
     - field.field.group.flexible_group.field_group_type
+    - field.field.group.flexible_group.field_group_posts_enabled
     - group.type.flexible_group
     - image.style.social_x_large
   module:
@@ -41,7 +42,7 @@ third_party_settings:
         - field_group_location
         - field_group_address
       parent_name: ''
-      weight: 2
+      weight: 3
       label: Location
       format_type: fieldset
       format_settings:
@@ -54,7 +55,7 @@ third_party_settings:
       children:
         - path
       parent_name: ''
-      weight: 4
+      weight: 5
       format_type: details
       format_settings:
         id: ''
@@ -78,7 +79,7 @@ third_party_settings:
       label: 'Access permissions'
       parent_name: ''
       region: content
-      weight: 1
+      weight: 2
     group_additional_details:
       children: {  }
       format_settings:
@@ -91,7 +92,20 @@ third_party_settings:
       label: 'Additional information'
       parent_name: ''
       region: content
-      weight: 3
+      weight: 4
+    group_personalisation:
+      children:
+        - field_group_posts_enabled
+      format_settings:
+        classes: ''
+        description: ''
+        id: ''
+        required_fields: true
+      format_type: fieldset
+      label: 'Personalisation'
+      parent_name: ''
+      region: content
+      weight: 1
 id: group.flexible_group.default
 targetEntityType: group
 bundle: flexible_group
@@ -159,6 +173,13 @@ content:
     settings: {  }
     third_party_settings: {  }
     type: categorized_options_buttons
+    region: content
+  field_group_posts_enabled:
+    weight: 99
+    settings:
+      display_label: true
+    third_party_settings: { }
+    type: boolean_checkbox
     region: content
   label:
     type: string_textfield

--- a/modules/social_features/social_group/modules/social_group_flexible_group/config/install/field.field.group.flexible_group.field_group_posts_enabled.yml
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/config/install/field.field.group.flexible_group.field_group_posts_enabled.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.group.field_group_posts_enabled
+    - group.type.flexible_group
+id: group.flexible_group.field_group_posts_enabled
+field_name: field_group_posts_enabled
+entity_type: group
+bundle: flexible_group
+label: 'Enable posts for members'
+description: 'If enabled, members will be able to publish posts in the group. If disabled, only group managers are able to publish posts.'
+required: false
+translatable: false
+default_value:
+  -
+    value: 1
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/modules/social_features/social_group/modules/social_group_flexible_group/config/install/field.storage.group.field_group_posts_enabled.yml
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/config/install/field.storage.group.field_group_posts_enabled.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - group
+  enforced:
+    module:
+      - social_group_flexible_group
+id: group.field_group_posts_enabled
+field_name: field_group_posts_enabled
+entity_type: group
+type: boolean
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/social_features/social_group/modules/social_group_flexible_group/config/static/field.field.group.field_group_posts_enabled_11201.yml
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/config/static/field.field.group.field_group_posts_enabled_11201.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.group.field_group_posts_enabled
+    - group.type.flexible_group
+id: group.flexible_group.field_group_posts_enabled
+field_name: field_group_posts_enabled
+entity_type: group
+bundle: flexible_group
+label: 'Enable posts for members'
+description: 'If enabled, members will be able to publish posts in the group. If disabled, only group managers are able to publish posts.'
+required: false
+translatable: false
+default_value:
+  -
+    value: 1
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/modules/social_features/social_group/modules/social_group_flexible_group/config/static/field.storage.group.field_group_posts_enabled_11201.yml
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/config/static/field.storage.group.field_group_posts_enabled_11201.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - group
+  enforced:
+    module:
+      - social_group_flexible_group
+id: group.field_group_posts_enabled
+field_name: field_group_posts_enabled
+entity_type: group
+type: boolean
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/social_features/social_group/modules/social_group_flexible_group/config/update/social_group_flexible_group_update_11202.yml
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/config/update/social_group_flexible_group_update_11202.yml
@@ -1,0 +1,38 @@
+core.entity_form_display.group.flexible_group.default:
+  expected_config: { }
+  update_actions:
+    add:
+      third_party_settings:
+        field_group:
+          group_personalisation:
+            children:
+              - field_group_posts_enabled
+            format_settings:
+              classes: ''
+              description: ''
+              id: ''
+              required_fields: true
+            format_type: fieldset
+            label: 'Personalisation'
+            parent_name: ''
+            region: content
+            weight: 1
+      content:
+        field_group_posts_enabled:
+          weight: 99
+          settings:
+            display_label: true
+          third_party_settings: { }
+          type: boolean_checkbox
+          region: content
+    change:
+      third_party_settings:
+        field_group:
+          group_access_permissions:
+            weight: 2
+          group_location:
+            weight: 3
+          group_additional_details:
+            weight: 4
+          group_settings:
+            weight: 5

--- a/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.install
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.install
@@ -442,3 +442,48 @@ function social_group_flexible_group_update_11002(): string {
   // Output logged messages to related channel of update execution.
   return $updateHelper->logger()->output();
 }
+
+/**
+ * Create a new field to disable posts in groups.
+ */
+function social_group_flexible_group_update_11201(): void {
+  $config_path = drupal_get_path('module', 'social_group_flexible_group') . '/config/static';
+  $source = new FileStorage($config_path);
+  $entity_type_manager = \Drupal::entityTypeManager();
+
+  /** @var \Drupal\Core\Config\Entity\ConfigEntityStorageInterface $field_storage_config_storage */
+  $field_storage_config_storage = $entity_type_manager->getStorage('field_storage_config');
+
+  // Create field storages.
+  $field_type_manager = \Drupal::service('plugin.manager.field.field_type');
+  $data = $source->read('field.storage.group.field_group_posts_enabled_11201');
+  if (is_array($data)) {
+    $class = $field_type_manager->getPluginClass($data['type']);
+    if (is_null($field_storage_config_storage->load($data['id']))) {
+      $data['settings'] = $class::storageSettingsFromConfigData($data['settings']);
+      $field_storage_config_storage->create($data)->save();
+    }
+  }
+
+  /** @var \Drupal\Core\Config\Entity\ConfigEntityStorageInterface $field_config_storage */
+  $field_config_storage = $entity_type_manager->getStorage('field_config');
+  // Create field settings.
+  $data = $source->read('field.field.group.field_group_posts_enabled_11201');
+  if (is_array($data) && is_null($field_config_storage->load($data['id']))) {
+    $field_config_storage->create($data)->save();
+  }
+}
+
+/**
+ * Updates the flexible group's display.
+ */
+function social_group_flexible_group_update_11202(): string {
+  /** @var \Drupal\update_helper\Updater $updateHelper */
+  $updateHelper = \Drupal::service('update_helper.updater');
+
+  // Execute configuration update definitions with logging of success.
+  $updateHelper->executeUpdate('social_group_flexible_group', __FUNCTION__);
+
+  // Output logged messages to related channel of update execution.
+  return $updateHelper->logger()->output();
+}

--- a/modules/social_features/social_group/social_group.module
+++ b/modules/social_features/social_group/social_group.module
@@ -1725,6 +1725,15 @@ function social_group_preprocess_views_view(&$variables) {
       ->getViewBuilder('block')
       ->view($entity);
   }
+
+  if ($view->id() === 'activity_stream_group') {
+    $group = _social_group_get_current_group();
+    if ($group instanceof GroupInterface) {
+      $variables['#cache']['tags'][] = 'group:' . $group->id();
+      $variables['#cache']['contexts'][] = 'route.group';
+      $variables['#cache']['contexts'][] = 'user.group_permissions';
+    }
+  }
 }
 
 /**

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -15600,7 +15600,7 @@ parameters:
 			path: modules/social_features/social_post/src/Plugin/Block/PostBlock.php
 
 		-
-			message: "#^Method Drupal\\\\social_post\\\\Plugin\\\\Block\\\\PostGroupBlock\\:\\:blockAccess\\(\\) should return Drupal\\\\Core\\\\Access\\\\AccessResult but returns Drupal\\\\Core\\\\Access\\\\AccessResultInterface\\.$#"
+			message: "#^Call to an undefined method Drupal\\\\Core\\\\Access\\\\AccessResultInterface\\:\\:addCacheContexts\\(\\).$#"
 			count: 1
 			path: modules/social_features/social_post/src/Plugin/Block/PostGroupBlock.php
 

--- a/tests/behat/features/capabilities/post/post-create-disabled.feature
+++ b/tests/behat/features/capabilities/post/post-create-disabled.feature
@@ -1,0 +1,70 @@
+@api @post @group @stability-1 @post-create @post-create-disabled @YANG-7371
+Feature: Group manager should to be able to disabled posts in groups for members
+  Benefit: Members are not allowed to create posts in group
+  Role: As a GM
+  Goal/desire: I want to disable posting in groups
+
+  Scenario: Create a flexible group with enabled/disabled posting
+    Given users:
+      | name          | mail             | status | roles    |
+      | Group Manager | gm_1@example.com | 1      | verified |
+      | Group Member  | gm_2@example.com | 1      | verified |
+    And I am logged in as "Group Manager"
+    And I am on "group/add"
+    Then I click radio button "Flexible group By choosing this option you can customize many group settings to your needs." with the id "edit-group-type-flexible-group"
+    And I press "Continue"
+    And I wait for AJAX to finish
+
+    Then I should see checked the box "Enable posts for members"
+    And I fill in "Title" with "Test flexible group"
+    And I fill in the "edit-field-group-description-0-value" WYSIWYG editor with "Description text"
+    And I click radio button "Community" with the id "edit-field-flexible-group-visibility-community"
+    And I show hidden inputs
+    Then I click radio button "Open to join" with the id "edit-field-group-allowed-join-method-direct"
+    And I press "Save"
+
+    When I click "Stream" in the "Tabs"
+    Then I fill in "Say something to the group" with "This is a post in Flexible Group."
+    And I press "Post"
+    Then I should see the success message "Your post has been posted."
+    And I should see "This is a post in Flexible Group."
+    And I should see "Group Manager posted in Test flexible group" in the "Main content front"
+
+    #Create the post as a group member.
+    Given I am logged in as "Group Member"
+    When I am on "all-groups"
+    Then I should see "Test flexible group"
+
+    When I click "Test flexible group"
+    And I should see the link "Join" in the "Hero block"
+    And I should not see "Say something to the group"
+
+    Then I click "Join"
+    And I should see "Join group Test flexible group"
+    And I press "Join group"
+    Then I should see "Say something to the group"
+    And I should see "Group Manager posted in Test flexible group" in the "Main content front"
+
+    When I fill in "Say something to the group" with "Member posted in Flexible Group."
+    And I press "Post"
+    Then I should see "Group Member posted in Test flexible group" in the "Main content front"
+    And I should see "Member posted in Flexible Group." in the "Main content front"
+
+    # Disable posting in flegible group.
+    Given I am logged in as "Group Manager"
+    Then I am on "all-groups"
+    And I click "Test flexible group"
+
+    Then I click "Edit group"
+    And I uncheck the box "Enable posts for members"
+    And I press "Save"
+
+    When I click "Stream" in the "Tabs"
+    Then I should see "Say something to the group"
+
+    Given I am logged in as "Group Member"
+    When I am on "all-groups"
+    And I click "Test flexible group"
+    Then I should not see "Say something to the group"
+    And I should see "Member posted in Flexible Group." in the "Main content front"
+    And I should see "This is a post in Flexible Group." in the "Main content front"


### PR DESCRIPTION
## Problem
In many communities, we have groups where all users are automatically added or groups that are used for coordination purposes only.
In these groups, we should be able to prevent regular users from posting so that communication is only going from the top-down and the purpose of the group can be fulfilled.

Right now every user can post so we end up with a lot of meaningless messages that push the user to mute the group altogether

## Solution
Create a new field in the group, for now only in the flexible group, that will allow GMs to disable posting in groups for members.

## Issue tracker
 - https://www.drupal.org/project/social/issues/3272707
 - https://getopensocial.atlassian.net/browse/YANG-7371

## Theme issue tracker
N/A

## How to test
- [x] As a CM
- [x] Add the `Flexible group` and make it open to join
- [x] The `Enable posts for members` should be enabled by default
- [x] As a `verified` user
- [x] Join the newly created `Flexible group`
- [x] You should be able to create a post in this group
- [x] As a group manager
- [x] Edit the `Flexible group`
- [x] Disable the `Enable posts for members` checkbox
- [x] As a `verified` user (group member)
- [x] You should not be able to leave a post or even see the post form.

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [x] All acceptance criteria were met
- [ ] If applicable (I.E. new hook_updates) the update path from previous versions (major and minor versions) is tested
- [x] This pull request has all required labels (team/type/priority)
- [x] This pull request has a milestone
- [x] This pull request has an assignee (if applicable)
- [x] Any front end changes are tested on all major browsers
- [x] New UI elements, or changes on UI elements are approved by the design team
- [x] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
#### New field
![зображення](https://user-images.githubusercontent.com/11648677/161086080-2007b8c0-696f-4495-b6af-094380cdfe4f.png)
#### As a group manager
![зображення](https://user-images.githubusercontent.com/11648677/161086330-d4d5544e-e604-4585-9250-3c06c8a116c2.png)
#### As a group member
![зображення](https://user-images.githubusercontent.com/11648677/161093058-300b26ec-5bd0-4dc2-be34-6dd890feff5b.png)


## Release notes
Group manager now able to disable posting in groups for group members

## Change Record
N/A

## Translations
N/A
