### PR TITLE
Issue #3273470 by Kingdutch: Installer options data is not translatable

### DIFF
--- a/yaml_translation_patterns.yml
+++ b/yaml_translation_patterns.yml
@@ -1,7 +1,7 @@
 # Contains translation patterns for the POTX tool that is used by Drupal and
 # Open Social to extract translatable strings. This is required to ensure that
 # strings in custom YAML file formats are translatable.
-translation_patters:
+translation_patterns:
   - matches: '*.installer_options.yml'
     translatable_keys:
       - name


### PR DESCRIPTION
## Problem
A <code>yaml_translation_patterns.yml</code> file exists to instruct the POTX tool on how to translate our custom installer_options.yml files. However the top level key in that file should be <code>translation_patterns</code> but we have <code>translation_patters</code>

This issue has existed since the file was originally created in January 2020. However apparently Open Social is not regularly installed in a non-English language before the language is switched to something else, not making this problem very visible.

The required key can be seen [in the POTX tool](https://git.drupalcode.org/project/potx/-/blob/8.x-1.x/potx.inc#L2315).

## Solution
Fix the typo

*Milestone set to 12.0.0 because translations are extracted from our `main` branch*. Therefore I believe no backport is required, unless this bug pops up in the community and translation on translations.drupal.org is required before 12.0.0.

## Issue tracker
https://www.drupal.org/project/social/issues/3273470

## How to test
- [ ] Check our translation tool and find all the *.installer_options.yml strings missing
- [ ] Fix the bug, run translation extraction using POTX
- [ ] Verify the strings are now present

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [x] If applicable (I.E. new hook_updates) the update path from previous versions (major and minor versions) are tested
- [x] This pull request has all required labels (team/type/priority)
- [x] This pull request has a milestone
- [x] This pull request has an assignee (if applicable)
- [x] Any front end changes are tested on all major browsers
- [x] New UI elements, or changes on UI elements are approved by the design team
- [x] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
N/a

## Release notes
Open Social includes the possibility of enabling some of its features during installation through the web UI. The names and descriptions of these features are now translatable as originally intended.
