### PR TITLE
Issue #3348281 - Fix expensive calls in config override of Social Follow Tag

### DIFF
--- a/modules/social_features/social_follow_taxonomy/modules/social_follow_tag/src/SocialFollowTagOverrides.php
+++ b/modules/social_features/social_follow_taxonomy/modules/social_follow_tag/src/SocialFollowTagOverrides.php
@@ -58,12 +58,12 @@ class SocialFollowTagOverrides implements ConfigFactoryOverrideInterface {
 
     // Add social_tagging taxonomy bundle to follow_term flag config.
     $config_name = 'flag.flag.follow_term';
-    $config = $this->configFactory->getEditable($config_name);
-    $bundles = $config->get('bundles');
-    if (!empty($bundles) && !in_array('social_tagging', $bundles)) {
-      array_push($bundles, 'social_tagging');
+    if (in_array($config_name, $names)) {
+      $config = $this->configFactory->getEditable($config_name);
+      $bundles = $config->get('bundles');
+      if (!empty($bundles) && !in_array('social_tagging', $bundles)) {
+        array_push($bundles, 'social_tagging');
 
-      if (in_array($config_name, $names)) {
         $overrides[$config_name] = [
           'bundles' => $bundles,
         ];


### PR DESCRIPTION
## Problem
We're doing expensive config gets in overrides and this is also the case for Social Follow Tag.

## Solution
Move the `if` statement that checks for the config name first before executing the config get call.

## Issue tracker
https://www.drupal.org/project/social/issues/3348281

## Theme issue tracker
N/a

## How to test
- [x] Enable social_follow_tag
- [x] Set a breakpoint, check that it's executed quite often.
- [x] Go to this branch, it's only executed a handful of times.

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
N/a

## Release notes
We improved performance by reducing the number of config get calls in Social Follow Tag.

## Change Record
N/a

## Translations
N/a