### PR TITLE
Internal: Disable clean-up in Behat tests

### DIFF
--- a/.github/workflows/behat.yml
+++ b/.github/workflows/behat.yml
@@ -335,6 +335,10 @@ jobs:
           # this makes local reproduction easier.
           cp `pwd`/installation.sql $OUTPUT_FOLDER/
 
+          # Dump the database with the state of the test failure to allow for
+          # local inspection.
+          drush sql-dump > $OUTPUT_FOLDER/at-test-failure.sql
+
       - name: Upload Behat Test Output
         if: failure()
         uses: actions/upload-artifact@v3

--- a/tests/behat/behat.yml
+++ b/tests/behat/behat.yml
@@ -15,12 +15,14 @@ default:
       filters:
         tags: "~@disabled"
       contexts:
-        - Drupal\DrupalExtension\Context\BatchContext
-        - Drupal\DrupalExtension\Context\ConfigContext
-        - Drupal\social\Behat\BookContext
-        - Drupal\social\Behat\CKEditorContext
+        # Our database context comes first since it also bootstraps the Drupal
+        # driver and should load the database first.
         - Drupal\social\Behat\DatabaseContext:
             - '%paths.base%/fixture'
+        - Drupal\DrupalExtension\Context\BatchContext
+        - Drupal\social\Behat\BookContext
+        - Drupal\social\Behat\CKEditorContext
+        - Drupal\social\Behat\ConfigContext
         - Drupal\social\Behat\EmailContext
         - Drupal\social\Behat\EventContext
         - Drupal\social\Behat\GroupContext
@@ -79,6 +81,8 @@ default:
         'Sidebar second': 'aside[role=complementary]'
         'Modal': '#drupal-modal'
         'Modal footer': '.modal-footer'
+      subcontexts:
+        autoload: 0
     FriendsOfBehat\MinkDebugExtension:
       directory: '%paths.base%/logs'
       screenshot: true

--- a/tests/behat/features/bootstrap/AvoidCleanupTrait.php
+++ b/tests/behat/features/bootstrap/AvoidCleanupTrait.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Drupal\social\Behat;
+
+/**
+ * A trait that can be used to avoid cleanup from RawDrupalContext.
+ *
+ * The ideal way is to avoid extending contexts from the DrupalExtension but
+ * sometimes that's unavoidable in which case this trait can be used to ensure
+ * the clean methods on RawDrupalContext don't run after a scenario.
+ */
+trait AvoidCleanupTrait {
+
+  /**
+   * Disable cleaning up to allow failed test inspection.
+   */
+  public function cleanUsers() : void {
+  }
+
+  /**
+   * Disable cleaning up to allow failed test inspection.
+   */
+  public function cleanNodes() : void {
+  }
+
+  /**
+   * Disable cleaning up to allow failed test inspection.
+   */
+  public function cleanLanguages() : void {
+  }
+
+  /**
+   * Disable cleaning up to allow failed test inspection.
+   */
+  public function cleanRoles() : void {
+  }
+
+  /**
+   * Disable cleaning up to allow failed test inspection.
+   */
+  public function cleanTerms() : void {
+  }
+
+}

--- a/tests/behat/features/bootstrap/ConfigContext.php
+++ b/tests/behat/features/bootstrap/ConfigContext.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Drupal\social\Behat;
+
+use Drupal\DrupalExtension\Context\ConfigContext as BaseConfigContext;
+
+/**
+ * Disables cleanup in the underlying Drupal extension's ConfigContext.
+ */
+class ConfigContext extends BaseConfigContext {
+
+  use AvoidCleanupTrait;
+
+  /**
+   * Disable cleaning up to allow failed test inspection.
+   */
+  public function cleanConfig() : void {}
+
+}

--- a/tests/behat/features/bootstrap/DatabaseContext.php
+++ b/tests/behat/features/bootstrap/DatabaseContext.php
@@ -56,6 +56,8 @@ class DatabaseContext implements Context {
     if (!$drupal_context instanceof SocialDrupalContext) {
       throw new \RuntimeException("Expected " . SocialDrupalContext::class . " to be configured for Behat.");
     }
+    // Call getDriver without arguments to boostrap the default driver.
+    $drupal_context->getDriver();
     $driver = $drupal_context->getDriver("drush");
     if (!$driver instanceof DrushDriver) {
       throw new \RuntimeException("Could not load the Drush driver. Make sure the DrupalExtension is configured to enable it.");
@@ -138,18 +140,6 @@ class DatabaseContext implements Context {
     if ($database_file[0] !== DIRECTORY_SEPARATOR) {
       $database_file = $this->fixturePath . DIRECTORY_SEPARATOR . $database_file;
     }
-
-
-    $data = [
-      'pre-reset' => [
-        'dblog.settings' => \Drupal::config("dblog.settings")->getRawData(),
-        'core.extension' => \Drupal::config("core.extension")->getRawData(),
-      ],
-    ];
-
-    try {
-      $data['pre-reset']['database'] = \Drupal::database()->query("SELECT * FROM config WHERE name='core.extension';")->fetchAll();
-    } catch (\Exception $e) { $data['database'] = NULL; }
 
     if (!is_file($database_file)) {
       throw new \RuntimeException("Scaffold file '$database_file' does not exist.");

--- a/tests/behat/features/bootstrap/EmailContext.php
+++ b/tests/behat/features/bootstrap/EmailContext.php
@@ -38,9 +38,6 @@ class EmailContext implements Context {
     $swiftmailer_config = \Drupal::configFactory()->getEditable('swiftmailer.transport');
     $swiftmailer_config->set('transport', 'native');
     $swiftmailer_config->save();
-
-    // Clean up emails after us.
-    $this->purgeSpool();
   }
 
   /**

--- a/tests/behat/features/bootstrap/EventContext.php
+++ b/tests/behat/features/bootstrap/EventContext.php
@@ -421,24 +421,9 @@ class EventContext extends RawMinkContext {
       throw new \RuntimeException("Field 'field_event_managers' not found, make sure you have the social_event_managers module enabled.");
     }
 
-    $event->get('field_event_managers')->appendItem(['target_id' => $current_user->uid]);
+    $event->get('field_event_managers')
+      ->appendItem(['target_id' => $current_user->uid]);
     $event->save();
-  }
-
-  /**
-   * Clean up any events created in this scenario.
-   *
-   * @AfterScenario
-   */
-  public function cleanUpEvents() : void {
-    foreach ($this->created as $idOrTitle) {
-      // Drupal's `id` method can return integers typed as string (e.g. `"1"`).
-      $nid = is_numeric($idOrTitle) ? $idOrTitle : $this->getEventIdFromTitle($idOrTitle);
-      // Ignore already deleted nodes, they may have been deleted in the test.
-      if ($nid !== NULL) {
-        Node::load($nid)?->delete();
-      }
-    }
   }
 
   /**

--- a/tests/behat/features/bootstrap/FeatureContext.php
+++ b/tests/behat/features/bootstrap/FeatureContext.php
@@ -698,6 +698,9 @@ class FeatureContext extends RawMinkContext {
     /**
      * Log out.
      *
+     * Until https://github.com/jhedstrom/drupalextension/issues/641
+     * @afterScenario
+     *
      * @Given /^(?:|I )logout$/
      */
     public function iLogOut()

--- a/tests/behat/features/bootstrap/FeatureContext.php
+++ b/tests/behat/features/bootstrap/FeatureContext.php
@@ -592,45 +592,6 @@ class FeatureContext extends RawMinkContext {
     }
 
     /**
-     * Remove any queue items that were created.
-     *
-     * @AfterScenario
-     */
-    public function cleanupQueue(AfterScenarioScope $scope)
-    {
-      $workerManager = \Drupal::service('plugin.manager.queue_worker');
-      /** @var Drupal\Core\Queue\QueueFactory; $queue */
-      $queue = \Drupal::service('queue');
-
-      foreach ($workerManager->getDefinitions() as $name => $info) {
-        /** @var Drupal\Core\Queue\QueueInterface $worker */
-        $worker = $queue->get($name);
-
-        if ($worker->numberOfItems() > 0) {
-          while ($item = $worker->claimItem()) {
-            // If we don't just delete them, process the item first.
-            $worker->deleteItem($item);
-          }
-        }
-      }
-    }
-
-  /**
-   * Remove any users that were created.
-   *
-   * @AfterScenario
-   */
-  public function cleanupUser(AfterScenarioScope $scope)
-  {
-    if (!empty($this->intended_user_names)) {
-      foreach ($this->intended_user_names as $name) {
-        $user_obj = user_load_by_name($name);
-        \Drupal::entityTypeManager()->getStorage('user')->load($user_obj->id())->delete();
-      }
-    }
-  }
-
-    /**
      * Checks if correct amount of uploaded files by user are private.
      *
      * @Then /User "(?P<username>[^"]+)" should have uploaded "(?P<private>[^"]+)" private files and "(?P<public>[^"]+)" public files$/
@@ -939,32 +900,4 @@ class FeatureContext extends RawMinkContext {
       $summary->click();
     }
 
-    /**
-     * Remove any user consents that were created.
-     *
-     * @AfterScenario @data-policy-create
-     */
-    public function deleteUserConsentEntities() {
-      $consents = \Drupal::entityTypeManager()
-        ->getStorage('user_consent')
-        ->loadMultiple();
-
-      foreach ($consents as $consent) {
-        try {
-          $consent->delete();
-        }
-        catch (\Throwable $e) {
-          // This can be fine.
-        }
-      }
-    }
-
-    /**
-     * Set "/stream" as a front page.
-     *
-     * @AfterScenario @alternative-frontpage
-     */
-    public function setFrontPage() {
-      \Drupal::configFactory()->getEditable('system.site')->set('page.front', '/stream')->save();
-    }
 }

--- a/tests/behat/features/bootstrap/GroupContext.php
+++ b/tests/behat/features/bootstrap/GroupContext.php
@@ -637,19 +637,6 @@ class GroupContext extends RawMinkContext {
   }
 
   /**
-   * Remove any groups that were created.
-   *
-   * @AfterScenario
-   */
-  public function cleanupGroups(AfterScenarioScope $scope) {
-    if (!empty($this->groups)) {
-      foreach ($this->groups as $group) {
-        $group->delete();
-      }
-    }
-  }
-
-  /**
    * Create a group.
    *
    * @param array $group

--- a/tests/behat/features/bootstrap/PostContext.php
+++ b/tests/behat/features/bootstrap/PostContext.php
@@ -115,37 +115,6 @@ class PostContext extends RawMinkContext {
   }
 
   /**
-   * Clean up posts created in scenarios.
-   *
-   * @AfterScenario
-   */
-  public function cleanupPost(AfterScenarioScope $scope) {
-    if (!empty($this->posts)) {
-      foreach ($this->posts as $post) {
-        $post->delete();
-      }
-    }
-
-    $query = \Drupal::entityQuery('post')
-      ->condition(
-        'field_post',
-        [
-          'This is a public post.',
-          'This is a community post.',
-        ],
-        'IN'
-      );
-
-    $post_ids = $query->execute();
-
-    $posts = \Drupal::entityTypeManager()->getStorage('post')->loadMultiple($post_ids);
-
-    foreach ($posts as $post) {
-      $post->delete();
-    }
-  }
-
-  /**
    * Create a post.
    *
    * @param array $post

--- a/tests/behat/features/bootstrap/SocialDrupalContext.php
+++ b/tests/behat/features/bootstrap/SocialDrupalContext.php
@@ -17,6 +17,8 @@ use Drupal\DrupalExtension\Hook\Scope\EntityScope;
  */
 class SocialDrupalContext extends DrupalContext {
 
+  use AvoidCleanupTrait;
+
   /**
    * Prepares Big Pipe NOJS cookie if needed.
    *
@@ -447,6 +449,5 @@ class SocialDrupalContext extends DrupalContext {
   public function iWaitForTheInstallerBatchJobToFinish() {
     $this->getSession()->wait(1800000, 'jQuery("#updateprogress").length === 0');
   }
-
 
 }

--- a/tests/behat/features/bootstrap/SocialMessageContext.php
+++ b/tests/behat/features/bootstrap/SocialMessageContext.php
@@ -11,6 +11,8 @@ use Drupal\DrupalExtension\Context\MessageContext;
  */
 class SocialMessageContext extends MessageContext {
 
+  use AvoidCleanupTrait;
+
   /**
    * Checks if the current page contains the given success message
    *

--- a/tests/behat/features/bootstrap/TopicContext.php
+++ b/tests/behat/features/bootstrap/TopicContext.php
@@ -365,22 +365,6 @@ class TopicContext extends RawMinkContext {
   }
 
   /**
-   * Clean up any topics created in this scenario.
-   *
-   * @AfterScenario
-   */
-  public function cleanUpTopics() : void {
-    foreach ($this->created as $idOrTitle) {
-      // Drupal's `id` method can return integers typed as string (e.g. `"1"`).
-      $nid = is_numeric($idOrTitle) ? $idOrTitle : $this->getTopicIdFromTitle($idOrTitle);
-      // Ignore already deleted nodes, they may have been deleted in the test.
-      if ($nid !== NULL) {
-        Node::load($nid)?->delete();
-      }
-    }
-  }
-
-  /**
    * Create a topic.
    *
    * @return \Drupal\node\Entity\Node

--- a/tests/behat/features/capabilities/dev-helpers/fail.feature
+++ b/tests/behat/features/capabilities/dev-helpers/fail.feature
@@ -1,6 +1,0 @@
-@dev-helpers @fail
-Feature: Failing test
-
-  Scenario: Drupal not available
-    When I am on the homepage
-    Then I should not see "Page not found"

--- a/tests/behat/features/capabilities/dev-helpers/pass.feature
+++ b/tests/behat/features/capabilities/dev-helpers/pass.feature
@@ -1,6 +1,0 @@
-@dev-helpers @pass
-Feature: Passing test
-
-  Scenario: Test drupal
-    When I am on the homepage
-    Then I should see "Explore"


### PR DESCRIPTION
# Problem / Solution
We previously utilised a lot of clean-up steps to make sure our tests didn't affect eachother. However we've since moved to a scenario where both in the CI and locally a new database is loaded between scenarios, this makes the clean-up no longer needed.

Additionally if the clean-up does run then this makes debugging a failed test a lot more difficult because you can't inspect the state of the platform at the time the test failed.

This commit ensures that all the clean-up that is provided by the DrupalExtension by default is disabled. For this we have to disable autoloading of sub-contexts (which we weren't using anyway) because the search_api contained a `behat.inc` file that would load the `RawDrupalContext` class which contained more cleaning.

There are DrupalExtension stories open to remove the cleaning from `RawDrupalContext`, but we don't have time to wait for that.

We also add a step in our CI to dump the failed database to disk along with the installation.sql file. This allows a developer to load the failed database locally and see what was going wrong without having to rerun the test.

## Issue tracker
Internal no issue

## How to test
- [ ] Create a test failure locally 
- [ ] Login to the platform as admin
- [ ] You should be able to see everything up to the test step failure

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status
