### PR TITLE
Issue #3344207 by nkoporec: Alternative frontpage settings causes an endless redirect loop

### DIFF
--- a/modules/custom/alternative_frontpage/alternative_frontpage.services.yml
+++ b/modules/custom/alternative_frontpage/alternative_frontpage.services.yml
@@ -1,6 +1,6 @@
 services:
   alternative_frontpage.redirect_homepage:
     class: Drupal\alternative_frontpage\EventSubscriber\RedirectHomepageSubscriber
-    arguments: ['@user.data', '@config.factory', '@current_user', '@path.matcher', '@state', '@entity_type.manager', '@language_manager']
+    arguments: ['@user.data', '@config.factory', '@current_user', '@path.matcher', '@state', '@entity_type.manager', '@language_manager', '@path_alias.repository']
     tags:
       - { name: event_subscriber }


### PR DESCRIPTION
## Problem
When using the alternative_frontpage module, users can create endless redirect loops if they use path aliases for path instead of actual url.

## Solution
 In RedirectHomepageSubscriber.php we are not checking if the frontpage path setting is an alias or an actual url. We need to always compare urls and not aliases and then decide if we need to do the redirect.

## Issue tracker
*https://www.drupal.org/project/social/issues/3344207

## Theme issue tracker
*[Required if applicable] Paste a link to the drupal.org theme issue queue item, either from [socialbase](https://www.drupal.org/project/socialbase) or [socialblue](https://www.drupal.org/project/socialblue). If any other issue trackers were used, include links to those too.*

## How to test
1. Install alternative_frontpage module
2. Create a basic page, that will be the frontpage for authenticated users (eq, /node/1), make sure it has an alias (eq. /front)
3. Set the frontpage to '/node/1' at /admin/config/system/site-information
4. Go to /admin/config/alternative_frontpage
5. Create a new alternative frontpage item for authenticated users
6. For 'Frontpage path' use the alias for the node previously created, eq. /front
7. Save
8. Try to login and access the homepage as authenticated user.
9. Endless redirect loop will occur.


## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
*[Required if new feature, and if applicable] If this Pull Request makes visual changes then please include some screenshots that show what has changed here. A before and after screenshot helps the reviewer determine what changes were made.*

## Release notes
Fixed a bug, where users could create endless redirect loops, if they used alternative_frontpage module and inserted path aliases instead of the actual page url.

## Change Record
The following change record needs to be published as soon as this issue is released https://www.drupal.org/node/3345224

## Translations
*[Optional]Translatable strings are always extracted from the latest development branch. To ensure translations remain available for platforms running older versions of Open Social the original string should be added to `translations.php` when it's changed or removed.*
- [ ] Changed or removed source strings are added to the `translations.php` file.
