### PR TITLE
Issue #3272941 by nijuley, tbsiqueria, Ressinel: PHP warning for event enrollment listing (with no-enrollment)

### DIFF
--- a/modules/social_features/social_event/modules/social_event_an_enroll_enrolments_export/src/SocialEventAnEnrollEnrolmentsExportOverrides.php
+++ b/modules/social_features/social_event/modules/social_event_an_enroll_enrolments_export/src/SocialEventAnEnrollEnrolmentsExportOverrides.php
@@ -41,7 +41,6 @@ class SocialEventAnEnrollEnrolmentsExportOverrides implements ConfigFactoryOverr
         ],
       ];
 
-      $overrides[$config_name]['display']['default']['display_options']['fields']['social_views_bulk_operations_bulk_form_enrollments_1']['selected_actions']['social_event_enrolments_export_enrollments_action'] = 0;
     }
 
     return $overrides;


### PR DESCRIPTION
## Problem
Open Social showing PHP notice when I see the event enrollment list with no-enrollment

Trying to use values of type `null, bool, int, float or resource `as an array (such as `$null["key"]`) will now generate a notice.
`https://www.php.net/manual/en/migration74.incompatible.php#migration74.incompatible.core.non-array-access`

## Solution
`open_social\modules\social_features\social_event\modules\social_event_an_enroll_enrolments_export\src\SocialEventAnEnrollEnrolmentsExportOverrides.php:44`

`$overrides[$config_name]['display']['default']['display_options']['fields']['social_views_bulk_operations_bulk_form_enrollments_1']['selected_actions']['social_event_enrolments_export_enrollments_action'] = 0;`

Assigning a zero value and is not checking if the actions are actually there in the configuration or not, commenting that line will fix the warning

## Issue tracker
https://www.drupal.org/project/social/issues/3272941

## Theme issue tracker
N/A

## How to test
- [x] On a fresh Installation or existing one,  enable `social_event` and `social_event_an_enroll_enrolments_export` module
- [x] Create an event node and view all enrollment (node/{node}/all-enrollments)
- [x] It will not show PHP notice

## Definition of done

### Before merge
- [x] Code/peer review is completed
- [x] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [x] All automated tests are green
- [x] Functional/manual tests of the acceptance criteria are approved
- [x] All acceptance criteria were met
- [x] If applicable (I.E. new hook_updates) the update path from previous versions (major and minor versions) are tested
- [x] This pull request has all required labels (team/type/priority)
- [x] This pull request has a milestone
- [x] This pull request has an assignee (if applicable)
- [x] Any front end changes are tested on all major browsers
- [x] New UI elements, or changes on UI elements are approved by the design team
- [x] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
Before
<img width="1195" alt="before" src="https://user-images.githubusercontent.com/4291466/161264182-4f8efec3-a590-4b6d-bc7f-bb1d72ba0ecc.png">
After

<img width="891" alt="after" src="https://user-images.githubusercontent.com/4291466/161265646-3ff4cace-07a1-4465-b7b6-9c0968ff66b5.png">

## Release notes
N/A

## Change Record
N/A

## Translations
N/A
