### PR TITLE
Issue #3294979 by zanvidmar: Disable "Get the related groups for this…

### DIFF
--- a/modules/social_features/social_group/social_group.post_update.php
+++ b/modules/social_features/social_group/social_group.post_update.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * @file
+ * Contains post update hook implementations.
+ */
+
+/**
+ * Disable "Get the related groups for this entity".
+ *
+ * Disable "Get the related groups for this entity" field on "Private Message
+ * Author" display for "User" entity if it is enabled.
+ */
+function social_group_post_update_11101_remove_user_related_groups_for_private_message_author_display(): void {
+  $pma_view_display = \Drupal::service('entity_type.manager')
+    ->getStorage('entity_view_display')
+    ->load('user.user.private_message_author');
+
+  if (!empty($pma_view_display) && $pma_view_display->getComponent('groups')) {
+    $pma_view_display->removeComponent('groups')->save();
+  }
+}


### PR DESCRIPTION
… entity" field on "Private Message Author" display for "User" entity if it is enabled.

## Problem
When opening a private message thread, instead of showing User name and User profile photo of the sender and receiver users, platform shows user’s groups data.

![image](https://user-images.githubusercontent.com/13753184/178722253-83771afa-e314-48a3-bfdf-becfd259d69c.png)

### Steps to reproduce
1. Check if private_message is enabled.
2. Go to admin/config/people/accounts/display/private_message_author
3. Look for field with label "Get the related groups for this entity"
"Get the related groups for this entity" field should be disabled by default, however in some projects (mostly older one before OS 11) this field is enabled. To be able to reproduce the error, enable this field.
4. Create a user that will be receiver of the message.
5. Make the receiver user member of one or more groups
6. Send private message to receiver
7. Result will be a private message thread with user’s groups data while expected result is to show User name and User profile photo without user’s groups data.

## Solution
Disable "groups" field from user entities as we do not use this field at user displays in Open Social with hook update.

## Issue tracker
[3294979](https://www.drupal.org/project/social/issues/3294979)
[PROD-1314](https://getopensocial.atlassian.net/browse/PROD-1314)

## Theme issue tracker
N/A

## How to test
### Option 1 (new projects)
- [ ] Follow the steps to reproduce and mimic the issue as described on point 3 and check A or B.
- [ ] Check A: That expected result is that after hook update, groups are not listed anymore on private messages
- [ ] Check B: That expected result is that "Get the related groups for this entity" is disabled (is in hidden region) on admin/config/people/accounts/display/private_message_author (Field UI need to be enabled)

### Option 2 (Existing projects)
Examples:
https://update-fe3qcpy-wnujvhjt2ik7y.eu-5.platformsh.site/private-messages/101 (hazlab update)
https://dutchcyclingcommunity.nl/ (this one has just enabled field "Get the related groups for this entity", but private messages are not, however hook update can be tested anyway)

- [ ] Check A: That expected result is that after hook update, groups are not listed anymore on private messages
- [ ] Check B: That expected result is that "Get the related groups for this entity" is disabled (is in hidden region) on admin/config/people/accounts/display/private_message_author (Field UI need to be enabled)

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
N/A

## Release notes
Disable "Get the related groups for this entity" field on "Private Message Author" display for "User" entity if it is enabled to fix unwanted result on private messages.

## Change Record
N/A

## Translations
N/A
