### PR TITLE
Issue #3278347 by navneet0693: Junk plugin data can crash activity entity related view

### DIFF
--- a/modules/custom/activity_basics/activity_basics.module
+++ b/modules/custom/activity_basics/activity_basics.module
@@ -74,7 +74,8 @@ function activity_basics_social_group_move(NodeInterface $node): void {
  *   The instance.
  */
 function _activity_basics_entity_action(EntityInterface $entity, $instance): void {
-  \Drupal::service('plugin.manager.activity_action.processor')
-    ->createInstance($instance)
-    ->create($entity);
+  $plugin_mananger = \Drupal::service('plugin.manager.activity_action.processor');
+  if ($plugin_mananger->hasDefinition($instance)) {
+    $plugin_mananger->createInstance($instance)->create($entity);
+  }
 }

--- a/modules/custom/activity_creator/activity_creator.module
+++ b/modules/custom/activity_creator/activity_creator.module
@@ -102,53 +102,55 @@ function activity_creator_message_insert(Message $entity) {
 
       $context_plugin_manager = \Drupal::service('plugin.manager.activity_context.processor');
 
-      /** @var \Drupal\activity_creator\Plugin\ActivityContextBase $plugin */
-      $plugin = $context_plugin_manager->createInstance($data['context']);
-      $recipients = $plugin->getRecipients($data, $data['last_uid'], 0);
-      $user_recipients = [];
-      $activity_factory = \Drupal::service('activity_creator.activity_factory');
-      if (!empty($recipients)) {
-        // Default activity creator template.
-        $activity_creator_data = [
-          'mid' => $data['mid'],
-          'message_template' => $data['message_template'],
-          'actor' => $data['actor'],
-          'context' => $data['context'],
-          'destination' => $data['destination'],
-          'related_object' => $data['related_object'],
-        ];
+      if ($context_plugin_manager->hasDefinition($data['context'])) {
+        /** @var \Drupal\activity_creator\Plugin\ActivityContextBase $plugin */
+        $plugin = $context_plugin_manager->createInstance($data['context']);
+        $recipients = $plugin->getRecipients($data, $data['last_uid'], 0);
+        $user_recipients = [];
+        $activity_factory = \Drupal::service('activity_creator.activity_factory');
+        if (!empty($recipients)) {
+          // Default activity creator template.
+          $activity_creator_data = [
+            'mid' => $data['mid'],
+            'message_template' => $data['message_template'],
+            'actor' => $data['actor'],
+            'context' => $data['context'],
+            'destination' => $data['destination'],
+            'related_object' => $data['related_object'],
+          ];
 
-        // Get all the activity recipient types. Maintain target IDs as key.
-        $activity_by_type = array_column($recipients, 'target_type');
-        foreach ($activity_by_type as $recipients_key => $target_type) {
-          // For all one to one target entity types we create an activity.
-          if ($target_type !== 'user') {
-            $activity_creator_data['recipient'] = $recipients[$recipients_key];
+          // Get all the activity recipient types. Maintain target IDs as key.
+          $activity_by_type = array_column($recipients, 'target_type');
+          foreach ($activity_by_type as $recipients_key => $target_type) {
+            // For all one to one target entity types we create an activity.
+            if ($target_type !== 'user') {
+              $activity_creator_data['recipient'] = $recipients[$recipients_key];
+              $activity_factory->createActivities($activity_creator_data);
+            }
+
+            if ($target_type === 'user') {
+              $user_recipients[] = $recipients[$recipients_key];
+            }
+          }
+
+          // When the activity should be created for a one to many user entity
+          // we like to group these.
+          if (!empty($user_recipients)) {
+            $activity_creator_data['recipient'] = $user_recipients;
             $activity_factory->createActivities($activity_creator_data);
           }
-
-          if ($target_type === 'user') {
-            $user_recipients[] = $recipients[$recipients_key];
-          }
         }
-
-        // When the activity should be created for a one to many user entity
-        // we like to group these.
-        if (!empty($user_recipients)) {
-          $activity_creator_data['recipient'] = $user_recipients;
+        else {
+          $activity_creator_data = [
+            'mid' => $data['mid'],
+            'message_template' => $data['message_template'],
+            'actor' => $data['actor'],
+            'context' => $data['context'],
+            'destination' => $data['destination'],
+            'related_object' => $data['related_object'],
+          ];
           $activity_factory->createActivities($activity_creator_data);
         }
-      }
-      else {
-        $activity_creator_data = [
-          'mid' => $data['mid'],
-          'message_template' => $data['message_template'],
-          'actor' => $data['actor'],
-          'context' => $data['context'],
-          'destination' => $data['destination'],
-          'related_object' => $data['related_object'],
-        ];
-        $activity_factory->createActivities($activity_creator_data);
       }
     }
     else {

--- a/modules/custom/activity_creator/src/Plugin/QueueWorker/ActivityWorkerLogger.php
+++ b/modules/custom/activity_creator/src/Plugin/QueueWorker/ActivityWorkerLogger.php
@@ -40,63 +40,65 @@ class ActivityWorkerLogger extends ActivityWorkerBase {
     $limit = 0;
     // @todo Move all this logic to a service.
     $context_plugin_manager = \Drupal::service('plugin.manager.activity_context.processor');
+    if ($context_plugin_manager->hasDefinition($data['context'])) {
 
-    /** @var \Drupal\activity_creator\Plugin\ActivityContextBase $plugin */
-    // @todo Do we need multiple context plugins? If so should we call Manager?
-    $plugin = $context_plugin_manager->createInstance($data['context']);
-    $recipients = $plugin->getRecipients($data, $data['last_uid'], $limit);
+      /** @var \Drupal\activity_creator\Plugin\ActivityContextBase $plugin */
+      // @todo Do we need multiple context plugins? If so should we call Manager?
+      $plugin = $context_plugin_manager->createInstance($data['context']);
+      $recipients = $plugin->getRecipients($data, $data['last_uid'], $limit);
 
-    if (!empty($recipients)) {
-      // Default activity creator template.
-      $activity_creator_data = [
-        'mid' => $data['mid'],
-        'message_template' => $data['message_template'],
-        'actor' => $data['actor'],
-        'context' => $data['context'],
-        'destination' => $data['destination'],
-        'related_object' => $data['related_object'],
-      ];
+      if (!empty($recipients)) {
+        // Default activity creator template.
+        $activity_creator_data = [
+          'mid' => $data['mid'],
+          'message_template' => $data['message_template'],
+          'actor' => $data['actor'],
+          'context' => $data['context'],
+          'destination' => $data['destination'],
+          'related_object' => $data['related_object'],
+        ];
 
-      // Get all the activity recipient types. Maintain target IDs as key.
-      $activity_by_type = array_column($recipients, 'target_type');
-      foreach ($activity_by_type as $recipients_key => $target_type) {
-        // For all one to one target entity types we create an activity.
-        if ($target_type !== 'user') {
-          $activity_creator_data['recipient'] = $recipients[$recipients_key];
+        // Get all the activity recipient types. Maintain target IDs as key.
+        $activity_by_type = array_column($recipients, 'target_type');
+        foreach ($activity_by_type as $recipients_key => $target_type) {
+          // For all one to one target entity types we create an activity.
+          if ($target_type !== 'user') {
+            $activity_creator_data['recipient'] = $recipients[$recipients_key];
+            $this->createQueueItem('activity_creator_activities', $activity_creator_data);
+          }
+
+          if ($target_type === 'user') {
+            $user_recipients[] = $recipients[$recipients_key];
+          }
+          $last_uid = $recipients[$recipients_key];
+        }
+
+        // When the activity should be created for a one to many user entity
+        // we like to group these.
+        if (!empty($user_recipients)) {
+          $activity_creator_data['recipient'] = $user_recipients;
           $this->createQueueItem('activity_creator_activities', $activity_creator_data);
         }
 
-        if ($target_type === 'user') {
-          $user_recipients[] = $recipients[$recipients_key];
+        // Now create new queue item for activity_creator_logger if necessary.
+        if ($limit !== 0 && isset($last_uid) && count($recipients) >= $limit) {
+          $data['last_uid'] = $last_uid;
+          $data['status'] = 'processing';
+          $this->createQueueItem('activity_creator_logger', $data);
         }
-        $last_uid = $recipients[$recipients_key];
       }
-
-      // When the activity should be created for a one to many user entity
-      // we like to group these.
-      if (!empty($user_recipients)) {
-        $activity_creator_data['recipient'] = $user_recipients;
+      else {
+        $activity_creator_data = [
+          'mid' => $data['mid'],
+          'message_template' => $data['message_template'],
+          'actor' => $data['actor'],
+          // Not necessary?
+          'context' => $data['context'],
+          'destination' => $data['destination'],
+          'related_object' => $data['related_object'],
+        ];
         $this->createQueueItem('activity_creator_activities', $activity_creator_data);
       }
-
-      // Now create new queue item for activity_creator_logger if necessary.
-      if ($limit !== 0 && isset($last_uid) && count($recipients) >= $limit) {
-        $data['last_uid'] = $last_uid;
-        $data['status'] = 'processing';
-        $this->createQueueItem('activity_creator_logger', $data);
-      }
-    }
-    else {
-      $activity_creator_data = [
-        'mid' => $data['mid'],
-        'message_template' => $data['message_template'],
-        'actor' => $data['actor'],
-        // Not necessary?
-        'context' => $data['context'],
-        'destination' => $data['destination'],
-        'related_object' => $data['related_object'],
-      ];
-      $this->createQueueItem('activity_creator_activities', $activity_creator_data);
     }
 
   }

--- a/modules/custom/activity_logger/src/Plugin/QueueWorker/MessageQueueCreator.php
+++ b/modules/custom/activity_logger/src/Plugin/QueueWorker/MessageQueueCreator.php
@@ -81,9 +81,11 @@ class MessageQueueCreator extends MessageQueueBase implements ContainerFactoryPl
         $this->createQueueItem('activity_logger_message', $data);
       }
       else {
-        // Trigger the create action for enttites.
-        $create_action = $this->actionManager->createInstance('create_entitiy_action');
-        $create_action->createMessage($entity);
+        // Trigger the create action for entities.
+        if ($this->actionManager->hasDefinition('create_entitiy_action')) {
+          $create_action = $this->actionManager->createInstance('create_entitiy_action');
+          $create_action->createMessage($entity);
+        }
       }
     }
   }

--- a/modules/custom/activity_logger/src/Service/ActivityLoggerFactory.php
+++ b/modules/custom/activity_logger/src/Service/ActivityLoggerFactory.php
@@ -169,7 +169,9 @@ class ActivityLoggerFactory {
       $mt_destinations = $messagetype->getThirdPartySetting('activity_logger', 'activity_destinations', NULL);
       $mt_entity_condition = $messagetype->getThirdPartySetting('activity_logger', 'activity_entity_condition', NULL);
 
-      if (!empty($mt_entity_condition)) {
+      if (!empty($mt_entity_condition)
+        && $this->activityEntityConditionManager->hasDefinition($mt_entity_condition)
+      ) {
         $entity_condition_plugin = $this->activityEntityConditionManager->createInstance($mt_entity_condition);
         $entity_condition = $entity_condition_plugin->isValidEntityCondition($entity);
       }
@@ -177,20 +179,22 @@ class ActivityLoggerFactory {
         $entity_condition = TRUE;
       }
 
-      $context_plugin = $this->activityContextManager->createInstance($mt_context);
+      if ($this->activityContextManager->hasDefinition($mt_context)) {
+        $context_plugin = $this->activityContextManager->createInstance($mt_context);
 
-      $entity_bundle_name = $entity->getEntityTypeId() . '-' . $entity->bundle();
-      if (in_array($entity_bundle_name, $mt_entity_bundles)
-        && $context_plugin->isValidEntity($entity)
-        && $entity_condition
-        && $action === $mt_action
-      ) {
-        $messagetypes[$key] = [
-          'messagetype' => $messagetype,
-          'bundle' => $entity_bundle_name,
-          'destinations' => $mt_destinations,
-          'context' => $mt_context,
-        ];
+        $entity_bundle_name = $entity->getEntityTypeId() . '-' . $entity->bundle();
+        if (in_array($entity_bundle_name, $mt_entity_bundles)
+          && $context_plugin->isValidEntity($entity)
+          && $entity_condition
+          && $action === $mt_action
+        ) {
+          $messagetypes[$key] = [
+            'messagetype' => $messagetype,
+            'bundle' => $entity_bundle_name,
+            'destinations' => $mt_destinations,
+            'context' => $mt_context,
+          ];
+        }
       }
     }
     // Return the message types that belong to the requested action.

--- a/modules/custom/activity_send/modules/activity_send_email/activity_send_email.module
+++ b/modules/custom/activity_send/modules/activity_send_email/activity_send_email.module
@@ -302,9 +302,11 @@ function activity_send_email_activity_insert(ActivityInterface $activity) {
   $activity_send_factory = \Drupal::service('plugin.manager.activity_send.processor');
 
   // Trigger the create action for entities.
-  /** @var \Drupal\activity_send_email\Plugin\ActivitySend\EmailActivitySend $create_action */
-  $create_action = $activity_send_factory->createInstance('email_activity_send');
-  $create_action->process($activity);
+  if ($activity_send_factory->hasDefinition('email_activity_send')) {
+    /** @var \Drupal\activity_send_email\Plugin\ActivitySend\EmailActivitySend $create_action */
+    $create_action = $activity_send_factory->createInstance('email_activity_send');
+    $create_action->process($activity);
+  }
 }
 
 /**

--- a/modules/custom/activity_send/modules/activity_send_email/src/Plugin/AdvancedQueue/JobType/ActivitySendEmailJobType.php
+++ b/modules/custom/activity_send/modules/activity_send_email/src/Plugin/AdvancedQueue/JobType/ActivitySendEmailJobType.php
@@ -306,8 +306,10 @@ class ActivitySendEmailJobType extends JobTypeBase implements ContainerFactoryPl
               );
             }
             // Send item to EmailFrequency instance.
-            $instance = $this->frequencyManager->createInstance($parameters['frequency']);
-            $instance->processItem($parameters['activity'], $parameters['message'], $target_account, $body_text);
+            if ($this->frequencyManager->hasDefinition($parameters['frequency'])) {
+              $instance = $this->frequencyManager->createInstance($parameters['frequency']);
+              $instance->processItem($parameters['activity'], $parameters['message'], $target_account, $body_text);
+            }
           }
         }
       }

--- a/modules/custom/activity_send/modules/activity_send_email/src/Plugin/QueueWorker/ActivitySendEmailWorker.php
+++ b/modules/custom/activity_send/modules/activity_send_email/src/Plugin/QueueWorker/ActivitySendEmailWorker.php
@@ -312,9 +312,12 @@ class ActivitySendEmailWorker extends ActivitySendWorkerBase implements Containe
                 $target_account->getPreferredLangcode()
               );
             }
-            // Send item to EmailFrequency instance.
-            $instance = $this->frequencyManager->createInstance($parameters['frequency']);
-            $instance->processItem($parameters['activity'], $parameters['message'], $target_account, $body_text);
+
+            if ($this->frequencyManager->hasDefinition($parameters['frequency'])) {
+              // Send item to EmailFrequency instance.
+              $instance = $this->frequencyManager->createInstance($parameters['frequency']);
+              $instance->processItem($parameters['activity'], $parameters['message'], $target_account, $body_text);
+            }
           }
         }
       }

--- a/modules/custom/activity_viewer/src/Plugin/views/row/ActivityRow.php
+++ b/modules/custom/activity_viewer/src/Plugin/views/row/ActivityRow.php
@@ -83,10 +83,12 @@ class ActivityRow extends EntityRow {
         $entity = $row->_entity;
 
         foreach ($entity->field_activity_destinations as $destination) {
-          /** @var \Drupal\activity_creator\Plugin\ActivityDestinationBase $plugin */
-          $plugin = $this->activityDestinationManager->createInstance($destination->value);
-          if ($plugin->isActiveInView($this->view)) {
-            $this->options['view_mode'] = $plugin->getViewMode($view_mode, $entity);
+          if ($this->activityDestinationManager->hasDefinition($destination->value)) {
+            /** @var \Drupal\activity_creator\Plugin\ActivityDestinationBase $plugin */
+            $plugin = $this->activityDestinationManager->createInstance($destination->value);
+            if ($plugin->isActiveInView($this->view)) {
+              $this->options['view_mode'] = $plugin->getViewMode($view_mode, $entity);
+            }
           }
         }
         $this->getEntityTranslationRenderer()->preRender($render_result);

--- a/modules/custom/social_queue_storage/social_queue_storage.module
+++ b/modules/custom/social_queue_storage/social_queue_storage.module
@@ -13,9 +13,10 @@ use Drupal\Core\Entity\EntityInterface;
 function social_queue_storage_entity_update(EntityInterface $entity) {
   /** @var \Drupal\social_queue_storage\Entity\QueueStorageEntity $entity */
   if ($entity->getEntityTypeId() === 'queue_storage_entity') {
-    \Drupal::service('plugin.manager.activity_action.processor')
-      ->createInstance('update_entity_action')
-      ->create($entity);
+    $plugin_manager = \Drupal::service('plugin.manager.activity_action.processor');
+    if ($plugin_manager->hasDefinition('update_entity_action')) {
+      $plugin_manager->createInstance('update_entity_action')->create($entity);
+    }
   }
 }
 

--- a/modules/social_features/social_content_block/social_content_block.install
+++ b/modules/social_features/social_content_block/social_content_block.install
@@ -514,9 +514,12 @@ function social_content_block_update_10302(&$sandbox) {
     $sort_by = $entity->field_sorting->getValue()[0]['value'];
 
     if ($sort_by !== $sandbox['sort_by']) {
+      $settings = NULL;
       $plugin_id = $entity->field_plugin_id->getValue()[0]['value'];
-      $plugin = $manager->createInstance($plugin_id);
-      $settings = $plugin->supportedSortOptions()[$sort_by];
+      if ($manager->hasDefinition($plugin_id)) {
+        $plugin = $manager->createInstance($plugin_id);
+        $settings = $plugin->supportedSortOptions()[$sort_by];
+      }
 
       if (is_array($settings) && isset($settings['limit']) && !$settings['limit']) {
         $sandbox['duration'] = NULL;

--- a/modules/social_features/social_content_block/social_content_block.module
+++ b/modules/social_features/social_content_block/social_content_block.module
@@ -182,10 +182,11 @@ function _social_content_block_allowed_values_callback(FieldStorageDefinitionInt
   }
 
   foreach ($plugin_ids as $plugin_id) {
-    $plugin = $manager->createInstance($plugin_id);
-
-    foreach ($plugin->supportedSortOptions() as $name => $settings) {
-      $values[$name] = is_array($settings) ? $settings['label'] : $settings;
+    if ($manager->hasDefinition($plugin_id)) {
+      $plugin = $manager->createInstance($plugin_id);
+      foreach ($plugin->supportedSortOptions() as $name => $settings) {
+        $values[$name] = is_array($settings) ? $settings['label'] : $settings;
+      }
     }
   }
 

--- a/modules/social_features/social_content_block/src/ContentBuilder.php
+++ b/modules/social_features/social_content_block/src/ContentBuilder.php
@@ -86,95 +86,95 @@ class ContentBuilder implements ContentBuilderInterface {
       ->load($block_id);
 
     $plugin_id = $block_content->field_plugin_id->getValue()[0]['value'];
-    $definition = $this->contentBlockManager->getDefinition($plugin_id);
-
-    // When the user didn't select any filter in the "Content selection" field
-    // then the block base query will be built based on all filled filterable
-    // fields.
-    if (($field = $block_content->field_plugin_field)->isEmpty()) {
-      // It could be that the plugin supports more fields than are currently
-      // available, those are removed.
-      $field_names = array_filter(
-        $definition['fields'],
-        static function ($field_name) use ($block_content) {
-          return $block_content->hasField($field_name);
-        }
-      );
-    }
-    // When the user selected some filter in the "Content selection" field then
-    // only condition based on this filter field will be added to the block base
-    // query.
-    else {
-      $field_names = array_column($field->getValue(), 'value');
-    }
-
-    $fields = [];
-
-    foreach ($field_names as $field_name) {
-      $field = $block_content->get($field_name);
-
-      if (!$field->isEmpty()) {
-        $fields[$field_name] = $field->getValue();
-
-        // Make non-empty entity reference fields easier to use.
-        if ($field instanceof EntityReferenceFieldItemListInterface) {
-          $fields[$field_name] = array_column($fields[$field_name], 'target_id');
-        }
-      }
-    }
-
-    /** @var \Drupal\Core\Entity\EntityTypeInterface $entity_type */
-    $entity_type = $this->entityTypeManager->getDefinition($definition['entityTypeId']);
-
-    $table = $entity_type->getDataTable();
-    if (!empty($table) && is_string($table)) {
-      $query = $this->connection->select($table, 'base_table')
-        ->addTag('social_content_block')
-        ->addMetaData('block_content', $block_content)
-        ->fields('base_table', [$entity_type->getKey('id')]);
-
-      if (isset($definition['bundle'])) {
-        $query->condition(
-          'base_table.' . $entity_type->getKey('bundle'),
-          $definition['bundle']
+    if ($definition = $this->contentBlockManager->getDefinition($plugin_id)) {
+      // When the user didn't select any filter in the "Content selection" field
+      // then the block base query will be built based on all filled filterable
+      // fields.
+      if (($field = $block_content->field_plugin_field)->isEmpty()) {
+        // It could be that the plugin supports more fields than are currently
+        // available, those are removed.
+        $field_names = array_filter(
+          $definition['fields'],
+          static function ($field_name) use ($block_content) {
+            return $block_content->hasField($field_name);
+          }
         );
       }
-
-      $plugin = $this->contentBlockManager->createInstance($plugin_id);
-
-      if ($fields) {
-        $plugin->query($query, $fields);
+      // When the user selected some filter in the "Content selection" field
+      // then only condition based on this filter field will be added to the
+      // block base query.
+      else {
+        $field_names = array_column($field->getValue(), 'value');
       }
 
-      // Apply our sorting logic.
-      $this->sortBy($query, $entity_type, $block_content, $plugin->supportedSortOptions());
+      $fields = [];
 
-      // Add range.
-      $query->range(0, $block_content->field_item_amount->value);
+      foreach ($field_names as $field_name) {
+        $field = $block_content->get($field_name);
 
-      // Execute the query to get the results.
-      $result = $query->execute();
-      $entities = $result !== NULL ? $result->fetchAllKeyed(0, 0) : NULL;
+        if (!$field->isEmpty()) {
+          $fields[$field_name] = $field->getValue();
 
-      if ($entities) {
-        // Load all the topics so we can give them back.
-        $entities = $this->entityTypeManager
-          ->getStorage($definition['entityTypeId'])
-          ->loadMultiple($entities);
-
-        foreach ($entities as $key => $entity) {
-          if ($entity->access('view') === FALSE) {
-            unset($entities[$key]);
-          }
-          else {
-            // Get entity translation if exists.
-            $entities[$key] = $this->entityRepository->getTranslationFromContext($entity);
+          // Make non-empty entity reference fields easier to use.
+          if ($field instanceof EntityReferenceFieldItemListInterface) {
+            $fields[$field_name] = array_column($fields[$field_name], 'target_id');
           }
         }
+      }
 
-        return $this->entityTypeManager
-          ->getViewBuilder($definition['entityTypeId'])
-          ->viewMultiple($entities, 'small_teaser');
+      /** @var \Drupal\Core\Entity\EntityTypeInterface $entity_type */
+      $entity_type = $this->entityTypeManager->getDefinition($definition['entityTypeId']);
+
+      $table = $entity_type->getDataTable();
+      if (!empty($table) && is_string($table)) {
+        $query = $this->connection->select($table, 'base_table')
+          ->addTag('social_content_block')
+          ->addMetaData('block_content', $block_content)
+          ->fields('base_table', [$entity_type->getKey('id')]);
+
+        if (isset($definition['bundle'])) {
+          $query->condition(
+            'base_table.' . $entity_type->getKey('bundle'),
+            $definition['bundle']
+          );
+        }
+
+        $plugin = $this->contentBlockManager->createInstance($plugin_id);
+
+        if ($fields) {
+          $plugin->query($query, $fields);
+        }
+
+        // Apply our sorting logic.
+        $this->sortBy($query, $entity_type, $block_content, $plugin->supportedSortOptions());
+
+        // Add range.
+        $query->range(0, $block_content->field_item_amount->value);
+
+        // Execute the query to get the results.
+        $result = $query->execute();
+        $entities = $result !== NULL ? $result->fetchAllKeyed(0, 0) : NULL;
+
+        if ($entities) {
+          // Load all the topics so we can give them back.
+          $entities = $this->entityTypeManager
+            ->getStorage($definition['entityTypeId'])
+            ->loadMultiple($entities);
+
+          foreach ($entities as $key => $entity) {
+            if ($entity->access('view') === FALSE) {
+              unset($entities[$key]);
+            }
+            else {
+              // Get entity translation if exists.
+              $entities[$key] = $this->entityRepository->getTranslationFromContext($entity);
+            }
+          }
+
+          return $this->entityTypeManager
+            ->getViewBuilder($definition['entityTypeId'])
+            ->viewMultiple($entities, 'small_teaser');
+        }
       }
     }
 

--- a/modules/social_features/social_event/modules/social_event_addtocal/social_event_addtocal.module
+++ b/modules/social_features/social_event/modules/social_event_addtocal/social_event_addtocal.module
@@ -87,30 +87,30 @@ function _social_event_addtocal_get_links(NodeInterface $node) {
   // Get allowed calendars.
   $allowed_calendars = $addtocal_config->get('allowed_calendars');
 
-  // Set links for dropdown.
-  foreach ($allowed_calendars as $allowed_calendar) {
-    // Check if calendar plugin enabled in config.
-    if ($allowed_calendar) {
-      /** @var \Drupal\social_event_addtocal\Plugin\SocialAddToCalendarInterface $calendar */
-      $calendar = $social_add_to_calendar->createInstance($allowed_calendar);
+  if (is_array($allowed_calendars)) {
+    // Set links for dropdown.
+    foreach ($allowed_calendars as $allowed_calendar) {
+      // Check if calendar plugin enabled in config.
+      if ($social_add_to_calendar->hasDefinition($allowed_calendar)) {
+        /** @var \Drupal\social_event_addtocal\Plugin\SocialAddToCalendarInterface $calendar */
+        $calendar = $social_add_to_calendar->createInstance($allowed_calendar);
 
-      // Exit if calendar plugin nor exist.
-      if (!$calendar instanceof SocialAddToCalendarInterface) {
-        continue;
+        // Exit if calendar plugin nor exist.
+        if (!$calendar instanceof SocialAddToCalendarInterface) {
+          continue;
+        }
+
+        // Set link for plugin instance.
+        $links[] = [
+          'title' => $calendar->getName(),
+          'url' => $calendar->generateUrl($node),
+        ];
       }
-
-      // Set link for plugin instance.
-      $links[] = [
-        'title' => $calendar->getName(),
-        'url' => $calendar->generateUrl($node),
-      ];
+    }
+    // Change title if only one calendar enabled.
+    if (count($links) === 1) {
+      $links[0]['title'] = t('Add to Calendar');
     }
   }
-
-  // Change title if only one calendar enabled.
-  if (count($links) === 1) {
-    $links[0]['title'] = t('Add to Calendar');
-  }
-
   return $links;
 }

--- a/modules/social_features/social_event/modules/social_event_managers/src/Plugin/views/field/SocialEventManagersViewsBulkOperationsBulkForm.php
+++ b/modules/social_features/social_event/modules/social_event_managers/src/Plugin/views/field/SocialEventManagersViewsBulkOperationsBulkForm.php
@@ -442,14 +442,15 @@ class SocialEventManagersViewsBulkOperationsBulkForm extends ViewsBulkOperations
     // Load each action and check the access.
     foreach ($bulkOptions as $id => $name) {
       $action_id = $this->options['selected_actions'][$id]['action_id'];
-      /** @var \Drupal\Core\Action\ActionInterface $action */
-      $action = $this->actionManager->createInstance($action_id);
-
-      // Check the access.
-      /** @var bool $access */
-      $access = $action->access($eventEnrollment, $this->currentUser);
-      if (!$access) {
-        unset($bulkOptions[$id]);
+      if ($this->actionManager->hasDefinition($action_id)) {
+        /** @var \Drupal\Core\Action\ActionInterface $action */
+        $action = $this->actionManager->createInstance($action_id);
+        // Check the access.
+        /** @var bool $access */
+        $access = $action->access($eventEnrollment, $this->currentUser);
+        if (!$access) {
+          unset($bulkOptions[$id]);
+        }
       }
     }
 

--- a/modules/social_features/social_follow_taxonomy/modules/social_follow_tag/social_follow_tag.module
+++ b/modules/social_features/social_follow_taxonomy/modules/social_follow_tag/social_follow_tag.module
@@ -227,9 +227,12 @@ function social_follow_tag_entity_update(EntityInterface $entity) {
 
     // Create activity notification.
     if (!empty($taxonomy_ids)) {
-      \Drupal::service('plugin.manager.activity_action.processor')
-        ->createInstance('update_entity_action')
-        ->create($entity);
+      $plugin_manager = \Drupal::service('plugin.manager.activity_action.processor');
+      if ($plugin_manager->hasDefinition('update_entity_action')) {
+        $plugin_manager
+          ->createInstance('update_entity_action')
+          ->create($entity);
+      }
     }
   }
 }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -4426,17 +4426,17 @@ parameters:
 			path: modules/social_features/social_activity/social_activity.module
 
 		-
-			message: "#^Function social_activity_social_core_default_main_menu_links_alter\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: modules/social_features/social_activity/social_activity.module
-
-		-
 			message: "#^Function social_activity_preprocess_block\\(\\) has parameter \\$variables with no type specified\\.$#"
 			count: 1
 			path: modules/social_features/social_activity/social_activity.module
 
 		-
 			message: "#^Function social_activity_social_account_notifications_counter\\(\\) never returns void so it can be removed from the return type\\.$#"
+			count: 1
+			path: modules/social_features/social_activity/social_activity.module
+
+		-
+			message: "#^Function social_activity_social_core_default_main_menu_links_alter\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: modules/social_features/social_activity/social_activity.module
 
@@ -6646,6 +6646,11 @@ parameters:
 			path: modules/social_features/social_core/social_core.module
 
 		-
+			message: "#^Function _social_core_default_main_menu_links\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: modules/social_features/social_core/social_core.module
+
+		-
 			message: "#^Function _social_core_node_cancel\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: modules/social_features/social_core/social_core.module
@@ -6681,6 +6686,11 @@ parameters:
 			path: modules/social_features/social_core/social_core.module
 
 		-
+			message: "#^Function social_core_entity_access\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: modules/social_features/social_core/social_core.module
+
+		-
 			message: "#^Function social_core_entity_form_display_alter\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: modules/social_features/social_core/social_core.module
@@ -6707,6 +6717,11 @@ parameters:
 
 		-
 			message: "#^Function social_core_filter_process_format\\(\\) has parameter \\$element with no type specified\\.$#"
+			count: 1
+			path: modules/social_features/social_core/social_core.module
+
+		-
+			message: "#^Function social_core_form_menu_edit_form_alter\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: modules/social_features/social_core/social_core.module
 
@@ -6872,21 +6887,6 @@ parameters:
 
 		-
 			message: "#^Function social_core_theme_registry_alter\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: modules/social_features/social_core/social_core.module
-
-		-
-			message: "#^Function _social_core_default_main_menu_links\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: modules/social_features/social_core/social_core.module
-
-		-
-			message: "#^Function social_core_form_menu_edit_form_alter\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: modules/social_features/social_core/social_core.module
-
-		-
-			message: "#^Function social_core_entity_access\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: modules/social_features/social_core/social_core.module
 
@@ -9350,11 +9350,6 @@ parameters:
 			path: modules/social_features/social_event/social_event.module
 
 		-
-			message: "#^Function social_event_social_core_default_main_menu_links_alter\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: modules/social_features/social_event/social_event.module
-
-		-
 			message: "#^Function social_event_date_after_build\\(\\) has parameter \\$form with no type specified\\.$#"
 			count: 1
 			path: modules/social_features/social_event/social_event.module
@@ -9536,6 +9531,11 @@ parameters:
 
 		-
 			message: "#^Function social_event_social_core_block_visibility_path\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: modules/social_features/social_event/social_event.module
+
+		-
+			message: "#^Function social_event_social_core_default_main_menu_links_alter\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: modules/social_features/social_event/social_event.module
 
@@ -12655,11 +12655,6 @@ parameters:
 			path: modules/social_features/social_group/social_group.module
 
 		-
-			message: "#^Function social_group_social_core_default_main_menu_links_alter\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: modules/social_features/social_group/social_group.module
-
-		-
 			message: "#^Function _social_group_grant_admin_role\\(\\) has parameter \\$gid with no type specified\\.$#"
 			count: 1
 			path: modules/social_features/social_group/social_group.module
@@ -12966,6 +12961,11 @@ parameters:
 
 		-
 			message: "#^Function social_group_save_group_from_node\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: modules/social_features/social_group/social_group.module
+
+		-
+			message: "#^Function social_group_social_core_default_main_menu_links_alter\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: modules/social_features/social_group/social_group.module
 
@@ -15440,7 +15440,7 @@ parameters:
 			path: modules/social_features/social_post/src/Plugin/Block/PostBlock.php
 
 		-
-			message: "#^Call to an undefined method Drupal\\\\Core\\\\Access\\\\AccessResultInterface\\:\\:addCacheContexts\\(\\).$#"
+			message: "#^Call to an undefined method Drupal\\\\Core\\\\Access\\\\AccessResultInterface\\:\\:addCacheContexts\\(\\)\\.$#"
 			count: 1
 			path: modules/social_features/social_post/src/Plugin/Block/PostGroupBlock.php
 
@@ -17225,11 +17225,6 @@ parameters:
 			path: modules/social_features/social_profile/social_profile.module
 
 		-
-			message: "#^Function social_profile_social_core_default_main_menu_links_alter\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: modules/social_features/social_profile/social_profile.module
-
-		-
 			message: "#^Function social_profile_form_user_form_alter\\(\\) has parameter \\$form with no type specified\\.$#"
 			count: 1
 			path: modules/social_features/social_profile/social_profile.module
@@ -17331,6 +17326,11 @@ parameters:
 
 		-
 			message: "#^Function social_profile_profile_view_alter\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: modules/social_features/social_profile/social_profile.module
+
+		-
+			message: "#^Function social_profile_social_core_default_main_menu_links_alter\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: modules/social_features/social_profile/social_profile.module
 
@@ -18340,11 +18340,6 @@ parameters:
 			path: modules/social_features/social_topic/social_topic.module
 
 		-
-			message: "#^Function social_topic_social_core_default_main_menu_links_alter\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: modules/social_features/social_topic/social_topic.module
-
-		-
 			message: "#^Function social_topic_allowed_values_function\\(\\) has parameter \\$cacheable with no type specified\\.$#"
 			count: 1
 			path: modules/social_features/social_topic/social_topic.module
@@ -18431,6 +18426,11 @@ parameters:
 
 		-
 			message: "#^Function social_topic_preprocess_node\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: modules/social_features/social_topic/social_topic.module
+
+		-
+			message: "#^Function social_topic_social_core_default_main_menu_links_alter\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: modules/social_features/social_topic/social_topic.module
 


### PR DESCRIPTION
## Problem

Certain scenarios like:

    1. configuration overrides
    2. undefensive code
    3. uninstalled modules not cleaning it's related data at the time of uninstalling

can lead to orphaned and/or junk data in entities in database. 

Sometimes the modules which are uninstalled may contain plugins and configuration overrides which can lead to the storage of unrequired data in the database. Also, on removal, these modules may not be related data from the database which leads to junk data.

These orphaned data crash pages and other views or blocks that render the "Activity" entity, for example.
    
A module declaring a plugin instance and attaching that instance with entities, for example, activities, was uninstalled; but during uninstall it didn't cleaned it's related data from activities. This will lead to PluginNotFoundException being thrown on the pages where activities are being processed. For example, home page, stream pages, group streams, notifications etc.

For example,

If there is a module that introduces an "ActivityDestination" plugin and activities containing that destination in the database. Upon uninstall, if the module doesn't cleans the data, then it will lead to PluginNotFoundException


## Solution
Make sure that before creating an instance of a plugin whose the plugin manager which extends 'DefaultPluginManager' class, we check that the plugin definition exists and it is successful in retrieving it without any errors.

    The hasDefinition function is defined as follows:
```

    public function hasDefinition($plugin_id) {
        return (bool) $this->getDefinition($plugin_id, FALSE);
    }

```
    which means that it is marking $exception_on_invalid parameter to be false, which simply says "If TRUE, an invalid plugin ID will throw an exception."

    now hasDefinition simply returns false in this logic if the plugin definition couldn't be found. This saves us from hard errors and we can safely say that call to "createInstance" will return a plugin instance.

## Issue tracker
https://www.drupal.org/project/social/issues/3278347

## Theme issue tracker
N.A

## How to test
- [ ] Perform general operations on Open Social installation.
- [ ] Check if notifications, emails and activities are being created.

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] If applicable (I.E. new hook_updates) the update path from previous versions (major and minor versions) are tested
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
N.A

## Release notes
N.A

## Change Record
N.A

## Translations
N.A