### PR TITLE
PROD-24543 - Add static caching to preprocess_profile()

### DIFF
--- a/modules/social_features/social_profile/social_profile.module
+++ b/modules/social_features/social_profile/social_profile.module
@@ -389,8 +389,7 @@ function social_profile_preprocess_profile(array &$variables) {
       $current_user->id() != $profile->getOwnerId() &&
       $current_user->hasPermission('use private messaging system') &&
       $current_user->hasPermission('create private messages thread') &&
-      User::load($profile->getOwnerId())
-        ->hasPermission('use private messaging system')
+      $user->hasPermission('use private messaging system')
     ) {
       $preprocessed_variables[$profile->id()]['profile_contact_label'] = 'private_message';
       $preprocessed_variables[$profile->id()]['#cache']['contexts'][] = 'user';

--- a/modules/social_features/social_profile/social_profile.module
+++ b/modules/social_features/social_profile/social_profile.module
@@ -367,47 +367,72 @@ function social_profile_preprocess_field__field_profile_image(array &$variables)
 function social_profile_preprocess_profile(array &$variables) {
   /** @var \Drupal\profile\Entity\Profile $profile */
   $profile = $variables['profile'];
-  $user = User::load($profile->getOwnerId());
   $current_user = \Drupal::currentUser();
 
-  // See social_user_user_format_name_alter(), DisplayName is either first name
-  // + last name, or username if both first and last name aren't filled out.
-  $variables['profile_name'] = $user->getDisplayName();
-  $variables['profile_contact_url'] = _social_profile_get_contact_url($user);
-  $variables['profile_stream_url'] = Url::fromUserInput('/user/' . $profile->getOwnerId() . '/stream');
-  $variables['profile_home'] = Url::fromRoute('entity.user.canonical', ['user' => $user->id()]);
+  $preprocessed_variables = &drupal_static(__FUNCTION__, []);
+  if (empty($preprocessed_variables[$profile->id()])) {
+    $user = User::load($profile->getOwnerId());
 
-  // Set a condition for the label to show in the teaser
-  // The actual label text should be changeable in the template.
-  // Disable for the LU's own profile.
-  $variables['profile_contact_label'] = 'profile_info';
-  if (
-    \Drupal::moduleHandler()->moduleExists('social_private_message') &&
-    $current_user->id() != $profile->getOwnerId() &&
-    $current_user->hasPermission('use private messaging system') &&
-    $current_user->hasPermission('create private messages thread') &&
-    User::load($profile->getOwnerId())
-      ->hasPermission('use private messaging system')
-  ) {
-    $variables['profile_contact_label'] = 'private_message';
-    $variables['#cache']['contexts'][] = 'user';
-  }
+    // See social_user_user_format_name_alter(), DisplayName is either first name
+    // + last name, or username if both first and last name aren't filled out.
+    $preprocessed_variables[$profile->id()]['profile_name'] = $user->getDisplayName();
+    $preprocessed_variables[$profile->id()]['profile_contact_url'] = _social_profile_get_contact_url($user);
+    $preprocessed_variables[$profile->id()]['profile_stream_url'] = Url::fromUserInput('/user/' . $profile->getOwnerId() . '/stream');
+    $preprocessed_variables[$profile->id()]['profile_home'] = Url::fromRoute('entity.user.canonical', ['user' => $user->id()]);
 
-  if (_social_profile_check_property_access($profile, $current_user, 'email')) {
-    // Derived from MailToFormatter.php.
-    $email = $user->getEmail();
-    if (!empty($email)) {
-      $variables['user_mail'] = Link::fromTextAndUrl($email, Url::fromUri('mailto:' . $email));
+    // Set a condition for the label to show in the teaser
+    // The actual label text should be changeable in the template.
+    // Disable for the LU's own profile.
+    $preprocessed_variables[$profile->id()]['profile_contact_label'] = 'profile_info';
+    if (
+      \Drupal::moduleHandler()->moduleExists('social_private_message') &&
+      $current_user->id() != $profile->getOwnerId() &&
+      $current_user->hasPermission('use private messaging system') &&
+      $current_user->hasPermission('create private messages thread') &&
+      User::load($profile->getOwnerId())
+        ->hasPermission('use private messaging system')
+    ) {
+      $preprocessed_variables[$profile->id()]['profile_contact_label'] = 'private_message';
+      $preprocessed_variables[$profile->id()]['#cache']['contexts'][] = 'user';
+    }
+
+    if (_social_profile_check_property_access($profile, $current_user, 'email')) {
+      // Derived from MailToFormatter.php.
+      $email = $user->getEmail();
+      if (!empty($email)) {
+        $preprocessed_variables[$profile->id()]['user_mail'] = Link::fromTextAndUrl($email, Url::fromUri('mailto:' . $email));
+      }
+    }
+
+    // Language field.
+    $language_manager = \Drupal::languageManager();
+    if ($language_manager->isMultilingual() &&
+      _social_profile_check_property_access($profile, $current_user, 'language')) {
+      // Add the user language.
+      $preprocessed_variables[$profile->id()]['user_lang'] = $language_manager->getLanguageName($user->getPreferredLangcode());
+    }
+
+    // Add the hero styled image if we have access to it.
+    if (!empty($profile->field_profile_banner_image->entity) && $profile->field_profile_banner_image->access('view')) {
+      $preprocessed_variables[$profile->id()]['profile_hero_styled_image_url'] = ImageStyle::load('social_xx_large')
+        ->buildUrl($profile->field_profile_banner_image->entity->getFileUri());
+    }
+
+    // Profile information URL.
+    $preprocessed_variables[$profile->id()]['profile_info_url'] = Url::fromRoute('view.user_information.user_information', ['user' => $profile->getOwnerId()]);
+
+    /** @var \Drupal\social_profile\SocialProfileTagServiceInterface $tag_service */
+    $tag_service = \Drupal::service('social_profile.tag_service');
+    $preprocessed_variables[$profile->id()]['profile_tagging_active'] = $tag_service->isActive();
+    $preprocessed_variables[$profile->id()]['profile_tagging_allow_split'] = $tag_service->allowSplit();
+
+    if (!$profile->get('field_profile_profile_tag')->isEmpty()) {
+      $tags = $profile->get('field_profile_profile_tag')->getValue();
+      $preprocessed_variables[$profile->id()]['profile_tagging_hierarchy'] = $tag_service->buildHierarchy($tags);
     }
   }
 
-  // Language field.
-  $language_manager = \Drupal::languageManager();
-  if ($language_manager->isMultilingual() &&
-    _social_profile_check_property_access($profile, $current_user, 'language')) {
-    // Add the user language.
-    $variables['user_lang'] = $language_manager->getLanguageName($user->getPreferredLangcode());
-  }
+  $variables = array_merge($variables, $preprocessed_variables[$profile->id()]);
 
   // Edit profile URL.
   // Get the current route name to check if the user is on the edit or delete
@@ -418,33 +443,16 @@ function social_profile_preprocess_profile(array &$variables) {
     $variables['#cache']['contexts'][] = 'route.name';
   }
 
-  // Add the hero styled image if we have access to it.
-  if (!empty($profile->field_profile_banner_image->entity) && $profile->field_profile_banner_image->access('view')) {
-    $variables['profile_hero_styled_image_url'] = ImageStyle::load('social_xx_large')
-      ->buildUrl($profile->field_profile_banner_image->entity->getFileUri());
-  }
-
-  // Profile information URL.
-  $variables['profile_info_url'] = Url::fromRoute('view.user_information.user_information', ['user' => $profile->getOwnerId()]);
-
   // Prepare variables for statistic block.
   if ($variables['elements']['#view_mode'] === 'statistic') {
+    $user = User::load($profile->getOwnerId());
+
     /** @var \Drupal\social_profile\UserStatistics $user_statistics */
     $user_statistics = \Drupal::service('social_profile.user_statistics');
     $variables['profile_topics'] = $user_statistics->nodeCount($user->id(), 'topic');
     $variables['profile_events'] = $user_statistics->nodeCount($user->id(), 'event');
     $variables['profile_groups'] = \Drupal::service('social_group.helper_service')
       ->countGroupMembershipsForUser($user->id());
-  }
-
-  /** @var \Drupal\social_profile\SocialProfileTagServiceInterface $tag_service */
-  $tag_service = \Drupal::service('social_profile.tag_service');
-  $variables['profile_tagging_active'] = $tag_service->isActive();
-  $variables['profile_tagging_allow_split'] = $tag_service->allowSplit();
-
-  if (!$profile->get('field_profile_profile_tag')->isEmpty()) {
-    $tags = $profile->get('field_profile_profile_tag')->getValue();
-    $variables['profile_tagging_hierarchy'] = $tag_service->buildHierarchy($tags);
   }
 }
 


### PR DESCRIPTION
## Problem
On a users stream page there are a lot of similar calls to this function making it unnecessary slow.

<img width="389" alt="Screenshot 2023-03-14 at 10 16 58" src="https://user-images.githubusercontent.com/7124754/224953644-c0c610c1-b195-422b-b548-1d8420485e26.png">

## Solution
80% of the code happening in social_profile_preprocess_profile() is executed multiple times unnecessary as it is generic and can be reused.

Two specific parts have been excluded as they seem to be specific for the route or the view mode.

## Issue tracker
*[Required] Paste a link to the drupal.org issue queue item. If any other issue trackers were used, include links to those too.*

## Theme issue tracker
*[Required if applicable] Paste a link to the drupal.org theme issue queue item, either from [socialbase](https://www.drupal.org/project/socialbase) or [socialblue](https://www.drupal.org/project/socialblue). If any other issue trackers were used, include links to those too.*

## How to test
*[Required] For example*
- [ ] Using version X.Y.Z of Open Social with the example module enabled
- [ ] As a sitemanager
- [ ] Try to enable the option B on screen c/d/e
- [ ] When saving I expect the result to be F but instead see G.
- [ ] The expected result F is attained when repeating the steps with this fix applied.

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
*[Required if new feature, and if applicable] If this Pull Request makes visual changes then please include some screenshots that show what has changed here. A before and after screenshot helps the reviewer determine what changes were made.*

## Release notes
*[Required if new feature, and if applicable] A short summary of the changes that were made that can be included in release notes.*

## Change Record
*[Required if applicable] If this Pull Request changes the way that developers should do things or introduces a new API for developers then a change record to document this is needed. Please provide a draft for a change record or a link to an unpublished change record below. Existing change records can be consulted as example. Please provide a draft for a change record or a link to an unpublished change record below. [Existing change records](https://www.drupal.org/list-changes/social) can be consulted as example.*

## Translations
*[Optional]Translatable strings are always extracted from the latest development branch. To ensure translations remain available for platforms running older versions of Open Social the original string should be added to `translations.php` when it's changed or removed.*
- [ ] Changed or removed source strings are added to the `translations.php` file.
