### PR TITLE
Issue #3342382: Don't validate language in `debugMessageTemplateIsCompatible`

### DIFF
--- a/modules/custom/activity_logger/src/Service/ActivityLoggerFactory.php
+++ b/modules/custom/activity_logger/src/Service/ActivityLoggerFactory.php
@@ -255,8 +255,7 @@ class ActivityLoggerFactory {
       !$field_message_context->status() ||
       $field_message_context->getType() !== 'list_string' ||
       $field_message_context->isRequired() ||
-      $field_message_context->isTranslatable() ||
-      $field_message_context->language()->getId() !== "en"
+      $field_message_context->isTranslatable()
     ) {
       return FALSE;
     }
@@ -269,8 +268,7 @@ class ActivityLoggerFactory {
       !$field_message_destination->status() ||
       $field_message_destination->getType() !== 'list_string' ||
       $field_message_destination->isRequired() ||
-      $field_message_destination->isTranslatable() ||
-      $field_message_destination->language()->getId() !== "en"
+      $field_message_destination->isTranslatable()
     ) {
       return FALSE;
     }
@@ -283,8 +281,7 @@ class ActivityLoggerFactory {
       !$field_message_related_object->status() ||
       $field_message_related_object->getType() !== 'dynamic_entity_reference' ||
       $field_message_related_object->isRequired() ||
-      $field_message_related_object->isTranslatable() ||
-      $field_message_related_object->language()->getId() !== "en"
+      $field_message_related_object->isTranslatable()
     ) {
       return FALSE;
     }


### PR DESCRIPTION
# Problem / Solution
Our tests only run in English so we don't encounter this in our CI. However some users with sites that have non-English languages might have assertions enabled in production.

In that case the language code will not be `en` and an exception will be thrown even if the rest of the config is correct. From a functionality point of view the langcode itself doesn't really matter.

Removing the language check removes the risk of distro users with misconfigured servers getting an exception thrown even when everything is fine.

## Issue tracker
https://www.drupal.org/project/social/issues/3342382

## How to test
- [ ] Install Open Social with social_like
- [ ] Enable a second language
- [ ] Like some content in the non-English language and process notifications in that language
- [ ] There should be no errors

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Release notes
Although we recommend disabling assertions for production environment, the activity system will no longer throw an exception about incorrectly installed fields for environments with assertions enabled that are processing non-English notifications.
