### PR TITLE
Internal: Add control around authors of content in tests

### DIFF
--- a/tests/behat/features/capabilities/contentmanagement/unpublished.feature
+++ b/tests/behat/features/capabilities/contentmanagement/unpublished.feature
@@ -17,7 +17,7 @@ Feature: Un/publish a node
 
   Scenario: Successfully publish an unpublished topic
     Given I am logged in as an "verified"
-    And topics:
+    And topics authored by current user:
       | title    | body            | field_content_visibility | field_topic_type | langcode    | status |
       | My title | My description  | public                   | News             | en          | 0         |
 
@@ -27,7 +27,7 @@ Feature: Un/publish a node
     Then I should see the topic I just updated
 
   Scenario: Normal user only sees published topics
-    Given topics:
+    Given topics with non-anonymous author:
       | title                     | body            | field_content_visibility | field_topic_type | langcode    | status |
       | This topic is published   | My description  | public                   | News             | en          | 1         |
       | This topic is unpublished | My description  | public                   | News             | en          | 0         |

--- a/tests/behat/features/capabilities/event/eventenrollment-manage.feature
+++ b/tests/behat/features/capabilities/event/eventenrollment-manage.feature
@@ -8,7 +8,7 @@ Feature: Manage event enrollment
     Given I enable the module "social_event_managers"
 
   Scenario: Can't manage an event by default
-    Given events:
+    Given events with non-anonymous author:
       | title        | body                  | field_content_visibility | field_event_date    | langcode |
       | Test content | Body description text | community                | 2100-01-01T12:00:00 | en       |
     And I am logged in as a user with the verified role
@@ -21,7 +21,7 @@ Feature: Manage event enrollment
     # @todo The order matters here because we don't have to be explicit about
     # authors yet, we have solved this for groups but not yet for topics/events.
     Given I am logged in as a user with the verified role
-    And events:
+    And events authored by current user:
       | title        | body                  | field_content_visibility | field_event_date    | langcode |
       | Test content | Body description text | community                | 2100-01-01T12:00:00 | en       |
     And users:
@@ -39,7 +39,7 @@ Feature: Manage event enrollment
     And I should see "Jane Doe" in the "Organisers" block
 
   Scenario: Event manager can see the manage enrollments link on events
-    Given events:
+    Given events with non-anonymous author:
       | title        | body                  | field_content_visibility | field_event_date    | langcode |
       | Test content | Body description text | community                | 2100-01-01T12:00:00 | en       |
     And I am logged in as a user with the verified role
@@ -50,7 +50,7 @@ Feature: Manage event enrollment
     Then I should see the link "Manage enrollments"
 
   Scenario: Event manager can see the empty state when there are no enrollments
-    Given events:
+    Given events with non-anonymous author:
       | title        | body                  | field_content_visibility | field_event_date    | langcode |
       | Test content | Body description text | community                | 2100-01-01T12:00:00 | en       |
     And I am logged in as a user with the verified role
@@ -62,7 +62,7 @@ Feature: Manage event enrollment
     And I should see the text "No one has enrolled for this event"
 
   Scenario: Event manager can see the event enrollments when there are enrollments
-    Given events:
+    Given events with non-anonymous author:
       | title        | body                  | field_content_visibility | field_event_date    | langcode |
       | Test content | Body description text | community                | 2100-01-01T12:00:00 | en       |
     And there are 2 event enrollments for the "Test content" event
@@ -78,7 +78,7 @@ Feature: Manage event enrollment
     And I should see the text "Operation"
 
   Scenario: Event manager gets a notification for an event enrollment
-    Given events:
+    Given events with non-anonymous author:
       | title        | body                  | field_content_visibility | field_event_date    | langcode |
       | Test content | Body description text | community                | 2100-01-01T12:00:00 | en       |
     And I am logged in as a user with the verified role

--- a/tests/behat/features/capabilities/groups/flexible/content/edit/group-admin/groups-flexible-content-edit-group-admin.feature
+++ b/tests/behat/features/capabilities/groups/flexible/content/edit/group-admin/groups-flexible-content-edit-group-admin.feature
@@ -9,7 +9,7 @@ Feature: Test edit access for content in groups as group admin
     Given groups with non-anonymous owner:
       | label      | field_group_description | type           | langcode | field_flexible_group_visibility |
       | Test group | Group description       | flexible_group | en       | <group_visibility>              |
-    And topics:
+    And topics with non-anonymous author:
       | title        | group      | field_topic_type | body                  | field_content_visibility | langcode |
       | Test content | Test group | News             | Body description text | <content_visibility>     | en       |
     And I am logged in as a user with the <role> role
@@ -46,7 +46,7 @@ Feature: Test edit access for content in groups as group admin
 #    Given groups with non-anonymous owner:
 #      | label      | field_group_description | type           | langcode | field_flexible_group_visibility |
 #      | Test group | Group description       | flexible_group | en       | <group_visibility>              |
-#    And events:
+#    And events with non-anonymous owner:
 #      | title        | group      | body                  | field_content_visibility | field_event_date    | langcode |
 #      | Test content | Test group | Body description text | <content_visibility>     | 2100-01-01T12:00:00 | en       |
 #    And I am logged in as a user with the <role> role

--- a/tests/behat/features/capabilities/groups/flexible/content/edit/group-manager/groups-flexible-content-edit-group-manager.feature
+++ b/tests/behat/features/capabilities/groups/flexible/content/edit/group-manager/groups-flexible-content-edit-group-manager.feature
@@ -9,7 +9,7 @@ Feature: Test edit access for content in groups as group manager
     Given groups with non-anonymous owner:
       | label      | field_group_description | type           | langcode | field_flexible_group_visibility |
       | Test group | Group description       | flexible_group | en       | <group_visibility>              |
-    And topics:
+    And topics with non-anonymous author:
       | title        | group      | field_topic_type | body                  | field_content_visibility | langcode |
       | Test content | Test group | News             | Body description text | <content_visibility>     | en       |
     And I am logged in as a user with the <role> role
@@ -44,7 +44,7 @@ Feature: Test edit access for content in groups as group manager
     Given groups with non-anonymous owner:
       | label      | field_group_description | type           | langcode | field_flexible_group_visibility |
       | Test group | Group description       | flexible_group | en       | <group_visibility>              |
-    And events:
+    And events with non-anonymous author:
       | title        | group      | body                  | field_content_visibility | field_event_date    | langcode |
       | Test content | Test group | Body description text | <content_visibility>     | 2100-01-01T12:00:00 | en       |
     And I am logged in as a user with the <role> role

--- a/tests/behat/features/capabilities/groups/flexible/content/edit/member/groups-flexible-content-edit-member.feature
+++ b/tests/behat/features/capabilities/groups/flexible/content/edit/member/groups-flexible-content-edit-member.feature
@@ -9,7 +9,7 @@ Feature: Test edit access for content in groups as member
     Given groups with non-anonymous owner:
       | label      | field_group_description | type           | langcode | field_flexible_group_visibility |
       | Test group | Group description       | flexible_group | en       | <group_visibility>              |
-    And topics:
+    And topics with non-anonymous author:
       | title        | group      | field_topic_type | body                  | field_content_visibility | langcode |
       | Test content | Test group | News             | Body description text | <content_visibility>     | en       |
     And I am logged in as a user with the <role> role
@@ -44,7 +44,7 @@ Feature: Test edit access for content in groups as member
     Given groups with non-anonymous owner:
       | label      | field_group_description | type           | langcode | field_flexible_group_visibility |
       | Test group | Group description       | flexible_group | en       | <group_visibility>              |
-    And events:
+    And events with non-anonymous author:
       | title        | group      | body                  | field_content_visibility | field_event_date    | langcode |
       | Test content | Test group | Body description text | <content_visibility>     | 2100-01-01T12:00:00 | en       |
     And I am logged in as a user with the <role> role

--- a/tests/behat/features/capabilities/groups/flexible/content/edit/outsider-platform-manager/groups-flexible-content-edit-outsider-platform-manager.feature
+++ b/tests/behat/features/capabilities/groups/flexible/content/edit/outsider-platform-manager/groups-flexible-content-edit-outsider-platform-manager.feature
@@ -9,7 +9,7 @@ Feature: Test edit access for content in groups
     Given groups with non-anonymous owner:
       | label      | field_group_description | type           | langcode | field_flexible_group_visibility |
       | Test group | Group description       | flexible_group | en       | <group_visibility>              |
-    And topics:
+    And topics with non-anonymous author:
       | title        | group      | field_topic_type | body                  | field_content_visibility | langcode |
       | Test content | Test group | News             | Body description text | <content_visibility>     | en       |
     And I am logged in as a user with the <role> role
@@ -43,7 +43,7 @@ Feature: Test edit access for content in groups
     Given groups with non-anonymous owner:
       | label      | field_group_description | type           | langcode | field_flexible_group_visibility |
       | Test group | Group description       | flexible_group | en       | <group_visibility>              |
-    And events:
+    And events with non-anonymous author:
       | title        | group      | body                  | field_content_visibility | field_event_date    | langcode |
       | Test content | Test group | Body description text | <content_visibility>     | 2100-01-01T12:00:00 | en       |
     And I am logged in as a user with the <role> role
@@ -77,7 +77,7 @@ Feature: Test edit access for content in groups
     Given groups with non-anonymous owner:
       | label      | field_group_description | type           | langcode | field_flexible_group_visibility |
       | Test group | Group description       | flexible_group | en       | <group_visibility>              |
-    And topics:
+    And topics with non-anonymous author:
       | title        | group      | field_topic_type | body                  | field_content_visibility | langcode |
       | Test content | Test group | News             | Body description text | <content_visibility>     | en       |
     And I am logged in as a user with the <role> role
@@ -112,7 +112,7 @@ Feature: Test edit access for content in groups
     Given groups with non-anonymous owner:
       | label      | field_group_description | type           | langcode | field_flexible_group_visibility |
       | Test group | Group description       | flexible_group | en       | <group_visibility>              |
-    And events:
+    And events with non-anonymous author:
       | title        | group      | body                  | field_content_visibility | field_event_date    | langcode |
       | Test content | Test group | Body description text | <content_visibility>     | 2100-01-01T12:00:00 | en       |
     And I am logged in as a user with the <role> role

--- a/tests/behat/features/capabilities/groups/flexible/content/edit/outsider/groups-flexible-content-edit-outsider.feature
+++ b/tests/behat/features/capabilities/groups/flexible/content/edit/outsider/groups-flexible-content-edit-outsider.feature
@@ -9,7 +9,7 @@ Feature: Test edit access for content in groups as outsider
     Given groups with non-anonymous owner:
       | label      | field_group_description | type           | langcode | field_flexible_group_visibility |
       | Test group | Group description       | flexible_group | en       | <group_visibility>              |
-    And topics:
+    And topics with non-anonymous author:
       | title        | group      | field_topic_type | body                  | field_content_visibility | langcode |
       | Test content | Test group | News             | Body description text | <content_visibility>     | en       |
     And I am logged in as a user with the <role> role
@@ -43,7 +43,7 @@ Feature: Test edit access for content in groups as outsider
     Given groups with non-anonymous owner:
       | label      | field_group_description | type           | langcode | field_flexible_group_visibility |
       | Test group | Group description       | flexible_group | en       | <group_visibility>              |
-    And events:
+    And events with non-anonymous author:
       | title        | group      | body                  | field_content_visibility | field_event_date    | langcode |
       | Test content | Test group | Body description text | <content_visibility>     | 2100-01-01T12:00:00 | en       |
     And I am logged in as a user with the <role> role

--- a/tests/behat/features/capabilities/groups/flexible/content/view/member/groups-flexible-content-view-member.feature
+++ b/tests/behat/features/capabilities/groups/flexible/content/view/member/groups-flexible-content-view-member.feature
@@ -9,7 +9,7 @@ Feature: Flexible groups content view access for group members
     Given groups with non-anonymous owner:
       | label      | field_group_description | type           | langcode | field_flexible_group_visibility |
       | Test group | Group description       | flexible_group | en       | <group_visibility>              |
-    And topics:
+    And topics with non-anonymous author:
       | title        | group      | field_topic_type | body                  | field_content_visibility | langcode |
       | Test content | Test group | News             | Body description text | <content_visibility>     | en       |
     And I am logged in as a user with the <role> role
@@ -66,7 +66,7 @@ Feature: Flexible groups content view access for group members
     Given groups with non-anonymous owner:
       | label      | field_group_description | type           | langcode | field_flexible_group_visibility |
       | Test group | Group description       | flexible_group | en       | <group_visibility>              |
-    And events:
+    And events with non-anonymous author:
       | title        | group      | body                  | field_content_visibility | field_event_date    | langcode |
       | Test content | Test group | Body description text | <content_visibility>     | 2100-01-01T12:00:00 | en       |
     And I am logged in as a user with the <role> role

--- a/tests/behat/features/capabilities/groups/flexible/content/view/outsider-anonymous/groups-flexible-content-view-outsider-anonymous.feature
+++ b/tests/behat/features/capabilities/groups/flexible/content/view/outsider-anonymous/groups-flexible-content-view-outsider-anonymous.feature
@@ -9,7 +9,7 @@ Feature: Flexible groups content view access for anonymous users
     Given groups with non-anonymous owner:
       | label      | field_group_description | type           | langcode | field_flexible_group_visibility |
       | Test group | Group description       | flexible_group | en       | public                          |
-    And topics:
+    And topics with non-anonymous author:
       | title        | group      | field_topic_type | body                  | field_content_visibility | langcode |
       | Test content | Test group | News             | Body description text | public                   | en       |
     And I am an anonymous user
@@ -23,7 +23,7 @@ Feature: Flexible groups content view access for anonymous users
     Given groups with non-anonymous owner:
       | label      | field_group_description | type           | langcode | field_flexible_group_visibility |
       | Test group | Group description       | flexible_group | en       | public                          |
-    And events:
+    And events with non-anonymous author:
       | title        | group      | body                  | field_content_visibility | field_event_date    | langcode |
       | Test content | Test group | Body description text | public                   | 2100-01-01T12:00:00 | en       |
     And I am an anonymous user
@@ -37,7 +37,7 @@ Feature: Flexible groups content view access for anonymous users
     Given groups with non-anonymous owner:
       | label      | field_group_description | type           | langcode | field_flexible_group_visibility |
       | Test group | Group description       | flexible_group | en       | public                          |
-    And topics:
+    And topics with non-anonymous author:
       | title        | group      | field_topic_type | body                  | field_content_visibility | langcode |
       | Test content | Test group | News             | Body description text | community                | en       |
     And I am an anonymous user
@@ -50,7 +50,7 @@ Feature: Flexible groups content view access for anonymous users
     Given groups with non-anonymous owner:
       | label      | field_group_description | type           | langcode | field_flexible_group_visibility |
       | Test group | Group description       | flexible_group | en       | public                          |
-    And events:
+    And events with non-anonymous author:
       | title        | group      | body                  | field_content_visibility | field_event_date    | langcode |
       | Test content | Test group | Body description text | community                | 2100-01-01T12:00:00 | en       |
     And I am an anonymous user
@@ -63,7 +63,7 @@ Feature: Flexible groups content view access for anonymous users
     Given groups with non-anonymous owner:
       | label      | field_group_description | type           | langcode | field_flexible_group_visibility |
       | Test group | Group description       | flexible_group | en       | public                          |
-    And topics:
+    And topics with non-anonymous author:
       | title        | group      | field_topic_type | body                  | field_content_visibility | langcode |
       | Test content | Test group | News             | Body description text | group                    | en       |
     And I am an anonymous user
@@ -76,7 +76,7 @@ Feature: Flexible groups content view access for anonymous users
     Given groups with non-anonymous owner:
       | label      | field_group_description | type           | langcode | field_flexible_group_visibility |
       | Test group | Group description       | flexible_group | en       | public                          |
-    And events:
+    And events with non-anonymous author:
       | title        | group      | body                  | field_content_visibility | field_event_date    | langcode |
       | Test content | Test group | Body description text | group                    | 2100-01-01T12:00:00 | en       |
     And I am an anonymous user
@@ -89,7 +89,7 @@ Feature: Flexible groups content view access for anonymous users
     Given groups with non-anonymous owner:
       | label      | field_group_description | type           | langcode | field_flexible_group_visibility |
       | Test group | Group description       | flexible_group | en       | community                       |
-    And topics:
+    And topics with non-anonymous author:
       | title        | group      | field_topic_type | body                  | field_content_visibility | langcode |
       | Test content | Test group | News             | Body description text | public                   | en       |
     And I am an anonymous user
@@ -103,7 +103,7 @@ Feature: Flexible groups content view access for anonymous users
     Given groups with non-anonymous owner:
       | label      | field_group_description | type           | langcode | field_flexible_group_visibility |
       | Test group | Group description       | flexible_group | en       | community                       |
-    And events:
+    And events wi
       | title        | group      | body                  | field_content_visibility | field_event_date    | langcode |
       | Test content | Test group | Body description text | public                   | 2100-01-01T12:00:00 | en       |
     And I am an anonymous user
@@ -117,7 +117,7 @@ Feature: Flexible groups content view access for anonymous users
     Given groups with non-anonymous owner:
       | label      | field_group_description | type           | langcode | field_flexible_group_visibility |
       | Test group | Group description       | flexible_group | en       | community                       |
-    And topics:
+    And topics with non-anonymous author:
       | title        | group      | field_topic_type | body                  | field_content_visibility | langcode |
       | Test content | Test group | News             | Body description text | community                | en       |
     And I am an anonymous user
@@ -130,7 +130,7 @@ Feature: Flexible groups content view access for anonymous users
     Given groups with non-anonymous owner:
       | label      | field_group_description | type           | langcode | field_flexible_group_visibility |
       | Test group | Group description       | flexible_group | en       | community                       |
-    And events:
+    And events with non-anonymous author:
       | title        | group      | body                  | field_content_visibility | field_event_date    | langcode |
       | Test content | Test group | Body description text | community                | 2100-01-01T12:00:00 | en       |
     And I am an anonymous user
@@ -143,7 +143,7 @@ Feature: Flexible groups content view access for anonymous users
     Given groups with non-anonymous owner:
       | label      | field_group_description | type           | langcode | field_flexible_group_visibility |
       | Test group | Group description       | flexible_group | en       | community                       |
-    And topics:
+    And topics with non-anonymous author:
       | title        | group      | field_topic_type | body                  | field_content_visibility | langcode |
       | Test content | Test group | News             | Body description text | group                    | en       |
     And I am an anonymous user
@@ -156,7 +156,7 @@ Feature: Flexible groups content view access for anonymous users
     Given groups with non-anonymous owner:
       | label      | field_group_description | type           | langcode | field_flexible_group_visibility |
       | Test group | Group description       | flexible_group | en       | community                       |
-    And events:
+    And events with non-anonymous author:
       | title        | group      | body                  | field_content_visibility | field_event_date    | langcode |
       | Test content | Test group | Body description text | group                    | 2100-01-01T12:00:00 | en       |
     And I am an anonymous user
@@ -169,7 +169,7 @@ Feature: Flexible groups content view access for anonymous users
     Given groups with non-anonymous owner:
       | label      | field_group_description | type           | langcode | field_flexible_group_visibility |
       | Test group | Group description       | flexible_group | en       | members                         |
-    And topics:
+    And topics with non-anonymous author:
       | title        | group      | field_topic_type | body                  | field_content_visibility | langcode |
       | Test content | Test group | News             | Body description text | public                   | en       |
     And I am an anonymous user
@@ -183,7 +183,7 @@ Feature: Flexible groups content view access for anonymous users
     Given groups with non-anonymous owner:
       | label      | field_group_description | type           | langcode | field_flexible_group_visibility |
       | Test group | Group description       | flexible_group | en       | members                         |
-    And events:
+    And events with non-anonymous author:
       | title        | group      | body                  | field_content_visibility | field_event_date    | langcode |
       | Test content | Test group | Body description text | public                   | 2100-01-01T12:00:00 | en       |
     And I am an anonymous user
@@ -197,7 +197,7 @@ Feature: Flexible groups content view access for anonymous users
     Given groups with non-anonymous owner:
       | label      | field_group_description | type           | langcode | field_flexible_group_visibility |
       | Test group | Group description       | flexible_group | en       | members                       |
-    And topics:
+    And topics with non-anonymous author:
       | title        | group      | field_topic_type | body                  | field_content_visibility | langcode |
       | Test content | Test group | News             | Body description text | community                | en       |
     And I am an anonymous user
@@ -210,7 +210,7 @@ Feature: Flexible groups content view access for anonymous users
     Given groups with non-anonymous owner:
       | label      | field_group_description | type           | langcode | field_flexible_group_visibility |
       | Test group | Group description       | flexible_group | en       | members                       |
-    And events:
+    And events with non-anonymous author:
       | title        | group      | body                  | field_content_visibility | field_event_date    | langcode |
       | Test content | Test group | Body description text | community                | 2100-01-01T12:00:00 | en       |
     And I am an anonymous user
@@ -223,7 +223,7 @@ Feature: Flexible groups content view access for anonymous users
     Given groups with non-anonymous owner:
       | label      | field_group_description | type           | langcode | field_flexible_group_visibility |
       | Test group | Group description       | flexible_group | en       | members                       |
-    And topics:
+    And topics with non-anonymous author:
       | title        | group      | field_topic_type | body                  | field_content_visibility | langcode |
       | Test content | Test group | News             | Body description text | group                    | en       |
     And I am an anonymous user
@@ -236,7 +236,7 @@ Feature: Flexible groups content view access for anonymous users
     Given groups with non-anonymous owner:
       | label      | field_group_description | type           | langcode | field_flexible_group_visibility |
       | Test group | Group description       | flexible_group | en       | members                       |
-    And events:
+    And events with non-anonymous author:
       | title        | group      | body                  | field_content_visibility | field_event_date    | langcode |
       | Test content | Test group | Body description text | group                    | 2100-01-01T12:00:00 | en       |
     And I am an anonymous user

--- a/tests/behat/features/capabilities/groups/flexible/content/view/outsider-authenticated/groups-flexible-content-view-outsider-authenticated.feature
+++ b/tests/behat/features/capabilities/groups/flexible/content/view/outsider-authenticated/groups-flexible-content-view-outsider-authenticated.feature
@@ -9,7 +9,7 @@ Feature: Flexible groups content view access for authenticated users
     Given groups with non-anonymous owner:
       | label      | field_group_description | type           | langcode | field_flexible_group_visibility |
       | Test group | Group description       | flexible_group | en       | public                          |
-    And topics:
+    And topics with non-anonymous author:
       | title        | group      | field_topic_type | body                  | field_content_visibility | langcode |
       | Test content | Test group | News             | Body description text | public                   | en       |
     And I am logged in as a user with the authenticated role
@@ -23,7 +23,7 @@ Feature: Flexible groups content view access for authenticated users
     Given groups with non-anonymous owner:
       | label      | field_group_description | type           | langcode | field_flexible_group_visibility |
       | Test group | Group description       | flexible_group | en       | public                          |
-    And events:
+    And events with non-anonymous author:
       | title        | group      | body                  | field_content_visibility | field_event_date    | langcode |
       | Test content | Test group | Body description text | public                   | 2100-01-01T12:00:00 | en       |
     And I am logged in as a user with the authenticated role
@@ -37,7 +37,7 @@ Feature: Flexible groups content view access for authenticated users
     Given groups with non-anonymous owner:
       | label      | field_group_description | type           | langcode | field_flexible_group_visibility |
       | Test group | Group description       | flexible_group | en       | public                          |
-    And topics:
+    And topics with non-anonymous author:
       | title        | group      | field_topic_type | body                  | field_content_visibility | langcode |
       | Test content | Test group | News             | Body description text | community                | en       |
     And I am logged in as a user with the authenticated role
@@ -50,7 +50,7 @@ Feature: Flexible groups content view access for authenticated users
     Given groups with non-anonymous owner:
       | label      | field_group_description | type           | langcode | field_flexible_group_visibility |
       | Test group | Group description       | flexible_group | en       | public                          |
-    And events:
+    And events with non-anonymous author:
       | title        | group      | body                  | field_content_visibility | field_event_date    | langcode |
       | Test content | Test group | Body description text | community                | 2100-01-01T12:00:00 | en       |
     And I am logged in as a user with the authenticated role
@@ -63,7 +63,7 @@ Feature: Flexible groups content view access for authenticated users
     Given groups with non-anonymous owner:
       | label      | field_group_description | type           | langcode | field_flexible_group_visibility |
       | Test group | Group description       | flexible_group | en       | public                          |
-    And topics:
+    And topics with non-anonymous author:
       | title        | group      | field_topic_type | body                  | field_content_visibility | langcode |
       | Test content | Test group | News             | Body description text | group                    | en       |
     And I am logged in as a user with the authenticated role
@@ -76,7 +76,7 @@ Feature: Flexible groups content view access for authenticated users
     Given groups with non-anonymous owner:
       | label      | field_group_description | type           | langcode | field_flexible_group_visibility |
       | Test group | Group description       | flexible_group | en       | public                          |
-    And events:
+    And events with non-anonymous author:
       | title        | group      | body                  | field_content_visibility | field_event_date    | langcode |
       | Test content | Test group | Body description text | group                    | 2100-01-01T12:00:00 | en       |
     And I am logged in as a user with the authenticated role
@@ -89,7 +89,7 @@ Feature: Flexible groups content view access for authenticated users
     Given groups with non-anonymous owner:
       | label      | field_group_description | type           | langcode | field_flexible_group_visibility |
       | Test group | Group description       | flexible_group | en       | community                       |
-    And topics:
+    And topics with non-anonymous author:
       | title        | group      | field_topic_type | body                  | field_content_visibility | langcode |
       | Test content | Test group | News             | Body description text | public                   | en       |
     And I am logged in as a user with the authenticated role
@@ -104,7 +104,7 @@ Feature: Flexible groups content view access for authenticated users
     Given groups with non-anonymous owner:
       | label      | field_group_description | type           | langcode | field_flexible_group_visibility |
       | Test group | Group description       | flexible_group | en       | community                       |
-    And events:
+    And events with non-anonymous author:
       | title        | group      | body                  | field_content_visibility | field_event_date    | langcode |
       | Test content | Test group | Body description text | public                   | 2100-01-01T12:00:00 | en       |
     And I am logged in as a user with the authenticated role
@@ -119,7 +119,7 @@ Feature: Flexible groups content view access for authenticated users
     Given groups with non-anonymous owner:
       | label      | field_group_description | type           | langcode | field_flexible_group_visibility |
       | Test group | Group description       | flexible_group | en       | community                       |
-    And topics:
+    And topics with non-anonymous author:
       | title        | group      | field_topic_type | body                  | field_content_visibility | langcode |
       | Test content | Test group | News             | Body description text | community                | en       |
     And I am logged in as a user with the authenticated role
@@ -132,7 +132,7 @@ Feature: Flexible groups content view access for authenticated users
     Given groups with non-anonymous owner:
       | label      | field_group_description | type           | langcode | field_flexible_group_visibility |
       | Test group | Group description       | flexible_group | en       | community                       |
-    And events:
+    And events with non-anonymous author:
       | title        | group      | body                  | field_content_visibility | field_event_date    | langcode |
       | Test content | Test group | Body description text | community                | 2100-01-01T12:00:00 | en       |
     And I am logged in as a user with the authenticated role
@@ -145,7 +145,7 @@ Feature: Flexible groups content view access for authenticated users
     Given groups with non-anonymous owner:
       | label      | field_group_description | type           | langcode | field_flexible_group_visibility |
       | Test group | Group description       | flexible_group | en       | community                       |
-    And topics:
+    And topics with non-anonymous author:
       | title        | group      | field_topic_type | body                  | field_content_visibility | langcode |
       | Test content | Test group | News             | Body description text | group                    | en       |
     And I am logged in as a user with the authenticated role
@@ -158,7 +158,7 @@ Feature: Flexible groups content view access for authenticated users
     Given groups with non-anonymous owner:
       | label      | field_group_description | type           | langcode | field_flexible_group_visibility |
       | Test group | Group description       | flexible_group | en       | community                       |
-    And events:
+    And events with non-anonymous author:
       | title        | group      | body                  | field_content_visibility | field_event_date    | langcode |
       | Test content | Test group | Body description text | group                    | 2100-01-01T12:00:00 | en       |
     And I am logged in as a user with the authenticated role
@@ -171,7 +171,7 @@ Feature: Flexible groups content view access for authenticated users
     Given groups with non-anonymous owner:
       | label      | field_group_description | type           | langcode | field_flexible_group_visibility |
       | Test group | Group description       | flexible_group | en       | members                         |
-    And topics:
+    And topics with non-anonymous author:
       | title        | group      | field_topic_type | body                  | field_content_visibility | langcode |
       | Test content | Test group | News             | Body description text | public                   | en       |
     And I am logged in as a user with the authenticated role
@@ -185,7 +185,7 @@ Feature: Flexible groups content view access for authenticated users
     Given groups with non-anonymous owner:
       | label      | field_group_description | type           | langcode | field_flexible_group_visibility |
       | Test group | Group description       | flexible_group | en       | members                         |
-    And events:
+    And events with non-anonymous author:
       | title        | group      | body                  | field_content_visibility | field_event_date    | langcode |
       | Test content | Test group | Body description text | public                   | 2100-01-01T12:00:00 | en       |
     And I am logged in as a user with the authenticated role
@@ -199,7 +199,7 @@ Feature: Flexible groups content view access for authenticated users
     Given groups with non-anonymous owner:
       | label      | field_group_description | type           | langcode | field_flexible_group_visibility |
       | Test group | Group description       | flexible_group | en       | members                       |
-    And topics:
+    And topics with non-anonymous author:
       | title        | group      | field_topic_type | body                  | field_content_visibility | langcode |
       | Test content | Test group | News             | Body description text | community                | en       |
     And I am logged in as a user with the authenticated role
@@ -212,7 +212,7 @@ Feature: Flexible groups content view access for authenticated users
     Given groups with non-anonymous owner:
       | label      | field_group_description | type           | langcode | field_flexible_group_visibility |
       | Test group | Group description       | flexible_group | en       | members                       |
-    And events:
+    And events with non-anonymous author:
       | title        | group      | body                  | field_content_visibility | field_event_date    | langcode |
       | Test content | Test group | Body description text | community                | 2100-01-01T12:00:00 | en       |
     And I am logged in as a user with the authenticated role
@@ -225,7 +225,7 @@ Feature: Flexible groups content view access for authenticated users
     Given groups with non-anonymous owner:
       | label      | field_group_description | type           | langcode | field_flexible_group_visibility |
       | Test group | Group description       | flexible_group | en       | members                       |
-    And topics:
+    And topics with non-anonymous author:
       | title        | group      | field_topic_type | body                  | field_content_visibility | langcode |
       | Test content | Test group | News             | Body description text | group                    | en       |
     And I am logged in as a user with the authenticated role
@@ -238,7 +238,7 @@ Feature: Flexible groups content view access for authenticated users
     Given groups with non-anonymous owner:
       | label      | field_group_description | type           | langcode | field_flexible_group_visibility |
       | Test group | Group description       | flexible_group | en       | members                       |
-    And events:
+    And events with non-anonymous author:
       | title        | group      | body                  | field_content_visibility | field_event_date    | langcode |
       | Test content | Test group | Body description text | group                    | 2100-01-01T12:00:00 | en       |
     And I am logged in as a user with the authenticated role

--- a/tests/behat/features/capabilities/groups/flexible/content/view/outsider-contentmanager/groups-flexible-content-view-outsider-contentmanager.feature
+++ b/tests/behat/features/capabilities/groups/flexible/content/view/outsider-contentmanager/groups-flexible-content-view-outsider-contentmanager.feature
@@ -9,7 +9,7 @@ Feature: Flexible groups content view access for contentmanager users
     Given groups with non-anonymous owner:
       | label      | field_group_description | type           | langcode | field_flexible_group_visibility |
       | Test group | Group description       | flexible_group | en       | public                          |
-    And topics:
+    And topics with non-anonymous author:
       | title        | group      | field_topic_type | body                  | field_content_visibility | langcode |
       | Test content | Test group | News             | Body description text | public                   | en       |
     And I am logged in as a user with the contentmanager role
@@ -23,7 +23,7 @@ Feature: Flexible groups content view access for contentmanager users
     Given groups with non-anonymous owner:
       | label      | field_group_description | type           | langcode | field_flexible_group_visibility |
       | Test group | Group description       | flexible_group | en       | public                          |
-    And events:
+    And events with non-anonymous author:
       | title        | group      | body                  | field_content_visibility | field_event_date    | langcode |
       | Test content | Test group | Body description text | public                   | 2100-01-01T12:00:00 | en       |
     And I am logged in as a user with the contentmanager role
@@ -37,7 +37,7 @@ Feature: Flexible groups content view access for contentmanager users
     Given groups with non-anonymous owner:
       | label      | field_group_description | type           | langcode | field_flexible_group_visibility |
       | Test group | Group description       | flexible_group | en       | public                          |
-    And topics:
+    And topics with non-anonymous author:
       | title        | group      | field_topic_type | body                  | field_content_visibility | langcode |
       | Test content | Test group | News             | Body description text | community                | en       |
     And I am logged in as a user with the contentmanager role
@@ -51,7 +51,7 @@ Feature: Flexible groups content view access for contentmanager users
     Given groups with non-anonymous owner:
       | label      | field_group_description | type           | langcode | field_flexible_group_visibility |
       | Test group | Group description       | flexible_group | en       | public                          |
-    And events:
+    And events with non-anonymous author:
       | title        | group      | body                  | field_content_visibility | field_event_date    | langcode |
       | Test content | Test group | Body description text | community                | 2100-01-01T12:00:00 | en       |
     And I am logged in as a user with the contentmanager role
@@ -65,7 +65,7 @@ Feature: Flexible groups content view access for contentmanager users
     Given groups with non-anonymous owner:
       | label      | field_group_description | type           | langcode | field_flexible_group_visibility |
       | Test group | Group description       | flexible_group | en       | public                          |
-    And topics:
+    And topics with non-anonymous author:
       | title        | group      | field_topic_type | body                  | field_content_visibility | langcode |
       | Test content | Test group | News             | Body description text | group                    | en       |
     And I am logged in as a user with the contentmanager role
@@ -79,7 +79,7 @@ Feature: Flexible groups content view access for contentmanager users
     Given groups with non-anonymous owner:
       | label      | field_group_description | type           | langcode | field_flexible_group_visibility |
       | Test group | Group description       | flexible_group | en       | public                          |
-    And events:
+    And events with non-anonymous author:
       | title        | group      | body                  | field_content_visibility | field_event_date    | langcode |
       | Test content | Test group | Body description text | group                    | 2100-01-01T12:00:00 | en       |
     And I am logged in as a user with the contentmanager role
@@ -93,7 +93,7 @@ Feature: Flexible groups content view access for contentmanager users
     Given groups with non-anonymous owner:
       | label      | field_group_description | type           | langcode | field_flexible_group_visibility |
       | Test group | Group description       | flexible_group | en       | community                       |
-    And topics:
+    And topics with non-anonymous author:
       | title        | group      | field_topic_type | body                  | field_content_visibility | langcode |
       | Test content | Test group | News             | Body description text | public                   | en       |
     And I am logged in as a user with the contentmanager role
@@ -107,7 +107,7 @@ Feature: Flexible groups content view access for contentmanager users
     Given groups with non-anonymous owner:
       | label      | field_group_description | type           | langcode | field_flexible_group_visibility |
       | Test group | Group description       | flexible_group | en       | community                       |
-    And events:
+    And events with non-anonymous author:
       | title        | group      | body                  | field_content_visibility | field_event_date    | langcode |
       | Test content | Test group | Body description text | public                   | 2100-01-01T12:00:00 | en       |
     And I am logged in as a user with the contentmanager role
@@ -121,7 +121,7 @@ Feature: Flexible groups content view access for contentmanager users
     Given groups with non-anonymous owner:
       | label      | field_group_description | type           | langcode | field_flexible_group_visibility |
       | Test group | Group description       | flexible_group | en       | community                       |
-    And topics:
+    And topics with non-anonymous author:
       | title        | group      | field_topic_type | body                  | field_content_visibility | langcode |
       | Test content | Test group | News             | Body description text | community                | en       |
     And I am logged in as a user with the contentmanager role
@@ -135,7 +135,7 @@ Feature: Flexible groups content view access for contentmanager users
     Given groups with non-anonymous owner:
       | label      | field_group_description | type           | langcode | field_flexible_group_visibility |
       | Test group | Group description       | flexible_group | en       | community                       |
-    And events:
+    And events with non-anonymous author:
       | title        | group      | body                  | field_content_visibility | field_event_date    | langcode |
       | Test content | Test group | Body description text | community                | 2100-01-01T12:00:00 | en       |
     And I am logged in as a user with the contentmanager role
@@ -149,7 +149,7 @@ Feature: Flexible groups content view access for contentmanager users
     Given groups with non-anonymous owner:
       | label      | field_group_description | type           | langcode | field_flexible_group_visibility |
       | Test group | Group description       | flexible_group | en       | community                       |
-    And topics:
+    And topics with non-anonymous author:
       | title        | group      | field_topic_type | body                  | field_content_visibility | langcode |
       | Test content | Test group | News             | Body description text | group                    | en       |
     And I am logged in as a user with the contentmanager role
@@ -163,7 +163,7 @@ Feature: Flexible groups content view access for contentmanager users
     Given groups with non-anonymous owner:
       | label      | field_group_description | type           | langcode | field_flexible_group_visibility |
       | Test group | Group description       | flexible_group | en       | community                       |
-    And events:
+    And events with non-anonymous author:
       | title        | group      | body                  | field_content_visibility | field_event_date    | langcode |
       | Test content | Test group | Body description text | group                    | 2100-01-01T12:00:00 | en       |
     And I am logged in as a user with the contentmanager role
@@ -177,7 +177,7 @@ Feature: Flexible groups content view access for contentmanager users
     Given groups with non-anonymous owner:
       | label      | field_group_description | type           | langcode | field_flexible_group_visibility |
       | Test group | Group description       | flexible_group | en       | members                         |
-    And topics:
+    And topics with non-anonymous author:
       | title        | group      | field_topic_type | body                  | field_content_visibility | langcode |
       | Test content | Test group | News             | Body description text | public                   | en       |
     And I am logged in as a user with the contentmanager role
@@ -191,7 +191,7 @@ Feature: Flexible groups content view access for contentmanager users
     Given groups with non-anonymous owner:
       | label      | field_group_description | type           | langcode | field_flexible_group_visibility |
       | Test group | Group description       | flexible_group | en       | members                         |
-    And events:
+    And events with non-anonymous author:
       | title        | group      | body                  | field_content_visibility | field_event_date    | langcode |
       | Test content | Test group | Body description text | public                   | 2100-01-01T12:00:00 | en       |
     And I am logged in as a user with the contentmanager role
@@ -205,7 +205,7 @@ Feature: Flexible groups content view access for contentmanager users
     Given groups with non-anonymous owner:
       | label      | field_group_description | type           | langcode | field_flexible_group_visibility |
       | Test group | Group description       | flexible_group | en       | members                       |
-    And topics:
+    And topics with non-anonymous author:
       | title        | group      | field_topic_type | body                  | field_content_visibility | langcode |
       | Test content | Test group | News             | Body description text | community                | en       |
     And I am logged in as a user with the contentmanager role
@@ -219,7 +219,7 @@ Feature: Flexible groups content view access for contentmanager users
     Given groups with non-anonymous owner:
       | label      | field_group_description | type           | langcode | field_flexible_group_visibility |
       | Test group | Group description       | flexible_group | en       | members                       |
-    And events:
+    And events with non-anonymous author:
       | title        | group      | body                  | field_content_visibility | field_event_date    | langcode |
       | Test content | Test group | Body description text | community                | 2100-01-01T12:00:00 | en       |
     And I am logged in as a user with the contentmanager role
@@ -233,7 +233,7 @@ Feature: Flexible groups content view access for contentmanager users
     Given groups with non-anonymous owner:
       | label      | field_group_description | type           | langcode | field_flexible_group_visibility |
       | Test group | Group description       | flexible_group | en       | members                       |
-    And topics:
+    And topics with non-anonymous author:
       | title        | group      | field_topic_type | body                  | field_content_visibility | langcode |
       | Test content | Test group | News             | Body description text | group                    | en       |
     And I am logged in as a user with the contentmanager role
@@ -247,7 +247,7 @@ Feature: Flexible groups content view access for contentmanager users
     Given groups with non-anonymous owner:
       | label      | field_group_description | type           | langcode | field_flexible_group_visibility |
       | Test group | Group description       | flexible_group | en       | members                       |
-    And events:
+    And events with non-anonymous author:
       | title        | group      | body                  | field_content_visibility | field_event_date    | langcode |
       | Test content | Test group | Body description text | group                    | 2100-01-01T12:00:00 | en       |
     And I am logged in as a user with the contentmanager role

--- a/tests/behat/features/capabilities/groups/flexible/content/view/outsider-sitemanager/groups-flexible-content-view-outsider-sitemanager.feature
+++ b/tests/behat/features/capabilities/groups/flexible/content/view/outsider-sitemanager/groups-flexible-content-view-outsider-sitemanager.feature
@@ -9,7 +9,7 @@ Feature: Flexible groups content view access for sitemanager users
     Given groups with non-anonymous owner:
       | label      | field_group_description | type           | langcode | field_flexible_group_visibility |
       | Test group | Group description       | flexible_group | en       | public                          |
-    And topics:
+    And topics with non-anonymous author:
       | title        | group      | field_topic_type | body                  | field_content_visibility | langcode |
       | Test content | Test group | News             | Body description text | public                   | en       |
     And I am logged in as a user with the sitemanager role
@@ -23,7 +23,7 @@ Feature: Flexible groups content view access for sitemanager users
     Given groups with non-anonymous owner:
       | label      | field_group_description | type           | langcode | field_flexible_group_visibility |
       | Test group | Group description       | flexible_group | en       | public                          |
-    And events:
+    And events with non-anonymous author:
       | title        | group      | body                  | field_content_visibility | field_event_date    | langcode |
       | Test content | Test group | Body description text | public                   | 2100-01-01T12:00:00 | en       |
     And I am logged in as a user with the sitemanager role
@@ -37,7 +37,7 @@ Feature: Flexible groups content view access for sitemanager users
     Given groups with non-anonymous owner:
       | label      | field_group_description | type           | langcode | field_flexible_group_visibility |
       | Test group | Group description       | flexible_group | en       | public                          |
-    And topics:
+    And topics with non-anonymous author:
       | title        | group      | field_topic_type | body                  | field_content_visibility | langcode |
       | Test content | Test group | News             | Body description text | community                | en       |
     And I am logged in as a user with the sitemanager role
@@ -51,7 +51,7 @@ Feature: Flexible groups content view access for sitemanager users
     Given groups with non-anonymous owner:
       | label      | field_group_description | type           | langcode | field_flexible_group_visibility |
       | Test group | Group description       | flexible_group | en       | public                          |
-    And events:
+    And events with non-anonymous author:
       | title        | group      | body                  | field_content_visibility | field_event_date    | langcode |
       | Test content | Test group | Body description text | community                | 2100-01-01T12:00:00 | en       |
     And I am logged in as a user with the sitemanager role
@@ -65,7 +65,7 @@ Feature: Flexible groups content view access for sitemanager users
     Given groups with non-anonymous owner:
       | label      | field_group_description | type           | langcode | field_flexible_group_visibility |
       | Test group | Group description       | flexible_group | en       | public                          |
-    And topics:
+    And topics with non-anonymous author:
       | title        | group      | field_topic_type | body                  | field_content_visibility | langcode |
       | Test content | Test group | News             | Body description text | group                    | en       |
     And I am logged in as a user with the sitemanager role
@@ -79,7 +79,7 @@ Feature: Flexible groups content view access for sitemanager users
     Given groups with non-anonymous owner:
       | label      | field_group_description | type           | langcode | field_flexible_group_visibility |
       | Test group | Group description       | flexible_group | en       | public                          |
-    And events:
+    And events with non-anonymous author:
       | title        | group      | body                  | field_content_visibility | field_event_date    | langcode |
       | Test content | Test group | Body description text | group                    | 2100-01-01T12:00:00 | en       |
     And I am logged in as a user with the sitemanager role
@@ -93,7 +93,7 @@ Feature: Flexible groups content view access for sitemanager users
     Given groups with non-anonymous owner:
       | label      | field_group_description | type           | langcode | field_flexible_group_visibility |
       | Test group | Group description       | flexible_group | en       | community                       |
-    And topics:
+    And topics with non-anonymous author:
       | title        | group      | field_topic_type | body                  | field_content_visibility | langcode |
       | Test content | Test group | News             | Body description text | public                   | en       |
     And I am logged in as a user with the sitemanager role
@@ -107,7 +107,7 @@ Feature: Flexible groups content view access for sitemanager users
     Given groups with non-anonymous owner:
       | label      | field_group_description | type           | langcode | field_flexible_group_visibility |
       | Test group | Group description       | flexible_group | en       | community                       |
-    And events:
+    And events with non-anonymous author:
       | title        | group      | body                  | field_content_visibility | field_event_date    | langcode |
       | Test content | Test group | Body description text | public                   | 2100-01-01T12:00:00 | en       |
     And I am logged in as a user with the sitemanager role
@@ -121,7 +121,7 @@ Feature: Flexible groups content view access for sitemanager users
     Given groups with non-anonymous owner:
       | label      | field_group_description | type           | langcode | field_flexible_group_visibility |
       | Test group | Group description       | flexible_group | en       | community                       |
-    And topics:
+    And topics with non-anonymous author:
       | title        | group      | field_topic_type | body                  | field_content_visibility | langcode |
       | Test content | Test group | News             | Body description text | community                | en       |
     And I am logged in as a user with the sitemanager role
@@ -135,7 +135,7 @@ Feature: Flexible groups content view access for sitemanager users
     Given groups with non-anonymous owner:
       | label      | field_group_description | type           | langcode | field_flexible_group_visibility |
       | Test group | Group description       | flexible_group | en       | community                       |
-    And events:
+    And events with non-anonymous author:
       | title        | group      | body                  | field_content_visibility | field_event_date    | langcode |
       | Test content | Test group | Body description text | community                | 2100-01-01T12:00:00 | en       |
     And I am logged in as a user with the sitemanager role
@@ -149,7 +149,7 @@ Feature: Flexible groups content view access for sitemanager users
     Given groups with non-anonymous owner:
       | label      | field_group_description | type           | langcode | field_flexible_group_visibility |
       | Test group | Group description       | flexible_group | en       | community                       |
-    And topics:
+    And topics with non-anonymous author:
       | title        | group      | field_topic_type | body                  | field_content_visibility | langcode |
       | Test content | Test group | News             | Body description text | group                    | en       |
     And I am logged in as a user with the sitemanager role
@@ -163,7 +163,7 @@ Feature: Flexible groups content view access for sitemanager users
     Given groups with non-anonymous owner:
       | label      | field_group_description | type           | langcode | field_flexible_group_visibility |
       | Test group | Group description       | flexible_group | en       | community                       |
-    And events:
+    And events with non-anonymous author:
       | title        | group      | body                  | field_content_visibility | field_event_date    | langcode |
       | Test content | Test group | Body description text | group                    | 2100-01-01T12:00:00 | en       |
     And I am logged in as a user with the sitemanager role
@@ -177,7 +177,7 @@ Feature: Flexible groups content view access for sitemanager users
     Given groups with non-anonymous owner:
       | label      | field_group_description | type           | langcode | field_flexible_group_visibility |
       | Test group | Group description       | flexible_group | en       | members                         |
-    And topics:
+    And topics with non-anonymous author:
       | title        | group      | field_topic_type | body                  | field_content_visibility | langcode |
       | Test content | Test group | News             | Body description text | public                   | en       |
     And I am logged in as a user with the sitemanager role
@@ -191,7 +191,7 @@ Feature: Flexible groups content view access for sitemanager users
     Given groups with non-anonymous owner:
       | label      | field_group_description | type           | langcode | field_flexible_group_visibility |
       | Test group | Group description       | flexible_group | en       | members                         |
-    And events:
+    And events with non-anonymous author:
       | title        | group      | body                  | field_content_visibility | field_event_date    | langcode |
       | Test content | Test group | Body description text | public                   | 2100-01-01T12:00:00 | en       |
     And I am logged in as a user with the sitemanager role
@@ -205,7 +205,7 @@ Feature: Flexible groups content view access for sitemanager users
     Given groups with non-anonymous owner:
       | label      | field_group_description | type           | langcode | field_flexible_group_visibility |
       | Test group | Group description       | flexible_group | en       | members                       |
-    And topics:
+    And topics with non-anonymous author:
       | title        | group      | field_topic_type | body                  | field_content_visibility | langcode |
       | Test content | Test group | News             | Body description text | community                | en       |
     And I am logged in as a user with the sitemanager role
@@ -219,7 +219,7 @@ Feature: Flexible groups content view access for sitemanager users
     Given groups with non-anonymous owner:
       | label      | field_group_description | type           | langcode | field_flexible_group_visibility |
       | Test group | Group description       | flexible_group | en       | members                       |
-    And events:
+    And events with non-anonymous author:
       | title        | group      | body                  | field_content_visibility | field_event_date    | langcode |
       | Test content | Test group | Body description text | community                | 2100-01-01T12:00:00 | en       |
     And I am logged in as a user with the sitemanager role
@@ -233,7 +233,7 @@ Feature: Flexible groups content view access for sitemanager users
     Given groups with non-anonymous owner:
       | label      | field_group_description | type           | langcode | field_flexible_group_visibility |
       | Test group | Group description       | flexible_group | en       | members                       |
-    And topics:
+    And topics with non-anonymous author:
       | title        | group      | field_topic_type | body                  | field_content_visibility | langcode |
       | Test content | Test group | News             | Body description text | group                    | en       |
     And I am logged in as a user with the sitemanager role
@@ -247,7 +247,7 @@ Feature: Flexible groups content view access for sitemanager users
     Given groups with non-anonymous owner:
       | label      | field_group_description | type           | langcode | field_flexible_group_visibility |
       | Test group | Group description       | flexible_group | en       | members                       |
-    And events:
+    And events with non-anonymous author:
       | title        | group      | body                  | field_content_visibility | field_event_date    | langcode |
       | Test content | Test group | Body description text | group                    | 2100-01-01T12:00:00 | en       |
     And I am logged in as a user with the sitemanager role

--- a/tests/behat/features/capabilities/groups/flexible/content/view/outsider-verified/groups-flexible-content-view-outsider-verified.feature
+++ b/tests/behat/features/capabilities/groups/flexible/content/view/outsider-verified/groups-flexible-content-view-outsider-verified.feature
@@ -9,7 +9,7 @@ Feature: Flexible groups content view access for verified users
     Given groups with non-anonymous owner:
       | label      | field_group_description | type           | langcode | field_flexible_group_visibility |
       | Test group | Group description       | flexible_group | en       | public                          |
-    And topics:
+    And topics with non-anonymous author:
       | title        | group      | field_topic_type | body                  | field_content_visibility | langcode |
       | Test content | Test group | News             | Body description text | public                   | en       |
     And I am logged in as a user with the verified role
@@ -23,7 +23,7 @@ Feature: Flexible groups content view access for verified users
     Given groups with non-anonymous owner:
       | label      | field_group_description | type           | langcode | field_flexible_group_visibility |
       | Test group | Group description       | flexible_group | en       | public                          |
-    And events:
+    And events with non-anonymous author:
       | title        | group      | body                  | field_content_visibility | field_event_date    | langcode |
       | Test content | Test group | Body description text | public                   | 2100-01-01T12:00:00 | en       |
     And I am logged in as a user with the verified role
@@ -37,7 +37,7 @@ Feature: Flexible groups content view access for verified users
     Given groups with non-anonymous owner:
       | label      | field_group_description | type           | langcode | field_flexible_group_visibility |
       | Test group | Group description       | flexible_group | en       | public                          |
-    And topics:
+    And topics with non-anonymous author:
       | title        | group      | field_topic_type | body                  | field_content_visibility | langcode |
       | Test content | Test group | News             | Body description text | community                | en       |
     And I am logged in as a user with the verified role
@@ -51,7 +51,7 @@ Feature: Flexible groups content view access for verified users
     Given groups with non-anonymous owner:
       | label      | field_group_description | type           | langcode | field_flexible_group_visibility |
       | Test group | Group description       | flexible_group | en       | public                          |
-    And events:
+    And events with non-anonymous author:
       | title        | group      | body                  | field_content_visibility | field_event_date    | langcode |
       | Test content | Test group | Body description text | community                | 2100-01-01T12:00:00 | en       |
     And I am logged in as a user with the verified role
@@ -65,7 +65,7 @@ Feature: Flexible groups content view access for verified users
     Given groups with non-anonymous owner:
       | label      | field_group_description | type           | langcode | field_flexible_group_visibility |
       | Test group | Group description       | flexible_group | en       | public                          |
-    And topics:
+    And topics with non-anonymous author:
       | title        | group      | field_topic_type | body                  | field_content_visibility | langcode |
       | Test content | Test group | News             | Body description text | group                    | en       |
     And I am logged in as a user with the verified role
@@ -78,7 +78,7 @@ Feature: Flexible groups content view access for verified users
     Given groups with non-anonymous owner:
       | label      | field_group_description | type           | langcode | field_flexible_group_visibility |
       | Test group | Group description       | flexible_group | en       | public                          |
-    And events:
+    And events with non-anonymous author:
       | title        | group      | body                  | field_content_visibility | field_event_date    | langcode |
       | Test content | Test group | Body description text | group                    | 2100-01-01T12:00:00 | en       |
     And I am logged in as a user with the verified role
@@ -91,7 +91,7 @@ Feature: Flexible groups content view access for verified users
     Given groups with non-anonymous owner:
       | label      | field_group_description | type           | langcode | field_flexible_group_visibility |
       | Test group | Group description       | flexible_group | en       | community                       |
-    And topics:
+    And topics with non-anonymous author:
       | title        | group      | field_topic_type | body                  | field_content_visibility | langcode |
       | Test content | Test group | News             | Body description text | public                   | en       |
     And I am logged in as a user with the verified role
@@ -105,7 +105,7 @@ Feature: Flexible groups content view access for verified users
     Given groups with non-anonymous owner:
       | label      | field_group_description | type           | langcode | field_flexible_group_visibility |
       | Test group | Group description       | flexible_group | en       | community                       |
-    And events:
+    And events with non-anonymous author:
       | title        | group      | body                  | field_content_visibility | field_event_date    | langcode |
       | Test content | Test group | Body description text | public                   | 2100-01-01T12:00:00 | en       |
     And I am logged in as a user with the verified role
@@ -119,7 +119,7 @@ Feature: Flexible groups content view access for verified users
     Given groups with non-anonymous owner:
       | label      | field_group_description | type           | langcode | field_flexible_group_visibility |
       | Test group | Group description       | flexible_group | en       | community                       |
-    And topics:
+    And topics with non-anonymous author:
       | title        | group      | field_topic_type | body                  | field_content_visibility | langcode |
       | Test content | Test group | News             | Body description text | community                | en       |
     And I am logged in as a user with the verified role
@@ -133,7 +133,7 @@ Feature: Flexible groups content view access for verified users
     Given groups with non-anonymous owner:
       | label      | field_group_description | type           | langcode | field_flexible_group_visibility |
       | Test group | Group description       | flexible_group | en       | community                       |
-    And events:
+    And events with non-anonymous author:
       | title        | group      | body                  | field_content_visibility | field_event_date    | langcode |
       | Test content | Test group | Body description text | community                | 2100-01-01T12:00:00 | en       |
     And I am logged in as a user with the verified role
@@ -147,7 +147,7 @@ Feature: Flexible groups content view access for verified users
     Given groups with non-anonymous owner:
       | label      | field_group_description | type           | langcode | field_flexible_group_visibility |
       | Test group | Group description       | flexible_group | en       | community                       |
-    And topics:
+    And topics with non-anonymous author:
       | title        | group      | field_topic_type | body                  | field_content_visibility | langcode |
       | Test content | Test group | News             | Body description text | group                    | en       |
     And I am logged in as a user with the verified role
@@ -160,7 +160,7 @@ Feature: Flexible groups content view access for verified users
     Given groups with non-anonymous owner:
       | label      | field_group_description | type           | langcode | field_flexible_group_visibility |
       | Test group | Group description       | flexible_group | en       | community                       |
-    And events:
+    And events with non-anonymous author:
       | title        | group      | body                  | field_content_visibility | field_event_date    | langcode |
       | Test content | Test group | Body description text | group                    | 2100-01-01T12:00:00 | en       |
     And I am logged in as a user with the verified role
@@ -175,7 +175,7 @@ Feature: Flexible groups content view access for verified users
     Given groups with non-anonymous owner:
       | label      | field_group_description | type           | langcode | field_flexible_group_visibility |
       | Test group | Group description       | flexible_group | en       | members                       |
-    And topics:
+    And topics with non-anonymous author:
       | title        | group      | field_topic_type | body                  | field_content_visibility | langcode |
       | Test content | Test group | News             | Body description text | group                    | en       |
     And I am logged in as a user with the verified role
@@ -188,7 +188,7 @@ Feature: Flexible groups content view access for verified users
     Given groups with non-anonymous owner:
       | label      | field_group_description | type           | langcode | field_flexible_group_visibility |
       | Test group | Group description       | flexible_group | en       | members                       |
-    And events:
+    And events with non-anonymous author:
       | title        | group      | body                  | field_content_visibility | field_event_date    | langcode |
       | Test content | Test group | Body description text | group                    | 2100-01-01T12:00:00 | en       |
     And I am logged in as a user with the verified role

--- a/tests/behat/features/capabilities/groups/groups-edit-type.feature
+++ b/tests/behat/features/capabilities/groups/groups-edit-type.feature
@@ -11,7 +11,7 @@ Feature: Edit group type after creation
     And "topic_type" terms:
       | name |
       | Blog |
-    And topics:
+    And topics with non-anonymous author:
       | title     | body      | group   | field_content_visibility | langcode | field_topic_type |
       | Nespresso | What else | Nescafe | group                    | en       | Blog             |
 

--- a/tests/behat/features/capabilities/groups/groups-management-for-platform-managers.feature
+++ b/tests/behat/features/capabilities/groups/groups-management-for-platform-managers.feature
@@ -8,7 +8,7 @@ Feature: Group management for CM+
     Given groups with non-anonymous owner:
       | label             | type         | field_group_description |
       | Test closed group | closed_group | Description text        |
-    And topics:
+    And topics with non-anonymous author:
       | title                   | group             | field_topic_type | body                  | field_content_visibility | langcode |
       | Test closed group topic | Test closed group | News             | Body description text | group                    | en       |
     And I am logged in as a user with the <role> role
@@ -51,7 +51,7 @@ Feature: Group management for CM+
     Given groups with non-anonymous owner:
       | label             | type         | field_group_description |
       | Test closed group | closed_group | Description text        |
-    And topics:
+    And topics with non-anonymous author:
       | title                   | group             | field_topic_type | body                  | field_content_visibility | langcode |
       | Test closed group topic | Test closed group | News             | Body description text | group                    | en       |
     And I am logged in as a user with the <role> role

--- a/tests/behat/features/capabilities/sharing/share.feature
+++ b/tests/behat/features/capabilities/sharing/share.feature
@@ -8,7 +8,7 @@ Feature: Social Sharing
     Given I enable the optional module social_sharing
 
   Scenario: Can share public content as authenticated user
-    Given topics:
+    Given topics with non-anonymous author:
       | title        | field_topic_type | body                      | field_content_visibility | path          |
       | Public Topic | News             | Testing public visibility | public                   | /public-topic |
 
@@ -18,7 +18,7 @@ Feature: Social Sharing
     Then I should see "Share this page"
 
   Scenario: Can share public content as anonymous user
-    Given topics:
+    Given topics with non-anonymous author:
       | title        | field_topic_type | body                      | field_content_visibility | path          |
       | Public Topic | News             | Testing public visibility | public                   | /public-topic |
 
@@ -27,7 +27,7 @@ Feature: Social Sharing
     Then I should see "Share this page"
 
   Scenario: Can not share community content
-    Given topics:
+    Given topics with non-anonymous author:
       | title           | field_topic_type | body                         | field_content_visibility | path             |
       | Community Topic | News             | Testing community visibility | community                | /community-topic |
 


### PR DESCRIPTION
## Problem / Solution
This replicates what we previously did for groups to events and topics so that we have better control of content ownership to improve test predictability and reliability.

## Issue tracker
Internal no issue

## How to test
- [ ] Behat should still pass

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status
