### PR TITLE
Internal: Re-enable and optimise share topic test

### DIFF
--- a/tests/behat/features/bootstrap/TopicContext.php
+++ b/tests/behat/features/bootstrap/TopicContext.php
@@ -16,6 +16,7 @@ use Symfony\Component\Yaml\Yaml;
  */
 class TopicContext extends RawMinkContext {
 
+  use EntityTrait;
   use NodeTrait;
 
   private const CREATE_PAGE = "/node/add/topic";
@@ -298,6 +299,7 @@ class TopicContext extends RawMinkContext {
       $topic['field_topic_type'] = $type_id;
     }
 
+    $this->validateEntityFields("node", $topic);
     $topic_object = Node::create($topic);
     $violations = $topic_object->validate();
     if ($violations->count() !== 0) {

--- a/tests/behat/features/capabilities/contentmanagement/unpublished.feature
+++ b/tests/behat/features/capabilities/contentmanagement/unpublished.feature
@@ -18,7 +18,7 @@ Feature: Un/publish a node
   Scenario: Successfully publish an unpublished topic
     Given I am logged in as an "verified"
     And topics:
-      | title    | body            | field_content_visibility | field_topic_type | language    | status |
+      | title    | body            | field_content_visibility | field_topic_type | langcode    | status |
       | My title | My description  | public                   | News             | en          | 0         |
 
     When I edit topic "My title" using its edit page:
@@ -28,7 +28,7 @@ Feature: Un/publish a node
 
   Scenario: Normal user only sees published topics
     Given topics:
-      | title                     | body            | field_content_visibility | field_topic_type | language    | status |
+      | title                     | body            | field_content_visibility | field_topic_type | langcode    | status |
       | This topic is published   | My description  | public                   | News             | en          | 1         |
       | This topic is unpublished | My description  | public                   | News             | en          | 0         |
     And I am logged in as a user with the "authenticated" role

--- a/tests/behat/features/capabilities/sharing/share.feature
+++ b/tests/behat/features/capabilities/sharing/share.feature
@@ -1,4 +1,4 @@
-@disabled @api @share @perfect @critical @DS-1829
+@api @share @perfect @critical @DS-1829
 Feature: Social Sharing
   Benefit: In order to share my page with external people
   Role: As a Verified

--- a/tests/behat/features/capabilities/sharing/share.feature
+++ b/tests/behat/features/capabilities/sharing/share.feature
@@ -4,30 +4,34 @@ Feature: Social Sharing
   Role: As a Verified
   Goal/desire: I want to share my public content
 
-  Scenario: Successfully create topic visible for community and public
-    Given I am logged in as an "verified"
-    And I am on "node/add/topic"
-    When I fill in "Title" with "This is a topic for community"
-    And I fill in the "edit-body-0-value" WYSIWYG editor with "This is a topic for community"
-    And I click radio button "Community"
-    And I check the box "News"
-    And I press "Create topic"
-    Then I should see "Topic This is a topic for community has been created."
-    And I should not see "Share this page"
-    And I am on "node/add/topic"
-    When I fill in "Title" with "This is a topic for public"
-    And I fill in the "edit-body-0-value" WYSIWYG editor with "This is a topic for public"
-    And I click radio button "Public"
-    And I check the box "News"
-    And I press "Create topic"
-    Then I should see "Topic This is a topic for public has been created."
-    And I should see "Share this page"
+  Background:
+    Given I enable the optional module social_sharing
 
-    # Now visit the pages as anonymous user.
-    When I logout
-    Given I open the "topic" node with title "This is a topic for public"
-    Then I should see "This is a topic for public"
-    And I should see "Share this page"
-    Given I open the "topic" node with title "This is a topic for community"
-    Then I should not see "This is a topic for community"
-    And I should see "Access denied."
+  Scenario: Can share public content as authenticated user
+    Given topics:
+      | title        | field_topic_type | body                      | field_content_visibility | path          |
+      | Public Topic | News             | Testing public visibility | public                   | /public-topic |
+
+    When I am logged in as a user with the "verified" role
+    And I am on "/public-topic"
+
+    Then I should see "Share this page"
+
+  Scenario: Can share public content as anonymous user
+    Given topics:
+      | title        | field_topic_type | body                      | field_content_visibility | path          |
+      | Public Topic | News             | Testing public visibility | public                   | /public-topic |
+
+    When I am on "/public-topic"
+
+    Then I should see "Share this page"
+
+  Scenario: Can not share community content
+    Given topics:
+      | title           | field_topic_type | body                         | field_content_visibility | path             |
+      | Community Topic | News             | Testing community visibility | community                | /community-topic |
+
+    When I am logged in as a user with the "verified" role
+    And I am on "/community-topic"
+
+    Then I should not see "Share this page"


### PR DESCRIPTION
## Problem
The share test had to be disabled because it wasn't working in all cases, this was caused by the share module not being enabled in the test (which only made it work when all optional modules were enabled).

## Solution
We enable the module at the start of the test. Additionally while working on the test we break the different assertions into multiple scenarios. Each scenario only tests a specific business rule to ensure that if a scenario fails we know what's broken without further debugging.

## Issue tracker
Internal change, no issue.

## How to test
- [ ] Test coverage should remain the same (requires manual review)
- [ ] Behat test should pass

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status
