### PR TITLE
Issue #3298713: Remove patch for empty langcode so we dont create regression

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -63,7 +63,6 @@
                 "Pagination does not work correctly for comment fields that are rendered using #lazy_builder": "https://www.drupal.org/files/issues/2020-12-22/pagination-does-not-work-with-lazy-builder-3189538-2.patch",
                 "Providing default route value for entity forms is not possible": "https://www.drupal.org/files/issues/2020-12-29/2921093-18.patch",
                 "Selecting the same day in a date between filter returns no results": "https://www.drupal.org/files/issues/2020-07-06/2842409-15.patch",
-                "Empty language (langcode) field wrapper inserted into contact form": "https://www.drupal.org/files/issues/2022-01-29/empty-langcode-field-wrapper-2842405-23.patch",
                 "Broken title in modal dialog when title is a render array": "https://www.drupal.org/files/issues/2019-10-21/2663316-76.drupal.Broken-title-in-modal-dialog-when-title-is-a-render-array.patch",
                 "Post update hook naming convention patch": "https://git.drupalcode.org/project/drupal/-/merge_requests/1215.patch",
                 "Flood MemoryBackend::events[] key of micro time cannot guarantee uniqueness": "https://www.drupal.org/files/issues/2022-02-14/2910000-mr-1451-d93--floodmemorybackend-time-local.diff",


### PR DESCRIPTION
## Problem
The patch for:

```
"Empty language (langcode) field wrapper inserted into contact form": "https://www.drupal.org/files/issues/2022-01-29/empty-langcode-field-wrapper-2842405-23.patch"
```
Created regression as we are revoking access, while all we want is to remove it from the render process in certain occassions.


## Solution
This is a 2 step solution.

1. Remove the patch.
2. Find a way to fix the use case we were trying to fix.

This PR is to fix number 1, so we don't cause regression and have this waiting for too long.
Also good to note is that the patch was already removed as part of #3045 in the 11.3.x, 11.2.x, 11.1.x branches.

## Issue tracker
https://www.drupal.org/project/social/issues/3298713

## How to test
This doesn't need a HTT, step 2 does when we fix it. 
See: https://www.drupal.org/project/drupal/issues/2842405#comment-14261236

## Release notes
Not necessary as this doesn't fix anything, nor does it close the ticket. It's just step one and to align it with #3045.
