### PR TITLE
Issue #3174548 - revert - Disable the reliance on graphql_oauth as it breaks current implementations

### DIFF
--- a/modules/custom/social_graphql/social_graphql.info.yml
+++ b/modules/custom/social_graphql/social_graphql.info.yml
@@ -4,6 +4,5 @@ type: module
 core_version_requirement: ^9
 dependencies:
   - graphql:graphql
-  - graphql_oauth:graphql_oauth
 package: Social (Experimental)
 hidden: true

--- a/modules/custom/social_graphql/src/Plugin/GraphQL/Schema/OpenSocialBaseSchema.php
+++ b/modules/custom/social_graphql/src/Plugin/GraphQL/Schema/OpenSocialBaseSchema.php
@@ -34,21 +34,6 @@ class OpenSocialBaseSchema extends SdlSchemaPluginBase {
   /**
    * {@inheritdoc}
    */
-  protected function getExtensions(): array {
-    $extensions = parent::getExtensions();
-    // Enable OAuth related directives in our schema.
-    $oauth_extension_plugin_id = 'graphql_oauth_schema_extension';
-    if (!isset($extensions[$oauth_extension_plugin_id])) {
-      /** @var \Drupal\graphql\Plugin\SchemaExtensionPluginInterface $plugin */
-      $plugin = $this->extensionManager->createInstance($oauth_extension_plugin_id);
-      $extensions[$oauth_extension_plugin_id] = $plugin;
-    }
-    return $extensions;
-  }
-
-  /**
-   * {@inheritdoc}
-   */
   public function getResolverRegistry() {
     return new ResolverRegistry();
   }

--- a/modules/custom/social_graphql/tests/src/Kernel/SocialGraphQLTestBase.php
+++ b/modules/custom/social_graphql/tests/src/Kernel/SocialGraphQLTestBase.php
@@ -20,7 +20,6 @@ abstract class SocialGraphQLTestBase extends GraphQLTestBase {
    */
   protected static $modules = [
     "entity",
-    "graphql_oauth",
     "social_graphql",
   ];
 


### PR DESCRIPTION
## Problem
We add a new dependency graphql_oauth:graphql_oauth but with a few flaws
- No update hook, so /graphql will now break because the plugin is missing
- Enabling the plugin will break as it enables simple_oauth without configuration, so no private keys etc. and this gives an error message with native app as that one relies on oauth2_server

## Solution
Revert the change to we can properly implement it on a later stage.

## Issue tracker
https://www.drupal.org/project/social/issues/3174548#comment-14772998

## How to test
- [ ] Update from OS 11.3.x to 11.4.x(or later) where social_graphql is enabled
- [ ] Go to /graphql and see wsod
- [ ] Enabled the graphql_oauth and notice it will still break because no key has been set for simple_oauth

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Release notes
Reverted a change where graphql_oauth dependency was added incorrectly, and adds new settings that are not being configured correctly without manual steps.

## Change record
We reverted the graphql_oauth dependency from our code until it gets fixed properly. However this means that whoever had simple_oauth enables because of this needs to uninstall it manually. This because we cannot assume that we are the only ones who are using this module and don't want to break open source installation that might have it enabled for other purposes.
