### PR TITLE
Issue #3300398 by nkoporec: MultipleContentBlock doesn't filter by content tags children

### DIFF
--- a/modules/social_features/social_content_block/src/Plugin/Block/MultipleContentBlock.php
+++ b/modules/social_features/social_content_block/src/Plugin/Block/MultipleContentBlock.php
@@ -385,7 +385,7 @@ class MultipleContentBlock extends BlockBase implements ContainerFactoryPluginIn
 
     /** @var \Drupal\taxonomy\TermStorage $term_storage */
     $term_storage = $this->entityTypeManager->getStorage('taxonomy_term');
-    $tree = $term_storage->loadTree($vid, (int) $term->id());
+    $tree = $term_storage->loadTree($vid['target_id'], (int) $term->id());
 
     if (empty($tree)) {
       return $children;

--- a/modules/social_features/social_content_block/src/Plugin/Block/MultipleContentBlock.php
+++ b/modules/social_features/social_content_block/src/Plugin/Block/MultipleContentBlock.php
@@ -380,7 +380,7 @@ class MultipleContentBlock extends BlockBase implements ContainerFactoryPluginIn
 
     /** @var array $vid_value */
     $vid_value = $term->get('vid')->getValue();
-    /** @var string $vid */
+    /** @var array $vid */
     $vid = end($vid_value);
 
     /** @var \Drupal\taxonomy\TermStorage $term_storage */


### PR DESCRIPTION
## Problem
If we have a following content tags structure:

```
1.Gloves
 1.1 Seamless
   1.1.1 Kevlar
    1.1.1.1 Shell
    1.1.1.2 Dots
    1.1.1.3 Coated
 1.2 mechanics
 1.3 cut and sewn
2.Apparels
 2.1 Coveralls
 2.2 Aprons
 2.3 Trousers
```

And we want to place a MultipleContentBlock, that shows all content tagged with `Gloves` and all its children, currently this will not work as the block only filters by first level.

## Solution
We add a new checkbox, that will allow to render content tagged with all the term parent children.


## Issue tracker
https://www.drupal.org/project/social/issues/3300398

## Theme issue tracker
*[Required if applicable] Paste a link to the drupal.org theme issue queue item, either from [socialbase](https://www.drupal.org/project/socialbase) or [socialblue](https://www.drupal.org/project/socialblue). If any other issue trackers were used, include links to those too.*

## How to test
- [ ] Enable mobule  "Social Content Block"
- [ ] Enable mobule  "Social Landing Page"
- [ ] Enable mobule  "Social Tagging"
- [ ] Create a similar content tag structure on "/admin/structure/taxonomy/manage/social_tagging/overview"
- [ ] Tag content with terms that are nested deeper.
- [ ] Create a MultipleContentBlock on a Landing page content type and set 'Content tags' to a term that has this new children ( this block needs the  module enabled )
- [ ] While creating the block, make sure to check "Content tags children" option
- [ ] Check if the block renders it.

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
![image](https://user-images.githubusercontent.com/35064680/181462899-53745796-87b1-486c-8ba8-698851ee59e1.png)


## Release notes
Added the ability to render MultipleContentBlock with content that is tagged with a term and all its children.

## Change Record
*[Required if applicable] If this Pull Request changes the way that developers should do things or introduces a new API for developers then a change record to document this is needed. Please provide a draft for a change record or a link to an unpublished change record below. Existing change records can be consulted as example. Please provide a draft for a change record or a link to an unpublished change record below. [Existing change records](https://www.drupal.org/list-changes/social) can be consulted as example.*

## Translations
*[Optional]Translatable strings are always extracted from the latest development branch. To ensure translations remain available for platforms running older versions of Open Social the original string should be added to `translations.php` when it's changed or removed.*
- [ ] Changed or removed source strings are added to the `translations.php` file.
