### PR TITLE
Issue #3314447 by rolki: Inconsistent in checking access to a group

### DIFF
--- a/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.module
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.module
@@ -501,7 +501,7 @@ function social_group_flexible_group_can_be_added(SocialGroupInterface $group): 
  *   TRUE when users can join.
  */
 function social_group_flexible_group_public_enabled(GroupInterface $group) {
-  $visibility_options = $group->get('field_group_allowed_visibility')->getValue();
+  $visibility_options = $group->get('field_flexible_group_visibility')->getValue();
 
   if (!in_array('public', array_column($visibility_options, 'value'), FALSE)) {
     return FALSE;
@@ -520,7 +520,7 @@ function social_group_flexible_group_public_enabled(GroupInterface $group) {
  *   TRUE when users can join.
  */
 function social_group_flexible_group_community_enabled(GroupInterface $group) {
-  $visibility_options = $group->get('field_group_allowed_visibility')->getValue();
+  $visibility_options = $group->get('field_flexible_group_visibility')->getValue();
 
   if (!in_array('community', array_column($visibility_options, 'value'), FALSE)) {
     return FALSE;
@@ -539,7 +539,7 @@ function social_group_flexible_group_community_enabled(GroupInterface $group) {
  *   TRUE when users can join.
  */
 function social_group_flexible_group_members_enabled(Group $group) {
-  $visibility_options = $group->get('field_group_allowed_visibility')->getValue();
+  $visibility_options = $group->get('field_flexible_group_visibility')->getValue();
 
   if (!in_array('group', array_column($visibility_options, 'value'), FALSE)) {
     return FALSE;


### PR DESCRIPTION
## Problem
Distro has those three functions that checking `group visibility` in a group:
- `social_group_flexible_group_public_enabled()`
- `social_group_flexible_group_community_enabled()`
- `social_group_flexible_group_members_enabled()`

The problem is that those functions check `field_group_allowed_visibility` field rather than `field_flexible_group_visibility` field. Checked field should be vise versa (`field_flexible_group_visibility` and not `field_group_allowed_visibility`) which is more logical and follows from the context (and functions names 🙂)

This also cause a problem that a flexible group can be created with public visibility and group visibility for content, as a result the group is not available to anonymous users.

## Solution
Check access to the group by `field_flexible_group_visibility`, not by `field_group_allowed_visibility`.

## Issue tracker
- https://www.drupal.org/project/social/issues/3314447
- https://getopensocial.atlassian.net/browse/PROD-22582

## Theme issue tracker
n/a

## How to test
- [ ] Login as CM+
- [ ] Create a flexible group with `public` group visibility and `community` group content visibility
- [ ] Go to this group under the anonymous user
- [ ] You should be able to view the group

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
<img width="1058" alt="Знімок екрана 2022-10-10 о 13 33 52" src="https://user-images.githubusercontent.com/50984627/194847203-752b10df-3b1e-421b-9ef4-fac64f8636b6.png">
<img width="929" alt="Знімок екрана 2022-10-10 о 13 34 38" src="https://user-images.githubusercontent.com/50984627/194847302-1e840c42-cc4f-4ad5-9e22-1debcc38692d.png">

## Release notes
From now on, the functions: `social_group_flexible_group_public_enabled()`, `social_group_flexible_group_community_enabled()` and `social_group_flexible_group_members_enabled()` are checked on the `field_flexible_group_visibility` field, not `field_group_allowed_visibility`.

## Change Record
The functions `social_group_flexible_group_public_enabled()`, `social_group_flexible_group_community_enabled()` and `social_group_flexible_group_members_enabled()` are checked on the `field_flexible_group_visibility` field, not `field_group_allowed_visibility`.

## Translations
n/a
