### PR TITLE
Issue #3311816 by tbsiqueira: Caching issues with ajax_comments module

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
                 "3248140: Symfony 4.4 event dispatcher parameter order change": "https://www.drupal.org/files/issues/2021-11-08/symfony-4-4-event-dispatcher-parameter-order-change-3248140-2.patch"
             },
             "drupal/ajax_comments": {
-                "Fix display mode issue": "https://www.drupal.org/files/issues/2021-03-19/ajax_comments-ajax_not_working_when_using_non_default_view_mode-2896916-beta3.patch"
+                "Fix display mode issue": "https://www.drupal.org/files/issues/2022-09-26/3311816-reroll-ajax-comments-patch-with-permission-check-2.patch"
             },
             "drupal/bootstrap": {
                 "Dropdown toggle variable ignored when using links__dropbutton": "https://www.drupal.org/files/issues/2018-12-19/dropdown-without-default-button-3021413-2.patch"


### PR DESCRIPTION
## Problem
Open Social is applying the following patch to ajax_comments: [https://www.drupal.org/files/issues/2021-03-19/ajax_comments-ajax_not_wo...](https://www.drupal.org/files/issues/2021-03-19/ajax_comments-ajax_not_working_when_using_non_default_view_mode-2896916-beta3.patch) unfortunately this patch is breaking caching for anonymous users.

https://www.drupal.org/project/ajax_comments/issues/2896916#comment-14508870

## Solution
Re-roll the patch and add a new condition to the altered function to check if current user has post message permissions

```
if (!\Drupal::currentUser()->hasPermission('post comments')) {
  return;
}
```

## Issue tracker
https://www.drupal.org/project/social/issues/3311816

## Theme issue tracker
N/A

## How to test
- [ ] Enable social_ajax_comments;
- [ ] Navigate to any page that has comments enabled;
- [ ] As AN user, check page loading time, should be less than one second with caches enabled;

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
N/A

## Release notes
Previous patch was not considering if user had permission to post comments on a page, this was breaking cache for anonymous users on entities that had comments enabled. We added a check to the patch that make sure to only apply changes on ajax_comments when users have permissions to post comments.

## Change Record
N/A

## Translations
N/A
