### PR TITLE
Issue #3339566 by vnech: Entity access is ignoring in "Custom content list block" block type

### DIFF
--- a/modules/social_features/social_content_block/social_content_block.services.yml
+++ b/modules/social_features/social_content_block/social_content_block.services.yml
@@ -18,6 +18,7 @@ services:
   social_content_block.content_builder:
     class: Drupal\social_content_block\ContentBuilder
     arguments:
+      - '@current_user'
       - '@entity_type.manager'
       - '@database'
       - '@string_translation'

--- a/modules/social_features/social_content_block/src/ContentBuilderInterface.php
+++ b/modules/social_features/social_content_block/src/ContentBuilderInterface.php
@@ -8,6 +8,7 @@ use Drupal\Core\Entity\EntityRepositoryInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Security\TrustedCallbackInterface;
+use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\StringTranslation\TranslationInterface;
 
 /**
@@ -20,6 +21,8 @@ interface ContentBuilderInterface extends TrustedCallbackInterface {
   /**
    * ContentBuilder constructor.
    *
+   * @param \Drupal\Core\Session\AccountInterface $account
+   *   User account entity.
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
    *   The entity type manager.
    * @param \Drupal\Core\Database\Connection $connection
@@ -34,6 +37,7 @@ interface ContentBuilderInterface extends TrustedCallbackInterface {
    *   The time service.
    */
   public function __construct(
+    AccountInterface $account,
     EntityTypeManagerInterface $entity_type_manager,
     Connection $connection,
     TranslationInterface $string_translation,


### PR DESCRIPTION
## Problem
Anonymous users can see <code>community</code> <code>secret</code> flexible group teasers in "Custom content list block" block:
<img src="https://www.drupal.org/files/issues/2023-02-06/Screenshot%202023-02-06%20at%2012.33.43.png" alt="alt" />

Should be:
<img src="https://www.drupal.org/files/issues/2023-02-06/Screenshot%202023-02-06%20at%2012.40.43.png" alt="alt" />

## Solution
Add access check before entities view build.

## Issue tracker
- https://www.drupal.org/project/social/issues/3339566
- https://getopensocial.atlassian.net/browse/PROD-24010

## Theme issue tracker
n/a

## How to test
- [ ] Login as admin
- [ ] Create flexible groups with different visibilities: `public`, `community`, `secret`
- [ ] Create a "**Custom content list block**" on _/block/add/custom_content_list_ to display created groups
- [ ] Place block to any visible region on "**Block layout**" (for example, "**Page title**")
- [ ] As anonymous user visit the page where this block appears

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
_Before changes_:
<img src="https://www.drupal.org/files/issues/2023-02-06/Screenshot%202023-02-06%20at%2012.33.43.png" alt="alt" />

_After changes_:
<img src="https://www.drupal.org/files/issues/2023-02-06/Screenshot%202023-02-06%20at%2012.40.43.png" alt="alt" />

## Release notes
Now "Custom content list block" block displays only content (and groups) that user has access to.

## Change Record
n/a

## Translations
n/a
