### PR TITLE
Issue #3336391: Allowing content tagging on Profile using the Settings Form incorrectly clears cache tags and could result in Unexpected Error

### DIFF
--- a/modules/social_features/social_tagging/src/Form/SocialTaggingSettingsForm.php
+++ b/modules/social_features/social_tagging/src/Form/SocialTaggingSettingsForm.php
@@ -222,18 +222,6 @@ class SocialTaggingSettingsForm extends ConfigFormBase implements ContainerInjec
       $config->clear('use_category_parent')->save();
     }
 
-    if ($form_state->hasValue('tag_type_profile')) {
-      $result = $this->database->select('cachetags', 'ct')
-        ->fields('ct', ['tag'])
-        ->condition('ct.tag', 'profile:%', 'LIKE')
-        ->execute();
-
-      if ($result !== NULL) {
-        // Clear cache tags of profiles.
-        $this->cacheTagsInvalidator->invalidateTags($result->fetchCol());
-      }
-    }
-
     foreach ($form_state->getValue('categories_order') as $tid => $categories_order_values) {
       $term = $this->entityTypeManager->getStorage('taxonomy_term')->load($tid);
       if ($term instanceof TermInterface) {

--- a/modules/social_features/social_tagging/src/Form/SocialTaggingSettingsForm.php
+++ b/modules/social_features/social_tagging/src/Form/SocialTaggingSettingsForm.php
@@ -222,13 +222,15 @@ class SocialTaggingSettingsForm extends ConfigFormBase implements ContainerInjec
       $config->clear('use_category_parent')->save();
     }
 
-    foreach ($form_state->getValue('categories_order') as $tid => $categories_order_values) {
-      $term = $this->entityTypeManager->getStorage('taxonomy_term')->load($tid);
-      if ($term instanceof TermInterface) {
-        // Update weight only if it was changed.
-        if ($term->getWeight() !== $categories_order_values['weight']) {
-          $term->setWeight($categories_order_values['weight']);
-          $term->save();
+    if (!empty($form_state->getValue('categories_order'))) {
+      foreach ($form_state->getValue('categories_order') as $tid => $categories_order_values) {
+        $term = $this->entityTypeManager->getStorage('taxonomy_term')->load($tid);
+        if ($term instanceof TermInterface) {
+          // Update weight only if it was changed.
+          if ($term->getWeight() !== $categories_order_values['weight']) {
+            $term->setWeight($categories_order_values['weight']);
+            $term->save();
+          }
         }
       }
     }


### PR DESCRIPTION
## Problem
In the Submit of the form the code checks:
```
public function submitForm(array &$form, FormStateInterface $form_state): void {
...
    if ($form_state->hasValue('tag_type_profile')) {
      $result = $this->database->select('cachetags', 'ct')
        ->fields('ct', ['tag'])
        ->condition('ct.tag', 'profile:%', 'LIKE')
        ->execute();

      if ($result !== NULL) {
        // Clear cache tags of profiles.
        $this->cacheTagsInvalidator->invalidateTags($result->fetchCol());
      }
    }
....
```

There are a number of issues with this:
1. `hasValue('tag_type_profile')` is always true, as the form state has this value even if it's not checked.
2.
```
 $result = $this->database->select('cachetags', 'ct')
        ->fields('ct', ['tag'])
        ->condition('ct.tag', 'profile:%', 'LIKE')
        ->execute(); 
```

Might return

```Uncaught PHP Exception Drupal\Core\Database\DatabaseExceptionWrapper: "SQLSTATE[42S02]: Base table or view not found: 1146 Table 'main.cachetags' doesn't exist: SELECT "ct"."tag" AS "tag"
FROM
"cachetags" "ct"
WHERE "ct"."tag" LIKE :db_condition_placeholder_0 ESCAPE '\\'; Array
(
    [:db_condition_placeholder_0] => profile:%
)
" at /app/html/core/modules/mysql/src/Driver/Database/mysql/ExceptionHandler.php line 53
```
Because the CacheTag table is only created on the first invalidation, so it might not exist.

3. The Cache Tag table is only there to keep track of invalidated tags, it's not there to determine which tags to invalidate. So this code doesn't actually clear all profiles correctly, only those that have been invalidated before.

## Solution
We can remove the code for now as it doesn't clear what it suppose to do, and because we use a preprocess to determine whether or not we show the profile content tag information based on the actual setting it seems to toggle the information correctly already.

Because of the work done in #2478 I will add test coverage in there. 
I need the Feature/Profile Context changes for this to be tested correctly.

## Issue tracker
https://www.drupal.org/project/social/issues/3336391

## How to test
- [ ] Enable `social_tagging`
- [ ] As a sitemanager
- [ ] Go to the tag settings page
- [ ] Enable content tagging for Profile
- [ ] Add content tags
- [ ] Edit a Profile and add content tags to that profile
- [ ] See that when you save, the content tags are shown on the users information page
- [ ] Disable the setting on the tag settings page for Profile
- [ ] See that the content tags are not shown on the users information page anymore

Unfortunately the field is still shown on the Profile edit page as it did before.
The PR mentioned in the solution will also take care of this.

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Release notes
When saving the Content Tagging we could have unexpected errors due to the cache tag table not existing yet.
