### PR TITLE
Issue #3282031 by navneet0693: Email subjects in message templates are not translatable.

### DIFF
--- a/modules/custom/activity_logger/config/schema/activity_logger.schema.yml
+++ b/modules/custom/activity_logger/config/schema/activity_logger.schema.yml
@@ -31,5 +31,5 @@ activity_logger.third_party_settings:
       type: string
       label: 'The entity condition for this message'
     email_subject:
-      type: string
+      type: label
       label: 'The email subject line'


### PR DESCRIPTION
## Problem
Email subjects were introduced in [#3236256] and https://github.com/goalgorilla/open_social/pull/2544. The email subjects are textfield but are not available for translation. This is due to schema being <code>type: string</code> for a textfield.

Read more at: https://www.drupal.org/docs/drupal-apis/configuration-api/configuration-schemametadata#types

## Solution
Change the schema of email_subject to "label".

## Issue tracker
https://www.drupal.org/project/social/issues/3282031

## Theme issue tracker
N.A

## How to test
- [x] Using version latest version of Open Social with the social_content_translation module enabled
- [x] Add Dutch as language (or any)
- [x] Go to /nl/admin/structure/message/manage/create_comment_author_node_post/translate/nl/add
- [x] You should not find email subject available for translation
- [x] Checkout to this branch and clear cache.
- [x] Refresh the page
- [x] See if the email subject is available for translation

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] If applicable (I.E. new hook_updates) the update path from previous versions (major and minor versions) are tested
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
**Before:**
![Screenshot 2022-05-24 at 1 25 54 PM](https://user-images.githubusercontent.com/8435994/169979434-67665839-c93d-4b8d-9ffa-671cb44e6163.png)


**After:**
![Screenshot 2022-05-24 at 1 23 54 PM](https://user-images.githubusercontent.com/8435994/169979138-d558831e-84ea-4291-a7fe-ffb4f036de1f.png)

## Release notes
Email subjects were introduced in Open Social 10.3 but they were not available for translations. We have now made them available for translations. Now, an admin should be able to add translations of message templates including email subjects.

## Change Record
N.A

## Translations
N.A