### PR TITLE
Internal: Implement GitHub Action translation extraction

### DIFF
--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -12,3 +12,94 @@ jobs:
     steps:
       - name: Install Gettext tools
         run: sudo apt-get install gettext
+
+      - name: Set default PHP7.4
+        run: sudo update-alternatives --set php /usr/bin/php7.4
+
+      - name: Configure Git
+        run: |
+          git config --global user.email "noreply@getopensocial.com"
+          git config --global user.name "Open Social Translation Workflow"
+
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          # Since composer must clone from this we require all the history.
+          fetch-depth: 0
+
+      - name: Prepare Installation Directory
+        run: |
+          mkdir ${RUNNER_TEMP}/installation
+          cp tests/composer.json ${RUNNER_TEMP}/installation/composer.json
+
+      - name: Install Open Social
+        working-directory: ${{ runner.temp }}/installation
+        run: |
+          composer config repositories.social vcs ${GITHUB_WORKSPACE}
+          composer require goalgorilla/open_social:dev-${GITHUB_REF_NAME}
+
+      - name: Install Open Social Translation Extractor
+        env:
+          COMPOSER_AUTH: '{"http-basic": {"repo.packagist.com": {"username": "token", "password": "${{secrets.COMPOSER_TOOLS_AUTH}}"}}}' # [tl! **]
+        run: |
+          mkdir ${RUNNER_TEMP}/oste
+          cd ${RUNNER_TEMP}/oste
+          composer init -n --name="goalgorilla/extractor"
+          composer config repositories.oste '{"type": "composer", "url": "https://repo.packagist.com/opensocial/distribution-tools/", "only": ["goalgorilla/oste"] }'
+          composer require --dev --prefer-dist --no-progress goalgorilla/oste:dev-main
+
+      - name: Setup Extractor
+        run: |
+          mkdir -p ${RUNNER_TEMP}/extractor
+          ${RUNNER_TEMP}/oste/vendor/goalgorilla/oste/bin/setup-extractor.sh ${RUNNER_TEMP}/extractor
+
+      - name: Extract Translations
+        working-directory: ${{ runner.temp }}/installation/html/profiles/contrib
+        run: |
+          CHANGES_FILE="${RUNNER_TEMP}/CHANGES.md"
+          touch $CHANGES_FILE
+
+          NAME="social"
+          TRANSLATIONS_FOLDER="${GITHUB_WORKSPACE}/translations"
+
+          ${RUNNER_TEMP}/oste/vendor/goalgorilla/oste/bin/extract-source.sh ${RUNNER_TEMP}/extractor "${NAME}" "${TRANSLATIONS_FOLDER}"
+
+          cd $GITHUB_WORKSPACE
+
+          CHANGES=`${RUNNER_TEMP}/oste/vendor/goalgorilla/oste/bin/list-changes.sh translations/en.pot`
+          if [[ ! -z "$CHANGES" ]]; then
+            echo "\`\`\`diff" >> $CHANGES_FILE
+            echo "$CHANGES" >> $CHANGES_FILE
+            echo "\`\`\`" >> $CHANGES_FILE
+          fi
+
+          # Commit the changes for Open Social
+          ${RUNNER_TEMP}/oste/vendor/goalgorilla/oste/bin/commit-updated-po-files.sh --yes Updating translation source strings
+
+      - name: Collect Changes
+        id: changesets
+        run: |
+          CHANGES="$(cat "${RUNNER_TEMP}/CHANGES.md")"
+
+          if [[ -z "$CHANGES" ]]; then
+            CHANGES="No changes"
+          fi
+
+          PR_BODY=$(cat <<EOF
+          # Summary of Translations
+          Below is a summary of the strings changed, removed, and updated in the template file.
+
+          $CHANGES
+          EOF
+          )
+
+          echo "$PR_BODY" > "${RUNNER_TEMP}/CHANGES.md"
+
+      - name: Create Pull Request
+        uses: goalgorilla/create-pull-request@patched-2022-08-30
+        with:
+          branch: automation/translations-source-extraction
+          delete-branch: true
+          title: Updated source translations
+          body-file: ${{ runner.temp }}/CHANGES.md
+          labels: automated,translations


### PR DESCRIPTION

## Problem
We currently run nightly translation extraction. This means there's a large feedback loop for new code added and translations being available in our translation tool.

## Solution
This implements translation extraction as a GitHub action, similar to what we've done internally. We re-use an internal tool using our private packagist subrepository created to provide access to tools only.

The GitHub action creates a pull request against the `main` branch for any new translations added whenever new code is pushed to that branch.

The labels `translated` and `automated` have been created and are added to any PR opened by the workflow so they can easily be identified or targetted by other processes (e.g. Mergeable could ignore PRs with the `automated` tag)

## Definition of done
### Before merge
- [x] Code/peer review is completed
- [x] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [x] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [x] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [x] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

