### PR TITLE
Internal: Update dependabot labels and max amount of open PRs configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,8 @@ updates:
       day: "saturday"
     labels:
       - "type: update"
-      - "team: nucleus"
+      - "status: needs review"
+      - "team: guardians"
 
   # Maintain dependencies for Composer.
   - package-ecosystem: "composer"
@@ -20,7 +21,8 @@ updates:
       timezone: "Europe/Amsterdam"
     labels:
       - "type: update"
-      - "team: nucleus"
+      - "status: needs review"
+      - "team: guardians"
     # Let core team maintainers review it.
     reviewers:
       - "goalgorilla/maintainers"
@@ -35,4 +37,4 @@ updates:
       prefix: "Updates: "
       include: "scope"
     # Allow up to 5 open pull requests for Drupal dependencies as we have some to go.
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 10


### PR DESCRIPTION
## Problem
There are a lot of pending module updates and currently dependabot only query five PRs at a time, besides that there is also an outdated configuration with dependabot labels.

## Solution

- Increate the amount of max open PRs from 5 to 10;
- Update outdated labels, change `team: nucleus` to `team: guardians`;
- Add a new `status: needs review` label;

## Issue tracker
N/A

## Theme issue tracker
N/A

## How to test
- [ ] Fork this repository, configure dependabot and check if more than 5 PRs were open;

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
N/A

## Release notes
N/A

## Change Record
N/A

## Translations
N/A
