### PR TITLE
Internal: Fix queue after cache in tests

### DIFF
--- a/tests/behat/features/bootstrap/SocialDrupalContext.php
+++ b/tests/behat/features/bootstrap/SocialDrupalContext.php
@@ -249,6 +249,17 @@ class SocialDrupalContext extends DrupalContext {
    *   If set to TRUE, it doesn't process the items, but simply deletes them.
    */
   protected function processQueue($just_delete = FALSE) {
+    // This step is sometimes called after a cache clear which rebuilds the
+    // container and unloads all modules. Normally an HTTP request will ensure
+    // all modules are loaded again, but if the cache clear is directly
+    // preceding queue processing then that's not the case.
+    // Normally this wouldn't even be a problem, but in some tests we have those
+    // two steps AND we have something in the queue that calls `renderPlain`
+    // (e.g. a message token) which will cause the theme system to balk at
+    // unloaded modules. Thus, to fix this we must now make sure all modules
+    // are loaded.
+    \Drupal::moduleHandler()->loadAll();
+
     $workerManager = \Drupal::service('plugin.manager.queue_worker');
     /** @var Drupal\Core\Queue\QueueFactory; $queue */
     $queue = \Drupal::service('queue');


### PR DESCRIPTION
## Problem / Solution
This step is sometimes called after a cache clear which rebuilds the container and unloads all modules. Normally an HTTP request will ensure all modules are loaded again, but if the cache clear is directly preceding queue processing then that's not the case. Normally this wouldn't even be a problem, but in some tests we have those two steps AND we have something in the queue that calls `renderPlain` (e.g. a message token) which will cause the theme system to balk at unloaded modules. Thus, to fix this we must now make sure all modules are loaded.

## Issue tracker
Internal no issue

## How to test
- [ ] Behat should pass

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status
