### PR TITLE
Internal: Make flood-edit test deterministic

### DIFF
--- a/tests/behat/behat.yml
+++ b/tests/behat/behat.yml
@@ -46,7 +46,7 @@ default:
       selectors:
         message_selector: '.alert'
         error_message_selector: '.alert.alert-danger'
-        success_message_selector: '.alert.alert-success'
+        success_message_selector: '.alert.alert-success, .messages.messages--status'
       text:
         username_field: 'Username or email address'
         log_in: "Log in"

--- a/tests/behat/features/capabilities/administration/flood-edit.feature
+++ b/tests/behat/features/capabilities/administration/flood-edit.feature
@@ -7,9 +7,7 @@ Feature: Edit flood settings
   @perfect
   Scenario: Successfully modify and see flood settings
     Given I am logged in as an "administrator"
-      And I click "Configuration"
-      And I click admin link "Account settings"
-      And I click "Flood settings"
+      And I am on "/admin/config/people/accounts/flood"
      Then I should see "IP limit"
       And I should see "IP window"
       And I should see "User limit"

--- a/tests/behat/features/capabilities/administration/flood-edit.feature
+++ b/tests/behat/features/capabilities/administration/flood-edit.feature
@@ -1,4 +1,4 @@
-@disabled @api @administration @javascript @DS-361 @ADMIN @flood-edit
+@api @administration @javascript @DS-361 @ADMIN @flood-edit
 Feature: Edit flood settings
   Benefit: Have an interface to edit flood settings
   Role: As an ADMIN


### PR DESCRIPTION
## Problem / Solution
Since we've added a `Configuration` item in the site manager menu, if the test starts before the admin menu has collapsed then Behat may press the wrong "Configuration" item. Since we don't want to test the menu structure of Drupal, it's safe to go to the path directly to ensure this functionality works.

## Issue tracker
Internal no ticket

## How to test
- [ ] Test should pass
- [ ] Test should test what we want

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status
