### PR TITLE
Validate authored date on topic creation

### DIFF
--- a/modules/social_features/social_topic/social_topic.module
+++ b/modules/social_features/social_topic/social_topic.module
@@ -26,6 +26,7 @@ use Drupal\social_topic\Controller\SocialTopicController;
 use Drupal\taxonomy\TermInterface;
 use Drupal\views\Plugin\views\query\QueryPluginBase;
 use Drupal\views\ViewExecutable;
+use Drupal\Core\Datetime\DrupalDateTime;
 
 /**
  * Prepares variables for node templates.
@@ -308,6 +309,34 @@ function social_topic_block_access(Block $block, $operation, AccountInterface $a
  */
 function social_topic_social_follow_content_types_alter(array &$types) {
   $types[] = 'topic';
+}
+
+/**
+ * Implements hook_form_alter().
+ */
+function social_topic_form_alter(&$form, &$form_state, $form_id) {
+  if ($form_id == 'node_topic_form' || $form_id == 'node_topic_edit_form') {
+    if (isset($form_state->getUserInput()['created'][0]['value']) && !empty($form_state->getUserInput()['created'][0]['value'])) {
+      $form['#validate'][] = 'author_date_validate_node_topic_form';
+    }
+  }
+}
+
+/**
+ * Validate Authoring date for Topic Contents.
+ *
+ * @param array $form
+ * @param $form_state
+ */
+function author_date_validate_node_topic_form(array $form, FormStateInterface $form_state) {
+  $currentdatetime = new DrupalDateTime();
+  $currentdatetime->setTimezone(new \DateTimeZone('UTC'));
+  $dateinput = $form_state->getUserInput()['created'][0]['value']['date'] . $form_state->getUserInput()['created'][0]['value']['time'];
+  $usersdatetime = new DrupalDateTime($dateinput);
+  $usersdatetime->setTimezone(new \DateTimeZone('UTC'));
+  if ($usersdatetime > $currentdatetime ) {
+    $form_state->setErrorByName('created', t('Authored on date/time cannot be a future date/time.'));
+  }
 }
 
 /**


### PR DESCRIPTION
## Problem

Don't allow setting the authored date in the future. 
Currently, users have the ability to set author information, inside of that fieldset, they also have the ability to change the created timestamp. We don't validate the date, so users can set the created date in the future, which is a problem, because this date is used in other parts of Open Social, for example, the activity entity is using it, and if the date is in the future then activity date will also be in the future, which means that on /stream page, it will always be on top.

## Solution

Add validation for that field, so users can't set the date in the future. Use `hook_form_alter` for add and edit form. 


## Issue tracker

`https://www.drupal.org/project/social/issues/3270714
`
## Theme issue tracker

N/A

## How to test
- [ ] Create a topic
- [ ] Under Author information set the authored on date in the future
- [ ] Try to Save the topic
- [ ] Validation applied now

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] If applicable (I.E. new hook_updates) the update path from previous versions (major and minor versions) are tested
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots

Before
![before](https://user-images.githubusercontent.com/4291466/162719617-b3819abe-3b45-4aba-beb1-8ca34dd96e77.png)

After
![after](https://user-images.githubusercontent.com/4291466/162719606-b4023443-1161-4128-bafb-985142d61f27.png)


## Release notes
N/A


## Change Record
N/A


## Translations
N/A
