### PR TITLE
Issue #3144794: Hero block display based on path is too fragile

### DIFF
--- a/modules/social_features/social_core/config/optional/block.block.socialblue_pagetitleblock_content.yml
+++ b/modules/social_features/social_core/config/optional/block.block.socialblue_pagetitleblock_content.yml
@@ -23,21 +23,3 @@ visibility:
     pages: "/search/*\r\n*/stream\r\n*/events\r\n*/topics\r\n*/groups\r\n*/information\r\n*/members\r\n*/membership\r\n*/about\r\n/data-policy\r\n/data-policy/*"
     negate: true
     context_mapping: {  }
-    'entity_bundle:node':
-      id: 'entity_bundle:node'
-      bundles:
-        event: event
-        page: page
-        topic: topic
-      negate: true
-      context_mapping:
-        node: '@node.node_route_context:node'
-    group_type:
-      id: group_type
-      group_types:
-        closed_group: closed_group
-        open_group: open_group
-        public_group: public_group
-      negate: false
-      context_mapping:
-        group: '@group.group_route_context:group'

--- a/modules/social_features/social_core/config/update/social_core_update_11402.yml
+++ b/modules/social_features/social_core/config/update/social_core_update_11402.yml
@@ -1,0 +1,8 @@
+block.block.socialblue_pagetitleblock_content:
+  expected_config: {  }
+  update_actions:
+    delete:
+      visibility:
+        request_path:
+          'entity_bundle:node': {  }
+          group_type: {  }

--- a/modules/social_features/social_core/social_core.install
+++ b/modules/social_features/social_core/social_core.install
@@ -1575,3 +1575,17 @@ function social_core_update_11401(): void {
   $source = new FileStorage($config_path);
   $config_storage->write('core.entity_view_mode.node.email_card', (array) $source->read('core.entity_view_mode.node.email_card_11401'));
 }
+
+/**
+ * Remove block visibility settings that were added in the wrong place.
+ */
+function social_core_update_11402(array &$sandbox): string {
+  /** @var \Drupal\update_helper\UpdaterInterface $update_helper */
+  $update_helper = \Drupal::service('update_helper.updater');
+
+  // Execute configuration update definitions with logging of success.
+  $update_helper->executeUpdate('social_core', __FUNCTION__);
+
+  // Output logged messages to related channel of update execution.
+  return $update_helper->logger()->output();
+}

--- a/modules/social_features/social_core/social_core.module
+++ b/modules/social_features/social_core/social_core.module
@@ -673,6 +673,29 @@ function social_core_block_access(Block $block, $operation, AccountInterface $ac
     }
   }
 
+  // Make sure that socialblue_pagetitleblock_content doesn't show on nodes
+  // pages. We can't add visibility 'entity_bundle:node' whether 'group_type'
+  // since the block will disappear from pages like Access denied and some tests
+  // will be failed. So, let's hide the block for node canonical instead.
+  if (
+    $operation === 'view' &&
+    $block->getPluginId() === 'social_page_title_block' &&
+    $block->id() === 'socialblue_pagetitleblock_content'
+  ) {
+    /** @var \Drupal\node\Entity\Node $node */
+    $node = \Drupal::routeMatch()->getParameter('node');
+    // Get the route name.
+    $route_name = \Drupal::routeMatch()->getRouteName();
+
+    // If it is a node we prevent the block from showing.
+    if (
+      $node instanceof NodeInterface &&
+      $route_name === 'entity.node.canonical'
+    ) {
+      return AccessResult::forbidden();
+    }
+  }
+
   // No opinion.
   return AccessResult::neutral();
 }


### PR DESCRIPTION
Related PR https://github.com/goalgorilla/open_social/pull/1960

## Problem
There is an issue of duplicate Hero Blocks when the URL has one of the words `add`, `edit`, or `delete`.

## Solution
Correct visibility settings for socialblue_pagetitleblock_content block.

## Issue tracker
- https://www.drupal.org/project/social/issues/3144794

## Theme issue tracker
N/A

## How to test
It is reproducible only in some environments but not on vanilla Open Social.
- [ ] Create a topic with a URL that has one of the words `add`, `edit`, or `delete`. E.g. `/topic/test-added-topic`
- [ ] You will see duplicate Hero Blocks
- [ ] Apply changes from this PR
- [ ] Re-do previous steps
- [ ] You should not see duplicate Hero Blocks

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] If applicable (I.E. new hook_updates) the update path from previous versions (major and minor versions) are tested
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
![175a660e80186c1b149435085a0e7d75](https://user-images.githubusercontent.com/10220937/171233980-37373254-3e33-48f1-8b74-58a01d3cc9e5.png)

## Release notes
N/A

## Change Record
N/A

## Translations
N/A
