### PR TITLE
Issue #3045872 by colan, Resssinel: Message related object entity type is randomly empty

### DIFF
--- a/modules/social_features/social_activity/src/EmailTokenServices.php
+++ b/modules/social_features/social_activity/src/EmailTokenServices.php
@@ -77,6 +77,10 @@ class EmailTokenServices {
    *   An entity object. NULL if no matching entity is found.
    */
   public function getRelatedObject(Message $message) {
+    if ($message->get('field_message_related_object')->isEmpty()) {
+      return NULL;
+    }
+
     $target_type = $message->getFieldValue('field_message_related_object', 'target_type');
     $target_id = $message->getFieldValue('field_message_related_object', 'target_id');
 


### PR DESCRIPTION
## Problem
`Drupal\Component\Plugin\Exception\PluginNotFoundException: The "" entity type does not exist. in Drupal\Core\Entity\EntityTypeManager->getDefinition() (line 150 of core/lib/Drupal/Core/Entity/EntityTypeManager.php).`

## Solution
Let's add check if the `field_message_related_object` is not empty to prevent errors.

## Issue tracker
- https://www.drupal.org/project/social/issues/3045872

## Theme issue tracker
N/A

## How to test
_It is not entirely clear how to reproduce this problem._

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] If applicable (I.E. new hook_updates) the update path from previous versions (major and minor versions) are tested
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
N/A

## Release notes
N/A

## Change Record
N/A

## Translations
N/A
