### PR TITLE
Issue #3274219 by tbsiqueira: New Dashboard throws fatal errors

### DIFF
--- a/modules/social_features/social_core/social_core.links.menu.yml
+++ b/modules/social_features/social_core/social_core.links.menu.yml
@@ -147,7 +147,6 @@ social_core.dashboard.appearance.change_colors_and_styling:
   route_name: social_core.dashboard.appearance.active_theme
   weight: -100
 
-# @todo Add documentation to explain.
 social_core.dashboard.appearance.active_homepage_configuration:
   parent: social_core.dashboard.appearance
   class: Drupal\social_core\Plugin\Menu\HomepageConfigurationHeroBlockLink

--- a/modules/social_features/social_core/src/Plugin/Menu/HomepageConfigurationHeroBlockLink.php
+++ b/modules/social_features/social_core/src/Plugin/Menu/HomepageConfigurationHeroBlockLink.php
@@ -71,8 +71,9 @@ class HomepageConfigurationHeroBlockLink extends MenuLinkDefault {
       $this->pluginDefinition['description'] = $this->t('Change the image and text on the home page.');
     }
     else {
-      // Disable the link.
-      $this->pluginDefinition['enabled'] = FALSE;
+      $this->pluginDefinition['url'] = "internal:/block/add/hero_call_to_action_block";
+      $this->pluginDefinition['title'] = $this->t('Customize home page hero header block');
+      $this->pluginDefinition['description'] = $this->t('Add a "Hero call to action block" and set it to hero region to customize front page.');
     }
   }
 


### PR DESCRIPTION
## Problem
If an installation doesn't have the default hero CTA block for the homepage it breaks the dashboard with an empty route exception.

## Solution
Because there will always be the need for a default URL, instead of hiding the menu item, invite users to create a new CTA block and place it to the hero region at the homepage.

## Issue tracker
https://www.drupal.org/project/social/issues/3274219

## Theme issue tracker
N/A

## How to test
- [ ] Remove the configured homepage Hero call to action block, reload the Dashboard and check the new link: "**Customize home page hero header block**"

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] If applicable (I.E. new hook_updates) the update path from previous versions (major and minor versions) are tested
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
![image](https://user-images.githubusercontent.com/11061892/167845626-df3f2eea-8c7c-4854-83c9-0eaed2e8d362.png)

## Release notes
A new option is available in case there is not default hero call to action block set up to the homepage. When clicking at the link, users will have the option to create a new "Hero call to action block".

![image](https://user-images.githubusercontent.com/11061892/167846025-0041fb86-0181-4700-beea-b5cf61207473.png)

This block will be available to be used at the _Block layout_ (_admin/structure/block_)part of the website, under "Hero" 

![image](https://user-images.githubusercontent.com/11061892/167846441-d4f1f2da-6328-411f-a765-80396965ba1f.png)

It should be configured to Anonymous user role only:

![image](https://user-images.githubusercontent.com/11061892/167846529-8dff8dee-1c6a-41a7-bfe5-a4f8c323ae76.png)


## Change Record
N/A

## Translations
N/A
