### PR TITLE
Issue #3276411 by tarikflz, Ressinel: SocialCommentBreadcrumbBuilder causes an error loading entities

### DIFF
--- a/modules/social_features/social_comment/src/SocialCommentBreadcrumbBuilder.php
+++ b/modules/social_features/social_comment/src/SocialCommentBreadcrumbBuilder.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\social_comment;
 
+use Drupal\comment\CommentInterface;
 use Drupal\Core\Breadcrumb\BreadcrumbBuilderInterface;
 use Drupal\Core\Breadcrumb\Breadcrumb;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
@@ -62,7 +63,9 @@ class SocialCommentBreadcrumbBuilder implements BreadcrumbBuilderInterface {
       case 'comment.reply':
         $page_title = $this->t('Reply to Comment');
         $pid = $route_match->getParameter('pid');
-        $comment = $this->storage->load($pid);
+        if ($pid) {
+          $comment = $this->storage->load($pid);
+        }
         break;
 
       case 'entity.comment.edit_form':
@@ -92,7 +95,10 @@ class SocialCommentBreadcrumbBuilder implements BreadcrumbBuilderInterface {
     }
 
     // Add Caching.
-    if ($comment) {
+    if (
+      isset($comment) &&
+      $comment instanceof CommentInterface
+    ) {
       $breadcrumb->addCacheableDependency($comment);
     }
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -5556,11 +5556,6 @@ parameters:
 			path: modules/social_features/social_comment/src/Routing/RouteSubscriber.php
 
 		-
-			message: "#^Variable \\$comment might not be defined\\.$#"
-			count: 1
-			path: modules/social_features/social_comment/src/SocialCommentBreadcrumbBuilder.php
-
-		-
 			message: "#^Parameter \\#3 \\$mode of method Drupal\\\\comment\\\\CommentStorage\\:\\:loadThread\\(\\) expects int, string given\\.$#"
 			count: 1
 			path: modules/social_features/social_comment/src/SocialCommentLazyRenderer.php


### PR DESCRIPTION
## Problem
```
Warning: array_flip(): Can only flip STRING and INTEGER values! in Drupal\Core\Entity\EntityStorageBase->loadMultiple() (line 261 of core/lib/Drupal/Core/Entity/EntityStorageBase.php).

Drupal\Core\Entity\EntityStorageBase->loadMultiple(Array) (Line: 245)
Drupal\Core\Entity\EntityStorageBase->load(NULL) (Line: 65)
Drupal\social_comment\SocialCommentBreadcrumbBuilder->build(Object) (Line: 83)
Drupal\Core\Breadcrumb\BreadcrumbManager->build(Object) (Line: 72)
Drupal\system\Plugin\Block\SystemBreadcrumbBlock->build() (Line: 171)
Drupal\block\BlockViewBuilder::preRender(Array)
call_user_func_array(Array, Array) (Line: 101)
Drupal\Core\Render\Renderer->doTrustedCallback(Array, Array, 'Render #pre_render callbacks must be methods of a class that implements \Drupal\Core\Security\TrustedCallbackInterface or be an anonymous function. The callback was %s. See https://www.drupal.org/node/2966725', 'exception', 'Drupal\Core\Render\Element\RenderCallbackInterface') (Line: 786)
Drupal\Core\Render\Renderer->doCallback('#pre_render', Array, Array) (Line: 377)
Drupal\Core\Render\Renderer->doRender(Array) (Line: 449)
Drupal\Core\Render\Renderer->doRender(Array, ) (Line: 201)
Drupal\Core\Render\Renderer->render(Array) (Line: 450)
Drupal\Core\Template\TwigExtension->escapeFilter(Object, Array, 'html', NULL, 1) (Line: 62)
__TwigTemplate_88b32511e3f402479badaeca3328686a4e787c99541f5ad4f0ba0398c3fa5bbf->doDisplay(Array, Array) (Line: 405)
Twig\Template->displayWithErrorHandling(Array, Array) (Line: 378)
Twig\Template->display(Array, Array) (Line: 44)
__TwigTemplate_ebfef33d4986ea27554f25a4dcbc4c170589d6d06002e41372cc1f77a9d795aa->doDisplay(Array, Array) (Line: 405)
Twig\Template->displayWithErrorHandling(Array, Array) (Line: 378)
Twig\Template->display(Array) (Line: 390)
Twig\Template->render(Array) (Line: 65)
twig_render_template('themes/contrib/socialbase/templates/comment/page--comment--reply.html.twig', Array) (Line: 384)
Drupal\Core\Theme\ThemeManager->render('page', Array) (Line: 436)
Drupal\Core\Render\Renderer->doRender(Array, ) (Line: 201)
Drupal\Core\Render\Renderer->render(Array) (Line: 450)
Drupal\Core\Template\TwigExtension->escapeFilter(Object, Array, 'html', NULL, 1) (Line: 106)
__TwigTemplate_6fa6f966809902cebe17d165d5770d66dee6df7b7df2a52eefc414f311ab7967->doDisplay(Array, Array) (Line: 405)
Twig\Template->displayWithErrorHandling(Array, Array) (Line: 378)
Twig\Template->display(Array) (Line: 390)
Twig\Template->render(Array) (Line: 65)
twig_render_template('themes/contrib/socialbase/templates/system/html.html.twig', Array) (Line: 384)
Drupal\Core\Theme\ThemeManager->render('html', Array) (Line: 436)
Drupal\Core\Render\Renderer->doRender(Array, ) (Line: 201)
Drupal\Core\Render\Renderer->render(Array) (Line: 162)
Drupal\Core\Render\MainContent\HtmlRenderer->Drupal\Core\Render\MainContent\{closure}() (Line: 578)
Drupal\Core\Render\Renderer->executeInRenderContext(Object, Object) (Line: 163)
Drupal\Core\Render\MainContent\HtmlRenderer->renderResponse(Array, Object, Object) (Line: 90)
Drupal\Core\EventSubscriber\MainContentViewSubscriber->onViewRenderArray(Object, 'kernel.view', Object)
call_user_func(Array, Object, 'kernel.view', Object) (Line: 142)
Drupal\Component\EventDispatcher\ContainerAwareEventDispatcher->dispatch(Object, 'kernel.view') (Line: 163)
Symfony\Component\HttpKernel\HttpKernel->handleRaw(Object, 1) (Line: 80)
Symfony\Component\HttpKernel\HttpKernel->handle(Object, 1, 1) (Line: 57)
Drupal\Core\StackMiddleware\Session->handle(Object, 1, 1) (Line: 47)
Drupal\Core\StackMiddleware\KernelPreHandle->handle(Object, 1, 1) (Line: 106)
Drupal\page_cache\StackMiddleware\PageCache->pass(Object, 1, 1) (Line: 85)
Drupal\page_cache\StackMiddleware\PageCache->handle(Object, 1, 1) (Line: 47)
Drupal\Core\StackMiddleware\ReverseProxyMiddleware->handle(Object, 1, 1) (Line: 52)
Drupal\Core\StackMiddleware\NegotiationMiddleware->handle(Object, 1, 1) (Line: 23)
Stack\StackedHttpKernel->handle(Object, 1, 1) (Line: 717)
Drupal\Core\DrupalKernel->handle(Object) (Line: 19)
```

## Solution
At `SocialCommentBreadcrumbBuilder` before loading comment entity we should check $pid really exists.

## Issue tracker
- https://www.drupal.org/project/social/issues/3276411

## Theme issue tracker
N/A

## How to test
- [ ] Add constraint to `field_comment_body`
- [ ] Reply a post with validation error

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] If applicable (I.E. new hook_updates) the update path from previous versions (major and minor versions) are tested
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
N/A

## Release notes
N/A

## Change Record
N/A

## Translations
N/A