### PR TITLE
Issue #3355315 by ronaldtebrake: Ensure we check for the mute notification flag and provide a session id for AN users.

### DIFF
--- a/modules/social_features/social_group/social_group.services.yml
+++ b/modules/social_features/social_group/social_group.services.yml
@@ -48,8 +48,7 @@ services:
     arguments: ['@database']
   social_group.group_mute_notify:
     class: Drupal\social_group\GroupMuteNotify
-    arguments:
-      - '@flag'
+    arguments: ['@flag', '@entity_type.manager']
   cache_context.social_group_join_method:
     class: Drupal\social_group\CacheContext\SocialGroupJoinMethodCacheContext
     arguments: []

--- a/modules/social_features/social_group/src/GroupMuteNotify.php
+++ b/modules/social_features/social_group/src/GroupMuteNotify.php
@@ -3,7 +3,9 @@
 namespace Drupal\social_group;
 
 use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Session\AccountInterface;
+use Drupal\flag\FlaggingInterface;
 use Drupal\flag\FlagServiceInterface;
 use Drupal\group\Entity\GroupContent;
 use Drupal\group\Entity\GroupContentInterface;
@@ -28,15 +30,26 @@ class GroupMuteNotify {
   protected $flagService;
 
   /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
    * GroupMuteNotify constructor.
    *
    * @param \Drupal\flag\FlagServiceInterface $flag_service
    *   Flag service.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager.
    */
   public function __construct(
-    FlagServiceInterface $flag_service
+    FlagServiceInterface $flag_service,
+    EntityTypeManagerInterface $entity_type_manager
   ) {
     $this->flagService = $flag_service;
+    $this->entityTypeManager = $entity_type_manager;
   }
 
   /**
@@ -51,9 +64,23 @@ class GroupMuteNotify {
    *   TRUE if a user muted notifications for a group.
    */
   public function groupNotifyIsMuted(GroupInterface $group, AccountInterface $account): bool {
-    $flaggings = $this->flagService->getAllEntityFlaggings($group, $account);
+    // Make sure we only check for the specific mute group flag.
+    /** @var \Drupal\flag\FlagInterface $flag */
+    $flag = $this->entityTypeManager->getStorage('flag')->load('mute_group_notifications');
+    $session_id = NULL;
+    // If the user is AN we need to provide a session id to the flagging
+    // service.
+    if ($account->isAnonymous()) {
+      $session_id = $this->flagService->getAnonymousSessionId();
+    }
+    $flags = $this->flagService->getFlagging($flag, $group, $account, $session_id);
 
-    return !empty($flaggings);
+    // If a user has the mute group flag set for a group we can return TRUE.
+    if ($flags instanceof FlaggingInterface) {
+      return TRUE;
+    }
+
+    return FALSE;
   }
 
   /**

--- a/modules/social_features/social_group/tests/src/Unit/GroupNotifyTest.php
+++ b/modules/social_features/social_group/tests/src/Unit/GroupNotifyTest.php
@@ -1,0 +1,154 @@
+<?php
+
+namespace Drupal\Tests\social_group\Unit;
+
+use Drupal\Core\Entity\EntityStorageInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Entity\EntityTypeRepositoryInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\flag\FlagInterface;
+use Prophecy\Prophecy\ProphecyInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Drupal\Core\Session\AccountProxyInterface;
+use Drupal\flag\FlagService;
+use Drupal\group\Entity\GroupInterface;
+use Drupal\Tests\UnitTestCase;
+use Prophecy\Prophet;
+use Drupal\social_group\GroupMuteNotify;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/**
+ * Unit tests for the flag action plugin.
+ *
+ * @group social_group
+ *
+ * @coversDefaultClass \Drupal\social_group\GroupMuteNotify
+ */
+class GroupNotifyTest extends UnitTestCase {
+
+  /**
+   * The current user.
+   *
+   * @var \Drupal\Core\Session\AccountInterface
+   */
+  protected AccountInterface $currentUser;
+
+  /**
+   * A dummy group to use in other prophecies.
+   *
+   * @var \Drupal\group\Entity\GroupInterface
+   */
+  protected GroupInterface $group;
+
+  /**
+   * The flag service.
+   *
+   * @var \Drupal\flag\FlagService
+   */
+  protected FlagService $flagService;
+
+  /**
+   * The group role synchronizer service.
+   *
+   * @var \Drupal\social_group\GroupMuteNotify
+   */
+  protected GroupMuteNotify $groupNotifyService;
+
+  /**
+   * The entity type manager service.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * The entity type manager service.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeRepositoryInterface|\Prophecy\Prophecy\ProphecyInterface
+   */
+  protected EntityTypeRepositoryInterface|ProphecyInterface $entityTypeRepository;
+
+  /**
+   * The container.
+   *
+   * @var \Symfony\Component\DependencyInjection\ContainerInterface|\Prophecy\Prophecy\ProphecyInterface
+   */
+  protected ContainerInterface|ProphecyInterface $container;
+
+  /**
+   * The request stack.
+   *
+   * @var \Symfony\Component\HttpFoundation\RequestStack
+   */
+  protected RequestStack $requestStack;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setUp(): void {
+    parent::setUp();
+    $prophet = new Prophet();
+    $this->group = $prophet->prophesize(GroupInterface::class)->reveal();
+    $this->flagService = $prophet->prophesize(FlagService::class)->reveal();
+
+    $account = $prophet->prophesize(AccountProxyInterface::class)->reveal();
+
+    // Mock the mute_group_notifications flag.
+    $entityFlagMock = $this->getMockBuilder(FlagInterface::class)
+      ->disableOriginalConstructor()
+      ->getMock();
+    $entityFlagMock->expects($this->any())
+      ->method('id')
+      ->will($this->returnValue('mute_group_notifications'));
+
+    // Mock the Entity Storage & Entity Type Manager for groupNOtifyIsMuted.
+    $entityStorage = $this->getMockBuilder(EntityStorageInterface::class)
+      ->disableOriginalConstructor()
+      ->getMock();
+    $entityStorage->expects($this->any())
+      ->method('load')
+      ->willReturn($entityFlagMock);
+
+    $entityTypeManager = $this->getMockBuilder(EntityTypeManagerInterface::class)
+      ->disableOriginalConstructor()
+      ->getMock();
+    $entityTypeManager->expects($this->any())
+      ->method('getstorage')
+      ->willReturn($entityStorage);
+
+    $this->entityTypeManager = $entityTypeManager;
+
+    // Make sure the entity type manager has the necessary mocked input for
+    // groupNotifyIsMuted to run and especially the user being the AN mocked
+    // user.
+    $container = new ContainerBuilder();
+    $container->set('current_user', $account);
+    $container->set('entity_type.manager', $entityTypeManager);
+    \Drupal::setContainer($container);
+    $this->currentUser = \Drupal::currentUser();
+  }
+
+  /**
+   * Tests GroupNotify.
+   *
+   * @covers ::groupNotifyIsMuted
+   */
+  public function testGroupNotifyAsAnonymous(): void {
+    $this->groupNotifyService = new GroupMuteNotify(
+      $this->flagService,
+      $this->entityTypeManager,
+    );
+
+    try {
+      // Ensure for AN users it doesn't result in an exception
+      // rather it returns FALSE as no flags were found.
+      $flags = $this->groupNotifyService->groupNotifyIsMuted($this->group, $this->currentUser);
+      $this->assertEquals(FALSE, $flags);
+    }
+    catch (\LogicException $e) {
+      $this->fail('An exception was thrown while it should not');
+    }
+  }
+
+}

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -12824,11 +12824,6 @@ parameters:
 			path: modules/social_features/social_post/social_post.admin.inc
 
 		-
-			message: "#^Function _social_post_mass_update_batch_process\\(\\) has parameter \\$context with generic interface ArrayAccess but does not specify its types\\: TKey, TValue$#"
-			count: 1
-			path: modules/social_features/social_post/social_post.admin.inc
-
-		-
 			message: "#^Function social_post_mass_update\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: modules/social_features/social_post/social_post.admin.inc

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -16,6 +16,9 @@ parameters:
       - translations/
     analyse:
       - *SocialProfileTrait.php
+  # Not sure we can specify generic types properly with Drupal coding standards
+  # yet, disable for now.
+  checkGenericClassInNonGenericObjectType: false
   drupal:
       drupal_root: %currentWorkingDirectory%/html/core
       entityMapping:
@@ -64,3 +67,4 @@ parameters:
       # The accessCheck test seems to be horribly broken and providing false positives
       # Disable until https://github.com/mglaman/phpstan-drupal/issues/396 is fixed.
       - "#^Missing explicit access check on entity query\\.$#"
+


### PR DESCRIPTION
## Problem
We got a `LogicException: An anonymous user must be identified by session ID` because we forgot to provide a session id if the user is anonymous. Something the `FlagService` expects as you can see below: 

```
    if (!isset($account)) {
      // If there isn't an account, set it to the current user.
      $account = $this->currentUser;
      // If the user is anonymous, get the session ID. Note that this does not
      // always mean that the session is started. Session is started explicitly
      // from FlagService->ensureSession() method.
      if (!isset($session_id) && $account->isAnonymous()) {
        $session_id = $this->getAnonymousSessionId();
      }
    }
    elseif ($account->isAnonymous() && $session_id === NULL) {
      throw new \LogicException('Anonymous users must be identified by session_id');
    }
```    
It could occur the user is deleted and everything is assigned to the AN user, or this is triggered on Cron which means the current user is anonymous when the getFlagging fallback is triggered and thus be a realistic scenario.
 
While doing so, we've uncovered the fact that we were basically checking if a user has flagged a group, regardless of which flag is used. This could result in unwanted side effects, because a Group could potentially be flagged by other flags too that are unrelated to the muting of a group. 

## Additional info
You can see on Elastic it's triggered quite often (top 4 errors logged)
![Screenshot 2023-04-21 at 13 16 17](https://user-images.githubusercontent.com/16667281/234010029-cf8d11a0-8cb4-42f4-b834-f853536b1c8a.png)

The code suggests it's likely during cron / activity processing it gets triggered:
![Screenshot 2023-04-24 at 15 24 48](https://user-images.githubusercontent.com/16667281/234010172-ca13fb6e-faf9-4230-a90b-5a5e9f9c744f.png)

## Solution
So we decided to specifically check on the mute_group_notifications flag for the given user and group.
Plus we use a fallback if the session_id is null and it is required.

## Issue tracker
https://www.drupal.org/project/social/issues/3355315

## How to test
 It's hard to reproduce as you'll need this to trigger as AN that's why i've created a Unit test to do so.

If you look at the screenshot provided above you'll see the likelyhood is this is being triggered on cron. 
I imagine it has to do with an activity being created, that is connected to groups, and the user connected to the activity is deleted and all data is assigned to the AN user.
- [x] Make sure cron is paused
- [x] As a LU
- [x] Mute a group
- [x] As a different LU
- [x] Mention someone in the stream of a group / like that group
- [x] Delete the LU's, assign it to AN
- [x] See that the cron still runs for this specific scenario

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Release notes
Make sure the error `LogicException: An anonymous user must be identified by session ID` is fixed and cron is unblocked for specific scenario's.

