### PR TITLE
Issue #330884: Verified user role weight should be lower than content manager

### DIFF
--- a/modules/social_features/social_core/config/install/user.role.verified.yml
+++ b/modules/social_features/social_core/config/install/user.role.verified.yml
@@ -3,6 +3,6 @@ status: true
 dependencies: {  }
 id: verified
 label: 'Verified user'
-weight: 5
+weight: 3
 is_admin: null
 permissions: {  }

--- a/modules/social_features/social_core/social_core.install
+++ b/modules/social_features/social_core/social_core.install
@@ -1470,8 +1470,8 @@ function social_core_update_10300() {
 function social_core_update_11001(): void {
   Role::create([
     'id' => 'verified',
-    'label' => t('Verified User'),
-    'weight' => 5,
+    'label' => 'Verified User',
+    'weight' => 3,
     'is_admin' => NULL,
     'permissions' => [],
   ])->save();
@@ -1624,4 +1624,18 @@ function social_core_update_11403(array &$sandbox): void {
       $style->flush();
     }
   }
+}
+
+/**
+ * Fix verified user role weight.
+ */
+function social_core_update_11404(): void {
+  // This should've been created in 11001.
+  $role = Role::load('verified');
+
+  if ($role === NULL) {
+    throw new \RuntimeException("Verified user role is required for Open Social to function.");
+  }
+
+  $role->setWeight(3)->save();
 }


### PR DESCRIPTION
This change was split out from https://github.com/goalgorilla/open_social/pull/2478

## Problem / Solution
This ensures that the verified user role shows up before the content manager and site manager roles in settings forms. This is sensible because usually the verified user role will be less permissioned. This follows other patterns in Drupal of presenting lower permissions roles first.

## Issue tracker
https://www.drupal.org/project/social/issues/3308584

## How to test
- [ ] Check that verified user role shows up before content manager and site manager in overviews

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Release notes
Ensured the verified user role is now shown before higher permissioned roles such as content manager and site manager.
