### PR TITLE
Issue #3296055: In a comments' pager shows the word "comments" instead of "first"

### DIFF
--- a/modules/social_features/social_comment/src/SocialCommentViewBuilder.php
+++ b/modules/social_features/social_comment/src/SocialCommentViewBuilder.php
@@ -77,9 +77,13 @@ class SocialCommentViewBuilder extends CommentViewBuilder {
   public function buildMultiple(array $build_list) {
     $build_list = parent::buildMultiple($build_list);
 
-    $tags = $build_list['pager']['#tags'] ?? [];
-    $tags[] = self::PAGER_TAG;
-    $build_list['pager']['#tags'] = $tags;
+    // Since PAGER_TAG need for social_ajax_comments_preprocess_pager(), let's
+    // add it only if the module social_ajax_comments is enabled.
+    if ($this->moduleHandler->moduleExists('social_ajax_comments')) {
+      $tags = $build_list['pager']['#tags'] ?? [];
+      $tags[] = self::PAGER_TAG;
+      $build_list['pager']['#tags'] = $tags;
+    }
 
     return $build_list;
   }


### PR DESCRIPTION
## Problem
If we are on any page of comments pager except the first one, instead of the word "first" we see "comments".

## Solution
Add tag in `SocialCommentViewBuilder::buildMultiple()` only if the module `social_ajax_comments` is enabled.

## Issue tracker
- https://www.drupal.org/project/social/issues/3296055

## Theme issue tracker
N/A

## How to test
- [ ] Make sure that module social_ajax_comments and ajax_comments are disabled
- [ ] Go to the page with comments which have a pager
- [ ] Go to the second pager page
- [ ] Instead word "first" you will see "comments"
- [ ] Apply change from this PR and text will be corrected

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
### Before
![817025f494a6bb8e571f46be38bc0858](https://user-images.githubusercontent.com/10220937/179164773-1939db8d-5b4c-425a-b50b-a8ee4690dcc0.png)

### After
![87d1fb5863b138d507ce03a7560039b1](https://user-images.githubusercontent.com/10220937/179164791-1265a825-5a3e-46ef-9833-713c7de8eca5.png)

## Release notes
Correct the comments pager button text.

## Change Record
N/A

## Translations
N/A
