### PR TITLE
Issue #3308580: Add `view debug` permission to social_core

### DIFF
--- a/modules/social_features/social_core/social_core.permissions.yml
+++ b/modules/social_features/social_core/social_core.permissions.yml
@@ -1,6 +1,12 @@
 access social_core dashboard:
   title: 'Access administration dashboard'
   description: 'Allows access to the administration dashboard.'
+
 bypass social_core menu links access:
   title: 'Access all Open Social menu links.'
   description: 'Allows access to all Open Social menu links.'
+
+view debug information:
+  title: 'View debug information'
+  description: 'Show debug information in Open Social modules. Intended for developers only.'
+  restrict access: true


### PR DESCRIPTION
This change was split out from https://github.com/goalgorilla/open_social/pull/2478

## Problem
In some cases we want to expose a bit more information to developers so that they can quickly diagnose issues. Information that may not be understandable to site managers (such as raw field names).


## Solution
To provide a unified solution for this that does not rely on the developer user having uid 1 we introduce a new permission. This is placed in social_core so that we can use it in all modules building on top of this.

## Issue tracker
https://www.drupal.org/project/social/issues/3308580

## How to test
- [ ] n/a?

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Release notes
`social_core` introduces the `view debug` permission which allows modules building on top of `social_core` to hide developer only information.
