### PR TITLE
Issue #3294502 by alex.ksis: Override a certain display instead of the whole view.

### DIFF
--- a/modules/social_features/social_tagging/social_tagging.install
+++ b/modules/social_features/social_tagging/social_tagging.install
@@ -271,3 +271,19 @@ function social_tagging_update_11401(): void {
   \Drupal::entityDefinitionUpdateManager()
     ->installFieldStorageDefinition('social_tagging', 'media', 'social_tagging', $field_storage_definition);
 }
+
+/**
+ * Remove filters from the views config so that it can be added in an overrider.
+ */
+function social_tagging_update_11402(): void {
+  $config = \Drupal::configFactory()->getEditable('views.view.newest_users');
+
+  if ($filters = $config->get('display.default.display_options.filters')) {
+    $filters = array_filter($filters, fn($filter) => $filter['field'] !== 'social_tagging_target_id');
+    $config->set('display.page_newest_users.display_options.filters', $filters);
+    $config->set('display.block_newest_users.display_options.filters', $filters);
+    $config->set('display.page_newest_users.display_options.defaults.filters', FALSE);
+    $config->set('display.block_newest_users.display_options.defaults.filters', FALSE);
+    $config->save(TRUE);
+  }
+}

--- a/modules/social_features/social_tagging/src/SocialTaggingOverrides.php
+++ b/modules/social_features/social_tagging/src/SocialTaggingOverrides.php
@@ -258,7 +258,7 @@ class SocialTaggingOverrides implements ConfigFactoryOverrideInterface {
     ];
 
     if ($tag_service->profileActive()) {
-      $config_overviews['views.view.newest_users'] = 'default';
+      $config_overviews['views.view.newest_users'] = 'page_newest_users';
     }
 
     foreach ($config_overviews as $config_name => $display) {


### PR DESCRIPTION
## Problem
When updating OS from 11.3 to 11.4, there is a new update hook appeared in the views module. This hook collects all the changes from the override services like SocialTaggingOverrides and adds them directly to the config. After that override services might not work correctly and as a result unnecessary filters are displayed in the newest members block.

## Solution
The SocialTaggingOverrides service adds filters by tags to all displays of the Newest members view. In this PR we are forcing all displays to have own filters instead of inheriting the default display. It will allow to override filters of a certain display in the SocialTaggingOverrides.

## Issue tracker
https://getopensocial.atlassian.net/browse/PROD-20227
https://www.drupal.org/project/social/issues/3294502

## How to test
- [ ] Install Open Social 11.3.
- [ ] Install the Social Tagging module.
- [ ] Enable tags for profiles and create a few tags.
- [ ] Upgrade to Open Social 11.4 (database update is required).
- [ ] Make sure there are no unnecessary filters by tags in the Newest members block
- [ ] Make sure filters by tags are correctly displayed on the /all-members page

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
![image](https://user-images.githubusercontent.com/4526828/178756328-31fc3dcc-f167-40bc-b277-8e37897ed905.png)

## Release notes
Force all displays of the Newest members view to have own filters instead of using the default ones.