### PR TITLE
Issue #TBD - `SocialGroupRequestConfigOverride` runs on every block instance and gets config unnecessary

### DIFF
--- a/modules/social_features/social_group/modules/social_group_request/src/SocialGroupRequestConfigOverride.php
+++ b/modules/social_features/social_group/modules/social_group_request/src/SocialGroupRequestConfigOverride.php
@@ -52,21 +52,29 @@ class SocialGroupRequestConfigOverride implements ConfigFactoryOverrideInterface
   public function loadOverrides($names) {
     $overrides = [];
 
-    foreach ($names as $name) {
-      if (strpos($name, 'block.block.') === 0) {
-        $config = $this->configFactory->getEditable($name);
+    $config_names = [
+      'block.block.socialblue_local_tasks',
+      'block.block.socialbase_local_tasks',
+    ];
 
-        if ($config->get('settings.id') == 'local_tasks_block') {
-          $visibility_paths = $config->get('visibility');
-          if (isset($visibility_paths['request_path']['pages'])) {
-            $overrides[$name] = [
-              'visibility' => [
-                'request_path' => [
-                  'pages' => $visibility_paths['request_path']['pages'] . "\r\n/group/*/membership-requests",
-                ],
+    // We only care about our own local tasks,
+    // other implementations have the Block UI.
+    // Also since it's an optional block, coming from social_core with a
+    // dependency on the theme, we can't do this on hook_install as we don't
+    // know when social_group_request will be installed and if the block already
+    // exists by then.
+    foreach ($config_names as $config_name) {
+      if (in_array($config_name, $names)) {
+        $config = $this->configFactory->getEditable($config_name);
+        $visibility_paths = $config->get('visibility');
+        if (isset($visibility_paths['request_path']['pages'])) {
+          $overrides[$config_name] = [
+            'visibility' => [
+              'request_path' => [
+                'pages' => $visibility_paths['request_path']['pages'] . "\r\n/group/*/membership-requests",
               ],
-            ];
-          }
+            ],
+          ];
         }
       }
     }


### PR DESCRIPTION
## Problem
By running:

```
    foreach ($names as $name) {
      if (strpos($name, 'block.block.') === 0) {
        $config = $this->configFactory->getEditable($name);        
```

We have, on **every page load** a getEditable running for all the blocks.

After checking, we can be sure this code only ran for two blocks:

The local tasks for socialbase and socialblue.

Because we check for `if (isset($visibility_paths['request_path']['pages'])) {` which by default isn't set for any other local tasks (like gin or bootstrap, see screenshots).

So we only ever cared about the ones provided by Open Socials themes.

## Solution
Since this only ran for the socialbase and socialblue ones, we can provide which two config names we want to act upon and thus won't create regression. Other implementations can still do it through the Block UI.

Also since it's an optional block, coming from `social_core` with a dependency on the theme, we can't do this on `hook_install `as we don't know when `social_group_request` will be installed and if the block already exists by then. 

So we make it more performant instead.

## Issue tracker
TBD.

## How to test
- [ ] Enable `social_group_request`
- [ ] As AN
- [ ] Set a breakpoint in the ConfigOverride
- [ ] See that it runs for eeeevery block.
- [ ] Checkout this branch and see that it only runs for the two mentioned ones.

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
See that for Gin & Bootstrap it never was added.

<img width="678" alt="Screenshot 2023-03-13 at 12 48 27" src="https://user-images.githubusercontent.com/16667281/224731686-aeaef1ef-91fb-4a34-8e17-2619881dea68.png">


<img width="469" alt="Screenshot 2023-03-13 at 12 48 18" src="https://user-images.githubusercontent.com/16667281/224731678-9caa95ac-50aa-48a6-bd63-8acd23a03306.png">


## Release notes
Make the config override, which removes the local tasks block from the membership overview pages more performant.
