### PR TITLE
Issue #3355419 - Make sure new search queries always start at the first page

### DIFF
--- a/modules/social_features/social_search/src/Form/SearchContentForm.php
+++ b/modules/social_features/social_search/src/Form/SearchContentForm.php
@@ -81,6 +81,11 @@ class SearchContentForm extends FormBase implements ContainerInjectionInterface 
   public function submitForm(array &$form, FormStateInterface $form_state) {
     $search_all_view = 'search_all';
     $query = UrlHelper::filterQueryParameters($this->requestStack->getCurrentRequest()->query->all());
+
+    // Unset the page parameter. When someone starts a new search query they
+    // should always start again at the first page.
+    unset($query['page']);
+
     $options = ['query' => $query];
     $parameters = [];
 

--- a/modules/social_features/social_search/src/Form/SearchHeroForm.php
+++ b/modules/social_features/social_search/src/Form/SearchHeroForm.php
@@ -96,6 +96,11 @@ class SearchHeroForm extends FormBase implements ContainerInjectionInterface {
     $route_parts = explode('.', ($current_route ?? ''));
 
     $query = UrlHelper::filterQueryParameters($this->requestStack->getCurrentRequest()->query->all());
+
+    // Unset the page parameter. When someone starts a new search query they
+    // should always start again at the first page.
+    unset($query['page']);
+
     $options = ['query' => $query];
     $parameters = [];
 

--- a/tests/behat/features/capabilities/search/search-content.feature
+++ b/tests/behat/features/capabilities/search/search-content.feature
@@ -11,19 +11,19 @@ Feature: Search
       | Event two         | Description   | 1      | public                   |
     And "topic" content:
       | title             | body          | status | field_content_visibility |
-      | Topic one         | Description   | 1      | public                   |
-      | Topic two         | Description   | 1      | community                |
-      | Topic three       | Description   | 1      | community                |
-      | Topic four        | Description   | 1      | community                |
-      | Topic five        | Description   | 1      | community                |
-      | Topic six         | Description   | 1      | community                |
-      | Topic seven       | Description   | 1      | community                |
-      | Topic eight       | Description   | 1      | community                |
-      | Topic nine        | Description   | 1      | community                |
-      | Topic ten         | Description   | 1      | community                |
-      | Topic eleven      | Description   | 1      | community                |
-      | Topic twelve      | Description   | 1      | community                |
-      | Topic thirteen    | Description   | 1      | community                |
+      | Topic one         | Shenanigans   | 1      | public                   |
+      | Topic two         | Shenanigans   | 1      | community                |
+      | Topic three       | Shenanigans   | 1      | community                |
+      | Topic four        | Shenanigans   | 1      | community                |
+      | Topic five        | Shenanigans   | 1      | community                |
+      | Topic six         | Shenanigans   | 1      | community                |
+      | Topic seven       | Shenanigans   | 1      | community                |
+      | Topic eight       | Shenanigans   | 1      | community                |
+      | Topic nine        | Shenanigans   | 1      | community                |
+      | Topic ten         | Shenanigans   | 1      | community                |
+      | Topic eleven      | Shenanigans   | 1      | community                |
+      | Topic twelve      | Shenanigans   | 1      | community                |
+      | Topic thirteen    | Shenanigans   | 1      | community                |
     And Search indexes are up to date
     And I am on "search/content"
     When I fill in the following:
@@ -50,7 +50,7 @@ Feature: Search
     # Test the pager.
     When I am on "search/content"
     And I fill in the following:
-      | search_input | topic |
+      | search_input | Shenanigans |
     And I press "Search"
     And I click the xth "0" element with the css ".pager-nav .pager__item--next"
     And I should see "Topic thirteen"

--- a/tests/behat/features/capabilities/search/search-content.feature
+++ b/tests/behat/features/capabilities/search/search-content.feature
@@ -53,7 +53,7 @@ Feature: Search
       | search_input | Shenanigans |
     And I press "Search"
     And I click the xth "0" element with the css ".pager-nav .pager__item--next"
-    And I should see "Topic thirteen"
+    And I should see "Topic" in the ".teaser-topic .teaser__title" element
     And I fill in the following:
       | search_input | four |
     And I press "Search"

--- a/tests/behat/features/capabilities/search/search-content.feature
+++ b/tests/behat/features/capabilities/search/search-content.feature
@@ -13,6 +13,17 @@ Feature: Search
       | title             | body          | status | field_content_visibility |
       | Topic one         | Description   | 1      | public                   |
       | Topic two         | Description   | 1      | community                |
+      | Topic three       | Description   | 1      | community                |
+      | Topic four        | Description   | 1      | community                |
+      | Topic five        | Description   | 1      | community                |
+      | Topic six         | Description   | 1      | community                |
+      | Topic seven       | Description   | 1      | community                |
+      | Topic eight       | Description   | 1      | community                |
+      | Topic nine        | Description   | 1      | community                |
+      | Topic ten         | Description   | 1      | community                |
+      | Topic eleven      | Description   | 1      | community                |
+      | Topic twelve      | Description   | 1      | community                |
+      | Topic thirteen    | Description   | 1      | community                |
     And Search indexes are up to date
     And I am on "search/content"
     When I fill in the following:
@@ -35,7 +46,20 @@ Feature: Search
     And I should see "Event one" in the "Main content"
     And I should see "Topic one"
     And I should not see "Event second"
-    # Scenario: Successfully filter search results
+
+    # Test the pager.
+    When I am on "search/content"
+    And I fill in the following:
+      | search_input | topic |
+    And I press "Search"
+    And I click the xth "1" element with the css ".pager-nav .pager__item"
+    And I should see "Topic thirteen"
+    And I fill in the following:
+      | search_input | four |
+    And I press "Search"
+    And I should see "Topic four"
+
+        # Scenario: Successfully filter search results
 #    When I select "topic" from "Content type"
 #    And I press "Filter" in the "Sidebar second"
 #    And I should see "Topic one"

--- a/tests/behat/features/capabilities/search/search-content.feature
+++ b/tests/behat/features/capabilities/search/search-content.feature
@@ -52,7 +52,7 @@ Feature: Search
     And I fill in the following:
       | search_input | topic |
     And I press "Search"
-    And I click the xth "1" element with the css ".pager-nav .pager__item"
+    And I click the xth "0" element with the css ".pager-nav .pager__item--next"
     And I should see "Topic thirteen"
     And I fill in the following:
       | search_input | four |


### PR DESCRIPTION
## Problem
When you have a search going on at `/search/content/queryterm?page=2` and you start a new one, you will stay at page 2 and not start anew, e.g. `/search/content/newqueryterm?page=2`.

1. Search for something
2. Go to page 2
3. Search for something new
4. You are still at page 2

## Solution
Always remove the `page` query parameter when starting a new search query.

## Issue tracker
- https://www.drupal.org/project/social/issues/3355419
- https://getopensocial.atlassian.net/browse/PROD-22096

## Theme issue tracker
N/a

## How to test
- [ ] Search for something, or leave it empty
- [ ] Go to page 2
- [ ] Search for something new, e.g. with only one result
- [ ] You see your result and you are at the first page

_Consider running the updated Behat test on a different branch. You will notice the final step failing._

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
N/a

## Release notes
Fixed an issue where a user would perform a search query further down the search result pages (e.g. on page 3), and they would stay at page 3 when performing a new search query. Now, when you start a new search you will always start from the first page as you would expect.

## Change Record
N/a

## Translations
N/a