### PR TITLE
Issue #3282031 by navneet0693: Email subjects in message templates are not translatable.

### DIFF
--- a/modules/social_features/social_activity/config/install/message.template.create_comment_community_node.yml
+++ b/modules/social_features/social_activity/config/install/message.template.create_comment_community_node.yml
@@ -12,8 +12,8 @@ third_party_settings:
     activity_destinations:
       stream_explore: stream_explore
       stream_profile: stream_profile
-    activity_create_direct: 1
-    activity_aggregate: 1
+    activity_create_direct: TRUE
+    activity_aggregate: TRUE
     activity_entity_condition: comment_not_reply
     email_subject: ''
 template: create_comment_community_node

--- a/modules/social_features/social_activity/config/install/message.template.create_comment_community_post.yml
+++ b/modules/social_features/social_activity/config/install/message.template.create_comment_community_post.yml
@@ -12,8 +12,8 @@ third_party_settings:
     activity_destinations:
       stream_explore: stream_explore
       stream_profile: stream_profile
-    activity_create_direct: 1
-    activity_aggregate: 1
+    activity_create_direct: TRUE
+    activity_aggregate: TRUE
     activity_entity_condition: comment_not_reply
     email_subject: ''
 template: create_comment_community_post
@@ -30,8 +30,4 @@ settings:
   'token options':
     clear: false
     'token replace': true
-  purge:
-    override: false
-    enabled: false
-    quota: null
-    days: null
+  purge_methods: {  }

--- a/modules/social_features/social_activity/config/install/message.template.create_comment_group_node.yml
+++ b/modules/social_features/social_activity/config/install/message.template.create_comment_group_node.yml
@@ -14,8 +14,8 @@ third_party_settings:
       stream_group: stream_group
       stream_home: stream_home
       stream_profile: stream_profile
-    activity_create_direct: 1
-    activity_aggregate: 1
+    activity_create_direct: TRUE
+    activity_aggregate: TRUE
     activity_entity_condition: comment_not_reply
     email_subject: ''
 template: create_comment_group_node

--- a/modules/social_features/social_activity/config/install/message.template.create_comment_group_post.yml
+++ b/modules/social_features/social_activity/config/install/message.template.create_comment_group_post.yml
@@ -12,8 +12,8 @@ third_party_settings:
     activity_destinations:
       stream_explore: stream_explore
       stream_profile: stream_profile
-    activity_create_direct: 1
-    activity_aggregate: 1
+    activity_create_direct: TRUE
+    activity_aggregate: TRUE
     activity_entity_condition: comment_not_reply
     email_subject: ''
 template: create_comment_group_post
@@ -30,8 +30,4 @@ settings:
   'token options':
     clear: false
     'token replace': true
-  purge:
-    override: false
-    enabled: false
-    quota: null
-    days: null
+  purge_methods: {  }

--- a/modules/social_features/social_activity/config/install/message.template.create_event_community.yml
+++ b/modules/social_features/social_activity/config/install/message.template.create_event_community.yml
@@ -12,7 +12,7 @@ third_party_settings:
       stream_group: stream_group
       stream_home: stream_home
       stream_profile: stream_profile
-    activity_create_direct: 0
+    activity_create_direct: FALSE
     activity_action: create_entitiy_action
     activity_bundle_entities:
       node-event: node-event
@@ -28,8 +28,4 @@ settings:
   'token options':
     clear: false
     'token replace': true
-  purge:
-    override: false
-    enabled: false
-    quota: null
-    days: null
+  purge_methods: {  }

--- a/modules/social_features/social_activity/config/install/message.template.create_event_group.yml
+++ b/modules/social_features/social_activity/config/install/message.template.create_event_group.yml
@@ -11,7 +11,7 @@ third_party_settings:
       stream_explore: stream_explore
       stream_home: stream_home
       stream_profile: stream_profile
-    activity_create_direct: 0
+    activity_create_direct: FALSE
     activity_action: create_entitiy_action
     activity_bundle_entities:
       node-event: node-event

--- a/modules/social_features/social_activity/config/install/message.template.create_post_community.yml
+++ b/modules/social_features/social_activity/config/install/message.template.create_post_community.yml
@@ -10,7 +10,7 @@ third_party_settings:
       stream_explore: stream_explore
       stream_home: stream_home
       stream_profile: stream_profile
-    activity_create_direct: 1
+    activity_create_direct: TRUE
     activity_action: create_entitiy_action
     activity_bundle_entities:
       post-post: post-post
@@ -26,8 +26,4 @@ settings:
   'token options':
     clear: false
     'token replace': true
-  purge:
-    override: false
-    enabled: false
-    quota: null
-    days: null
+  purge_methods: {  }

--- a/modules/social_features/social_activity/config/install/message.template.create_post_group.yml
+++ b/modules/social_features/social_activity/config/install/message.template.create_post_group.yml
@@ -11,7 +11,7 @@ third_party_settings:
       stream_group: stream_group
       stream_home: stream_home
       stream_profile: stream_profile
-    activity_create_direct: 1
+    activity_create_direct: TRUE
     activity_action: create_entitiy_action
     activity_bundle_entities:
       post-post: post-post
@@ -27,8 +27,4 @@ settings:
   'token options':
     clear: false
     'token replace': true
-  purge:
-    override: false
-    enabled: false
-    quota: null
-    days: null
+  purge_methods: {  }

--- a/modules/social_features/social_activity/config/install/message.template.create_post_profile_stream.yml
+++ b/modules/social_features/social_activity/config/install/message.template.create_post_profile_stream.yml
@@ -8,11 +8,11 @@ third_party_settings:
     activity_context: profile_activity_context
     activity_destinations:
       stream_profile: stream_profile
-    activity_create_direct: 1
+    activity_create_direct: TRUE
     activity_bundle_entities:
       post-post: post-post
     activity_action: create_entitiy_action
-    activity_aggregate: 0
+    activity_aggregate: FALSE
     email_subject: ''
 template: create_post_profile_stream
 label: 'Create post on profile stream output'
@@ -31,8 +31,4 @@ settings:
   'token options':
     clear: false
     'token replace': true
-  purge:
-    override: false
-    enabled: false
-    quota: null
-    days: null
+  purge_methods: {  }

--- a/modules/social_features/social_activity/config/install/message.template.create_topic_community.yml
+++ b/modules/social_features/social_activity/config/install/message.template.create_topic_community.yml
@@ -12,7 +12,7 @@ third_party_settings:
       stream_group: stream_group
       stream_home: stream_home
       stream_profile: stream_profile
-    activity_create_direct: 0
+    activity_create_direct: FALSE
     activity_action: create_entitiy_action
     activity_bundle_entities:
       node-topic: node-topic
@@ -28,8 +28,4 @@ settings:
   'token options':
     clear: false
     'token replace': true
-  purge:
-    override: false
-    enabled: false
-    quota: null
-    days: null
+  purge_methods: {  }

--- a/modules/social_features/social_activity/config/install/message.template.create_topic_group.yml
+++ b/modules/social_features/social_activity/config/install/message.template.create_topic_group.yml
@@ -11,7 +11,7 @@ third_party_settings:
       stream_explore: stream_explore
       stream_home: stream_home
       stream_profile: stream_profile
-    activity_create_direct: 0
+    activity_create_direct: FALSE
     activity_action: create_entitiy_action
     activity_bundle_entities:
       node-topic: node-topic

--- a/modules/social_features/social_activity/config/install/message.template.moved_content_between_groups.yml
+++ b/modules/social_features/social_activity/config/install/message.template.moved_content_between_groups.yml
@@ -12,8 +12,8 @@ third_party_settings:
     activity_context: group_activity_context
     activity_destinations:
       stream_home: stream_home
-    activity_create_direct: 1
-    activity_aggregate: 0
+    activity_create_direct: TRUE
+    activity_aggregate: FALSE
     activity_entity_condition: ''
     email_subject: ''
 template: moved_content_between_groups

--- a/modules/social_features/social_activity/config/update/social_activity_update_11001.yml
+++ b/modules/social_features/social_activity/config/update/social_activity_update_11001.yml
@@ -1,0 +1,209 @@
+message.template.create_comment_community_node:
+  expected_config:
+    third_party_settings:
+      activity_logger:
+        activity_aggregate: true
+        activity_create_direct: true
+  update_actions:
+    change:
+      third_party_settings:
+        activity_logger:
+          activity_aggregate: 1
+          activity_create_direct: 1
+message.template.create_comment_community_post:
+  expected_config:
+    settings:
+      purge_methods: {  }
+    third_party_settings:
+      activity_logger:
+        activity_aggregate: true
+        activity_create_direct: true
+  update_actions:
+    delete:
+      settings:
+        purge_methods: {  }
+    change:
+      settings:
+        purge:
+          days: null
+          enabled: false
+          override: false
+          quota: null
+      third_party_settings:
+        activity_logger:
+          activity_aggregate: 1
+          activity_create_direct: 1
+message.template.create_comment_group_node:
+  expected_config:
+    third_party_settings:
+      activity_logger:
+        activity_aggregate: true
+        activity_create_direct: true
+  update_actions:
+    change:
+      third_party_settings:
+        activity_logger:
+          activity_aggregate: 1
+          activity_create_direct: 1
+message.template.create_comment_group_post:
+  expected_config:
+    settings:
+      purge_methods: {  }
+    third_party_settings:
+      activity_logger:
+        activity_aggregate: true
+        activity_create_direct: true
+  update_actions:
+    delete:
+      settings:
+        purge_methods: {  }
+    change:
+      settings:
+        purge:
+          days: null
+          enabled: false
+          override: false
+          quota: null
+      third_party_settings:
+        activity_logger:
+          activity_aggregate: 1
+          activity_create_direct: 1
+message.template.create_event_community:
+  expected_config:
+    settings:
+      purge_methods: {  }
+    third_party_settings:
+      activity_logger:
+        activity_create_direct: false
+  update_actions:
+    delete:
+      settings:
+        purge_methods: {  }
+    change:
+      settings:
+        purge:
+          days: null
+          enabled: false
+          override: false
+          quota: null
+      third_party_settings:
+        activity_logger:
+          activity_create_direct: 0
+message.template.create_event_group:
+  expected_config:
+    third_party_settings:
+      activity_logger:
+        activity_create_direct: false
+  update_actions:
+    change:
+      third_party_settings:
+        activity_logger:
+          activity_create_direct: 0
+message.template.create_post_community:
+  expected_config:
+    settings:
+      purge_methods: {  }
+    third_party_settings:
+      activity_logger:
+        activity_create_direct: true
+  update_actions:
+    delete:
+      settings:
+        purge_methods: {  }
+    change:
+      settings:
+        purge:
+          days: null
+          enabled: false
+          override: false
+          quota: null
+      third_party_settings:
+        activity_logger:
+          activity_create_direct: 1
+message.template.create_post_group:
+  expected_config:
+    settings:
+      purge_methods: {  }
+    third_party_settings:
+      activity_logger:
+        activity_create_direct: true
+  update_actions:
+    delete:
+      settings:
+        purge_methods: {  }
+    change:
+      settings:
+        purge:
+          days: null
+          enabled: false
+          override: false
+          quota: null
+      third_party_settings:
+        activity_logger:
+          activity_create_direct: 1
+message.template.create_post_profile_stream:
+  expected_config:
+    settings:
+      purge_methods: {  }
+    third_party_settings:
+      activity_logger:
+        activity_aggregate: false
+        activity_create_direct: true
+  update_actions:
+    delete:
+      settings:
+        purge_methods: {  }
+    change:
+      settings:
+        purge:
+          days: null
+          enabled: false
+          override: false
+          quota: null
+      third_party_settings:
+        activity_logger:
+          activity_aggregate: 0
+          activity_create_direct: 1
+message.template.create_topic_community:
+  expected_config:
+    settings:
+      purge_methods: {  }
+    third_party_settings:
+      activity_logger:
+        activity_create_direct: false
+  update_actions:
+    delete:
+      settings:
+        purge_methods: {  }
+    change:
+      settings:
+        purge:
+          days: null
+          enabled: false
+          override: false
+          quota: null
+      third_party_settings:
+        activity_logger:
+          activity_create_direct: 0
+message.template.create_topic_group:
+  expected_config:
+    third_party_settings:
+      activity_logger:
+        activity_create_direct: false
+  update_actions:
+    change:
+      third_party_settings:
+        activity_logger:
+          activity_create_direct: 0
+message.template.moved_content_between_groups:
+  expected_config:
+    third_party_settings:
+      activity_logger:
+        activity_aggregate: false
+        activity_create_direct: true
+  update_actions:
+    change:
+      third_party_settings:
+        activity_logger:
+          activity_aggregate: 0
+          activity_create_direct: 1

--- a/modules/social_features/social_activity/social_activity.info.yml
+++ b/modules/social_features/social_activity/social_activity.info.yml
@@ -21,6 +21,7 @@ dependencies:
   - drupal:options
   - profile:profile
   - search_api:search_api
+  - social:activity_logger
   - social:social_comment
   - social:social_editor
   - social:social_event

--- a/modules/social_features/social_activity/social_activity.install
+++ b/modules/social_features/social_activity/social_activity.install
@@ -369,7 +369,7 @@ function social_activity_update_10303() {
 /**
  * Updating  configuration keys as per underlying schema.
  */
-function social_activity_update_11001() {
+function social_activity_update_11001() : string {
   /** @var \Drupal\update_helper\Updater $updater */
   $updater = \Drupal::service('update_helper.updater');
 

--- a/modules/social_features/social_activity/social_activity.install
+++ b/modules/social_features/social_activity/social_activity.install
@@ -365,3 +365,17 @@ function social_activity_update_10303() {
     }
   }
 }
+
+/**
+ * Updating  configuration keys as per underlying schema.
+ */
+function social_activity_update_11001() {
+  /** @var \Drupal\update_helper\Updater $updater */
+  $updater = \Drupal::service('update_helper.updater');
+
+  // Execute configuration update definitions with logging of success.
+  $updater->executeUpdate('social_activity', 'social_activity_update_11001');
+
+  // Output logged messages to related channel of update execution.
+  return $updater->logger()->output();
+}

--- a/modules/social_features/social_mentions/config/install/message.template.create_mention_comment_stream.yml
+++ b/modules/social_features/social_mentions/config/install/message.template.create_mention_comment_stream.yml
@@ -11,8 +11,8 @@ third_party_settings:
     activity_context: mention_activity_context
     activity_destinations:
       stream_profile: stream_profile
-    activity_create_direct: 1
-    activity_aggregate: 0
+    activity_create_direct: TRUE
+    activity_aggregate: FALSE
     activity_entity_condition: mention_comment
     email_subject: ''
 template: create_mention_comment_stream

--- a/modules/social_features/social_mentions/config/install/message.template.create_mention_post_stream.yml
+++ b/modules/social_features/social_mentions/config/install/message.template.create_mention_post_stream.yml
@@ -11,8 +11,8 @@ third_party_settings:
     activity_context: mention_activity_context
     activity_destinations:
       stream_profile: stream_profile
-    activity_create_direct: 1
-    activity_aggregate: 0
+    activity_create_direct: TRUE
+    activity_aggregate: FALSE
     activity_entity_condition: mention_post
     email_subject: ''
 template: create_mention_post_stream

--- a/modules/social_features/social_mentions/config/update/social_mentions_update_11001.yml
+++ b/modules/social_features/social_mentions/config/update/social_mentions_update_11001.yml
@@ -1,0 +1,24 @@
+message.template.create_mention_comment_stream:
+  expected_config:
+    third_party_settings:
+      activity_logger:
+        activity_aggregate: false
+        activity_create_direct: true
+  update_actions:
+    change:
+      third_party_settings:
+        activity_logger:
+          activity_aggregate: 0
+          activity_create_direct: 1
+message.template.create_mention_post_stream:
+  expected_config:
+    third_party_settings:
+      activity_logger:
+        activity_aggregate: false
+        activity_create_direct: true
+  update_actions:
+    change:
+      third_party_settings:
+        activity_logger:
+          activity_aggregate: 0
+          activity_create_direct: 1

--- a/modules/social_features/social_mentions/social_mentions.install
+++ b/modules/social_features/social_mentions/social_mentions.install
@@ -101,7 +101,7 @@ function social_mentions_update_10301() {
 /**
  * Updating  configuration keys as per underlying schema.
  */
-function social_mentions_update_11001() {
+function social_mentions_update_11001() : string {
   /** @var \Drupal\update_helper\Updater $updater */
   $updater = \Drupal::service('update_helper.updater');
 

--- a/modules/social_features/social_mentions/social_mentions.install
+++ b/modules/social_features/social_mentions/social_mentions.install
@@ -97,3 +97,17 @@ function social_mentions_update_10301() {
     }
   }
 }
+
+/**
+ * Updating  configuration keys as per underlying schema.
+ */
+function social_mentions_update_11001() {
+  /** @var \Drupal\update_helper\Updater $updater */
+  $updater = \Drupal::service('update_helper.updater');
+
+  // Execute configuration update definitions with logging of success.
+  $updater->executeUpdate('social_mentions', 'social_mentions_update_11001');
+
+  // Output logged messages to related channel of update execution.
+  return $updater->logger()->output();
+}

--- a/translations.php
+++ b/translations.php
@@ -108,6 +108,27 @@ new TranslatableMarkup("Group content visibility options");
 new TranslatableMarkup("Choose the visibility options allowed for the group content.");
 new TranslatableMarkup("Join methods");
 new TranslatableMarkup("How can people join this group. Group managers can always add members directly, regardless of the chosen join method.");
+new TranslatableMarkup("Someone commented on your content");
+new TranslatableMarkup("You have a new comment on a post");
+new TranslatableMarkup("You have a new reply to your comment");
+new TranslatableMarkup("New content has been added to a group you are in");
+new TranslatableMarkup("There is a new post in your stream");
+new TranslatableMarkup("Your request to enroll to an event has been accepted");
+new TranslatableMarkup("Someone joined one of your groups");
+new TranslatableMarkup("Someone wants to enroll to your event");
+new TranslatableMarkup("Someone reported content as inappropriate");
+new TranslatableMarkup("You have a new enrollment to your event");
+new TranslatableMarkup("You have been invited to an event");
+new TranslatableMarkup("You have been added to an event");
+new TranslatableMarkup("Someone commented on your content");
+new TranslatableMarkup("Someone added content you might be interested in");
+new TranslatableMarkup("Your request to join a group has been accepted");
+new TranslatableMarkup("Someone wants to join your group");
+new TranslatableMarkup("Your content has been liked");
+new TranslatableMarkup("You have been mentioned");
+new TranslatableMarkup("You have a new reply to a thread you were mentioned in");
+new TranslatableMarkup("You have received a new private message");
+
 // Following plural strings are not translatable due to the @todo in
 // _social_event_managers_action_batch_finish().
 new PluralTranslatableMarkup(0, '1 selected enrollee has been exported successfully', '@count selected enrollees have been exported successfully');


### PR DESCRIPTION
## Problem
Follow up of #2946 

The email subjects are not being detected in weblate and also POTX tool is not able to extract them for translations.

## Solution
Add them to translations.php file for enabling to detect and translate them.

## Issue tracker
https://www.drupal.org/project/social/issues/3282031

## Theme issue tracker
N.A

## How to test
- [ ] Checkout to this branch
- [ ] `drush cr; drush updb -y`
- [ ] Follow the steps on the original PR

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] If applicable (I.E. new hook_updates) the update path from previous versions (major and minor versions) are tested
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
N.A

## Release notes
N.A

## Change Record
N.A

## Translations
- [ ] Source strings are added to the `translations.php` file.
