### PR TITLE
Issue #3201416 by hotwebmatter, DamienMcKenna, Ressinel: Spelling for "Notification Centre" should be American English

### DIFF
--- a/modules/custom/activity_creator/js/notifications.js
+++ b/modules/custom/activity_creator/js/notifications.js
@@ -5,7 +5,7 @@
 
 (function ($, Drupal, once) {
   /**
-   * Notification centre bell update behavior.
+   * Notification Center bell update behavior.
    */
   Drupal.behaviors.notificationUpdate = {
     attach: function (context) {

--- a/modules/social_features/social_activity/social_activity.module
+++ b/modules/social_features/social_activity/social_activity.module
@@ -39,7 +39,7 @@ function social_activity_social_user_account_header_items(array $context) {
       '#wrapper_attributes' => [
         'class' => ['desktop', 'notification-bell'],
       ],
-      '#title' => new TranslatableMarkup('Notification Centre'),
+      '#title' => new TranslatableMarkup('Notification Center'),
       '#icon' => $num_notifications > 0 ? 'notifications' : 'notifications_none',
       '#label' => new TranslatableMarkup('Notifications'),
       '#url' => Url::fromRoute('view.activity_stream_notifications.page_1'),
@@ -47,7 +47,7 @@ function social_activity_social_user_account_header_items(array $context) {
       '#weight' => 800,
       'header' => [
         '#wrapper_attributes' => ['class' => 'dropdown-header'],
-        '#markup' => new TranslatableMarkup('Notification Centre'),
+        '#markup' => new TranslatableMarkup('Notification Center'),
       ],
       'header-divider' => [
         '#wrapper_attributes' => ['class' => 'divider'],
@@ -138,11 +138,11 @@ function social_activity_social_user_account_header_account_links(array $context
       '#weight' => 300,
       '#type' => 'link',
       '#attributes' => [
-        'title' => new TranslatableMarkup('Notification Centre'),
+        'title' => new TranslatableMarkup('Notification Center'),
       ],
       '#title' => [
         '#type' => 'inline_template',
-        '#template' => '<span>{% trans %}Notification Centre{% endtrans %}</span><span{{ attributes }}>{{ icon }}</span>',
+        '#template' => '<span>{% trans %}Notification Center{% endtrans %}</span><span{{ attributes }}>{{ icon }}</span>',
         '#context' => [
           'attributes' => new Attribute(['class' => $label_classes]),
           'icon' => (string) $num_notifications,

--- a/modules/social_features/social_swiftmail/src/Form/SocialSwiftmailSettingsForm.php
+++ b/modules/social_features/social_swiftmail/src/Form/SocialSwiftmailSettingsForm.php
@@ -181,7 +181,7 @@ class SocialSwiftmailSettingsForm extends ConfigFormBase {
     $form['do_not_send_emails_new_users'] = [
       '#type' => 'checkbox',
       '#title' => $this->t("Don't send email notifications to users who have never logged in"),
-      '#description' => $this->t('When this setting is enabled, users who have never logged in will not receive email notifications, they still receive notifications via the notification centre within the community.'),
+      '#description' => $this->t('When this setting is enabled, users who have never logged in will not receive email notifications, they still receive notifications via the notification center within the community.'),
       '#default_value' => $config->get('do_not_send_emails_new_users'),
     ];
 

--- a/tests/behat/features/capabilities/like/like-create-event.feature
+++ b/tests/behat/features/capabilities/like/like-create-event.feature
@@ -35,5 +35,5 @@ Feature: Create event like
     Given I am logged in as "user_1"
       And I wait for the queue to be empty
       And I click the xth "0" element with the css ".notification-bell a"
-     Then I should see "Notification centre"
+     Then I should see "Notification center"
       And I should see "Isaac Newton likes your event"

--- a/tests/behat/features/capabilities/like/like-create-topic.feature
+++ b/tests/behat/features/capabilities/like/like-create-topic.feature
@@ -33,5 +33,5 @@ Feature: Create topic like
     Given I am logged in as "user_1"
       And I wait for the queue to be empty
       And I click the xth "0" element with the css ".notification-bell a"
-     Then I should see "Notification centre"
+     Then I should see "Notification center"
       And I should see "Charles Darwin likes your topic"


### PR DESCRIPTION
## Problem
The spelling of "Centre" should be "Center".

## Solution
Replace "Centre" with "Center" throughout all the Distro.

## Issue tracker
- https://www.drupal.org/project/social/issues/3201416

## Theme issue tracker
N/A

## How to test
- [ ] You should not see the word "Centre" on English site language anymore

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] If applicable (I.E. new hook_updates) the update path from previous versions (major and minor versions) are tested
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
N/A

## Release notes
The word "Centre" was replaced with "Center" throughout all the Open Social.

## Change Record
N/A

## Translations
N/A
