### PR TITLE
Issue #3284367 by colan, Ressinel: Improved event date field UX by providing default values.

### DIFF
--- a/modules/social_features/social_event/config/install/field.field.node.event.field_event_date.yml
+++ b/modules/social_features/social_event/config/install/field.field.node.event.field_event_date.yml
@@ -14,7 +14,10 @@ label: Start
 description: ''
 required: true
 translatable: false
-default_value: {  }
+default_value:
+  -
+    default_date_type: now
+    default_date: now
 default_value_callback: ''
 settings: {  }
 field_type: datetime

--- a/modules/social_features/social_event/config/install/field.field.node.event.field_event_date_end.yml
+++ b/modules/social_features/social_event/config/install/field.field.node.event.field_event_date_end.yml
@@ -14,7 +14,10 @@ label: End
 description: ''
 required: false
 translatable: false
-default_value: {  }
+default_value:
+  -
+    default_date_type: relative
+    default_date: '+1 hour'
 default_value_callback: ''
 settings: {  }
 field_type: datetime

--- a/modules/social_features/social_event/config/install/field.field.node.event.field_event_date_end.yml
+++ b/modules/social_features/social_event/config/install/field.field.node.event.field_event_date_end.yml
@@ -14,10 +14,7 @@ label: End
 description: ''
 required: false
 translatable: false
-default_value:
-  -
-    default_date_type: relative
-    default_date: '+1 hour'
+default_value: {  }
 default_value_callback: ''
 settings: {  }
 field_type: datetime

--- a/modules/social_features/social_event/config/update/social_event_update_11404.yml
+++ b/modules/social_features/social_event/config/update/social_event_update_11404.yml
@@ -7,12 +7,3 @@ field.field.node.event.field_event_date:
         -
           default_date: now
           default_date_type: now
-field.field.node.event.field_event_date_end:
-  expected_config:
-    default_value: {  }
-  update_actions:
-    change:
-      default_value:
-        -
-          default_date_type: relative
-          default_date: '+1 hour'

--- a/modules/social_features/social_event/config/update/social_event_update_11404.yml
+++ b/modules/social_features/social_event/config/update/social_event_update_11404.yml
@@ -1,0 +1,18 @@
+field.field.node.event.field_event_date:
+  expected_config:
+    default_value: {  }
+  update_actions:
+    change:
+      default_value:
+        -
+          default_date: now
+          default_date_type: now
+field.field.node.event.field_event_date_end:
+  expected_config:
+    default_value: {  }
+  update_actions:
+    change:
+      default_value:
+        -
+          default_date_type: relative
+          default_date: '+1 hour'

--- a/modules/social_features/social_event/social_event.install
+++ b/modules/social_features/social_event/social_event.install
@@ -2163,3 +2163,17 @@ function social_event_update_11403(): string {
   // Output logged messages to related channel of update execution.
   return $updateHelper->logger()->output();
 }
+
+/**
+ * Add event dates fields default values.
+ */
+function social_event_update_11404(): string {
+  /** @var \Drupal\update_helper\Updater $updater */
+  $updater = \Drupal::service('update_helper.updater');
+
+  // Execute configuration update definitions with logging of success.
+  $updater->executeUpdate('social_event', __FUNCTION__);
+
+  // Output logged messages to related channel of update execution.
+  return $updater->logger()->output();
+}


### PR DESCRIPTION
## Problem
See https://www.drupal.org/project/social/issues/3284367.

## Solution
Provide default values for the event date.

**Updated:** Add default value only for the start date that is a required field. When we will add a default value for the end date as well it likely will be redundant for users that will force to remove it when no need for the end date for an event.

## Issue tracker
- https://www.drupal.org/project/social/issues/3284367

## Theme issue tracker
N/A

## How to test
- [ ] Create an event
- [ ] ~~Notice that the start and end dates are empty~~ Notice that the start date is empty
- [ ] With the PR applied, ~~the start and end dates are filled in with the current time and one hour from now (respectively).~~ the start date is filled in with the current time.

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
N/A

## Release notes
Improved event date field UX by providing default values.

## Change Record
N/A

## Translations
N/A
