### PR TITLE
Issue #3341270: Update the empty behaviour text for follower_user and…

### DIFF
--- a/modules/social_features/social_follow_user/config/install/views.view.followers_user.yml
+++ b/modules/social_features/social_follow_user/config/install/views.view.followers_user.yml
@@ -170,7 +170,7 @@ display:
           admin_label: ''
           empty: true
           tokenize: false
-          content: 'You do not have any followers.'
+          content: 'This user does not have any followers.'
           plugin_id: text_custom
       relationships:
         profile:

--- a/modules/social_features/social_follow_user/config/install/views.view.following_users.yml
+++ b/modules/social_features/social_follow_user/config/install/views.view.following_users.yml
@@ -169,7 +169,7 @@ display:
           admin_label: ''
           empty: true
           tokenize: false
-          content: 'You do not follow any users.'
+          content: 'This user does not follow any users.'
           plugin_id: text_custom
       relationships:
         flag_follow_user:

--- a/modules/social_features/social_follow_user/config/update/social_follow_user_update_11701.yml
+++ b/modules/social_features/social_follow_user/config/update/social_follow_user_update_11701.yml
@@ -1,0 +1,31 @@
+views.view.followers_user:
+  expected_config:
+    default:
+      display_options:
+        empty:
+          area_text_custom:
+            content: 'You do not have any followers.'
+  update_actions:
+    change:
+      display:
+        default:
+          display_options:
+            empty:
+              area_text_custom:
+                content: 'This user does not have any followers.'
+views.view.following_users:
+  expected_config:
+    display:
+      default:
+        display_options:
+          empty:
+            area_text_custom:
+              content: 'You do not follow any users.'
+  update_actions:
+    change:
+      display:
+        default:
+          display_options:
+            empty:
+              area_text_custom:
+                content: 'This user does not follow any users.'

--- a/modules/social_features/social_follow_user/social_follow_user.install
+++ b/modules/social_features/social_follow_user/social_follow_user.install
@@ -410,3 +410,17 @@ function social_follow_user_update_11406() : void {
   $form_mode->setThirdPartySetting("field_group", "group_privacy", $privacy_group);
   $form_mode->save();
 }
+
+/**
+ * Update the empty behaviour text for follower_user and following_users.
+ */
+function social_follow_user_update_11701(): string {
+  /** @var \Drupal\update_helper\UpdaterInterface $update_helper */
+  $update_helper = \Drupal::service('update_helper.updater');
+
+  // Execute configuration update definitions with logging of success.
+  $update_helper->executeUpdate('social_follow_user', __FUNCTION__);
+
+  // Output logged messages to related channel of update execution.
+  return $update_helper->logger()->output();
+}

--- a/tests/behat/features/capabilities/follow-users/follow-users.feature
+++ b/tests/behat/features/capabilities/follow-users/follow-users.feature
@@ -60,7 +60,7 @@ Feature: Follow Users
 
     # Check if followers page is accessible.
     When I click "0 followers"
-    And I should see the text "You do not have any followers"
+    And I should see the text "This user does not have any followers"
 
     # Check if following page is accessible as well.
     When I click the xth "0" element with the css ".navbar-nav .profile"


### PR DESCRIPTION
## Problem
On the user profile the empty behaviour for content is by default using the pattern: "This user x", but in the social_follow_user it's "You do not follow any users."

## Solution
Make the wording consistent by changing the text.

## Issue tracker
https://www.drupal.org/project/social/issues/3341270

## How to test
- [ ]  Enable the social_follow_user
- [ ]  Go to your user profile or any other, and go to the tab following or followers
- [ ]  See the wording as stated in the problem.
- [ ]  Go to the groups/topics etc. tab and see a different wording as stated in the problem
- [ ] Check out to this branch, drush updb and check again.

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Release notes
We updated the follow users detail views texts when you have no followers or don't follow anyone.
/user/x/followers
You do not have any followers. -> This user does not have any followers.
user/x/following/users
You do not follow any users. -> This user does not follow any users.

## Change Record
When going to the page:
/user/x/followers
You do not have any followers. -> This user does not have any followers.
user/x/following/users
You do not follow any users. -> This user does not follow any users.
