### PR TITLE
Issue #3272898 by navneet0693: Add a default of 50 if the entity_update_batch_size is not defined.

### DIFF
--- a/modules/social_features/social_event/social_event.install
+++ b/modules/social_features/social_event/social_event.install
@@ -1975,8 +1975,9 @@ function social_event_update_10306(&$sandbox) {
     }
   }
 
-  // Try to update 25 events at a time.
-  $events_ids = array_slice($sandbox['ids'], $sandbox['current'], Settings::get('entity_update_batch_size'));
+  // Set the batch size equivalent to entity_update_batch_size defined.
+  // @see: https://git.drupalcode.org/project/drupal/-/blob/9.2.16/sites/default/default.settings.php#L764
+  $events_ids = array_slice($sandbox['ids'], $sandbox['current'], Settings::get('entity_update_batch_size') ?? 50);
 
   /** @var \Drupal\node\NodeInterface $event */
   foreach ($node_storage->loadMultiple($events_ids) as $event) {


### PR DESCRIPTION
## Problem
In https://github.com/goalgorilla/open_social/pull/2849 we missed defining a default size for the batch in `social_event_update_10306`. There can be a condition where project has not copied https://git.drupalcode.org/project/drupal/-/blob/9.2.16/sites/default/default.settings.php#L764 in their settings.php.

## Solution
Add a default.

## Issue tracker
https://www.drupal.org/project/social/issues/3272898

## Theme issue tracker
N.A

## How to test
- [ ] Using version 10.2.x of Open Social which Event enrollment feature is enabled.
- [ ] Create more than 6000 events.
- [ ] Update to Open Social 11.1.1
- [ ] Run `drush updb`
- [ ] You may face PHP memory outage.
- [ ] Checkout to this branch. You should not face any PHP memory outage on the execution of this particular hook.

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] If applicable (I.E. new hook_updates) the update path from previous versions (major and minor versions) are tested
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
N.A

## Release notes
Copy from https://github.com/goalgorilla/open_social/pull/2849

## Change Record
N.A

## Translations
N.A