### PR TITLE
Internal: Updated patch on ctools from https://www.drupal.org/project/ctools/issues/3191286.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -66,9 +66,6 @@
             "drupal/config_update": {
                 "3248161: Symfony 4.4 event dispatcher parameter order change": "https://www.drupal.org/files/issues/2021-11-08/symfony-4-4-event-dispatcher-parameter-order-change-3248161-3.patch"
             },
-            "drupal/ctools": {
-                "Signature of EventDispatcherInterface::dispatch() has changed": "https://www.drupal.org/files/issues/2021-01-14/3191286-14.patch"
-            },
             "drupal/dynamic_entity_reference": {
                 "Errors when new entity types are added (in certain cases)": "https://www.drupal.org/files/issues/2022-02-14/3099176-1.x-14.patch",
                 "Return the same content list after content type is changed": "https://www.drupal.org/files/issues/2021-08-27/dynamic_entity_reference-the_same_content_list-3230158-2.patch"


### PR DESCRIPTION
## Problem
Ctools patch doesn't apply after https://github.com/goalgorilla/open_social/pull/3194

## Solution
Remove patch.

## Issue tracker
N.A

## Theme issue tracker
N.A

## How to test
- [ ] All checks should pass

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
N.A

## Release notes
N.A

## Change Record
N.A

## Translations
N.A