### PR TITLE
Issue #3322858 by zanvidmar: Broken date filter on search

### DIFF
--- a/modules/social_features/social_search/social_search.module
+++ b/modules/social_features/social_search/social_search.module
@@ -97,8 +97,8 @@ function social_search_alter_content_exposed_filter_block(&$form, FormStateInter
     $form['type']['#weight'] = '-100';
   }
 
-  if (!empty($form['field_event_date_wrapper']['field_event_date'])
-    && !empty($form['field_event_date_wrapper']['field_event_date_op'])) {
+  if (!empty($form['field_event_date_wrapper']['field_event_date_wrapper']['field_event_date'])
+    && !empty($form['field_event_date_wrapper']['field_event_date_wrapper']['field_event_date_op'])) {
     if (!empty($form['settings'])) {
       $form['settings']['#states'] = [
         'visible' => [
@@ -110,8 +110,8 @@ function social_search_alter_content_exposed_filter_block(&$form, FormStateInter
 
     }
 
-    $form['settings']['field_event_date_op'] = $form['field_event_date_wrapper']['field_event_date_op'];
-    $form['settings']['field_event_date'] = $form['field_event_date_wrapper']['field_event_date'];
+    $form['settings']['field_event_date_op'] = $form['field_event_date_wrapper']['field_event_date_wrapper']['field_event_date_op'];
+    $form['settings']['field_event_date'] = $form['field_event_date_wrapper']['field_event_date_wrapper']['field_event_date'];
     unset($form['field_event_date_wrapper']);
   }
 


### PR DESCRIPTION
The Date of Event filter on the Search > Content page is not working correctly.

## Problem
Social search depends on better_exposed_filters. In the 6.0.x version of better_exposed_filters an extra container has been added ([code](https://git.drupalcode.org/project/better_exposed_filters/-/blob/6.0.x/src/Plugin/better_exposed_filters/filter/FilterWidgetBase.php#L253)) and this breaks the process logic how to make changes for the filter block on the content search page.

## Solution
Update social_search_alter_content_exposed_filter_block() code take into account an extra container added by better_exposed_filters.

## Issue tracker
[3322858](https://www.drupal.org/project/social/issues/3322858)

## Theme issue tracker
N/A

## How to test
Steps to reproduce
- [ ] Install Open social
- [ ] Create some events
- [ ] Go to /search/content
- [ ] Check the filter in the sidebar: you will see broken filter in sidebar as on screenshot ![](https://www.drupal.org/files/issues/2022-11-21/issue.png)
- [ ] With the fix applied date field in filter is hidden until "Event" is not selected as "Content type".
fix ![](https://www.drupal.org/files/issues/2022-11-21/fix.png)

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
N/A

## Release notes
Update social_search_alter_content_exposed_filter_block() code to take into account an extra container added by better_exposed_filters 6.0.x. because of (https://git.drupalcode.org/project/better_exposed_filters/-/blob/6.0.x/src/Plugin/better_exposed_filters/filter/FilterWidgetBase.php#L253)

## Change Record
N/A

## Translations
N/A
