### PR TITLE
Issue #3281332 by rolki: Fix sorting options for custom content list block on dashboard when choose events

### DIFF
--- a/modules/social_features/social_content_block/src/ContentBuilder.php
+++ b/modules/social_features/social_content_block/src/ContentBuilder.php
@@ -333,9 +333,8 @@ class ContentBuilder implements ContentBuilderInterface {
       }
     }
 
-    $field = $element['field_sorting']['#group'];
-    $element[$field]['#prefix'] = '<div id="' . $element['field_plugin_id']['widget'][0]['value']['#ajax']['wrapper'] . '">';
-    $element[$field]['#suffix'] = '</div>';
+    $element['field_sorting']['#prefix'] = '<div id="' . $element['field_plugin_id']['widget'][0]['value']['#ajax']['wrapper'] . '">';
+    $element['field_sorting']['#suffix'] = '</div>';
 
     if (!$selected_plugin) {
       return $element;
@@ -387,10 +386,6 @@ class ContentBuilder implements ContentBuilderInterface {
   public function updateFormSortingOptions(array $form, FormStateInterface $form_state): array {
     $parents = ['field_sorting'];
 
-    if ($form_state->has('layout_builder__component')) {
-      $parents = array_merge(['settings', 'block_form'], $parents);
-    }
-
     // Check that the currently selected value is valid and change it otherwise.
     $value_parents = array_merge($parents, ['0', 'value']);
     $sort_value = $form_state->getValue($value_parents);
@@ -405,8 +400,6 @@ class ContentBuilder implements ContentBuilderInterface {
       $form_state->clearErrors();
       $form_state->setValue($value_parents, key($options));
     }
-
-    $parents = [NestedArray::getValue($form, array_merge($parents, ['#group']))];
 
     if ($form_state->has('layout_builder__component')) {
       $parents = array_merge(['settings', 'block_form'], $parents);


### PR DESCRIPTION
## Problem
In custom content list I can choose between different type of content. When I choose “Events” some extra filter options become available like Event types and Date period.

However, in the sorting options I still see the standard elements.

After I create the block and I place it on the dashboard, if I edit it again I suddenly have a new sorting option available “Event date”.

## Solution
The “Event date” sorting option should be available during the creation of the block once “Events” is selected as Type of content on Dashboard.

Probably some code refactoring need to implement this.

P.S. Fix can be checked on ECI: https://enterprise.getopensocial.net/

## Issue tracker
- https://www.drupal.org/project/social/issues/3281332
- https://getopensocial.atlassian.net/browse/YANG-7074

## Theme issue tracker
None.

## How to test
- [ ] Create/edit the Dashboard page
- [ ] Add a new custom content list block
- [ ] Choose "Event"
- [ ] Scroll to sorting options and u should see 2 additional options: "Oldest -> Newest", "Newest -> Oldest"

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] If applicable (I.E. new hook_updates) the update path from previous versions (major and minor versions) are tested
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
![image](https://user-images.githubusercontent.com/50984627/169304408-466fa190-8852-461c-9cdc-2ebbf67b653b.png)
![image](https://user-images.githubusercontent.com/50984627/169304597-1c4f4d6d-3863-42ea-be10-3e6db968628b.png)
![Screenshot 2022-05-19 at 16 28 35](https://user-images.githubusercontent.com/50984627/169304694-4f36fc03-2f02-430d-9f08-f328ed87023b.png)


## Release notes
None.

## Change Record
None.

## Translations
None.
