### PR TITLE
Issue #3276000 by SV: AJAXify Follow button on Profile preview

### DIFF
--- a/modules/social_features/social_profile/modules/social_profile_preview/assets/js/social_profile_preview.js
+++ b/modules/social_features/social_profile/modules/social_profile_preview/assets/js/social_profile_preview.js
@@ -2,6 +2,7 @@
   Drupal.behaviors.socialProfilePreview = {
     attach: function attach(context) {
       var timeouts = [], dialogs = [], profiles = [];
+      var refresh = -1;
       var delay = 200;
       var delta = 0;
 
@@ -41,7 +42,9 @@
                       .on('mouseleave', function () {
                         timeouts[selector] = window.setTimeout(function () {
                           dialogs[selector].close();
-                          dialogs = [];
+                          if (refresh === 1) {
+                            dialogs = [];
+                          }
                         }, delay);
                       })
                       .find('.ui-dialog-titlebar-close').remove();
@@ -58,6 +61,7 @@
 
             if (dialogs[selector] !== undefined) {
               dialogs[selector].showModal();
+              Drupal.ajax.bindAjaxLinks(document.body);
             }
             else {
               var ajax = Drupal.ajax({
@@ -75,8 +79,9 @@
               ajax.execute();
             }
             // When page structure has been changed bind Ajax functionality.
-            $(document).ajaxComplete(function() {
+            $(document).ajaxComplete(function(event, request, settings) {
               Drupal.ajax.bindAjaxLinks(document.body);
+              refresh = settings.url.indexOf('flag');
             });
 
           }, delay);
@@ -90,7 +95,9 @@
             if (dialogs[selector] !== undefined && dialogs[selector].open) {
               dialogs[selector].close();
             }
-            dialogs = [];
+            if (refresh === 1) {
+              dialogs = [];
+            }
           }, delay);
         });
     }

--- a/modules/social_features/social_profile/modules/social_profile_preview/assets/js/social_profile_preview.js
+++ b/modules/social_features/social_profile/modules/social_profile_preview/assets/js/social_profile_preview.js
@@ -41,6 +41,7 @@
                       .on('mouseleave', function () {
                         timeouts[selector] = window.setTimeout(function () {
                           dialogs[selector].close();
+                          dialogs = [];
                         }, delay);
                       })
                       .find('.ui-dialog-titlebar-close').remove();
@@ -58,9 +59,6 @@
             if (dialogs[selector] !== undefined) {
               dialogs[selector].showModal();
             }
-            else if (profiles[identifier] !== undefined) {
-              dialog();
-            }
             else {
               var ajax = Drupal.ajax({
                 url: Drupal.url('profile/' + identifier + '/preview')
@@ -76,6 +74,11 @@
 
               ajax.execute();
             }
+            // When page structure has been changed bind Ajax functionality.
+            $(document).ajaxComplete(function() {
+              Drupal.ajax.bindAjaxLinks(document.body);
+            });
+
           }, delay);
         })
         .on('mouseout', function () {
@@ -87,6 +90,7 @@
             if (dialogs[selector] !== undefined && dialogs[selector].open) {
               dialogs[selector].close();
             }
+            dialogs = [];
           }, delay);
         });
     }

--- a/modules/social_features/social_profile/modules/social_profile_preview/assets/js/social_profile_preview.js
+++ b/modules/social_features/social_profile/modules/social_profile_preview/assets/js/social_profile_preview.js
@@ -42,8 +42,13 @@
                       .on('mouseleave', function () {
                         timeouts[selector] = window.setTimeout(function () {
                           dialogs[selector].close();
+
                           if (refresh === 1) {
-                            dialogs = [];
+                            Object.entries(dialogs).forEach(([key, val]) => {
+                              if (dialogs[key].deleted == true){
+                                delete(dialogs[key]);
+                              }
+                            });
                           }
                         }, delay);
                       })
@@ -57,6 +62,7 @@
               );
 
               dialogs[selector].showModal();
+              dialogs[selector].profile_id = $element.attr('data-profile');
             }
 
             if (dialogs[selector] !== undefined) {
@@ -82,6 +88,22 @@
             $(document).ajaxComplete(function(event, request, settings) {
               Drupal.ajax.bindAjaxLinks(document.body);
               refresh = settings.url.indexOf('flag');
+              selector = $element.attr('id');
+
+              if (dialogs[selector] !== undefined) {
+                profile_id = dialogs[selector].profile_id;
+
+                if (refresh === 1) {
+                  Object.entries(dialogs).forEach(([key, val]) => {
+                    if (val.profile_id === profile_id) {
+                      dialogs[key].deleted = true;
+                    }
+                    else {
+                      dialogs[key].deleted = false;
+                    }
+                  });
+                }
+              }
             });
 
           }, delay);
@@ -94,9 +116,6 @@
           timeouts[selector] = window.setTimeout(function () {
             if (dialogs[selector] !== undefined && dialogs[selector].open) {
               dialogs[selector].close();
-            }
-            if (refresh === 1) {
-              dialogs = [];
             }
           }, delay);
         });


### PR DESCRIPTION
## Problem
Currently, there is a redirect when LU clicks on follow users button from profile preview.

![follow-preview](https://user-images.githubusercontent.com/25609390/164030438-37527098-8253-4be3-a302-3ffac33d5a72.gif)


## Solution
It would be good to AJAXify Follow button on Profile preview the same as on normal teasers.

## Issue tracker
- https://www.drupal.org/project/social/issues/3276000
- https://getopensocial.atlassian.net/browse/YANG-7532

## How to test
- [ ] Using the latest version of Open Social with the social_follow_user & social_profile_preview modules enabled
- [ ] As administrator go to "/admin/config/opensocial/follow-user" and enable follow user option
- [ ] Next, switch to LU and go to the "/stream" page
- [ ] Then, hover of other user names/images and click on follow/unfollow button in the modal window
- [ ] After, I expect that the "follow" action has been applied but instead, there is a redirect.
- [ ] The expected result is attained when repeating the steps with this fix applied.