### PR TITLE
Do not use ajax comments on standalone comment reply/edit page

### DIFF
--- a/modules/custom/social_ajax_comments/social_ajax_comments.module
+++ b/modules/custom/social_ajax_comments/social_ajax_comments.module
@@ -234,10 +234,11 @@ function _social_ajax_comments_pager(array &$items) {
  * Implements hook_form_FORM_ID_alter().
  */
 function social_ajax_comments_form_comment_form_alter(&$form, FormStateInterface $form_state, $form_id) {
-  // The comment below is copied from "ajax_comments" module version "8.x-1.0-beta4".
-  // Comment is located at "ajax_comments/src/Form/AjaxCommentsForm.php" in "buildForm()" method.
-  // In case the logic of contrib module will be changed in the future, the logic
-  // below should follow accordingly.
+  // The comment below is copied from "ajax_comments" module version
+  // "8.x-1.0-beta4". Comment is located at
+  // "ajax_comments/src/Form/AjaxCommentsForm.php" in "buildForm()" method.
+  // In case the logic of contrib module will be changed in the future,
+  // the logic below should follow accordingly.
   //
   // Ajax replies to other comments should happen on the canonical entity page
   // (note this functionality has not been ported to D8, yet).

--- a/modules/custom/social_ajax_comments/social_ajax_comments.module
+++ b/modules/custom/social_ajax_comments/social_ajax_comments.module
@@ -229,3 +229,22 @@ function _social_ajax_comments_pager(array &$items) {
     }
   }
 }
+
+/**
+ * Implements hook_form_FORM_ID_alter().
+ */
+function social_ajax_comments_form_comment_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+  // The comment below is copied from "ajax_comments" module version "8.x-1.0-beta4".
+  // Comment is located at "ajax_comments/src/Form/AjaxCommentsForm.php" in "buildForm()" method.
+  // In case the logic of contrib module will be changed in the future, the logic
+  // below should follow accordingly.
+  //
+  // Ajax replies to other comments should happen on the canonical entity page
+  // (note this functionality has not been ported to D8, yet).
+  // If the user is on the standalone comment reply page or comment edit page,
+  // it means JavaScript is disabled or the ajax functionality is not working.
+  // Do not proceed with the form alter.
+  if (in_array(\Drupal::routeMatch()->getRouteName(), ['comment.reply', 'entity.comment.edit_form'])) {
+    unset($form['actions']['submit']['#ajax']);
+  }
+}

--- a/modules/custom/social_ajax_comments/social_ajax_comments.module
+++ b/modules/custom/social_ajax_comments/social_ajax_comments.module
@@ -232,8 +232,13 @@ function _social_ajax_comments_pager(array &$items) {
 
 /**
  * Implements hook_form_FORM_ID_alter().
+ *
+ * @param array<mixed> $form
+ * @param FormStateInterface $form_state
+ * @param string $form_id
+ * @return void
  */
-function social_ajax_comments_form_comment_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+function social_ajax_comments_form_comment_form_alter(array &$form, FormStateInterface $form_state, string $form_id) :void {
   // The comment below is copied from "ajax_comments" module version
   // "8.x-1.0-beta4". Comment is located at
   // "ajax_comments/src/Form/AjaxCommentsForm.php" in "buildForm()" method.

--- a/modules/custom/social_ajax_comments/social_ajax_comments.module
+++ b/modules/custom/social_ajax_comments/social_ajax_comments.module
@@ -232,11 +232,6 @@ function _social_ajax_comments_pager(array &$items) {
 
 /**
  * Implements hook_form_FORM_ID_alter().
- *
- * @param array<mixed> $form
- * @param FormStateInterface $form_state
- * @param string $form_id
- * @return void
  */
 function social_ajax_comments_form_comment_form_alter(array &$form, FormStateInterface $form_state, string $form_id) :void {
   // The comment below is copied from "ajax_comments" module version


### PR DESCRIPTION
Contrib module ajax_comments does not support ajax comments on standalone comment reply page
or comment edit page. Because submit button ajax property is set by ajax_comments module anyway,
it has to be removed, otherwise comment in comment form is never submitted.

## Problem
TL;DR: Reply button / commenting is not working on standalone comment reply page when ajax_comments module is enabled.

Someone has commented my topic. I receive a notification in the notification center or via E-Mail, click on the notification and I am directed to this page, that only shows the comment and a reply button: 
https://{domain-name}.com/comment/reply/node/{node_id}/field_topic_comments/{comment_id} 

I type in my reply but after I have pressed "reply" nothing happens and my reply is not submitted (screenshot)

When I don´t click on the notification, but go to the topic, scroll down until I see the comments and reply there, it works.



## Solution
Remove the ajax trigger in commenting handler as if it would be handled without ajax_comments module enabled.

## Issue tracker
[TB-6733](https://getopensocial.atlassian.net/browse/TB-6733)
[3281095](https://www.drupal.org/project/social/issues/3281095)

## Theme issue tracker
/

## How to test
As a user, try to reply a comment on standalone comment reply page (url pattern: https://{domain-name}.com/comment/reply/node/{node_id}/field_topic_comments/{comment_id} or visit routes: `comment.reply`, `entity.comment.edit_form` )

## Definition of done
### Before merge
- [x] Code/peer review is completed
- [x] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [x] All automated tests are green
- [x] Functional/manual tests of the acceptance criteria are approved
- [x] All acceptance criteria were met
- [x] If applicable (I.E. new hook_updates) the update path from previous versions (major and minor versions) are tested
- [x] This pull request has all required labels (team/type/priority)
- [x] This pull request has a milestone
- [x] This pull request has an assignee (if applicable)
- [x] Any front end changes are tested on all major browsers
- [x] New UI elements, or changes on UI elements are approved by the design team
- [x] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
![](https://www.drupal.org/files/issues/2022-05-18/Screenshot_2022-05-18_at_12_44_58.png)

## Release notes
Comments on standalone comment reply/edit page work as designed if ajax_comments module is enabled.

## Change Record
No

## Translations
No changes
