### PR TITLE
Issue #3346912 by zanvidmar: Profile pictures missing on landing page

### DIFF
--- a/modules/social_features/social_profile/social_profile.module
+++ b/modules/social_features/social_profile/social_profile.module
@@ -714,9 +714,9 @@ function social_profile_profile_view_alter(array &$build, EntityInterface $entit
   /** @var \Drupal\Core\Session\AccountProxy $current_user */
   $current_user = \Drupal::currentUser();
 
-  // If the current user is anonymous, it means it does not have access to the
-  // users profile.
-  if ($current_user->isAnonymous() &&
+  // If the current user has no access to viewing user profiles, it might not
+  // have access to the users profile.
+  if (!$current_user->hasPermission('view any profile profile') &&
     isset($display->get('content')['field_profile_image'])
   ) {
 


### PR DESCRIPTION
Profile pictures missing on landing page content type for LU that is not VU.

## Problem
This is the FUP of [3237](https://github.com/goalgorilla/open_social/pull/3237)
For authenticated user, which is not verified user, the user profile image is not loaded and appears broken instead of the default placeholder.

## Solution
Use permission system instead of role based logic which is not covering all the cases.

## Issue tracker
[3346912](https://www.drupal.org/project/social/issues/3346912)

## Theme issue tracker
N/A

## How to test
- [ ] Using the latest version of Open Social with the social_landing_page and ~~social_private_file~~ social_file_private modules enabled
- [ ] Define `$settings['file_private_path']` in settings.php
- [ ] As a site manager, create a landing page, add "featured content" section and select any profile entities
- [ ] When I open the created page as anonymous I expect to see added profiles with default profile images shown.
- [ ] When I open the created page as authenticated user without verified user role, I expect to see added profiles with default profile images shown.

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
N/A

## Release notes
When the website was using private file, then the profile images appear to be broken on landing pages for Authenticated users without verified user role, if a featured content or a stream view was added. We resolved the access problem for given users and now the default profile picture is displayed.

## Change Record
N/A

## Translations
N/A
