### PR TITLE
Issue #3348272 - Fix config override cache gets for Social Comment Upload

### DIFF
--- a/modules/social_features/social_comment_upload/src/SocialCommentUploadConfigOverride.php
+++ b/modules/social_features/social_comment_upload/src/SocialCommentUploadConfigOverride.php
@@ -42,7 +42,7 @@ class SocialCommentUploadConfigOverride implements ConfigFactoryOverrideInterfac
     $overrides = [];
 
     // Add field_group and field_comment_files.
-    // We don't need to add any fields if uploads are disabled, so let's check.
+    // We need to add the necessary fields if uploads are enabled.
     $config_name = 'core.entity_form_display.comment.comment.default';
     if (in_array($config_name, $names) &&
       $this->configFactory->getEditable('social_comment_upload.settings')->getOriginal('allow_upload_comments', TRUE)) {
@@ -88,7 +88,7 @@ class SocialCommentUploadConfigOverride implements ConfigFactoryOverrideInterfac
     }
 
     // Add field_comment_files.
-    // We don't need to add any fields if uploads are disabled, so let's check.
+    // We need to add the necessary field if uploads are enabled.
     $config_name = 'core.entity_view_display.comment.comment.default';
     if (in_array($config_name, $names) &&
       $this->configFactory->getEditable('social_comment_upload.settings')->getOriginal('allow_upload_comments', TRUE)) {

--- a/modules/social_features/social_comment_upload/src/SocialCommentUploadConfigOverride.php
+++ b/modules/social_features/social_comment_upload/src/SocialCommentUploadConfigOverride.php
@@ -41,15 +41,11 @@ class SocialCommentUploadConfigOverride implements ConfigFactoryOverrideInterfac
   public function loadOverrides($names) {
     $overrides = [];
 
-    // We don't need to add any fields if uploads are disabled.
-    // We use getEditable and getOriginal to avoid override loops.
-    if ($this->configFactory->getEditable('social_comment_upload.settings')->getOriginal('allow_upload_comments', TRUE) == FALSE) {
-      return $overrides;
-    }
-
     // Add field_group and field_comment_files.
+    // We don't need to add any fields if uploads are disabled, so let's check.
     $config_name = 'core.entity_form_display.comment.comment.default';
-    if (in_array($config_name, $names)) {
+    if (in_array($config_name, $names) &&
+      $this->configFactory->getEditable('social_comment_upload.settings')->getOriginal('allow_upload_comments', TRUE)) {
       $third_party = [
         'field_group' => [
           'group_add_attachment' => [
@@ -92,8 +88,10 @@ class SocialCommentUploadConfigOverride implements ConfigFactoryOverrideInterfac
     }
 
     // Add field_comment_files.
+    // We don't need to add any fields if uploads are disabled, so let's check.
     $config_name = 'core.entity_view_display.comment.comment.default';
-    if (in_array($config_name, $names)) {
+    if (in_array($config_name, $names) &&
+      $this->configFactory->getEditable('social_comment_upload.settings')->getOriginal('allow_upload_comments', TRUE)) {
       $content = [
         'field_comment_files' => [
           'weight' => 1,


### PR DESCRIPTION
## Problem
We're doing expensive config gets in overrides and this is also for Social Comment Upload.

## Solution
Move the expensive calls within the `if` statement to avoid it being executed more often than necessary.

## Issue tracker
https://www.drupal.org/project/social/issues/3348272

## Theme issue tracker
N/a

## How to test
- [ ] Set a breakpoint, check that it's executed quite often.
- [ ] Go to this branch, it's only executed a handful of times.

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
N/a

## Release notes
We improved performance by reducing the number of config get calls in Social Comment Upload.

## Change Record
N/a

## Translations
N/a
