### PR TITLE
Issue #3281598 by nkoporec: Unable to show event default menu local tasks on a custom subpage

### DIFF
--- a/modules/social_features/social_event/modules/social_event_managers/social_event_managers.module
+++ b/modules/social_features/social_event/modules/social_event_managers/social_event_managers.module
@@ -304,13 +304,8 @@ function social_event_managers_node_access(NodeInterface $node, $op, AccountInte
  */
 function social_event_managers_menu_local_tasks_alter(&$data, $route_name) {
   $can_show_managers_link = FALSE;
-  $routes_to_check = [
-    'view.event_enrollments.view_enrollments',
-    'entity.node.canonical',
-    'view.managers.view_managers',
-    'view.manage_enrollments.page',
-    'view.event_manage_enrollments.page_manage_enrollments',
-  ];
+  $routes_to_check = _social_event_menu_local_tasks_routes();
+
   if (in_array($route_name, $routes_to_check)) {
     $node = \Drupal::service('current_route_match')->getParameter('node');
     if (!is_null($node) && (!$node instanceof Node)) {

--- a/modules/social_features/social_event/social_event.api.php
+++ b/modules/social_features/social_event/social_event.api.php
@@ -35,5 +35,17 @@ function hook_social_event_enroll_method_description_alter($key, &$description) 
 }
 
 /**
+ * Provide a way to add event menu local tasks to custom pages.
+ *
+ * @param array $routes
+ *   Array of routes where local tasks show show up.
+ *
+ * @ingroup social_event_api
+ */
+function hook_social_event_menu_local_tasks_routes_alter(&$routes) {
+  return $routes;
+}
+
+/**
  * @} End of "addtogroup hooks".
  */

--- a/modules/social_features/social_event/social_event.api.php
+++ b/modules/social_features/social_event/social_event.api.php
@@ -42,7 +42,7 @@ function hook_social_event_enroll_method_description_alter($key, &$description) 
  *
  * @ingroup social_event_api
  */
-function hook_social_event_menu_local_tasks_routes_alter(&$routes) {
+function hook_social_event_menu_local_tasks_routes_alter(array &$routes) {
   return $routes;
 }
 

--- a/modules/social_features/social_event/social_event.module
+++ b/modules/social_features/social_event/social_event.module
@@ -284,13 +284,8 @@ function social_event_block_view_alter(array &$build, BlockPluginInterface $bloc
  */
 function social_event_menu_local_tasks_alter(&$data, $route_name) {
   $can_show_enrollments_link = FALSE;
-  $routes_to_check = [
-    'view.event_enrollments.view_enrollments',
-    'entity.node.canonical',
-    'view.managers.view_managers',
-    'view.manage_enrollments.page',
-    'view.event_manage_enrollments.page_manage_enrollments',
-  ];
+  $routes_to_check = _social_event_menu_local_tasks_routes();
+
   if (in_array($route_name, $routes_to_check)) {
     $node = \Drupal::service('current_route_match')->getParameter('node');
     if (!is_null($node) && (!$node instanceof Node)) {
@@ -1449,4 +1444,23 @@ function social_event_preprocess_html(array &$variables): void {
     '#type' => 'inline_template',
     '#template' => '<span class="hidden">' . $icons . '</span>',
   ];
+}
+
+/**
+ * Array of routes where the special event local tasks are displayed.
+ *
+ * See social_event_menu_local_tasks_alter().
+ */
+function _social_event_menu_local_tasks_routes(): array {
+  $routes = [
+    'view.event_enrollments.view_enrollments',
+    'entity.node.canonical',
+    'view.managers.view_managers',
+    'view.manage_enrollments.page',
+    'view.event_manage_enrollments.page_manage_enrollments',
+  ];
+
+  \Drupal::moduleHandler()->invokeAll('social_event_menu_local_tasks_routes_alter', [&$routes]);
+
+  return $routes;
 }


### PR DESCRIPTION
## Problem
I want to create a subpage on /node/{id)/page , that renders a form. As part of the requirements, this page should include all menu local tasks that are currently present on /node/{id} page.

Currently, there is no way to show links like 'Enrollments', 'Manage enrollments', 'Organisers'. The reason for this is because we programmatically remove this menu links via hook_menu_local_tasks_alter() for all pages except certain ones, which are hard coded inside an array.

## Solution
We need to provide a way to alter this hard coded list of routes where this special event menu local tasks are shown. The most straightforward way is to create a new hook, where user will be able to alter this array. 

## Issue tracker
https://www.drupal.org/project/social/issues/3281598

## Theme issue tracker
*[Required if applicable] Paste a link to the drupal.org theme issue queue item, either from [socialbase](https://www.drupal.org/project/socialbase) or [socialblue](https://www.drupal.org/project/socialblue). If any other issue trackers were used, include links to those too.*

## How to test
1. Create a new form, with route /node/{node}/page
2. Create a new menu local task for this route that shows up on entity.node.canonical page
3. Go to an event, you should be able to see your new local task and also other ones, such as 'Enrollments'
4. Go to this new route and check the local task.
5. You will not see local tasks such as 'Enrollments', 'Manage enrollments', 'Organisers'

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] If applicable (I.E. new hook_updates) the update path from previous versions (major and minor versions) are tested
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
Before:
![image](https://user-images.githubusercontent.com/35064680/169534486-c93180c2-ee7e-496d-99d5-282cbd2fb186.png)



After:
![image](https://user-images.githubusercontent.com/35064680/169534554-a4644dd1-1884-4a3f-87e4-de19cc4c2e13.png)



## Release notes
Added a new hook `hook_social_event_menu_local_tasks_routes_alter()`, it adds ability to alter the routes on which special event menu local task links are displayed.

## Change Record
*[Required if applicable] If this Pull Request changes the way that developers should do things or introduces a new API for developers then a change record to document this is needed. Please provide a draft for a change record or a link to an unpublished change record below. Existing change records can be consulted as example. Please provide a draft for a change record or a link to an unpublished change record below. [Existing change records](https://www.drupal.org/list-changes/social) can be consulted as example.*

## Translations
*[Optional]Translatable strings are always extracted from the latest development branch. To ensure translations remain available for platforms running older versions of Open Social the original string should be added to `translations.php` when it's changed or removed.*
- [ ] Changed or removed source strings are added to the `translations.php` file.
