### PR TITLE
Issue #3281618 by zanvidmar: Show enroll button on multi-group event if user is member of at least one group

### DIFF
--- a/modules/social_features/social_event/src/Form/EnrollActionForm.php
+++ b/modules/social_features/social_event/src/Form/EnrollActionForm.php
@@ -145,6 +145,12 @@ class EnrollActionForm extends FormBase {
       && !social_event_manager_or_organizer()
     ) {
 
+      // Default prediction is that user does not have permissions to enroll
+      // to event and this is why $enroll_to_events_in_groups is set to FALSE.
+      // If user has permission 'enroll to events in groups' in at least one
+      // group in "$groups", this value will be changed to TRUE.
+      $enroll_to_events_in_groups = FALSE;
+
       $group_type_ids = $this->configFactory->get('social_event.settings')
         ->get('enroll');
 
@@ -155,12 +161,23 @@ class EnrollActionForm extends FormBase {
         // be joined by outsiders, which makes sense, since they also
         // couldn't see these events in the first place.
         if (in_array($group->bundle(), $group_type_ids, TRUE) && $group->hasPermission('join group', $current_user)) {
+          $enroll_to_events_in_groups = TRUE;
           break;
         }
 
-        if (!$group->hasPermission('enroll to events in groups', $current_user)) {
-          return [];
+        if ($group->hasPermission('enroll to events in groups', $current_user)) {
+          $enroll_to_events_in_groups = TRUE;
+
+          // Skip permission validation if 'enroll to events in groups' is
+          // already granted.
+          break;
         }
+      }
+
+      // Do not render form if user does not have permission
+      // 'enroll to events in groups' for at least one group in "$groups".
+      if (!$enroll_to_events_in_groups) {
+        return [];
       }
     }
 


### PR DESCRIPTION
Show enroll button on multi-group event if user is member of at least one group

Previous / deprecated PR: [2941](https://github.com/goalgorilla/open_social/pull/2941)

Users are not able to join the multi-group event if they are not members of both groups, which is unexpected behaviour.
Changing the conceptual permission logic from "and" (user must be member of all groups) to "or" (user must be member of at least one group) fixes that issue.

## Problem
Situation:
- **Event 1**:
   - Group: “Group A” and “Group B”
   - Visibility: Members,
   - Registration method: Open registration
   - Unchecked: Allow Logins or Enrollments from Non-Group Members)
- **Group A**:
   - Members: 
      - User A
      - User C
- **Group B**:
   - Members:
      - User B
      - User C
- **User D**:
  - Not member of Group A and Group B

Facts:  
- User A can not enroll to Event 1 (bug)
- User B can not enroll to Event 1 (bug)
- User C can enroll to Event 1 (expected behaviour)
- User D can not enroll to Event 1 (expected behaviour)

## Solution
- User A should be able to see enroll button and enroll to Event 1
- User B should be able to see enroll button and enroll to Event 1
They both need to be able to see enroll button and to enroll to  Event 1 because they are both members of at least one group related to Event 1

## Issue tracker
[TB-6819](https://getopensocial.atlassian.net/browse/TB-6819)
[3281618](https://www.drupal.org/project/social/issues/3281618)

## Theme issue tracker
/

## How to test
- [x] Set up the same "Situation" as described under "Problem"

QA 1:
- [x] As UL User A (member of Group A) try to enroll the Event 1 (event related to Group A and Group B).
- [x] It is expect that "Enroll" button is visible but it is not.
- [x] The expected result to see the "Enroll" button is attained with this fix applied.

QA 2:
- [x] As UL User B (member of Group B) try to enroll the Event 1 (event related to Group A and Group B).
- [x] It is expect that "Enroll" button is visible but it is not.
- [x] The expected result to see the "Enroll" button is attained with this fix applied.

QA 3:
- [x] As UL User C (member of Group A and B) try to enroll the Event 1 (event related to Group A and Group B).
- [x] It is expect that "Enroll" button is visible.
- [x] The expected result to see the "Enroll" button with fix applied, confirms that fix did not break existing expected behaviour.

QA 4:
- [x] As UL User D ( nor member of Group A or B) try to enroll the Event 1 (event related to Group A and Group B).
- [x] It is expect that "Enroll" button is not visible nor user can even access the event.
- [x] The expected result with fix applied, confirms that fix did not break existing expected behaviour.

## Definition of done
### Before merge
- [x] Code/peer review is completed
- [x] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [x] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [x] All acceptance criteria were met
- [x] If applicable (I.E. new hook_updates) the update path from previous versions (major and minor versions) are tested
- [x] This pull request has all required labels (team/type/priority)
- [x] This pull request has a milestone
- [x] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [x] New UI elements, or changes on UI elements are approved by the design team
- [x] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
![](https://www.drupal.org/files/issues/2022-05-20/Screenshot_2022-05-20_at_16_01_14.png)

## Release notes
Group members can now enroll to multi-group events if they are members of at least one of groups.

## Change Record
/

## Translations
/
