### PR TITLE
Issue #3329802 by navneet0693: Organization tags display doesn't respect current language

### DIFF
--- a/modules/social_features/social_profile/modules/social_profile_organization_tag/social_profile_organization_tag.module
+++ b/modules/social_features/social_profile/modules/social_profile_organization_tag/social_profile_organization_tag.module
@@ -98,9 +98,16 @@ function social_profile_organization_tag_fetch(Profile $profile, $return_html = 
           if ($return_html === TRUE) {
             $value = '<span class="profile-organization-tag">&nbsp;<span class="text">@org</span></span>';
           }
-          $arguments = [
-            '@org' => $organization->label(),
-          ];
+          if (\Drupal::languageManager()->isMultilingual()) {
+            $arguments = [
+              '@org' => $organization->getTranslation(\Drupal::languageManager()->getCurrentLanguage()->getId())->label(),
+            ];
+          }
+          else {
+            $arguments = [
+              '@org' => $organization->label(),
+            ];
+          }
           return new FormattableMarkup($value, $arguments);
         }
       }

--- a/modules/social_features/social_profile/modules/social_profile_organization_tag/social_profile_organization_tag.module
+++ b/modules/social_features/social_profile/modules/social_profile_organization_tag/social_profile_organization_tag.module
@@ -87,29 +87,30 @@ function social_profile_organization_tag_tokens_alter(array &$replacements, arra
  * Function that fetches the extra organizational info for a profile.
  */
 function social_profile_organization_tag_fetch(Profile $profile, $return_html = TRUE) {
-  if ($profile instanceof Profile) {
-    if (!$profile->get('field_profile_organization_tag')->isEmpty()) {
-      $organization_tag = $profile->get('field_profile_organization_tag');
-      $organization_tag_entities = $organization_tag->referencedEntities();
-      if (count($organization_tag_entities) === 1) {
-        /** @var \Drupal\taxonomy\Entity\Term $organization */
-        foreach ($organization_tag_entities as $organization) {
-          $value = t('from @org');
-          if ($return_html === TRUE) {
-            $value = '<span class="profile-organization-tag">&nbsp;<span class="text">@org</span></span>';
-          }
-          if (\Drupal::languageManager()->isMultilingual()) {
+  if (!$profile->get('field_profile_organization_tag')->isEmpty()) {
+    $organization_tag = $profile->get('field_profile_organization_tag');
+    $organization_tag_entities = $organization_tag->referencedEntities();
+    if (count($organization_tag_entities) === 1) {
+      /** @var \Drupal\taxonomy\Entity\Term $organization */
+      foreach ($organization_tag_entities as $organization) {
+        $value = t('from @org');
+        if ($return_html === TRUE) {
+          $value = '<span class="profile-organization-tag">&nbsp;<span class="text">@org</span></span>';
+        }
+        $arguments = [
+          '@org' => $organization->label(),
+        ];
+        if (\Drupal::languageManager()->isMultilingual()) {
+          try {
             $arguments = [
               '@org' => $organization->getTranslation(\Drupal::languageManager()->getCurrentLanguage()->getId())->label(),
             ];
           }
-          else {
-            $arguments = [
-              '@org' => $organization->label(),
-            ];
+          catch (InvalidArgumentException $exception) {
+            \Drupal::logger('social_profile_organization_tag')->info($exception->getMessage());
           }
-          return new FormattableMarkup($value, $arguments);
         }
+        return new FormattableMarkup($value, $arguments);
       }
     }
   }


### PR DESCRIPTION
## Problem
On multilingual website the organization tags on the profile stream page are displayed in the default language instead of current language. The yellow marker contains the tag name in language which doesn't matches the current language or user's preferred language.

**Steps to reproduce**
1. Install Open Social
2. Enable social content language module and configure more than one languages.
3. Enable social profile organization tags module
4. Add profile tags and also add translations for them
5. Edit a profile and add the organization tag to it
6. Visit the profile.
7. Regardless of the current language selected, the yellow marker tooltip will show the organization tag in default language only.

## Solution
Add conditions to check if the website is multilingual and then fetch the correct translation of term here https://github.com/goalgorilla/open_social/blob/11.1.16/modules/social_features/social_profile/modules/social_profile_organization_tag/social_profile_organization_tag.module#L103

## Issue tracker
https://www.drupal.org/project/social/issues/3329802

## Theme issue tracker
N.A

## How to test
- [ ] Using latest version of Open Social with the social content translations and social profile organization tag module enabled
- [ ] Enable more than one language on the website
- [ ] As a sitemanager
- [ ] Add terms in profile organization tag vocab and translate them
- [ ] Edit a profile or add a profile with one of the organization tag
- [ ] Visit the profile in all the languages configured
- [ ] You should be able to see correct language in yellow marker tooltip.

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
**Before**
![Screenshot 2022-12-27 at 5 01 07 PM](https://user-images.githubusercontent.com/8435994/209662423-d946da4d-2086-4699-b94f-7e9314026c6c.png)

**After**
![Screenshot 2022-12-27 at 5 02 10 PM](https://user-images.githubusercontent.com/8435994/209662455-c5d9a762-cb2c-4ab5-9085-a43664463cac.png)


## Release notes
The organization tags on the profile were not appearing in correct language on a multilingual website. We did some magic to display them in correct language.

## Change Record
N.A

## Translations
N.A