### PR TITLE
Issue #3106344 by alduya: Use $this->tableAlias instead of hardcoded table name

### DIFF
--- a/modules/social_features/social_group/src/Plugin/views/argument/UserUid.php
+++ b/modules/social_features/social_group/src/Plugin/views/argument/UserUid.php
@@ -9,7 +9,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 /**
  * Argument handler to accept a user id.
  *
- * This checks for groups that user created or is a member off.
+ * This checks for groups that user created or is a member of.
  *
  * @ingroup views_argument_handlers
  *
@@ -56,18 +56,18 @@ class UserUid extends ArgumentPluginBase {
     $this->ensureMyTable();
 
     // Use the table definition to correctly add this user ID condition.
-    if ($this->table != 'group_content_field_data') {
+    if ($this->table !== 'group_content_field_data') {
       $subselect2 = $this->database->select('group_content_field_data', 'gc');
       $subselect2->addField('gc', 'gid');
       $subselect2->condition('gc.entity_id', $this->argument);
       $subselect2->condition('gc.type', '%' . $this->database->escapeLike('membership') . '%', 'LIKE');
 
       if ($this->usesOptions && isset($this->options['group'])) {
-        $this->query->addWhere($this->options['group'], 'groups_field_data.id', $subselect2, 'IN');
+        $this->query->addWhere($this->options['group'], $this->tableAlias . '.id', $subselect2, 'IN');
       }
       else {
         // Add with default options (AND).
-        $this->query->addWhere(0, 'groups_field_data.id', $subselect2, 'IN');
+        $this->query->addWhere(0, $this->tableAlias . '.id', $subselect2, 'IN');
       }
     }
   }


### PR DESCRIPTION
## Problem
In the `Drupal\social_group\Plugin\views\argument\UserUid` views argument plugin, `groups_field_data.id` is used. If `groups_field_data` is replaced by `$this->tableAlias`, the argument can also be used in views that do not start from groups. And the existing views that use the argument keep working.

## Solution
Use `$this->tableAlias` instead of hardcoded table name.

## Issue tracker
- https://www.drupal.org/project/social/issues/3106344

## Theme issue tracker
N/A

## How to test
- [ ] These changes should not affect any functionality
- [ ] All tests should be green

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
N/A

## Release notes
N/A

## Change Record
N/A

## Translations
N/A
