### PR TITLE
Issue #3305677: Remove destination in group invites url

### DIFF
--- a/modules/social_features/social_group/modules/social_group_invite/social_group_invite.module
+++ b/modules/social_features/social_group/modules/social_group_invite/social_group_invite.module
@@ -685,7 +685,11 @@ function social_group_invite_tokens_alter(array &$replacements, array $context, 
     /** @var \Drupal\group\Entity\GroupContentInterface $group_content */
     $group_content = $context["data"]["group_content"];
     $group_content_id = $group_content->get('id')->getString();
+
+    // We are using a destination for use with the register link.
+    // This destination is only used when user's don't have an account yet.
     $destination = 'destination=/social-group-invite/' . $group_content_id . '/accept';
+    $group_invite_url = Url::fromRoute('social_group_invite.invitation.accept', ['group_content' => $group_content_id], ['absolute' => TRUE])->toString();
 
     // For groups that only group members have access to, we should change the
     // destination to the user's invites page.
@@ -696,8 +700,11 @@ function social_group_invite_tokens_alter(array &$replacements, array $context, 
       $group->get('field_flexible_group_visibility')->getValue()[0]['value'] === 'members') ||
       in_array($group->bundle(), ['closed_group', 'secret_group'])
     ) {
+
+      // Update the destination for use with the register link.
       $url = Url::fromRoute('social_core.my_invites')->toString();
       $destination = 'destination=' . $url;
+      $group_invite_url = Url::fromRoute('social_core.my_invites', [], ['absolute' => TRUE])->toString();
     }
     // Attach destination to accept invite. So, after sign up/sign step the
     // invite will be accepted and user  will be redirected to the invited page.
@@ -714,8 +721,7 @@ function social_group_invite_tokens_alter(array &$replacements, array $context, 
       $context["tokens"]["my_invitations_link"] === '[group_content:my_invitations_link]'
     ) {
       // For existing users for my_invitations_link token.
-      $group_invitations_link = Url::fromRoute('user.login', [], ['absolute' => TRUE])->toString();
-      $replacements["[group_content:my_invitations_link]"] = "{$group_invitations_link}?{$destination}";
+      $replacements["[group_content:my_invitations_link]"] = $group_invite_url;
     }
   }
 }


### PR DESCRIPTION
Because of the app's architecture the group invitation urls are not working. By removing the destination logic and using the url directly and let Drupal handle the login logic, this will work for both app and desktop.

## Problem
When sending group invitation mails, we include the accept url for the invite. We are sending the user to /user/login page with the accept url as a destination. However, this interferes with the app.

When you are invited to a private group, you get a mail, which contains a link to the new group. If you click on the link, you accept the invite. The link is going to /user/login with the accept url as a destination (https://example.com/user/login?destination=/social-group-invite/{group_id}/accept).

This doesn't work on the app, because all user/login url's are forced to open in the browser. From the moment you log in, you are redirected to the app, but it doesn't show you the accept url anymore, because it has lost that context. If you we send the user directly to the app (by not using /user/login, but the accept url directly, it will open the app (and if necessary) redirect the user to the browser to login. If the user is already logged in, it will show in the app.

## Solution
Change the url, so it doesn't contain the destination part anymore. Use the accept url as url for the email. Drupal will handle the login logic.

## Issue tracker
* https://www.drupal.org/project/social/issues/3305677
* https://getopensocial.atlassian.net/browse/APP-364

## How to test
- [x] Create a private group
- [x] Create a test user
- [x] Receive an invitation to any private group to the new user
- [x] If you don't receive a mail, try running cron
- [x] Open the email with an invitation
- [x] Tap the button

## Definition of done
### Before merge
- [x] Code/peer review is completed
- [x] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [x] All automated tests are green
- [x] Functional/manual tests of the acceptance criteria are approved
- [x] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [x] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [x] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [x] This pull request has all required labels (team/type/priority)
- [x] This pull request has a milestone
- [x] This pull request has an assignee (if applicable)
- [x] Any front end changes are tested on all major browsers
- [x] New UI elements, or changes on UI elements are approved by the design team
- [x] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
*[Required if new feature, and if applicable] If this Pull Request makes visual changes then please include some screenshots that show what has changed here. A before and after screenshot helps the reviewer determine what changes were made.*

## Release notes
*[Required if new feature, and if applicable] A short summary of the changes that were made that can be included in release notes.*

## Change Record
*[Required if applicable] If this Pull Request changes the way that developers should do things or introduces a new API for developers then a change record to document this is needed. Please provide a draft for a change record or a link to an unpublished change record below. Existing change records can be consulted as example. Please provide a draft for a change record or a link to an unpublished change record below. [Existing change records](https://www.drupal.org/list-changes/social) can be consulted as example.*

## Translations
*[Optional]Translatable strings are always extracted from the latest development branch. To ensure translations remain available for platforms running older versions of Open Social the original string should be added to `translations.php` when it's changed or removed.*
- [ ] Changed or removed source strings are added to the `translations.php` file.
