### PR TITLE
Issue #3348199 by zanvidmar: Flexible groups are not properly updated…

### DIFF
--- a/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.install
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.install
@@ -530,3 +530,75 @@ function social_group_flexible_group_update_11402(): string {
   // Output logged messages to related channel of update execution.
   return $update_helper->logger()->output();
 }
+
+/**
+ * Apply default value of field_group_posts_enabled where it is not defined.
+ *
+ * Before field_group_posts_enabled was introduced, all users were able to post
+ * by default as this was a hardcoded functionality. If the flexible group was
+ * created before field_group_posts_enabled existed, this value is not defined
+ * in the database. If field_group_posts_enabled is not defined (not in the
+ * database) and the group is edited without any changes, the default value is
+ * not set and this results in the group being updated with
+ * field_group_posts_enabled disabled (value 0). Because of these facts, we need
+ * to define the field_group_posts_enabled value for each flexible group where
+ * it is not defined. The field_group_posts_enabled value is defined based on
+ * the field_group_posts_enabled default value.
+ */
+function social_group_flexible_group_update_11701(&$sandbox) {
+  if (!isset($sandbox['total'])) {
+    $sandbox['total'] = \Drupal::entityQuery('group')
+      ->condition('type', 'flexible_group')
+      ->notExists('field_group_posts_enabled')
+      ->count()
+      ->execute();
+
+    if (!$sandbox['total']) {
+      return t('No flexibe groups were updated.');
+    }
+
+    $definitions = \Drupal::service('entity_field.manager')->getFieldDefinitions('group', 'flexible_group');
+    if (isset($definitions['field_group_posts_enabled'])) {
+      $sandbox['field_group_posts_enabled_default_value'] =
+        $definitions['field_group_posts_enabled']->getDefaultValueLiteral()[0]['value'];
+    } else {
+      return t('field_group_posts_enabled does not exist. No flexibe groups were updated.');
+    }
+
+    $sandbox['processed'] = 0;
+    $sandbox['current_id'] = -1;
+    $sandbox['limit'] = Settings::get('entity_update_batch_size', 10);
+  }
+
+  $entity_ids = \Drupal::entityQuery('group')
+    ->condition('type', 'flexible_group')
+    ->condition('id', $sandbox['current_id'], '>')
+    ->notExists('field_group_posts_enabled')
+    ->sort('id')
+    ->range(0, $sandbox['limit'])
+    ->execute();
+
+  $storage = \Drupal::entityTypeManager()->getStorage('group');
+
+  foreach ($entity_ids as $entity_id) {
+    /** @var \Drupal\social_group\Entity\Group $entity */
+    $entity = $storage->load($entity_id);
+    $entity->field_group_posts_enabled->value =
+      $sandbox['field_group_posts_enabled_default_value'];
+    $entity->save();
+
+    $sandbox['processed']++;
+    $sandbox['current_id'] = $entity_id;
+    $sandbox['processed_ids'][] = $entity_id;
+  }
+
+  $sandbox['#finished'] = $sandbox['processed'] >= $sandbox['total'] ? TRUE : $sandbox['processed'] / $sandbox['total'];
+
+  if ($sandbox['#finished'] === TRUE) {
+    return t('Post for group members was @status for @count flexible groups (ids): @ids', [
+      '@status' => $sandbox['field_group_posts_enabled_default_value'] === 1 ? t('enabled') : t('disabled'),
+      '@count' => count($sandbox['processed_ids']),
+      '@ids' => implode(', ', $sandbox['processed_ids']),
+    ]);
+  }
+}


### PR DESCRIPTION
Flexible groups are not properly updated after field_group_posts_enabled was introduced.

## Problem
Before [field_group_posts_enabled was introduced](https://github.com/goalgorilla/open_social/pull/2848/commits/b693adc6d9797644f193325019f4f758d8d1ea66), all users were able to post by default, as this was a hardcoded functionality. If the flexible group was created before field_group_posts_enabled existed, this value is not defined in the database. If field_group_posts_enabled is not defined (not in the database) and the group is edited without any changes, the default value is not set and this results in the group being updated with field_group_posts_enabled disabled (value 0).

**Issue**: field_group_posts_enabled in old flexible groups does not reflect the fields default value.
**Expected result**: after update, field_group_posts_enabled in old flexible groups should be updated to reflect the fields default value.

## Solution
We need to define the field_group_posts_enabled value for each flexible group where it is not defined. The field_group_posts_enabled value is defined based on the field_group_posts_enabled default value (field setting).

## Issue tracker
[3348199](https://www.drupal.org/project/social/issues/3348199)

## Theme issue tracker
N/A

## How to test
- [ ] Install Open Social 11.2.0-alpha2 or lower
- [ ] Create 2 flexible groups
- [ ] You can see that members are by default allowed to post on activity stream
- [ ] Update Open Social to 11.2.0-alpha3
- [ ] Edit previously created flexible group 1
- [ ] Do not change anything and you will see that field "Enable posts for members" is disabled (but it should be enabled).
- [ ] Save the group and now you will see that members are by not allowed to post on activity stream anymore
- [ ] Update Open Social to this PR and trigger hook update.
- [ ] In Group 1 "Enable posts for members" should remain unchecked in Group 2 "Enable posts for members" should be checked.

**Note1**: If flexible group have "Enable posts for members" defined in database as 0 or 1 before the hook update is triggered, they should not be changed.

**Note2**: If default value of "Enable posts for members" (determined in field settings) is defined as disabled, update hook will define this value for all flexible groups where this value is not set.

**Note3**: In the database, table group__field_group_posts_enabled can be observed before and after triggering hook update to get more context about the change.

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
N/A

## Release notes
Set correct default value of "Enable posts for members" in existing flexible groups where it was not yet defined.

## Change Record
N/A

## Translations
*[Optional]Translatable strings are always extracted from the latest development branch. To ensure translations remain available for platforms running older versions of Open Social the original string should be added to `translations.php` when it's changed or removed.*
- [ ] Changed or removed source strings are added to the `translations.php` file.
