### PR TITLE
Issue #3157094 and #3232246 by Kingdutch: Fix Message entity handling in activity system

### DIFF
--- a/modules/custom/activity_creator/activity_creator.module
+++ b/modules/custom/activity_creator/activity_creator.module
@@ -68,11 +68,16 @@ function activity_creator_message_insert(Message $entity) {
   $message_template_id = $entity->getTemplate()->id();
   $actor = $entity->getOwner()->id();
 
-  // If one field of field_message_context, field_message_destination or
+  // Messages that are not part of the activity system may not have the fields
+  // we need. Similarly for our activity system we always ensure they are all
+  // filled thus if one of field_message_context, field_message_destination or
   // field_message_related_object is empty, don't create activities.
   if (
+    !$entity->hasField('field_message_context') ||
     $entity->get('field_message_context')->isEmpty() ||
+    !$entity->hasField('field_message_destination') ||
     $entity->get('field_message_destination')->isEmpty() ||
+    !$entity->hasField('field_message_related_object') ||
     $entity->get('field_message_related_object')->isEmpty()
   ) {
     return;

--- a/modules/custom/activity_logger/activity_logger.install
+++ b/modules/custom/activity_logger/activity_logger.install
@@ -5,6 +5,8 @@
  * Installation code for the activity_logger module.
  */
 
+use Drupal\message\Entity\MessageTemplate;
+
 /**
  * Implements hook_update_dependencies().
  */
@@ -72,5 +74,66 @@ function activity_logger_update_10301() {
     }
     $config->set('third_party_settings.activity_logger', $activity_logger_settings);
     $config->save();
+  }
+}
+
+/**
+ * Create activity fields for supporting templates.
+ */
+function activity_logger_update_11001() : void {
+  $fields = [
+    ['name' => 'field_message_context', 'type' => 'list_string'],
+    ['name' => 'field_message_destination', 'type' => 'list_string'],
+    [
+      'name' => 'field_message_related_object',
+      'type' => 'dynamic_entity_reference',
+    ],
+  ];
+  $config_storage = \Drupal::entityTypeManager()->getStorage('field_config');
+
+  // We assume there are about 100 message templates even in the case of very
+  // complex sites. They're also relatively simple entities, so it's safe to
+  // load them all.
+  $message_templates = MessageTemplate::loadMultiple();
+  foreach ($message_templates as $message_template) {
+    if (empty($message_template->getThirdPartySettings('activity_logger'))) {
+      continue;
+    }
+    $message_type = $message_template->id();
+    foreach ($fields as $field) {
+      $id = 'message.' . $message_type . '.' . $field['name'];
+      if ($config_storage->load($id) === NULL) {
+        $field_instance = [
+          'langcode' => 'en',
+          'status' => TRUE,
+          'config' => [
+            'field.storage.message.' . $field['name'],
+            'message.template.' . $message_type,
+          ],
+          'module' => ['options'],
+          'id' => $id,
+          'field_name' => $field['name'],
+          'entity_type' => 'message',
+          'bundle' => $message_type,
+          'label' => '',
+          'description' => '',
+          'required' => FALSE,
+          'translatable' => FALSE,
+          'default_value' => [],
+          'default_value_callback' => '',
+          'field_type' => $field['type'],
+        ];
+
+        if ($field['type'] === 'list_string') {
+          $field_instance['module'] = ['options'];
+          $field_instance['settings'] = [];
+        }
+        elseif ($field['type'] === 'dynamic_entity_reference') {
+          $field_instance['module'] = ['dynamic_entity_reference'];
+          $field_instance['settings'] = [];
+        }
+        $config_storage->create($field_instance)->save();
+      }
+    }
   }
 }

--- a/modules/custom/social_queue_storage/config/install/field.field.message.background_process_finished.field_message_context.yml
+++ b/modules/custom/social_queue_storage/config/install/field.field.message.background_process_finished.field_message_context.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.message.field_message_context
+    - message.template.background_process_finished
+  module:
+    - options
+id: message.background_process_finished.field_message_context
+field_name: field_message_context
+entity_type: message
+bundle: background_process_finished
+label: field_message_context
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/modules/custom/social_queue_storage/config/install/field.field.message.background_process_finished.field_message_destination.yml
+++ b/modules/custom/social_queue_storage/config/install/field.field.message.background_process_finished.field_message_destination.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.message.field_message_destination
+    - message.template.background_process_finished
+  module:
+    - options
+id: message.background_process_finished.field_message_destination
+field_name: field_message_destination
+entity_type: message
+bundle: background_process_finished
+label: field_message_destination
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/modules/custom/social_queue_storage/config/install/field.field.message.background_process_finished.field_message_related_object.yml
+++ b/modules/custom/social_queue_storage/config/install/field.field.message.background_process_finished.field_message_related_object.yml
@@ -1,0 +1,89 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.message.field_message_related_object
+    - message.template.background_process_finished
+  module:
+    - dynamic_entity_reference
+id: message.background_process_finished.field_message_related_object
+field_name: field_message_related_object
+entity_type: message
+bundle: background_process_finished
+label: field_message_related_object
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  activity:
+    handler: 'default:activity'
+    handler_settings: {  }
+  comment:
+    handler: 'default:comment'
+    handler_settings: {  }
+  node:
+    handler: 'default:node'
+    handler_settings: {  }
+  crop:
+    handler: 'default:crop'
+    handler_settings: {  }
+  block_content:
+    handler: 'default:block_content'
+    handler_settings: {  }
+  menu_link_content:
+    handler: 'default:menu_link_content'
+    handler_settings: {  }
+  event_enrollment:
+    handler: 'default:event_enrollment'
+    handler_settings: {  }
+  file:
+    handler: 'default:file'
+    handler_settings: {  }
+  flagging:
+    handler: 'default:flagging'
+    handler_settings: {  }
+  font:
+    handler: 'default:font'
+    handler_settings: {  }
+  group:
+    handler: 'default:group'
+    handler_settings: {  }
+  group_content:
+    handler: 'default:group_content'
+    handler_settings: {  }
+  mentions:
+    handler: 'default:mentions'
+    handler_settings: {  }
+  message:
+    handler: 'default:message'
+    handler_settings: {  }
+  post:
+    handler: 'default:post'
+    handler_settings: {  }
+  profile:
+    handler: 'default:profile'
+    handler_settings: {  }
+  search_api_task:
+    handler: 'default:search_api_task'
+    handler_settings: {  }
+  taxonomy_term:
+    handler: 'default:taxonomy_term'
+    handler_settings: {  }
+  user:
+    handler: 'default:user'
+    handler_settings: {  }
+  vote:
+    handler: 'default:vote'
+    handler_settings: {  }
+  vote_result:
+    handler: 'default:vote_result'
+    handler_settings: {  }
+  queue_storage_entity:
+    handler: 'default:queue_storage_entity'
+    handler_settings: {  }
+  path_alias:
+    handler: 'default:path_alias'
+    handler_settings: {  }
+field_type: dynamic_entity_reference

--- a/modules/social_features/social_activity/config/install/field.field.message.create_content_in_joined_group.field_message_context.yml
+++ b/modules/social_features/social_activity/config/install/field.field.message.create_content_in_joined_group.field_message_context.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.message.field_message_context
+    - message.template.create_content_in_joined_group
+  module:
+    - options
+id: message.create_content_in_joined_group.field_message_context
+field_name: field_message_context
+entity_type: message
+bundle: create_content_in_joined_group
+label: field_message_context
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/modules/social_features/social_activity/config/install/field.field.message.create_content_in_joined_group.field_message_destination.yml
+++ b/modules/social_features/social_activity/config/install/field.field.message.create_content_in_joined_group.field_message_destination.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.message.field_message_destination
+    - message.template.create_content_in_joined_group
+  module:
+    - options
+id: message.create_content_in_joined_group.field_message_destination
+field_name: field_message_destination
+entity_type: message
+bundle: create_content_in_joined_group
+label: field_message_destination
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/modules/social_features/social_activity/config/install/field.field.message.create_content_in_joined_group.field_message_related_object.yml
+++ b/modules/social_features/social_activity/config/install/field.field.message.create_content_in_joined_group.field_message_related_object.yml
@@ -1,0 +1,89 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.message.field_message_related_object
+    - message.template.create_content_in_joined_group
+  module:
+    - dynamic_entity_reference
+id: message.create_content_in_joined_group.field_message_related_object
+field_name: field_message_related_object
+entity_type: message
+bundle: create_content_in_joined_group
+label: field_message_related_object
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  activity:
+    handler: 'default:activity'
+    handler_settings: {  }
+  comment:
+    handler: 'default:comment'
+    handler_settings: {  }
+  node:
+    handler: 'default:node'
+    handler_settings: {  }
+  crop:
+    handler: 'default:crop'
+    handler_settings: {  }
+  block_content:
+    handler: 'default:block_content'
+    handler_settings: {  }
+  menu_link_content:
+    handler: 'default:menu_link_content'
+    handler_settings: {  }
+  event_enrollment:
+    handler: 'default:event_enrollment'
+    handler_settings: {  }
+  file:
+    handler: 'default:file'
+    handler_settings: {  }
+  flagging:
+    handler: 'default:flagging'
+    handler_settings: {  }
+  font:
+    handler: 'default:font'
+    handler_settings: {  }
+  group:
+    handler: 'default:group'
+    handler_settings: {  }
+  group_content:
+    handler: 'default:group_content'
+    handler_settings: {  }
+  mentions:
+    handler: 'default:mentions'
+    handler_settings: {  }
+  message:
+    handler: 'default:message'
+    handler_settings: {  }
+  post:
+    handler: 'default:post'
+    handler_settings: {  }
+  profile:
+    handler: 'default:profile'
+    handler_settings: {  }
+  search_api_task:
+    handler: 'default:search_api_task'
+    handler_settings: {  }
+  taxonomy_term:
+    handler: 'default:taxonomy_term'
+    handler_settings: {  }
+  user:
+    handler: 'default:user'
+    handler_settings: {  }
+  vote:
+    handler: 'default:vote'
+    handler_settings: {  }
+  vote_result:
+    handler: 'default:vote_result'
+    handler_settings: {  }
+  queue_storage_entity:
+    handler: 'default:queue_storage_entity'
+    handler_settings: {  }
+  path_alias:
+    handler: 'default:path_alias'
+    handler_settings: {  }
+field_type: dynamic_entity_reference

--- a/modules/social_features/social_activity/config/install/field.field.message.create_event_gc.field_message_context.yml
+++ b/modules/social_features/social_activity/config/install/field.field.message.create_event_gc.field_message_context.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.message.field_message_context
+    - message.template.create_event_gc
+  module:
+    - options
+id: message.create_event_gc.field_message_context
+field_name: field_message_context
+entity_type: message
+bundle: create_event_gc
+label: field_message_context
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/modules/social_features/social_activity/config/install/field.field.message.create_event_gc.field_message_destination.yml
+++ b/modules/social_features/social_activity/config/install/field.field.message.create_event_gc.field_message_destination.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.message.field_message_destination
+    - message.template.create_event_gc
+  module:
+    - options
+id: message.create_event_gc.field_message_destination
+field_name: field_message_destination
+entity_type: message
+bundle: create_event_gc
+label: field_message_destination
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/modules/social_features/social_activity/config/install/field.field.message.create_event_gc.field_message_related_object.yml
+++ b/modules/social_features/social_activity/config/install/field.field.message.create_event_gc.field_message_related_object.yml
@@ -1,0 +1,89 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.message.field_message_related_object
+    - message.template.create_event_gc
+  module:
+    - dynamic_entity_reference
+id: message.create_event_gc.field_message_related_object
+field_name: field_message_related_object
+entity_type: message
+bundle: create_event_gc
+label: field_message_related_object
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  activity:
+    handler: 'default:activity'
+    handler_settings: {  }
+  comment:
+    handler: 'default:comment'
+    handler_settings: {  }
+  node:
+    handler: 'default:node'
+    handler_settings: {  }
+  crop:
+    handler: 'default:crop'
+    handler_settings: {  }
+  block_content:
+    handler: 'default:block_content'
+    handler_settings: {  }
+  menu_link_content:
+    handler: 'default:menu_link_content'
+    handler_settings: {  }
+  event_enrollment:
+    handler: 'default:event_enrollment'
+    handler_settings: {  }
+  file:
+    handler: 'default:file'
+    handler_settings: {  }
+  flagging:
+    handler: 'default:flagging'
+    handler_settings: {  }
+  font:
+    handler: 'default:font'
+    handler_settings: {  }
+  group:
+    handler: 'default:group'
+    handler_settings: {  }
+  group_content:
+    handler: 'default:group_content'
+    handler_settings: {  }
+  mentions:
+    handler: 'default:mentions'
+    handler_settings: {  }
+  message:
+    handler: 'default:message'
+    handler_settings: {  }
+  post:
+    handler: 'default:post'
+    handler_settings: {  }
+  profile:
+    handler: 'default:profile'
+    handler_settings: {  }
+  search_api_task:
+    handler: 'default:search_api_task'
+    handler_settings: {  }
+  taxonomy_term:
+    handler: 'default:taxonomy_term'
+    handler_settings: {  }
+  user:
+    handler: 'default:user'
+    handler_settings: {  }
+  vote:
+    handler: 'default:vote'
+    handler_settings: {  }
+  vote_result:
+    handler: 'default:vote_result'
+    handler_settings: {  }
+  queue_storage_entity:
+    handler: 'default:queue_storage_entity'
+    handler_settings: {  }
+  path_alias:
+    handler: 'default:path_alias'
+    handler_settings: {  }
+field_type: dynamic_entity_reference

--- a/modules/social_features/social_activity/config/install/field.field.message.create_post_profile_stream.field_message_context.yml
+++ b/modules/social_features/social_activity/config/install/field.field.message.create_post_profile_stream.field_message_context.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.message.field_message_context
+    - message.template.create_post_profile_stream
+  module:
+    - options
+id: message.create_post_profile_stream.field_message_context
+field_name: field_message_context
+entity_type: message
+bundle: create_post_profile_stream
+label: field_message_context
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/modules/social_features/social_activity/config/install/field.field.message.create_post_profile_stream.field_message_destination.yml
+++ b/modules/social_features/social_activity/config/install/field.field.message.create_post_profile_stream.field_message_destination.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.message.field_message_destination
+    - message.template.create_post_profile_stream
+  module:
+    - options
+id: message.create_post_profile_stream.field_message_destination
+field_name: field_message_destination
+entity_type: message
+bundle: create_post_profile_stream
+label: field_message_destination
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/modules/social_features/social_activity/config/install/field.field.message.create_post_profile_stream.field_message_related_object.yml
+++ b/modules/social_features/social_activity/config/install/field.field.message.create_post_profile_stream.field_message_related_object.yml
@@ -1,0 +1,89 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.message.field_message_related_object
+    - message.template.create_post_profile_stream
+  module:
+    - dynamic_entity_reference
+id: message.create_post_profile_stream.field_message_related_object
+field_name: field_message_related_object
+entity_type: message
+bundle: create_post_profile_stream
+label: field_message_related_object
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  activity:
+    handler: 'default:activity'
+    handler_settings: {  }
+  comment:
+    handler: 'default:comment'
+    handler_settings: {  }
+  node:
+    handler: 'default:node'
+    handler_settings: {  }
+  crop:
+    handler: 'default:crop'
+    handler_settings: {  }
+  block_content:
+    handler: 'default:block_content'
+    handler_settings: {  }
+  menu_link_content:
+    handler: 'default:menu_link_content'
+    handler_settings: {  }
+  event_enrollment:
+    handler: 'default:event_enrollment'
+    handler_settings: {  }
+  file:
+    handler: 'default:file'
+    handler_settings: {  }
+  flagging:
+    handler: 'default:flagging'
+    handler_settings: {  }
+  font:
+    handler: 'default:font'
+    handler_settings: {  }
+  group:
+    handler: 'default:group'
+    handler_settings: {  }
+  group_content:
+    handler: 'default:group_content'
+    handler_settings: {  }
+  mentions:
+    handler: 'default:mentions'
+    handler_settings: {  }
+  message:
+    handler: 'default:message'
+    handler_settings: {  }
+  post:
+    handler: 'default:post'
+    handler_settings: {  }
+  profile:
+    handler: 'default:profile'
+    handler_settings: {  }
+  search_api_task:
+    handler: 'default:search_api_task'
+    handler_settings: {  }
+  taxonomy_term:
+    handler: 'default:taxonomy_term'
+    handler_settings: {  }
+  user:
+    handler: 'default:user'
+    handler_settings: {  }
+  vote:
+    handler: 'default:vote'
+    handler_settings: {  }
+  vote_result:
+    handler: 'default:vote_result'
+    handler_settings: {  }
+  queue_storage_entity:
+    handler: 'default:queue_storage_entity'
+    handler_settings: {  }
+  path_alias:
+    handler: 'default:path_alias'
+    handler_settings: {  }
+field_type: dynamic_entity_reference

--- a/modules/social_features/social_activity/config/install/field.field.message.create_topic_gc.field_message_context.yml
+++ b/modules/social_features/social_activity/config/install/field.field.message.create_topic_gc.field_message_context.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.message.field_message_context
+    - message.template.create_topic_gc
+  module:
+    - options
+id: message.create_topic_gc.field_message_context
+field_name: field_message_context
+entity_type: message
+bundle: create_topic_gc
+label: field_message_context
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/modules/social_features/social_activity/config/install/field.field.message.create_topic_gc.field_message_destination.yml
+++ b/modules/social_features/social_activity/config/install/field.field.message.create_topic_gc.field_message_destination.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.message.field_message_destination
+    - message.template.create_topic_gc
+  module:
+    - options
+id: message.create_topic_gc.field_message_destination
+field_name: field_message_destination
+entity_type: message
+bundle: create_topic_gc
+label: field_message_destination
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/modules/social_features/social_activity/config/install/field.field.message.create_topic_gc.field_message_related_object.yml
+++ b/modules/social_features/social_activity/config/install/field.field.message.create_topic_gc.field_message_related_object.yml
@@ -1,0 +1,89 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.message.field_message_related_object
+    - message.template.create_topic_gc
+  module:
+    - dynamic_entity_reference
+id: message.create_topic_gc.field_message_related_object
+field_name: field_message_related_object
+entity_type: message
+bundle: create_topic_gc
+label: field_message_related_object
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  activity:
+    handler: 'default:activity'
+    handler_settings: {  }
+  comment:
+    handler: 'default:comment'
+    handler_settings: {  }
+  node:
+    handler: 'default:node'
+    handler_settings: {  }
+  crop:
+    handler: 'default:crop'
+    handler_settings: {  }
+  block_content:
+    handler: 'default:block_content'
+    handler_settings: {  }
+  menu_link_content:
+    handler: 'default:menu_link_content'
+    handler_settings: {  }
+  event_enrollment:
+    handler: 'default:event_enrollment'
+    handler_settings: {  }
+  file:
+    handler: 'default:file'
+    handler_settings: {  }
+  flagging:
+    handler: 'default:flagging'
+    handler_settings: {  }
+  font:
+    handler: 'default:font'
+    handler_settings: {  }
+  group:
+    handler: 'default:group'
+    handler_settings: {  }
+  group_content:
+    handler: 'default:group_content'
+    handler_settings: {  }
+  mentions:
+    handler: 'default:mentions'
+    handler_settings: {  }
+  message:
+    handler: 'default:message'
+    handler_settings: {  }
+  post:
+    handler: 'default:post'
+    handler_settings: {  }
+  profile:
+    handler: 'default:profile'
+    handler_settings: {  }
+  search_api_task:
+    handler: 'default:search_api_task'
+    handler_settings: {  }
+  taxonomy_term:
+    handler: 'default:taxonomy_term'
+    handler_settings: {  }
+  user:
+    handler: 'default:user'
+    handler_settings: {  }
+  vote:
+    handler: 'default:vote'
+    handler_settings: {  }
+  vote_result:
+    handler: 'default:vote_result'
+    handler_settings: {  }
+  queue_storage_entity:
+    handler: 'default:queue_storage_entity'
+    handler_settings: {  }
+  path_alias:
+    handler: 'default:path_alias'
+    handler_settings: {  }
+field_type: dynamic_entity_reference

--- a/modules/social_features/social_activity/config/install/field.field.message.join_to_group.field_message_context.yml
+++ b/modules/social_features/social_activity/config/install/field.field.message.join_to_group.field_message_context.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.message.field_message_context
+    - message.template.join_to_group
+  module:
+    - options
+id: message.join_to_group.field_message_context
+field_name: field_message_context
+entity_type: message
+bundle: join_to_group
+label: field_message_context
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/modules/social_features/social_activity/config/install/field.field.message.join_to_group.field_message_destination.yml
+++ b/modules/social_features/social_activity/config/install/field.field.message.join_to_group.field_message_destination.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.message.field_message_destination
+    - message.template.join_to_group
+  module:
+    - options
+id: message.join_to_group.field_message_destination
+field_name: field_message_destination
+entity_type: message
+bundle: join_to_group
+label: field_message_destination
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/modules/social_features/social_activity/config/install/field.field.message.join_to_group.field_message_related_object.yml
+++ b/modules/social_features/social_activity/config/install/field.field.message.join_to_group.field_message_related_object.yml
@@ -1,0 +1,89 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.message.field_message_related_object
+    - message.template.join_to_group
+  module:
+    - dynamic_entity_reference
+id: message.join_to_group.field_message_related_object
+field_name: field_message_related_object
+entity_type: message
+bundle: join_to_group
+label: field_message_related_object
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  activity:
+    handler: 'default:activity'
+    handler_settings: {  }
+  comment:
+    handler: 'default:comment'
+    handler_settings: {  }
+  node:
+    handler: 'default:node'
+    handler_settings: {  }
+  crop:
+    handler: 'default:crop'
+    handler_settings: {  }
+  block_content:
+    handler: 'default:block_content'
+    handler_settings: {  }
+  menu_link_content:
+    handler: 'default:menu_link_content'
+    handler_settings: {  }
+  event_enrollment:
+    handler: 'default:event_enrollment'
+    handler_settings: {  }
+  file:
+    handler: 'default:file'
+    handler_settings: {  }
+  flagging:
+    handler: 'default:flagging'
+    handler_settings: {  }
+  font:
+    handler: 'default:font'
+    handler_settings: {  }
+  group:
+    handler: 'default:group'
+    handler_settings: {  }
+  group_content:
+    handler: 'default:group_content'
+    handler_settings: {  }
+  mentions:
+    handler: 'default:mentions'
+    handler_settings: {  }
+  message:
+    handler: 'default:message'
+    handler_settings: {  }
+  post:
+    handler: 'default:post'
+    handler_settings: {  }
+  profile:
+    handler: 'default:profile'
+    handler_settings: {  }
+  search_api_task:
+    handler: 'default:search_api_task'
+    handler_settings: {  }
+  taxonomy_term:
+    handler: 'default:taxonomy_term'
+    handler_settings: {  }
+  user:
+    handler: 'default:user'
+    handler_settings: {  }
+  vote:
+    handler: 'default:vote'
+    handler_settings: {  }
+  vote_result:
+    handler: 'default:vote_result'
+    handler_settings: {  }
+  queue_storage_entity:
+    handler: 'default:queue_storage_entity'
+    handler_settings: {  }
+  path_alias:
+    handler: 'default:path_alias'
+    handler_settings: {  }
+field_type: dynamic_entity_reference

--- a/modules/social_features/social_activity/config/install/field.field.message.request_event_enrollment.field_message_context.yml
+++ b/modules/social_features/social_activity/config/install/field.field.message.request_event_enrollment.field_message_context.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.message.field_message_context
+    - message.template.request_event_enrollment
+  module:
+    - options
+id: message.request_event_enrollment.field_message_context
+field_name: field_message_context
+entity_type: message
+bundle: request_event_enrollment
+label: field_message_context
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/modules/social_features/social_activity/config/install/field.field.message.request_event_enrollment.field_message_destination.yml
+++ b/modules/social_features/social_activity/config/install/field.field.message.request_event_enrollment.field_message_destination.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.message.field_message_destination
+    - message.template.request_event_enrollment
+  module:
+    - options
+id: message.request_event_enrollment.field_message_destination
+field_name: field_message_destination
+entity_type: message
+bundle: request_event_enrollment
+label: field_message_destination
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/modules/social_features/social_activity/config/install/field.field.message.request_event_enrollment.field_message_related_object.yml
+++ b/modules/social_features/social_activity/config/install/field.field.message.request_event_enrollment.field_message_related_object.yml
@@ -1,0 +1,89 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.message.field_message_related_object
+    - message.template.request_event_enrollment
+  module:
+    - dynamic_entity_reference
+id: message.request_event_enrollment.field_message_related_object
+field_name: field_message_related_object
+entity_type: message
+bundle: request_event_enrollment
+label: field_message_related_object
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  activity:
+    handler: 'default:activity'
+    handler_settings: {  }
+  comment:
+    handler: 'default:comment'
+    handler_settings: {  }
+  node:
+    handler: 'default:node'
+    handler_settings: {  }
+  crop:
+    handler: 'default:crop'
+    handler_settings: {  }
+  block_content:
+    handler: 'default:block_content'
+    handler_settings: {  }
+  menu_link_content:
+    handler: 'default:menu_link_content'
+    handler_settings: {  }
+  event_enrollment:
+    handler: 'default:event_enrollment'
+    handler_settings: {  }
+  file:
+    handler: 'default:file'
+    handler_settings: {  }
+  flagging:
+    handler: 'default:flagging'
+    handler_settings: {  }
+  font:
+    handler: 'default:font'
+    handler_settings: {  }
+  group:
+    handler: 'default:group'
+    handler_settings: {  }
+  group_content:
+    handler: 'default:group_content'
+    handler_settings: {  }
+  mentions:
+    handler: 'default:mentions'
+    handler_settings: {  }
+  message:
+    handler: 'default:message'
+    handler_settings: {  }
+  post:
+    handler: 'default:post'
+    handler_settings: {  }
+  profile:
+    handler: 'default:profile'
+    handler_settings: {  }
+  search_api_task:
+    handler: 'default:search_api_task'
+    handler_settings: {  }
+  taxonomy_term:
+    handler: 'default:taxonomy_term'
+    handler_settings: {  }
+  user:
+    handler: 'default:user'
+    handler_settings: {  }
+  vote:
+    handler: 'default:vote'
+    handler_settings: {  }
+  vote_result:
+    handler: 'default:vote_result'
+    handler_settings: {  }
+  queue_storage_entity:
+    handler: 'default:queue_storage_entity'
+    handler_settings: {  }
+  path_alias:
+    handler: 'default:path_alias'
+    handler_settings: {  }
+field_type: dynamic_entity_reference

--- a/modules/social_features/social_event/config/optional/field.field.message.activity_on_events_im_organizing.field_message_context.yml
+++ b/modules/social_features/social_event/config/optional/field.field.message.activity_on_events_im_organizing.field_message_context.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.message.field_message_context
+    - message.template.activity_on_events_im_organizing
+  module:
+    - options
+id: message.activity_on_events_im_organizing.field_message_context
+field_name: field_message_context
+entity_type: message
+bundle: activity_on_events_im_organizing
+label: field_message_context
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/modules/social_features/social_event/config/optional/field.field.message.activity_on_events_im_organizing.field_message_destination.yml
+++ b/modules/social_features/social_event/config/optional/field.field.message.activity_on_events_im_organizing.field_message_destination.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.message.field_message_destination
+    - message.template.activity_on_events_im_organizing
+  module:
+    - options
+id: message.activity_on_events_im_organizing.field_message_destination
+field_name: field_message_destination
+entity_type: message
+bundle: activity_on_events_im_organizing
+label: field_message_destination
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/modules/social_features/social_event/config/optional/field.field.message.activity_on_events_im_organizing.field_message_related_object.yml
+++ b/modules/social_features/social_event/config/optional/field.field.message.activity_on_events_im_organizing.field_message_related_object.yml
@@ -1,0 +1,89 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.message.field_message_related_object
+    - message.template.activity_on_events_im_organizing
+  module:
+    - dynamic_entity_reference
+id: message.activity_on_events_im_organizing.field_message_related_object
+field_name: field_message_related_object
+entity_type: message
+bundle: activity_on_events_im_organizing
+label: field_message_related_object
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  activity:
+    handler: 'default:activity'
+    handler_settings: {  }
+  comment:
+    handler: 'default:comment'
+    handler_settings: {  }
+  node:
+    handler: 'default:node'
+    handler_settings: {  }
+  crop:
+    handler: 'default:crop'
+    handler_settings: {  }
+  block_content:
+    handler: 'default:block_content'
+    handler_settings: {  }
+  menu_link_content:
+    handler: 'default:menu_link_content'
+    handler_settings: {  }
+  event_enrollment:
+    handler: 'default:event_enrollment'
+    handler_settings: {  }
+  file:
+    handler: 'default:file'
+    handler_settings: {  }
+  flagging:
+    handler: 'default:flagging'
+    handler_settings: {  }
+  font:
+    handler: 'default:font'
+    handler_settings: {  }
+  group:
+    handler: 'default:group'
+    handler_settings: {  }
+  group_content:
+    handler: 'default:group_content'
+    handler_settings: {  }
+  mentions:
+    handler: 'default:mentions'
+    handler_settings: {  }
+  message:
+    handler: 'default:message'
+    handler_settings: {  }
+  post:
+    handler: 'default:post'
+    handler_settings: {  }
+  profile:
+    handler: 'default:profile'
+    handler_settings: {  }
+  search_api_task:
+    handler: 'default:search_api_task'
+    handler_settings: {  }
+  taxonomy_term:
+    handler: 'default:taxonomy_term'
+    handler_settings: {  }
+  user:
+    handler: 'default:user'
+    handler_settings: {  }
+  vote:
+    handler: 'default:vote'
+    handler_settings: {  }
+  vote_result:
+    handler: 'default:vote_result'
+    handler_settings: {  }
+  queue_storage_entity:
+    handler: 'default:queue_storage_entity'
+    handler_settings: {  }
+  path_alias:
+    handler: 'default:path_alias'
+    handler_settings: {  }
+field_type: dynamic_entity_reference

--- a/modules/social_features/social_event/config/optional/field.field.message.user_was_enrolled_to_event.field_message_context.yml
+++ b/modules/social_features/social_event/config/optional/field.field.message.user_was_enrolled_to_event.field_message_context.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.message.field_message_context
+    - message.template.user_was_enrolled_to_event
+  module:
+    - options
+id: message.user_was_enrolled_to_event.field_message_context
+field_name: field_message_context
+entity_type: message
+bundle: user_was_enrolled_to_event
+label: field_message_context
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/modules/social_features/social_event/config/optional/field.field.message.user_was_enrolled_to_event.field_message_destination.yml
+++ b/modules/social_features/social_event/config/optional/field.field.message.user_was_enrolled_to_event.field_message_destination.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.message.field_message_destination
+    - message.template.user_was_enrolled_to_event
+  module:
+    - options
+id: message.user_was_enrolled_to_event.field_message_destination
+field_name: field_message_destination
+entity_type: message
+bundle: user_was_enrolled_to_event
+label: field_message_destination
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/modules/social_features/social_event/config/optional/field.field.message.user_was_enrolled_to_event.field_message_related_object.yml
+++ b/modules/social_features/social_event/config/optional/field.field.message.user_was_enrolled_to_event.field_message_related_object.yml
@@ -1,0 +1,89 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.message.field_message_related_object
+    - message.template.user_was_enrolled_to_event
+  module:
+    - dynamic_entity_reference
+id: message.user_was_enrolled_to_event.field_message_related_object
+field_name: field_message_related_object
+entity_type: message
+bundle: user_was_enrolled_to_event
+label: field_message_related_object
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  activity:
+    handler: 'default:activity'
+    handler_settings: {  }
+  comment:
+    handler: 'default:comment'
+    handler_settings: {  }
+  node:
+    handler: 'default:node'
+    handler_settings: {  }
+  crop:
+    handler: 'default:crop'
+    handler_settings: {  }
+  block_content:
+    handler: 'default:block_content'
+    handler_settings: {  }
+  menu_link_content:
+    handler: 'default:menu_link_content'
+    handler_settings: {  }
+  event_enrollment:
+    handler: 'default:event_enrollment'
+    handler_settings: {  }
+  file:
+    handler: 'default:file'
+    handler_settings: {  }
+  flagging:
+    handler: 'default:flagging'
+    handler_settings: {  }
+  font:
+    handler: 'default:font'
+    handler_settings: {  }
+  group:
+    handler: 'default:group'
+    handler_settings: {  }
+  group_content:
+    handler: 'default:group_content'
+    handler_settings: {  }
+  mentions:
+    handler: 'default:mentions'
+    handler_settings: {  }
+  message:
+    handler: 'default:message'
+    handler_settings: {  }
+  post:
+    handler: 'default:post'
+    handler_settings: {  }
+  profile:
+    handler: 'default:profile'
+    handler_settings: {  }
+  search_api_task:
+    handler: 'default:search_api_task'
+    handler_settings: {  }
+  taxonomy_term:
+    handler: 'default:taxonomy_term'
+    handler_settings: {  }
+  user:
+    handler: 'default:user'
+    handler_settings: {  }
+  vote:
+    handler: 'default:vote'
+    handler_settings: {  }
+  vote_result:
+    handler: 'default:vote_result'
+    handler_settings: {  }
+  queue_storage_entity:
+    handler: 'default:queue_storage_entity'
+    handler_settings: {  }
+  path_alias:
+    handler: 'default:path_alias'
+    handler_settings: {  }
+field_type: dynamic_entity_reference

--- a/modules/social_features/social_event/modules/social_event_invite/config/install/field.field.message.invite_event_enrollment.field_message_context.yml
+++ b/modules/social_features/social_event/modules/social_event_invite/config/install/field.field.message.invite_event_enrollment.field_message_context.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.message.field_message_context
+    - message.template.invite_event_enrollment
+  module:
+    - options
+id: message.invite_event_enrollment.field_message_context
+field_name: field_message_context
+entity_type: message
+bundle: invite_event_enrollment
+label: field_message_context
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/modules/social_features/social_event/modules/social_event_invite/config/install/field.field.message.invite_event_enrollment.field_message_destination.yml
+++ b/modules/social_features/social_event/modules/social_event_invite/config/install/field.field.message.invite_event_enrollment.field_message_destination.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.message.field_message_destination
+    - message.template.invite_event_enrollment
+  module:
+    - options
+id: message.invite_event_enrollment.field_message_destination
+field_name: field_message_destination
+entity_type: message
+bundle: invite_event_enrollment
+label: field_message_destination
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/modules/social_features/social_event/modules/social_event_invite/config/install/field.field.message.invite_event_enrollment.field_message_related_object.yml
+++ b/modules/social_features/social_event/modules/social_event_invite/config/install/field.field.message.invite_event_enrollment.field_message_related_object.yml
@@ -1,0 +1,89 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.message.field_message_related_object
+    - message.template.invite_event_enrollment
+  module:
+    - dynamic_entity_reference
+id: message.invite_event_enrollment.field_message_related_object
+field_name: field_message_related_object
+entity_type: message
+bundle: invite_event_enrollment
+label: field_message_related_object
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  activity:
+    handler: 'default:activity'
+    handler_settings: {  }
+  comment:
+    handler: 'default:comment'
+    handler_settings: {  }
+  node:
+    handler: 'default:node'
+    handler_settings: {  }
+  crop:
+    handler: 'default:crop'
+    handler_settings: {  }
+  block_content:
+    handler: 'default:block_content'
+    handler_settings: {  }
+  menu_link_content:
+    handler: 'default:menu_link_content'
+    handler_settings: {  }
+  event_enrollment:
+    handler: 'default:event_enrollment'
+    handler_settings: {  }
+  file:
+    handler: 'default:file'
+    handler_settings: {  }
+  flagging:
+    handler: 'default:flagging'
+    handler_settings: {  }
+  font:
+    handler: 'default:font'
+    handler_settings: {  }
+  group:
+    handler: 'default:group'
+    handler_settings: {  }
+  group_content:
+    handler: 'default:group_content'
+    handler_settings: {  }
+  mentions:
+    handler: 'default:mentions'
+    handler_settings: {  }
+  message:
+    handler: 'default:message'
+    handler_settings: {  }
+  post:
+    handler: 'default:post'
+    handler_settings: {  }
+  profile:
+    handler: 'default:profile'
+    handler_settings: {  }
+  search_api_task:
+    handler: 'default:search_api_task'
+    handler_settings: {  }
+  taxonomy_term:
+    handler: 'default:taxonomy_term'
+    handler_settings: {  }
+  user:
+    handler: 'default:user'
+    handler_settings: {  }
+  vote:
+    handler: 'default:vote'
+    handler_settings: {  }
+  vote_result:
+    handler: 'default:vote_result'
+    handler_settings: {  }
+  queue_storage_entity:
+    handler: 'default:queue_storage_entity'
+    handler_settings: {  }
+  path_alias:
+    handler: 'default:path_alias'
+    handler_settings: {  }
+field_type: dynamic_entity_reference

--- a/modules/social_features/social_event/modules/social_event_managers/config/optional/field.field.message.member_added_by_event_organiser.field_message_context.yml
+++ b/modules/social_features/social_event/modules/social_event_managers/config/optional/field.field.message.member_added_by_event_organiser.field_message_context.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.message.field_message_context
+    - message.template.member_added_by_event_organiser
+  module:
+    - options
+id: message.member_added_by_event_organiser.field_message_context
+field_name: field_message_context
+entity_type: message
+bundle: member_added_by_event_organiser
+label: field_message_context
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/modules/social_features/social_event/modules/social_event_managers/config/optional/field.field.message.member_added_by_event_organiser.field_message_destination.yml
+++ b/modules/social_features/social_event/modules/social_event_managers/config/optional/field.field.message.member_added_by_event_organiser.field_message_destination.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.message.field_message_destination
+    - message.template.member_added_by_event_organiser
+  module:
+    - options
+id: message.member_added_by_event_organiser.field_message_destination
+field_name: field_message_destination
+entity_type: message
+bundle: member_added_by_event_organiser
+label: field_message_destination
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/modules/social_features/social_event/modules/social_event_managers/config/optional/field.field.message.member_added_by_event_organiser.field_message_related_object.yml
+++ b/modules/social_features/social_event/modules/social_event_managers/config/optional/field.field.message.member_added_by_event_organiser.field_message_related_object.yml
@@ -1,0 +1,89 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.message.field_message_related_object
+    - message.template.member_added_by_event_organiser
+  module:
+    - dynamic_entity_reference
+id: message.member_added_by_event_organiser.field_message_related_object
+field_name: field_message_related_object
+entity_type: message
+bundle: member_added_by_event_organiser
+label: field_message_related_object
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  activity:
+    handler: 'default:activity'
+    handler_settings: {  }
+  comment:
+    handler: 'default:comment'
+    handler_settings: {  }
+  node:
+    handler: 'default:node'
+    handler_settings: {  }
+  crop:
+    handler: 'default:crop'
+    handler_settings: {  }
+  block_content:
+    handler: 'default:block_content'
+    handler_settings: {  }
+  menu_link_content:
+    handler: 'default:menu_link_content'
+    handler_settings: {  }
+  event_enrollment:
+    handler: 'default:event_enrollment'
+    handler_settings: {  }
+  file:
+    handler: 'default:file'
+    handler_settings: {  }
+  flagging:
+    handler: 'default:flagging'
+    handler_settings: {  }
+  font:
+    handler: 'default:font'
+    handler_settings: {  }
+  group:
+    handler: 'default:group'
+    handler_settings: {  }
+  group_content:
+    handler: 'default:group_content'
+    handler_settings: {  }
+  mentions:
+    handler: 'default:mentions'
+    handler_settings: {  }
+  message:
+    handler: 'default:message'
+    handler_settings: {  }
+  post:
+    handler: 'default:post'
+    handler_settings: {  }
+  profile:
+    handler: 'default:profile'
+    handler_settings: {  }
+  search_api_task:
+    handler: 'default:search_api_task'
+    handler_settings: {  }
+  taxonomy_term:
+    handler: 'default:taxonomy_term'
+    handler_settings: {  }
+  user:
+    handler: 'default:user'
+    handler_settings: {  }
+  vote:
+    handler: 'default:vote'
+    handler_settings: {  }
+  vote_result:
+    handler: 'default:vote_result'
+    handler_settings: {  }
+  queue_storage_entity:
+    handler: 'default:queue_storage_entity'
+    handler_settings: {  }
+  path_alias:
+    handler: 'default:path_alias'
+    handler_settings: {  }
+field_type: dynamic_entity_reference

--- a/modules/social_features/social_follow_taxonomy/modules/social_follow_tag/config/install/field.field.message.create_node_following_tag.field_message_context.yml
+++ b/modules/social_features/social_follow_taxonomy/modules/social_follow_tag/config/install/field.field.message.create_node_following_tag.field_message_context.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.message.field_message_context
+    - message.template.create_node_following_tag
+  module:
+    - options
+id: message.create_node_following_tag.field_message_context
+field_name: field_message_context
+entity_type: message
+bundle: create_node_following_tag
+label: create_node_following_tag
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/modules/social_features/social_follow_taxonomy/modules/social_follow_tag/config/install/field.field.message.create_node_following_tag.field_message_destination.yml
+++ b/modules/social_features/social_follow_taxonomy/modules/social_follow_tag/config/install/field.field.message.create_node_following_tag.field_message_destination.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.message.field_message_destination
+    - message.template.create_node_following_tag
+  module:
+    - options
+id: message.create_node_following_tag.field_message_destination
+field_name: field_message_destination
+entity_type: message
+bundle: create_node_following_tag
+label: field_message_destination
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/modules/social_features/social_follow_taxonomy/modules/social_follow_tag/config/install/field.field.message.create_node_following_tag.field_message_related_object.yml
+++ b/modules/social_features/social_follow_taxonomy/modules/social_follow_tag/config/install/field.field.message.create_node_following_tag.field_message_related_object.yml
@@ -1,0 +1,89 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.message.field_message_related_object
+    - message.template.create_node_following_tag
+  module:
+    - dynamic_entity_reference
+id: message.create_node_following_tag.field_message_related_object
+field_name: field_message_related_object
+entity_type: message
+bundle: create_node_following_tag
+label: field_message_related_object
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  activity:
+    handler: 'default:activity'
+    handler_settings: {  }
+  comment:
+    handler: 'default:comment'
+    handler_settings: {  }
+  node:
+    handler: 'default:node'
+    handler_settings: {  }
+  crop:
+    handler: 'default:crop'
+    handler_settings: {  }
+  block_content:
+    handler: 'default:block_content'
+    handler_settings: {  }
+  menu_link_content:
+    handler: 'default:menu_link_content'
+    handler_settings: {  }
+  event_enrollment:
+    handler: 'default:event_enrollment'
+    handler_settings: {  }
+  file:
+    handler: 'default:file'
+    handler_settings: {  }
+  flagging:
+    handler: 'default:flagging'
+    handler_settings: {  }
+  font:
+    handler: 'default:font'
+    handler_settings: {  }
+  group:
+    handler: 'default:group'
+    handler_settings: {  }
+  group_content:
+    handler: 'default:group_content'
+    handler_settings: {  }
+  mentions:
+    handler: 'default:mentions'
+    handler_settings: {  }
+  message:
+    handler: 'default:message'
+    handler_settings: {  }
+  post:
+    handler: 'default:post'
+    handler_settings: {  }
+  profile:
+    handler: 'default:profile'
+    handler_settings: {  }
+  search_api_task:
+    handler: 'default:search_api_task'
+    handler_settings: {  }
+  taxonomy_term:
+    handler: 'default:taxonomy_term'
+    handler_settings: {  }
+  user:
+    handler: 'default:user'
+    handler_settings: {  }
+  vote:
+    handler: 'default:vote'
+    handler_settings: {  }
+  vote_result:
+    handler: 'default:vote_result'
+    handler_settings: {  }
+  queue_storage_entity:
+    handler: 'default:queue_storage_entity'
+    handler_settings: {  }
+  path_alias:
+    handler: 'default:path_alias'
+    handler_settings: {  }
+field_type: dynamic_entity_reference

--- a/modules/social_features/social_follow_taxonomy/modules/social_follow_tag/config/install/field.field.message.update_node_following_tag.field_message_context.yml
+++ b/modules/social_features/social_follow_taxonomy/modules/social_follow_tag/config/install/field.field.message.update_node_following_tag.field_message_context.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.message.field_message_context
+    - message.template.update_node_following_tag
+  module:
+    - options
+id: message.update_node_following_tag.field_message_context
+field_name: field_message_context
+entity_type: message
+bundle: update_node_following_tag
+label: field_message_context
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/modules/social_features/social_follow_taxonomy/modules/social_follow_tag/config/install/field.field.message.update_node_following_tag.field_message_destination.yml
+++ b/modules/social_features/social_follow_taxonomy/modules/social_follow_tag/config/install/field.field.message.update_node_following_tag.field_message_destination.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.message.field_message_destination
+    - message.template.update_node_following_tag
+  module:
+    - options
+id: message.update_node_following_tag.field_message_destination
+field_name: field_message_destination
+entity_type: message
+bundle: update_node_following_tag
+label: field_message_destination
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/modules/social_features/social_follow_taxonomy/modules/social_follow_tag/config/install/field.field.message.update_node_following_tag.field_message_related_object.yml
+++ b/modules/social_features/social_follow_taxonomy/modules/social_follow_tag/config/install/field.field.message.update_node_following_tag.field_message_related_object.yml
@@ -1,0 +1,89 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.message.field_message_related_object
+    - message.template.update_node_following_tag
+  module:
+    - dynamic_entity_reference
+id: message.update_node_following_tag.field_message_related_object
+field_name: field_message_related_object
+entity_type: message
+bundle: update_node_following_tag
+label: field_message_related_object
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  activity:
+    handler: 'default:activity'
+    handler_settings: {  }
+  comment:
+    handler: 'default:comment'
+    handler_settings: {  }
+  node:
+    handler: 'default:node'
+    handler_settings: {  }
+  crop:
+    handler: 'default:crop'
+    handler_settings: {  }
+  block_content:
+    handler: 'default:block_content'
+    handler_settings: {  }
+  menu_link_content:
+    handler: 'default:menu_link_content'
+    handler_settings: {  }
+  event_enrollment:
+    handler: 'default:event_enrollment'
+    handler_settings: {  }
+  file:
+    handler: 'default:file'
+    handler_settings: {  }
+  flagging:
+    handler: 'default:flagging'
+    handler_settings: {  }
+  font:
+    handler: 'default:font'
+    handler_settings: {  }
+  group:
+    handler: 'default:group'
+    handler_settings: {  }
+  group_content:
+    handler: 'default:group_content'
+    handler_settings: {  }
+  mentions:
+    handler: 'default:mentions'
+    handler_settings: {  }
+  message:
+    handler: 'default:message'
+    handler_settings: {  }
+  post:
+    handler: 'default:post'
+    handler_settings: {  }
+  profile:
+    handler: 'default:profile'
+    handler_settings: {  }
+  search_api_task:
+    handler: 'default:search_api_task'
+    handler_settings: {  }
+  taxonomy_term:
+    handler: 'default:taxonomy_term'
+    handler_settings: {  }
+  user:
+    handler: 'default:user'
+    handler_settings: {  }
+  vote:
+    handler: 'default:vote'
+    handler_settings: {  }
+  vote_result:
+    handler: 'default:vote_result'
+    handler_settings: {  }
+  queue_storage_entity:
+    handler: 'default:queue_storage_entity'
+    handler_settings: {  }
+  path_alias:
+    handler: 'default:path_alias'
+    handler_settings: {  }
+field_type: dynamic_entity_reference


### PR DESCRIPTION
## Review Guideline
This PR contains 14 commits but only two are actually unique which is 50c615dc0ae96d95354e9e2a73e6e5faad1c66f7 and f7a8a06b496b1fa1de3948e235e08e58bb0b036e (the first and last commit). All commits in between are updates to configuration which should be checked as follow:

Check that the commit for the message template(s) it modifies contains 
- `field_message_context`
- `field_message_destination`
- `field_message_related_object`

For each of those three fields check that the following properties are updated to contain the template's id:
- `dependencies.config`
- `id`
- `bundle`

## Problem
It was discovered while working on #3282 that message fields were being created at runtime, that solution was added in #150. However, there were also code paths that tried to access fields before this code had run.

This code is brittle and we should really be creating the necessary fields at install time.

## Solution
This PR solves two issues:

1. It prevents treating all message inserts as being part of the activity system by checking the fields we need exist on the message entity in the _insert hook. This allows the message entity to be used for non-activity purposes.
2. It no longer automatically creates config fields during content creation but instead asserts that they're present. This also ensures we catch the problem but forces developers to deal with it by flagging it in tests and development.

## Issue tracker
https://www.drupal.org/project/social/issues/3157094
https://www.drupal.org/project/social/issues/3232246

## How to test
- [ ] Create a site-install without demo content
- [ ] Create content that triggers notifications, this should now work for all notifications

I've assumed that all notifications that we have were covered by test coverage.

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Release notes
Open Social no longer errors when a Message entity is created outside of the activity system. Message entities are no longer modified when incompatible with the activity system, an error will be thrown instead and the developer should provide the necessary fields.

## Change Record
[Notification message templates should now also create the `field_message_context`, `field_message_destination` and `field_message_related_object` fields](https://www.drupal.org/node/3333024)

## Milestone
I believe we can put this in a minor version. The config for a new install has been added based on our test coverage. Additionally we add an update hook to create the fields for any message templates that currently exist (even if no notification has been sent yet). The service method has been deprecated for major version removal but is still available.
