### PR TITLE
Issue #3247457 by latinyanin, tbsiqueira, navneet0693: Confirmation message for bulk actions on enrollments management doesn't display correct selected users

### DIFF
--- a/modules/social_features/social_event/src/Entity/EventEnrollment.php
+++ b/modules/social_features/social_event/src/Entity/EventEnrollment.php
@@ -109,6 +109,17 @@ class EventEnrollment extends ContentEntityBase implements EventEnrollmentInterf
   /**
    * {@inheritdoc}
    */
+  public function label() {
+    $label = $this->getName();
+    if (empty($label)) {
+      $label = $this->get('field_account')->entity->label();
+    }
+    return $label;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function setName($name) {
     $this->set('name', $name);
     return $this;


### PR DESCRIPTION
## Problem
While managing event enrollments, any of the bulk operations confirmation screen display an "empty" list of enrollees, even though it works as it should. This prevents users to double checking if they selected the right attendees.

## Solution
Fix the issue with the labels to display the correct values.

## Issue tracker
https://www.drupal.org/project/social/issues/3247457

## Theme issue tracker
N.A

## How to test
- [ ] Create an event
- [ ] Go to "Manage Enrollments"
- [ ] Select any number of enrollees
- [ ] Choose any action, for example: "Remove selected enrollees"
- [ ] Verify that the "Items selected:" list shows empty labels

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
N.A

## Release notes
The names of the users enrolled in an event were not displayed on an action confirmation page. We fixed the problem and the names are displayed now.

## Change Record
N.A

## Translations
N.A