### PR TITLE
Issue #3284885 by vnech: Fix comments field place in entity form creation page

### DIFF
--- a/modules/social_features/social_core/social_core.module
+++ b/modules/social_features/social_core/social_core.module
@@ -7,6 +7,7 @@
 
 use Drupal\block\Entity\Block;
 use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Entity\Display\EntityFormDisplayInterface;
 use Drupal\Core\Field\FieldItemList;
 use Drupal\Core\File\FileSystemInterface;
@@ -1013,6 +1014,27 @@ function social_core_form_node_form_alter(&$form, FormStateInterface $form_state
       // Remove the preview button.
       if (isset($form['actions']['preview'])) {
         unset($form['actions']['preview']);
+      }
+    }
+  }
+}
+
+/**
+ * Implements hook_form_alter().
+ */
+function social_core_form_alter(array &$form, FormStateInterface $form_state, string $form_id): void {
+  // This code will move the comments field to the "Settings" field group
+  // only if $form['advanced'] does not exist.
+  if (method_exists($form_state->getFormObject(), 'getEntity')) {
+    $entity = $form_state->getFormObject()->getEntity();
+    if ($entity instanceof ContentEntityInterface) {
+      // Move comments field to "group_settings" field group.
+      $comments_field = "field_{$entity->bundle()}_comments";
+      if (!empty($form[$comments_field])) {
+        if (!empty($form['#fieldgroups']['group_settings'])) {
+          $form[$comments_field]['#group'] = 'group_settings';
+          $form['#group_children']['group_settings'] = $comments_field;
+        }
       }
     }
   }


### PR DESCRIPTION
## Problem
Sometimes "Comments Settings" field is placed out of the "Settings" group field on entity create page.

<img width="935" alt="Screenshot 2022-06-09 at 18 02 15" src="https://user-images.githubusercontent.com/19921926/172879956-87b6e931-5f12-4d07-9cec-4d8d85461678.png">

## Solution
Hardcode comments field in "settings" field group.

## Issue tracker
- https://www.drupal.org/project/social/issues/3284885
- https://getopensocial.atlassian.net/browse/YANG-7700

## Theme issue tracker
N/A

## How to test
- [ ] Login as an admin
- [ ] Create a new content type - `Dummy`
- [ ] Implement `hook_social_content_type_alter()` and `hook_social_core_compatible_content_forms_alter()` for the node type
- [ ] Enable comments in this content type
- [ ] Visit add/edit pages for the content type

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] If applicable (I.E. new hook_updates) the update path from previous versions (major and minor versions) are tested
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
N/A

## Release notes
*Fix comments field place in entity form creation page.*

## Change Record
N/A

## Translations
N/A
