### PR TITLE
Issue #3313504 by vnech: Make "basic_html" text format as default for "text" and "text_long" field types

### DIFF
--- a/modules/social_features/social_core/social_core.module
+++ b/modules/social_features/social_core/social_core.module
@@ -748,6 +748,19 @@ function social_core_field_widget_form_alter(&$element, FormStateInterface $form
     $default_country = \Drupal::config('system.date')->get('country.default');
     $element['address']['#default_value']['country_code'] = $element['address']['#default_value']['country_code'] ?? $default_country;
   }
+
+  // In some cases users are not allowed to choose "text format" in the text
+  // fields (because the list of text formats is hidden from UI).
+  // This cause issues with unexpected displaying the field value during a time.
+  // If "text format" isn't specified a text field get the "text format" with
+  // the highest weight in the list on "/admin/config/content/formats".
+  // To avoid this unexpected behaviour we hardly specify "basic_html"
+  // text format as default for "text" and "text_long" field types.
+  if (in_array($field_definition->getType(), ['text', 'text_long'])) {
+    if (empty($element['#format'])) {
+      $element['#format'] = 'basic_html';
+    }
+  }
 }
 
 /**

--- a/modules/social_features/social_post/social_post.module
+++ b/modules/social_features/social_post/social_post.module
@@ -51,10 +51,6 @@ function social_post_form_post_form_alter(&$form, FormStateInterface $form_state
       $form['field_post']['widget'][0]['#title'] = $title;
       $form['field_post']['widget'][0]['#placeholder'] = $title;
     }
-
-    if (empty($form['field_post']['widget'][0]['#format'])) {
-      $form['field_post']['widget'][0]['#format'] = 'basic_html';
-    }
   }
 }
 

--- a/modules/social_features/social_post/social_post.module
+++ b/modules/social_features/social_post/social_post.module
@@ -16,7 +16,7 @@ use Drupal\group\Entity\Group;
 use Drupal\user\UserInterface;
 
 /**
- * Implements hook_form_FORM_ID_alter().
+ * Implements hook_form_FORM_ID_alter() for "post_form".
  */
 function social_post_form_post_form_alter(&$form, FormStateInterface $form_state, $form_id) {
 
@@ -50,6 +50,10 @@ function social_post_form_post_form_alter(&$form, FormStateInterface $form_state
       $title = t('Say something to the Community');
       $form['field_post']['widget'][0]['#title'] = $title;
       $form['field_post']['widget'][0]['#placeholder'] = $title;
+    }
+
+    if (empty($form['field_post']['widget'][0]['#format'])) {
+      $form['field_post']['widget'][0]['#format'] = 'basic_html';
     }
   }
 }


### PR DESCRIPTION
## Problem
The post field field_post with the text doesn't allows to user to choose text format. After submitting this field gets the most higher text format in the list from *admin/config/content/formats*. 

That means that the posts can have text with different text format and, as a result, different text displaying. 

This also create an issue with mentions if I add some custom text format with the highest weight like this:
<img width="1583" alt="Screenshot 2022-10-04 at 20 29 11" src="https://user-images.githubusercontent.com/19921926/193889074-3e72f326-018a-4550-af0b-b206c54340c3.png">

Mentions in post:
<img width="646" alt="Screenshot 2022-10-04 at 20 44 24" src="https://user-images.githubusercontent.com/19921926/193889484-3930de4f-d232-46ce-abc0-1ef9ed34c3c4.png">

## Solution
- Make `basic_html` as a default text format for `text` and `text_long` field types

## Issue tracker
- https://www.drupal.org/project/social/issues/3313504
- https://getopensocial.atlassian.net/browse/PROD-22258

## Theme issue tracker
n/a

## How to test
- [ ] Login as an admin
- [ ] Add a new text format and make it the highest weight on *admin/config/content/formats*
- [ ] Create a post with mentions

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
n/a

## Release notes
*Make `basic_html` as a default text format for `text` and `text_long` field types.*

## Change Record
n/a

## Translations
n/a
