### PR TITLE
Issue #3295894 by navneet0693: Junk data crashes queues.

### DIFF
--- a/modules/custom/activity_basics/src/Plugin/ActivityContext/ContentInMyGroupActivityContext.php
+++ b/modules/custom/activity_basics/src/Plugin/ActivityContext/ContentInMyGroupActivityContext.php
@@ -155,8 +155,6 @@ class ContentInMyGroupActivityContext extends ActivityContextBase {
 
         /** @var \Drupal\group\GroupMembership $membership */
         foreach ($memberships as $membership) {
-          // Check if this not the created user and didn't mute the group
-          // notifications.
           // Check if this is not the created user and didn't mute the group
           // notifications.
           // There can be incidences where even if the user was deleted

--- a/modules/custom/activity_basics/src/Plugin/ActivityContext/ContentInMyGroupActivityContext.php
+++ b/modules/custom/activity_basics/src/Plugin/ActivityContext/ContentInMyGroupActivityContext.php
@@ -164,9 +164,11 @@ class ContentInMyGroupActivityContext extends ActivityContextBase {
           // group_content_field_data, so, it is necessary to check
           // if the user actually exists in system.
           $group_user = $membership->getUser();
-          if ($group_user !== NULL &&
+          if (
+            $group_user !== NULL &&
             $owner_id != $membership->getUser()->id() &&
-            !$this->groupMuteNotify->groupNotifyIsMuted($group, $membership->getUser())) {
+            !$this->groupMuteNotify->groupNotifyIsMuted($group, $membership->getUser())
+          ) {
             $recipients[] = [
               'target_type' => 'user',
               'target_id' => $membership->getUser()->id(),

--- a/modules/custom/activity_basics/src/Plugin/ActivityContext/ContentInMyGroupActivityContext.php
+++ b/modules/custom/activity_basics/src/Plugin/ActivityContext/ContentInMyGroupActivityContext.php
@@ -157,7 +157,16 @@ class ContentInMyGroupActivityContext extends ActivityContextBase {
         foreach ($memberships as $membership) {
           // Check if this not the created user and didn't mute the group
           // notifications.
-          if ($owner_id != $membership->getUser()->id() && !$this->groupMuteNotify->groupNotifyIsMuted($group, $membership->getUser())) {
+          // Check if this is not the created user and didn't mute the group
+          // notifications.
+          // There can be incidences where even if the user was deleted
+          // its membership data was left in the table
+          // group_content_field_data, so, it is necessary to check
+          // if the user actually exists in system.
+          $group_user = $membership->getUser();
+          if ($group_user !== NULL &&
+            $owner_id != $membership->getUser()->id() &&
+            !$this->groupMuteNotify->groupNotifyIsMuted($group, $membership->getUser())) {
             $recipients[] = [
               'target_type' => 'user',
               'target_id' => $membership->getUser()->id(),

--- a/modules/social_features/social_content_report/social_content_report.tokens.inc
+++ b/modules/social_features/social_content_report/social_content_report.tokens.inc
@@ -89,30 +89,28 @@ function social_content_report_tokens_alter(array &$replacements, array $context
 
         if ($target_type === 'flagging') {
           $message_template_id = $message->getTemplate()->id();
-          switch ($message_template_id) {
-            case 'content_reported':
-              // Load the flag.
-              $flagging_id = $message->getFieldValue('field_message_related_object', 'target_id');
-              $storage = \Drupal::entityTypeManager()->getStorage('flagging');
+          if ($message_template_id === 'content_reported') {
+            // Load the flag.
+            $flagging_id = $message->getFieldValue('field_message_related_object', 'target_id');
+            $storage = \Drupal::entityTypeManager()->getStorage('flagging');
 
-              // Replace the preview token.
-              if (isset($context['tokens']['cta_button'])) {
-                $link = Url::fromRoute('view.report_overview.overview');
-                $cta_button = $email_token_services->getCtaButton($link, new TranslatableMarkup('Check the reported contents'));
-                $replacements[$context['tokens']['cta_button']] = \Drupal::service('renderer')->renderPlain($cta_button);
-              }
+            // Replace the preview token.
+            if (isset($context['tokens']['cta_button'])) {
+              $link = Url::fromRoute('view.report_overview.overview');
+              $cta_button = $email_token_services->getCtaButton($link, new TranslatableMarkup('Check the reported contents'));
+              $replacements[$context['tokens']['cta_button']] = \Drupal::service('renderer')->renderPlain($cta_button);
+            }
 
-              // Replace the preview token.
-              if (isset($context['tokens']['preview'])) {
+            // Replace the preview token.
+            if (isset($context['tokens']['preview'])) {
+              $flagging = $storage->load($flagging_id);
+              $preview_info = [];
+              // Check if the flagging entity exists in database.
+              if ($flagging !== NULL) {
                 /** @var \Drupal\flag\FlaggingInterface $flagging */
-                $flagging = $storage->load($flagging_id);
-
                 // Load the flagged entity.
                 $entity = $flagging->getFlaggable();
                 $entity_type = $entity->getEntityTypeId();
-
-                $summary = '';
-                $preview_info = [];
 
                 switch ($entity_type) {
                   case 'post':
@@ -137,10 +135,12 @@ function social_content_report_tokens_alter(array &$replacements, array $context
                     $replacements[$context['tokens']['preview']] = \Drupal::service('renderer')->renderPlain($preview_info);
                     break;
                 }
+              }
+              else {
                 $replacements[$context['tokens']['preview']] = \Drupal::service('renderer')
                   ->renderPlain($preview_info);
               }
-              break;
+            }
           }
         }
       }


### PR DESCRIPTION
## Problems

**Problem 1**
This was a special case scenario where a queue was created by activity_creator_logger . It was trying to send notifications/emails to all the members.

`Error: Call to a member function id() on null in Drupal\activity_basics\Plugin\ActivityContext\ContentInMyGroupActivityContext->getRecipients() (line 160 of html/profiles/contrib/social/modules/custom/activity_basics/src/Plugin/ActivityContext/ContentInMyGroupActivityContext.php) #0 html/profiles/contrib/social/modules/custom/activity_creator/src/Plugin/QueueWorker/ActivityWorkerLogger.php(48): Drupal\activity_basics\Plugin\ActivityContext\ContentInMyGroupActivityContext->getRecipients(Array, 0, 0)`

While processing all the memberships at https://github.com/goalgorilla/open_social/blob/11.1.13/modules/custom/activity_basics/src/Plugin/ActivityContext/ContentInMyGroupActivityContext.php#L157

$membership->getUser() was returning NULL when it was trying to fetch the user with a particular user ID.

This particular user was not existing in the system.

**Problem 2**

When content is reported (technically flagged) an activity is created to send out notifications. Sometimes, the flagging entity doesn't exist, which then crashes the queue.

` [error]  Error: Call to a member function getFlaggable() on null in social_content_report_tokens_alter() (line 111 of /app/html/profiles/contrib/social/modules/social_features/social_content_report/social_content_report.tokens.inc`

## Solution
To avoid such scenarios, 

1. Add a check if the $membership->getUser() returns a valid user entity.
2. Add a check if $flaggable is an existing entity.


## Issue tracker
https://www.drupal.org/project/social/issues/3295894

## Theme issue tracker
N.A

## How to test
**For Problem 1**
- [ ] It's hard to reproduce this scenario but one can try.
- [ ] Create a group
- [ ] Add a certain user to that group
- [ ] Create a content in the user group
- [ ] Delete the user data from `user` and `user_field_data` tables ( or try deleting via UI by checking "keep the content" option.)
- [ ] Run cron

**For Problem 2**
- [ ] It's kind of hard to reproduce.

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
N.A

## Release notes
Our queues get stuck once a user from the platform was deleted but its membership from a certain group where it was a membership didn't get removed. We resolved these issues by adding defensive checks to our code.

## Change Record
N.A

## Translations
N.A