### PR TITLE
Add right permissions for Albums in groups

### DIFF
--- a/modules/social_features/social_album/social_album.install
+++ b/modules/social_features/social_album/social_album.install
@@ -318,3 +318,40 @@ function social_album_update_11001(): void {
     ]
   );
 }
+
+/**
+ * Grant group albums permissions for anonymous users.
+ */
+function social_album_update_11002(): void {
+  /** @var \Drupal\group\Entity\GroupRoleInterface $group_role_anonymous */
+  $group_role_anonymous = \Drupal::entityTypeManager()->getStorage('group_role')->load('flexible_group-anonymous');
+  $group_role_anonymous->grantPermissions(['view group_node:album content', 'view group_node:album entity'])->save();
+}
+
+/**
+ * Grant group albums permissions for group outsiders.
+ */
+function social_album_update_11003(): void {
+  /** @var \Drupal\group\Entity\GroupRoleInterface $group_role_outsider */
+  $group_role_outsider = \Drupal::entityTypeManager()->getStorage('group_role')->load('flexible_group-outsider');
+  $group_role_outsider->grantPermissions(['view group_node:album content', 'view group_node:album entity'])->save();
+}
+
+/**
+ * Update Album permissions.
+ */
+function social_album_update_11004(): void {
+  user_role_grant_permissions(
+    RoleInterface::ANONYMOUS_ID,
+    [
+      'view node.album.field_content_visibility:public content',
+    ]
+  );
+
+  user_role_grant_permissions(
+    'verified',
+    [
+      'view node.album.field_content_visibility:community content',
+    ]
+  );
+}

--- a/modules/social_features/social_album/social_album.install
+++ b/modules/social_features/social_album/social_album.install
@@ -14,6 +14,12 @@ use Drupal\user\RoleInterface;
 function social_album_install() {
   // Grant the default permissions for this feature.
   user_role_grant_permissions(
+    RoleInterface::ANONYMOUS_ID,
+    [
+      'view node.album.field_content_visibility:public content',
+    ]
+  );
+  user_role_grant_permissions(
     RoleInterface::AUTHENTICATED_ID,
     [
       'view node.album.field_content_visibility:public content',
@@ -50,6 +56,16 @@ function social_album_install() {
       'administer social_album settings',
     ]
   );
+
+  // Add the right permissions to group roles.
+
+  /** @var \Drupal\group\Entity\GroupRoleInterface $group_role_outsider */
+  $group_role_outsider = \Drupal::entityTypeManager()->getStorage('group_role')->load('flexible_group-outsider');
+  $group_role_outsider->grantPermissions(['view group_node:album content', 'view group_node:album entity'])->save();
+
+  /** @var \Drupal\group\Entity\GroupRoleInterface $group_role_anonymous */
+  $group_role_anonymous = \Drupal::entityTypeManager()->getStorage('group_role')->load('flexible_group-anonymous');
+  $group_role_anonymous->grantPermissions(['view group_node:album content', 'view group_node:album entity'])->save();
 
   module_set_weight('social_album', 5);
 


### PR DESCRIPTION
## Problem
When viewing a public group, anonymous users don't see the album link, although the module is enabled.

## Solution
By adding the right permissions to the anonymous users for flexible groups, anonymous users are able to see both the Albums link and Albums page.

## Issue tracker
*[Required] Paste a link to the drupal.org issue queue item. If any other issue trackers were used, include links to those too.*

## Theme issue tracker
*[Required if applicable] Paste a link to the drupal.org theme issue queue item, either from [socialbase](https://www.drupal.org/project/socialbase) or [socialblue](https://www.drupal.org/project/socialblue). If any other issue trackers were used, include links to those too.*

## How to test
- [ ] Make sure the `social_album` module is installed
- [ ] Create a public group
- [ ] As an anonymous user
- [ ] Open the public group
- [ ] You should see the Albums link
- [ ] Click on the Albums link
- [ ] You should see `No albums in this group`
- [ ] If you add a public album, this should also be visible when viewing the Albums page.

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
*[Required if new feature, and if applicable] If this Pull Request makes visual changes then please include some screenshots that show what has changed here. A before and after screenshot helps the reviewer determine what changes were made.*

## Release notes
*[Required if new feature, and if applicable] A short summary of the changes that were made that can be included in release notes.*

## Change Record
*[Required if applicable] If this Pull Request changes the way that developers should do things or introduces a new API for developers then a change record to document this is needed. Please provide a draft for a change record or a link to an unpublished change record below. Existing change records can be consulted as example. Please provide a draft for a change record or a link to an unpublished change record below. [Existing change records](https://www.drupal.org/list-changes/social) can be consulted as example.*

## Translations
*[Optional]Translatable strings are always extracted from the latest development branch. To ensure translations remain available for platforms running older versions of Open Social the original string should be added to `translations.php` when it's changed or removed.*
- [ ] Changed or removed source strings are added to the `translations.php` file.
