### PR TITLE
Issue #3351326 by vnech: Skip activities creation during content migration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -63,7 +63,8 @@
                 "Issue #2998390: Cache is not invalidated when comment deleted": "https://www.drupal.org/files/issues/2022-02-07/2998390-8.patch",
                 "Issue #3282073: Comment the \"user_post_update_update_roles\" that was added in Drupal 9.3": "https://www.drupal.org/files/issues/2023-04-07/social-comment_the_user_post_update_update_roles-3282073_d95.diff",
                 "Image derivative generation does not work if effect \"Convert\" in use and file stored in private filesystem": "https://www.drupal.org/files/issues/2022-09-23/2786735-39.patch",
-                "Issue #2107455: Image field default value not shown when upload destination set to private file storage": "https://www.drupal.org/files/issues/2022-06-24/2107455-75.patch"
+                "Issue #2107455: Image field default value not shown when upload destination set to private file storage": "https://www.drupal.org/files/issues/2022-06-24/2107455-75.patch",
+                "Issue #3052115: Mark an entity as 'syncing' during a migration update": "https://www.drupal.org/files/issues/2023-02-01/3052115-59.patch"
             },
             "drupal/config_update": {
                 "3248161: Symfony 4.4 event dispatcher parameter order change": "https://www.drupal.org/files/issues/2021-11-08/symfony-4-4-event-dispatcher-parameter-order-change-3248161-3.patch"

--- a/modules/custom/activity_basics/activity_basics.module
+++ b/modules/custom/activity_basics/activity_basics.module
@@ -8,6 +8,7 @@
 use Drupal\activity_creator\Plugin\ActivityActionInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityPublishedInterface;
+use Drupal\Core\Entity\SynchronizableInterface;
 use Drupal\node\NodeInterface;
 use Drupal\group\Entity\GroupContent;
 
@@ -75,9 +76,14 @@ function activity_basics_social_group_move(NodeInterface $node): void {
  *   The instance.
  */
 function _activity_basics_entity_action(EntityInterface $entity, $instance): void {
-  $plugin_mananger = \Drupal::service('plugin.manager.activity_action.processor');
-  if ($plugin_mananger->hasDefinition($instance)) {
-    $plugin = $plugin_mananger->createInstance($instance);
+  // During migration activities should not be created as this may flood stream.
+  if ($entity instanceof SynchronizableInterface && $entity->isSyncing()) {
+    return;
+  }
+
+  $plugin_manager = \Drupal::service('plugin.manager.activity_action.processor');
+  if ($plugin_manager->hasDefinition($instance)) {
+    $plugin = $plugin_manager->createInstance($instance);
     assert($plugin instanceof ActivityActionInterface);
     $plugin->create($entity);
   }

--- a/modules/social_features/social_follow_taxonomy/modules/social_follow_tag/social_follow_tag.module
+++ b/modules/social_features/social_follow_taxonomy/modules/social_follow_tag/social_follow_tag.module
@@ -299,12 +299,7 @@ function social_follow_tag_entity_update(EntityInterface $entity) {
 
     // Create activity notification.
     if (!empty($taxonomy_ids)) {
-      $plugin_manager = \Drupal::service('plugin.manager.activity_action.processor');
-      if ($plugin_manager->hasDefinition('update_entity_action')) {
-        $plugin_manager
-          ->createInstance('update_entity_action')
-          ->create($entity);
-      }
+      _activity_basics_entity_action($entity, 'update_entity_action');
     }
   }
 }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -8869,11 +8869,6 @@ parameters:
 			path: modules/social_features/social_follow_taxonomy/modules/social_follow_tag/social_follow_tag.install
 
 		-
-			message: "#^Call to an undefined method object\\:\\:create\\(\\)\\.$#"
-			count: 1
-			path: modules/social_features/social_follow_taxonomy/modules/social_follow_tag/social_follow_tag.module
-
-		-
 			message: "#^Function social_follow_tag_entity_update\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: modules/social_features/social_follow_taxonomy/modules/social_follow_tag/social_follow_tag.module


### PR DESCRIPTION
## Problem
When migrate a content activities are created as well. As a result when there are a huge of amount content this can cause a bad users experience because of streams flooding.

## Solution
Create an activity only if entity is not syncing.

## Issue tracker
- https://getopensocial.atlassian.net/browse/PROD-24731
- https://www.drupal.org/project/social/issues/3351326
- https://www.drupal.org/project/drupal/issues/3052115

## Theme issue tracker
n/a

## How to test
This can be faced on content migration.

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
n/a

## Release notes
Skip activities creation during content migration.

## Change Record
n/a

## Translations
n/a
