### PR TITLE
Issue #3278469 by alex.ksis: Force adding #process and #pre_render callbacks for the social_tagging views filters.

### DIFF
--- a/modules/social_features/social_tagging/social_tagging.info.yml
+++ b/modules/social_features/social_tagging/social_tagging.info.yml
@@ -8,3 +8,4 @@ dependencies:
   - drupal:taxonomy
   - social:social_core
   - social:social_search
+  - select2:select2

--- a/modules/social_features/social_tagging/social_tagging.module
+++ b/modules/social_features/social_tagging/social_tagging.module
@@ -18,6 +18,7 @@ use Drupal\taxonomy\Entity\Term;
 use Drupal\Core\Database\Database;
 use Drupal\views\Plugin\views\query\QueryPluginBase;
 use Drupal\views\ViewExecutable;
+use Drupal\select2\Element\Select2;
 
 /**
  * Implements hook_help().
@@ -521,6 +522,18 @@ function social_tagging_form_views_exposed_form_alter(&$form, FormStateInterface
         $form[$label]['#options'] += $tag_service->getChildren($tid);
         $form[$label]['#type'] = 'select2';
         $form[$label]['#size'] = NULL;
+
+        if (isset($form[$label]['#context']['#plugin_type']) && $form[$label]['#context']['#plugin_type'] == 'bef') {
+          $form[$label]['#select2'] = [];
+          $form[$label]['#process'] = [
+            [Select2::class, 'processSelect'],
+          ];
+          $form[$label]['#pre_render'] = [
+            [Select2::class, 'preRenderSelect'],
+            [Select2::class, 'preRenderAutocomplete'],
+            [Select2::class, 'preRenderOverwrites'],
+          ];
+        }
 
         /** @var \Symfony\Component\HttpFoundation\ParameterBag $query */
         $query = \Drupal::request()->query;


### PR DESCRIPTION
## Problem
The select2 plugin is not attached to the views filters provided by the social_tagging module if they are rendered using BEF.
If we just change the widget #type to select2, it won't work because these widgets will be rendered by the BEF plugin which adds the default #process and #pre_render callbacks.

## Solution
In order to solve it, we need to force adding the correct callbacks which are provided by the select2 module.

## Issue tracker
Drupal.org issue: https://www.drupal.org/project/social/issues/3278469
Jira ticket: https://getopensocial.atlassian.net/browse/YANG-7506

## How to test
- [ ] Install the social_tagging module. The default configuration will be enough.
- [ ] Create a few tags on the /admin/structure/taxonomy/manage/social_tagging/add.
- [ ] Create a node and add a few tags to it. Make sure it is published so that we will see it in the search results.
- [ ] Go to the /search/content. You should see a new filter with the tags you've created before.
- [ ] Make sure this filter is rendered using the select2 plugin, like on the second screenshot.

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] If applicable (I.E. new hook_updates) the update path from previous versions (major and minor versions) are tested
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
<img width="431" alt="image" src="https://user-images.githubusercontent.com/4526828/166667719-564204d6-cfdc-43a2-aa9d-4b0ea809f155.png">

<img width="436" alt="image" src="https://user-images.githubusercontent.com/4526828/166667664-4d026583-6185-4dbc-b4d5-37fd09f6de04.png">


## Release notes
Made social tagging filters compatible with Select2 and Better exposed filters.

