### PR TITLE
Issue #3356324 by SV: Fix duplicated names of "Activity Stream: Homepage stream block"

### DIFF
--- a/modules/social_features/social_activity/config/optional/views.view.activity_stream.yml
+++ b/modules/social_features/social_activity/config/optional/views.view.activity_stream.yml
@@ -363,7 +363,7 @@ display:
   block_stream_homepage:
     display_plugin: block
     id: block_stream_homepage
-    display_title: 'Homepage stream block'
+    display_title: 'Homepage stream block (with post form)'
     position: 3
     display_options:
       display_extenders: {  }

--- a/modules/social_features/social_activity/config/update/social_activity_update_11701.yml
+++ b/modules/social_features/social_activity/config/update/social_activity_update_11701.yml
@@ -1,0 +1,7 @@
+views.view.activity_stream:
+  expected_config: { }
+  update_actions:
+    change:
+      display:
+        block_stream_homepage:
+          display_title: 'Homepage stream block (with post form)'

--- a/modules/social_features/social_activity/social_activity.install
+++ b/modules/social_features/social_activity/social_activity.install
@@ -393,3 +393,17 @@ function social_activity_update_11401(): string {
   // Output logged messages to related channel of update execution.
   return $updateHelper->logger()->output();
 }
+
+/**
+ * Fix duplicated names of "Activity Stream: Homepage stream block".
+ */
+function social_activity_update_11701(): string {
+  /** @var \Drupal\update_helper\Updater $updateHelper */
+  $updateHelper = \Drupal::service('update_helper.updater');
+
+  // Execute configuration update definitions with logging of success.
+  $updateHelper->executeUpdate('social_activity', __FUNCTION__);
+
+  // Output logged messages to related channel of update execution.
+  return $updateHelper->logger()->output();
+}


### PR DESCRIPTION
## Problem
Currently, we have two different blocks (block_stream_homepage, block_stream_homepage_without_post) with the same name in the activity_stream views that can confuse users when there is a possibility to select a block and there are two duplicated items.

## Solution
Rename duplicate block label in views:
- `block_stream_homepage` => **Homepage stream block (with post form)**

## Issue tracker
- https://www.drupal.org/project/social/issues/3356324
- https://getopensocial.atlassian.net/browse/PROD-24014

## Theme issue tracker
N/A

## How to test
- [ ] Using the latest version of Open Social with the social_dashboard module enabled
- [ ] As a sitemanager
- [ ] Try to add a block on dashboard page
- [ ] When I click "add block" I expect that there are no duplicates at the right side on edit layout page
- [ ] The expected result is attained when repeating the steps with this fix applied.

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
Before:
<img width="398" alt="image" src="https://user-images.githubusercontent.com/2241917/234855239-c8d5aea8-65c0-44d6-ba44-6b870d893fa9.png">

After:
<img width="391" alt="image" src="https://user-images.githubusercontent.com/2241917/234854857-3ffdfd82-7249-47bc-82c4-3e134cb5181d.png">


## Release notes
Fix duplicated names for "Activity Stream: Homepage stream block"

## Change Record
N/A

## Translations
N/A
