### PR TITLE
Issue #3318902 by rolki: Add a new filtering option by "Future and ongoing" to Custom content list block

### DIFF
--- a/modules/social_features/social_content_block/modules/social_event_content_block/config/install/field.storage.block_content.field_event_date.yml
+++ b/modules/social_features/social_content_block/modules/social_event_content_block/config/install/field.storage.block_content.field_event_date.yml
@@ -29,6 +29,9 @@ settings:
       value: ongoing
       label: 'Ongoing'
     -
+      value: future_ongoing
+      label: 'Future and ongoing'
+    -
       value: last_30
       label: 'Last 30 days'
     -

--- a/modules/social_features/social_content_block/modules/social_event_content_block/social_event_content_block.install
+++ b/modules/social_features/social_content_block/modules/social_event_content_block/social_event_content_block.install
@@ -64,6 +64,10 @@ function social_event_content_block_update_8002() {
             'label' => t('Ongoing'),
           ],
           [
+            'value' => 'future_ongoing',
+            'label' => t('Future and ongoing'),
+          ],
+          [
             'value' => 'last_30',
             'label' => t('Last 30 days'),
           ],
@@ -146,6 +150,20 @@ function social_event_content_block_update_8003() {
   $allowed_values[] = [
     'value' => 'ongoing',
     'label' => t('Ongoing'),
+  ];
+
+  $event_date_storage->set('settings.allowed_values', $allowed_values)->save();
+}
+
+/**
+ * Add "future_ongoing" allowed value to the event date field storage.
+ */
+function social_event_content_block_update_11501(): void {
+  $event_date_storage = \Drupal::configFactory()->getEditable('field.storage.block_content.field_event_date');
+  $allowed_values = $event_date_storage->get('settings.allowed_values');
+  $allowed_values[] = [
+    'value' => 'future_ongoing',
+    'label' => t('Future and ongoing'),
   ];
 
   $event_date_storage->set('settings.allowed_values', $allowed_values)->save();

--- a/modules/social_features/social_content_block/modules/social_event_content_block/src/Plugin/ContentBlock/EventContentBlock.php
+++ b/modules/social_features/social_content_block/modules/social_event_content_block/src/Plugin/ContentBlock/EventContentBlock.php
@@ -128,8 +128,13 @@ class EventContentBlock extends ContentBlockBase implements ContainerFactoryPlug
 
             case 'future_ongoing':
               $range['start'] = new \DateTime('-30 days');
-              $query->innerJoin('node__field_event_date_end', 'nfede', "nfede.entity_id = base_table.nid AND nfede.bundle = 'event'");
-              $query->condition('nfede.field_event_date_end_value', (new \DateTime())->format(DateTimeItemInterface::DATETIME_STORAGE_FORMAT), '>');
+
+              $query->leftJoin('node__field_event_date_end', 'nfede', "nfede.entity_id = base_table.nid AND nfede.bundle = 'event'");
+              $or = $query->orConditionGroup();
+              $or->condition('nfede.field_event_date_end_value', (new \DateTime())->format(DateTimeItemInterface::DATETIME_STORAGE_FORMAT), '>');
+              $or->isNull('nfede.entity_id');
+
+              $query->condition($or);
               break;
 
             case 'last_30':

--- a/modules/social_features/social_content_block/modules/social_event_content_block/src/Plugin/ContentBlock/EventContentBlock.php
+++ b/modules/social_features/social_content_block/modules/social_event_content_block/src/Plugin/ContentBlock/EventContentBlock.php
@@ -91,76 +91,75 @@ class EventContentBlock extends ContentBlockBase implements ContainerFactoryPlug
         case 'field_event_date':
           $query->innerJoin('node__field_event_date', 'nfed', "nfed.entity_id = base_table.nid AND nfed.bundle = 'event'");
           $range = ['start' => NULL, 'end' => NULL];
-          $timezone = new \DateTimeZone(date_default_timezone_get());
 
           $start_operator = '>=';
           $end_operator = '<';
           // Apply a range based on a value.
           switch ($field_value[0]['value']) {
             case 'future':
-              $range['start'] = new \DateTime('now', $timezone);
+              $range['start'] = new \DateTime();
               break;
 
             case 'past':
-              $range['end'] = new \DateTime('now', $timezone);
+              $range['end'] = new \DateTime();
               break;
 
             case 'last_month':
-              $range['start'] = new \DateTime('first day of last month 00:00', $timezone);
-              $range['end'] = new \DateTime('last day of last month 23:59', $timezone);
+              $range['start'] = new \DateTime('first day of last month 00:00');
+              $range['end'] = new \DateTime('last day of last month 23:59');
               break;
 
             case 'current_month':
-              $range['start'] = new \DateTime('first day of this month 00:00', $timezone);
-              $range['end'] = new \DateTime('last day of this month 23:59', $timezone);
+              $range['start'] = new \DateTime('first day of this month 00:00');
+              $range['end'] = new \DateTime('last day of this month 23:59');
               break;
 
             case 'next_month':
-              $range['start'] = new \DateTime('first day of next month 00:00', $timezone);
-              $range['end'] = new \DateTime('last day of next month 23:59', $timezone);
+              $range['start'] = new \DateTime('first day of next month 00:00');
+              $range['end'] = new \DateTime('last day of next month 23:59');
               break;
 
             case 'ongoing':
-              $range['start'] = new \DateTime('-30 days', $timezone);
-              $range['end'] = new \DateTime('now', $timezone);
+              $range['start'] = new \DateTime('-30 days');
+              $range['end'] = new \DateTime();
               $end_operator = '>';
-              $query->condition('nfed.field_event_date_value', (new \DateTime('now', $timezone))->format(DateTimeItemInterface::DATETIME_STORAGE_FORMAT), '<');
+              $query->condition('nfed.field_event_date_value', (new \DateTime())->format(DateTimeItemInterface::DATETIME_STORAGE_FORMAT), '<');
               break;
 
             case 'future_ongoing':
-              $range['start'] = new \DateTime('-30 days', $timezone);
+              $range['start'] = new \DateTime('-30 days');
               $query->innerJoin('node__field_event_date_end', 'nfede', "nfede.entity_id = base_table.nid AND nfede.bundle = 'event'");
-              $query->condition('nfede.field_event_date_end_value', (new \DateTime('now', $timezone))->format(DateTimeItemInterface::DATETIME_STORAGE_FORMAT), '>');
+              $query->condition('nfede.field_event_date_end_value', (new \DateTime())->format(DateTimeItemInterface::DATETIME_STORAGE_FORMAT), '>');
               break;
 
             case 'last_30':
-              $range['start'] = new \DateTime('-30 days', $timezone);
-              $range['end'] = new \DateTime('now', $timezone);
+              $range['start'] = new \DateTime('-30 days');
+              $range['end'] = new \DateTime();
               break;
 
             case 'next_30':
-              $range['start'] = new \DateTime('now', $timezone);
-              $range['end'] = new \DateTime('+30 days', $timezone);
+              $range['start'] = new \DateTime();
+              $range['end'] = new \DateTime('+30 days');
               break;
 
             case 'last_14':
-              $range['start'] = new \DateTime('-14 days', $timezone);
-              $range['end'] = new \DateTime('now', $timezone);
+              $range['start'] = new \DateTime('-14 days');
+              $range['end'] = new \DateTime();
               break;
 
             case 'next_14':
-              $range['start'] = new \DateTime('now', $timezone);
-              $range['end'] = new \DateTime('+14 days', $timezone);
+              $range['start'] = new \DateTime();
+              $range['end'] = new \DateTime('+14 days');
               break;
 
             case 'last_7':
-              $range['start'] = new \DateTime('-7 days', $timezone);
-              $range['end'] = new \DateTime('now', $timezone);
+              $range['start'] = new \DateTime('-7 days');
+              $range['end'] = new \DateTime();
               break;
 
             case 'next_7':
-              $range['start'] = new \DateTime('now', $timezone);
-              $range['end'] = new \DateTime('+7 days', $timezone);
+              $range['start'] = new \DateTime();
+              $range['end'] = new \DateTime('+7 days');
               break;
 
             default:
@@ -169,11 +168,11 @@ class EventContentBlock extends ContentBlockBase implements ContainerFactoryPlug
           }
           // Only apply range constraints if any were actually set.
           if (isset($range['start'])) {
-            $query->condition('nfed.field_event_date_value', $range['start'] instanceof \DateTime ? $range['start']->setTimezone(new \DateTimeZone(DateTimeItemInterface::STORAGE_TIMEZONE))->format(DateTimeItemInterface::DATETIME_STORAGE_FORMAT) : $range['start'], $start_operator);
+            $query->condition('nfed.field_event_date_value', $range['start'] instanceof \DateTime ? $range['start']->format(DateTimeItemInterface::DATETIME_STORAGE_FORMAT) : $range['start'], $start_operator);
           }
           if (isset($range['end'])) {
             $query->innerJoin('node__field_event_date_end', 'nfede', "nfede.entity_id = base_table.nid AND nfede.bundle = 'event'");
-            $query->condition('nfede.field_event_date_end_value', $range['end'] instanceof \DateTime ? $range['end']->setTimezone(new \DateTimeZone(DateTimeItemInterface::STORAGE_TIMEZONE))->format(DateTimeItemInterface::DATETIME_STORAGE_FORMAT) : $range['end'], $end_operator);
+            $query->condition('nfede.field_event_date_end_value', $range['end'] instanceof \DateTime ? $range['end']->format(DateTimeItemInterface::DATETIME_STORAGE_FORMAT) : $range['end'], $end_operator);
           }
           break;
       }

--- a/modules/social_features/social_content_block/modules/social_event_content_block/src/Plugin/ContentBlock/EventContentBlock.php
+++ b/modules/social_features/social_content_block/modules/social_event_content_block/src/Plugin/ContentBlock/EventContentBlock.php
@@ -91,69 +91,76 @@ class EventContentBlock extends ContentBlockBase implements ContainerFactoryPlug
         case 'field_event_date':
           $query->innerJoin('node__field_event_date', 'nfed', "nfed.entity_id = base_table.nid AND nfed.bundle = 'event'");
           $range = ['start' => NULL, 'end' => NULL];
+          $timezone = new \DateTimeZone(date_default_timezone_get());
 
           $start_operator = '>=';
           $end_operator = '<';
           // Apply a range based on a value.
           switch ($field_value[0]['value']) {
             case 'future':
-              $range['start'] = new \DateTime();
+              $range['start'] = new \DateTime('now', $timezone);
               break;
 
             case 'past':
-              $range['end'] = new \DateTime();
+              $range['end'] = new \DateTime('now', $timezone);
               break;
 
             case 'last_month':
-              $range['start'] = new \DateTime('first day of last month 00:00');
-              $range['end'] = new \DateTime('last day of last month 23:59');
+              $range['start'] = new \DateTime('first day of last month 00:00', $timezone);
+              $range['end'] = new \DateTime('last day of last month 23:59', $timezone);
               break;
 
             case 'current_month':
-              $range['start'] = new \DateTime('first day of this month 00:00');
-              $range['end'] = new \DateTime('last day of this month 23:59');
+              $range['start'] = new \DateTime('first day of this month 00:00', $timezone);
+              $range['end'] = new \DateTime('last day of this month 23:59', $timezone);
               break;
 
             case 'next_month':
-              $range['start'] = new \DateTime('first day of next month 00:00');
-              $range['end'] = new \DateTime('last day of next month 23:59');
+              $range['start'] = new \DateTime('first day of next month 00:00', $timezone);
+              $range['end'] = new \DateTime('last day of next month 23:59', $timezone);
               break;
 
             case 'ongoing':
-              $range['start'] = new \DateTime('-30 days');
-              $range['end'] = new \DateTime();
+              $range['start'] = new \DateTime('-30 days', $timezone);
+              $range['end'] = new \DateTime('now', $timezone);
               $end_operator = '>';
-              $query->condition('nfed.field_event_date_value', (new \DateTime())->format(DateTimeItemInterface::DATETIME_STORAGE_FORMAT), '<');
+              $query->condition('nfed.field_event_date_value', (new \DateTime('now', $timezone))->format(DateTimeItemInterface::DATETIME_STORAGE_FORMAT), '<');
+              break;
+
+            case 'future_ongoing':
+              $range['start'] = new \DateTime('-30 days', $timezone);
+              $query->innerJoin('node__field_event_date_end', 'nfede', "nfede.entity_id = base_table.nid AND nfede.bundle = 'event'");
+              $query->condition('nfede.field_event_date_end_value', (new \DateTime('now', $timezone))->format(DateTimeItemInterface::DATETIME_STORAGE_FORMAT), '>');
               break;
 
             case 'last_30':
-              $range['start'] = new \DateTime('-30 days');
-              $range['end'] = new \DateTime();
+              $range['start'] = new \DateTime('-30 days', $timezone);
+              $range['end'] = new \DateTime('now', $timezone);
               break;
 
             case 'next_30':
-              $range['start'] = new \DateTime();
-              $range['end'] = new \DateTime('+30 days');
+              $range['start'] = new \DateTime('now', $timezone);
+              $range['end'] = new \DateTime('+30 days', $timezone);
               break;
 
             case 'last_14':
-              $range['start'] = new \DateTime('-14 days');
-              $range['end'] = new \DateTime();
+              $range['start'] = new \DateTime('-14 days', $timezone);
+              $range['end'] = new \DateTime('now', $timezone);
               break;
 
             case 'next_14':
-              $range['start'] = new \DateTime();
-              $range['end'] = new \DateTime('+14 days');
+              $range['start'] = new \DateTime('now', $timezone);
+              $range['end'] = new \DateTime('+14 days', $timezone);
               break;
 
             case 'last_7':
-              $range['start'] = new \DateTime('-7 days');
-              $range['end'] = new \DateTime();
+              $range['start'] = new \DateTime('-7 days', $timezone);
+              $range['end'] = new \DateTime('now', $timezone);
               break;
 
             case 'next_7':
-              $range['start'] = new \DateTime();
-              $range['end'] = new \DateTime('+7 days');
+              $range['start'] = new \DateTime('now', $timezone);
+              $range['end'] = new \DateTime('+7 days', $timezone);
               break;
 
             default:
@@ -162,11 +169,11 @@ class EventContentBlock extends ContentBlockBase implements ContainerFactoryPlug
           }
           // Only apply range constraints if any were actually set.
           if (isset($range['start'])) {
-            $query->condition('nfed.field_event_date_value', $range['start'] instanceof \DateTime ? $range['start']->format(DateTimeItemInterface::DATETIME_STORAGE_FORMAT) : $range['start'], $start_operator);
+            $query->condition('nfed.field_event_date_value', $range['start'] instanceof \DateTime ? $range['start']->setTimezone(new \DateTimeZone(DateTimeItemInterface::STORAGE_TIMEZONE))->format(DateTimeItemInterface::DATETIME_STORAGE_FORMAT) : $range['start'], $start_operator);
           }
           if (isset($range['end'])) {
             $query->innerJoin('node__field_event_date_end', 'nfede', "nfede.entity_id = base_table.nid AND nfede.bundle = 'event'");
-            $query->condition('nfede.field_event_date_end_value', $range['end'] instanceof \DateTime ? $range['end']->format(DateTimeItemInterface::DATETIME_STORAGE_FORMAT) : $range['end'], $end_operator);
+            $query->condition('nfede.field_event_date_end_value', $range['end'] instanceof \DateTime ? $range['end']->setTimezone(new \DateTimeZone(DateTimeItemInterface::STORAGE_TIMEZONE))->format(DateTimeItemInterface::DATETIME_STORAGE_FORMAT) : $range['end'], $end_operator);
           }
           break;
       }


### PR DESCRIPTION
## Problem
When an event is “ongoing” meaning that we are within the date range it should not disappear from a custom content list showing upcoming events until that event has ended.

## Solution
The suggestion here is to create a new Date period option called "`Future and ongoing`" when “`Events`” are selected as the content type.
We already have “`Future`” and we already have “`Ongoing`” so it will be a combination of the two.

## Issue tracker
- https://www.drupal.org/project/social/issues/3318902
- https://getopensocial.atlassian.net/browse/PROD-22336

## Theme issue tracker
NONE.

## How to test
*Future and ongoing*
- [x] Apply these changes
- [x] Enable Social Event Content Block
- [x] Create custom content list block
- [x] Choose events and "Future and ongoing" date period
- [x] Add your "custom content list" block to some page or Dashboard
- [x] You should see events that are currently ongoing and all future events

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
<img width="1583" alt="Знімок екрана 2022-11-04 о 11 43 30" src="https://user-images.githubusercontent.com/50984627/199942431-916ded2c-ffec-46a0-b083-91fac1cbb34c.png">

## Release notes
Now we have an additional filter for events in the "Custom content list block" which is "Future and ongoing" and can be selected in the "Date period field".

## Change Record
NONE.

## Translations
NONE.
