### PR TITLE
Issue #3349597 by ronaldtebrake: Part 1: Improve admin menu performance by using correct cache contexts

### DIFF
--- a/modules/custom/social_admin_menu/social_admin_menu.info.yml
+++ b/modules/custom/social_admin_menu/social_admin_menu.info.yml
@@ -6,4 +6,4 @@ package: Social
 dependencies:
   - drupal:toolbar
   - admin_toolbar:admin_toolbar
-  - admin_toolbar_tools:admin_toolbar_tools
+  - gin_toolbar:gin_toolbar

--- a/modules/custom/social_admin_menu/social_admin_menu.module
+++ b/modules/custom/social_admin_menu/social_admin_menu.module
@@ -18,20 +18,6 @@ function social_admin_menu_toolbar_alter(array &$items): void {
 }
 
 /**
- * Implements hook_module_implements_alter().
- */
-function social_admin_menu_module_implements_alter(array &$implementations, string $hook): void {
-  // Remove the toolbar implementations from gin.
-  // we are doing our own pre render in this module, and will add the
-  // gin requirements in there.
-  if ($hook === 'toolbar') {
-    if (isset($implementations['gin_toolbar'])) {
-      unset($implementations['gin_toolbar']);
-    }
-  }
-}
-
-/**
  * Implements hook_theme_registry_alter().
  */
 function social_admin_menu_theme_registry_alter(array &$theme_registry): void {

--- a/modules/custom/social_admin_menu/social_admin_menu.module
+++ b/modules/custom/social_admin_menu/social_admin_menu.module
@@ -8,11 +8,89 @@
 /**
  * Implements hook_toolbar_alter().
  */
-function social_admin_menu_toolbar_alter(&$items) {
+function social_admin_menu_toolbar_alter(array &$items): void {
   $items['administration']['tray']['toolbar_administration'] = [
     '#lazy_builder' => [
       'social_admin_menu.administrator_menu_tree_manipulators:renderForm',
       [],
     ],
   ];
+}
+
+/**
+ * Implements hook_module_implements_alter().
+ */
+function social_admin_menu_module_implements_alter(array &$implementations, string $hook): void {
+  // Remove the toolbar implementations from gin.
+  // we are doing our own pre render in this module, and will add the
+  // gin requirements in there.
+  if ($hook === 'toolbar') {
+    if (isset($implementations['gin_toolbar'])) {
+      unset($implementations['gin_toolbar']);
+    }
+  }
+}
+
+/**
+ * Implements hook_theme_registry_alter().
+ */
+function social_admin_menu_theme_registry_alter(array &$theme_registry): void {
+  // Unfortunately the preprocess functions aren't ordered by module weight.
+  // Changing module weight doesn't work, also with dependency set to
+  // gin_toolbar this should be dealt with but is not.
+  // So we enforce our preprocess after gin_toolbar all the way at the end.
+  if (!empty($theme_registry['toolbar']['preprocess functions'])) {
+    $current_key = array_search('social_admin_menu_preprocess_toolbar', $theme_registry['toolbar']['preprocess functions'], FALSE);
+    unset($theme_registry['toolbar']['preprocess functions'][$current_key]);
+    // Give it a new key all the way at the end.
+    $theme_registry['toolbar']['preprocess functions'][] = 'social_admin_menu_preprocess_toolbar';
+  }
+  // Make sure our menu preprocess also runs at the end as src/Bootstrap.php
+  // adds unnecessary cache contexts to our admin menu. Because cache is
+  // bubbled, we need to do it for every preprocess function the render cache
+  // for a menu in a toolbar container hits.
+  if (!empty($theme_registry['menu__toolbar']['preprocess functions'])) {
+    $current_key = array_search('social_admin_menu_preprocess_menu__toolbar', $theme_registry['menu__toolbar']['preprocess functions'], FALSE);
+    unset($theme_registry['menu__toolbar']['preprocess functions'][$current_key]);
+    // Give it a new key all the way at the end.
+    $theme_registry['menu__toolbar']['preprocess functions'][] = 'social_admin_menu_preprocess_menu__toolbar';
+  }
+}
+
+/**
+ * Implements hook_preprocess_toolbar().
+ */
+function social_admin_menu_preprocess_toolbar(array &$variables): void {
+  if (!empty($variables['#cache']['contexts'])) {
+    // Gin wants to cache the toolbar per route, this so it can render an active
+    // menu trail, which we rather not do for caching purposes.
+    // So we can cache it across routes.
+    if (($route_context = array_search('route', $variables['#cache']['contexts'])) !== FALSE) {
+      unset($variables['#cache']['contexts'][$route_context]);
+    }
+    // Bootstrap varies the cache by if it's front or not, see src/Bootstrap.php
+    // in the bootstrap module.
+    // Since our toolbar implementation works across all pages, front or not,
+    // we can remove this from our toolbar render array as well.
+    if (($is_front = array_search('url.path.is_front', $variables['#cache']['contexts'])) !== FALSE) {
+      unset($variables['#cache']['contexts'][$is_front]);
+    }
+  }
+}
+
+/**
+ * Implements hook_preprocess_menu__toolbar().
+ */
+function social_admin_menu_preprocess_menu__toolbar(array &$variables): void {
+  // Bootstrap varies the cache by if it's front or not, see src/Bootstrap.php
+  // in the bootstrap module.
+  // Since our toolbar implementation works across all pages, front or not,
+  // we can remove this from our toolbar render array as well.
+  if ($variables['menu_name'] === 'social_core.dashboard') {
+    if (!empty($variables['#cache']['contexts'])) {
+      if (($is_front = array_search('url.path.is_front', $variables['#cache']['contexts'])) !== FALSE) {
+        unset($variables['#cache']['contexts'][$is_front]);
+      }
+    }
+  }
 }

--- a/modules/custom/social_admin_menu/social_admin_menu.module
+++ b/modules/custom/social_admin_menu/social_admin_menu.module
@@ -86,7 +86,7 @@ function social_admin_menu_preprocess_menu__toolbar(array &$variables): void {
   // in the bootstrap module.
   // Since our toolbar implementation works across all pages, front or not,
   // we can remove this from our toolbar render array as well.
-  if ($variables['menu_name'] === 'social_core.dashboard') {
+  if ($variables['menu_name'] === 'admin') {
     if (!empty($variables['#cache']['contexts'])) {
       if (($is_front = array_search('url.path.is_front', $variables['#cache']['contexts'])) !== FALSE) {
         unset($variables['#cache']['contexts'][$is_front]);

--- a/modules/custom/social_admin_menu/src/Menu/SocialAdminMenuAdministratorMenuLinkTreeManipulators.php
+++ b/modules/custom/social_admin_menu/src/Menu/SocialAdminMenuAdministratorMenuLinkTreeManipulators.php
@@ -159,11 +159,6 @@ class SocialAdminMenuAdministratorMenuLinkTreeManipulators extends DefaultMenuLi
       '#attributes' => [
         'class' => ['toolbar-menu-administration'],
       ],
-      '#cache' => [
-        'contexts' => [
-          'user.roles',
-        ],
-      ],
       'administration_menu' => $this->toolbarMenuLinkTree->build($tree),
     ];
     return $element;

--- a/modules/custom/social_admin_menu/src/Menu/SocialAdminMenuAdministratorMenuLinkTreeManipulators.php
+++ b/modules/custom/social_admin_menu/src/Menu/SocialAdminMenuAdministratorMenuLinkTreeManipulators.php
@@ -152,7 +152,7 @@ class SocialAdminMenuAdministratorMenuLinkTreeManipulators extends DefaultMenuLi
       ['callable' => 'toolbar_tools_menu_navigation_links'],
       ['callable' => 'social_admin_menu.administrator_menu_tree_manipulators:checkAccess'],
     ];
-    $tree = $this->toolbarMenuLinkTree->load(NULL, $parameters);
+    $tree = $this->toolbarMenuLinkTree->load('system.admin', $parameters);
     $tree = $this->toolbarMenuLinkTree->transform($tree, $manipulators);
     $element['toolbar_administration'] = [
       '#type' => 'container',

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2186,21 +2186,6 @@ parameters:
 			path: modules/custom/sitewide_js/src/Form/SiteWideJSForm.php
 
 		-
-			message: "#^Function social_admin_menu_toolbar_alter\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: modules/custom/social_admin_menu/social_admin_menu.module
-
-		-
-			message: "#^Function social_admin_menu_toolbar_alter\\(\\) has parameter \\$items with no type specified\\.$#"
-			count: 1
-			path: modules/custom/social_admin_menu/social_admin_menu.module
-
-		-
-			message: "#^Parameter \\#1 \\$menu_name of method Drupal\\\\Core\\\\Menu\\\\MenuLinkTree\\:\\:load\\(\\) expects string, null given\\.$#"
-			count: 1
-			path: modules/custom/social_admin_menu/src/Menu/SocialAdminMenuAdministratorMenuLinkTreeManipulators.php
-
-		-
 			message: "#^Function social_advanced_queue_install\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: modules/custom/social_advanced_queue/social_advanced_queue.install


### PR DESCRIPTION
## Info
This is part of a bigger performance improvement;
#3355 is the bigger chunk where we will work on reducing links as well as creating our own admin menu where we have all control but it's under construction as that is a massive overhaul that might need a major version.

## Problem
Part of the problem is that we have different modules enabled that all want to take part in rendering (and caching) our admin menu.

For example;
1. Gin_toolbar wants to cache it per route; 
https://git.drupalcode.org/project/gin_toolbar/-/blob/8.x-1.x/gin_toolbar.module#L191 so the active menu trail works.

2. Bootstrap wants to add a cache based on if it's the frontpage or not and does this globally, so it runs for multiple preprocesses which are bubbled up 
https://git.drupalcode.org/project/bootstrap/-/blob/8.x-3.x/src/Bootstrap.php#L1420

## Solution
Make sure we control the cache contexts, we know we should be able to cache this for users with the same set of permissions, theme, and language. This should work for our product as well as the open source version. 
Even if that means things like the active trail does not work in our menu, it's something we can live with.

## Issue tracker
https://www.drupal.org/project/social/issues/3349597

## Theme issue tracker
https://www.drupal.org/project/socialbase/issues/3349585

## How to test
- [ ] Enable `social_admin_menu`
- [ ] See that there is a Cache hit on the admin menu for people with the same roles (or permission if you will)
- [ ] It should only have to load the menu in cache once which should persist over other routes
- [ ] See that for our CM/SM roles the menu does not change visually nor menu links

### Performance improvements (cache context) 
**Before**
Here you can see how it runs before
https://www.loom.com/share/1b8e000b4d624d20b2af136b3084883d

- Note, no caches across routes
- Note the amount of cache contexts for the menu

**After**
Here you can see how it runs on a cache clear and enabling the `social_admin_menu`
https://www.loom.com/share/ac0b142f619841b0be93c83a06c463c2

- Note that the cache is immediately build by the first user
- Note that its reused across all the subsequent routes the individual visites after
- Note that the second user (chris who I made a SM) also benefits from the same cache 
- Note that that also works no a new route (all topics) that was never visited before

So caching works again  🎉 

## Definition of done
### Before merge
- [x] Code/peer review is completed
- [x] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [x] All automated tests are green
- [x] Functional/manual tests of the acceptance criteria are approved
- [x] All acceptance criteria were met
- [x] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [x] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [x] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [x] This pull request has all required labels (team/type/priority)
- [x] This pull request has a milestone
- [x] This pull request has an assignee (if applicable)
- [x] Any front end changes are tested on all major browsers
- [x] New UI elements, or changes on UI elements are approved by the design team
- [x] New features, or feature changes are approved by the product owner

### After merge
- [x] Code is tested on all branches that it has been cherry-picked
- [x] Update hook number might need adjustment, make sure they have the correct order
- [x] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
TBD

## Release notes
We have now made a more performant admin menu for users sharing the same permissions, in our case that works for the site and content managers as those roles have the same permissions by default. We've also ensured the cache persists over routes so it only has to be built by one user for a given role.

