### PR TITLE
Internal: Dump pre-update database to GitHub artifact

### DIFF
--- a/.github/workflows/behat.yml
+++ b/.github/workflows/behat.yml
@@ -124,6 +124,15 @@ jobs:
           drush cset -y swiftmailer.transport smtp_host 'mailcatcher'
           drush cset -y swiftmailer.transport smtp_port 1025
 
+          # Dump the database to our test-output folder so that we can locally
+          # debug if the update fails.
+          mkdir -p behat-test-output
+          if [[ "${{ matrix.with_optional }}" == "with-optional" ]]; then
+            drush sql-dump > behat-test-output/pre-update-with-optional.sql
+          else
+            drush sql-dump > behat-test-output/pre-update.sql
+          fi
+
           # Composer has special handling for "version-like" branch names
           if [[ $BRANCH_NAME =~ [0-9]+\.[0-9]+\.x ]]; then
             export OPEN_SOCIAL_VERSION=$BRANCH_NAME-dev


### PR DESCRIPTION
## Problem/Solution
It can be difficult to get an older version of Open Social installed locally (e.g. due to unsupported PHP versions). This commit dumps the database after installing the older version so that it can easily be loaded for local debugging in case the upgrade path is broken.

The GitHub artefact is only created in case the test fails so we don't waste any storage space on success.

## Issue tracker
Internal change no ticket

## How to test
*[Required] For example*
- [ ] Using version X.Y.Z of Open Social with the example module enabled
- [ ] As a sitemanager
- [ ] Try to enable the option B on screen c/d/e
- [ ] When saving I expect the result to be F but instead see G.
- [ ] The expected result F is attained when repeating the steps with this fix applied.

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status
