### PR TITLE
Issue #2995574 by Ressinel: Move eventHasBeenFinished into a trait

### DIFF
--- a/modules/social_features/social_event/src/Form/EnrollActionForm.php
+++ b/modules/social_features/social_event/src/Form/EnrollActionForm.php
@@ -7,7 +7,6 @@ use Drupal\Core\Ajax\OpenModalDialogCommand;
 use Drupal\Core\Ajax\RedirectCommand;
 use Drupal\Core\Ajax\ReplaceCommand;
 use Drupal\Core\Cache\Cache;
-use Drupal\Core\Datetime\DrupalDateTime;
 use Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Link;
@@ -23,6 +22,8 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  * @package Drupal\social_event\Form
  */
 class EnrollActionForm extends FormBase {
+
+  use SocialEventTrait;
 
   /**
    * The routing matcher to get the nid.
@@ -502,34 +503,6 @@ class EnrollActionForm extends FormBase {
     }
 
     return $groups;
-  }
-
-  /**
-   * Function to determine if an event has been finished.
-   *
-   * @param \Drupal\node\NodeInterface $node
-   *   The event.
-   *
-   * @return bool
-   *   TRUE if the evens is finished / completed.
-   */
-  protected function eventHasBeenFinished(NodeInterface $node) {
-    // Use the start date when the end date is not set to determine if the
-    // event is closed.
-    /** @var \Drupal\Core\Datetime\DrupalDateTime $check_end_date */
-    $check_end_date = $node->field_event_date->date;
-
-    if (isset($node->field_event_date_end->date)) {
-      $check_end_date = $node->field_event_date_end->date;
-    }
-
-    $current_time = new DrupalDateTime();
-
-    // The event has finished if the end date is smaller than the current date.
-    if ($current_time > $check_end_date) {
-      return TRUE;
-    }
-    return FALSE;
   }
 
 }

--- a/modules/social_features/social_event/src/Form/EnrollActionForm.php
+++ b/modules/social_features/social_event/src/Form/EnrollActionForm.php
@@ -14,6 +14,7 @@ use Drupal\Core\Url;
 use Drupal\group\Entity\GroupContent;
 use Drupal\node\NodeInterface;
 use Drupal\social_event\EventEnrollmentInterface;
+use Drupal\social_event\SocialEventTrait;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**

--- a/modules/social_features/social_event/src/SocialEventTrait.php
+++ b/modules/social_features/social_event/src/SocialEventTrait.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Drupal\social_event;
+
+use Drupal\Core\Datetime\DrupalDateTime;
+use Drupal\node\Entity\Node;
+
+/**
+ * Trait SocialEventTrait.
+ *
+ * @package Drupal\social_event
+ */
+trait SocialEventTrait {
+
+  /**
+   * Function to determine if an event has been finished.
+   *
+   * @param \Drupal\node\Entity\Node $node
+   *   The event.
+   *
+   * @return bool
+   *   TRUE if the evens is finished/completed.
+   */
+  protected function eventHasBeenFinished(Node $node): bool {
+    $current_time = new DrupalDateTime();
+
+    // Use the start date when the end date is not set to determine if the event
+    // is closed.
+    /** @var \Drupal\Core\Datetime\DrupalDateTime $check_end_date */
+    $check_end_date = $node->field_event_date_end->date ?? $node->field_event_date->date;
+
+    // The event has finished if the end date is smaller than the current date.
+    return $current_time > $check_end_date;
+  }
+
+}

--- a/modules/social_features/social_event/src/SocialEventTrait.php
+++ b/modules/social_features/social_event/src/SocialEventTrait.php
@@ -3,7 +3,7 @@
 namespace Drupal\social_event;
 
 use Drupal\Core\Datetime\DrupalDateTime;
-use Drupal\node\Entity\Node;
+use Drupal\node\NodeInterface;
 
 /**
  * Trait SocialEventTrait.
@@ -15,13 +15,13 @@ trait SocialEventTrait {
   /**
    * Function to determine if an event has been finished.
    *
-   * @param \Drupal\node\Entity\Node $node
+   * @param \Drupal\node\NodeInterface $node
    *   The event.
    *
    * @return bool
    *   TRUE if the evens is finished/completed.
    */
-  protected function eventHasBeenFinished(Node $node): bool {
+  protected function eventHasBeenFinished(NodeInterface $node): bool {
     $current_time = new DrupalDateTime();
 
     // Use the start date when the end date is not set to determine if the event

--- a/modules/social_features/social_event/src/SocialEventTrait.php
+++ b/modules/social_features/social_event/src/SocialEventTrait.php
@@ -28,8 +28,9 @@ trait SocialEventTrait {
 
     // Use the start date when the end date is not set to determine if the event
     // is closed.
-    /** @var \Drupal\Core\Datetime\DrupalDateTime $check_end_date */
-    $check_end_date = $node->get('field_event_date_end')->getString() ?? $node->get('field_event_date')->getString();
+    $check_end_date = $node->get('field_event_date_end')->isEmpty()
+      ? $node->get('field_event_date')->getString()
+      : $node->get('field_event_date_end')->getString();
 
     // Retrieve timezone from current time.
     $timezone = $current_time->getTimezone()->getName();

--- a/modules/social_features/social_event/src/SocialEventTrait.php
+++ b/modules/social_features/social_event/src/SocialEventTrait.php
@@ -2,6 +2,8 @@
 
 namespace Drupal\social_event;
 
+use DateTime;
+use DateTimeZone;
 use Drupal\Core\Datetime\DrupalDateTime;
 use Drupal\node\NodeInterface;
 
@@ -27,10 +29,16 @@ trait SocialEventTrait {
     // Use the start date when the end date is not set to determine if the event
     // is closed.
     /** @var \Drupal\Core\Datetime\DrupalDateTime $check_end_date */
-    $check_end_date = $node->field_event_date_end->date ?? $node->field_event_date->date;
+    $check_end_date = $node->get('field_event_date_end')->getString() ?? $node->get('field_event_date')->getString();
+
+    // Retrieve timezone from current time.
+    $timezone = $current_time->getTimezone()->getName();
+
+    $start_datetime = new DateTime($check_end_date, new DateTimeZone($timezone));
+    $start_datetime = $start_datetime->getTimestamp();
 
     // The event has finished if the end date is smaller than the current date.
-    return $current_time > $check_end_date;
+    return $current_time->getTimestamp() > $start_datetime;
   }
 
 }

--- a/modules/social_features/social_event/src/SocialEventTrait.php
+++ b/modules/social_features/social_event/src/SocialEventTrait.php
@@ -2,8 +2,6 @@
 
 namespace Drupal\social_event;
 
-use DateTime;
-use DateTimeZone;
 use Drupal\Core\Datetime\DrupalDateTime;
 use Drupal\node\NodeInterface;
 
@@ -26,20 +24,19 @@ trait SocialEventTrait {
   protected function eventHasBeenFinished(NodeInterface $node): bool {
     $current_time = new DrupalDateTime();
 
+    // Retrieve timezone from current time.
+    $timezone = $current_time->getTimezone()->getName();
+
     // Use the start date when the end date is not set to determine if the event
     // is closed.
     $check_end_date = $node->get('field_event_date_end')->isEmpty()
       ? $node->get('field_event_date')->getString()
       : $node->get('field_event_date_end')->getString();
-
-    // Retrieve timezone from current time.
-    $timezone = $current_time->getTimezone()->getName();
-
-    $start_datetime = new DateTime($check_end_date, new DateTimeZone($timezone));
-    $start_datetime = $start_datetime->getTimestamp();
+    $check_end_date = new \DateTime($check_end_date, new \DateTimeZone($timezone));
+    $check_end_date = $check_end_date->getTimestamp();
 
     // The event has finished if the end date is smaller than the current date.
-    return $current_time->getTimestamp() > $start_datetime;
+    return $current_time->getTimestamp() > $check_end_date;
   }
 
 }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -9225,11 +9225,6 @@ parameters:
 			path: modules/social_features/social_event/src/Form/EnrollActionForm.php
 
 		-
-			message: "#^Access to an undefined property Drupal\\\\Core\\\\Field\\\\FieldItemListInterface\\:\\:\\$date\\.$#"
-			count: 1
-			path: modules/social_features/social_event/src/Form/EnrollActionForm.php
-
-		-
 			message: "#^Method Drupal\\\\social_event\\\\Form\\\\EnrollActionForm\\:\\:create\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: modules/social_features/social_event/src/Form/EnrollActionForm.php


### PR DESCRIPTION
## Problem
AS per https://github.com/goalgorilla/open_social/pull/792#discussion_r213029760 `EventAnEnrollActionForm` extends `EnrollActionForm` although this is probably not needed as there are more differences than overlap.

## Solution
We can move the common functionality that needs to be shared into a trait that they can both use. This also makes it possible for other forms to easily reuse this logic in the future.

## Issue tracker
- https://www.drupal.org/project/social/issues/2995574

## Theme issue tracker
N/A

## How to test
- [ ] No changes in functionality. All checks should be green.

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] If applicable (I.E. new hook_updates) the update path from previous versions (major and minor versions) are tested
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
N/A

## Release notes
EnrollActionForm::eventHasBeenFinished() was moved into a trait SocialEventTrait.

## Change Record
### EnrollActionForm::eventHasBeenFinished() was moved into a trait SocialEventTrait.

We moved the `eventHasBeenFinished()` into the trait `SocialEventTrait`. That makes it possible for other forms to easily reuse this method by adding a trait.

#### Before:
`modules/social_features/social_event/src/Form/EnrollActionForm::eventHasBeenFinished()`

#### After:
`modules/social_features/social_event/src/SocialEventTrait::eventHasBeenFinished()`

## Translations
N/A
