### PR TITLE
Patch Drupal 9.2.x with backported fixes for drupal core SA-CORE-2022

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -64,12 +64,15 @@
                 "Pagination does not work correctly for comment fields that are rendered using #lazy_builder": "https://www.drupal.org/files/issues/2020-12-22/pagination-does-not-work-with-lazy-builder-3189538-2.patch",
                 "Providing default route value for entity forms is not possible": "https://www.drupal.org/files/issues/2020-12-29/2921093-18.patch",
                 "Selecting the same day in a date between filter returns no results": "https://www.drupal.org/files/issues/2020-07-06/2842409-15.patch",
-                "Empty language (langcode) field wrapper inserted into contact form": "https://www.drupal.org/files/issues/2021-11-04/empty-langcode-field-wrapper-2842405-20.patch",
                 "Broken title in modal dialog when title is a render array": "https://www.drupal.org/files/issues/2019-10-21/2663316-76.drupal.Broken-title-in-modal-dialog-when-title-is-a-render-array.patch",
                 "Post update hook naming convention patch": "https://git.drupalcode.org/project/drupal/-/merge_requests/1215.patch",
                 "Flood MemoryBackend::events[] key of micro time cannot guarantee uniqueness": "https://www.drupal.org/files/issues/2021-12-12/2910000-33--floodmemorybackend-time-local.patch",
                 "Issue #3251856: Incorrect typehint for FieldConfig::loadByName": "https://www.drupal.org/files/issues/2021-12-12/drupal9-incorrect_typehint-3251856-7.patch",
-                "Issue #2998390: Cache is not invalidated when comment deleted": "https://www.drupal.org/files/issues/2022-01-27/2998390-invalidate-cache-on-delete-6.diff"
+                "Issue #2998390: Cache is not invalidated when comment deleted": "https://www.drupal.org/files/issues/2022-01-27/2998390-invalidate-cache-on-delete-6.diff",
+                "Backport of issue SA-CORE-2022-012": "https://www.drupal.org/files/issues/2022-07-20/2022-12-1.patch",
+                "Backport of issue SA-CORE-2022-013": "https://www.drupal.org/files/issues/2022-07-20/2022-013.patch",
+                "Backport of issue SA-CORE-2022-014": "https://www.drupal.org/files/issues/2022-07-20/2022-014.patch",
+                "Backport of issue SA-CORE-2022-015": "https://www.drupal.org/files/issues/2022-07-20/2022-015.patch"
             },
             "drupal/config_update": {
                 "3248161: Symfony 4.4 event dispatcher parameter order change": "https://www.drupal.org/files/issues/2021-11-08/symfony-4-4-event-dispatcher-parameter-order-change-3248161-3.patch"


### PR DESCRIPTION
## Problem
Core released:

https://www.drupal.org/sa-core-2022-012
https://www.drupal.org/sa-core-2022-013
https://www.drupal.org/sa-core-2022-014
https://www.drupal.org/sa-core-2022-015

But since we still support versions 9.2.x in Open Social we need to backport this.

## Solution
Backport issues as patch, I'm trying directly to see if this applies to our 11.3.x branch.

## Issue tracker
https://drupal.org/node/3298688

## How to test
See that all our tests pass.
