### PR TITLE
Issue #3281332 by robertragas, navneet0693, rolki, ressinel: Fix sorting options for custom content list block on dashboard when choose eventsi

### DIFF
--- a/modules/social_features/social_content_block/config/static/field.storage.block_content.field_sorting_11001.yml
+++ b/modules/social_features/social_content_block/config/static/field.storage.block_content.field_sorting_11001.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - block_content
+    - options
+id: block_content.field_sorting
+field_name: field_sorting
+entity_type: block_content
+type: list_string
+settings:
+  allowed_values: {  }
+  allowed_values_function: '_social_content_block_allowed_values_callback'
+module: options
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/social_features/social_content_block/modules/social_event_content_block/src/Plugin/ContentBlock/EventContentBlock.php
+++ b/modules/social_features/social_content_block/modules/social_event_content_block/src/Plugin/ContentBlock/EventContentBlock.php
@@ -192,11 +192,13 @@ class EventContentBlock extends ContentBlockBase implements ContainerFactoryPlug
       // Sort in "ASC" order.
       'event_date' => [
         'label' => $this->t('Oldest -> Newest'),
+        'description' => 'Sorts in ascending order.',
         'limit' => FALSE,
       ],
       // Sort in "DESC" order.
       'event_date_desc' => [
         'label' => $this->t('Newest -> Oldest'),
+        'description' => 'Sorts in descending order.',
         'limit' => FALSE,
       ],
     ];

--- a/modules/social_features/social_content_block/social_content_block.install
+++ b/modules/social_features/social_content_block/social_content_block.install
@@ -12,48 +12,6 @@ use Drupal\Core\Field\FieldConfigInterface;
 use Symfony\Component\Yaml\Yaml;
 
 /**
- * Implements hook_modules_installed().
- */
-function social_content_block_modules_installed() {
-  // When the set of installed modules change, reload the sorting optios.
-  _social_content_block_update_sorting_options();
-}
-
-/**
- * Update the allowed values in the sorting options field based on plugins.
- */
-function _social_content_block_update_sorting_options() {
-  /** @var \Drupal\social_content_block\ContentBlockManagerInterface $content_block_manager */
-  $content_block_manager = \Drupal::service('plugin.manager.content_block');
-
-  // Retrieve all sort options, removing duplicates and format them to the
-  // format of field storage configuration.
-  $sort_options = [];
-
-  foreach (array_keys($content_block_manager->getDefinitions()) as $plugin_id) {
-    $plugin = $content_block_manager->createInstance($plugin_id);
-
-    foreach ($plugin->supportedSortOptions() as $name => $settings) {
-      $sort_options[] = [
-        'value' => $name,
-        'label' => is_array($settings) ? $settings['label'] : $settings,
-      ];
-    }
-  }
-
-  // Load the existing configuration and update it if it's different.
-  $config_name = 'field.storage.block_content.field_sorting';
-  $config = \Drupal::configFactory()->getEditable($config_name);
-  $config_data = $config->getRawData();
-
-  if ($sort_options !== $config_data['settings']['allowed_values']) {
-    $config_data['settings']['allowed_values'] = $sort_options;
-    $config->setData($config_data)->save();
-    \Drupal::service('entity_field.manager')->clearCachedFieldDefinitions();
-  }
-}
-
-/**
  * Add fields for plugin ID and plugin fields to the block content form.
  */
 function social_content_block_update_8001(&$sandbox) {
@@ -575,5 +533,25 @@ function social_content_block_update_10501(): void {
     $config->setData($config_data)->save();
     // Make sure we clear cached definitions for the fields.
     \Drupal::service('entity_field.manager')->clearCachedFieldDefinitions();
+  }
+}
+
+/**
+ * Reset the field_sorting storage configuration.
+ *
+ * This will remove obselete allowed values which was added due to malformed
+ * code.
+ *
+ * @see:
+ */
+function social_content_block_update_11001() {
+  $config_file = \Drupal::service('extension.list.module')->getPath('social_content_block') . '/config/static/field.storage.block_content.field_sorting_11001.yml';
+  if (is_file($config_file)) {
+    $settings = Yaml::parse(file_get_contents($config_file));
+    if (is_array($settings)) {
+      $config = \Drupal::configFactory()
+        ->getEditable('field.storage.block_content.field_sorting');
+      $config->setData($settings)->save(TRUE);
+    }
   }
 }

--- a/modules/social_features/social_content_block/social_content_block.install
+++ b/modules/social_features/social_content_block/social_content_block.install
@@ -366,7 +366,7 @@ function social_content_block_update_8005() {
  * Add event date as sorting option for events.
  */
 function social_content_block_update_8006() {
-  _social_content_block_update_sorting_options();
+  // Emptied in https://github.com/goalgorilla/open_social/pull/3315
 }
 
 /**
@@ -544,10 +544,11 @@ function social_content_block_update_10501(): void {
  *
  * @see: https://github.com/goalgorilla/open_social/pull/3315
  */
-function social_content_block_update_11001() {
+function social_content_block_update_11001(): void {
   $config_file = \Drupal::service('extension.list.module')->getPath('social_content_block') . '/config/static/field.storage.block_content.field_sorting_11001.yml';
-  if (is_file($config_file)) {
-    $settings = Yaml::parse(file_get_contents($config_file));
+  if (is_file($config_file)
+    && !empty($file_content = file_get_contents($config_file))) {
+    $settings = Yaml::parse($file_content);
     if (is_array($settings)) {
       $config = \Drupal::configFactory()
         ->getEditable('field.storage.block_content.field_sorting');

--- a/modules/social_features/social_content_block/social_content_block.install
+++ b/modules/social_features/social_content_block/social_content_block.install
@@ -542,7 +542,7 @@ function social_content_block_update_10501(): void {
  * This will remove obselete allowed values which was added due to malformed
  * code.
  *
- * @see:
+ * @see: https://github.com/goalgorilla/open_social/pull/3315
  */
 function social_content_block_update_11001() {
   $config_file = \Drupal::service('extension.list.module')->getPath('social_content_block') . '/config/static/field.storage.block_content.field_sorting_11001.yml';

--- a/modules/social_features/social_content_block/src/ContentBuilder.php
+++ b/modules/social_features/social_content_block/src/ContentBuilder.php
@@ -378,28 +378,19 @@ class ContentBuilder implements ContentBuilderInterface {
    * {@inheritdoc}
    */
   public static function updateFormSortingOptions(array $form, FormStateInterface $form_state): array {
-    $parents = ['field_sorting'];
-
     // Check that the currently selected value is valid and change it otherwise.
-    $value_parents = array_merge($parents, ['0', 'value']);
-    $sort_value = $form_state->getValue($value_parents);
-
-    $options = NestedArray::getValue(
-      $form,
-      array_merge($parents, ['widget', '#options'])
+    $sort_value = $form_state->getValue(
+      ['settings', 'block_form', 'field_sorting', '0', 'value']
     );
-
-    if ($sort_value === NULL || !isset($options[$sort_value])) {
+    if ($sort_value === NULL || !isset($form['settings']['block_form']['field_sorting']['widget']['#options'][$sort_value])) {
       // Unfortunately this has already triggered a validation error.
       $form_state->clearErrors();
-      $form_state->setValue($value_parents, key($options));
+      $form_state->setValue(
+        ['settings', 'block_form', 'field_sorting', '0', 'value'],
+        key($form['settings']['block_form']['field_sorting']['widget']['#options'])
+      );
     }
-
-    if ($form_state->has('layout_builder__component')) {
-      $parents = array_merge(['settings', 'block_form'], $parents);
-    }
-
-    return NestedArray::getValue($form, $parents);
+    return $form['settings']['block_form']['field_sorting'];
   }
 
   /**

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -4741,16 +4741,6 @@ parameters:
 			path: modules/social_features/social_content_block/social_content_block.install
 
 		-
-			message: "#^Function _social_content_block_update_sorting_options\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: modules/social_features/social_content_block/social_content_block.install
-
-		-
-			message: "#^Function social_content_block_modules_installed\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: modules/social_features/social_content_block/social_content_block.install
-
-		-
 			message: "#^Function social_content_block_update_10300\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: modules/social_features/social_content_block/social_content_block.install


### PR DESCRIPTION
## Problem
As a SM I create a custom content list block on a Dashboard page. When I select “Events” as Type of content, I should see the following options: Oldest -> Newest and Newest -> Oldest, but the options are not displayed.

## Solution

**Step 1**
https://github.com/goalgorilla/open_social/blob/11.5.9/modules/social_features/social_content_block/social_content_block.install#L17 acted on every module got installed on the platform as described in https://api.drupal.org/api/drupal/core%21lib%21Drupal%21Core%21Extension%21module.api.php/function/hook_modules_installed/8.9.x

The function at https://github.com/goalgorilla/open_social/blob/11.5.9/modules/social_features/social_content_block/social_content_block.install#L25 called from the above mentioned hook and it added the allowed values to given field storage. There was no defensive check in order to determine if the value already exists, which means an allowed value could be repeated. This lead to the following configuration state in one of the platforms.

````````````````````````````````````````````````````````````````````````````````````````````````````````````````````````````````````````````````````````````````````````````````````````````````````````````````````uuid: d7490143-e5c9-4c17-a102-2e65838ab848
langcode: de
status: true
dependencies:
  module:
    - block_content
    - options
_core:
  default_config_hash: QJV_qv560nqafTe7wVgTTQHLIUZ_Vl9rzK1o3pTg8h0
id: block_content.field_sorting
field_name: field_sorting
entity_type: block_content
type: list_string
settings:
  allowed_values:
    -
      value: created
      label: 'Most recent'
    -
      value: changed
      label: 'Letztes Update'
    -
      value: most_commented
      label: 'Am meisten kommentiert'
    -
      value: last_commented
      label: 'Last commented'
    -
      value: most_liked
      label: 'Am meisten geliked'
    -
      value: last_interacted
      label: Trending
    -
      value: trending
      label: 'Most popular'
    -
      value: created
      label: 'Most recent'
    -
      value: changed
      label: 'Letztes Update'
    -
      value: most_commented
      label: 'Am meisten kommentiert'
    -
      value: last_commented
      label: 'Last commented'
    -
      value: most_liked
      label: 'Am meisten geliked'
    -
      value: last_interacted
      label: Trending
    -
      value: trending
      label: 'Most popular'
    -
      value: created
      label: 'Most recent'
    -
      value: changed
      label: 'Letztes Update'
    -
      value: most_commented
      label: 'Am meisten kommentiert'
    -
      value: last_commented
      label: 'Last commented'
    -
      value: most_liked
      label: 'Am meisten geliked'
    -
      value: last_interacted
      label: Trending
    -
      value: trending
      label: 'Most popular'
    -
      value: event_date
      label: 'Oldest -> Newest'
    -
      value: event_date_desc
      label: 'Newest -> Oldest'
    -
      value: created
      label: 'Most recent'
    -
      value: changed
      label: 'Letztes Update'
    -
      value: most_commented
      label: 'Am meisten kommentiert'
    -
      value: last_commented
      label: 'Last commented'
    -
      value: most_liked
      label: 'Am meisten geliked'
    -
      value: last_interacted
      label: Trending
    -
      value: trending
      label: 'Most popular'
    -
      value: created
      label: 'Most recent'
    -
      value: changed
      label: 'Letztes Update'
    -
      value: most_commented
      label: 'Am meisten kommentiert'
    -
      value: last_commented
      label: 'Last commented'
    -
      value: most_liked
      label: 'Am meisten geliked'
    -
      value: last_interacted
      label: Trending
    -
      value: trending
      label: 'Most popular'
  allowed_values_function: _social_content_block_allowed_values_callback
module: options
locked: false
cardinality: 1
translatable: true
indexes: {  }
persist_with_no_fields: false
custom_storage: false

````````````````````````````````````````````````````````````````````````````````````````````````````````````````````````````````````````````````````````````````````````````````````````````````````````````````````

Later, in https://github.com/goalgorilla/open_social/pull/2474, specifically in https://github.com/goalgorilla/open_social/commit/1a032b34fa0d7cc1778ec3da6ed573b0f8b010ea#diff-1dbad080e044f8dda3b79fa316b7c19719e226e66602fc775cd1a974ef7fac8aR13, the following was added:

```
  allowed_values_function: '_social_content_block_allowed_values_callback'
```

which made the function in https://github.com/goalgorilla/open_social/blob/11.5.9/modules/social_features/social_content_block/social_content_block.install#L17 unnecessary.

So, we are reverting the https://github.com/goalgorilla/open_social/blob/11.5.9/modules/social_features/social_content_block/config/install/field.storage.block_content.field_sorting.yml to it's original state.

===========================================================================================

**Step 2**
_Added description in sorting options available in EventContentBlock::supportedSortOptions()._

The Content block sorting widget was checking for description of each sorting option. This was added in https://github.com/goalgorilla/open_social/commit/2e624164ad455cce971a5618ecc10176b640ce97

Now, because of the following condition

```
if (
          in_array($name, $names) ||
          !is_array($settings) ||
          empty($settings['description'])
        ) {
          continue;
        }
```

in https://github.com/goalgorilla/open_social/blob/11.5.9/modules/social_features/social_content_block/src/Plugin/Field/FieldWidget/ContentBlockSortingWidget.php#L132 and because we didn't had description in sorting options of EventContentBlock supported sort options here https://github.com/goalgorilla/open_social/blob/11.5.9/modules/social_features/social_content_block/modules/social_event_content_block/src/Plugin/ContentBlock/EventContentBlock.php#L193 it was not being added to widget's options.

===========================================================================================

**Step 3**
_Refactor the logic of adding sort values during ajax call._

Whenever a user selected Event in Content Type, the sorting options would have been updated by ajax called defined in https://github.com/goalgorilla/open_social/blob/11.5.9/modules/social_features/social_content_block/src/ContentBuilder.php#L302

The sort values being fetched in https://github.com/goalgorilla/open_social/blob/11.5.9/modules/social_features/social_content_block/src/ContentBuilder.php#L385 were returning `NULL` due to which current widget options were also being set to `NULL` in https://github.com/goalgorilla/open_social/blob/11.5.9/modules/social_features/social_content_block/src/ContentBuilder.php#L387

This lead to an error in https://github.com/goalgorilla/open_social/blob/11.5.9/modules/social_features/social_content_block/src/ContentBuilder.php#L395 which crashed the AJAX.

 Error:

    ```
    TypeError: key(): Argument #1 ($array) must be of type array, null given in key() (line 411 of /var/www/html/profiles/contrib/social/modules/social_features/social_content_block/src/ContentBuilder.php)
    ```
![Screenshot 2023-02-16 at 5 45 27 PM](https://user-images.githubusercontent.com/8435994/219393283-16b75db8-b832-425f-bc6d-ea4773c77985.png)

So, we refactored the logic which made it possible to fetch the correct sorting options and set the updated values.

## Issue tracker
1. https://www.drupal.org/project/social/issues/3281332
2. https://getopensocial.atlassian.net/browse/PROD-24113

## Theme issue tracker
N.A

## How to test
- [ ] Create/edit the Dashboard page
- [ ]  Add a new custom content list block
- [ ]  Choose "Event"
- [ ]  Scroll to sorting options and u should see 2 additional options: "Oldest -> Newest", "Newest -> Oldest"

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
**Before**
![Screenshot 2023-02-16 at 6 51 02 PM](https://user-images.githubusercontent.com/8435994/219393400-8fb7849e-57f8-4007-a6d2-01835e45c8d4.png)

**After**
![Screenshot 2023-02-16 at 6 51 39 PM](https://user-images.githubusercontent.com/8435994/219393421-06696ded-15b4-4b67-8b5f-78812b47f468.png)

## Release notes
Earlier, a SM was not able to see the follow sorting options on selecting 'Event' on Dashboard while adding 'Custom content block'

1. Oldest -> Newest
2. Newest -> Oldest

## Change Record
N.A

## Translations
N.A