### PR TITLE
Revert "Updates: (deps): Update drupal/swiftmailer requirement from 2.3.0 to 2.4.0"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -163,7 +163,7 @@
         "drupal/shariff": "1.7",
         "drupal/social_tour": "1.0.0-alpha2",
         "drupal/socialblue": "~2.4.2",
-        "drupal/swiftmailer": "2.4.0",
+        "drupal/swiftmailer": "2.3.0",
         "drupal/token": "1.11.0",
         "drupal/ultimate_cron": "2.0.0-alpha6",
         "drupal/update_helper": "3.0.4",


### PR DESCRIPTION
Reverting merge due to the new feature that might be BC breaking change:

[#2892104](https://www.drupal.org/i/2892104) by idimopoulos, claudiu.cristea, alexpott, webflo, benelori, mikhailkrainiuk, geek-merlin, blade_ukraine: Add support for CC and BCC headers