### PR TITLE
Issue #3232309 by navneet0693: Switched if-else condition in social_embed_post_update_11001_populate_field_embed_content_settings.

### DIFF
--- a/modules/social_features/social_embed/social_embed.post_update.php
+++ b/modules/social_features/social_embed/social_embed.post_update.php
@@ -8,16 +8,22 @@
 use Drupal\Core\Site\Settings;
 
 /**
- * Populate the default value in new field for already existing users.
+ * Empty post update hook.
  */
 function social_embed_post_update_11001_populate_field_embed_content_settings(array &$sandbox): void {
+  // Moved to 11002.
+}
+
+/**
+ * Populate the default value in new field for already existing users.
+ */
+function social_embed_post_update_11002_populate_field_embed_content_settings(array &$sandbox): void {
   // Even though we have provided 'field_user_embed_content_consent',
   // a default value of 1. This will only pre-fill for any newly created
   // users, but not already existing users.
   // We need populate the field value of newly added field for existing users.
   // @see social_embed_update_11002().
-  $all_bundle_fields = \Drupal::service('entity_field.manager')
-    ->getFieldDefinitions('user', 'user');
+  $all_bundle_fields = \Drupal::service('entity_field.manager')->getFieldDefinitions('user', 'user');
 
   // Proceed only if the new field is installed.
   if (isset($all_bundle_fields['field_user_embed_content_consent'])
@@ -34,16 +40,16 @@ function social_embed_post_update_11001_populate_field_embed_content_settings(ar
       if (!empty($query)) {
         // If 'count' is empty, we have nothing to process.
         if (!empty($uids = $query->fetchCol())) {
-          $sandbox['#finished'] = 1;
-          return;
-        }
-        else {
           // Let's store the user IDs and their count.
           $sandbox['uids'] = $uids;
           $sandbox['count'] = count($uids);
 
           // 'progress' will represent the current progress of our processing.
           $sandbox['progress'] = 0;
+        }
+        else {
+          $sandbox['#finished'] = 1;
+          return;
         }
       }
     }
@@ -77,6 +83,8 @@ function social_embed_post_update_11001_populate_field_embed_content_settings(ar
         )
         ->execute();
       $sandbox['progress']++;
+      \Drupal::messenger()
+        ->addMessage($uid . ' user processed.');
     }
 
     // Drupal’s Batch API will stop executing our update hook as soon as

--- a/modules/social_features/social_embed/social_embed.post_update.php
+++ b/modules/social_features/social_embed/social_embed.post_update.php
@@ -37,13 +37,36 @@ function social_embed_post_update_11002_populate_field_embed_content_settings(ar
         ->fields('u', ['uid'])
         ->condition('uid', '0', '>')
         ->execute();
-      if (!empty($query)) {
-        // If 'count' is empty, we have nothing to process.
-        if (!empty($uids = $query->fetchCol())) {
+
+      // If 'count' is empty, we have nothing to process.
+      if (!empty($query)
+        && !empty($uids = $query->fetchCol())
+      ) {
+
+        // As this feature was release in Open Social 11, and because we are
+        // moving this code to a new update, there can be a scenario where
+        // users might have already set their preferences. So, we don't want
+        // to process such uids to keep them safe.
+        $existing_uids_query = $database->select('user__field_user_embed_content_consent', 'ufu')
+          ->fields('ufu', ['entity_id'])
+          ->condition('entity_id', '0', '>')
+          ->execute();
+
+        if (!empty($existing_uids_query)
+          && !empty($existing_uids = $existing_uids_query->fetchCol())
+        ) {
+          $uids_diff = array_diff($uids, $existing_uids);
+
           // Let's store the user IDs and their count.
+          $sandbox['uids'] = $uids_diff;
+          $sandbox['count'] = count($uids_diff);
+        }
+        else {
           $sandbox['uids'] = $uids;
           $sandbox['count'] = count($uids);
+        }
 
+        if ($sandbox['count'] > 0) {
           // 'progress' will represent the current progress of our processing.
           $sandbox['progress'] = 0;
         }
@@ -51,6 +74,10 @@ function social_embed_post_update_11002_populate_field_embed_content_settings(ar
           $sandbox['#finished'] = 1;
           return;
         }
+      }
+      else {
+        $sandbox['#finished'] = 1;
+        return;
       }
     }
 
@@ -83,8 +110,6 @@ function social_embed_post_update_11002_populate_field_embed_content_settings(ar
         )
         ->execute();
       $sandbox['progress']++;
-      \Drupal::messenger()
-        ->addMessage($uid . ' user processed.');
     }
 
     // Drupal’s Batch API will stop executing our update hook as soon as


### PR DESCRIPTION
## Problem
The if condition was meant for executing the update in database but it was in-correctly written. So, if the conditions were true, it said Batch API that it has finished instead of doing the update. 

## Solution
Switch the if-else condition logic.

## Issue tracker
https://www.drupal.org/project/social/issues/3232309

## Theme issue tracker
N.A

## How to test
- [ ] Checkout to this branch
- [ ] Do a `drush updb -y`
- [ ] Check the values in table `user__field_user_embed_content_consent` after the update.
 
## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] If applicable (I.E. new hook_updates) the update path from previous versions (major and minor versions) are tested
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
N.A

## Release notes
We corrected an update that was meant to enable embed-consent for all users on existing platforms by default. This means that on an existing platform with social_embed module enabled, once the site manager enables the feature at `/admin/config/opensocial/embed-consent`, it will enable opt-in embed-consent option for all users automatically.

## Change Record
N.A

## Translations
N.A