### PR TITLE
Hotfix: Check if flagging exists before loading the entity

### DIFF
--- a/modules/social_features/social_content_report/social_content_report.tokens.inc
+++ b/modules/social_features/social_content_report/social_content_report.tokens.inc
@@ -56,12 +56,15 @@ function social_content_report_tokens($type, $tokens, array $data, array $option
           /** @var \Drupal\flag\FlaggingInterface $flagging */
           $flagging = $storage->load($flagging_id);
 
-          // Load the flagged entity.
-          /** @var \Drupal\Core\Entity\EntityInterface $entity */
-          $entity = $flagging->getFlaggable();
+          // Check if the flagging entity exists in database.
+          if ($flagging !== NULL) {
+            // Load the flagged entity.
+            /** @var \Drupal\Core\Entity\EntityInterface $entity */
+            $entity = $flagging->getFlaggable();
 
-          // Set the URL for the entity.
-          $replacements[$original] = $entity->toUrl()->setAbsolute()->toString();
+            // Set the URL for the entity.
+            $replacements[$original] = $entity->toUrl()->setAbsolute()->toString();
+          }
         }
       }
     }


### PR DESCRIPTION
## Problem
When content is flagged and the content item is deleted before the activity is created, the cron fails, because the entity cannot be loaded anymore.

## Solution
By adding a check to see if the flagging still exists, we prevent the cron from failing.

## Issue tracker
https://www.drupal.org/project/social/issues/3315916

## How to test
- [ ] Flag a content item
- [ ] Delete the content item
- [ ] Run cron, so it creates the activity
- [ ] Cron should not fail, because of the check we added.

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status
