### PR TITLE
Internal: Update ctools version from 3.7 to 3.11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -140,7 +140,7 @@
         "drupal/core-composer-scaffold": "~9.4.8",
         "drupal/crop": "2.3.0",
         "drupal/csv_serialization": "2.0",
-        "drupal/ctools": "3.7",
+        "drupal/ctools": "3.11",
         "drupal/data_policy": "2.0.0-beta3",
         "drupal/dynamic_entity_reference": "1.16.0",
         "drupal/editor_advanced_link": "2.0.0",


### PR DESCRIPTION
## Problem
drupal/ctools has a new version

## Solution
Update drupal/ctools from 3.7 to 3.11

Please note that drupal/ctools has a newer 4.x version, but for now that version is not recommended, this is why we canceled PR https://github.com/goalgorilla/open_social/pull/3187 created by dependabot and are creating this one.

## Issue tracker
N/A

## Theme issue tracker
N/A

## How to test
- [ ] After update, site should work as intended

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
N/A

## Release notes
N/A

## Change Record
N/A

## Translations
N/A
