### PR TITLE
Internal: Modify ChromeDriver to fix CKEditor race condition

### DIFF
--- a/tests/behat/behat.yml
+++ b/tests/behat/behat.yml
@@ -34,7 +34,7 @@ default:
         - Drupal\social\Behat\ThemeContext
         - Drupal\social\Behat\TopicContext
   extensions:
-    DMore\ChromeExtension\Behat\ServiceContainer\ChromeExtension: ~
+    Drupal\social\Behat\Chrome\ChromeExtension: ~
     Drupal\MinkExtension:
       base_url: 'http://web'
       files_path: '%paths.base%/features'

--- a/tests/behat/features/bootstrap/Chrome/ChromeDriver.php
+++ b/tests/behat/features/bootstrap/Chrome/ChromeDriver.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\social\Behat\Chrome;
+
+use DMore\ChromeDriver\ChromeDriver as ChromeDriverBase;
+
+/**
+ * Contains Open Social specific modifications to the Chrome Driver.
+ */
+class ChromeDriver extends ChromeDriverBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function visit($url) {
+    parent::visit($url);
+    // We overwrite the visit method because Open Social uses the CKEditor on
+    // some pages. The editor waits until the page is loaded similarly to our
+    // Behat driver. This can cause a race condition between the CKEditor and
+    // our driver, which may cause the driver to calculate a position for an
+    // element and have that position change before the driver interacts with it
+    // causing random test failures.
+    //
+    // Ideally we'd put this overwrite in our test contexts but since the test
+    // context method exists in RawMinkContext and is used through various
+    // routes of inheritance, it's easier to tackle this at the driver level and
+    // ensure we actually handle all page visits.
+    //
+    // To solve the race condition we add a snippet of JavaScript code here that
+    // lets us wait for all CKEditors to indicate they're ready if there are any
+    // on the page.
+    do {
+      $attempts = ($attempts ?? 0) + 1;
+      $ready = $this->evaluateScript(<<<JS
+        // If there's no CKEditor on this page then we're done immediately.
+        if (typeof CKEDITOR === "undefined") {
+          return true;
+        }
+
+        // Find any instance that is not in a state where they're not performing
+        // any work.
+        for (const instance of Object.values(CKEDITOR.instances)) {
+          if (instance.status !== "ready" && instance.status !== "destroyed") {
+            return false;
+          }
+        }
+
+        // If we get here all instances on the page (if any) were in a state
+        // where they were no longer making changes to the page.
+        return true;
+      JS);
+      // Keep checking if the instances are ready until they are.
+      // We cap the number of attempts to avoid creating an infinite loop.
+    } while (!$ready && $attempts <= 100);
+
+    // It's not necessarily a problem if editors aren't ready on the page but
+    // we'd rather fail our test and improve the above logic or the page loading
+    // than to silently have flakey tests.
+    if (!$ready) {
+      $path = $this->getCurrentUrl();
+      throw new \RuntimeException("Found CKEditor instances on the page ($path) but they were not ready sufficiently quickly after page load which could cause tests to randomly fail in future steps, aborting.");
+    }
+  }
+
+}

--- a/tests/behat/features/bootstrap/Chrome/ChromeExtension.php
+++ b/tests/behat/features/bootstrap/Chrome/ChromeExtension.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\social\Behat\Chrome;
+
+use Behat\Testwork\ServiceContainer\ExtensionManager;
+use DMore\ChromeExtension\Behat\ServiceContainer\ChromeExtension as ChromeExtensionBase;
+
+/**
+ * Overwrites DMore/../ChromeExtension to load our adapted driver.
+ */
+class ChromeExtension extends ChromeExtensionBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function initialize(ExtensionManager $extensionManager) {
+    // Must be kept in sync with parent::iniitalize but use our own factory.
+    if (null !== $minkExtension = $extensionManager->getExtension('mink')) {
+      /** @var $minkExtension \Behat\MinkExtension\ServiceContainer\MinkExtension */
+      $minkExtension->registerDriverFactory(new ChromeFactory());
+    }
+  }
+
+}

--- a/tests/behat/features/bootstrap/Chrome/ChromeFactory.php
+++ b/tests/behat/features/bootstrap/Chrome/ChromeFactory.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\social\Behat\Chrome;
+
+use Behat\MinkExtension\ServiceContainer\Driver\DriverFactory;
+use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
+use Symfony\Component\DependencyInjection\Definition;
+
+/**
+ * Rewrites DMore/../ChromeFactory to load our adapted driver.
+ *
+ * Unfortunately we must copy and keep in sync the entire factory since the
+ * class is marked as final.
+ *
+ * If we can find an easy way to adapt `buildDriver` and change the class of
+ * the definition provided to
+ * \Behat\MinkExtension\ServiceContainer\MinkExtension then we can remove this
+ * class.
+ */
+final class ChromeFactory implements DriverFactory {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getDriverName() {
+    return 'chrome';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function configure(ArrayNodeDefinition $builder) {
+    $builder->children()
+      ->scalarNode('api_url')->end()
+      ->booleanNode('validate_certificate')->defaultTrue()->end()
+      ->enumNode('download_behavior')
+      ->values(['allow', 'default', 'deny'])->defaultValue('default')->end()
+      ->scalarNode('download_path')->defaultValue('/tmp')->end()
+      ->integerNode('socket_timeout')->defaultValue(10)->end()
+      ->integerNode('dom_wait_timeout')->defaultValue(3000)->end()
+      ->end();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildDriver(array $config) {
+    $validateCert = isset($config['validate_certificate']) ? $config['validate_certificate'] : TRUE;
+    $socketTimeout = $config['socket_timeout'];
+    $domWaitTimeout = $config['dom_wait_timeout'];
+    $downloadBehavior = $config['download_behavior'];
+    $downloadPath = $config['download_path'];
+    return new Definition(ChromeDriver::class, [
+      $this->resolveApiUrl($config['api_url']),
+      NULL,
+      '%mink.base_url%',
+      [
+        'validateCertificate' => $validateCert,
+        'socketTimeout' => $socketTimeout,
+        'domWaitTimeout' => $domWaitTimeout,
+        'downloadBehavior' => $downloadBehavior,
+        'downloadPath' => $downloadPath,
+      ]
+    ]);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function supportsJavascript() {
+    return TRUE;
+  }
+
+  private function resolveApiUrl($url) {
+    $host = parse_url($url, PHP_URL_HOST);
+
+    if (filter_var($host, FILTER_VALIDATE_IP)) {
+      return $url;
+    }
+
+    return str_replace($host, gethostbyname($host), $url);
+  }
+}


### PR DESCRIPTION
## Problem
We've had flaky tests in our test suite for a long time but never quite knew why.

A current working theory is that it might be caused by a race condition between our usage of CKEditor and the way the Behat ChromeDriver (and potentially other Behat drivers) click on elements.

To make sure page rendering is not blocked the CKEditor will wait with loading itself until the page is ready. Similarly when visiting a page the Behat ChromeDriver will wait with further test steps until a page is loaded. This means that CKEditor starts its initialization at the same time that test steps after visiting a page are resumed.

The ChromeDriver click implementation is performed by sending instructions to the browser to move the mouse to a specific location and then sending a mouse down event. This method is preferred over e.g. executing JavaScript with `element.click()` because events originating in JavaScript are treated with less trust than those initiated by the browser and thus may be interpreted differently by scripts running in our application. However, to find this specific location the browser must still access the DOM for which it executes a snippet of JavaScript that finds the x and y coordinates to send the click event to.

The race condition can then occur when the steps after a page visit are such that a "click" step in some form occurs almost instantly. This can cause the CKEditor code the complete its loading in the moment between the script execution finding the coordinates to click and the driver actually sending a mouse click event for that position. When the CKEditor completes loading it renders its toolbar which causes the layout of the page to shift slightly. This may cause the determined click position to become invalidated and make it "miss" the desired element.

This theory matches with observed behavior of failing tests where a failure often came directly after some kind of press (e.g. pressing "Save" on a content edit page). In other instances the test failure would have come later but in the observed cases the failing step was still the first step that would actually use the results of the missed button press some steps earlier.

## Solution
With our current knowledge we believe the CKEditor is the culprit in the majority of our flaky test failures. To ensure the page doesn't shift we must wait after a page visit to ensure the CKEditor is done loading and the page won't shift around.

We could add an "I wait X seconds" after every step that switches pages. However, this may not be enough time, or it may be way too much time. Similarly there may not be a CKEditor on the page which makes the waiting unneccessary altogether. Finally this solution would be prone to re-introducing the issue as we expand or modify our tests.

An alternative is to add this logic to our test Context's which would be desirable since this is a limitation caused by our application and our test contexts are there to help our test steps properly interface with our application. However, the `visit` method which would be the best candidate lives in `RawMinkContext`. This method is then called through many different inheritance routes that would require many classes to be extended and modified.

Since the Context route is infeasible we go one level deeper. All `visit` calls in contexts will eventually delegate to the driver. Thus we modify the driver's visit mechanism to run a script that checks, once the page is loaded, whether CKEditor is on the page. It will then check if all instances of the CKEditor are ready. If this is not the case it will re-attempt this check some times, assuming the time needed for communication between Behat and the browser should be enough for CKEditor to finish its set-up. If after those tries CKEditor is still not ready we will abort the test altogether. The idea here is that it's preferred to consistently fail at this stage and allow a developer to find a solution than to continue and perhaps lose time to debugging.

## Issue tracker
Internal change, no issue

## How to test
Racing conditions are inherently difficult to test. If this fixes our problem I would expect the entire test suite to pass in one go. If this PR requires re-runs of individual tests then we probably haven't fixed the problem completely.

The idea of the above is that with running all tests there's a higher chance one will run into the race condition, and just rerunning one test is very unlikely to catch the race condition.

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status
