### PR TITLE
Issue #3291092 by vnech: Hide revisions form field on group create & edit pages

### DIFF
--- a/modules/social_features/social_group/social_group.module
+++ b/modules/social_features/social_group/social_group.module
@@ -1032,6 +1032,14 @@ function social_group_form_alter(&$form, FormStateInterface $form_state, $form_i
       ];
       array_unshift($form['actions']['submit']['#submit'], '_social_group_delete_group');
     }
+
+    if (!empty($form['advanced']) && Element::isVisibleElement($form['advanced'])) {
+      // Hide revision fields.
+      $form['advanced']['#access'] =
+      $form['revision']['#access'] =
+      $form['revision_log']['#access'] =
+      $form['revision_information']['#access'] = FALSE;
+    }
   }
 
   if (

--- a/modules/social_features/social_group/social_group.module
+++ b/modules/social_features/social_group/social_group.module
@@ -1033,6 +1033,21 @@ function social_group_form_alter(&$form, FormStateInterface $form_state, $form_i
       array_unshift($form['actions']['submit']['#submit'], '_social_group_delete_group');
     }
 
+    // Move "path" field to "Settings" section if the "Social Path Manager"
+    // module is disabled.
+    if (!\Drupal::moduleHandler()->moduleExists('social_path_manager')) {
+      if (!empty($form['path'])) {
+        $form['path']['#type'] = 'fieldset';
+        if (Element::isVisibleElement($form['path'])) {
+          if (!empty($form['#fieldgroups']['group_settings'])) {
+            $form['path']['#group'] = 'group_settings';
+            $form['#fieldgroups']['group_settings']->children[] = 'path';
+          }
+        }
+      }
+    }
+
+    // Hide default field group "advanced" for group entities.
     if (!empty($form['advanced']) && Element::isVisibleElement($form['advanced'])) {
       // Hide revision fields.
       $form['advanced']['#access'] =


### PR DESCRIPTION
## Problem
"Url alias" and "Revisions" form fields are placed out of the field groups:

<img width="791" alt="Screenshot 2022-06-17 at 15 05 07" src="https://user-images.githubusercontent.com/19921926/174294948-d84dc52f-c766-4700-8174-9b348c17d785.png">


## Solution
- Hide "Advanced" vertical tab fieldset
- Hide "Revisions" form field

## Issue tracker
- https://www.drupal.org/project/social/issues/3291092
- https://getopensocial.atlassian.net/browse/YANG-7715

## Theme issue tracker
N/A

## How to test
- [ ] Login as a site manager
- [ ] Visit flexible group create/edit page

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
Before:
<img width="791" alt="Screenshot 2022-06-17 at 15 05 07" src="https://user-images.githubusercontent.com/19921926/174295004-82a971c9-faaf-4691-b4e1-53fab9b01716.png">

After:
<img width="791" alt="Screenshot 2022-06-17 at 15 04 19" src="https://user-images.githubusercontent.com/19921926/174294998-16bcf2f1-f0d5-4996-af7c-b7851424fe34.png">


## Release notes
*Hide revisions form fields on group create/edit pages.*

## Change Record
N/A

## Translations
N/A
