### PR TITLE
Internal: Remove redundant highlight dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -177,7 +177,6 @@
         "npm-asset/bootstrap": "v3.4.1",
         "npm-asset/d3": "v3.5.17",
         "npm-asset/diff": "^3.5",
-        "npm-asset/highlight.js": "~9.15.6",
         "npm-asset/jquery.caret": "^0.3.1",
         "npm-asset/jquery-ui-touch-punch": "^0.2.3",
         "npm-asset/lazysizes": "^5.3",


### PR DESCRIPTION
## Problem
The library `npm-asset/highlight.js` is not used by Open Social but it is mentioned as requirement in composer.json

## Solution
Remove the redundant library.

## Issue tracker
N.A

## Theme issue tracker
N.A

## How to test
- [ ] All checks should pass.

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
N.A

## Release notes
N.A

## Change Record
N.A

## Translations
N.A