### PR TITLE
Internal: #3363814 by zanvidmar: Behat step definition to enroll users to event

### DIFF
--- a/tests/behat/features/bootstrap/EventContext.php
+++ b/tests/behat/features/bootstrap/EventContext.php
@@ -7,11 +7,15 @@ use Behat\Gherkin\Node\TableNode;
 use Behat\Mink\Exception\ElementNotFoundException;
 use Behat\MinkExtension\Context\RawMinkContext;
 use Drupal\Component\Plugin\Exception\PluginNotFoundException;
+use Drupal\Component\Utility\Crypt;
 use Drupal\DrupalExtension\Context\DrupalContext;
 use Drupal\DrupalExtension\Context\MinkContext;
 use Drupal\group\Entity\Group;
 use Drupal\node\Entity\Node;
 use Drupal\social_event\Entity\EventEnrollment;
+use Drupal\social_event\Entity\Node\Event;
+use Drupal\user\Entity\User;
+use Drupal\user\UserInterface;
 use Symfony\Component\Yaml\Yaml;
 
 /**
@@ -459,6 +463,81 @@ class EventContext extends RawMinkContext {
         'field_enrollment_status' => '1',
         'field_account' => $user->uid,
       ])->save();
+    }
+  }
+
+  /**
+   * Add enrollees to event.
+   *
+   * Adds enrollees to a specific event
+   * | event    | user      |
+   * | My event | Jane Doe  |
+   * | ...      | ...       |
+   *
+   * @Given event enrollees:
+   */
+  public function createEventEnrollees(TableNode $eventEnrolleesTable) {
+
+    foreach ($eventEnrolleesTable->getHash() as $eventEnrolleesHash) {
+      $event_title = $eventEnrolleesHash['event'];
+      $event_id = $this->getEventIdFromTitle($event_title);
+      if ($event_id === NULL) {
+        throw new \Exception("Event '${event_title}' does not exist.");
+      }
+
+      $event = Event::load($event_id);
+      assert($event instanceof Node);
+
+      $user = User::load($this->drupalContext->getUserManager()->getUser($eventEnrolleesHash['user'])->uid);
+      assert($user instanceof UserInterface);
+      assert($user->id() !== null, "Enrollment of anonymous users is not allowed for '@Given event enrollees'. Please use '@Given anonymous event enrollees:' instead.");
+
+      EventEnrollment::create([
+        'user_id' => $user->id(),
+        'field_event' => $event_id,
+        'field_enrollment_status' => '1',
+        'field_account' => $user->id(),
+      ])->save();
+    }
+  }
+
+  /**
+   * Add anonymous enrollees to event.
+   *
+   * Adds anonymous enrollees to a specific event
+   * | event    | name | lastname | email               |
+   * | My event | Jane | Doe      | example@example.com |
+   * | ...      | ...  | ...      | ...                 |
+   *
+   * @Given anonymous event enrollees:
+   */
+  public function createAnonymousEventEnrollees(TableNode $eventAnonymousEnrolleesTable) {
+    foreach ($eventAnonymousEnrolleesTable->getHash() as $eventEnrolleesHash) {
+      $event_title = $eventEnrolleesHash['event'];
+      $event_id = $this->getEventIdFromTitle($event_title);
+      if ($event_id === NULL) {
+        throw new \Exception("Event '${event_title}' does not exist.");
+      }
+
+      $event = Event::load($event_id);
+      assert($event instanceof Node);
+
+      if ($event->field_event_an_enroll->value !== '1') {
+        throw new \Exception("Event '${event_title}' is not suitable to enroll anonymous users.");
+      }
+
+      $token = Crypt::randomBytesBase64();
+
+      $values['user_id'] = '0';
+      $values['field_account'] = '0';
+      $values['field_email'] = $eventEnrolleesHash['email'];
+      $values['field_enrollment_status'] = '1';
+      $values['field_event'] = $event_id;
+      $values['field_first_name'] = $eventEnrolleesHash['name'];
+      $values['field_last_name'] = $eventEnrolleesHash['lastname'];
+      $values['field_token'] = $token;
+
+      EventEnrollment::create($values)->save();
     }
   }
 


### PR DESCRIPTION
Provide Behat step definition where enrollees can be added to event.

## Problem
As a developer I want to have Behat step definition where I can programatically enroll users to an event.

## Solution
Add new functionalities to EventContext.php in Behat test folder.

## Issue tracker
[3363814](https://www.drupal.org/project/social/issues/3363814)

## Theme issue tracker
N/A

## How to test
N/A

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
N/A

## Release notes
Improve Behat test step definitions for event.

## Change Record
N/A

## Translations
N/A