### PR TITLE
Issue #3325955 by navneet0693: Profile pictures missing on landing page content type.

### DIFF
--- a/modules/social_features/social_profile/social_profile.module
+++ b/modules/social_features/social_profile/social_profile.module
@@ -714,9 +714,12 @@ function social_profile_profile_view_alter(array &$build, EntityInterface $entit
   /** @var \Drupal\Core\Session\AccountProxy $current_user */
   $current_user = \Drupal::currentUser();
 
-  // If the current user has no access to viewing user profiles, it might not
-  // have access to the users profile.
-  if (!$current_user->hasPermission('view any profile profile') && isset($display->get('content')['field_profile_image'])) {
+  // If the current user is anonymous, it means it does not have access to the
+  // users profile.
+  if ($current_user->isAnonymous() &&
+    isset($display->get('content')['field_profile_image'])
+  ) {
+
     // Try to load the profile picture.
     $image = $entity->get('field_profile_image')->entity;
 
@@ -724,7 +727,8 @@ function social_profile_profile_view_alter(array &$build, EntityInterface $entit
     if ($image instanceof FileInterface) {
       // Potentially the file is in the private file system. In that case,
       // anonymous user don't have access to it.
-      if (!$image->access('view', $current_user)) {
+      $file_scheme = \Drupal::service('stream_wrapper_manager')->getScheme($image->getFileUri());
+      if ($file_scheme === 'private') {
         // Load default data.
         $replacement_data = social_profile_get_default_image();
         // Time to override the data that going to be rendered.


### PR DESCRIPTION
## Problem
The user images were not being displayed on the when profile entity is somehow added to landing_page content type, for example, having a featured section in a landing page having profile entity display.

## Solution

1. https://github.com/goalgorilla/open_social/blob/main/modules/social_features/social_profile/social_profile.module#L727 called for access check on File entity.
2. This called https://git.drupalcode.org/project/drupal/-/blob/9.5.x/core/modules/file/src/FileAccessControlHandler.php#L21
3. In the function mentioned above, the `$entity_and_field_access = $referencing_entity->access('view', $account, TRUE)->andIf($referencing_entity->$field_name->access('view', $account, TRUE));` resulted in `AccessResultAllowed`
4. This line checked for access on both **File** `$referencing_entity->$field_name->access('view', $account, TRUE)` and **Profile** `$referencing_entity->access('view', $account, TRUE)`
5. Now, File access check returned false but Profile access check returned TRUE which shouldn’t be the access as our user is anonymous.
6. On further digging, Profile entity access check was passed through https://git.drupalcode.org/project/drupal/-/blob/9.5.x/core/lib/Drupal/Core/Entity/EntityAccessControlHandler.php#L61
7. This called for invoking of alter hooks in `$this->moduleHandler()->invokeAll('entity_access', [$entity, $operation, $account])` and `$this->moduleHandler()->invokeAll($entity->getEntityTypeId() . '_access', [$entity, $operation, $account])`
8. We have written `social_profile_profile_access` which was introduced in
https://github.com/goalgorilla/open_social/pull/2224
9. This checked for current node type and provided access for profiles to anonymous users.
10. This made the statement mentioned in step 3 return “Allowed” instead of “Neutral” which then failed in the https://github.com/goalgorilla/open_social/blob/main/modules/social_features/social_profile/social_profile.module#L727
11. On **landing_page**, where this code mentioned in `social_profile_profile_access` is called and due to which the reported behavior is seen.
12. So, we added checks on basis of current user status and file system to avoid this conflict.

## Issue tracker
https://www.drupal.org/project/social/issues/3325955

## Theme issue tracker
N.A

## How to test
- [x] Using the latest version of Open Social with the social_landing_page and ~~social_private_file~~ social_file_private modules enabled
- [x] Define `$settings['file_private_path']` in settings.php
- [x] As a site manager, create a landing page, add "featured content" section and select any profile entities
- [x] When I open the created page as anonymous I expect to see added profiles with default profile images shown.

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [x] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [x] All automated tests are green
- [x] Functional/manual tests of the acceptance criteria are approved
- [x] All acceptance criteria were met
- [x] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [x] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [x] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [x] This pull request has all required labels (team/type/priority)
- [x] This pull request has a milestone
- [x] This pull request has an assignee (if applicable)
- [x] Any front end changes are tested on all major browsers
- [x] New UI elements, or changes on UI elements are approved by the design team
- [x] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
N.A

## Release notes
When the website was using private file, then the profile images appear to be broken on landing pages for Anonymous users, if a featured content or a stream view was added. We resolved the access problem for anonymous users and now the default profile picture will be displayed.

## Change Record
N.A

## Translations
N.A