### PR TITLE
As an AN commenting on a content I should be redirected to the same content after I login

### DIFF
--- a/modules/custom/group_core_comments/src/Plugin/Field/FieldFormatter/CommentGroupContentFormatter.php
+++ b/modules/custom/group_core_comments/src/Plugin/Field/FieldFormatter/CommentGroupContentFormatter.php
@@ -266,7 +266,7 @@ class CommentGroupContentFormatter extends CommentDefaultFormatter {
 
     if (!$this->currentUser->hasPermission('post comments')) {
       // Add log in and sign up links below discussion comments for AN user.
-      $log_in_url = Url::fromRoute('user.login');
+      $log_in_url = Url::fromRoute('user.login', ['destination' => Url::fromRoute('<current>')->toString() . '#section-comments']);
       $log_in_link = Link::fromTextAndUrl(t('log in'), $log_in_url)
         ->toString();
       $create_account_url = Url::fromRoute('user.register');

--- a/modules/social_features/social_post/src/Plugin/Field/FieldFormatter/CommentPostFormatter.php
+++ b/modules/social_features/social_post/src/Plugin/Field/FieldFormatter/CommentPostFormatter.php
@@ -138,7 +138,7 @@ class CommentPostFormatter extends CommentDefaultFormatter {
         }
         else {
           // Add log in and sign up links below discussion comments for AN user.
-          $log_in_url = Url::fromRoute('user.login');
+          $log_in_url = Url::fromRoute('user.login', ['destination' => Url::fromRoute('<current>')->toString()]);
           $log_in_link = Link::fromTextAndUrl(t('log in'), $log_in_url)
             ->toString();
           $create_account_url = Url::fromRoute('user.register');


### PR DESCRIPTION
## Problem
If a user is not logged in and is on a topic/event/discussion page and wants to leave a comment or enroll, they are required to log in first. And as they log in they are redirected to a homepage and not the content page where they wanted to perform an action.

## Solution
After logging in a user is redirected to the same page from which log in was performed.

## Issue tracker
- https://www.drupal.org/project/social/issues/3282392
- https://getopensocial.atlassian.net/browse/YANG-7769

## Theme issue tracker
None.

## How to test
- [ ] Go to the content page (topic, discussion, event)
- [ ] Scroll to comment section and click the "log-in" link
- [ ] After login process you should be redirected to that content page

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] If applicable (I.E. new hook_updates) the update path from previous versions (major and minor versions) are tested
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
<img width="1178" alt="Screenshot 2022-05-26 at 12 10 36" src="https://user-images.githubusercontent.com/50984627/170457124-b8858a6f-a310-4217-ba6f-8c0944b0efa5.png">
<img width="1022" alt="Screenshot 2022-05-26 at 13 09 13" src="https://user-images.githubusercontent.com/50984627/170467256-29bd3fa5-955c-4878-aa8b-5699d93d630e.png">

## Release notes
None.

## Change Record
Now, after logging user is redirected to the same page from which log in was performed to comment. This change also works properly with "Alternative front page".

## Translations
None.
