### PR TITLE
Internal: Increase dependabot open PR limit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,5 +36,5 @@ updates:
     commit-message:
       prefix: "Updates: "
       include: "scope"
-    # Allow up to 5 open pull requests for Drupal dependencies as we have some to go.
-    open-pull-requests-limit: 10
+    # Control the maxmimum number of pull requests dependabot is allowed to have open
+    open-pull-requests-limit: 100


### PR DESCRIPTION


## Problem / Solution
We've made improvements to the stability of our tests which should make it a lot easier to review whether a dependabot PR can be merged quickly or requires a larger amount of work.

We increase the number of dependabot PRs that are allowed to be open so it's easier to see which module updates we can easily perform.

## Issue tracker
Internal issue no change

## How to test
- [ ] Dependabot should run? 🤷‍♂️ 

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status
