### PR TITLE
Issue #3358171 : Multilanguage: Activity stream items are not showing in the correct language

### DIFF
--- a/modules/custom/activity_creator/activity_creator.module
+++ b/modules/custom/activity_creator/activity_creator.module
@@ -294,7 +294,7 @@ function activity_creator_entity_view(array &$build, EntityInterface $entity, En
     $message = Message::load($entity->get('field_activity_message')->target_id);
     if ($message instanceof Message) {
       // Get the text in the users language.
-      $output = \Drupal::service('activity_creator.activity_factory')->getMessageText($message);
+      $output = \Drupal::service('activity_creator.activity_factory')->getMessageText($message, \Drupal::languageManager()->getCurrentLanguage()->getId());
       // Replace the old text with the correct one.
       $build['field_activity_output_text'][0]['#text'] = $output[0];
     }


### PR DESCRIPTION
## Problem
When enabling social_language it should support multiple language, but the actvity stream items keep in the default language.

## Solution
Make sure the activities get loaded in the correct language before outputting them

## Issue tracker
https://www.drupal.org/project/social/issues/3358171

## How to test
- [ ] Enable social_language
- [ ] Add multiple languages
- [ ] Browse the site in a different language than default
- [ ] Create a topic so it created an item on the /stream
- [ ] See that the header is english

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Release notes
We fixed an issue where activity stream items would show in the wrong language if you would have multiple languages.

## Change Record
*[Required if applicable] If this Pull Request changes the way that developers should do things or introduces a new API for developers then a change record to document this is needed. Please provide a draft for a change record or a link to an unpublished change record below. Existing change records can be consulted as example. Please provide a draft for a change record or a link to an unpublished change record below. [Existing change records](https://www.drupal.org/list-changes/social) can be consulted as example.*

## Translations
*[Optional]Translatable strings are always extracted from the latest development branch. To ensure translations remain available for platforms running older versions of Open Social the original string should be added to `translations.php` when it's changed or removed.*
- [ ] Changed or removed source strings are added to the `translations.php` file.
