### PR TITLE
Issue #3353948 by Kingdutch: Add the Config Modify module

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -121,6 +121,7 @@
         "drupal/ajax_comments": "1.0-beta4",
         "drupal/better_exposed_filters": "6.0.3",
         "drupal/block_field": "1.0.0-rc4",
+        "drupal/config_modify": "^1",
         "drupal/config_update": "1.7",
         "drupal/core-recommended": "~9.5.3",
         "drupal/core-composer-scaffold": "~9.5.3",

--- a/modules/social_features/social_core/config/update/social_core_update_11900.yml
+++ b/modules/social_features/social_core/config/update/social_core_update_11900.yml
@@ -1,0 +1,3 @@
+__global_actions:
+  install_modules:
+    - config_modify

--- a/modules/social_features/social_core/social_core.info.yml
+++ b/modules/social_features/social_core/social_core.info.yml
@@ -6,6 +6,7 @@ dependencies:
   - admin_toolbar_tools:admin_toolbar_tools
   - drupal:block
   - drupal:block_content
+  - config_modify:config_modify
   - crop:crop
   - drupal:field
   - field_group:field_group

--- a/modules/social_features/social_core/social_core.install
+++ b/modules/social_features/social_core/social_core.install
@@ -1642,3 +1642,17 @@ function social_core_update_11405(): string {
   // Output logged messages to related channel of update execution.
   return $update_helper->logger()->output();
 }
+
+/**
+ * Enable the Config Modify module.
+ */
+function social_core_update_11900() : string {
+  /** @var \Drupal\update_helper\UpdaterInterface $update_helper */
+  $update_helper = \Drupal::service('update_helper.updater');
+
+  // Execute configuration update definitions with logging of success.
+  $update_helper->executeUpdate('social_core', __FUNCTION__);
+
+  // Output logged messages to related channel of update execution.
+  return $update_helper->logger()->output();
+}


### PR DESCRIPTION
## Problem / Solution
The [Config Modify](https://www.drupal.org/project/config_modify/) module is a project we created to allow us to re-use the Update Helper's Configuration Update Definitions for configuration at install time.

For example this allows us to move our current permission set function calls to YML files but it also allows us to remove bridge modules such as `social_book_featured` by letting us modify form/view configuration automatically based on what modules are enabled.

## Issue tracker
https://www.drupal.org/project/social/issues/3353948

## How to test
- [ ] Update hook should work
- [ ] New platform install should work
- [ ] Both cases should have the module enabled

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Release notes
Open Social now supports providing install configuration using `config/modify` files read by the [Config Modify](https://www.drupal.org/project/config_modify/) module.
