### PR TITLE
Fix enroll button parameter conversion logic

### DIFF
--- a/modules/social_features/social_event/src/Form/EnrollActionForm.php
+++ b/modules/social_features/social_event/src/Form/EnrollActionForm.php
@@ -107,20 +107,20 @@ class EnrollActionForm extends FormBase {
    * {@inheritdoc}
    */
   public function buildForm(array $form, FormStateInterface $form_state) {
-    $nid = $this->routeMatch->getParameter('node');
+    $node = $this->routeMatch->getParameter('node');
     $current_user = $this->currentUser();
+
+    // It's possible this form is rendered through a route that doesn't properly
+    // convert the parameter to a node. So in that case we must do so manually.
+    if (is_numeric($node)) {
+      $node = $this->entityTypeManager
+        ->getStorage('node')
+        ->load($node);
+    }
 
     // This entire function collapses if we don't have a node so we just short-
     // circuit early.
-    if (!is_numeric($nid)) {
-      return [];
-    }
-
-    $node = $this->entityTypeManager
-      ->getStorage('node')
-      ->load($nid);
-
-    if ($node === NULL) {
+    if (!$node instanceof NodeInterface) {
       return [];
     }
 


### PR DESCRIPTION


## Problem
During a final rebase the logic for optionally converting a route
parameter was messed up. This caused the enroll button to never render.


## Solution

This commit fixes that logic to accept having a pre-converted node
rather than a string/int ID as well.

## Issue tracker
Regression caused by https://github.com/goalgorilla/open_social/pull/2948/files#diff-76a00b0f3e321114351f9f6f10225febb389f8f0a7a5e4dbd9780bc0bfe7e499

## How to test

- [ ] Check that enroll button shows up as expected

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] If applicable (I.E. new hook_updates) the update path from previous versions (major and minor versions) are tested
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Release notes
N/a unreleased bug
