### PR TITLE
Issue #3354659 by zanvidmar: Update Gin version to 8.x-3.0-rc2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -134,7 +134,7 @@
         "drupal/exif_orientation": "1.2.0",
         "drupal/field_group": "3.2.0",
         "drupal/flag": "4.0.0-beta4",
-        "drupal/gin": "3.0-beta3",
+        "drupal/gin": "3.0-rc2",
         "drupal/gin_toolbar": "1.0.0-rc1",
         "drupal/ginvite": "2.1.0",
         "drupal/graphql": "4.4.0",

--- a/composer.json
+++ b/composer.json
@@ -159,7 +159,7 @@
         "drupal/select2": "1.13.0",
         "drupal/shariff": "1.7",
         "drupal/social_tour": "1.0.0-alpha2",
-        "drupal/socialblue": "~2.4.2",
+        "drupal/socialblue": "~2.5.0",
         "drupal/swiftmailer": "2.3.0",
         "drupal/token": "1.11.0",
         "drupal/ultimate_cron": "2.0.0-alpha6",

--- a/tests/behat/features/capabilities/alternative-frontpage/alternative-frontpage.feature
+++ b/tests/behat/features/capabilities/alternative-frontpage/alternative-frontpage.feature
@@ -44,7 +44,7 @@ Feature: Set alternative frontpage
     And I click radio button "Authenticated user"
     And I press "Save"
     And the cache has been cleared
-    And I click "Home"
+    And I click "Back to site"
     Then I should see "Frontpage LU"
     # See as AN
     Given I logout
@@ -59,6 +59,6 @@ Feature: Set alternative frontpage
     When I am on "admin/config/alternative_frontpage/manage/logged_users/delete"
     And I click the xth "0" element with the css "#edit-submit"
     Then I should see "Logged users has been deleted."
-    When I click "Home"
+    When I click "Back to site"
     And the cache has been cleared
     Then I am on "stream"


### PR DESCRIPTION
## Problem
We updated Open Social to Drupal 9.5.3 ([PR](https://github.com/goalgorilla/open_social/pull/3369))
We need to upgrade Gin to at least 8.x-3.0-rc1 as stated in PR.

Check the Gin issue for more info: https://www.drupal.org/project/gin/issues/3309113

## Solution
Update Gin version to 8.x-3.0-rc2

## Issue tracker
[3354659](https://www.drupal.org/project/social/issues/3354659)

## Theme issue tracker
[3309113](https://www.drupal.org/project/gin/issues/3309113)

## How to test
- [ ] Update Gin to 3.0-rc2
- [ ] Check if Gin theme is not broken 
- [ ] Use the system, specially the admin area and common content and check for visual issues

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
N/A

## Release notes
Gin has been updated to 3.0-rc2

## Change Record
Gin has been updated to 3.0-rc2. RC1 deprecated the CamelCase CSS3 classes in favor of kebab case classnames. They will be removed in the stable release. See [#3309113: Change CSS3 variables from camelCase to kebab-case](https://www.drupal.org/project/gin/issues/3309113)

## Translations
N/A
