### PR TITLE
Issue #3273357 by Ressinel: Fix issue where translated topic is displayed twice on the group topics page

### DIFF
--- a/modules/social_features/social_group/config/install/views.view.group_topics.yml
+++ b/modules/social_features/social_group/config/install/views.view.group_topics.yml
@@ -319,6 +319,46 @@ display:
             default_group_multiple: {  }
             group_items: {  }
           plugin_id: node_access
+        default_langcode:
+          admin_label: ''
+          entity_field: default_langcode
+          entity_type: node
+          expose:
+            description: ''
+            identifier: ''
+            label: ''
+            multiple: false
+            operator: ''
+            operator_id: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            remember: false
+            remember_roles:
+              authenticated: authenticated
+            required: false
+            use_operator: false
+          exposed: false
+          field: default_langcode
+          group: 1
+          group_info:
+            default_group: All
+            default_group_multiple: {  }
+            description: ''
+            group_items: {  }
+            identifier: ''
+            label: ''
+            multiple: false
+            optional: true
+            remember: false
+            widget: select
+          group_type: group
+          id: default_langcode
+          is_grouped: false
+          operator: '='
+          plugin_id: boolean
+          relationship: gc__node
+          table: node_field_data
+          value: '1'
       sorts:
         created:
           id: created
@@ -438,6 +478,7 @@ display:
       display_extenders: {  }
       path: group/%group/topics
       exposed_block: true
+      rendering_language: '***LANGUAGE_language_interface***'
     cache_metadata:
       max-age: -1
       contexts:

--- a/modules/social_features/social_group/config/update/social_group_update_11004.yml
+++ b/modules/social_features/social_group/config/update/social_group_update_11004.yml
@@ -1,0 +1,51 @@
+views.view.group_topics:
+  expected_config: {  }
+  update_actions:
+    add:
+      display:
+        default:
+          display_options:
+            filters:
+              default_langcode:
+                admin_label: ''
+                entity_field: default_langcode
+                entity_type: node
+                expose:
+                  description: ''
+                  identifier: ''
+                  label: ''
+                  multiple: false
+                  operator: ''
+                  operator_id: ''
+                  operator_limit_selection: false
+                  operator_list: { }
+                  remember: false
+                  remember_roles:
+                    authenticated: authenticated
+                  required: false
+                  use_operator: false
+                exposed: false
+                field: default_langcode
+                group: 1
+                group_info:
+                  default_group: All
+                  default_group_multiple: { }
+                  description: ''
+                  group_items: { }
+                  identifier: ''
+                  label: ''
+                  multiple: false
+                  optional: true
+                  remember: false
+                  widget: select
+                group_type: group
+                id: default_langcode
+                is_grouped: false
+                operator: '='
+                plugin_id: boolean
+                relationship: gc__node
+                table: node_field_data
+                value: '1'
+        page_group_topics:
+          display_options:
+            rendering_language: '***LANGUAGE_language_interface***'

--- a/modules/social_features/social_group/social_group.install
+++ b/modules/social_features/social_group/social_group.install
@@ -960,3 +960,17 @@ function social_group_update_11003(array &$sandbox): void {
   $config->set('display.default.display_options.fields.views_bulk_operations_bulk_form.selected_actions', $selected_actions);
   $config->save();
 }
+
+/**
+ * Change Rendering Language settings for Group Events (Group content) view.
+ */
+function social_group_update_11004(): string {
+  /** @var \Drupal\update_helper\Updater $updateHelper */
+  $updateHelper = \Drupal::service('update_helper.updater');
+
+  // Execute configuration update definitions with logging of success.
+  $updateHelper->executeUpdate('social_group', __FUNCTION__);
+
+  // Output logged messages to related channel of update execution.
+  return $updateHelper->logger()->output();
+}


### PR DESCRIPTION
## Problem
![translated-topic-is-displayed-twice](https://user-images.githubusercontent.com/10220937/161601732-f500bd59-01b2-43cc-afdb-2bc135983620.png)

## Solution
Update the **Group Topics (Group content)** view by adding appropriate translation settings.

## Issue tracker
- https://www.drupal.org/project/social/issues/3273357

## Theme issue tracker
N/A

## How to test
- [ ] Make sure that your site has at least two languages
- [ ] Create a group
- [ ] Create a topic for the created group and translate that topic
- [ ] Go to the created group topics page `/group/[group_id]/topics`
- [ ] You will see a created topic that is displayed twice
- [ ] Apply changes from this PR
- [ ] Go to the created group topics page `/group/[group_id]/topics`
- [ ] You will see a created topic that is displayed only once

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] If applicable (I.E. new hook_updates) the update path from previous versions (major and minor versions) are tested
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
N/A

## Release notes
Fix the issue where a translated topic is displayed twice on the group topics page.

## Change Record
N/A

## Translations
N/A
