### PR TITLE
Issue #3275980 by navneet0693: Switching language on multilingual platform leads to unexpected error

### DIFF
--- a/modules/social_features/social_core/social_core.module
+++ b/modules/social_features/social_core/social_core.module
@@ -1140,55 +1140,58 @@ function social_core_preprocess_flag(array &$variables): void {
  * Get all default main menu links that ships with Open Social.
  */
 function _social_core_default_main_menu_links() {
-  $default_os_links = [
-    'Home' => [
-      'link' => 'internal:/',
-      'menu_name' => 'main',
-    ],
-    'Explore' => [
-      'link' => 'internal:',
-      'menu_name' => 'main',
-    ],
-  ];
-
-  $entity_type_manager = \Drupal::entityTypeManager();
-  $menu_links = $entity_type_manager
-    ->getStorage('menu_link_content')
-    ->loadByProperties(['menu_name' => 'main']);
-
-  $links = [];
-
-  /** @var \Drupal\menu_link_content\MenuLinkContentInterface $link */
-  foreach ($menu_links as $link) {
-    if (!in_array($link->getTitle(), array_keys($default_os_links))) {
-      continue;
-    }
-
-    $os_link = $default_os_links[$link->getTitle()];
-    $link_uri = $link->get('link')->getValue();
-    $link_uri = end($link_uri);
-    $link_uri = $link_uri['uri'];
-    if ($link_uri !== $os_link['link']) {
-      continue;
-    }
-
-    if ($link->getMenuName() !== $os_link['menu_name']) {
-      continue;
-    }
-
-    $links[] = $link;
-  }
-
-  // Enable modules to alter the list.
-  \Drupal::moduleHandler()->invokeAll(
-    'social_core_default_main_menu_links_alter',
-    [&$links]
-  );
-
   // If user has a permission to bypass all the restrictions, then
   // we don't return any links.
   if (\Drupal::currentUser()->hasPermission('bypass social_core menu links access')) {
     return [];
+  }
+
+  $links = &drupal_static(__FUNCTION__);
+
+  if (empty($links)) {
+    $default_os_links = [
+      'Home' => [
+        'link' => 'internal:/',
+        'menu_name' => 'main',
+      ],
+      'Explore' => [
+        'link' => 'internal:',
+        'menu_name' => 'main',
+      ],
+    ];
+
+    $entity_type_manager = \Drupal::entityTypeManager();
+    $menu_links = $entity_type_manager
+      ->getStorage('menu_link_content')
+      ->loadByProperties(['menu_name' => 'main']);
+
+    $links = [];
+
+    /** @var \Drupal\menu_link_content\MenuLinkContentInterface $link */
+    foreach ($menu_links as $link) {
+      if (!in_array($link->getTitle(), array_keys($default_os_links))) {
+        continue;
+      }
+
+      $os_link = $default_os_links[$link->getTitle()];
+      $link_uri = $link->get('link')->getValue();
+      $link_uri = end($link_uri);
+      $link_uri = $link_uri['uri'];
+      if ($link_uri !== $os_link['link']) {
+        continue;
+      }
+
+      if ($link->getMenuName() !== $os_link['menu_name']) {
+        continue;
+      }
+
+      $links[] = $link;
+    }
+    // Enable modules to alter the list.
+    \Drupal::moduleHandler()->invokeAll(
+      'social_core_default_main_menu_links_alter',
+      [&$links]
+    );
   }
 
   return $links;
@@ -1202,30 +1205,31 @@ function _social_core_default_main_menu_links() {
 function social_core_entity_access(EntityInterface $entity, string $operation, AccountInterface $account) {
   $entity_type = $entity->getEntityTypeId();
 
-  if ($entity_type !== 'menu_link_content') {
-    return;
-  }
+  if (
+    ($entity_type === 'menu_link_content')
+    && $operation !== 'view'
+    && $account->isAuthenticated()
+    && !$account->hasPermission('bypass social_core menu links access')
+    && $account->hasPermission('administer menu')
+  ) {
+    /** @var \Drupal\menu_link_content\MenuLinkContentInterface $entity */
+    $name = $entity->getTitle();
+    $link = $entity->get('link')->getValue();
+    $link = end($link);
 
-  if ($operation === 'view') {
-    return;
-  }
+    $default_os_links = _social_core_default_main_menu_links();
 
-  /** @var \Drupal\menu_link_content\MenuLinkContentInterface $entity */
-  $name = $entity->getTitle();
-  $link = $entity->get('link')->getValue();
-  $link = end($link);
-
-  $default_os_links = _social_core_default_main_menu_links();
-
-  /** @var \Drupal\menu_link_content\MenuLinkContentInterface $os_link */
-  foreach ($default_os_links as $os_link) {
-    $os_link_title = $os_link->getTitle();
-    $os_link_uri = $entity->get('link')->getValue();
-    $os_link_uri = end($os_link_uri)['uri'];
-    if ($name === $os_link_title && $link['uri'] === $os_link_uri) {
-      return AccessResult::forbidden();
+    /** @var \Drupal\menu_link_content\MenuLinkContentInterface $os_link */
+    foreach ($default_os_links as $os_link) {
+      $os_link_title = $os_link->getTitle();
+      $os_link_uri = $entity->get('link')->getValue();
+      $os_link_uri = end($os_link_uri)['uri'];
+      if ($name === $os_link_title && $link['uri'] === $os_link_uri) {
+        return AccessResult::forbidden();
+      }
     }
   }
+  return AccessResult::neutral();
 }
 
 /**


### PR DESCRIPTION
## Problem
1. On Open Social 11.1.2 based multilingual platform with social_language and content_translation module enabled.
2. Open the website as an anonymous user.
3. Try to switch language from one language to another where one of the menu links doesn't have translated version of that particular language.

The PR #2831 introduced a problem where it throws an error whenever an anonymous user tried to switch website language via a language switcher blocker on an existing multilingual platform.

Switching of language triggers an action in Drupal core which checks for fallback language. See https://git.drupalcode.org/project/drupal/-/blob/9.2.17/core/modules/language/src/ConfigurableLanguageManager.php#L387 which also invokes https://git.drupalcode.org/project/drupal/-/blob/9.2.17/core/modules/content_translation/content_translation.module#L444 which then invokes https://github.com/goalgorilla/open_social/blob/main/modules/social_features/social_core/social_core.module#L1202 which only checks for 'view' operations.

```
The website encountered an unexpected error. Please try again later.
Error: Call to a member function getTitle() on bool in social_core_entity_access() (line 1209 of profiles/contrib/social/modules/social_features/social_core/social_core.module).
social_core_entity_access(Object, 'update', Object)
call_user_func_array('social_core_entity_access', Array) (Line: 403)
Drupal\Core\Extension\ModuleHandler->invokeAll('entity_access', Array) (Line: 96)
Drupal\Core\Entity\EntityAccessControlHandler->access(Object, 'update', Object, 1) (Line: 754)
Drupal\Core\Entity\ContentEntityBase->access('update', Object, 1) (Line: 298)
Drupal\content_translation\ContentTranslationHandler->getTranslationAccess(Object, 'update') (Line: 444)
content_translation_language_fallback_candidates_entity_view_alter(Array, Array, NULL) (Line: 539)
Drupal\Core\Extension\ModuleHandler->alter('language_fallback_candidates_entity_view', Array, Array) (Line: 393)
Drupal\language\ConfigurableLanguageManager->getFallbackCandidates(Array) (Line: 107)
Drupal\Core\Entity\EntityRepository->getTranslationFromContext(Object) (Line: 150)
Drupal\menu_link_content\Plugin\Menu\MenuLinkContent->getEntity() (Line: 179)
Drupal\menu_link_content\Plugin\Menu\MenuLinkContent->getDescription() (Line: 124)
Drupal\Core\Menu\MenuLinkBase->getUrlObject() (Line: 203)
Drupal\Core\Menu\DefaultMenuLinkTreeManipulators->menuLinkCheckAccess(Object) (Line: 92)
Drupal\Core\Menu\DefaultMenuLinkTreeManipulators->checkAccess(Array)
call_user_func(Array, Array) (Line: 149)
Drupal\Core\Menu\MenuLinkTree->transform(Array, Array) (Line: 193)
Drupal\system\Plugin\Block\SystemMenuBlock->build() (Line: 171)
Drupal\block\BlockViewBuilder::preRender(Array)
call_user_func_array(Array, Array) (Line: 101)
Drupal\Core\Render\Renderer->doTrustedCallback(Array, Array, 'Render #pre_render callbacks must be methods of a class that implements \Drupal\Core\Security\TrustedCallbackInterface or be an anonymous function. The callback was %s. See https://www.drupal.org/node/2966725', 'exception', 'Drupal\Core\Render\Element\RenderCallbackInterface') (Line: 786)
Drupal\Core\Render\Renderer->doCallback('#pre_render', Array, Array) (Line: 377)
Drupal\Core\Render\Renderer->doRender(Array) (Line: 449)
Drupal\Core\Render\Renderer->doRender(Array, ) (Line: 201)
Drupal\Core\Render\Renderer->render(Array) (Line: 450)
Drupal\Core\Template\TwigExtension->escapeFilter(Object, Array, 'html', NULL, 1) (Line: 51)
__TwigTemplate_ba314446071f979df534b71899790e3135dfdf967672294ec369e9eab42f9fcf->doDisplay(Array, Array) (Line: 405)
Twig\Template->displayWithErrorHandling(Array, Array) (Line: 378)
Twig\Template->display(Array) (Line: 390)
Twig\Template->render(Array) (Line: 65)
twig_render_template('profiles/contrib/social/modules/social_features/social_landing_page/templates/page--node--landing-page.html.twig', Array) (Line: 384)
Drupal\Core\Theme\ThemeManager->render('page', Array) (Line: 436)
Drupal\Core\Render\Renderer->doRender(Array, ) (Line: 201)
Drupal\Core\Render\Renderer->render(Array) (Line: 450)
Drupal\Core\Template\TwigExtension->escapeFilter(Object, Array, 'html', NULL, 1) (Line: 106)
__TwigTemplate_511701f8f7c74596b482a8249a92b62cc4866f4a3832d07be0ccdbe9ba648e4e->doDisplay(Array, Array) (Line: 405)
Twig\Template->displayWithErrorHandling(Array, Array) (Line: 378)
Twig\Template->display(Array) (Line: 390)
Twig\Template->render(Array) (Line: 65)
twig_render_template('themes/contrib/socialbase/templates/system/html.html.twig', Array) (Line: 384)
Drupal\Core\Theme\ThemeManager->render('html', Array) (Line: 436)
Drupal\Core\Render\Renderer->doRender(Array, ) (Line: 201)
Drupal\Core\Render\Renderer->render(Array) (Line: 162)
Drupal\Core\Render\MainContent\HtmlRenderer->Drupal\Core\Render\MainContent\{closure}() (Line: 578)
Drupal\Core\Render\Renderer->executeInRenderContext(Object, Object) (Line: 163)
Drupal\Core\Render\MainContent\HtmlRenderer->renderResponse(Array, Object, Object) (Line: 90)
Drupal\Core\EventSubscriber\MainContentViewSubscriber->onViewRenderArray(Object, 'kernel.view', Object)
call_user_func(Array, Object, 'kernel.view', Object) (Line: 142)
Drupal\Component\EventDispatcher\ContainerAwareEventDispatcher->dispatch(Object, 'kernel.view') (Line: 163)
Symfony\Component\HttpKernel\HttpKernel->handleRaw(Object, 1) (Line: 80)
Symfony\Component\HttpKernel\HttpKernel->handle(Object, 1, 1) (Line: 57)
Drupal\Core\StackMiddleware\Session->handle(Object, 1, 1) (Line: 47)
Drupal\Core\StackMiddleware\KernelPreHandle->handle(Object, 1, 1) (Line: 320)
Drupal\cleantalk\EventSubscriber\BootSubscriber->handle(Object, 1, 1) (Line: 50)
Drupal\ban\BanMiddleware->handle(Object, 1, 1) (Line: 47)
Drupal\Core\StackMiddleware\ReverseProxyMiddleware->handle(Object, 1, 1) (Line: 52)
Drupal\Core\StackMiddleware\NegotiationMiddleware->handle(Object, 1, 1) (Line: 23)
Stack\StackedHttpKernel->handle(Object, 1, 1) (Line: 717)
Drupal\Core\DrupalKernel->handle(Object) (Line: 19)

```

## Solution
1. Add more inline documentation to the code.
2. Take care of all CRUD operations in the logic added.
3. Statically cache all the default menu links shipped with Open Social.
4. Add proper release notes.
5. Add documentation for impact on developers.

## Issue tracker
https://www.drupal.org/project/social/issues/3275980

## Theme issue tracker
N.A

## How to test
- [ ] Using version 11.1.2 of Open Social with the social_language, social_landing_page & content_translation module enabled
- [ ] Add some languages to the website
- [ ] Added a language switcher block in the header
- [ ] Add a landing page in the default language
- [ ] Make the landing page home page.
- [ ] Visit the website as a user either anonymous or LU.
- [ ] Visit the landing page.
- [ ] Change the language
- [ ] You shouldn't face any issues.

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] If applicable (I.E. new hook_updates) the update path from previous versions (major and minor versions) are tested
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
N.A

## Release notes
We have prohibited the Site Managers from deleting the default menus which Open Social ships with. These menus are required by many internal pages in Open Social installation for delivering the functionality. The deletion for such menu would have led to broken pages in Open Social, so we have limited their deletion.

## Change Record
We added the ability to alter the main menu links that ships with Open Social. Developers can add/remove links via a new hook `hook_social_core_default_main_menu_links_alter()`. 

An example of how to add a new link:
```
/**
 * Implements hook_social_core_default_main_menu_links_alter().
 */
function hook_social_core_default_main_menu_links_alter(array &$links) {
  $link = \Drupal::entityTypeManager()->getStorage('menu_link_content')
    ->loadByProperties([
      'title' => 'Community',
      'menu_name' => 'main',
      'link' => 'internal:/explore',
    ]);
  $link = end($link);

  $links[] = $link;
}
```

https://www.drupal.org/node/3278932


## Translations
N.A