### PR TITLE
Issue #3306207 by navneet0693, robertragas, ronaldtebrake: Tag categories do not appear on add/edit page on multilingual websites

### DIFF
--- a/modules/social_features/social_core/social_core.services.yml
+++ b/modules/social_features/social_core/social_core.services.yml
@@ -26,3 +26,7 @@ services:
     tags:
       - { name: config.factory.override, priority: 5 }
       - { name: social_language_defaults }
+
+  social_core.machine_name:
+    class: Drupal\social_core\Service\MachineName
+    arguments: ['@transliteration']

--- a/modules/social_features/social_core/src/Service/MachineName.php
+++ b/modules/social_features/social_core/src/Service/MachineName.php
@@ -4,7 +4,6 @@ namespace Drupal\social_core\Service;
 
 use Drupal\Component\Transliteration\TransliterationInterface;
 use Drupal\Core\Language\LanguageInterface;
-use Drupal\Core\Render\Element\Page;
 
 /**
  * Creates a machine name.
@@ -34,7 +33,6 @@ class MachineName {
    */
   protected $transliteration;
 
-
   /**
    * SocialTaggingService constructor.
    *
@@ -50,6 +48,8 @@ class MachineName {
    *
    * @param string $value
    *   The value to be transformed.
+   * @param string $replacePattern
+   *   The replacement pattern for regex.
    *
    * @return string
    *   The newly transformed value.
@@ -57,13 +57,15 @@ class MachineName {
   public function transform(string $value, string $replacePattern = '/[^a-z0-9_]+/'): string {
     $new_value = $this->transliteration->transliterate($value, LanguageInterface::LANGCODE_DEFAULT, '_');
     $new_value = strtolower($new_value);
-    $new_value = preg_replace($replacePattern, '_', $new_value);
-    if (!is_null($new_value)) {
-      $new_value = preg_replace('/_+/', '_', $new_value);
+    $replaced_special = preg_replace($replacePattern, '_', $new_value);
+    $replaced_underscores = '';
+    if (!is_null($replaced_special)) {
+      $replaced_underscores = preg_replace('/_+/', '_', $replaced_special);
     }
-    if (!is_null($new_value)) {
-      return $new_value;
+    if (!is_null($replaced_underscores)) {
+      return $replaced_underscores;
     }
     return '';
   }
+
 }

--- a/modules/social_features/social_core/src/Service/MachineName.php
+++ b/modules/social_features/social_core/src/Service/MachineName.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Drupal\social_core\Service;
+
+use Drupal\Component\Transliteration\TransliterationInterface;
+use Drupal\Core\Language\LanguageInterface;
+use Drupal\Core\Render\Element\Page;
+
+/**
+ * Creates a machine name.
+ *
+ * This functions takes a string input and turns it into a
+ * machine-readable name via the following four steps:
+ *
+ * 1. Language decorations and accents are removed by transliterating the source
+ *    value.
+ * 2. The resulting value is made lowercase.
+ * 3. Any special characters are replaced with an underscore. By default,
+ *    anything that is not a number or a letter is replaced, but additional
+ *    characters can be allowed or further restricted by using the
+ *    replace_pattern configuration as described below.
+ * 4. Any duplicate underscores either in the source value or as a result of
+ *    replacing special characters are removed.
+ *
+ * This class is inspiration from the class
+ * @link https://api.drupal.org/api/drupal/core%21modules%21migrate%21src%21Plugin%21migrate%21process%21MachineName.php/class/MachineName/9.4.x @endlink
+ */
+class MachineName {
+
+  /**
+   * The transliteration service.
+   *
+   * @var \Drupal\Component\Transliteration\TransliterationInterface
+   */
+  protected $transliteration;
+
+
+  /**
+   * SocialTaggingService constructor.
+   *
+   * @param \Drupal\Component\Transliteration\TransliterationInterface $transliteration
+   *   The transliteration service.
+   */
+  public function __construct(TransliterationInterface $transliteration) {
+    $this->transliteration = $transliteration;
+  }
+
+  /**
+   * Transforms given string to machine name.
+   *
+   * @param string $value
+   *   The value to be transformed.
+   *
+   * @return string
+   *   The newly transformed value.
+   */
+  public function transform(string $value, string $replacePattern = '/[^a-z0-9_]+/'): string {
+    $new_value = $this->transliteration->transliterate($value, LanguageInterface::LANGCODE_DEFAULT, '_');
+    $new_value = strtolower($new_value);
+    $new_value = preg_replace($replacePattern, '_', $new_value);
+    if (!is_null($new_value)) {
+      $new_value = preg_replace('/_+/', '_', $new_value);
+    }
+    if (!is_null($new_value)) {
+      return $new_value;
+    }
+    return '';
+  }
+}

--- a/modules/social_features/social_tagging/social_tagging.module
+++ b/modules/social_features/social_tagging/social_tagging.module
@@ -576,16 +576,24 @@ function social_tagging_form_views_exposed_form_alter(&$form, FormStateInterface
 }
 
 /**
- * Main term names to machine name for on node edit / validate.
+ * Transforms term names to machine name for on node edit / validate.
+ *
+ * This will convert the term names from any language.
  *
  * @param string $text
  *   A node.
  *
- * @return mixed|string
- *   A machine name so it can be used pogrammatically.
+ * @return string
+ *   A machine name so it can be used programmatically.
+ *
+ * @deprecated in social:11.5.0 and is removed from social:12.0.0. Use
+ *   \Drupal::service('social_tagging.tag_service')->transform() instead.
  */
 function social_tagging_to_machine_name($text) {
-  return preg_replace('@[^a-z0-9-]+@', '_', strtolower($text));
+  @trigger_error('social_tagging_to_machine_name() is deprecated in social:11.5.0 and is removed from social:12.0.0. Use "\Drupal::service(\'social_core.machine_name\')->transform()" instead. See https://www.drupal.org/node/3306214', E_USER_DEPRECATED);
+  /** @var \Drupal\social_core\Service\MachineName $machine_name */
+  $machine_name = \Drupal::service('social_core.machine_name');
+  return $machine_name->transform($text);
 }
 
 /**

--- a/modules/social_features/social_tagging/social_tagging.module
+++ b/modules/social_features/social_tagging/social_tagging.module
@@ -587,7 +587,9 @@ function social_tagging_form_views_exposed_form_alter(&$form, FormStateInterface
  *   A machine name so it can be used programmatically.
  *
  * @deprecated in social:11.5.0 and is removed from social:12.0.0. Use
- *   \Drupal::service('social_tagging.tag_service')->transform() instead.
+ *   \Drupal::service('social_core.machine_name')->transform() instead.
+ *
+ * @see https://www.drupal.org/node/3306214
  */
 function social_tagging_to_machine_name($text) {
   @trigger_error('social_tagging_to_machine_name() is deprecated in social:11.5.0 and is removed from social:12.0.0. Use "\Drupal::service(\'social_core.machine_name\')->transform()" instead. See https://www.drupal.org/node/3306214', E_USER_DEPRECATED);

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -6650,11 +6650,6 @@ parameters:
 			path: modules/social_features/social_event/modules/social_event_an_enroll_enrolments_export/social_event_an_enroll_enrolments_export.module
 
 		-
-			message: "#^Method Drupal\\\\social_event_an_enroll_enrolments_export\\\\SocialEventAnEnrollEnrolmentsExportOverrides\\:\\:createConfigObject\\(\\) should return Drupal\\\\Core\\\\Config\\\\StorableConfigBase but returns null\\.$#"
-			count: 1
-			path: modules/social_features/social_event/modules/social_event_an_enroll_enrolments_export/src/SocialEventAnEnrollEnrolmentsExportOverrides.php
-
-		-
 			message: "#^Function social_event_enrolments_export_file_download\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: modules/social_features/social_event/modules/social_event_enrolments_export/social_event_enrolments_export.module
@@ -9000,6 +8995,15 @@ parameters:
 			path: modules/social_features/social_follow_taxonomy/modules/social_follow_landing_page/social_follow_landing_page.module
 
 		-
+			message: """
+				#^Call to deprecated function social_tagging_to_machine_name\\(\\)\\:
+				in social\\:11\\.5\\.0 and is removed from social\\:12\\.0\\.0\\. Use
+				  \\\\Drupal\\:\\:service\\('social_core\\.machine_name'\\)\\-\\>transform\\(\\) instead\\.$#
+			"""
+			count: 5
+			path: modules/social_features/social_follow_taxonomy/modules/social_follow_landing_page/social_follow_landing_page.module
+
+		-
 			message: "#^Function _social_follow_landing_page_entity_validate\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: modules/social_features/social_follow_taxonomy/modules/social_follow_landing_page/social_follow_landing_page.module
@@ -9158,6 +9162,15 @@ parameters:
 			message: "#^Parameter \\#2 \\$nid of method Drupal\\\\social_follow_taxonomy\\\\Plugin\\\\ActivityContext\\\\FollowTaxonomyActivityContext\\:\\:haveAccessToNode\\(\\) expects int\\|string, int\\|string\\|null given\\.$#"
 			count: 1
 			path: modules/social_features/social_follow_taxonomy/modules/social_follow_tag/src/Plugin/ActivityContext/FollowTagActivityContext.php
+
+		-
+			message: """
+				#^Call to deprecated function social_tagging_to_machine_name\\(\\)\\:
+				in social\\:11\\.5\\.0 and is removed from social\\:12\\.0\\.0\\. Use
+				  \\\\Drupal\\:\\:service\\('social_core\\.machine_name'\\)\\-\\>transform\\(\\) instead\\.$#
+			"""
+			count: 1
+			path: modules/social_features/social_follow_taxonomy/modules/social_follow_tag/src/SocialFollowTagLazyBuilder.php
 
 		-
 			message: "#^Method Drupal\\\\social_follow_tag\\\\SocialFollowTagLazyBuilder\\:\\:lazyBuild\\(\\) has no return type specified\\.$#"
@@ -9428,6 +9441,11 @@ parameters:
 			message: "#^Method Drupal\\\\social_group_default_route\\\\RouteSubscriber\\\\RouteSubscriber\\:\\:alterRoutes\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: modules/social_features/social_group/modules/social_group_default_route/src/RouteSubscriber/RouteSubscriber.php
+
+		-
+			message: "#^Method Drupal\\\\social_flexible_group_book\\\\Plugin\\\\ActivityEntityCondition\\\\BookParentOnlyActivityEntityCondition\\:\\:isValidEntityCondition\\(\\) has parameter \\$entity with no type specified\\.$#"
+			count: 1
+			path: modules/social_features/social_group/modules/social_group_flexible_group/modules/social_flexible_group_book/src/Plugin/ActivityEntityCondition/BookParentOnlyActivityEntityCondition.php
 
 		-
 			message: "#^Cannot call method clear\\(\\) on Drupal\\\\search_api\\\\Entity\\\\Index\\|null\\.$#"
@@ -15465,6 +15483,16 @@ parameters:
 			path: modules/social_features/social_profile/src/Plugin/views/filter/SocialSearchApiSplitProfileTerms.php
 
 		-
+			message: "#^Method Drupal\\\\social_profile\\\\Plugin\\\\views\\\\filter\\\\SocialSplitProfileTerms\\:\\:validateExposed\\(\\) has parameter \\$form with no type specified\\.$#"
+			count: 1
+			path: modules/social_features/social_profile/src/Plugin/views/filter/SocialSplitProfileTerms.php
+
+		-
+			message: "#^Method Drupal\\\\social_profile\\\\Plugin\\\\views\\\\filter\\\\SocialSplitProfileTerms\\:\\:valueForm\\(\\) has parameter \\$form with no type specified\\.$#"
+			count: 1
+			path: modules/social_features/social_profile/src/Plugin/views/filter/SocialSplitProfileTerms.php
+
+		-
 			message: "#^Expression in empty\\(\\) is not falsy\\.$#"
 			count: 1
 			path: modules/social_features/social_profile/src/SocialProfileNameService.php
@@ -15528,16 +15556,6 @@ parameters:
 			message: "#^Parameter \\#1 \\$json of function json_decode expects string, string\\|false given\\.$#"
 			count: 1
 			path: modules/social_features/social_profile/tests/src/Kernel/GraphQLUsersEndpointTest.php
-
-		-
-		  message: "#^Method Drupal\\\\social_profile\\\\Plugin\\\\views\\\\filter\\\\SocialSplitProfileTerms\\:\\:valueForm\\(\\) has parameter \\$form with no type specified\\.$#"
-		  count: 1
-		  path: modules/social_features/social_profile/src/Plugin/views/filter/SocialSplitProfileTerms.php
-
-		-
-		  message: "#^Method Drupal\\\\social_profile\\\\Plugin\\\\views\\\\filter\\\\SocialSplitProfileTerms\\:\\:validateExposed\\(\\) has parameter \\$form with no type specified\\.$#"
-		  count: 1
-		  path: modules/social_features/social_profile/src/Plugin/views/filter/SocialSplitProfileTerms.php
 
 		-
 			message: "#^Parameter \\#1 \\$user of method Drupal\\\\Tests\\\\social_profile\\\\Kernel\\\\GraphQLUsersEndpointTest\\:\\:ensureTestProfile\\(\\) expects Drupal\\\\Core\\\\Session\\\\AccountInterface, Drupal\\\\user\\\\Entity\\\\User\\|false given\\.$#"
@@ -15920,6 +15938,15 @@ parameters:
 			path: modules/social_features/social_tagging/social_tagging.module
 
 		-
+			message: """
+				#^Call to deprecated function social_tagging_to_machine_name\\(\\)\\:
+				in social\\:11\\.5\\.0 and is removed from social\\:12\\.0\\.0\\. Use
+				  \\\\Drupal\\:\\:service\\('social_core\\.machine_name'\\)\\-\\>transform\\(\\) instead\\.$#
+			"""
+			count: 4
+			path: modules/social_features/social_tagging/social_tagging.module
+
+		-
 			message: "#^Function _social_tagging_entity_validate\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: modules/social_features/social_tagging/social_tagging.module
@@ -16090,6 +16117,15 @@ parameters:
 			path: modules/social_features/social_tagging/src/Form/SocialTaggingSettingsForm.php
 
 		-
+			message: """
+				#^Call to deprecated function social_tagging_to_machine_name\\(\\)\\:
+				in social\\:11\\.5\\.0 and is removed from social\\:12\\.0\\.0\\. Use
+				  \\\\Drupal\\:\\:service\\('social_core\\.machine_name'\\)\\-\\>transform\\(\\) instead\\.$#
+			"""
+			count: 3
+			path: modules/social_features/social_tagging/src/SocialTaggingOverrides.php
+
+		-
 			message: "#^Method Drupal\\\\social_tagging\\\\SocialTaggingOverrides\\:\\:createConfigObject\\(\\) should return Drupal\\\\Core\\\\Config\\\\StorableConfigBase but returns null\\.$#"
 			count: 1
 			path: modules/social_features/social_tagging/src/SocialTaggingOverrides.php
@@ -16098,6 +16134,15 @@ parameters:
 			message: "#^\\\\Drupal calls should be avoided in classes, use dependency injection instead$#"
 			count: 1
 			path: modules/social_features/social_tagging/src/SocialTaggingOverrides.php
+
+		-
+			message: """
+				#^Call to deprecated function social_tagging_to_machine_name\\(\\)\\:
+				in social\\:11\\.5\\.0 and is removed from social\\:12\\.0\\.0\\. Use
+				  \\\\Drupal\\:\\:service\\('social_core\\.machine_name'\\)\\-\\>transform\\(\\) instead\\.$#
+			"""
+			count: 1
+			path: modules/social_features/social_tagging/src/SocialTaggingService.php
 
 		-
 			message: "#^Parameter \\#1 \\$tid of method Drupal\\\\taxonomy\\\\TermStorage\\:\\:loadParents\\(\\) expects int, int\\|string\\|null given\\.$#"
@@ -17228,8 +17273,3 @@ parameters:
 			message: "#^\\\\Drupal calls should be avoided in classes, use dependency injection instead$#"
 			count: 2
 			path: modules/social_features/social_user_export/src/Plugin/Action/ExportUser.php
-
-		-
-			message: "#^Method Drupal\\\\social_flexible_group_book\\\\Plugin\\\\ActivityEntityCondition\\\\BookParentOnlyActivityEntityCondition\\:\\:isValidEntityCondition\\(\\) has parameter \\$entity with no type specified\\.$#"
-			count: 1
-			path: modules/social_features/social_group/modules/social_group_flexible_group/modules/social_flexible_group_book/src/Plugin/ActivityEntityCondition/BookParentOnlyActivityEntityCondition.php


### PR DESCRIPTION
## Problem
On a multilingual website of Open Social installed with English as the base language, if a content manager or site manager adds/edits content where tags (Social Tagging feature) are enabled then the translated tag categories don't appear on the page.

The code https://github.com/goalgorilla/open_social/blob/11.4.0/modules/social_features/social_tagging/social_tagging.module#L237  tries to convert the names of “Taxonomy” in a machine name.

So, the function https://github.com/goalgorilla/open_social/blob/11.4.x/modules/social_features/social_tagging/social_tagging.module#L587 doesn’t considers the “non-english” language to be present in the given text which then fails.

## Solution
Our goal was to make the improvements in the logic of converting the terms/given strings to machine_name irrespective of characters of language. We also wanted to maintain the backward compatiblity and also, to not suddenly make changes which may break a platform using function social_tagging_to_machine_name().

So, we decided the following thing.

1. Create a new service  for allowing the strings to be converted to machine name.
2. Make sure it is independent of "language characters", which means the text can be in Arabic or Russian or Greek.
3. Deprecate the social_tagging_to_machine_name() in Open Social 11.5.0 with removal in next major release which is Open Social 12.0.0
4. Took inspiration from https://api.drupal.org/api/drupal/core%21modules%21migrate%21src%21Plugin%21migrate%21process%21MachineName.php/function/MachineName%3A%3Atransform/9.4.x
5. Improve the current social_tagging_to_machine_name() function to fix the problem by invoking the method transform() added in MachineName.php service.

## Issue tracker
https://www.drupal.org/project/social/issues/3306207

## Theme issue tracker
*[Required if applicable] Paste a link to the drupal.org theme issue queue item, either from [socialbase](https://www.drupal.org/project/socialbase) or [socialblue](https://www.drupal.org/project/socialblue). If any other issue trackers were used, include links to those too.*

## How to test
- [ ] Install Open Social v11.4.0 with Social tagging feature enabled. Configure the tagging feature for using category split and enable it for certain content types on /admin/config/opensocial/tagging-settings
- [ ] Enable at least two languages let's say English and Arabic
- [ ] Add "terms" in Content Tags vocabulary as "Category" and it's "Children" in the first language. And translate them into a second language
- [ ] Now, try to add/edit content in the second language.
- [ ] You should not be able to see categories
- [ ] Checkout to this branch,
- [ ] Do a `drush cr`
- [ ] Edit the node in both languages
- [ ] Make sure that tag categories and tag children of respective categories are present.

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
N.A

## Release notes
On a multilingual platform, a user was not able to choose different tag categories in Tagging settings while adding/editing content on the platform where the social tagging feature was enabled when the current language was non-English. However, this only happened in certain languages such as Arabic. We have now fixed this problem and users will be able to select all the tag categories and it's children configured on a website while adding/editing content that has Tagging settings on the form.

## Change Record
https://www.drupal.org/node/3306214

## Translations
N.A