### PR TITLE
Issue #3345231 by zanivdmar: Missing option to accept invite 

### DIFF
--- a/modules/social_features/social_group/modules/social_group_invite/social_group_invite.module
+++ b/modules/social_features/social_group/modules/social_group_invite/social_group_invite.module
@@ -908,7 +908,7 @@ function social_group_invite_field_formatter_info_alter(array &$info): void {
 /**
  * Implements hook_social_group_join_method_usage_alter().
  */
-function social_group_invite_social_group_join_method_usage_alter(array &$items) {
+function social_group_invite_social_group_join_method_usage_alter(array &$items): void {
 
   // Ads "added" method for flexible_group, because users with certain
   // permissions (SM/GM) can always invite users (member management feature),
@@ -920,7 +920,8 @@ function social_group_invite_social_group_join_method_usage_alter(array &$items)
         if (is_string($item['method'])) {
           $item['method'] = [$item['method']];
         }
-      } else {
+      }
+      else {
         $item['method'] = [];
       }
 

--- a/modules/social_features/social_group/modules/social_group_invite/social_group_invite.module
+++ b/modules/social_features/social_group/modules/social_group_invite/social_group_invite.module
@@ -906,15 +906,13 @@ function social_group_invite_field_formatter_info_alter(array &$info): void {
 }
 
 /**
- * Ads "added" method for flexible_group, because users with certain permissions
- * (SM/GM) can always invite users (member management feature), despite what
- * join method is selected per flexible group.
- *
- * @param array $items
- * @return void
+ * Implements hook_social_group_join_method_usage_alter().
  */
 function social_group_invite_social_group_join_method_usage_alter(array &$items) {
 
+  // Ads "added" method for flexible_group, because users with certain
+  // permissions (SM/GM) can always invite users (member management feature),
+  // despite what join method is selected per flexible group.
   foreach ($items as &$item) {
 
     if (isset($item['bundle']) && in_array('flexible_group', (array) $item['bundle'])) {

--- a/modules/social_features/social_group/modules/social_group_invite/social_group_invite.module
+++ b/modules/social_features/social_group/modules/social_group_invite/social_group_invite.module
@@ -917,7 +917,7 @@ function social_group_invite_social_group_join_method_usage_alter(array &$items)
 
   foreach ($items as &$item) {
 
-    if (isset($item['bundle']) && $item['bundle'] === 'flexible_group') {
+    if (isset($item['bundle']) && in_array('flexible_group', (array) $item['bundle'])) {
       if (isset($item['method'])) {
         if (is_string($item['method'])) {
           $item['method'] = [$item['method']];

--- a/modules/social_features/social_group/modules/social_group_invite/social_group_invite.module
+++ b/modules/social_features/social_group/modules/social_group_invite/social_group_invite.module
@@ -904,3 +904,31 @@ function social_group_invite_field_formatter_info_alter(array &$info): void {
     $info['entity_reference_label']['class'] = EntityReferenceLabelFormatterOverrider::class;
   }
 }
+
+/**
+ * Ads "added" method for flexible_group, because users with certain permissions
+ * (SM/GM) can always invite users (member management feature), despite what
+ * join method is selected per flexible group.
+ *
+ * @param array $items
+ * @return void
+ */
+function social_group_invite_social_group_join_method_usage_alter(array &$items) {
+
+  foreach ($items as &$item) {
+
+    if (isset($item['bundle']) && $item['bundle'] === 'flexible_group') {
+      if (isset($item['method'])) {
+        if (is_string($item['method'])) {
+          $item['method'] = [$item['method']];
+        }
+      } else {
+        $item['method'] = [];
+      }
+
+      if (!array_search('added', $item['method'])) {
+        $item['method'][] = 'added';
+      }
+    }
+  }
+}

--- a/modules/social_features/social_group/modules/social_group_invite/src/Plugin/Join/SocialGroupInviteJoin.php
+++ b/modules/social_features/social_group/modules/social_group_invite/src/Plugin/Join/SocialGroupInviteJoin.php
@@ -105,6 +105,12 @@ class SocialGroupInviteJoin extends SocialGroupDirectJoin {
       $variables['#cache']['tags'][] = 'group_content_list:entity:' . $this->currentUser->id();
       $variables['#cache']['tags'][] = 'group_content_list:plugin:group_invitation:entity:' . $this->currentUser->id();
     }
+    elseif ($entity->field_group_allowed_join_method->value === 'direct') {
+      $items = parent::actions($entity, $variables);
+      $variables['#cache']['contexts'][] = 'user';
+      $variables['#cache']['tags'][] = 'group_content_list:entity:' . $this->currentUser->id();
+      $variables['#cache']['tags'][] = 'group_content_list:plugin:group_invitation:entity:' . $this->currentUser->id();
+    }
     elseif (
       count($items = parent::actions($entity, $variables)) === 1 &&
       in_array($entity->bundle(), $this->types()) ||

--- a/modules/social_features/social_group/modules/social_group_invite/src/Plugin/Join/SocialGroupInviteJoin.php
+++ b/modules/social_features/social_group/modules/social_group_invite/src/Plugin/Join/SocialGroupInviteJoin.php
@@ -105,7 +105,10 @@ class SocialGroupInviteJoin extends SocialGroupDirectJoin {
       $variables['#cache']['tags'][] = 'group_content_list:entity:' . $this->currentUser->id();
       $variables['#cache']['tags'][] = 'group_content_list:plugin:group_invitation:entity:' . $this->currentUser->id();
     }
-    elseif ($entity->field_group_allowed_join_method->value === 'direct') {
+    elseif (
+      $entity->hasField('field_group_allowed_join_method') &&
+      $entity->field_group_allowed_join_method->value === 'direct'
+    ) {
       $items = parent::actions($entity, $variables);
       $variables['#cache']['contexts'][] = 'user';
       $variables['#cache']['tags'][] = 'group_content_list:entity:' . $this->currentUser->id();

--- a/modules/social_features/social_group/modules/social_group_request/src/Plugin/Join/SocialGroupRequestJoin.php
+++ b/modules/social_features/social_group/modules/social_group_request/src/Plugin/Join/SocialGroupRequestJoin.php
@@ -6,6 +6,7 @@ use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Link;
 use Drupal\Core\Url;
 use Drupal\ginvite\GroupInvitationLoaderInterface;
+use Drupal\ginvite\Plugin\GroupContentEnabler\GroupInvitation as GroupInvitationEnabler;
 use Drupal\grequest\Plugin\GroupContentEnabler\GroupMembershipRequest;
 use Drupal\social_group\EntityMemberInterface;
 use Drupal\social_group\JoinBase;
@@ -80,8 +81,9 @@ class SocialGroupRequestJoin extends JoinBase {
     // If user has a pending invite we should skip the request button.
     if ($this->loader !== NULL) {
       $group_invites = $this->loader->loadByProperties([
-        'gid' => $group->id(),
-        'uid' => $this->currentUser->id(),
+        'entity_id' => $this->currentUser->id(),
+        'gid' => $entity->id(),
+        'invitation_status' => GroupInvitationEnabler::INVITATION_PENDING,
       ]);
 
       if ($group_invites !== []) {

--- a/modules/social_features/social_group/social_group.module
+++ b/modules/social_features/social_group/social_group.module
@@ -1135,16 +1135,20 @@ function social_group_form_alter(&$form, FormStateInterface $form_state, $form_i
       }
 
       // These conditions are here to check exactly the same as the code above
-      // except that `!isset($data['method']) &&` is not part of the conditions
-      // anymore. The reason why we did this is that initial architecture of
-      // @Join plugins predicted that plugins could be initiated only by field
-      // or only by method, but there can be group types where it should
-      // be initiated by both. The conditions below are respecting that fact,
-      // which is needed to change the field type of the field which is
-      // responsible for listing all join options accordingly.
-      $field_found = FALSE;
+      // except that `!isset($data['method']) &&` is replaced by
+      // `$data['field'] === 'field_group_allowed_join_method'` instead.
+      // The reason why we did this is that initial architecture of
+      // @Join plugins predicted that plugins where "method" is defined,
+      // should not be altered in this process, but there are groups which have
+      // "method" defined for fallback reasons and this is why we need to
+      // process them the same way as there would be no "method" defined.
+      // Currently, we are limiting this exception only for the groups with
+      // field field_group_allowed_join_method. In the future we can change this
+      // logic in a way that it would not be based on field name but rather on
+      // plugin setting.
       if (
         isset($data['field'], $form[$data['field']]) &&
+        $data['field'] === 'field_group_allowed_join_method' &&
         $data['entity_type'] === $entity_type_id &&
         (
           !isset($data['bundle']) &&
@@ -1152,21 +1156,17 @@ function social_group_form_alter(&$form, FormStateInterface $form_state, $form_i
           in_array($bundle, (array) $data['bundle'])
         )
       ) {
-        $field_found = TRUE;
+        $found = TRUE;
         break;
-      }
-    }
-
-    if ($field_found && isset($data)) {
-      $field = &$form[$data['field']]['widget'];
-
-      if ($field['#type'] === 'checkboxes') {
-        $field['#type'] = 'radios';
       }
     }
 
     if ($found && isset($data)) {
       $field = &$form[$data['field']]['widget'];
+
+      if ($field['#type'] === 'checkboxes') {
+        $field['#type'] = 'radios';
+      }
 
       if ($entity->isNew()) {
         $hook = 'social_group_join_method_info';

--- a/modules/social_features/social_group/social_group.module
+++ b/modules/social_features/social_group/social_group.module
@@ -1133,14 +1133,40 @@ function social_group_form_alter(&$form, FormStateInterface $form_state, $form_i
         $found = TRUE;
         break;
       }
+
+      // These conditions are here to check exactly the same as the code above
+      // except that `!isset($data['method']) &&` is not part of the conditions
+      // anymore. The reason why we did this is that initial architecture of
+      // @Join plugins predicted that plugins could be initiated only by field
+      // or only by method, but there can be group types where it should
+      // be initiated by both. The conditions below are respecting that fact,
+      // which is needed to change the field type of the field which is
+      // responsible for listing all join options accordingly.
+      $field_found = FALSE;
+      if (
+        isset($data['field'], $form[$data['field']]) &&
+        $data['entity_type'] === $entity_type_id &&
+        (
+          !isset($data['bundle']) &&
+          $bundle === NULL ||
+          in_array($bundle, (array) $data['bundle'])
+        )
+      ) {
+        $field_found = TRUE;
+        break;
+      }
     }
 
-    if ($found && isset($data)) {
+    if ($field_found && isset($data)) {
       $field = &$form[$data['field']]['widget'];
 
       if ($field['#type'] === 'checkboxes') {
         $field['#type'] = 'radios';
       }
+    }
+
+    if ($found && isset($data)) {
+      $field = &$form[$data['field']]['widget'];
 
       if ($entity->isNew()) {
         $hook = 'social_group_join_method_info';

--- a/modules/social_features/social_group/social_group.module
+++ b/modules/social_features/social_group/social_group.module
@@ -1138,7 +1138,7 @@ function social_group_form_alter(&$form, FormStateInterface $form_state, $form_i
       // except that `!isset($data['method']) &&` is replaced by
       // `$data['field'] === 'field_group_allowed_join_method'` instead.
       // The reason why we did this is that initial architecture of
-      // @Join plugins predicted that plugins where "method" is defined,
+      // `@Join` plugins predicted that plugins where "method" is defined,
       // should not be altered in this process, but there are groups which have
       // "method" defined for fallback reasons and this is why we need to
       // process them the same way as there would be no "method" defined.


### PR DESCRIPTION
## Problem
Invited user is missing option to accept/reject invitation when they are invited to "request to join" group.

## Solution
Which "join plugin" is initiated with given group can be determined by field or by method. Flexible groups are defining this by field_group_allowed_join_method "Join methods". In the code, there was already predicted that If user has a pending invite, we should skip the request button and go to "fallback" `added` join method, but that never worked since https://github.com/goalgorilla/open_social/pull/2658. To fix this we added `added` join method as something that is always available for flexible groups despite and in addition to what is selected by "Join methods"

## Code explanation
[social_group_invite.module](https://github.com/goalgorilla/open_social/pull/3326/files#diff-676d9bcf9065b481e26a458b6df37aa9832e783f8f98d2900b03091c3010c2aa)

![Screenshot 2023-03-01 at 15 13 29](https://user-images.githubusercontent.com/13753184/222165400-d1ae553b-bc05-470c-a2d3-eb674782a934.png)

![Screenshot 2023-03-01 at 15 20 43](https://user-images.githubusercontent.com/13753184/222167143-a3794b13-9788-4a14-a61f-7266d88ee224.png)

Users with certain permissions (SM/GM) can always invite users (member management feature), despite what join method is selected per flexible group. Join options are provided by plugins and which plugins are initiated per entity type, can be defined by field (for example by field_group_allowed_join_method in flexible groups) or by method. If something is defined by field, this is considered as something that user can determine while methods are a bit more predefined. 
In this part of code, we are simply adding `added` join method in addition to what is selected by "Join methods". The only case where adding the `added` method is actually used, is when "Request to join" option in "Join methods" is selected.

[social_group.module](https://github.com/goalgorilla/open_social/pull/3326/files#diff-edd44b4e9fde46402d56b864e01c3bb74a7ff121d3d800c7e54905c1784ab7d1)
On flexible group create (group/add/flexible_group), there is "Join methods" field which is expected to list of radio buttons. Because we added `added` method to the conditions that triggers the code below are not met anymore.
```
      if ($field['#type'] === 'checkboxes') {
        $field['#type'] = 'radios';
      }
```
Ideally we should check differently, when we should show checkboxes, but this piece of code was introduced as something that disturbs the process flow as less as possible as this has effect on all the groups.

[SocialGroupRequestJoin.php](https://github.com/goalgorilla/open_social/pull/3326/files#diff-2d9bc106cbcad9cd664da592757058068dcf934c7f4a098136d7996c2fb39e1f)
This piece of code is checking whether "fallback" invite buttons should be shown instead of request to join.
`uid` has been changed to `entity_id` because we are interested if current user has invitation and not if current user created invitation. `invitation_status` was introduced to narrow down only pending invitations. 

## Issue tracker
[3345231](https://www.drupal.org/project/social/issues/3345231)

Related issue on social course [3345506](https://www.drupal.org/project/social_course/issues/3345506)

## Theme issue tracker
N/A

## How to test
- [x] Clean install of Open social
- [x] As a site manager create a new group where "Join methods" is "Request to join"
- [x] As a group/site manager invite logged in user to join the group via group/{group_id}/membership > Add member > Invite users.
- [x] As logged in user you will get notification in notification center that you are invited to group. 
- [x] As logged in user click on notification and you will be redirected to group/{group_id}/stream where "Request to join" button will be shown which is a bug.
- [x] The expected result with button to accept/reject button is attained when repeating the steps with this fix applied.

## Additional tests
- [x] use this [patch](https://git.drupalcode.org/issue/social_course-3345506/-/commit/f101ff1377cf05cf3c0263bfdbaee58c8219e72e.diff) from the issue [3345506](https://www.drupal.org/project/social_course/issues/3345506)
- [x] Test all other joining methods flows within flexible group in combination whit or without site/group manager invite.
- [x] Test all joining methods also with all other groups (public, open, closed, courses,..) and check if the fields on the create/edit form of this entity types are exactly the same with or without this fix applied. 


## Definition of done
### Before merge
- [x] Code/peer review is completed
- [x] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [x] All automated tests are green
- [x] Functional/manual tests of the acceptance criteria are approved
- [x] All acceptance criteria were met
- [x] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [x] This pull request has all required labels (team/type/priority)
- [x] This pull request has a milestone
- [x] This pull request has an assignee (if applicable)
- [x] Any front end changes are tested on all major browsers
- [x] New UI elements, or changes on UI elements are approved by the design team
- [x] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status
- [ ] **Check the remaining tasks on [3345506](https://www.drupal.org/project/social_course/issues/3345506)**

## Screenshots
![actual](https://user-images.githubusercontent.com/13753184/222158389-bce5d12b-5540-4f2e-b2d5-d9e05d78a093.png)
![expected](https://user-images.githubusercontent.com/13753184/222158443-c81222da-51ef-45bb-a46c-4647d7916503.png)


## Release notes
Invited user is missing option to accept/reject invitation when they are invited to "request to join" flexible group. This regression is fixed by this update.

## Change Record
N/A

## Translations
N/A
- [ ] Changed or removed source strings are added to the `translations.php` file.
