### PR TITLE
Issue #3281476 by alex.ksis: Hide path alias field from the approve membership form.

### DIFF
--- a/modules/social_features/social_group/social_group.module
+++ b/modules/social_features/social_group/social_group.module
@@ -797,6 +797,9 @@ function social_group_form_alter(&$form, FormStateInterface $form_state, $form_i
 
   // Perform alterations on joining / leaving groups.
   if (in_array($form_id, $action_forms)) {
+    if (isset($form['path'])) {
+      $form['path']['#access'] = FALSE;
+    }
 
     // Add cancel option on join and leave form.
     $form['actions']['cancel'] = [


### PR DESCRIPTION
Since we do not have a separate membership page, aliases are not necessary.

## Problem
An unnecessary field is displayed in the Approve membership form.

## Solution
Hide the field.

## Issue tracker
https://www.drupal.org/project/social/issues/3281476
https://getopensocial.atlassian.net/browse/YANG-7784

## How to test
- [x] Create a Flexible group with "Request to join".
- [x] As a LU, send a request to this group.
- [x] Go to the membership requests overview page and click "Approve membership".

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] If applicable (I.E. new hook_updates) the update path from previous versions (major and minor versions) are tested
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
![image](https://user-images.githubusercontent.com/4526828/169404634-5ae3e81c-ca63-4563-b9f3-f0de26ff898b.png)

## Release notes
Hide the path alias field from the approve membership form.

