### PR TITLE
Issue #3313663: Deprecated plugin filter node_type for Open Social default blocks

### DIFF
--- a/modules/social_features/social_album/config/optional/block.block.socialblue_album_count_and_add.yml
+++ b/modules/social_features/social_album/config/optional/block.block.socialblue_album_count_and_add.yml
@@ -19,8 +19,8 @@ settings:
   provider: social_album
   label_display: '0'
 visibility:
-  node_type:
-    id: node_type
+  entity_bundle:node:
+    id: 'entity_bundle:node'
     bundles:
       album: album
     negate: false

--- a/modules/social_features/social_album/social_album.post_update.php
+++ b/modules/social_features/social_album/social_album.post_update.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * @file
+ * Contains post-update hooks for the Social Album module.
+ */
+
+/**
+ * Updates the node type visibility condition.
+ */
+function social_album_post_update_replace_node_type_condition(): void {
+  $config_factory = \Drupal::configFactory();
+
+  $block = $config_factory->getEditable('block.block.socialblue_album_count_and_add');
+
+  if ($block->get('visibility.node_type')) {
+    $configuration = $block->get('visibility.node_type');
+    $configuration['id'] = 'entity_bundle:node';
+    $block->set('visibility.entity_bundle:node', $configuration);
+    $block->clear('visibility.node_type');
+    $block->save(TRUE);
+  }
+}

--- a/modules/social_features/social_book/config/optional/block.block.booknavigation.yml
+++ b/modules/social_features/social_book/config/optional/block.block.booknavigation.yml
@@ -19,8 +19,8 @@ settings:
   label_display: visible
   block_mode: 'book pages'
 visibility:
-  node_type:
-    id: node_type
+  entity_bundle:node:
+    id: 'entity_bundle:node'
     bundles:
       book: book
     negate: false

--- a/modules/social_features/social_book/config/optional/block.block.booknavigation_2.yml
+++ b/modules/social_features/social_book/config/optional/block.block.booknavigation_2.yml
@@ -19,8 +19,8 @@ settings:
   label_display: visible
   block_mode: 'book pages'
 visibility:
-  node_type:
-    id: node_type
+  entity_bundle:node:
+    id: 'entity_bundle:node'
     bundles:
       book: book
     negate: false

--- a/modules/social_features/social_book/social_book.post_update.php
+++ b/modules/social_features/social_book/social_book.post_update.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * @file
+ * Contains post-update hooks for the Social Book module.
+ */
+
+/**
+ * Updates the node type visibility condition.
+ */
+function social_book_post_update_replace_node_type_condition(): void {
+  $config_factory = \Drupal::configFactory();
+
+  $block_list = [
+    'block.block.booknavigation',
+    'block.block.booknavigation_2',
+  ];
+
+  foreach ($block_list as $block_config_name) {
+    $block = $config_factory->getEditable($block_config_name);
+
+    if ($block->get('visibility.node_type')) {
+      $configuration = $block->get('visibility.node_type');
+      $configuration['id'] = 'entity_bundle:node';
+      $block->set('visibility.entity_bundle:node', $configuration);
+      $block->clear('visibility.node_type');
+      $block->save(TRUE);
+    }
+  }
+}

--- a/modules/social_features/social_core/config/optional/block.block.socialbase_pagetitleblock.yml
+++ b/modules/social_features/social_core/config/optional/block.block.socialbase_pagetitleblock.yml
@@ -19,8 +19,8 @@ settings:
   provider: social_core
   label_display: '0'
 visibility:
-  node_type:
-    id: node_type
+  entity_bundle:node:
+    id: 'entity_bundle:node'
     bundles:
       event: event
       page: page

--- a/modules/social_features/social_core/config/optional/block.block.socialblue_pagetitleblock.yml
+++ b/modules/social_features/social_core/config/optional/block.block.socialblue_pagetitleblock.yml
@@ -19,8 +19,8 @@ settings:
   provider: social_core
   label_display: '0'
 visibility:
-  node_type:
-    id: node_type
+  entity_bundle:node:
+    id: 'entity_bundle:node'
     bundles:
       event: event
       page: page

--- a/modules/social_features/social_core/social_core.post_update.php
+++ b/modules/social_features/social_core/social_core.post_update.php
@@ -22,3 +22,27 @@ function social_core_post_update_8702_enable_select2() {
     'select2',
   ]);
 }
+
+/**
+ * Updates the node type visibility condition.
+ */
+function social_core_post_update_replace_node_type_condition(): void {
+  $config_factory = \Drupal::configFactory();
+
+  $block_list = [
+    'block.block.socialbase_pagetitleblock',
+    'block.block.socialblue_pagetitleblock',
+  ];
+
+  foreach ($block_list as $block_config_name) {
+    $block = $config_factory->getEditable($block_config_name);
+
+    if ($block->get('visibility.node_type')) {
+      $configuration = $block->get('visibility.node_type');
+      $configuration['id'] = 'entity_bundle:node';
+      $block->set('visibility.entity_bundle:node', $configuration);
+      $block->clear('visibility.node_type');
+      $block->save(TRUE);
+    }
+  }
+}

--- a/modules/social_features/social_event/config/optional/block.block.socialblue_views_block__event_enrollments_event_enrollments_socialbase.yml
+++ b/modules/social_features/social_event/config/optional/block.block.socialblue_views_block__event_enrollments_event_enrollments_socialbase.yml
@@ -23,8 +23,8 @@ settings:
   views_label: ''
   items_per_page: none
 visibility:
-  node_type:
-    id: node_type
+  entity_bundle:node:
+    id: 'entity_bundle:node'
     bundles:
       event: event
     negate: false

--- a/modules/social_features/social_event/config/optional/block.block.views_block__event_enrollments_event_enrollments_socialbase.yml
+++ b/modules/social_features/social_event/config/optional/block.block.views_block__event_enrollments_event_enrollments_socialbase.yml
@@ -22,8 +22,8 @@ settings:
   views_label: ''
   items_per_page: none
 visibility:
-  node_type:
-    id: node_type
+  entity_bundle:node:
+    id: 'entity_bundle:node'
     bundles:
       event: event
     negate: false

--- a/modules/social_features/social_event/modules/social_event_managers/config/optional/block.block.views_block__managers_event_managers.yml
+++ b/modules/social_features/social_event/modules/social_event_managers/config/optional/block.block.views_block__managers_event_managers.yml
@@ -22,8 +22,8 @@ settings:
   views_label: 'Event Organisers'
   items_per_page: none
 visibility:
-  node_type:
-    id: node_type
+  entity_bundle:node:
+    id: 'entity_bundle:node'
     bundles:
       event: event
     negate: false

--- a/modules/social_features/social_event/modules/social_event_managers/config/optional/block.block.views_block__managers_event_managers_2.yml
+++ b/modules/social_features/social_event/modules/social_event_managers/config/optional/block.block.views_block__managers_event_managers_2.yml
@@ -22,8 +22,8 @@ settings:
   views_label: ''
   items_per_page: none
 visibility:
-  node_type:
-    id: node_type
+  entity_bundle:node:
+    id: 'entity_bundle:node'
     bundles:
       event: event
     negate: false

--- a/modules/social_features/social_event/modules/social_event_managers/social_event_managers.post_update.php
+++ b/modules/social_features/social_event/modules/social_event_managers/social_event_managers.post_update.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * @file
+ * Contains post-update hooks for the Social Event Managers module.
+ */
+
+/**
+ * Updates the node type visibility condition.
+ */
+function social_event_managers_post_update_replace_node_type_condition(): void {
+  $config_factory = \Drupal::configFactory();
+
+  $block_list = [
+    'block.block.views_block__managers_event_managers',
+    'block.block.views_block__managers_event_managers_2',
+  ];
+
+  foreach ($block_list as $block_config_name) {
+    $block = $config_factory->getEditable($block_config_name);
+
+    if ($block->get('visibility.node_type')) {
+      $configuration = $block->get('visibility.node_type');
+      $configuration['id'] = 'entity_bundle:node';
+      $block->set('visibility.entity_bundle:node', $configuration);
+      $block->clear('visibility.node_type');
+      $block->save(TRUE);
+    }
+  }
+}

--- a/modules/social_features/social_event/social_event.post_update.php
+++ b/modules/social_features/social_event/social_event.post_update.php
@@ -126,3 +126,27 @@ function social_event_post_update_10302_set_all_day_value(array &$sandbox): void
     $sandbox['#finished'] = ($sandbox['current'] / $sandbox['total']);
   }
 }
+
+/**
+ * Updates the node type visibility condition.
+ */
+function social_event_post_update_replace_node_type_condition(): void {
+  $config_factory = \Drupal::configFactory();
+
+  $block_list = [
+    'block.block.socialblue_views_block__event_enrollments_event_enrollments_socialbase',
+    'block.block.views_block__event_enrollments_event_enrollments_socialbase',
+  ];
+
+  foreach ($block_list as $block_config_name) {
+    $block = $config_factory->getEditable($block_config_name);
+
+    if ($block->get('visibility.node_type')) {
+      $configuration = $block->get('visibility.node_type');
+      $configuration['id'] = 'entity_bundle:node';
+      $block->set('visibility.entity_bundle:node', $configuration);
+      $block->clear('visibility.node_type');
+      $block->save(TRUE);
+    }
+  }
+}

--- a/modules/social_features/social_sharing/config/optional/block.block.shariffsharebuttons.yml
+++ b/modules/social_features/social_sharing/config/optional/block.block.shariffsharebuttons.yml
@@ -19,8 +19,8 @@ settings:
   label_display: visible
   shariff_default_settings: 1
 visibility:
-  node_type:
-    id: node_type
+  entity_bundle:node:
+    id: 'entity_bundle:node'
     bundles:
       event: event
       page: page

--- a/modules/social_features/social_sharing/config/optional/block.block.shariffsharebuttons_2.yml
+++ b/modules/social_features/social_sharing/config/optional/block.block.shariffsharebuttons_2.yml
@@ -19,8 +19,8 @@ settings:
   label_display: visible
   shariff_default_settings: 1
 visibility:
-  node_type:
-    id: node_type
+  entity_bundle:node:
+    id: 'entity_bundle:node'
     bundles:
       event: event
       page: page

--- a/modules/social_features/social_sharing/social_sharing.post_update.php
+++ b/modules/social_features/social_sharing/social_sharing.post_update.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * @file
+ * Contains post-update hooks for the Social Sharing module.
+ */
+
+/**
+ * Updates the node type visibility condition.
+ */
+function social_sharing_managers_post_update_replace_node_type_condition(): void {
+  $config_factory = \Drupal::configFactory();
+
+  $block_list = [
+    'block.block.shariffsharebuttons',
+    'block.block.shariffsharebuttons_2',
+  ];
+
+  foreach ($block_list as $block_config_name) {
+    $block = $config_factory->getEditable($block_config_name);
+
+    if ($block->get('visibility.node_type')) {
+      $configuration = $block->get('visibility.node_type');
+      $configuration['id'] = 'entity_bundle:node';
+      $block->set('visibility.entity_bundle:node', $configuration);
+      $block->clear('visibility.node_type');
+      $block->save(TRUE);
+    }
+  }
+}


### PR DESCRIPTION
## Problem
As per change record https://www.drupal.org/node/2983299 node_type plugin condition is now deprecated and replaced by a generic entity_bundle condition.

Open Social has a couple of default blocks still using the deprecated condition and needs update.

## Solution
Follow the same code on block_post_update_replace_node_type_condition and update Open Social block configuration on optional and default blocks.

## Issue tracker
https://www.drupal.org/project/social/issues/3313663

## Theme issue tracker
N/A

## How to test
- [x] Update or install this version
- [x] Enable social_album module
- [x] Using drush run the following command: `drush cget block.block.socialblue_album_count_and_add`
- [x] Double check `visibility` configuration and make sure that `entity_bundle:node` and `id: 'entity_bundle:node'` are set on the configuration array

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
N/A

## Release notes
N/A

## Change Record
N/A

## Translations
N/A
