### PR TITLE
Issue #3211735 by SocialNicheGuru, Ressinel: Profile Image Header disappears when saved

### DIFF
--- a/modules/social_features/social_user/src/ContextProvider/UserRouteContext.php
+++ b/modules/social_features/social_user/src/ContextProvider/UserRouteContext.php
@@ -100,6 +100,7 @@ class UserRouteContext implements ContextProviderInterface {
    */
   public function getAvailableContexts() {
     return [
+      'user' => EntityContext::fromEntityTypeId('user', $this->t('User entity from URL')),
       'social_user' => EntityContext::fromEntityTypeId('user', $this->t('Social User entity from URL')),
     ];
   }


### PR DESCRIPTION
## Problem
Profile hero block disappears when saved.

## Solution
Revert context id as it was before to fix an issue where the profile hero block disappears after saving.

## Issue tracker
- https://www.drupal.org/project/social/issues/3211735

## Theme issue tracker
N/A

## How to test
- [ ] Goto `/admin/structure/block/manage/socialblue_profile_hero_block`
- [ ] Select `Social User Entity from URL` in the **Select a user value** field
- [ ] Press save
- [ ] Go to the profile page and you will see that the Hero block has gone
- [ ] Apply changes from this PR and try to redo previous steps
- [ ] Hero block should not disappear on the profile page

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
### Before:

![5a83f06b7626ee031983c1da8229b26e](https://user-images.githubusercontent.com/10220937/174852692-a3784e5c-43c5-4745-86c7-d2c18b456a5b.png)

### After:

![1a8f0a640073a1fc6e7ac0c1f3e175d0](https://user-images.githubusercontent.com/10220937/174852659-1c440979-fa3f-4ff3-810b-7de9e48f39c6.png)

## Release notes
N/A

## Change Record
N/A

## Translations
N/A
