### PR TITLE
Internal: Export screenshots for Behat test failures

### DIFF
--- a/.github/workflows/behat-stability-1-basic-installation.yml
+++ b/.github/workflows/behat-stability-1-basic-installation.yml
@@ -47,3 +47,10 @@ jobs:
 
       - name: Run Integration tests
         run: docker exec -i social_ci_web bash /var/www/scripts/social/behatstability.sh "stability-1&&~DS-1136&&~DS-3605 --stop-on-failure --strict  --colors"
+
+      - name: Upload Behat Test Output
+        if: failure()
+        uses: actions/upload-artifact@v3
+        with:
+          name: behat-output
+          path: html/profiles/contrib/social/tests/behat/logs

--- a/.github/workflows/behat-stability-1-upgrade-path.yml
+++ b/.github/workflows/behat-stability-1-upgrade-path.yml
@@ -82,3 +82,10 @@ jobs:
       # Run the upgrade path behat tests
       - name: Run Integration tests
         run: docker exec -i social_ci_web sh /var/www/scripts/social/behatstability.sh "stability-1&&~DS-1136&&~DS-3605 --stop-on-failure --strict  --colors"
+
+      - name: Upload Behat Test Output
+        if: failure()
+        uses: actions/upload-artifact@v3
+        with:
+          name: behat-output
+          path: html/profiles/contrib/social/tests/behat/logs

--- a/.github/workflows/behat-stability-1.yml
+++ b/.github/workflows/behat-stability-1.yml
@@ -47,3 +47,10 @@ jobs:
 
       - name: Run Integration tests
         run: docker exec -i social_ci_web bash /var/www/scripts/social/behatstability.sh "stability-1 --stop-on-failure --strict --colors"
+
+      - name: Upload Behat Test Output
+        if: failure()
+        uses: actions/upload-artifact@v3
+        with:
+          name: behat-output
+          path: html/profiles/contrib/social/tests/behat/logs

--- a/.github/workflows/behat-stability-2.yml
+++ b/.github/workflows/behat-stability-2.yml
@@ -47,3 +47,10 @@ jobs:
 
       - name: Run Integration tests
         run: docker exec -i social_ci_web bash /var/www/scripts/social/behatstability.sh "stability-2 --stop-on-failure --strict  --colors"
+
+      - name: Upload Behat Test Output
+        if: failure()
+        uses: actions/upload-artifact@v3
+        with:
+          name: behat-output
+          path: html/profiles/contrib/social/tests/behat/logs

--- a/.github/workflows/behat-stability-3.yml
+++ b/.github/workflows/behat-stability-3.yml
@@ -54,3 +54,10 @@ jobs:
 
       - name: Run Integration tests
         run: docker exec -i social_ci_web bash /var/www/scripts/social/behatstability.sh "stability-3 --stop-on-failure --strict  --colors"
+
+      - name: Upload Behat Test Output
+        if: failure()
+        uses: actions/upload-artifact@v3
+        with:
+          name: behat-output
+          path: html/profiles/contrib/social/tests/behat/logs

--- a/.github/workflows/behat-stability-4.yml
+++ b/.github/workflows/behat-stability-4.yml
@@ -47,3 +47,10 @@ jobs:
 
       - name: Run Integration tests
         run: docker exec -i social_ci_web bash /var/www/scripts/social/behatstability.sh "stability-4 --stop-on-failure --strict  --colors"
+
+      - name: Upload Behat Test Output
+        if: failure()
+        uses: actions/upload-artifact@v3
+        with:
+          name: behat-output
+          path: html/profiles/contrib/social/tests/behat/logs

--- a/tests/behat/features/bootstrap/SocialMinkContext.php
+++ b/tests/behat/features/bootstrap/SocialMinkContext.php
@@ -3,8 +3,7 @@
 
 namespace Drupal\social\Behat;
 
-use Behat\Mink\Element\NodeElement;
-use Behat\Mink\Exception\ElementNotFoundException;
+use Behat\Mink\Exception\UnsupportedDriverActionException;
 use Behat\Testwork\Tester\Result\TestResult;
 use Drupal\DrupalExtension\Context\MinkContext;
 use Behat\Behat\Context\Context;
@@ -59,26 +58,6 @@ class SocialMinkContext extends MinkContext {
     ");
 
     parent::assertCheckBox($checkbox);
-  }
-
-
-  /**
-   * @Given /^I make a screenshot$/
-   */
-  public function iMakeAScreenshot() {
-    $this->iMakeAScreenshotWithFileName('screenshot');
-  }
-
-  /**
-   * @Given /^I make a screenshot with the name "([^"]*)"$/
-   */
-  public function iMakeAScreenshotWithFileName($filename) {
-    $screenshot = $this->getSession()->getDriver()->getScreenshot();
-    $dir = '/var/www/test_images';
-    if (is_writeable($dir)) {
-      $file_and_path = $dir . '/' . $filename . '.jpg';
-      file_put_contents($file_and_path, $screenshot);
-    }
   }
 
   /**
@@ -138,33 +117,6 @@ class SocialMinkContext extends MinkContext {
 
     $clearButton->click();
   }
-
-
-  /**
-   * @AfterStep
-   */
-  public function takeScreenShotAfterFailedStep(AfterStepScope $scope)
-  {
-    if (TestResult::FAILED === $scope->getTestResult()->getResultCode()) {
-      $driver = $this->getSession()->getDriver();
-      if (!($driver instanceof Selenium2Driver)) {
-        return;
-      }
-      $feature = $scope->getFeature();
-      $title = $feature->getTitle();
-
-      $filename = date("Ymd-H_i_s");
-
-      if (!empty($title)) {
-        $filename .= '-' . str_replace(' ', '-', strtolower($title));
-      }
-
-      $filename .= '-error';
-
-      $this->iMakeAScreenshotWithFileName($filename);
-    }
-  }
-
 
   /**
    * Attaches file to field with specified name.

--- a/tests/behat/features/bootstrap/SocialMinkContext.php
+++ b/tests/behat/features/bootstrap/SocialMinkContext.php
@@ -3,19 +3,7 @@
 
 namespace Drupal\social\Behat;
 
-use Behat\Mink\Exception\UnsupportedDriverActionException;
-use Behat\Testwork\Tester\Result\TestResult;
 use Drupal\DrupalExtension\Context\MinkContext;
-use Behat\Behat\Context\Context;
-use Behat\Behat\Context\SnippetAcceptingContext;
-use Behat\Gherkin\Node\PyStringNode;
-use Behat\Gherkin\Node\TableNode;
-use Drupal\DrupalExtension\Context\DrupalContext;
-use Behat\MinkExtension\Context\RawMinkContext;
-use PHPUnit\Framework\Assert as PHPUnit;
-use Drupal\DrupalExtension\Hook\Scope\EntityScope;
-use Behat\Mink\Driver\Selenium2Driver;
-use Behat\Behat\Hook\Scope\AfterStepScope;
 
 /**
  * Defines application features from the specific context.

--- a/tests/behat/features/bootstrap/SocialMinkContext.php
+++ b/tests/behat/features/bootstrap/SocialMinkContext.php
@@ -5,6 +5,7 @@ namespace Drupal\social\Behat;
 
 use Behat\Mink\Element\NodeElement;
 use Behat\Mink\Exception\ElementNotFoundException;
+use Behat\Testwork\Tester\Result\TestResult;
 use Drupal\DrupalExtension\Context\MinkContext;
 use Behat\Behat\Context\Context;
 use Behat\Behat\Context\SnippetAcceptingContext;
@@ -73,7 +74,7 @@ class SocialMinkContext extends MinkContext {
    */
   public function iMakeAScreenshotWithFileName($filename) {
     $screenshot = $this->getSession()->getDriver()->getScreenshot();
-    $dir = '/var/www/travis_artifacts';
+    $dir = '/var/www/test_images';
     if (is_writeable($dir)) {
       $file_and_path = $dir . '/' . $filename . '.jpg';
       file_put_contents($file_and_path, $screenshot);
@@ -144,7 +145,7 @@ class SocialMinkContext extends MinkContext {
    */
   public function takeScreenShotAfterFailedStep(AfterStepScope $scope)
   {
-    if (99 === $scope->getTestResult()->getResultCode()) {
+    if (TestResult::FAILED === $scope->getTestResult()->getResultCode()) {
       $driver = $this->getSession()->getDriver();
       if (!($driver instanceof Selenium2Driver)) {
         return;


### PR DESCRIPTION
## Problem / Solution
We already have configuration that would create a screenshot if a test failed. The only issue was that when we moved off of Travis this data was no longer made available.

This commit makes the required folders in the GitHub action and uploads the screenshots as job artifacts so that they can be viewed by developers.

## Issue tracker
Internal Change

## How to test
- [ ] Fail a test in the CI and see that the screenshot is attached to the GitHub action

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status
