### PR TITLE
Issue #3291633: Update socialblue dependency to 2.2.4 on 11.3.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -188,7 +188,7 @@
         "drupal/select2": "1.13.0",
         "drupal/shariff": "1.7",
         "drupal/social_tour": "1.0.0-alpha2",
-        "drupal/socialblue": "2.2.2",
+        "drupal/socialblue": "2.2.4",
         "drupal/swiftmailer": "2.2.0",
         "drupal/token": "1.10.0",
         "drupal/ultimate_cron": "2.0-alpha5",


### PR DESCRIPTION
## Problem
Update socialblue dependency to 2.2.4 on 11.3.x

## Solution
Update socialblue dependency to 2.2.4 on 11.3.x

## Issue tracker
*[Required] Paste a link to the drupal.org issue queue item. If any other issue trackers were used, include links to those too.*

## Theme issue tracker
https://www.drupal.org/project/social/issues/3291633

## How to test
- [ ] After installation make sure that socialblue is on 2.2.4 version and socialbase is locked on 2.2.3

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
N/A

## Release notes
N/A

## Change Record
N/A

## Translations
N/A
