### PR TITLE
Issue #3316310 - Recreate update hook for updating field group allowed join methods as it failed on expected config

### DIFF
--- a/modules/social_features/social_group/modules/social_group_flexible_group/config/update/social_group_flexible_group_update_11402.yml
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/config/update/social_group_flexible_group_update_11402.yml
@@ -1,0 +1,7 @@
+field.storage.group.field_group_allowed_join_method:
+  expected_config: {  }
+  update_actions:
+    change:
+      settings:
+        allowed_values: {  }
+        allowed_values_function: '_social_group_allowed_values_callback'

--- a/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.install
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.install
@@ -516,3 +516,17 @@ function social_group_flexible_group_update_11401(): string {
   // Output logged messages to related channel of update execution.
   return $update_helper->logger()->output();
 }
+
+/**
+ * Allow extending list of allowed join methods dynamically.
+ */
+function social_group_flexible_group_update_11402(): string {
+  /** @var \Drupal\update_helper\UpdaterInterface $update_helper */
+  $update_helper = \Drupal::service('update_helper.updater');
+
+  // Execute configuration update definitions with logging of success.
+  $update_helper->executeUpdate('social_group_flexible_group', __FUNCTION__);
+
+  // Output logged messages to related channel of update execution.
+  return $update_helper->logger()->output();
+}


### PR DESCRIPTION
## Problem
In https://www.drupal.org/project/social/issues/3254715 we have tried to make our allowed join group method field re-usable, instead of providing storage options, we opted for a callback. Super helpful if people wanted to extend it.

However the actual update hook implied, expected configuration to be there. Which in our case wasn't always the case due to the field storage already being updated and altered with more configuration.

The exact scenario why we want to have a callback for the allowed values.

## Solution
I've recreated the update hook, made sure there is no expected config so it runs always.
We can point to the actual release notes of the issue there is no additional value created.
I have tried to put it in a test case, but because of the way we have set our dependencies I have to enable over 40 modules for this scenario alone:

```
public function testAllowedJoinGroupCallback() {
    /** @var \Drupal\field\FieldStorageConfigInterface $field_storage */
    $field_storage = FieldStorageConfig::load('group.field_group_allowed_join_method');
    $this->assertInstanceOf(FieldStorageConfigInterface::class, $field_storage);
    $this->assertSame('_social_group_allowed_values_callback', $field_storage->getSetting('allowed_values_function'));
  }
```
Which ultimately doesn't really test much, just the fact we have our callback there instead of the options.

Therefor I have decided not to write a test for it. 
Browser/Behat based would only allow us to test for the Allowed values itself, which would be the same as it was before.

## Issue tracker
https://www.drupal.org/project/social/issues/3316310

## How to test

- [ ] Test upgrade path
- [ ] Verify using `drush cget field.storage.group.field_group_allowed_join_method` now has `allowed_values_function: _social_group_allowed_values_callback`  
- [ ] Join methods functionality for groups should work as before.

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
*[Required if new feature, and if applicable] If this Pull Request makes visual changes then please include some screenshots that show what has changed here. A before and after screenshot helps the reviewer determine what changes were made.*

## Release notes
(Copied from #2658) - Join methods can be used for other entity types.

## Change Record
(Copied from #2658) - https://www.drupal.org/node/3284696