### PR TITLE
Issue #3323562 by zanvidmar: Disable secondary toolbar on frontend in Gin theme by default

### DIFF
--- a/social.install
+++ b/social.install
@@ -24,4 +24,27 @@ function social_install() {
   $user = User::load(1);
   $user->roles[] = 'administrator';
   $user->save();
+
+  // Disable secondary toolbar on frontend in Gin theme.
+  _social_core_disable_secondary_gin_toolbar();
+}
+
+/**
+ * Disable secondary toolbar on frontend in Gin theme.
+ */
+function _social_core_disable_secondary_gin_toolbar() {
+  $config = \Drupal::configFactory()->getEditable('gin.settings');
+  if (!empty($config->getRawData())) {
+    \Drupal::configFactory()
+      ->getEditable('gin.settings')
+      ->set('secondary_toolbar_frontend', FALSE)
+      ->save(TRUE);
+  }
+}
+
+/**
+ * Disable secondary toolbar on frontend in Gin theme.
+ */
+function social_update_11501() {
+  _social_core_disable_secondary_gin_toolbar();
 }


### PR DESCRIPTION
## Problem
As a CM+ I see not needed div element class="gin-secondary-toolbar gin-secondary-toolbar--frontend" behind the navbar on every page.

## Solution
Disable secondary toolbar on frontend in Gin theme.

## Issue tracker
[3323562](https://www.drupal.org/project/social/issues/3323562)

## Theme issue tracker
N/A

## How to test
*Install scenario*
- [ ] Install OS as usual
- [ ] go to admin/appearance/settings/gin under Settings > Show Secondary Toolbar in Frontend and you will see that this setting is enabled.
- [ ]  with this fix applied this setting is disabled by default.

*Update scenario*
- [ ] go to admin/appearance/settings/gin under Settings > Show Secondary Toolbar in Frontend and enable it (if not already enabled).
- [ ]  with this fix applied run hook update and Secondary Toolbar in Frontend should be now disabled.

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
![](https://www.drupal.org/files/issues/2022-11-24/image-20221109-155226.png)

## Release notes
Disable secondary toolbar on frontend in Gin theme by default.

## Change Record
N/A

## Translations
N/A
