### PR TITLE
Fix user groups overview and block permissions

### DIFF
--- a/modules/social_features/social_group/src/Controller/SocialGroupController.php
+++ b/modules/social_features/social_group/src/Controller/SocialGroupController.php
@@ -214,7 +214,7 @@ class SocialGroupController extends ControllerBase {
       $account,
       // Own profile?
       $user->id() === $account->id()
-        ? 'view groups on other profiles' : 'view groups on my profile',
+        ? 'view groups on my profile' : 'view groups on other profiles',
     );
   }
 


### PR DESCRIPTION
## Problem
Currently, the social_group module sets wrong user permissions for accessing the user groups pages and this leads to unexpected results and denied access.

If a user has the "View the My groups overview and block on your own profile" permission, they cannot actually see their own groups information as their access is denied. Instead, they can see the groups info of other users, which is, in general, not desirable (if not explicitly set). The following error is returned as can be seen in the db logs:
"Drupal\Core\Http\Exception\CacheableAccessDeniedHttpException: The 'view any profile profile' permission is required. in Drupal\Core\Routing\AccessAwareRouter->checkAccess() "

In the same time, if a user has "View the My groups overview and block on other peoples profile" permission, they can access only their own groups info, while the groups info of other users is denied.

## Solution
Return the correct permission after checking whether the user tries to access their own profile, or that of another user.

## Issue tracker
https://www.drupal.org/project/social/issues/3319775#comment-14776745

## How to test
*[Required] For example*
- [ ] Log in as admin and assign the "View the My groups overview and block on your own profile" permission to a given role, let's say Verified user.
- [ ] Log in as a verified user and check your own groups page.
- [ ] Now log in as admin again, remove the above permission and assign the "View the My groups overview and block on other peoples profile" one to the Verified user role. Check the groups page of another user. Test loading your own groups page. 
- [ ] Before the fix you get just the opposite of what you have configured. After the fix everything works properly and as expected.