### PR TITLE
Issue #3309222: Assign the right permissions for social_album

### DIFF
--- a/modules/social_features/social_album/social_album.install
+++ b/modules/social_features/social_album/social_album.install
@@ -14,6 +14,12 @@ use Drupal\user\RoleInterface;
 function social_album_install() {
   // Grant the default permissions for this feature.
   user_role_grant_permissions(
+    RoleInterface::ANONYMOUS_ID,
+    [
+      'view node.album.field_content_visibility:public content',
+    ]
+  );
+  user_role_grant_permissions(
     RoleInterface::AUTHENTICATED_ID,
     [
       'view node.album.field_content_visibility:public content',
@@ -50,6 +56,8 @@ function social_album_install() {
       'administer social_album settings',
     ]
   );
+
+  _social_album_set_group_permissions();
 
   module_set_weight('social_album', 5);
 
@@ -93,12 +101,18 @@ function social_album_uninstall() {
  */
 function _social_album_set_group_permissions() {
   $common_permissions = [
-    'anonymous' => [],
+    'anonymous' => [
+      'view group_node:album content',
+      'view group_node:album entity',
+    ],
     'outsider' => [
       'update own group_node:album entity',
+      'view group_node:album content',
+      'view group_node:album entity',
     ],
     'member' => [
       'create group_node:album entity',
+      'create group_node:album content',
       'delete own group_node:album entity',
       'view group_node:album entity',
       'view group_node:album content',
@@ -317,4 +331,30 @@ function social_album_update_11001(): void {
       'view node.album.field_content_visibility:public content',
     ]
   );
+}
+
+/**
+ * Update Album permissions.
+ */
+function social_album_update_11301(): void {
+  user_role_grant_permissions(
+    RoleInterface::ANONYMOUS_ID,
+    [
+      'view node.album.field_content_visibility:public content',
+    ]
+  );
+
+  user_role_grant_permissions(
+    'verified',
+    [
+      'view node.album.field_content_visibility:community content',
+    ]
+  );
+}
+
+/**
+ * Update Album permissions.
+ */
+function social_album_update_11302(): void {
+  _social_album_set_group_permissions();
 }


### PR DESCRIPTION
## Problem
When viewing a public group, anonymous users don't see the album link, although the module is enabled.

## Solution
By adding the right permissions to the anonymous users for flexible groups, anonymous users are able to see both the Albums link and Albums page.

## Issue tracker
https://www.drupal.org/project/social/issues/3309222#comment-14689753

## How to test
- [ ] Make sure the `social_album` module is installed
- [ ] Create a public group
- [ ] As an anonymous user
- [ ] Open the public group
- [ ] You should see the Albums link
- [ ] Click on the Albums link
- [ ] You should see `No albums in this group`
- [ ] If you add a public album, this should also be visible when viewing the Albums page.

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Change Record
Please be aware that this change has permission changes. This is going to change the way users are able to view albums.

AN users will be able to view any public album you create
LU users will be able to view any public and community album you create.
