### PR TITLE
Issue #3308363 by rolki: Improve access checking and fix possible performance issue for custom content list block

### DIFF
--- a/modules/social_features/social_content_block/src/ContentBuilder.php
+++ b/modules/social_features/social_content_block/src/ContentBuilder.php
@@ -73,7 +73,7 @@ class ContentBuilder implements ContentBuilderInterface {
   /**
    * {@inheritdoc}
    */
-  public static function trustedCallbacks() {
+  public static function trustedCallbacks(): array {
     return ['getEntities', 'build'];
   }
 
@@ -148,27 +148,40 @@ class ContentBuilder implements ContentBuilderInterface {
         // Apply our sorting logic.
         $this->sortBy($query, $entity_type, $block_content, $plugin->supportedSortOptions());
 
-        // Add range.
-        $query->range(0, $block_content->field_item_amount->value);
-
         // Execute the query to get the results.
         $result = $query->execute();
         $entities = $result !== NULL ? $result->fetchAllKeyed(0, 0) : NULL;
 
         if ($entities) {
+          // In order not to load the objects of all sorted entities
+          // and not to check whether the user has access to view
+          // ($entity->access('view')), we can simply do it at the query level
+          // and iterate only the necessary number of elements. This approach
+          // is much faster than loading all entities.
+          $limit = $block_content->field_item_amount->value;
+
+          foreach ($entities as $entity_id) {
+            $eid = $this->entityTypeManager->getStorage($entity_type->id())->getQuery()
+              ->accessCheck(TRUE)
+              ->condition((string) $entity_type->getKey('id'), $entity_id)
+              ->execute();
+
+            if (!empty($eid)) {
+              $allowed_entities[$entity_id] = $entity_id;
+            }
+
+            if (!empty($allowed_entities) && count($allowed_entities) >= $limit) {
+              break;
+            }
+          }
+
           // Load all the topics so we can give them back.
           $entities = $this->entityTypeManager
             ->getStorage($definition['entityTypeId'])
-            ->loadMultiple($entities);
+            ->loadMultiple($allowed_entities ?? NULL);
 
           foreach ($entities as $key => $entity) {
-            if ($entity->access('view') === FALSE) {
-              unset($entities[$key]);
-            }
-            else {
-              // Get entity translation if exists.
-              $entities[$key] = $this->entityRepository->getTranslationFromContext($entity);
-            }
+            $entities[$key] = $this->entityRepository->getTranslationFromContext($entity);
           }
 
           return $this->entityTypeManager


### PR DESCRIPTION
## Problem
After processing of all plugins in `social_content_block/ContentBuilder`, we have an array of entities, after which we sort them and limit the number of results using `$query->range(0, $block_content->field_item_amount->value);` 
The problem is that after limiting, we load the objects entities and check whether the user has access to them, this is not correct as the selection is already limited to, for example, 5 items, but the user has access to only 2, in this case, even though 5 is selected in the block settings, only 2 will be displayed.

Another problem is that some sites, to solve the problem above, simply remove this range and add `array_slice` after the objects are loaded and checked for access - and this is even worse since `5000+` (depends on platform) entities can be loaded and checked for access. As a result, a serious performance problem arises.

## Solution
Access checking should be performed at the range and at the database level.

## Issue tracker

- https://www.drupal.org/project/social/issues/3308363
- https://getopensocial.atlassian.net/browse/PROD-22116

## Theme issue tracker
NONE.

## How to test

- [ ] A custom content list block was added to the site, and to ensure that a lot of data was included in the sample
- [ ] Entities with different visibility options should be displayed
- [ ] Log in as a user who cannot see all entities

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
NONE.

## Release notes
Improve access checking and fix possible performance issue for custom content list block.
Now access is checked at the earliest stage, using the `ENTITY_access` tag

## Change Record
NONE.

## Translations
NONE.
