### PR TITLE
Issue #3275980 by Ressinel: Add defensive checks to fix error when we try to retrieve a link title

### DIFF
--- a/modules/social_features/social_activity/social_activity.module
+++ b/modules/social_features/social_activity/social_activity.module
@@ -9,6 +9,7 @@ use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\Core\Template\Attribute;
 use Drupal\Core\Url;
+use Drupal\menu_link_content\MenuLinkContentInterface;
 use Drupal\node\NodeInterface;
 use Drupal\views\ViewExecutable;
 
@@ -356,5 +357,8 @@ function social_activity_social_core_default_main_menu_links_alter(array &$links
     ]);
   $link = end($link);
 
-  $links[] = $link;
+  // Ensure that the end() doesn't return FALSE, and we have link instance.
+  if ($link instanceof MenuLinkContentInterface) {
+    $links[] = $link;
+  }
 }

--- a/modules/social_features/social_core/social_core.module
+++ b/modules/social_features/social_core/social_core.module
@@ -22,6 +22,7 @@ use Drupal\filter\Entity\FilterFormat;
 use Drupal\group\Entity\Group;
 use Drupal\group\Entity\GroupInterface;
 use Drupal\image\Entity\ImageStyle;
+use Drupal\menu_link_content\MenuLinkContentInterface;
 use Drupal\node\NodeInterface;
 use Drupal\path\Plugin\Field\FieldWidget\PathWidget;
 use Drupal\user\Entity\User;
@@ -1261,6 +1262,11 @@ function social_core_entity_access(EntityInterface $entity, string $operation, A
 
     /** @var \Drupal\menu_link_content\MenuLinkContentInterface $os_link */
     foreach ($default_os_links as $os_link) {
+      // Ensure that we have link instance.
+      if (!($os_link instanceof MenuLinkContentInterface)) {
+        continue;
+      }
+
       $os_link_title = $os_link->getTitle();
       $os_link_uri = $entity->get('link')->getValue();
       $os_link_uri = end($os_link_uri)['uri'];

--- a/modules/social_features/social_event/social_event.module
+++ b/modules/social_features/social_event/social_event.module
@@ -24,6 +24,7 @@ use Drupal\Core\Url;
 use Drupal\datetime\Plugin\Field\FieldType\DateTimeItemInterface;
 use Drupal\group\Entity\GroupContent;
 use Drupal\group\GroupMembershipLoaderInterface;
+use Drupal\menu_link_content\MenuLinkContentInterface;
 use Drupal\node\Entity\Node;
 use Drupal\node\NodeInterface;
 use Drupal\social_event\Controller\SocialEventController;
@@ -1378,5 +1379,8 @@ function social_event_social_core_default_main_menu_links_alter(array &$links) {
     ]);
   $link = end($link);
 
-  $links[] = $link;
+  // Ensure that the end() doesn't return FALSE, and we have link instance.
+  if ($link instanceof MenuLinkContentInterface) {
+    $links[] = $link;
+  }
 }

--- a/modules/social_features/social_group/social_group.module
+++ b/modules/social_features/social_group/social_group.module
@@ -34,6 +34,7 @@ use Drupal\group\Entity\GroupInterface;
 use Drupal\group\Entity\GroupType;
 use Drupal\group\GroupMembership;
 use Drupal\image\Entity\ImageStyle;
+use Drupal\menu_link_content\MenuLinkContentInterface;
 use Drupal\node\Entity\Node;
 use Drupal\node\NodeInterface;
 use Drupal\social_group\Controller\SocialGroupController;
@@ -3169,5 +3170,8 @@ function social_group_social_core_default_main_menu_links_alter(array &$links) {
     ]);
   $link = end($link);
 
-  $links[] = $link;
+  // Ensure that the end() doesn't return FALSE, and we have link instance.
+  if ($link instanceof MenuLinkContentInterface) {
+    $links[] = $link;
+  }
 }

--- a/modules/social_features/social_profile/social_profile.module
+++ b/modules/social_features/social_profile/social_profile.module
@@ -24,6 +24,7 @@ use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\Core\Url;
 use Drupal\file\FileInterface;
 use Drupal\image\Entity\ImageStyle;
+use Drupal\menu_link_content\MenuLinkContentInterface;
 use Drupal\node\Entity\Node;
 use Drupal\profile\Entity\Profile;
 use Drupal\profile\Entity\ProfileInterface;
@@ -1080,5 +1081,8 @@ function social_profile_social_core_default_main_menu_links_alter(array &$links)
     ]);
   $link = end($link);
 
-  $links[] = $link;
+  // Ensure that the end() doesn't return FALSE, and we have link instance.
+  if ($link instanceof MenuLinkContentInterface) {
+    $links[] = $link;
+  }
 }

--- a/modules/social_features/social_topic/social_topic.module
+++ b/modules/social_features/social_topic/social_topic.module
@@ -21,6 +21,7 @@ use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\Core\Url;
 use Drupal\field\Entity\FieldStorageConfig;
 use Drupal\group\Entity\GroupInterface;
+use Drupal\menu_link_content\MenuLinkContentInterface;
 use Drupal\node\NodeInterface;
 use Drupal\social_topic\Controller\SocialTopicController;
 use Drupal\taxonomy\TermInterface;
@@ -392,5 +393,8 @@ function social_topic_social_core_default_main_menu_links_alter(array &$links) {
     ]);
   $link = end($link);
 
-  $links[] = $link;
+  // Ensure that the end() doesn't return FALSE, and we have link instance.
+  if ($link instanceof MenuLinkContentInterface) {
+    $links[] = $link;
+  }
 }


### PR DESCRIPTION
PR for 11.1.x https://github.com/goalgorilla/open_social/pull/3022

## Problem
When we use code like $link = end($link); the function end() can return FALSE for empty array. And when we try to retrieve link title we have FALSE instead of link instance.

`Error: Call to a member function getTitle() on bool in social_core_entity_access() (line 1239 of profiles/contrib/social/modules/social_features/social_core/social_core.module).`

## Solution
Add defensive checks.

## Issue tracker
- https://www.drupal.org/project/social/issues/3275980

## Theme issue tracker
N/A

## How to test
- [ ] TBD

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
N/A

## Release notes
N/A

## Change Record
N/A

## Translations
N/A
