### PR TITLE
Issue #3063436 by Ressinel: Social landing page gives: Warning: array_flip(): Can only flip STRING and INTEGER values

### DIFF
--- a/modules/social_features/social_landing_page/social_landing_page.module
+++ b/modules/social_features/social_landing_page/social_landing_page.module
@@ -299,6 +299,10 @@ function _social_landing_page_get_hero_image(NodeInterface $node) {
 
   /** @var \Drupal\paragraphs\ParagraphInterface $paragraph_section */
   foreach ($landing_page_section_field->referencedEntities() as $paragraph_section) {
+    if ($paragraph_section->get('field_section_paragraph')->isEmpty()) {
+      continue;
+    }
+
     // Get the related paragraph (the one with the actual content)
     $section_id = $paragraph_section->get('field_section_paragraph')->target_id;
     $paragraph_content = Paragraph::load($section_id);


### PR DESCRIPTION
## Problem
```
Warning: array_flip(): Can only flip STRING and INTEGER values! in Drupal\Core\Entity\EntityStorageBase->loadMultiple() (line 261 of core/lib/Drupal/Core/Entity/EntityStorageBase.php).

Drupal\Core\Entity\EntityStorageBase->loadMultiple(Array) (Line: 245)
Drupal\Core\Entity\EntityStorageBase->load(NULL) (Line: 488)
Drupal\Core\Entity\EntityBase::load(NULL) (Line: 308)
_social_landing_page_get_hero_image(Object) (Line: 252)
social_landing_page_preprocess_node(Array, 'node', Array) (Line: 287)
Drupal\Core\Theme\ThemeManager->render('node', Array) (Line: 436)
Drupal\Core\Render\Renderer->doRender(Array, ) (Line: 201)
Drupal\Core\Render\Renderer->render(Array, ) (Line: 241)
Drupal\Core\Render\MainContent\HtmlRenderer->Drupal\Core\Render\MainContent\{closure}() (Line: 578)
Drupal\Core\Render\Renderer->executeInRenderContext(Object, Object) (Line: 242)
Drupal\Core\Render\MainContent\HtmlRenderer->prepare(Array, Object, Object) (Line: 132)
Drupal\Core\Render\MainContent\HtmlRenderer->renderResponse(Array, Object, Object) (Line: 90)
Drupal\Core\EventSubscriber\MainContentViewSubscriber->onViewRenderArray(Object, 'kernel.view', Object)
call_user_func(Array, Object, 'kernel.view', Object) (Line: 142)
Drupal\Component\EventDispatcher\ContainerAwareEventDispatcher->dispatch(Object, 'kernel.view') (Line: 163)
Symfony\Component\HttpKernel\HttpKernel->handleRaw(Object, 1) (Line: 80)
Symfony\Component\HttpKernel\HttpKernel->handle(Object, 1, 1) (Line: 57)
Drupal\Core\StackMiddleware\Session->handle(Object, 1, 1) (Line: 47)
Drupal\Core\StackMiddleware\KernelPreHandle->handle(Object, 1, 1) (Line: 106)
Drupal\page_cache\StackMiddleware\PageCache->pass(Object, 1, 1) (Line: 85)
Drupal\page_cache\StackMiddleware\PageCache->handle(Object, 1, 1) (Line: 47)
Drupal\Core\StackMiddleware\ReverseProxyMiddleware->handle(Object, 1, 1) (Line: 52)
Drupal\Core\StackMiddleware\NegotiationMiddleware->handle(Object, 1, 1) (Line: 23)
Stack\StackedHttpKernel->handle(Object, 1, 1) (Line: 717)
Drupal\Core\DrupalKernel->handle(Object) (Line: 19)
```

## Solution
Add check for empty section in `_social_landing_page_get_hero_image()`.

## Issue tracker
- https://www.drupal.org/project/social/issues/3063436

## Theme issue tracker
N/A

## How to test
- [ ] Create a **Landing page** with an empty section.

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] If applicable (I.E. new hook_updates) the update path from previous versions (major and minor versions) are tested
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
N/A

## Release notes
N/A

## Change Record
N/A

## Translations
N/A
