### PR TITLE
Internal: Make Open Social Dev compatible with 10.x

### DIFF
--- a/.github/workflows/behat.yml
+++ b/.github/workflows/behat.yml
@@ -70,11 +70,15 @@ jobs:
         working-directory: /var/www
 
     steps:
-      # Checkout Drupal Social.
       - uses: actions/checkout@v3
         with:
-          repository: 'goalgorilla/drupal_social'
-          ref: '6.2.0'
+          path: ${{ github.workspace }}/tmp
+
+      # Checkout Drupal Social.
+      - name: Prepare composer
+        run: |
+          cp tmp/tests/composer.json composer.json
+          rm -r tmp
 
       # Install the version of Open Social under test.
       - name: Composer require current branch

--- a/tests/composer.json
+++ b/tests/composer.json
@@ -22,7 +22,7 @@
     },
     "require": {},
     "require-dev": {
-        "goalgorilla/open_social_dev": "dev-main"
+        "goalgorilla/open_social_dev": "~1.0.0"
     },
     "repositories": [
         {


### PR DESCRIPTION
## Problem
We want to do upgrade path testing in #3138 but that has some other problems that are related to Open Social 10. This draft PR exists to show that https://github.com/goalgorilla/open_social_dev/pull/44 is otherwise fine and the removal of `drupal/core-dev` has no adverse effects on the Open Social test suite.

When this is green then the open_social_dev PR can be merged and tagged as stable version which allows this repository to use tagged versions rather than `dev-main`.
