### PR TITLE
Issue #3308535: GraphQL API returns types for profile that violate schema

### DIFF
--- a/modules/custom/social_graphql/src/Plugin/GraphQL/DataProducer/Field/Field.php
+++ b/modules/custom/social_graphql/src/Plugin/GraphQL/DataProducer/Field/Field.php
@@ -50,11 +50,19 @@ class Field extends DataProducerPluginBase {
       return NULL;
     }
 
-    $value = $entity->get($field);
     // A FieldableEntityInterface::get will always return a
     // FieldItemListInterface which implements AccessibleInterface. Thus no
     // further typechecking is needed.
-    return $value->access('view') ? $value : NULL;
+    $entity_field = $entity->get($field);
+    if (!$entity_field->access('view')) {
+      return NULL;
+    }
+
+    if ($entity_field->isEmpty()) {
+      return NULL;
+    }
+
+    return $entity_field;
   }
 
 }


### PR DESCRIPTION
This was split out from https://github.com/goalgorilla/open_social/pull/2478

## Problem
The producer returned a field item for empty fields which could cause
non-nullable sub-fields to return NULL instead (e.g. for a formatted
text field). Returning NULL for an empty field ensures that we don't try
to access sub-fields.

Our profile field isn't allowed to return NULL because all users should
have a profile (and profiles aren't accessible as standalone data) so if
a user is not allowed to view profile data then we just fake this by
returning an empty profile instead. The profile fields are already
nullable because users can choose visibility on a per-field basis.

## Solution
Change the relevant dataproducers.

## Issue tracker
https://www.drupal.org/project/social/issues/3308535

## How to test
- [ ] Try to access an empty formatted text field in the API
- [ ] Try to fetch a user without a profile in the GraphQL API
- [ ] Both cases cause incorrect responses before the changes and correct ones after

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Release notes
The GraphQL response for profiles violated the schema in some edge cases.
