### PR TITLE
Internal: Improve test fixture creation for taxonomy references and dates

### DIFF
--- a/tests/behat/features/bootstrap/EntityTrait.php
+++ b/tests/behat/features/bootstrap/EntityTrait.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Drupal\social\Behat;
 
 use Drupal\Core\Entity\EntityTypeInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Entity\FieldableEntityInterface;
 
 /**
@@ -22,11 +23,14 @@ trait EntityTrait {
    *
    * @param string $entity_type
    *   The entity type.
-   * @param array $values
-   *   The provided values.
+   * @param array &$values
+   *   The provided values. These may be massaged to convert e.g. taxonomy term
+   *   IDs to numeric IDs.
    */
-  protected function validateEntityFields(string $entity_type, array $values) : void {
-    $definition = \Drupal::service("entity_type.manager")->getDefinition($entity_type);
+  protected function validateEntityFields(string $entity_type, array &$values) : void {
+    $entity_type_manager = \Drupal::service("entity_type.manager");
+    assert($entity_type_manager instanceof EntityTypeManagerInterface);
+    $definition = $entity_type_manager->getDefinition($entity_type);
     assert($definition instanceof EntityTypeInterface);
     /** @var ?string $bundle */
     $bundle = $definition->getKey('bundle') ?: NULL;
@@ -38,9 +42,47 @@ trait EntityTrait {
     /** @var \Drupal\Core\Entity\EntityInterface $dummy */
     $dummy = $entityClass::create([$bundle => $values[$bundle]]);
 
-    foreach ($values as $field => $_) {
-      if ($definition->get($field) === NULL && !($dummy instanceof FieldableEntityInterface && $dummy->hasField($field))) {
-        throw new \Exception("Entity type '$entity_type' does not have property or field '$field'.");
+    foreach ($values as $field_name => $field_value) {
+      if ($definition->get($field_name) === NULL && !($dummy instanceof FieldableEntityInterface && $dummy->hasField($field_name))) {
+        throw new \Exception("Entity type '$entity_type' does not have property or field '$field_name'.");
+      }
+
+      // Allow taxonomy fields to be a comma separated list of IDs or labels.
+      // We can only do this for the default handler because other handlers
+      // might have a different settings format so we can't know the target
+      // bundles.
+      $field_definition = $dummy->getFieldDefinition($field_name);
+      if ($field_definition !== NULL && $field_definition->getType() === "entity_reference" && $field_definition->getSetting("target_type") === "taxonomy_term") {
+        $taxonomy_storage = $entity_type_manager->getStorage("taxonomy_term");
+        if ($field_definition->getSetting("handler") === "default:taxonomy_term") {
+          assert(is_string($field_value), "The taxonomy value for '$field_name' has already been converted to entities but this isn't needed.");
+          if (trim($field_value) === "") {
+            unset($values[$field_name]);
+            continue;
+          }
+          $allowed_bundles = $field_definition->getSetting("handler_settings")["target_bundles"];
+          // Split 0,1 to [0, 1] and convert 2,someLabel to [2, 4], making a
+          // lookup of the taxonomy id by name.
+          $values[$field_name] = array_map(
+            function ($id_or_name) use ($taxonomy_storage, $allowed_bundles) {
+              $id_or_name = trim($id_or_name);
+              if (is_numeric($id_or_name)) {
+                return ["target_id" => $id_or_name];
+              }
+
+              $term_ids = $taxonomy_storage->getQuery()
+                ->condition("vid", $allowed_bundles, "IN")
+                ->condition("name", $id_or_name)
+                ->execute();
+
+              if (!is_array($term_ids) || empty($term_ids)) {
+                throw new \InvalidArgumentException("Taxonomy term $id_or_name does not exist within vocabulary " . implode(", ", $allowed_bundles));
+              }
+              return ["target_id" => (int) reset($term_ids)];
+            },
+            explode(",", $field_value)
+          );
+        }
       }
     }
   }

--- a/tests/behat/features/bootstrap/EntityTrait.php
+++ b/tests/behat/features/bootstrap/EntityTrait.php
@@ -84,6 +84,11 @@ trait EntityTrait {
           );
         }
       }
+      // Allow date time fields to be provided as an offset to the current day
+      // (e.g. "+1 day" or "-5 days").
+      if ($field_definition !== NULL && $field_definition->getType() === "datetime") {
+        $values[$field_name] = date('Y-m-d\TH:i:s', strtotime($values[$field_name]));
+      }
     }
   }
 

--- a/tests/behat/features/bootstrap/TopicContext.php
+++ b/tests/behat/features/bootstrap/TopicContext.php
@@ -393,7 +393,7 @@ class TopicContext extends RawMinkContext {
 
     $account = user_load_by_name($topic['author']);
     if ($account === FALSE) {
-      throw new \Exception(sprintf("User with username '%s' does not exist.", $event['author']));
+      throw new \Exception(sprintf("User with username '%s' does not exist.", $topic['author']));
     }
     $topic['uid'] = $account->id();
     unset($topic['author']);
@@ -407,14 +407,6 @@ class TopicContext extends RawMinkContext {
     }
 
     $topic['type'] = 'topic';
-
-    if (isset($topic['field_topic_type'])) {
-      $type_id = $this->getTopicTypeIdFromLabel($topic['field_topic_type']);
-      if ($type_id === NULL) {
-        throw new \Exception("Topic Type with label '{$topic['field_topic_type']}' does not exist.");
-      }
-      $topic['field_topic_type'] = $type_id;
-    }
 
     $this->validateEntityFields("node", $topic);
     $topic_object = Node::create($topic);
@@ -449,36 +441,6 @@ class TopicContext extends RawMinkContext {
    */
   private function getTopicIdFromTitle(string $topic_title) : ?int {
     return $this->getNodeIdFromTitle("topic", $topic_title);
-  }
-
-  /**
-   * Get the Term ID for a topic type from its label.
-   *
-   * @param string $label
-   *   The label.
-   *
-   * @return int|null
-   *   The topic type ID or NULL if it can't be found.
-   */
-  private function getTopicTypeIdFromLabel(string $label) : ?int {
-    $query = \Drupal::entityQuery('taxonomy_term')
-      ->accessCheck(FALSE)
-      ->condition('vid', 'topic_types')
-      ->condition('name', $label);
-
-    $term_ids = $query->execute();
-    $terms = \Drupal::entityTypeManager()->getStorage('taxonomy_term')->loadMultiple($term_ids);
-
-    if (count($terms) !== 1) {
-      return NULL;
-    }
-
-    $term_id = reset($terms)->id();
-    if ($term_id !== 0) {
-      return $term_id;
-    }
-
-    return NULL;
   }
 
 }


### PR DESCRIPTION
## Problem / Solution
This commit allows taxonomy reference data to be provided as a comma separated list of IDs or term names (mixing is allowed). This can now be used in tables for e.g. groups, topics and events. By putting this in the validate method we can use this everywhere.

This ensures we deduplicate the taxonomy title lookup so that we don't break on a pre-fetched value. Since we now do it by field type we no longer need to do it by field name.

Additionally we allow date fields to be filled using a human readable date (e.g. `-1 seconds` or `+ 1 hours`).

## Example usage
```cucumber
  Scenario: Reference a tag by name
    Given social_tagging terms:
      | name      | parent   |
      | Clothing  |          |
      | Pants     | Clothing |
    And groups with non-anonymous owner:
      | label            | type           | field_flexible_group_visibility | field_social_tagging |
      | Group with a tag | flexible_group | public                          | Pants                |

  Scenario: Use a relative date in a datetime field
    Given topics with non-anonymous author:
      | title                  | created     | body          | status | field_content_visibility | field_topic_type |
      | Topic one              | -13 seconds | Shenanigans   | 1      | community                | news             |
```

## Issue tracker
Internal no issue

## How to test
- [ ] Tests should pass :)

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status