### PR TITLE
get correct node for correct group on second way

### DIFF
--- a/modules/social_features/social_group/social_group.module
+++ b/modules/social_features/social_group/social_group.module
@@ -1839,6 +1839,14 @@ function _social_group_get_current_group($entity = NULL): ?SocialGroupInterface 
           ->load($gid_from_entity);
       }
     }
+    else {
+      $entity_type = \Drupal::routeMatch()->getParameter('entity_type');
+      $entity = \Drupal::routeMatch()->getParameter('entity');
+      if ($entity_type == 'node') {
+        $group = _social_group_get_current_group($entity);
+        $nid = $entity->id();
+      }
+    }
   }
 
   // If we have a cache key we store the value.


### PR DESCRIPTION
Follow up on https://github.com/goalgorilla/open_social/pull/1997 with new solution
## Problem
OLD:
Just figured out, that I can not access the group manage members tab, after one of the last upgrades. fe. /group/34/membership
Even with user 1 I receive a "You are not authorized to access this page."
NEW:
When using ajax comments and you need to figure out the group during comment insert _social_group_get_current_group() will not return the group

## Solution
OLD:
This seems to be a "multilayer issue" on most installs I got rid of the behaviour by rebuilding node access permission.
But on one install I still got "You are not authorized to access this page." after rebuilding the permission.
NEW:
Get the correct node (to get correct group) on second way by using other parameters delivered by \Drupal::routeMatch().

See issue https://www.drupal.org/project/social/issues/3173334

## Issue tracker
https://www.drupal.org/project/social/issues/3173334

## How to test
*For example*
- [ ] Using version X.Y.Z of Open Social with the example module enabled
- [ ] As a sitemanager
- [ ] Try to enable the option B on screen c/d/e
- [ ] When saving I expect the result to be F but instead see G.
- [ ] The expected result F is attained when repeating the steps with this fix applied.

## Screenshots
*If this Pull Request makes visual changes then please include some screenshots that show what has changed here. A before and after screenshot helps the reviewer determine what changes were made.*

## Release notes
*A short summary of the changes that were made that can be included in release notes.*

## Change Record
*If this Pull Request changes the way that developers should do things or introduces a new API for developers then a change record to document this is needed. Please provide a draft for a change record or a link to an unpublished change record below. [Existing change records](https://www.drupal.org/list-changes/social) can be consulted as example.*

## Translations
*Translatable strings are always extracted from the latest development branch. To ensure translations remain available for platforms running older versions of Open Social the original string should be added to `translations.php` when it's changed or removed.*
- [ ] Changed or removed source strings are added to the `translations.php` file.
