### PR TITLE
Internal: Re-enable and simplify the user consent test

### DIFF
--- a/tests/behat/behat.yml
+++ b/tests/behat/behat.yml
@@ -21,6 +21,7 @@ default:
         - Drupal\social\Behat\CKEditorContext
         - Drupal\social\Behat\EmailContext
         - Drupal\social\Behat\GroupContext
+        - Drupal\social\Behat\GDPRContext
         - Drupal\social\Behat\PostContext
         - Drupal\social\Behat\FeatureContext
         - Drupal\social\Behat\ModuleContext

--- a/tests/behat/features/bootstrap/GDPRContext.php
+++ b/tests/behat/features/bootstrap/GDPRContext.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\social\Behat;
+
+use Behat\Gherkin\Node\TableNode;
+use Behat\MinkExtension\Context\RawMinkContext;
+use Drupal\data_policy\Entity\DataPolicy;
+
+/**
+ * Defines test steps around the usage of the GPDR module.
+ */
+class GDPRContext extends RawMinkContext {
+
+  /**
+   * Keep track of the data policies that were created.
+   *
+   * This allows us to clean up at the end of the scenario. The array contains
+   * the ID if we already have it in the step or the title otherwise. We avoid
+   * looking up the topic because a user may be testing an error state.
+   *
+   * @var array
+   * @phpstan-var array<int|string>
+   */
+  private array $created = [];
+
+  /**
+   * Create multiple data policies at the start of a test.
+   *
+   * Creates data policies provided in the form:
+   * | name               | field_description       | revision_log_message |
+   * | Terms & Conditions | No rights in this test  |                      |
+   * | ...                | ...                     | ...                  |
+   *
+   * @Given data_policies:
+   */
+  public function createDataPolicies(TableNode $dataPoliciesTable) : void {
+    foreach ($dataPoliciesTable->getHash() as $dataPolicyHash) {
+      $dataPolicy = $this->dataPolicyCreate($dataPolicyHash);
+      $this->created[] = $dataPolicy->id();
+    }
+  }
+
+  /**
+   * Set the GDPR consent text confguration.
+   *
+   * @Given /^(?:|I )set the GDPR Consent Text to "(?P<text>[^"]+)"$/
+   */
+  public function setGdprContsentText(string $text) {
+    $config = \Drupal::configFactory()
+      ->getEditable('data_policy.data_policy');
+
+    if ($config->isNew()) {
+      throw new \Exception("The data_policy.data_policy configuration did not yet exist, is the social_Gdpr module enabled?");
+    }
+
+    $config->set('consent_text', $text)->save();
+  }
+
+  /**
+   * Create a data policy.
+   *
+   * @return \Drupal\data_policy\Entity\DataPolicy
+   *   The data policy values.
+   */
+  private function dataPolicyCreate($data_policy) : DataPolicy {
+    $data_policy_object = DataPolicy::create($data_policy);
+    $violations = $data_policy_object->validate();
+    if ($violations->count() !== 0) {
+      throw new \Exception("The data policy you tried to create is invalid: $violations");
+    }
+    $data_policy_object->save();
+
+    return $data_policy_object;
+  }
+
+}

--- a/tests/behat/features/capabilities/gdpr/user-consent.feature
+++ b/tests/behat/features/capabilities/gdpr/user-consent.feature
@@ -1,38 +1,23 @@
-@disabled @api @gdpr @user-consent @DS-5586 @stability @stability-4
+@api @gdpr @user-consent @DS-5586 @stability @stability-4
 Feature: Give user consent
   Benefit: So I can decide what to do with users personal data
   Role: As a SM
   Goal/desire: I want to know which users did (not) gave consent to the data policy
 
   Scenario: Successfully view user consent
-
-    Given users:
+    Given I enable the module "social_gdpr"
+    And users:
       | name             | mail                         | status | roles       |
       | behatsitemanager | behatsitemanager@example.com | 1      | sitemanager |
       | behatuser1       | behatuser1@example.com       | 1      | verified    |
       | behatuser2       | behatuser2@example.com       | 1      | verified    |
       | behatuser3       | behatuser3@example.com       | 1      | verified    |
+    And data_policies:
+      | name               | field_description       |
+      | Terms & Conditions | No rights in this test  |
+    And I set the GDPR Consent Text to "I agree with the [id:1]"
+    And I am logged in as "behatuser1"
 
-    Given I enable the module "social_gdpr"
-
-    Given I am logged in as "behatsitemanager" with the "without consent" permission
-    When I am on "admin/config/people/data-policy/settings"
-    Then I should see the heading "Data policy settings" in the "Admin page title block" region
-    And the response should contain "I agree with the [id:1*]"
-    When I fill in "Consent text" with "I agree with the [id:1]"
-    Then I press "Save configuration"
-    And I should see the text "The configuration options have been saved."
-    And the response should contain "I agree with the [id:1]"
-
-    When I am on "admin/reports/data-policy-agreements"
-    Then I should see the heading "Data Policy Agreements" in the "Admin page title block" region
-    And I should see the text "Data policy revision"
-    And I should see unchecked the box "Agree"
-    And I should see unchecked the box "Not agree"
-    And I should see unchecked the box "Undecided"
-    And I should see the text "User consents not found."
-
-    Given I am logged in as "behatuser1"
     Then I should be on the homepage
     And I should see the success message "We published a new version of the data policy. You can review the data policy here."
 


### PR DESCRIPTION
## Problem / Solution
We re-enable the test which was broken in the non-optional modules test suite (since social_gdpr) wasn't enabled. We also introduce the GDPRContext to simplify creation of data policies so we can avoid going through the form.

## Issue tracker
Internal test change no ticket

## How to test
*[Required] For example*
- [ ] Behat should pass

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status
