### PR TITLE
Issue #3312530: Backport latest Drupal SU to Open Social 11.3.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -221,7 +221,7 @@
         "spatie/color": "^1.2",
         "swiftmailer/swiftmailer": "6.2.4",
         "webonyx/graphql-php": ">=14.5.0",
-        "twig/twig": "^v2.15.3 as v2.14.11"
+        "twig/twig": "^v2.15.3"
     },
     "require-dev": {
         "drupal/coder": "^8.3",

--- a/composer.json
+++ b/composer.json
@@ -69,11 +69,11 @@
                 "Flood MemoryBackend::events[] key of micro time cannot guarantee uniqueness": "https://www.drupal.org/files/issues/2021-12-12/2910000-33--floodmemorybackend-time-local.patch",
                 "Issue #3251856: Incorrect typehint for FieldConfig::loadByName": "https://www.drupal.org/files/issues/2021-12-12/drupal9-incorrect_typehint-3251856-7.patch",
                 "Issue #2998390: Cache is not invalidated when comment deleted": "https://www.drupal.org/files/issues/2022-01-27/2998390-invalidate-cache-on-delete-6.diff",
+                "Backport of issue SA-CORE-2022-016": "https://www.drupal.org/files/issues/2022-10-03/3312530-SA-CORE-2022-016-CORE-9-2-backport-3.patch",
                 "Backport of issue SA-CORE-2022-012": "https://www.drupal.org/files/issues/2022-07-20/2022-12-1.patch",
                 "Backport of issue SA-CORE-2022-013": "https://www.drupal.org/files/issues/2022-07-20/2022-013.patch",
                 "Backport of issue SA-CORE-2022-014": "https://www.drupal.org/files/issues/2022-07-20/2022-014.patch",
-                "Backport of issue SA-CORE-2022-015": "https://www.drupal.org/files/issues/2022-07-20/2022-015.patch",
-                "Backport of issue SA-CORE-2022-016": "https://www.drupal.org/files/issues/2022-10-03/3312530-SA-CORE-2022-016-CORE-9-2-backport-3.patch"
+                "Backport of issue SA-CORE-2022-015": "https://www.drupal.org/files/issues/2022-07-20/2022-015.patch"
             },
             "drupal/config_update": {
                 "3248161: Symfony 4.4 event dispatcher parameter order change": "https://www.drupal.org/files/issues/2021-11-08/symfony-4-4-event-dispatcher-parameter-order-change-3248161-3.patch"

--- a/composer.json
+++ b/composer.json
@@ -72,7 +72,8 @@
                 "Backport of issue SA-CORE-2022-012": "https://www.drupal.org/files/issues/2022-07-20/2022-12-1.patch",
                 "Backport of issue SA-CORE-2022-013": "https://www.drupal.org/files/issues/2022-07-20/2022-013.patch",
                 "Backport of issue SA-CORE-2022-014": "https://www.drupal.org/files/issues/2022-07-20/2022-014.patch",
-                "Backport of issue SA-CORE-2022-015": "https://www.drupal.org/files/issues/2022-07-20/2022-015.patch"
+                "Backport of issue SA-CORE-2022-015": "https://www.drupal.org/files/issues/2022-07-20/2022-015.patch",
+                "Backport of issue SA-CORE-2022-016": "https://www.drupal.org/files/issues/2022-10-03/3312530-SA-CORE-2022-016-CORE-9-2-backport-3.patch"
             },
             "drupal/config_update": {
                 "3248161: Symfony 4.4 event dispatcher parameter order change": "https://www.drupal.org/files/issues/2021-11-08/symfony-4-4-event-dispatcher-parameter-order-change-3248161-3.patch"
@@ -219,7 +220,8 @@
         "oomphinc/composer-installers-extender": "~1.0 || ~2.0",
         "spatie/color": "^1.2",
         "swiftmailer/swiftmailer": "6.2.4",
-        "webonyx/graphql-php": ">=14.5.0"
+        "webonyx/graphql-php": ">=14.5.0",
+        "twig/twig": "^2.15.3 as ^2.12.0"
     },
     "require-dev": {
         "drupal/coder": "^8.3",

--- a/composer.json
+++ b/composer.json
@@ -221,7 +221,7 @@
         "spatie/color": "^1.2",
         "swiftmailer/swiftmailer": "6.2.4",
         "webonyx/graphql-php": ">=14.5.0",
-        "twig/twig": "v2.15.3 as v2.14.11"
+        "twig/twig": "v2.15.3"
     },
     "require-dev": {
         "drupal/coder": "^8.3",
@@ -236,7 +236,8 @@
         "phpstan/phpstan-deprecation-rules": "^1.0"
     },
     "replace": {
-        "drupal/social": "self.version"
+        "drupal/social": "self.version",
+        "twig/twig": "v2.14.11"
     },
     "config": {
         "sort-packages": true

--- a/composer.json
+++ b/composer.json
@@ -236,7 +236,8 @@
         "phpstan/phpstan-deprecation-rules": "^1.0"
     },
     "replace": {
-        "drupal/social": "self.version"
+        "drupal/social": "self.version",
+        "twig/twig": "v2.14.11"
     },
     "config": {
         "sort-packages": true

--- a/composer.json
+++ b/composer.json
@@ -221,7 +221,7 @@
         "spatie/color": "^1.2",
         "swiftmailer/swiftmailer": "6.2.4",
         "webonyx/graphql-php": ">=14.5.0",
-        "twig/twig": "^2.15.3 as ^2.14.11"
+        "twig/twig": "^v2.15.3 as ^v2.14.11"
     },
     "require-dev": {
         "drupal/coder": "^8.3",

--- a/composer.json
+++ b/composer.json
@@ -221,7 +221,7 @@
         "spatie/color": "^1.2",
         "swiftmailer/swiftmailer": "6.2.4",
         "webonyx/graphql-php": ">=14.5.0",
-        "twig/twig": "v2.14.11 as ^v2.15.3"
+        "twig/twig": "v2.15.3 as v2.14.11"
     },
     "require-dev": {
         "drupal/coder": "^8.3",

--- a/composer.json
+++ b/composer.json
@@ -221,7 +221,7 @@
         "spatie/color": "^1.2",
         "swiftmailer/swiftmailer": "6.2.4",
         "webonyx/graphql-php": ">=14.5.0",
-        "twig/twig": "^v2.15.3"
+        "twig/twig": "v2.14.11 as ^v2.15.3"
     },
     "require-dev": {
         "drupal/coder": "^8.3",
@@ -236,8 +236,7 @@
         "phpstan/phpstan-deprecation-rules": "^1.0"
     },
     "replace": {
-        "drupal/social": "self.version",
-        "twig/twig": "v2.14.11"
+        "drupal/social": "self.version"
     },
     "config": {
         "sort-packages": true

--- a/composer.json
+++ b/composer.json
@@ -221,7 +221,7 @@
         "spatie/color": "^1.2",
         "swiftmailer/swiftmailer": "6.2.4",
         "webonyx/graphql-php": ">=14.5.0",
-        "twig/twig": "^2.15.3 as ^2.12.0"
+        "twig/twig": "^2.15.3 as ^2.14.11"
     },
     "require-dev": {
         "drupal/coder": "^8.3",

--- a/composer.json
+++ b/composer.json
@@ -51,29 +51,7 @@
                 "Allow class property types instead of @var comments": "https://www.drupal.org/files/issues/2021-09-21/coder-3123282-3.patch"
             },
             "drupal/core": {
-                "Backport of issue SA-CORE-2022-016": "https://www.drupal.org/files/issues/2022-10-03/3312530-SA-CORE-2022-016-CORE-9-2-backport-4.patch",
-                "Color module html preview optional": "https://www.drupal.org/files/issues/color-optional-html-preview-2844190-2.patch",
-                "Restrict images to this site blocks image style derivatives": "https://www.drupal.org/files/issues/2019-05-10/2528214-54.patch",
-                "Optimize getCommentedEntity()": "https://www.drupal.org/files/issues/2018-12-28/2580551-72.patch",
-                "#states cannot check/uncheck 'radios' and 'checkboxes' elements": "https://www.drupal.org/files/issues/drupal-994360-74-states-checkboxes-checked.patch",
-                "Multiple usages of FieldPluginBase::getEntity do not check for NULL, leading to WSOD": "https://www.drupal.org/files/issues/2021-01-06/3007424-108.patch",
-                "Default role id causes issues with validation on VBO": "https://www.drupal.org/files/issues/2018-05-24/2974925-default-rid-config-causes-illegal-error.patch",
-                "Ensure views exposed form in a form block keeps contextual arguments (Updated)": "https://www.drupal.org/files/issues/2020-06-17/views-exposed-form-block-args-2821962-39-8.9-notest.patch",
-                "Display Bug when using #states (Forms API) with Ajax Request": "https://www.drupal.org/files/issues/2021-11-05/1091852-150.patch",
-                "Can't specify the language in TermStorage::loadTree": "https://www.drupal.org/files/issues/2021-08-13/drupal-termstorage-loadTree-lang-3123561-10.patch",
-                "Issue #3188258: Aggregation queries fail across entity references": "https://www.drupal.org/files/issues/2020-12-18/drupal-3188258-aggregation-across-entity-reference-fail-2.patch",
-                "Pagination does not work correctly for comment fields that are rendered using #lazy_builder": "https://www.drupal.org/files/issues/2020-12-22/pagination-does-not-work-with-lazy-builder-3189538-2.patch",
-                "Providing default route value for entity forms is not possible": "https://www.drupal.org/files/issues/2020-12-29/2921093-18.patch",
-                "Selecting the same day in a date between filter returns no results": "https://www.drupal.org/files/issues/2020-07-06/2842409-15.patch",
-                "Broken title in modal dialog when title is a render array": "https://www.drupal.org/files/issues/2019-10-21/2663316-76.drupal.Broken-title-in-modal-dialog-when-title-is-a-render-array.patch",
-                "Post update hook naming convention patch": "https://git.drupalcode.org/project/drupal/-/merge_requests/1215.patch",
-                "Flood MemoryBackend::events[] key of micro time cannot guarantee uniqueness": "https://www.drupal.org/files/issues/2021-12-12/2910000-33--floodmemorybackend-time-local.patch",
-                "Issue #3251856: Incorrect typehint for FieldConfig::loadByName": "https://www.drupal.org/files/issues/2021-12-12/drupal9-incorrect_typehint-3251856-7.patch",
-                "Issue #2998390: Cache is not invalidated when comment deleted": "https://www.drupal.org/files/issues/2022-01-27/2998390-invalidate-cache-on-delete-6.diff",
-                "Backport of issue SA-CORE-2022-012": "https://www.drupal.org/files/issues/2022-07-20/2022-12-1.patch",
-                "Backport of issue SA-CORE-2022-013": "https://www.drupal.org/files/issues/2022-07-20/2022-013.patch",
-                "Backport of issue SA-CORE-2022-014": "https://www.drupal.org/files/issues/2022-07-20/2022-014.patch",
-                "Backport of issue SA-CORE-2022-015": "https://www.drupal.org/files/issues/2022-07-20/2022-015.patch"
+                "Backport of issue SA-CORE-2022-016": "https://www.drupal.org/files/issues/2022-10-03/3312530-SA-CORE-2022-016-CORE-9-2-backport-4.patch"
             },
             "drupal/config_update": {
                 "3248161: Symfony 4.4 event dispatcher parameter order change": "https://www.drupal.org/files/issues/2021-11-08/symfony-4-4-event-dispatcher-parameter-order-change-3248161-3.patch"

--- a/composer.json
+++ b/composer.json
@@ -221,7 +221,7 @@
         "spatie/color": "^1.2",
         "swiftmailer/swiftmailer": "6.2.4",
         "webonyx/graphql-php": ">=14.5.0",
-        "twig/twig": "v2.15.3"
+        "twig/twig": "v2.15.3 as v2.14.11"
     },
     "require-dev": {
         "drupal/coder": "^8.3",
@@ -236,8 +236,7 @@
         "phpstan/phpstan-deprecation-rules": "^1.0"
     },
     "replace": {
-        "drupal/social": "self.version",
-        "twig/twig": "v2.14.11"
+        "drupal/social": "self.version"
     },
     "config": {
         "sort-packages": true

--- a/composer.json
+++ b/composer.json
@@ -51,6 +51,7 @@
                 "Allow class property types instead of @var comments": "https://www.drupal.org/files/issues/2021-09-21/coder-3123282-3.patch"
             },
             "drupal/core": {
+                "Backport of issue SA-CORE-2022-016": "https://www.drupal.org/files/issues/2022-10-03/3312530-SA-CORE-2022-016-CORE-9-2-backport-3.patch",
                 "Color module html preview optional": "https://www.drupal.org/files/issues/color-optional-html-preview-2844190-2.patch",
                 "Restrict images to this site blocks image style derivatives": "https://www.drupal.org/files/issues/2019-05-10/2528214-54.patch",
                 "Optimize getCommentedEntity()": "https://www.drupal.org/files/issues/2018-12-28/2580551-72.patch",
@@ -69,7 +70,6 @@
                 "Flood MemoryBackend::events[] key of micro time cannot guarantee uniqueness": "https://www.drupal.org/files/issues/2021-12-12/2910000-33--floodmemorybackend-time-local.patch",
                 "Issue #3251856: Incorrect typehint for FieldConfig::loadByName": "https://www.drupal.org/files/issues/2021-12-12/drupal9-incorrect_typehint-3251856-7.patch",
                 "Issue #2998390: Cache is not invalidated when comment deleted": "https://www.drupal.org/files/issues/2022-01-27/2998390-invalidate-cache-on-delete-6.diff",
-                "Backport of issue SA-CORE-2022-016": "https://www.drupal.org/files/issues/2022-10-03/3312530-SA-CORE-2022-016-CORE-9-2-backport-3.patch",
                 "Backport of issue SA-CORE-2022-012": "https://www.drupal.org/files/issues/2022-07-20/2022-12-1.patch",
                 "Backport of issue SA-CORE-2022-013": "https://www.drupal.org/files/issues/2022-07-20/2022-013.patch",
                 "Backport of issue SA-CORE-2022-014": "https://www.drupal.org/files/issues/2022-07-20/2022-014.patch",

--- a/composer.json
+++ b/composer.json
@@ -221,7 +221,7 @@
         "spatie/color": "^1.2",
         "swiftmailer/swiftmailer": "6.2.4",
         "webonyx/graphql-php": ">=14.5.0",
-        "twig/twig": "^v2.15.3 as ^v2.14.11"
+        "twig/twig": "^v2.15.3 as v2.14.11"
     },
     "require-dev": {
         "drupal/coder": "^8.3",

--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,29 @@
                 "Allow class property types instead of @var comments": "https://www.drupal.org/files/issues/2021-09-21/coder-3123282-3.patch"
             },
             "drupal/core": {
-                "Backport of issue SA-CORE-2022-016": "https://www.drupal.org/files/issues/2022-10-03/3312530-SA-CORE-2022-016-CORE-9-2-backport-4.patch"
+                "Color module html preview optional": "https://www.drupal.org/files/issues/color-optional-html-preview-2844190-2.patch",
+                "Restrict images to this site blocks image style derivatives": "https://www.drupal.org/files/issues/2019-05-10/2528214-54.patch",
+                "Optimize getCommentedEntity()": "https://www.drupal.org/files/issues/2018-12-28/2580551-72.patch",
+                "#states cannot check/uncheck 'radios' and 'checkboxes' elements": "https://www.drupal.org/files/issues/drupal-994360-74-states-checkboxes-checked.patch",
+                "Multiple usages of FieldPluginBase::getEntity do not check for NULL, leading to WSOD": "https://www.drupal.org/files/issues/2021-01-06/3007424-108.patch",
+                "Default role id causes issues with validation on VBO": "https://www.drupal.org/files/issues/2018-05-24/2974925-default-rid-config-causes-illegal-error.patch",
+                "Ensure views exposed form in a form block keeps contextual arguments (Updated)": "https://www.drupal.org/files/issues/2020-06-17/views-exposed-form-block-args-2821962-39-8.9-notest.patch",
+                "Display Bug when using #states (Forms API) with Ajax Request": "https://www.drupal.org/files/issues/2021-11-05/1091852-150.patch",
+                "Can't specify the language in TermStorage::loadTree": "https://www.drupal.org/files/issues/2021-08-13/drupal-termstorage-loadTree-lang-3123561-10.patch",
+                "Issue #3188258: Aggregation queries fail across entity references": "https://www.drupal.org/files/issues/2020-12-18/drupal-3188258-aggregation-across-entity-reference-fail-2.patch",
+                "Pagination does not work correctly for comment fields that are rendered using #lazy_builder": "https://www.drupal.org/files/issues/2020-12-22/pagination-does-not-work-with-lazy-builder-3189538-2.patch",
+                "Providing default route value for entity forms is not possible": "https://www.drupal.org/files/issues/2020-12-29/2921093-18.patch",
+                "Selecting the same day in a date between filter returns no results": "https://www.drupal.org/files/issues/2020-07-06/2842409-15.patch",
+                "Broken title in modal dialog when title is a render array": "https://www.drupal.org/files/issues/2019-10-21/2663316-76.drupal.Broken-title-in-modal-dialog-when-title-is-a-render-array.patch",
+                "Post update hook naming convention patch": "https://git.drupalcode.org/project/drupal/-/merge_requests/1215.patch",
+                "Flood MemoryBackend::events[] key of micro time cannot guarantee uniqueness": "https://www.drupal.org/files/issues/2021-12-12/2910000-33--floodmemorybackend-time-local.patch",
+                "Issue #3251856: Incorrect typehint for FieldConfig::loadByName": "https://www.drupal.org/files/issues/2021-12-12/drupal9-incorrect_typehint-3251856-7.patch",
+                "Issue #2998390: Cache is not invalidated when comment deleted": "https://www.drupal.org/files/issues/2022-01-27/2998390-invalidate-cache-on-delete-6.diff",
+                "Backport of issue SA-CORE-2022-012": "https://www.drupal.org/files/issues/2022-07-20/2022-12-1.patch",
+                "Backport of issue SA-CORE-2022-013": "https://www.drupal.org/files/issues/2022-07-20/2022-013.patch",
+                "Backport of issue SA-CORE-2022-014": "https://www.drupal.org/files/issues/2022-07-20/2022-014.patch",
+                "Backport of issue SA-CORE-2022-015": "https://www.drupal.org/files/issues/2022-07-20/2022-015.patch",
+                "Backport of issue SA-CORE-2022-016": "https://www.drupal.org/files/issues/2022-10-03/3312530-SA-CORE-2022-016-CORE-9-2-backport-5.patch"
             },
             "drupal/config_update": {
                 "3248161: Symfony 4.4 event dispatcher parameter order change": "https://www.drupal.org/files/issues/2021-11-08/symfony-4-4-event-dispatcher-parameter-order-change-3248161-3.patch"

--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,7 @@
                 "Allow class property types instead of @var comments": "https://www.drupal.org/files/issues/2021-09-21/coder-3123282-3.patch"
             },
             "drupal/core": {
-                "Backport of issue SA-CORE-2022-016": "https://www.drupal.org/files/issues/2022-10-03/3312530-SA-CORE-2022-016-CORE-9-2-backport-3.patch",
+                "Backport of issue SA-CORE-2022-016": "https://www.drupal.org/files/issues/2022-10-03/3312530-SA-CORE-2022-016-CORE-9-2-backport-4.patch",
                 "Color module html preview optional": "https://www.drupal.org/files/issues/color-optional-html-preview-2844190-2.patch",
                 "Restrict images to this site blocks image style derivatives": "https://www.drupal.org/files/issues/2019-05-10/2528214-54.patch",
                 "Optimize getCommentedEntity()": "https://www.drupal.org/files/issues/2018-12-28/2580551-72.patch",


### PR DESCRIPTION
## Problem
Drupal released a new security update, we need to backport it to Open Social 11.3.x

https://www.drupal.org/sa-core-2022-016
https://git.drupalcode.org/project/drupal/-/commits/9.3.x
[https://git.drupalcode.org/project/drupal/-/commit/4b52a987420be1df4f181...](https://git.drupalcode.org/project/drupal/-/commit/4b52a987420be1df4f18150e0b67b2c2c07e7e9b)

## Solution
Backport d.org patch to Drupal core 9.2

## Issue tracker
https://www.drupal.org/project/social/issues/3312530

## Theme issue tracker
N/A

## How to test
- [ ] Update Open Social 11.3.x to the latest version and check if the new twig version was installed

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
N/A

## Release notes
Twig will now be updated to `2.15.3`

## Change Record
N/A

## Translations
N/A
