### PR TITLE
Issue #3278697 by SV: Fix a bug with profile preview on the Inbox page and disable it in notification popup

### DIFF
--- a/modules/social_features/social_profile/modules/social_profile_preview/social_profile_preview.module
+++ b/modules/social_features/social_profile/modules/social_profile_preview/social_profile_preview.module
@@ -8,6 +8,7 @@
 use Drupal\Core\Entity\Display\EntityViewDisplayInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityTypeInterface;
+use Drupal\profile\Entity\ProfileInterface;
 use Drupal\Core\Template\Attribute;
 use Drupal\Core\Url;
 
@@ -65,8 +66,42 @@ function social_profile_preview_preprocess_field__field_activity_output_text(arr
 /**
  * Implements hook_preprocess_HOOK().
  */
+function social_profile_preview_preprocess_profile__profile__name_raw(array &$variables): void {
+  if ($variables['profile'] instanceof ProfileInterface) {
+    /** @var Drupal\profile\Entity\ProfileInterface $profile */
+    $profile = $variables['profile'];
+
+    // Get & attach modal attributes.
+    \Drupal::service('social_profile_preview.helper')
+      ->alter($profile, $variables, 'temp_attributes');
+
+    $profile_name = \Drupal::service('social_profile.name_service')
+      ->getProfileName($profile);
+
+    // Override profile name to display modal window on hover.
+    if (isset($variables['temp_attributes'])) {
+      $variables['temp_attributes']['class'][] = 'notranslate';
+      $variables['profile_name'] = [
+        '#markup' => '<span ' . new Attribute($variables['temp_attributes']) . '>' . $profile_name . '</span>',
+      ];
+      unset($variables['temp_attributes']);
+    }
+  }
+}
+
+/**
+ * Implements hook_preprocess_HOOK().
+ */
 function social_profile_preview_preprocess_field__field_profile_image(array &$variables): void {
   $element = $variables['element'];
+
+  /** @var \Drupal\Core\Routing\CurrentRouteMatch $current_route */
+  $current_route = \Drupal::service('current_route_match');
+
+  // Disable modal preview profile in the popup window of notification center.
+  if ($current_route->getRouteName() === 'activity_creator.stream.notifications') {
+    return;
+  }
 
   if (in_array($element['#view_mode'], ['compact', 'compact_notification'])) {
     /** @var \Drupal\profile\Entity\ProfileInterface $profile */


### PR DESCRIPTION
## Problem
1. If LU hover on the user's name on the "/user/inbox" page then the modal window doesn't appear:

<img src="https://www.drupal.org/files/issues/2022-05-04/Screenshot-2022-05-04-at-16-28-09-png-2906%C3%971636-.png" alt="preview" />

2. The modal profile preview displays in notification popup:

<img width="1560" alt="Screenshot 2022-05-05 at 21 37 36" src="https://user-images.githubusercontent.com/25609390/166998240-f876688d-d4bc-438e-b2d5-fa7c1196e229.png">

## Solution
1. Attach profile preview classes to the profile name of private message to display profile preview on hover (for example, like on the stream page).
2. Disable profile preview in notification popup

## Issue tracker
- https://www.drupal.org/project/social/issues/3278697
- https://getopensocial.atlassian.net/browse/YANG-7470

## How to test
- [ ] Using the latest version of Open Social with the social_profile_preview module enabled
- [ ] As a LU
- [ ] Try to click on the icon of the notification center
- [ ] When I hover on the user name above any message items(like on the screenshot) I expected to see a modal preview but nothing happens
- [ ] The expected result is attained when repeating the steps with this fix applied.
- [ ] As a LU
- [ ] Try to click on the icon of the notification center
- [ ] When I hover on the user name above any message items I do not expect to see a modal preview inside the popup
- [ ] The expected result is attained when repeating the steps with this fix applied.

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] If applicable (I.E. new hook_updates) the update path from previous versions (major and minor versions) are tested
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Release notes
- Fixes a bug with profile preview on the Inbox page
- Disable profile preview in notification popup
