### PR TITLE
Issue #3276299 by alex.ksis: Do not chec "view" permission if node does not exist.

### DIFF
--- a/modules/custom/entity_access_by_field/src/EntityAccessHelper.php
+++ b/modules/custom/entity_access_by_field/src/EntityAccessHelper.php
@@ -127,7 +127,7 @@ class EntityAccessHelper {
     // If the social_event_invite module is enabled and a person got invited
     // then allow access to view the node.
     // @todo Come up with a better solution for this code.
-    if ($moduleHandler->moduleExists('social_event_invite')) {
+    if ($moduleHandler->moduleExists('social_event_invite') && $node->id()) {
       if ($op == 'view') {
         $conditions = [
           'field_account' => $account->id(),


### PR DESCRIPTION
## Problem
Cannot create an idea in a challenge because of a fatal error

## Solution
Skip "view" access check triggered if a node doest not exist. 

## Issue tracker
https://www.drupal.org/project/social/issues/3276299

## How to test
- [ ] Create a challenge with a few phases with create,edit,view ideas permissions
- [ ] As a regular user open with challenge and click "Create idea" button

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] If applicable (I.E. new hook_updates) the update path from previous versions (major and minor versions) are tested
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

