### PR TITLE
Issue #TBD - PROD-24539 - Statically cache block access, ensure db cache is also utilized.

### DIFF
--- a/modules/social_features/social_core/social_core.module
+++ b/modules/social_features/social_core/social_core.module
@@ -642,24 +642,32 @@ function social_core_filter_process_format($element) {
  * Implements hook_block_access().
  */
 function social_core_block_access(Block $block, $operation, AccountInterface $account) {
-  $blocks = &drupal_static(__FUNCTION__);
-  $blocks = [];
+  $blocks = &drupal_static(__FUNCTION__, []);
 
-  // First check if we have it cached before we run the modulehandler alter.
-  /** @var \Drupal\Core\Cache\CacheBackendInterface $cache */
-  $cache = \Drupal::service('cache.default');
-  if ($cache->get('social_core.block_visibility_cache') === FALSE) {
-    // Allow other modules to change the block visibility.
-    $blocks = \Drupal::moduleHandler()->invokeAll('social_core_block_visibility_path');
-
-    // Set the cache expire to 1 week.
-    $date = new DateTime(date('Y-m-d'));
-    $date->modify('+7 day');
-
-    $cache->set('social_core.block_visibility_cache', $blocks, $date->getTimestamp(), ['social_core.block_visibility_cache']);
+  // We only care about view operations right now.
+  if ($operation !== 'view') {
+    return AccessResult::neutral();
   }
-  else {
-    $blocks = $cache->get('social_core.block_visibility_cache')->data;
+
+  // If we didnt have statically cached blocks,
+  // lets see if we can grab it from the cache instead.
+  if (empty($blocks)) {
+    // First check if we have it cached before we run the modulehandler alter.
+    /** @var \Drupal\Core\Cache\CacheBackendInterface $cache */
+    $cache = \Drupal::service('cache.default');
+    if ($cache->get('social_core.block_visibility_cache') === FALSE) {
+      // Allow other modules to change the block visibility.
+      $blocks = \Drupal::moduleHandler()->invokeAll('social_core_block_visibility_path');
+
+      // Set the cache expire to 1 week.
+      $date = new DateTime(date('Y-m-d'));
+      $date->modify('+7 day');
+
+      $cache->set('social_core.block_visibility_cache', $blocks, $date->getTimestamp(), ['social_core.block_visibility_cache']);
+    }
+    else {
+      $blocks = $cache->get('social_core.block_visibility_cache')->data;
+    }
   }
 
   // Alter the access based on the blocks array.


### PR DESCRIPTION
## Problem
We tried to do some nice static caching, but it still hurt Redis a lot in trying to get the `$blocks = $cache->get('social_core.block_visibility_cache')->data;` which was unnecessary.

## Solution
When doing these block access checks, what we try to do is first check if the request already statically cached which blocks it wants to alter. Otherwise, it gets it from the DB, to see if someone already has done the caching in the database. Othwerise, it sets the cache in the db for the next person/request, as well as statically for the request.

## Issue tracker
TBD.

## How to test
- [ ] As AN
- [ ] On the Homepage
- [ ] See that when you put a breakpoint on social_core.module lines:
`if ($cache->get('social_core.block_visibility_cache') === FALSE) {`
`$blocks = $cache->get('social_core.block_visibility_cache')->data;` 
- [ ] It's running pretty often, even if it should be cached.
- [ ] Checkout this branch;
- [ ] See that only on the first uncached load, it sets the cache 
- [ ] On the subsequent blocks it gets it from the static cache
- [ ] Perform a new request
- [ ] See that on the first block it gets it from the database cache 
- [ ] On the subsequent blocks it gets it from the static cache

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Release notes
Improve static caching for `social_core_block_access()` which should result in a minor performance improvement.

## Translations
*[Optional]Translatable strings are always extracted from the latest development branch. To ensure translations remain available for platforms running older versions of Open Social the original string should be added to `translations.php` when it's changed or removed.*
- [ ] Changed or removed source strings are added to the `translations.php` file.
