### PR TITLE
Issue #3347315 by bramtenhove: Move execution of expensive invitation data to when it is needed for sending notifications 

### DIFF
--- a/modules/social_features/social_core/src/EventSubscriber/SocialInviteSubscriber.php
+++ b/modules/social_features/social_core/src/EventSubscriber/SocialInviteSubscriber.php
@@ -96,7 +96,6 @@ class SocialInviteSubscriber implements EventSubscriberInterface {
   public function notifyAboutPendingInvitations(RequestEvent $event) {
     // Only show this message when a user is logged in.
     if ($this->currentUser->isAuthenticated()) {
-      $data = $this->inviteService->getInviteData();
       /** @var \Symfony\Component\HttpFoundation\Request $request */
       $request = $event->getRequest();
       $request_path = $request->getPathInfo();
@@ -120,6 +119,8 @@ class SocialInviteSubscriber implements EventSubscriberInterface {
       // the front page set for authenticated users
       // or the stream being the social_core.homepage.
       if (in_array($request_path, $paths_allowed) || in_array($route_name, $routes_allowed)) {
+        $data = $this->inviteService->getInviteData();
+
         if (!empty($data['name']) && !empty($data['amount'])) {
           $replacement_url = [
             '@url' => Url::fromRoute($data['name'], ['user' => $this->currentUser->id()])


### PR DESCRIPTION
## Problem
We execute `$this->inviteService->getInviteData();` on every page load (also file loads from the private file system).

## Solution
Move execution inside of the existing `if` statement controlling the actual notification.

## Issue tracker
- https://www.drupal.org/project/social/issues/3347315

## Theme issue tracker
N/a

## How to test
- [ ] Prepare an invite
- [ ] Load the front page and see that you get a notification about a pending invite

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
N/a

## Release notes
Slightly improve performance by removing unnecessary load of pending invite data.

## Change Record
N/a

## Translations
N/a
