### PR TITLE
Issue #3293556 by sjoerdvandervis: Add link to calendar description

### DIFF
--- a/modules/social_features/social_event/modules/social_event_addtocal/src/Plugin/SocialAddToCalendarBase.php
+++ b/modules/social_features/social_event/modules/social_event_addtocal/src/Plugin/SocialAddToCalendarBase.php
@@ -133,8 +133,11 @@ abstract class SocialAddToCalendarBase extends PluginBase implements SocialAddTo
    * {@inheritdoc}
    */
   public function getEventDescription(NodeInterface $node) {
+    // Get event URL.
+    $node_url = '<p>Event link: ' . $node->toUrl('canonical', ['absolute' => TRUE])->toString() . '</p>';
+
     // Get event description.
-    $description = $node->body->value;
+    $description = $node_url . $node->body->value;
 
     // Strings for replace.
     $replace_strings = [

--- a/modules/social_features/social_event/modules/social_event_addtocal/src/Plugin/SocialAddToCalendarBase.php
+++ b/modules/social_features/social_event/modules/social_event_addtocal/src/Plugin/SocialAddToCalendarBase.php
@@ -6,6 +6,7 @@ use Drupal\Component\Plugin\PluginBase;
 use Drupal\Component\Utility\Unicode;
 use Drupal\Core\Extension\ModuleExtensionList;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Core\Url;
 use Drupal\datetime\Plugin\Field\FieldType\DateTimeItemInterface;
 use Drupal\node\NodeInterface;
@@ -15,6 +16,8 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  * Base class for Social add to calendar plugins.
  */
 abstract class SocialAddToCalendarBase extends PluginBase implements SocialAddToCalendarInterface, ContainerFactoryPluginInterface {
+
+  use StringTranslationTrait;
 
   /**
    * The module extension list.
@@ -133,11 +136,8 @@ abstract class SocialAddToCalendarBase extends PluginBase implements SocialAddTo
    * {@inheritdoc}
    */
   public function getEventDescription(NodeInterface $node) {
-    // Get event URL.
-    $node_url = '<p>Event link: ' . $node->toUrl('canonical', ['absolute' => TRUE])->toString() . '</p>';
-
     // Get event description.
-    $description = $node_url . $node->body->value;
+    $description = $node->body->value;
 
     // Strings for replace.
     $replace_strings = [
@@ -150,6 +150,11 @@ abstract class SocialAddToCalendarBase extends PluginBase implements SocialAddTo
     foreach ($replace_strings as $search => $replace) {
       $description = str_replace($search, $replace, $description);
     }
+
+    // Get event URL.
+    $node_url = $this->t('Event link: @link', ['@link' => $node->toUrl('canonical', ['absolute' => TRUE])->toString()]) . PHP_EOL;
+    // Update event description with adding event link.
+    $description = $node_url . $description;
 
     return Unicode::truncate(strip_tags($description), 1000, TRUE, TRUE);
   }


### PR DESCRIPTION
## Problem
Whenever a user adds an event to his / her / their calendar, there is no trace of the event anymore in the personal calendar.

## Solution
Add a link to the event in the calendar description.

## Issue tracker
https://www.drupal.org/project/social/issues/3293556

## How to test
- [ ] Enable the module `social_event_addtocal` and configure the possibility to add events to a calendar
- [ ] Create an event
- [ ] Use the add to calendar functionality to add the event to your personal calendar
- [ ] See that there is no link to the event
- [ ] Repeat the above on this branch. See that it now contains a link to the event.

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Release notes
* We've added a link to the event in Open Social to the description when adding an event to a personal calendar.
