### PR TITLE
Issue #3366143 by agami4: Add improvements to the profile preview window

### DIFF
--- a/modules/social_features/social_profile/modules/social_profile_preview/assets/js/social_profile_preview.js
+++ b/modules/social_features/social_profile/modules/social_profile_preview/assets/js/social_profile_preview.js
@@ -20,7 +20,7 @@
             }
           }
         })
-        .on('mouseover', function () {
+        .once('socialProfilePreview').on('mouseover', function () {
           var $element = $(this);
           var selector = $element.attr('id');
 

--- a/modules/social_features/social_profile/modules/social_profile_preview/social_profile_preview.libraries.yml
+++ b/modules/social_features/social_profile/modules/social_profile_preview/social_profile_preview.libraries.yml
@@ -6,3 +6,4 @@ base:
     assets/js/social_profile_preview.js: {}
   dependencies:
     - core/drupal.dialog.ajax
+    - core/once


### PR DESCRIPTION
## Problem
As a LU+ I see multiple profile previews at once when I hover on a user’s profile image or name

## Solution
Add `once` to the mouseover event.

## Issue tracker

- https://www.drupal.org/project/social/issues/3366143
- https://getopensocial.atlassian.net/browse/PROD-25712

## Theme issue tracker
N/A

## How to test
- [ ] Go to the event page.
- [ ] Hover on the profile avatar
- [ ] You should see profile preview popup in normal style.

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
Before:
![image-20230609-141500](https://github.com/goalgorilla/open_social/assets/16086340/d1245a0b-7109-4c0b-8414-eeb7a1ced6e1)

After:
<img width="1375" alt="Screenshot 2023-06-12 at 10 43 12" src="https://github.com/goalgorilla/open_social/assets/16086340/301c724e-0e1e-4381-a0f7-f0852e5aa70a">

## Release notes
Display only one preview profile window when hovering over the profile avatar.

## Change Record
N/A

## Translations
N/A
