### PR TITLE
Issue #3330544 by nkoporec: Social follow taxonomy popup doesn't appear

### DIFF
--- a/modules/social_features/social_follow_taxonomy/modules/social_follow_tag/social_follow_tag.module
+++ b/modules/social_features/social_follow_taxonomy/modules/social_follow_tag/social_follow_tag.module
@@ -45,7 +45,7 @@ function social_follow_tag_theme() {
 /**
  * Implements hook_module_implements_alter().
  */
-function social_follow_tag_module_implements_alter(&$implementations, $hook): void {
+function social_follow_tag_module_implements_alter(array &$implementations, string $hook): void {
   switch ($hook) {
     // Move our hook_theme() implementation to the end of the list.
     case 'theme':

--- a/modules/social_features/social_follow_taxonomy/modules/social_follow_tag/social_follow_tag.module
+++ b/modules/social_features/social_follow_taxonomy/modules/social_follow_tag/social_follow_tag.module
@@ -43,6 +43,20 @@ function social_follow_tag_theme() {
 }
 
 /**
+ * Implements hook_module_implements_alter().
+ */
+function social_follow_tag_module_implements_alter(&$implementations, $hook): void {
+  switch ($hook) {
+    // Move our hook_theme() implementation to the end of the list.
+    case 'theme':
+      $group = $implementations['social_follow_tag'];
+      unset($implementations['social_follow_tag']);
+      $implementations['social_follow_tag'] = $group;
+      break;
+  }
+}
+
+/**
  * Implements hook_social_follow_taxonomy_terms_list_alter().
  *
  * {@inheritdoc}


### PR DESCRIPTION
## Problem
When the social_follow_tag and social_follow_taxonomy modules are enabled, it should show a popup when you click on a tag that is used in a topic/node. I enabled both of the modules but when I click on the tag, nothing happens, the page simply reloads.

## Solution
The problem is that social_follow_tag overrides the default template of social_tagging via the hook_theme, and there is no dependency on social_tagging, so it could happen that the module weight is set before the social_tagging one, this causes the hook_theme is executed before social_tagging, so effectively the template is not overridden. We need to make sure that we always execute the hook_theme after social_tagging.


## Issue tracker
https://www.drupal.org/project/social/issues/3330544

## Theme issue tracker
*[Required if applicable] Paste a link to the drupal.org theme issue queue item, either from [socialbase](https://www.drupal.org/project/socialbase) or [socialblue](https://www.drupal.org/project/socialblue). If any other issue trackers were used, include links to those too.*

## How to test
1. Enable social_follow_tag and social_follow_taxonomy
2. Make sure its module weight is before social_tagging, so set the social_tagging to module weight 1 and social_follow_tag and social_follow_taxonomy to 0.
3. Create tags and content with these tags set.
4. Go to this node and try to click the content tag.


## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
https://monosnap.com/file/ULizq9UzrOTfLhpoBIPPMq2Sr9Vuul

## Release notes
Fixed a bug where social_follow_tag popup didn't appear due to the module weight.

## Change Record
*[Required if applicable] If this Pull Request changes the way that developers should do things or introduces a new API for developers then a change record to document this is needed. Please provide a draft for a change record or a link to an unpublished change record below. Existing change records can be consulted as example. Please provide a draft for a change record or a link to an unpublished change record below. [Existing change records](https://www.drupal.org/list-changes/social) can be consulted as example.*

## Translations
*[Optional]Translatable strings are always extracted from the latest development branch. To ensure translations remain available for platforms running older versions of Open Social the original string should be added to `translations.php` when it's changed or removed.*
- [ ] Changed or removed source strings are added to the `translations.php` file.
