### PR TITLE
Issue #3351588 by zanvidmar: Wrong number of items on Custom content list block

### DIFF
--- a/modules/social_features/social_content_block/social_content_block.services.yml
+++ b/modules/social_features/social_content_block/social_content_block.services.yml
@@ -22,6 +22,7 @@ services:
       - '@entity_type.manager'
       - '@database'
       - '@string_translation'
+      - '@language_manager'
       - '@plugin.manager.content_block'
       - '@entity.repository'
       - '@datetime.time'

--- a/modules/social_features/social_content_block/src/ContentBuilderInterface.php
+++ b/modules/social_features/social_content_block/src/ContentBuilderInterface.php
@@ -7,6 +7,7 @@ use Drupal\Core\Database\Connection;
 use Drupal\Core\Entity\EntityRepositoryInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Language\LanguageManagerInterface;
 use Drupal\Core\Security\TrustedCallbackInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\StringTranslation\TranslationInterface;
@@ -29,6 +30,8 @@ interface ContentBuilderInterface extends TrustedCallbackInterface {
    *   The current active database's master connection.
    * @param \Drupal\Core\StringTranslation\TranslationInterface $string_translation
    *   The string translation.
+   * @param \Drupal\Core\Language\LanguageManagerInterface $language_manager
+   *   The language manager.
    * @param \Drupal\social_content_block\ContentBlockManagerInterface $content_block_manager
    *   The content block manager.
    * @param \Drupal\Core\Entity\EntityRepositoryInterface $entity_repository
@@ -41,6 +44,7 @@ interface ContentBuilderInterface extends TrustedCallbackInterface {
     EntityTypeManagerInterface $entity_type_manager,
     Connection $connection,
     TranslationInterface $string_translation,
+    LanguageManagerInterface $language_manager,
     ContentBlockManagerInterface $content_block_manager,
     EntityRepositoryInterface $entity_repository,
     TimeInterface $time


### PR DESCRIPTION
## Problem
Custom content list block does not display the correct number of items when content is translated.

## Solution
Adding language filtering to remove translation duplicates in a query that returns an entity list for the "Custom content list block".

## Issue tracker
[3351588](https://www.drupal.org/project/social/issues/3351588)

## Theme issue tracker
N/A

## How to test
- [x] Install Open Social 
- [x] Enable social_content_block
- [x] Enable social_language with two languages (English by default, and for example add Dutch)
- [x] Go to Content language (admin/config/regional/content-language) and tick "Content" and then "Topic" so you can translate topics.
- [x] Go to "Custom block library" (admin/structure/block/block-content), click on "Add custom block" and select "Custom content list block"
- [x] Select:
  Type of content: Topic
  Topic type: News 
  Number of items: 5
  Sort: Most recent
 and save the changes
- [x] Go to the block layout (/admin/structure/block) and add the newly created block to content (or any region where you can see the block).
- [x] Create 5 new topics (news) in English.
- [x] Translate 1 one of the newly created topics except for the last one (for example translate 3rd)
- [x] Clear the cache
- [x] You will see that the "Custom content list block" only shows you 4 results, even though the "Number of items" selected is 5.
- [x] The expected result is attained when repeating the steps with this fix applied (just switch to this branch with `composer require goalgorilla/open_social:dev-issue/3351588-custom-content-list-block-trans-filter -W` and clear the cache via UI).

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
N/A

## Release notes
The "Custom content list block" now displays the correct number of items when content on the list is translated.

## Change Record
N/A

## Translations
N/A
