### PR TITLE
Issue #3367602 by vnech: Hide "Group type" filter on search pages

### DIFF
--- a/modules/social_features/social_group/social_group.module
+++ b/modules/social_features/social_group/social_group.module
@@ -43,6 +43,7 @@ use Drupal\social_group\Element\SocialGroupEntityAutocomplete;
 use Drupal\social_group\Entity\Access\SocialGroupAccessControlHandler;
 use Drupal\social_group\Entity\Group;
 use Drupal\social_group\Form\SocialGroupAddForm;
+use Drupal\social_group\Form\SocialGroupSettings;
 use Drupal\social_group\GroupContentVisibilityUpdate;
 use Drupal\social_group\SocialGroupInterface;
 use Drupal\user\Entity\Role;
@@ -1179,11 +1180,19 @@ function social_group_form_alter(&$form, FormStateInterface $form_state, $form_i
   }
 
   // Exposed Filter block on the all-groups overview.
-  if ($form['#id'] === 'views-exposed-form-newest-groups-page-all-groups' ||
+  if (
+    $form['#id'] === 'views-exposed-form-newest-groups-page-all-groups' ||
     $form['#id'] === 'views-exposed-form-search-groups-page-no-value' ||
-    $form['#id'] === 'views-exposed-form-search-groups-page') {
+    $form['#id'] === 'views-exposed-form-search-groups-page'
+  ) {
+    // If LU aren't allowed create more than one group type,
+    // we hide the filter.
+    if (count(SocialGroupSettings::getGroupTypeIdsUsersCanCreate()) <= 1) {
+      $form['type']['#access'] = FALSE;
+    }
+
     $account = \Drupal::currentUser();
-    if (!empty($form['type']['#options'])) {
+    if (Element::isVisibleElement($form['type']) && !empty($form['type']['#options'])) {
       foreach ($form['type']['#options'] as $type => $label) {
         // All / Any we can skip they are optional translatable options
         // and not group types.

--- a/modules/social_features/social_group/src/Form/SocialGroupSettings.php
+++ b/modules/social_features/social_group/src/Form/SocialGroupSettings.php
@@ -23,6 +23,13 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 class SocialGroupSettings extends ConfigFormBase {
 
   /**
+   * Config settings.
+   *
+   * @var string
+   */
+  const SETTINGS = 'social_group.settings';
+
+  /**
    * The group content plugin manager.
    *
    * @var \Drupal\group\Plugin\GroupContentEnablerManagerInterface
@@ -84,7 +91,7 @@ class SocialGroupSettings extends ConfigFormBase {
    */
   protected function getEditableConfigNames() {
     return [
-      'social_group.settings',
+      self::SETTINGS,
     ];
   }
 
@@ -311,6 +318,30 @@ class SocialGroupSettings extends ConfigFormBase {
     }
 
     return $options ?? [];
+  }
+
+  /**
+   * Returns group types IDs that LU can create.
+   *
+   * @return array
+   *   An array with group type IDs.
+   */
+  public static function getGroupTypeIdsUsersCanCreate(): array {
+    $settings = \Drupal::config(self::SETTINGS);
+
+    if (!$settings->get('allow_group_create')) {
+      return [];
+    }
+
+    $prefix = 'disallow_lu_create_groups_';
+    foreach ($settings->getRawData() as $key => $value) {
+      // Why enabled a group type key has value "FALSE"?
+      if (strpos($key, $prefix) !== FALSE && !$value) {
+        $group_type_ids[] = substr($key, strlen($prefix));
+      }
+    }
+
+    return $group_type_ids ?? [];
   }
 
 }


### PR DESCRIPTION
## Problem
In distro we have settings page (<em>/admin/config/opensocial/social-group</em>) where we can allow for LU to create specific types of groups:
<img src="https://www.drupal.org/files/issues/2023-06-19/Screenshot%202023-06-19%20at%2011.10.13.png"/>

On groups search pages (<em>/all-groups</em> and <em>/search/groups</em>) we have "Group type" filter and in a case when only one group type is allowed this filter has no sense.

## Solution
Hide "Group type" filter on search pages when LU can create only one group type.

## Issue tracker
- https://www.drupal.org/project/social/issues/3367602
- https://getopensocial.atlassian.net/browse/PROD-24504

## Theme issue tracker
n/a

## How to test
- [ ] Login as SM
- [ ] On page "_/admin/config/opensocial/social-group_" allow for LU to create only one group type
- [ ] Visit "_/all-groups_" and make sure the filter "Group type" isn't visible

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
n/a

## Release notes
Hide "Group type" filter on search pages when LU can create only one group type.

## Change Record
n/a

## Translations
n/a
