### PR TITLE
Issue #3276307 by alex.ksis: Display the URL alias field in the Settings fieldset.

### DIFF
--- a/modules/social_features/social_group/social_group.module
+++ b/modules/social_features/social_group/social_group.module
@@ -942,24 +942,30 @@ function social_group_form_alter(&$form, FormStateInterface $form_state, $form_i
     $group_form_ids[] = 'group_' . $group_type . '_add_form';
   }
 
-  if (isset($form['field_group_allowed_join_method']) && in_array($form_id, $group_form_ids)) {
-    $join_method_default_value = 'added';
-    // Ensure we have a better descriptive label.
-    if (array_key_exists('added', $form['field_group_allowed_join_method']['widget']['#options'])) {
-      $form['field_group_allowed_join_method']['widget']['#options']['added'] = t('Invite only');
+  if (in_array($form_id, $group_form_ids)) {
+    if (isset($form['field_group_allowed_join_method'])) {
+      $join_method_default_value = 'added';
+      // Ensure we have a better descriptive label.
+      if (array_key_exists('added', $form['field_group_allowed_join_method']['widget']['#options'])) {
+        $form['field_group_allowed_join_method']['widget']['#options']['added'] = t('Invite only');
+      }
+      if (array_key_exists('direct', $form['field_group_allowed_join_method']['widget']['#options'])) {
+        $form['field_group_allowed_join_method']['widget']['#options']['direct'] = t('Open to join');
+      }
+      // If directly exists it's becoming the default.
+      if (in_array('direct', $form['field_group_allowed_join_method']['widget']['#default_value'])) {
+        $join_method_default_value = 'direct';
+      }
+      elseif (in_array('request', $form['field_group_allowed_join_method']['widget']['#default_value'])) {
+        $join_method_default_value = 'request';
+      }
+      $form['field_group_allowed_join_method']['widget']['#type'] = 'radios';
+      $form['field_group_allowed_join_method']['widget']['#default_value'] = $join_method_default_value;
     }
-    if (array_key_exists('direct', $form['field_group_allowed_join_method']['widget']['#options'])) {
-      $form['field_group_allowed_join_method']['widget']['#options']['direct'] = t('Open to join');
+
+    if (isset($form['path']['widget'][0]['#group'])) {
+      unset($form['path']['widget'][0]['#group']);
     }
-    // If directly exists it's becoming the default.
-    if (in_array('direct', $form['field_group_allowed_join_method']['widget']['#default_value'])) {
-      $join_method_default_value = 'direct';
-    }
-    elseif (in_array('request', $form['field_group_allowed_join_method']['widget']['#default_value'])) {
-      $join_method_default_value = 'request';
-    }
-    $form['field_group_allowed_join_method']['widget']['#type'] = 'radios';
-    $form['field_group_allowed_join_method']['widget']['#default_value'] = $join_method_default_value;
   }
 
   // Exposed Filter block on the all-groups overview.


### PR DESCRIPTION
## Problem
The URL alias field is displayed below the form, but the container for this field is empty and displayed on the form.

## Solution
Move the field from the bottom to its container.

## Issue tracker
https://www.drupal.org/project/social/issues/3276307

## How to test
Open group add/edit form.

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] If applicable (I.E. new hook_updates) the update path from previous versions (major and minor versions) are tested
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
<img width="864" alt="image" src="https://user-images.githubusercontent.com/4526828/164303930-4db7e4a3-b7ea-4f3a-b4d6-e31215bb65fe.png">

