### PR TITLE
Issue #3346966 by ronaldtebrake: Social Content Translation Config Override runs in unnecessary circumstances.

### DIFF
--- a/modules/social_features/social_core/src/ContentTranslationConfigOverrideBase.php
+++ b/modules/social_features/social_core/src/ContentTranslationConfigOverrideBase.php
@@ -5,6 +5,7 @@ namespace Drupal\social_core;
 use Drupal\Core\Cache\CacheableMetadata;
 use Drupal\Core\Config\Config;
 use Drupal\Core\Config\ConfigFactoryOverrideInterface;
+use Drupal\Core\Config\StorableConfigBase;
 use Drupal\Core\Config\StorageInterface;
 
 /**
@@ -29,7 +30,7 @@ abstract class ContentTranslationConfigOverrideBase implements ConfigFactoryOver
   /**
    * Returns the module that provides the overrides.
    *
-   * This is used as the social_contant_translation.settings configuration key
+   * This is used as the social_content_translation.settings configuration key
    * as well as in the cache suffix for the overrides.
    *
    * @return string
@@ -40,7 +41,7 @@ abstract class ContentTranslationConfigOverrideBase implements ConfigFactoryOver
   /**
    * Returns the display name for this set of configuration overrides.
    *
-   * This can be used in a user interface to let sitemanagers determine which
+   * This can be used in a user interface to let site managers determine which
    * parts of Open Social should be translatable. For consistency when
    * displaying this should always be a plural string.
    *
@@ -77,8 +78,7 @@ abstract class ContentTranslationConfigOverrideBase implements ConfigFactoryOver
     if (!$is_enabled) {
       return $overrides;
     }
-
-    if ($is_enabled) {
+    else {
       $translation_overrides = $this->getTranslationOverrides();
 
       foreach ($translation_overrides as $name => $override) {
@@ -100,7 +100,7 @@ abstract class ContentTranslationConfigOverrideBase implements ConfigFactoryOver
   protected function getContentTranslationSettings(): Config {
     $settings = &drupal_static(__FUNCTION__);
 
-    // Lets statically cache this, because of performance reasons
+    // Let's statically cache this, because of performance reasons
     // this could get called quite often (for all the loadOverrides).
     if (empty($settings)) {
       $settings = \Drupal::configFactory()->getEditable('social_content_translation.settings');
@@ -151,7 +151,7 @@ abstract class ContentTranslationConfigOverrideBase implements ConfigFactoryOver
   /**
    * {@inheritdoc}
    */
-  public function createConfigObject($name, $collection = StorageInterface::DEFAULT_COLLECTION) {
+  public function createConfigObject($name, $collection = StorageInterface::DEFAULT_COLLECTION): ?StorableConfigBase {
     return NULL;
   }
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -5796,11 +5796,6 @@ parameters:
 			path: modules/social_features/social_core/social_core.post_update.php
 
 		-
-			message: "#^Method Drupal\\\\social_core\\\\ContentTranslationConfigOverrideBase\\:\\:createConfigObject\\(\\) should return Drupal\\\\Core\\\\Config\\\\StorableConfigBase but returns null\\.$#"
-			count: 1
-			path: modules/social_features/social_core/src/ContentTranslationConfigOverrideBase.php
-
-		-
 			message: "#^\\\\Drupal calls should be avoided in classes, use dependency injection instead$#"
 			count: 1
 			path: modules/social_features/social_core/src/ContentTranslationConfigOverrideBase.php
@@ -16706,3 +16701,8 @@ parameters:
 			message: "#^Access to an undefined property Drupal\\\\Core\\\\Field\\\\FieldItemListInterface\\:\\:\\$date\\.$#"
 			count: 4
 			path: modules/social_features/social_event/src/SocialEventTrait.php
+
+		-
+			message: "#^\\\\Drupal calls should be avoided in classes, use dependency injection instead$#"
+			count: 1
+			path: modules/social_features/social_core/src/ContentTranslationConfigOverrideBase.php


### PR DESCRIPTION
## Problem
As we're adding this to social_core, so we can easily and always extend this (without creating dependencies) we need to make sure we worry about performance as well. The config override is added on runtime for every request now; but it should only kick in when:

- Social content translation is enabled.
- The module, extending, is configured to be true in the content translation settings
- The config name matches the overridden translations from the extending plugin

## Solution
If its not enabled, lets return early, saves a hell of a lot of checks. 
If it is enabled, lets make sure we statically cache the settings from config, 
otherwise we need to load that over and over.
Otherwise continue as normal, as we are already only overriding things when the config name is in the array of the plugin extending.


## Issue tracker
https://www.drupal.org/project/social/issues/3346966

## How to test
- [x] Reinstall (without social_content_translation) on main
- [x] Put a breakpoint in ContentTranslationConfigOverrideBase
- [x] See that the settings are loaded over and over again 
- [x] Checkout this branch
- [x] See that it exits early
- [x] Enable `social_content_translation`
- [x] See that the settings are cached statically, so it doesn't have to grab that every single time
- [x] See that we only override for given config as determined by the plugin extending the base class.

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

## Screenshots
Here you can see on a prod environment using blackfire what difference it makes:
![Screenshot 2023-03-10 at 14 12 29](https://user-images.githubusercontent.com/16667281/224324986-4a76cc69-c3f7-4ef4-813d-c189fc080c5f.png)


### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Release notes
TBD