### PR TITLE
Issue 3276402 by Corn696: Fix social_user_post_update_10101 in combin…

### DIFF
--- a/modules/social_features/social_user/social_user.post_update.php
+++ b/modules/social_features/social_user/social_user.post_update.php
@@ -56,7 +56,9 @@ function social_user_post_update_10101_add_verified_role_to_existing_users(array
       // Add role "verified".
       $account->addRole('verified');
       $account->save();
-      \Drupal::service('ldap.drupal_user_processor')->reset();
+      if (\Drupal::moduleHandler()->moduleExists('ldap_user')) {
+        \Drupal::service('ldap.drupal_user_processor')->reset();
+      }
     }
   }
 

--- a/modules/social_features/social_user/social_user.post_update.php
+++ b/modules/social_features/social_user/social_user.post_update.php
@@ -56,6 +56,7 @@ function social_user_post_update_10101_add_verified_role_to_existing_users(array
       // Add role "verified".
       $account->addRole('verified');
       $account->save();
+      \Drupal::service('ldap.drupal_user_processor')->reset();
     }
   }
 


### PR DESCRIPTION
…ation with ldap module

Reset the ldap.drupal_user_processor after saving an account.

## Problem
The following database update fails if the LDAP user module is installed.
social_user_post_update_10101_add_verified_role_to_existing_users

## Solution
Reset the ldap.drupal_user_processor after saving an account.

\Drupal::service('ldap.drupal_user_processor')->reset();

## Issue tracker
[https://www.drupal.org/project/social/issues/3276402](https://www.drupal.org/project/social/issues/3276402)

## How to test
- [ ] Upgrade to version 11 of Open Social with the ldap user module enabled
- [ ] Try to update the database
- [ ] The update social_user_post_update_10101 will fail
- [ ] The update will work if the ldap.drupal_user_processor gets reset after saving an account 

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] If applicable (I.E. new hook_updates) the update path from previous versions (major and minor versions) are tested
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status
