### PR TITLE
Issue #3345231 by zanivdmar: Missing option to accept invite | REVERT

### DIFF
--- a/modules/social_features/social_group/modules/social_group_invite/social_group_invite.module
+++ b/modules/social_features/social_group/modules/social_group_invite/social_group_invite.module
@@ -906,13 +906,15 @@ function social_group_invite_field_formatter_info_alter(array &$info): void {
 }
 
 /**
- * Implements hook_social_group_join_method_usage_alter().
+ * Ads "added" method for flexible_group, because users with certain permissions
+ * (SM/GM) can always invite users (member management feature), despite what
+ * join method is selected per flexible group.
+ *
+ * @param array $items
+ * @return void
  */
 function social_group_invite_social_group_join_method_usage_alter(array &$items) {
 
-  // Ads "added" method for flexible_group, because users with certain
-  // permissions (SM/GM) can always invite users (member management feature),
-  // despite what join method is selected per flexible group.
   foreach ($items as &$item) {
 
     if (isset($item['bundle']) && in_array('flexible_group', (array) $item['bundle'])) {

--- a/modules/social_features/social_group/modules/social_group_invite/social_group_invite.module
+++ b/modules/social_features/social_group/modules/social_group_invite/social_group_invite.module
@@ -908,7 +908,7 @@ function social_group_invite_field_formatter_info_alter(array &$info): void {
 /**
  * Implements hook_social_group_join_method_usage_alter().
  */
-function social_group_invite_social_group_join_method_usage_alter(array &$items): void {
+function social_group_invite_social_group_join_method_usage_alter(array &$items) {
 
   // Ads "added" method for flexible_group, because users with certain
   // permissions (SM/GM) can always invite users (member management feature),
@@ -920,8 +920,7 @@ function social_group_invite_social_group_join_method_usage_alter(array &$items)
         if (is_string($item['method'])) {
           $item['method'] = [$item['method']];
         }
-      }
-      else {
+      } else {
         $item['method'] = [];
       }
 

--- a/modules/social_features/social_group/modules/social_group_invite/social_group_invite.module
+++ b/modules/social_features/social_group/modules/social_group_invite/social_group_invite.module
@@ -917,7 +917,7 @@ function social_group_invite_social_group_join_method_usage_alter(array &$items)
 
   foreach ($items as &$item) {
 
-    if (isset($item['bundle']) && in_array('flexible_group', (array) $item['bundle'])) {
+    if (isset($item['bundle']) && $item['bundle'] === 'flexible_group') {
       if (isset($item['method'])) {
         if (is_string($item['method'])) {
           $item['method'] = [$item['method']];

--- a/modules/social_features/social_group/modules/social_group_invite/social_group_invite.module
+++ b/modules/social_features/social_group/modules/social_group_invite/social_group_invite.module
@@ -904,31 +904,3 @@ function social_group_invite_field_formatter_info_alter(array &$info): void {
     $info['entity_reference_label']['class'] = EntityReferenceLabelFormatterOverrider::class;
   }
 }
-
-/**
- * Ads "added" method for flexible_group, because users with certain permissions
- * (SM/GM) can always invite users (member management feature), despite what
- * join method is selected per flexible group.
- *
- * @param array $items
- * @return void
- */
-function social_group_invite_social_group_join_method_usage_alter(array &$items) {
-
-  foreach ($items as &$item) {
-
-    if (isset($item['bundle']) && $item['bundle'] === 'flexible_group') {
-      if (isset($item['method'])) {
-        if (is_string($item['method'])) {
-          $item['method'] = [$item['method']];
-        }
-      } else {
-        $item['method'] = [];
-      }
-
-      if (!array_search('added', $item['method'])) {
-        $item['method'][] = 'added';
-      }
-    }
-  }
-}

--- a/modules/social_features/social_group/modules/social_group_invite/src/Plugin/Join/SocialGroupInviteJoin.php
+++ b/modules/social_features/social_group/modules/social_group_invite/src/Plugin/Join/SocialGroupInviteJoin.php
@@ -105,10 +105,7 @@ class SocialGroupInviteJoin extends SocialGroupDirectJoin {
       $variables['#cache']['tags'][] = 'group_content_list:entity:' . $this->currentUser->id();
       $variables['#cache']['tags'][] = 'group_content_list:plugin:group_invitation:entity:' . $this->currentUser->id();
     }
-    elseif (
-      $entity->hasField('field_group_allowed_join_method') &&
-      $entity->field_group_allowed_join_method->value === 'direct'
-    ) {
+    elseif ($entity->field_group_allowed_join_method->value === 'direct') {
       $items = parent::actions($entity, $variables);
       $variables['#cache']['contexts'][] = 'user';
       $variables['#cache']['tags'][] = 'group_content_list:entity:' . $this->currentUser->id();

--- a/modules/social_features/social_group/modules/social_group_invite/src/Plugin/Join/SocialGroupInviteJoin.php
+++ b/modules/social_features/social_group/modules/social_group_invite/src/Plugin/Join/SocialGroupInviteJoin.php
@@ -105,12 +105,6 @@ class SocialGroupInviteJoin extends SocialGroupDirectJoin {
       $variables['#cache']['tags'][] = 'group_content_list:entity:' . $this->currentUser->id();
       $variables['#cache']['tags'][] = 'group_content_list:plugin:group_invitation:entity:' . $this->currentUser->id();
     }
-    elseif ($entity->field_group_allowed_join_method->value === 'direct') {
-      $items = parent::actions($entity, $variables);
-      $variables['#cache']['contexts'][] = 'user';
-      $variables['#cache']['tags'][] = 'group_content_list:entity:' . $this->currentUser->id();
-      $variables['#cache']['tags'][] = 'group_content_list:plugin:group_invitation:entity:' . $this->currentUser->id();
-    }
     elseif (
       count($items = parent::actions($entity, $variables)) === 1 &&
       in_array($entity->bundle(), $this->types()) ||

--- a/modules/social_features/social_group/modules/social_group_request/src/Plugin/Join/SocialGroupRequestJoin.php
+++ b/modules/social_features/social_group/modules/social_group_request/src/Plugin/Join/SocialGroupRequestJoin.php
@@ -6,7 +6,6 @@ use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Link;
 use Drupal\Core\Url;
 use Drupal\ginvite\GroupInvitationLoaderInterface;
-use Drupal\ginvite\Plugin\GroupContentEnabler\GroupInvitation as GroupInvitationEnabler;
 use Drupal\grequest\Plugin\GroupContentEnabler\GroupMembershipRequest;
 use Drupal\social_group\EntityMemberInterface;
 use Drupal\social_group\JoinBase;
@@ -81,9 +80,8 @@ class SocialGroupRequestJoin extends JoinBase {
     // If user has a pending invite we should skip the request button.
     if ($this->loader !== NULL) {
       $group_invites = $this->loader->loadByProperties([
-        'entity_id' => $this->currentUser->id(),
-        'gid' => $entity->id(),
-        'invitation_status' => GroupInvitationEnabler::INVITATION_PENDING,
+        'gid' => $group->id(),
+        'uid' => $this->currentUser->id(),
       ]);
 
       if ($group_invites !== []) {

--- a/modules/social_features/social_group/social_group.module
+++ b/modules/social_features/social_group/social_group.module
@@ -1138,7 +1138,7 @@ function social_group_form_alter(&$form, FormStateInterface $form_state, $form_i
       // except that `!isset($data['method']) &&` is replaced by
       // `$data['field'] === 'field_group_allowed_join_method'` instead.
       // The reason why we did this is that initial architecture of
-      // `@Join` plugins predicted that plugins where "method" is defined,
+      // @Join plugins predicted that plugins where "method" is defined,
       // should not be altered in this process, but there are groups which have
       // "method" defined for fallback reasons and this is why we need to
       // process them the same way as there would be no "method" defined.

--- a/modules/social_features/social_group/social_group.module
+++ b/modules/social_features/social_group/social_group.module
@@ -1135,20 +1135,16 @@ function social_group_form_alter(&$form, FormStateInterface $form_state, $form_i
       }
 
       // These conditions are here to check exactly the same as the code above
-      // except that `!isset($data['method']) &&` is replaced by
-      // `$data['field'] === 'field_group_allowed_join_method'` instead.
-      // The reason why we did this is that initial architecture of
-      // @Join plugins predicted that plugins where "method" is defined,
-      // should not be altered in this process, but there are groups which have
-      // "method" defined for fallback reasons and this is why we need to
-      // process them the same way as there would be no "method" defined.
-      // Currently, we are limiting this exception only for the groups with
-      // field field_group_allowed_join_method. In the future we can change this
-      // logic in a way that it would not be based on field name but rather on
-      // plugin setting.
+      // except that `!isset($data['method']) &&` is not part of the conditions
+      // anymore. The reason why we did this is that initial architecture of
+      // @Join plugins predicted that plugins could be initiated only by field
+      // or only by method, but there can be group types where it should
+      // be initiated by both. The conditions below are respecting that fact,
+      // which is needed to change the field type of the field which is
+      // responsible for listing all join options accordingly.
+      $field_found = FALSE;
       if (
         isset($data['field'], $form[$data['field']]) &&
-        $data['field'] === 'field_group_allowed_join_method' &&
         $data['entity_type'] === $entity_type_id &&
         (
           !isset($data['bundle']) &&
@@ -1156,17 +1152,21 @@ function social_group_form_alter(&$form, FormStateInterface $form_state, $form_i
           in_array($bundle, (array) $data['bundle'])
         )
       ) {
-        $found = TRUE;
+        $field_found = TRUE;
         break;
       }
     }
 
-    if ($found && isset($data)) {
+    if ($field_found && isset($data)) {
       $field = &$form[$data['field']]['widget'];
 
       if ($field['#type'] === 'checkboxes') {
         $field['#type'] = 'radios';
       }
+    }
+
+    if ($found && isset($data)) {
+      $field = &$form[$data['field']]['widget'];
 
       if ($entity->isNew()) {
         $hook = 'social_group_join_method_info';

--- a/modules/social_features/social_group/social_group.module
+++ b/modules/social_features/social_group/social_group.module
@@ -1133,40 +1133,14 @@ function social_group_form_alter(&$form, FormStateInterface $form_state, $form_i
         $found = TRUE;
         break;
       }
-
-      // These conditions are here to check exactly the same as the code above
-      // except that `!isset($data['method']) &&` is not part of the conditions
-      // anymore. The reason why we did this is that initial architecture of
-      // @Join plugins predicted that plugins could be initiated only by field
-      // or only by method, but there can be group types where it should
-      // be initiated by both. The conditions below are respecting that fact,
-      // which is needed to change the field type of the field which is
-      // responsible for listing all join options accordingly.
-      $field_found = FALSE;
-      if (
-        isset($data['field'], $form[$data['field']]) &&
-        $data['entity_type'] === $entity_type_id &&
-        (
-          !isset($data['bundle']) &&
-          $bundle === NULL ||
-          in_array($bundle, (array) $data['bundle'])
-        )
-      ) {
-        $field_found = TRUE;
-        break;
-      }
     }
 
-    if ($field_found && isset($data)) {
+    if ($found && isset($data)) {
       $field = &$form[$data['field']]['widget'];
 
       if ($field['#type'] === 'checkboxes') {
         $field['#type'] = 'radios';
       }
-    }
-
-    if ($found && isset($data)) {
-      $field = &$form[$data['field']]['widget'];
 
       if ($entity->isNew()) {
         $hook = 'social_group_join_method_info';


### PR DESCRIPTION
After extensive tests for 11.8.1, we noticed that this fix introduced a new issue where users are not able to ask to join a group that is "invitation only".

We decided to roll back the change.

Reverts goalgorilla/open_social#3326