### PR TITLE
Issue #3291105 by vnech: Hide redundant form fields labels if user doesn't have an access to them

### DIFF
--- a/modules/social_features/social_core/social_core.module
+++ b/modules/social_features/social_core/social_core.module
@@ -11,6 +11,7 @@ use Drupal\Core\Entity\Display\EntityFormDisplayInterface;
 use Drupal\Core\Field\FieldItemList;
 use Drupal\Core\File\FileSystemInterface;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Render\Element;
 use Drupal\file\Entity\File;
 use Drupal\filter\FilterFormatInterface;
 use Drupal\Core\Session\AccountInterface;
@@ -868,7 +869,7 @@ function social_core_form_node_form_alter(&$form, FormStateInterface $form_state
         }
 
         // Move the Published status to group settings with a new wrapper.
-        if (!empty($form['status'])) {
+        if (!empty($form['status']) && Element::isVisibleElement($form['status'])) {
           // Add an details element to status.
           $form['status_label'] = [
             '#type' => 'details',
@@ -883,15 +884,17 @@ function social_core_form_node_form_alter(&$form, FormStateInterface $form_state
           unset($form['status']);
         }
 
-        // Node author information for administrators.
-        $form['author_info'] = [
-          '#type' => 'details',
-          '#title' => t('Author Information'),
-          '#description' => '',
-          '#open' => TRUE,
-          '#weight' => 100,
-          '#group' => 'group_settings',
-        ];
+        if (Element::isVisibleElement($form['uid']) || Element::isVisibleElement($form['created'])) {
+          // Node author information for administrators.
+          $form['author_info'] = [
+            '#type' => 'details',
+            '#title' => t('Author Information'),
+            '#description' => '',
+            '#open' => TRUE,
+            '#weight' => 100,
+            '#group' => 'group_settings',
+          ];
+        }
 
         // Move author uid to the new author info fieldset,
         // and remove descriptive text.


### PR DESCRIPTION
## Problem
User still can see field labels even he doesn't have access to these fields:
<img width="766" alt="Screenshot 2022-06-17 at 16 11 43" src="https://user-images.githubusercontent.com/19921926/174307402-d97dbdc6-6af4-4b85-8f5c-42a04c5633d9.png">

## Solution
Hide un-useful form fields labels if user don't have an access to these labels (for nodes)

## Issue tracker
- https://www.drupal.org/project/social/issues/3291105
- https://getopensocial.atlassian.net/browse/YANG-7716

## Theme issue tracker
N/A

## How to test
- [ ] Revoke permission `administer nodes` for the `contentmanager` role
- [ ] Login as a `contentmanager`
- [ ] Visit topic creation page - `/node/add/topic` 

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
Before:
<img width="766" alt="Screenshot 2022-06-17 at 16 11 43" src="https://user-images.githubusercontent.com/19921926/174307786-df14bda9-2ba4-46dd-ac68-58afef2c3fad.png">

After:
<img width="783" alt="Screenshot 2022-06-17 at 16 10 44" src="https://user-images.githubusercontent.com/19921926/174307822-251070d7-638a-4ceb-96b3-a24d08fe2a0f.png">

## Release notes
*Hide un-useful form fields labels if user don't have an access to these labels (for nodes)*

## Change Record
N/A

## Translations
N/A