### PR TITLE
Issue #3322194: Image style that uses convert and private file system is not working

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -61,7 +61,8 @@
                 "Flood MemoryBackend::events[] key of micro time cannot guarantee uniqueness": "https://www.drupal.org/files/issues/2022-02-14/2910000-mr-1451-d93--floodmemorybackend-time-local.diff",
                 "Issue #3251856: Incorrect typehint for FieldConfig::loadByName": "https://www.drupal.org/files/issues/2021-12-12/drupal9-incorrect_typehint-3251856-7.patch",
                 "Issue #2998390: Cache is not invalidated when comment deleted": "https://www.drupal.org/files/issues/2022-02-07/2998390-8.patch",
-                "Issue #3282073: Comment the \"user_post_update_update_roles\" that was added in Drupal 9.3": "https://www.drupal.org/files/issues/2022-05-24/social-comment_the_user_post_update_update_roles-3282073-2.patch"
+                "Issue #3282073: Comment the \"user_post_update_update_roles\" that was added in Drupal 9.3": "https://www.drupal.org/files/issues/2022-05-24/social-comment_the_user_post_update_update_roles-3282073-2.patch",
+                "Image derivative generation does not work if effect \"Convert\" in use and file stored in private filesystem": "https://www.drupal.org/files/issues/2022-09-23/2786735-39.patch"
             },
             "drupal/config_update": {
                 "3248161: Symfony 4.4 event dispatcher parameter order change": "https://www.drupal.org/files/issues/2021-11-08/symfony-4-4-event-dispatcher-parameter-order-change-3248161-3.patch"


### PR DESCRIPTION
## Problem
Open Social introduced a new image effect, "convert to webp". This effect is not working as intended when images are uploaded to a private file system.

The new effect was introduced here: https://github.com/goalgorilla/open_social/pull/3085

## Solution
Follow proposed solution on https://www.drupal.org/project/drupal/issues/2786735 and apply patch #39

## Issue tracker
https://www.drupal.org/project/social/issues/3322194

## Theme issue tracker
N/A

## How to test
- [ ] Install Open Social with demo content
- [ ] Add a post with an image
- [ ] Preview should work
- [ ] Save post, image should work

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
Before:

![image](https://user-images.githubusercontent.com/11061892/202470082-8fd31822-79f1-4b53-9a90-c5c7adc86be7.png)

After:

![image](https://user-images.githubusercontent.com/11061892/202470325-4a7b978f-71b8-4d38-84da-93dd8c9c97f7.png)

HTML:

![image](https://user-images.githubusercontent.com/11061892/202470421-428a884e-7e66-4f17-87dd-ed146d2d0927.png)


## Release notes
N/A

## Change Record
N/A

## Translations
N/A
