### PR TITLE
Internal: Rewrite the group edit group type test

### DIFF
--- a/tests/behat/features/bootstrap/GroupContext.php
+++ b/tests/behat/features/bootstrap/GroupContext.php
@@ -429,6 +429,38 @@ class GroupContext extends RawMinkContext {
   }
 
   /**
+   * Assert we're on the group page.
+   *
+   * Can be used to check that a redirect was implemented correctly.
+   *
+   * @Then I should be viewing the group :group
+   * @Then should be viewing the group :group
+   */
+  public function shouldBeViewingGroup(string $group) : void {
+    $group_id = $this->getNewestGroupIdFromTitle($group);
+    if ($group_id === NULL) {
+      throw new \Exception("Group '${group}' does not exist.");
+    }
+    $this->assertSession()->statusCodeEquals(200);
+    // We may need to change the path here since the default group page is
+    // configurable.
+    $this->assertSession()->addressEquals("/group/${group_id}/about");
+  }
+
+  /**
+   * Edit a specific group.
+   *
+   * This mirrors editingTopic even though we already have viewPageInGroup which
+   * could be used. A little duplication makes easier test writing.
+   *
+   * @When I am editing the group :group
+   * @When am editing the group :group
+   */
+  public function editingGroup(string $group) : void {
+    $this->viewPageInGroup("edit", $group);
+  }
+
+  /**
    * Open the group on a specific page.
    *
    * @When I am viewing the :group_page page of group :group

--- a/tests/behat/features/bootstrap/SocialMinkContext.php
+++ b/tests/behat/features/bootstrap/SocialMinkContext.php
@@ -136,6 +136,9 @@ class SocialMinkContext extends MinkContext {
 
   /**
    * @Then I should see checked the box :checkbox
+   *
+   * @todo This doesn't actually check that the radio button is visible for the
+   *   user, e.g. it may be hidden in a closed details element.
    */
   public function iShouldSeeCheckedTheBox($checkbox) {
     $checkbox = $this->fixStepArgument($checkbox);


### PR DESCRIPTION
## Problem
This test was failing randomly in some of our automated testing with an unclear reason.

## Solution
The rewrite aims to have the same coverage but uses some of our new testing primitives introduced in the flexible groups rewrite to make the test more compact and readable. We also add a new assertion to properly expand the settings tab that contains the group type settings field which should ensure the test no longer fails randomly.

Some future optimizations remain and I'm not entirely happy with the fact we have multiple assertions in a single test, but I couldn't figure out how to achieve the same coverage in separate tests.

## Issue tracker
Internal test change no issue

## How to test
- [ ] CI should pass
- [ ] Check that the coverage indeed remains the same

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status
