### PR TITLE
Issue #3275943 by alex.ksis: Reset cache of the commented entity.

### DIFF
--- a/modules/custom/social_ajax_comments/src/Controller/AjaxCommentsController.php
+++ b/modules/custom/social_ajax_comments/src/Controller/AjaxCommentsController.php
@@ -181,6 +181,14 @@ class AjaxCommentsController extends ContribController {
       // AjaxCommentsForm::save() during the previous HTTP request.
       $cid = $this->tempStore->getCid();
 
+      // Reset cache of the commented entity.
+      // @todo Investigate why the caches are not cleared correctly in the \Drupal\comment\Entity\Comment::postSave().
+      if ($cid) {
+        $this->entityTypeManager()
+          ->getStorage($entity->getEntityTypeId())
+          ->resetCache([$entity->id()]);
+      }
+
       // Try to insert the message above the new comment.
       if (
         !empty($cid) &&


### PR DESCRIPTION
## Problem
Moderators do not see new comments in a discussion until cache is flushed.

## Solution
Reset discussion cache after a new comment was posted.

## Issue tracker
- https://www.drupal.org/project/social/issues/3275943
- https://getopensocial.atlassian.net/browse/YANG-7566

## How to test
- [x] Create a discussion with manual comments approval, add a regular user as a moderator.
- [x] Open the discussion as the moderator, make sure there are no comments.
- [x] As a CM+ post a comment, make sure it is unpublished.
- [x] Open the discussion as the moderator, make sure the created comment is not displayed.
- [x] Clear cache, verify that the comment appeared.

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] If applicable (I.E. new hook_updates) the update path from previous versions (major and minor versions) are tested
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status
