### PR TITLE
Issue #3306207 by navneet0693, robertragas, ronaldtebrake: Tag categries do not appear on add/edit page on multilingual websites.

### DIFF
--- a/modules/social_features/social_core/social_core.services.yml
+++ b/modules/social_features/social_core/social_core.services.yml
@@ -26,3 +26,7 @@ services:
     tags:
       - { name: config.factory.override, priority: 5 }
       - { name: social_language_defaults }
+
+  social_core.machine_name:
+    class: Drupal\social_core\Service\MachineName
+    arguments: ['@transliteration']

--- a/modules/social_features/social_core/src/Service/MachineName.php
+++ b/modules/social_features/social_core/src/Service/MachineName.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Drupal\social_core\Service;
+
+use Drupal\Component\Transliteration\TransliterationInterface;
+use Drupal\Core\Language\LanguageInterface;
+
+/**
+ * Creates a machine name.
+ *
+ * This functions takes a string input and turns it into a
+ * machine-readable name via the following four steps:
+ *
+ * 1. Language decorations and accents are removed by transliterating the source
+ *    value.
+ * 2. The resulting value is made lowercase.
+ * 3. Any special characters are replaced with an underscore. By default,
+ *    anything that is not a number or a letter is replaced, but additional
+ *    characters can be allowed or further restricted by using the
+ *    replace_pattern configuration as described below.
+ * 4. Any duplicate underscores either in the source value or as a result of
+ *    replacing special characters are removed.
+ *
+ * This class is inspiration from the class
+ * @link https://api.drupal.org/api/drupal/core%21modules%21migrate%21src%21Plugin%21migrate%21process%21MachineName.php/class/MachineName/9.4.x @endlink
+ */
+class MachineName {
+
+  /**
+   * The transliteration service.
+   *
+   * @var \Drupal\Component\Transliteration\TransliterationInterface
+   */
+  protected TransliterationInterface $transliteration;
+
+  /**
+   * SocialTaggingService constructor.
+   *
+   * @param \Drupal\Component\Transliteration\TransliterationInterface $transliteration
+   *   The transliteration service.
+   */
+  public function __construct(TransliterationInterface $transliteration) {
+    $this->transliteration = $transliteration;
+  }
+
+  /**
+   * Transforms given string to machine name.
+   *
+   * @param string $value
+   *   The value to be transformed.
+   * @param string $replacePattern
+   *   The replacement pattern for regex.
+   *
+   * @return string
+   *   The newly transformed value.
+   */
+  public function transform(string $value, string $replacePattern = '/[^a-z0-9_]+/'): string {
+    $new_value = $this->transliteration->transliterate($value, LanguageInterface::LANGCODE_DEFAULT, '_');
+    $new_value = strtolower($new_value);
+    $replaced_special = preg_replace($replacePattern, '_', $new_value);
+    $replaced_underscores = '';
+    if (!is_null($replaced_special)) {
+      $replaced_underscores = preg_replace('/_+/', '_', $replaced_special);
+    }
+    if (!is_null($replaced_underscores)) {
+      return $replaced_underscores;
+    }
+    return '';
+  }
+
+}

--- a/modules/social_features/social_follow_taxonomy/modules/social_follow_landing_page/social_follow_landing_page.module
+++ b/modules/social_features/social_follow_taxonomy/modules/social_follow_landing_page/social_follow_landing_page.module
@@ -60,11 +60,11 @@ function social_follow_landing_page_preprocess_paragraph(&$variables) {
               $parent = reset($parents);
               $category = $parent->getName();
               // Use the name of parent term as id of the filter parameter.
-              $parameter = social_tagging_to_machine_name($category);
+              $parameter = \Drupal::service('social_core.machine_name')->transform($category);
             }
             elseif ($tag_service->useCategoryParent()) {
               $category = $term->getName();
-              $parameter = social_tagging_to_machine_name($category);
+              $parameter = \Drupal::service('social_core.machine_name')->transform($category);
             }
           }
           $url = Url::fromRoute($route, [
@@ -232,7 +232,7 @@ function social_follow_landing_page_field_widget_entity_reference_paragraphs_for
       $categories = $tag_service->getCategories();
       // Loop over the categories.
       foreach ($categories as $tid => $category) {
-        $field_name = 'social_tagging_' . social_tagging_to_machine_name($category);
+        $field_name = 'social_tagging_' . \Drupal::service('social_core.machine_name')->transform($category);
         // Get the corresponding items.
         $options = $tag_service->getChildren($tid);
         // Only add a field if the category has any options.
@@ -295,8 +295,9 @@ function _social_follow_landing_page_entity_validate($element, FormStateInterfac
 
       // Loop over the categories.
       foreach ($categories as $category) {
-        if (!empty($tag_value['social_tagging_' . social_tagging_to_machine_name($category)])) {
-          foreach ($tag_value['social_tagging_' . social_tagging_to_machine_name($category)] as $selected) {
+        $machine_name = \Drupal::service('social_core.machine_name')->transform($category);
+        if (!empty($tag_value['social_tagging_' . $machine_name])) {
+          foreach ($tag_value['social_tagging_' . $machine_name] as $selected) {
             $tagging_values[] = [
               'target_id' => $selected,
               '_weight' => (string) $counter,

--- a/modules/social_features/social_follow_taxonomy/modules/social_follow_tag/src/SocialFollowTagLazyBuilder.php
+++ b/modules/social_features/social_follow_taxonomy/modules/social_follow_tag/src/SocialFollowTagLazyBuilder.php
@@ -118,7 +118,8 @@ class SocialFollowTagLazyBuilder implements TrustedCallbackInterface {
     if ($this->tagService->allowSplit()) {
       foreach ($this->tagService->getCategories() as $tid => $value) {
         if (!empty($this->tagService->getChildren($tid))) {
-          $identifiers[] = social_tagging_to_machine_name($value);
+          // @todo Replace with dependency injection in Open Social 12.0.0.
+          $identifiers[] = \Drupal::service('social_core.machine_name')->transform($value);
         }
       }
     }

--- a/modules/social_features/social_tagging/social_tagging.module
+++ b/modules/social_features/social_tagging/social_tagging.module
@@ -234,7 +234,7 @@ function social_tagging_social_tagging_field_form_alter(array &$form, FormStateI
         $categories = $tag_service->getCategories();
         // Loop over the categories.
         foreach ($categories as $tid => $category) {
-          $field_name = 'social_tagging_' . social_tagging_to_machine_name($category);
+          $field_name = 'social_tagging_' . \Drupal::service('social_core.machine_name')->transform($category);
           // Get the corresponding items.
           $options = $tag_service->getChildren($tid);
 
@@ -299,8 +299,9 @@ function _social_tagging_entity_validate($form, FormStateInterface $form_state) 
   $counter = 0;
   // Loop over the categories.
   foreach ($categories as $category) {
-    if (!empty($form_state->getValue('social_tagging_' . social_tagging_to_machine_name($category)))) {
-      foreach ($form_state->getValue('social_tagging_' . social_tagging_to_machine_name($category)) as $selected) {
+    $machine_name = \Drupal::service('social_core.machine_name');
+    if (!empty($form_state->getValue('social_tagging_' . $machine_name->transform($category)))) {
+      foreach ($form_state->getValue('social_tagging_' . $machine_name->transform($category)) as $selected) {
         $tagging_values[] = [
           'target_id' => $selected,
           '_weight' => (string) $counter,
@@ -518,7 +519,7 @@ function social_tagging_form_views_exposed_form_alter(&$form, FormStateInterface
   }
   if ($tag_service->allowSplit()) {
     foreach ($tag_service->getCategories() as $tid => $term_name) {
-      $label = social_tagging_to_machine_name($term_name);
+      $label = \Drupal::service('social_core.machine_name')->transform($term_name);
 
       if (isset($form[$label])) {
         $form[$label]['#options'] = [];
@@ -582,9 +583,15 @@ function social_tagging_form_views_exposed_form_alter(&$form, FormStateInterface
  *   A node.
  *
  * @return mixed|string
- *   A machine name so it can be used pogrammatically.
+ *   A machine name so it can be used programmatically.
+ *
+ * @deprecated in social:11.3.10 and is removed from social:12.0.0. Use
+ *   \Drupal::service('social_core.machine_name')->transform() instead.
+ *
+ * @see https://www.drupal.org/node/3306214
  */
 function social_tagging_to_machine_name($text) {
+  @trigger_error('social_tagging_to_machine_name() is deprecated in social:11.3.10 and is removed from social:12.0.0. Use "\Drupal::service(\'social_core.machine_name\')->transform()" instead. See https://www.drupal.org/node/3306214', E_USER_DEPRECATED);
   return preg_replace('@[^a-z0-9-]+@', '_', strtolower($text));
 }
 

--- a/modules/social_features/social_tagging/src/SocialTaggingOverrides.php
+++ b/modules/social_features/social_tagging/src/SocialTaggingOverrides.php
@@ -88,6 +88,10 @@ class SocialTaggingOverrides implements ConfigFactoryOverrideInterface {
 
     /** @var \Drupal\social_tagging\SocialTaggingService $tag_service */
     $tag_service = \Drupal::service('social_tagging.tag_service');
+
+    /** @var \Drupal\social_core\Service\MachineName $machine_name */
+    $machine_name_service = \Drupal::service('social_core.machine_name');
+
     $config = $this->configFactory;
 
     // Check if tagging is active.
@@ -127,14 +131,16 @@ class SocialTaggingOverrides implements ConfigFactoryOverrideInterface {
       foreach ($tag_service->getCategories() as $tid => $value) {
         if (!empty($tag_service->getChildren($tid))) {
           $fields['social_tagging_' . $tid] = [
-            'identifier' => social_tagging_to_machine_name($value),
+            // @todo Replace with dependency injection in Open Social 12.0.0.
+            'identifier' => $machine_name_service->transform($value),
             'label' => $value,
           ];
         }
         // Display parent of tags.
         elseif ($tag_service->useCategoryParent()) {
           $fields['social_tagging_' . $tid] = [
-            'identifier' => social_tagging_to_machine_name($value),
+            // @todo Replace with dependency injection in Open Social 12.0.0.
+            'identifier' => $machine_name_service->transform($value),
             'label' => $value,
           ];
         }
@@ -238,7 +244,8 @@ class SocialTaggingOverrides implements ConfigFactoryOverrideInterface {
       foreach ($tag_service->getCategories() as $tid => $value) {
         if (!empty($tag_service->getChildren($tid))) {
           $fields['social_tagging_target_id_' . $tid] = [
-            'identifier' => social_tagging_to_machine_name($value),
+            // @todo Replace with dependency injection in Open Social 12.0.0.
+            'identifier' => $machine_name_service->transform($value),
             'label' => $value,
           ];
         }

--- a/modules/social_features/social_tagging/src/SocialTaggingService.php
+++ b/modules/social_features/social_tagging/src/SocialTaggingService.php
@@ -275,7 +275,8 @@ class SocialTaggingService {
           $parent = $current_term;
         }
         // Prepare the parameter;.
-        $parameter = $allowSplit ? social_tagging_to_machine_name($category_label) : 'tag';
+        // @todo Replace with dependency injection in Open Social 12.0.0.
+        $parameter = $allowSplit ? \Drupal::service('social_core.machine_name')->transform($category_label) : 'tag';
 
         $route_parameters = [
           $parameter . '[]' => $current_term->id(),

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -9160,6 +9160,11 @@ parameters:
 			path: modules/social_features/social_follow_taxonomy/modules/social_follow_tag/src/SocialFollowTagLazyBuilder.php
 
 		-
+			message: "#^\\\\Drupal calls should be avoided in classes, use dependency injection instead$#"
+			count: 1
+			path: modules/social_features/social_follow_taxonomy/modules/social_follow_tag/src/SocialFollowTagLazyBuilder.php
+
+		-
 			message: "#^Method Drupal\\\\social_follow_tag\\\\SocialFollowTagOverrides\\:\\:createConfigObject\\(\\) should return Drupal\\\\Core\\\\Config\\\\StorableConfigBase but returns null\\.$#"
 			count: 1
 			path: modules/social_features/social_follow_taxonomy/modules/social_follow_tag/src/SocialFollowTagOverrides.php
@@ -16095,12 +16100,22 @@ parameters:
 			path: modules/social_features/social_tagging/src/SocialTaggingOverrides.php
 
 		-
-			message: "#^\\\\Drupal calls should be avoided in classes, use dependency injection instead$#"
+			message: "#^Variable \\$machine_name in PHPDoc tag @var does not match assigned variable \\$machine_name_service\\.$#"
 			count: 1
 			path: modules/social_features/social_tagging/src/SocialTaggingOverrides.php
 
 		-
+			message: "#^\\\\Drupal calls should be avoided in classes, use dependency injection instead$#"
+			count: 2
+			path: modules/social_features/social_tagging/src/SocialTaggingOverrides.php
+
+		-
 			message: "#^Parameter \\#1 \\$tid of method Drupal\\\\taxonomy\\\\TermStorage\\:\\:loadParents\\(\\) expects int, int\\|string\\|null given\\.$#"
+			count: 1
+			path: modules/social_features/social_tagging/src/SocialTaggingService.php
+
+		-
+			message: "#^\\\\Drupal calls should be avoided in classes, use dependency injection instead$#"
 			count: 1
 			path: modules/social_features/social_tagging/src/SocialTaggingService.php
 


### PR DESCRIPTION

On a multilingual website of Open Social installed with English as the base language, if a content manager or site manager adds/edits content where tags (Social Tagging feature) are enabled then the translated tag categories don't appear on the page.

The code https://github.com/goalgorilla/open_social/blob/11.4.0/modules/social_features/social_tagging/social_tagging.module#L237  tries to convert the names of “Taxonomy” in a machine name.

So, the function https://github.com/goalgorilla/open_social/blob/11.4.x/modules/social_features/social_tagging/social_tagging.module#L587 doesn’t considers the “non-english” language to be present in the given text which then fails.

## Problem
On a multilingual website of Open Social installed with English as the base language, if a content manager or site manager adds/edits content where tags (Social Tagging feature) are enabled then the translated tag categories don't appear on the page.

The code https://github.com/goalgorilla/open_social/blob/11.4.0/modules/social_features/social_tagging/social_tagging.module#L237 tries to convert the names of “Taxonomy” in a machine name.

So, the function https://github.com/goalgorilla/open_social/blob/11.4.x/modules/social_features/social_tagging/social_tagging.module#L587 doesn’t considers the “non-english” language to be present in the given text which then fails.

## Solution
Our goal was to make the improvements in the logic of converting the terms/given strings to machine_name irrespective of characters of language. We also wanted to maintain the backward compatiblity and also, to not suddenly make changes which may break a platform using function social_tagging_to_machine_name().

So, we decided the following thing.

1. Create a new service for allowing the strings to be converted to machine name.
2. Make sure it is independent of "language characters", which means the text can be in Arabic or Russian or Greek.
3. Deprecate the social_tagging_to_machine_name() in Open Social 11.5.0 with removal in next major release which is Open Social 12.0.0
4. Took inspiration from https://api.drupal.org/api/drupal/core%21modules%21migrate%21src%21Plugin%21migrate%21process%21MachineName.php/function/MachineName%3A%3Atransform/9.4.x
5. Improve the current social_tagging_to_machine_name() function to fix the problem by invoking the method transform() added in MachineName.php service.
6. The initial PR was https://github.com/goalgorilla/open_social/pull/3082 which was reverted in https://github.com/goalgorilla/open_social/pull/3090 in order to make these changes release in patch version release of Open Social.
7. At the time of this commit, we are also update phpstan baseline to ignore \Drupal calls in classes as we cannot add "parameters" to constructor of these classes in order to do dependency injection as that will break the backward compatiblity.
8. Also, I have added todos to do the DI once we are developing for Open Social 12.0.0

## Issue tracker
https://www.drupal.org/project/social/issues/3306207

## Theme issue tracker
N.A

## How to test
- [ ] Install Open Social v11.4.0 with Social tagging feature enabled. Configure the tagging feature for using category split and enable it for certain content types on /admin/config/opensocial/tagging-settings
- [ ] Enable at least two languages let's say English and Arabic
- [ ] Add "terms" in Content Tags vocabulary as "Category" and it's "Children" in the first language. And translate them into a second language
- [ ] Now, try to add/edit content in the second language.
- [ ] You should not be able to see categories
- [ ] Checkout to this branch,
- [ ] Do a `drush cr`
- [ ] Edit the node in both languages
- [ ] Make sure that tag categories and tag children of respective categories are present.

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
N.A

## Release notes
On a multilingual platform, a user was not able to choose different tag categories in Tagging settings while adding/editing content on the platform where the social tagging feature was enabled when the current language was non-English. However, this only happened in certain languages such as Arabic. We have now fixed this problem and users will be able to select all the tag categories and it's children configured on a website while adding/editing content that has Tagging settings on the form.

## Change Record
https://www.drupal.org/node/3306214

## Translations
N.A