### PR TITLE
Internal: Improve test asset naming and contents

### DIFF
--- a/.github/workflows/behat.yml
+++ b/.github/workflows/behat.yml
@@ -293,9 +293,33 @@ jobs:
             echo "::endgroup::"
           done
 
+      - name: Move test artifacts into upload folder
+        if: failure()
+        run: |
+          set -e
+
+          # Make the output folder
+          if [[ ! -z "${{ matrix.update }}" ]] && [[ ! -z "${{ matrix.with_optional }}" ]]; then
+            export OUTPUT_FOLDER=behat-test-output/${{ matrix.feature }}/update-with-optional
+          elif [[ ! -z "${{ matrix.update }}" ]]; then
+            export OUTPUT_FOLDER=behat-test-output/${{ matrix.feature }}/update
+          elif [[ ! -z "${{ matrix.with_optional }}" ]]; then
+            export OUTPUT_FOLDER=behat-test-output/${{ matrix.feature }}/with-optional
+          else
+            export OUTPUT_FOLDER=behat-test-output/${{ matrix.feature }}
+          fi
+          mkdir -p $OUTPUT_FOLDER
+
+          # Move test results to the output folder
+          mv html/profiles/contrib/social/tests/behat/logs/* $OUTPUT_FOLDER/
+
+          # Copy the installation database to the output folder
+          # this makes local reproduction easier.
+          cp `pwd`/installation.sql $OUTPUT_FOLDER/
+
       - name: Upload Behat Test Output
         if: failure()
         uses: actions/upload-artifact@v3
         with:
-          name: behat-output-${{ matrix.feature }}${{ matrix.with_optional }}
-          path: html/profiles/contrib/social/tests/behat/logs
+          name: behat-test-output
+          path: behat-test-output


### PR DESCRIPTION
## Problem
Nested test failures currently don't produce assets due to incorrect pathnames. Additionally if an update test fails it may be difficult to reproduce the failure locally because you'd need to install an older version of Open Social.

## Solution
- Add a script to create a folder hierarchy of test outputs and use GitHub's asset action behaviour of appending to the same asset to merge all the test output into a single downloadable archive
- Include the `installation.sql` database which is loaded at the start of the test in the output so that it can be downloaded and loaded locally.

## Issue tracker
Internal, no issue

## How to test
- [ ] Behat should still pass
- [ ] Add a failing test and inspect the output of the CI

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Release notes
N/a
