### PR TITLE
Issue #3291646: Update socialblue dependency to 2.3.0 on 11.4.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -131,12 +131,6 @@
             },
             "drupal/redirect": {
                 "Redirection issue when interface language is different from content language": "https://www.drupal.org/files/issues/2020-06-01/redirect-interface_language_different_from_content_language_2991423-13.patch"
-            },
-            "drupal/socialbase": {
-                "Make join methods for groups re-usable": "https://www.drupal.org/files/issues/2021-12-29/re-use-group-join-methods-3256324-3.patch"
-            },
-            "drupal/socialblue": {
-                "Make join methods for groups re-usable": "https://www.drupal.org/files/issues/2022-06-06/re-use-group-join-methods-3256328-8.patch"
             }
         }
     },
@@ -189,7 +183,7 @@
         "drupal/select2": "1.13.0",
         "drupal/shariff": "1.7",
         "drupal/social_tour": "1.0.0-alpha2",
-        "drupal/socialblue": "2.2.3",
+        "drupal/socialblue": "2.3.0",
         "drupal/swiftmailer": "2.2.0",
         "drupal/token": "1.10.0",
         "drupal/ultimate_cron": "2.0-alpha5",


### PR DESCRIPTION
## Problem
Update socialblue dependency to 2.3.0 on 11.4.x

## Solution
Update socialblue dependency to 2.3.0 on 11.4.x

## Issue tracker
https://www.drupal.org/project/social/issues/3291646

## Theme issue tracker
N/A

## How to test
- [ ] Install branch and make sure that both socialbase and socialblue are locked to 2.3.0 versions

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
N/A

## Release notes
N/A

## Change Record
N/A

## Translations
N/A
