### PR TITLE
Issue #3311064: Update socialblue to 2.3.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -126,12 +126,6 @@
             },
             "drupal/redirect": {
                 "Redirection issue when interface language is different from content language": "https://www.drupal.org/files/issues/2020-06-01/redirect-interface_language_different_from_content_language_2991423-13.patch"
-            },
-            "drupal/socialbase": {
-                "As a LU I want to disable following me for other users": "https://www.drupal.org/files/issues/2022-06-23/socialbase-disable-user-follow-3283522-6.patch"
-            },
-            "drupal/socialblue": {
-                "As a LU I want to disable following me for other users": "https://www.drupal.org/files/issues/2022-06-23/socialblue-disable-user-follow-3283531-6.patch"
             }
         }
     },
@@ -184,7 +178,7 @@
         "drupal/select2": "1.13.0",
         "drupal/shariff": "1.7",
         "drupal/social_tour": "1.0.0-alpha2",
-        "drupal/socialblue": "2.3.0",
+        "drupal/socialblue": "2.3.2",
         "drupal/swiftmailer": "2.2.0",
         "drupal/token": "1.10.0",
         "drupal/ultimate_cron": "2.0-alpha5",


### PR DESCRIPTION
## Problem
Socialblue has a new version 2.3.2 and we should update it on Open Social

## Solution
Update socialblue to 2.3.2

## Issue tracker
https://www.drupal.org/project/social/issues/3311064

## Theme issue tracker
N/A

## How to test
- [ ] After installing or updating open social, socialblue should be in version 2.3.2

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
N/A

## Release notes
N/A

## Change Record
N/A

## Translations
N/A
