### PR TITLE
Issue #3278207 by msti: Search users page exposed filters not working

### DIFF
--- a/modules/social_features/social_search/src/EventSubscriber/RedirectSubscriber.php
+++ b/modules/social_features/social_search/src/EventSubscriber/RedirectSubscriber.php
@@ -102,8 +102,9 @@ class RedirectSubscriber implements EventSubscriberInterface {
     $query = $this->requestStack->getCurrentRequest()->query->all();
 
     // Workaround for drupal.org issue #3085806.
-    if (empty($query) || empty($query['created_op'])) {
-      $query = ['created_op' => '<'];
+    if (is_array($query) && empty($query['created_op'])) {
+      $created_op = ['created_op' => '<'];
+      $query = empty($query) ? $created_op : array_merge($query, $created_op);
       $parameters = $this->currentRoute->getParameters();
       $redirect_path = $this->currentRoute->getRouteName();
       $options = ['query' => $query];


### PR DESCRIPTION
## Problem
When the exposed filter Profile datasource: Owner » User » Created (exposed) is removed from the search/users view, the exposed filters are not submittable.

## Solution
This is a bug introduced by this fix [#3085806: Pagination does not work anymore on Search Users page: "An illegal choice has been detected."](https://www.drupal.org/project/social/issues/3085806) which aims to solve another bug.
The fix assumes that the exposed filter "created" will always be present which is not always the case if the search view is customized.
It can be fixed by merging the `$query` param with the `['created_op' => '<']`;

## Issue tracker
- https://www.drupal.org/project/social/issues/3278207

## Theme issue tracker
N/A

## How to test
- [ ] Remove the exposed filter Profile datasource: Owner » User » Created (exposed) from the users search view: `/admin/structure/views/view/search_users/edit/page`
- [ ] Use any of the exposed filters in the /search/users/all page and submit the search.
- [ ] The page refreshes and the URL changes to `/search/users/all?created_op=<` 
- [ ] The exposed filter has not been submitted.
- [ ] Apply changes from this PR and filters should work properly

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] If applicable (I.E. new hook_updates) the update path from previous versions (major and minor versions) are tested
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
N/A

## Release notes
Was fixed user search page filters in case the view was customized and the exposed filter "created" is not present.

## Change Record
N/A

## Translations
N/A
