### PR TITLE
Issue #3324960 by nkoporec: Make user greeting optional for certain emails

### DIFF
--- a/modules/social_features/social_swiftmail/config/schema/social_swiftmail.schema.yml
+++ b/modules/social_features/social_swiftmail/config/schema/social_swiftmail.schema.yml
@@ -28,3 +28,6 @@ social_swiftmail.settings:
     do_not_send_emails_new_users:
       type: boolean
       label: "Don't send email notifications to users who have never logged in"
+    disable_user_greeting_keys:
+      type: string
+      label: 'Disabled email message keys with user greeting'

--- a/modules/social_features/social_swiftmail/social_swiftmail.install
+++ b/modules/social_features/social_swiftmail/social_swiftmail.install
@@ -90,3 +90,11 @@ function social_swiftmail_update_8003() {
     user_role_grant_permissions($role, ['use text format mail_html']);
   }
 }
+
+/**
+ * Add a new module setting.
+ */
+function social_swiftmail_update_9000() {
+  $settings = \Drupal::configFactory()->getEditable('social_swiftmail.settings');
+  $settings->set('disabled_user_greeting_key', 'register_no_approval_required')->save();
+}

--- a/modules/social_features/social_swiftmail/social_swiftmail.install
+++ b/modules/social_features/social_swiftmail/social_swiftmail.install
@@ -94,7 +94,7 @@ function social_swiftmail_update_8003() {
 /**
  * Add a new module setting.
  */
-function social_swiftmail_update_9000(): void {
+function social_swiftmail_update_11001(): void {
   $settings = \Drupal::configFactory()->getEditable('social_swiftmail.settings');
   $settings->set('disabled_user_greeting_key', 'register_no_approval_required')->save();
 }

--- a/modules/social_features/social_swiftmail/social_swiftmail.install
+++ b/modules/social_features/social_swiftmail/social_swiftmail.install
@@ -94,7 +94,7 @@ function social_swiftmail_update_8003() {
 /**
  * Add a new module setting.
  */
-function social_swiftmail_update_9000() {
+function social_swiftmail_update_9000(): void {
   $settings = \Drupal::configFactory()->getEditable('social_swiftmail.settings');
   $settings->set('disabled_user_greeting_key', 'register_no_approval_required')->save();
 }

--- a/modules/social_features/social_swiftmail/social_swiftmail.module
+++ b/modules/social_features/social_swiftmail/social_swiftmail.module
@@ -116,9 +116,19 @@ function social_swiftmail_preprocess_swiftmailer(array &$variables) {
       $display_name = $message['params']['context']['display_name'];
     }
 
+    $disabled_greeting_keys = $social_swiftmail_config->get("disabled_user_greeting_keys");
+    $disabled_greeting_keys = explode("\r\n", $disabled_greeting_keys);
     $replace = [
       '@display_name' => $display_name,
     ];
+
+    if (isset($message['key'])) {
+      if (!in_array($message['key'], $disabled_greeting_keys)) {
+        $variables['heading'] = t('Hi <strong>@display_name</strong>', $replace, $options);
+      }
+      return;
+    }
+
     $variables['heading'] = t('Hi <strong>@display_name</strong>', $replace, $options);
   }
 }

--- a/modules/social_features/social_swiftmail/src/Form/SocialSwiftmailSettingsForm.php
+++ b/modules/social_features/social_swiftmail/src/Form/SocialSwiftmailSettingsForm.php
@@ -185,6 +185,13 @@ class SocialSwiftmailSettingsForm extends ConfigFormBase {
       '#default_value' => $config->get('do_not_send_emails_new_users'),
     ];
 
+    $form['disabled_user_greeting_keys'] = [
+      '#type' => 'textarea',
+      '#title' => $this->t('Disabled email message keys with user greeting'),
+      '#description' => $this->t("Each email comes with a user greeting on top, in some cases we don't want that, so any message key listed here(one per line) will not include the greeting."),
+      '#default_value' => $config->get('disabled_user_greeting_keys'),
+    ];
+
     return parent::buildForm($form, $form_state);
   }
 
@@ -198,6 +205,7 @@ class SocialSwiftmailSettingsForm extends ConfigFormBase {
     $config = $this->config('social_swiftmail.settings');
     $config->set('remove_open_social_branding', $form_state->getValue('remove_open_social_branding'));
     $config->set('do_not_send_emails_new_users', $form_state->getValue('do_not_send_emails_new_users'));
+    $config->set('disabled_user_greeting_keys', $form_state->getValue('disabled_user_greeting_keys'));
 
     // Set notification settings.
     $templates = $this->emailActivityDestination->getSendEmailMessageTemplates();


### PR DESCRIPTION
## Problem
Currently we hardcode the user greeting when we sent any email, eq: (https://monosnap.com/file/B5sMPud3I3kTSHdFO7il7AcnVW7ca7)

This is not ideal and it would be good to have some kind of setting where you could configure this.

## Solution
It doesn't make sense to hard-code the user greeting since it might not be relevant for certain email templates.

There are a couple of templates that doesn't need the user greeting, since by default it already includes one, so we could either hard-code the template names or create a settings form to be configurable. I prefer the second option even thought this is not something that will change a lot, it still has value to be able to alter it via the UI. So I suggest to create a new setting for social_swiftmailer where you add the template name that should not include the user  greeting on top.


## Issue tracker
https://www.drupal.org/project/social/issues/3324960

## Theme issue tracker
*[Required if applicable] Paste a link to the drupal.org theme issue queue item, either from [socialbase](https://www.drupal.org/project/socialbase) or [socialblue](https://www.drupal.org/project/socialblue). If any other issue trackers were used, include links to those too.*

## How to test
1. Install Open Social
2. Create a new account
3. Check that you have two greetings in the email (like the one is the screenshot).
4. Checkout this branch and redo the 1-3 steps.
5. Check the email again, there should only be one greeting.
6. Go to /admin/config/opensocial/swiftmail and remove everything in 'Disabled email message keys with user greeting' textarea and save the form.
7. Re-do the 1-3 steps and check the email, there should be 2 greetings again.


## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
<img width="592" alt="MailHog+2022-12-02+12-39-44" src="https://user-images.githubusercontent.com/35064680/205288406-03bea2f2-efb9-46e7-bc15-fc9aa676e3a2.png">

![2022-12-06_12-52](https://user-images.githubusercontent.com/35064680/205904725-df57e547-ab9f-44ea-9aef-d72ef623e982.png)


## Release notes
Added a new setting to social_swiftmailer module which enables administrators/site managers to define message keys that will not include the user greeting in email templates, a sensible default has been set.

## Change Record
*[Required if applicable] If this Pull Request changes the way that developers should do things or introduces a new API for developers then a change record to document this is needed. Please provide a draft for a change record or a link to an unpublished change record below. Existing change records can be consulted as example. Please provide a draft for a change record or a link to an unpublished change record below. [Existing change records](https://www.drupal.org/list-changes/social) can be consulted as example.*

## Translations
*[Optional]Translatable strings are always extracted from the latest development branch. To ensure translations remain available for platforms running older versions of Open Social the original string should be added to `translations.php` when it's changed or removed.*
- [ ] Changed or removed source strings are added to the `translations.php` file.
