### PR TITLE
Internal: Add CI check to prevent Config Overrides being added

### DIFF
--- a/.github/workflows/bestPractices.yml
+++ b/.github/workflows/bestPractices.yml
@@ -1,0 +1,30 @@
+# This file contains custom lints that are not common to PHP/Drupal projects but
+# are specific to how we want to build products at Open Social. These only run
+# on pull requests since they are input for reviewer conversations and not hard
+# rules such as our quality checks.
+name: Best practices
+
+on:
+  pull_request: { }
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  # Contrary to the other jobs we only perform this check on pull requests and
+  # accept that if a PR is merged despite this check we can ignore the addition
+  # on the main branch.
+  config_overrides:
+    name: No config overrides added
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      # We're only interested in config overrides being added.
+      # grep exits with 0 if it has matches, which we consider to be a fail
+      # so we invert.
+      - run: "! git diff ${{ github.event.pull_request.base.sha }} ${{ github.sha }} -- '**/*.services.yml' | grep -e '^+' | grep config.factory.override"


### PR DESCRIPTION
## Problem / Solution
We've found that config overrides cause a lot of performance issues because they'll be called in a lot of scenarios. We used to need them when we were still using Features, but these days 99.9% of the config overrides can be replaced with a config update in an install hook and uninstall hook instead.

We add a one-liner check to ensure that no new config overrides are being added to our code. In case someone does add one the CI check will fail which can prompt a discussion on the PR for alternative solutions. In case the PR is merged with the override still in then we won't keep complaining on the merged branch.

## Issue tracker
Internal change no issue

## How to test
- [ ] CI should pass
- [ ] CI should fail on the added debug step

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status
