### PR TITLE
Issue #3291402 by alex.ksis: Add redirect to the correct membership requests page.

### DIFF
--- a/modules/social_features/social_group/src/EventSubscriber/RedirectSubscriber.php
+++ b/modules/social_features/social_group/src/EventSubscriber/RedirectSubscriber.php
@@ -39,12 +39,17 @@ class RedirectSubscriber implements EventSubscriberInterface {
     }
 
     // Get the current route name for the checks being performed below.
-    $routeMatch = \Drupal::routeMatch()->getRouteName();
+    $route_name = \Drupal::routeMatch()->getRouteName();
 
     // Redirect the group content collection index to the group canonical URL.
-    if ($routeMatch === 'entity.group_content.collection') {
+    if ($route_name === 'entity.group_content.collection') {
       $event->setResponse(new RedirectResponse(Url::fromRoute('entity.group.canonical', ['group' => $group->id()])
         ->toString()));
+    }
+    elseif ($route_name === 'view.group_pending_members.page_1') {
+      $event->setResponse(new RedirectResponse(Url::fromRoute('view.group_pending_members.membership_requests', [
+        'arg_0' => $group->id(),
+      ])->toString()));
     }
 
     // Get the current user.
@@ -63,7 +68,7 @@ class RedirectSubscriber implements EventSubscriberInterface {
           return;
         }
         // If the user is not an member of this group.
-        elseif (!$group->hasMember($user) && in_array($routeMatch, $routes)) {
+        elseif (!$group->hasMember($user) && in_array($route_name, $routes)) {
           $event->setResponse(new RedirectResponse(Url::fromRoute('view.group_information.page_group_about', ['group' => $group->id()])
             ->toString()));
         }

--- a/modules/social_features/social_group/src/EventSubscriber/RedirectSubscriber.php
+++ b/modules/social_features/social_group/src/EventSubscriber/RedirectSubscriber.php
@@ -47,6 +47,9 @@ class RedirectSubscriber implements EventSubscriberInterface {
         ->toString()));
     }
     elseif ($route_name === 'view.group_pending_members.page_1') {
+      // We have two pages with a list of group members. One of them is provided
+      // by the grequest module and is not correct. So we add a redirect to the
+      // custom one.
       $event->setResponse(new RedirectResponse(Url::fromRoute('view.group_pending_members.membership_requests', [
         'arg_0' => $group->id(),
       ])->toString()));


### PR DESCRIPTION
There are two pages with membership requests. One is provided by the `grequest` module, another one is provided by the `social_group` module.

## Problem
There are two pages with membership requests. One of them is not correct and has broken "Approve" and "Reject" links.

## Solution
Create a redirect to the correct page.

## Issue tracker
https://getopensocial.atlassian.net/browse/YANG-8012
https://www.drupal.org/project/social/issues/3291402

## How to test
- [ ] Go to to the /group/%/members-pending
- [ ] Make sure you were redirected to the /group/%/membership-requests

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Release notes
Added redirect from the "Membership requests" page provided by the grequest module to the page provided by the social group module.