### PR TITLE
Issue #3317257: Change the 'Who else is going' target from blank to same window

### DIFF
--- a/modules/social_features/social_event/social_event.module
+++ b/modules/social_features/social_event/social_event.module
@@ -84,7 +84,6 @@ function social_event_preprocess_event_enrollment_confirmation(array &$variables
   $variables['event_date'] = _social_event_format_date($node, 'hero');
   $options = [
     'attributes' => [
-      'target' => '_blank',
       'class' => [
         'btn',
         'btn-sm',


### PR DESCRIPTION
## Problem
When you click on the "See who else is going" link after enrolling in an event, you are forced to view the result in a new tab.
The pop-up with the link (nice improvement!) was introduced in #2830.

<img width="640" alt="Pop-up with details rendered after enrolling into an event" src="https://user-images.githubusercontent.com/7124754/197607140-905b6697-b799-4e14-b69d-f63a3479a0c8.png">

This is not a great interaction and it will leave a "zombie" tab behind.

## Solution
Remove `target=blank`.

## Issue tracker
- https://www.drupal.org/project/social/issues/3317257
- https://getopensocial.atlassian.net/browse/PROD-22910

## Theme issue tracker
N/a

## How to test
- [ ] RSVP to an event
- [ ] Click the "See who else is going" link
- [ ] The page reloads and the attendee list is visible

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
N/a

## Release notes
After enrolling to an event a pop-up is opened. The link to view who else is also attending the event now opens in the same window instead of opening a new one.

## Change Record
N/a

## Translations
N/a
