### PR TITLE
Internal: Move Behat CI over to new PHP images

### DIFF
--- a/.github/workflows/behat.yml
+++ b/.github/workflows/behat.yml
@@ -39,7 +39,7 @@ jobs:
     name: "Install previous Open Social major version"
     runs-on: ubuntu-22.04
     container:
-      image: goalgorilla/open_social_docker:ci-php7
+      image: ghcr.io/goalgorilla/open-social-dev-php:cli-7.4-3.16
       volumes:
         - ${{ github.workspace }}:/var/www
 
@@ -140,7 +140,7 @@ jobs:
     name: "Install Open Social"
     runs-on: ubuntu-22.04
     container:
-      image: goalgorilla/open_social_docker:ci
+      image: ghcr.io/goalgorilla/open-social-dev-php:cli-8.0-3.16
       volumes:
         - ${{ github.workspace }}:/var/www
 
@@ -269,7 +269,7 @@ jobs:
     name: 'Tests'
     runs-on: ubuntu-22.04
     container:
-      image: goalgorilla/open_social_docker:ci
+      image: ghcr.io/goalgorilla/open-social-dev-php:fpm-8.0-3.16
       volumes:
         - ${{ github.workspace }}:/var/www
 
@@ -286,7 +286,7 @@ jobs:
 
     services:
       web:
-        image: goalgorilla/open_social_docker:ci
+        image: ghcr.io/goalgorilla/open-social-dev-router:nginx-1.25.1-3.17
         env:
           DRUPAL_SETTINGS: production
         volumes:

--- a/.github/workflows/behat.yml
+++ b/.github/workflows/behat.yml
@@ -293,7 +293,7 @@ jobs:
     name: 'Tests'
     runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/goalgorilla/open-social-ci-php:fpm-8.0-3.16
+      image: ghcr.io/goalgorilla/open-social-ci-php:cli-8.0-3.16
       volumes:
         - ${{ github.workspace }}:/app
 
@@ -311,12 +311,14 @@ jobs:
     services:
       web:
         image: ghcr.io/goalgorilla/open-social-ci-router:nginx-1.25.1-3.17
-        env:
-          DRUPAL_SETTINGS: production
         volumes:
           - ${{ github.workspace }}:/app
         ports:
           - "80"
+      opensocial:
+        image: ghcr.io/goalgorilla/open-social-ci-php:fpm-8.0-3.16
+        volumes:
+          - ${{ github.workspace }}:/app
       db:
         image: mariadb:10.7
         env:

--- a/.github/workflows/behat.yml
+++ b/.github/workflows/behat.yml
@@ -39,7 +39,7 @@ jobs:
     container:
       image: ghcr.io/goalgorilla/open-social-ci-php:cli-7.4-3.16
       volumes:
-        - ${{ github.workspace }}:/var/www
+        - ${{ github.workspace }}:/app
 
     strategy:
       matrix:
@@ -66,7 +66,7 @@ jobs:
     defaults:
       run:
         shell: bash
-        working-directory: /var/www
+        working-directory: /app
 
     steps:
       - uses: actions/checkout@v3
@@ -95,8 +95,8 @@ jobs:
           # This is purposefully duplicated because we may change how
           # installation works between major versions, so this provides us the
           # flexibility to reflect that in the workflow.
-          cp tmp/tests/default.settings.php /var/www/html/sites/default/default.settings.php
-          mkdir /var/www/files_private
+          cp tmp/tests/default.settings.php /app/html/sites/default/default.settings.php
+          mkdir /app/files_private
 
           export OPTIONAL=""
           if [[ "${{ matrix.with_optional }}" == "with-optional" ]]; then
@@ -139,7 +139,7 @@ jobs:
     container:
       image: ghcr.io/goalgorilla/open-social-ci-php:cli-8.0-3.16
       volumes:
-        - ${{ github.workspace }}:/var/www
+        - ${{ github.workspace }}:/app
 
     strategy:
       matrix:
@@ -169,7 +169,7 @@ jobs:
     defaults:
       run:
         shell: bash
-        working-directory: /var/www
+        working-directory: /app
 
     steps:
       - name: Retrieve previous version
@@ -197,8 +197,8 @@ jobs:
             composer require goalgorilla/open_social:dev-$BRANCH_NAME
           fi
 
-          cp tmp/tests/default.settings.php /var/www/html/sites/default/default.settings.php
-          mkdir -p /var/www/files_private
+          cp tmp/tests/default.settings.php /app/html/sites/default/default.settings.php
+          mkdir -p /app/files_private
 
           rm -r tmp/
 
@@ -244,7 +244,7 @@ jobs:
           fi
 
       - name: Fix owner of web files
-        run: chown -R www-data:www-data /var/www
+        run: chown -R www-data:www-data /app
 
       - name: Package up site
         uses: actions/cache@v3
@@ -268,7 +268,7 @@ jobs:
     container:
       image: ghcr.io/goalgorilla/open-social-ci-php:fpm-8.0-3.16
       volumes:
-        - ${{ github.workspace }}:/var/www
+        - ${{ github.workspace }}:/app
 
     strategy:
       fail-fast: false
@@ -287,7 +287,7 @@ jobs:
         env:
           DRUPAL_SETTINGS: production
         volumes:
-          - ${{ github.workspace }}:/var/www
+          - ${{ github.workspace }}:/app
         ports:
           - "80"
       db:
@@ -314,7 +314,7 @@ jobs:
     defaults:
       run:
         shell: bash
-        working-directory: /var/www
+        working-directory: /app
 
     steps:
       - name: Download Site

--- a/.github/workflows/behat.yml
+++ b/.github/workflows/behat.yml
@@ -226,10 +226,6 @@ jobs:
             composer require goalgorilla/open_social:dev-$BRANCH_NAME
           fi
 
-          ln -s /etc/opensocial-ci/settings.php /app/html/sites/default/settings.php
-          ln -s /etc/opensocial-ci/settings.docker.php /app/html/sites/default/settings.docker.php
-          mkdir -p /app/files_private
-
           rm -r tmp/
 
       - name: Update the previous major version to HEAD
@@ -247,6 +243,10 @@ jobs:
         if: ${{ matrix.update == '' }}
         run: |
           set -e
+
+          ln -s /etc/opensocial-ci/settings.php /app/html/sites/default/settings.php
+          ln -s /etc/opensocial-ci/settings.docker.php /app/html/sites/default/settings.docker.php
+          mkdir -p /app/files_private
 
           export OPTIONAL=""
           if [[ "${{ matrix.with_optional }}" == "with-optional" ]]; then

--- a/.github/workflows/behat.yml
+++ b/.github/workflows/behat.yml
@@ -15,6 +15,14 @@ on:
 env:
   BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
 
+  OPENSOCIAL_DATABASE: social
+  OPENSOCIAL_DATABASE_USERNAME: root
+  OPENSOCIAL_DATABASE_PASSWORD: root
+  OPENSOCIAL_DATABASE_HOST: db
+  OPENSOCIAL_DATABASE_PORT: 3306
+
+  OPENSOCIAL_PROJECT_ENTROPY: thisisnotrandom
+
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   feature_discovery:
@@ -95,7 +103,8 @@ jobs:
           # This is purposefully duplicated because we may change how
           # installation works between major versions, so this provides us the
           # flexibility to reflect that in the workflow.
-          cp tmp/tests/default.settings.php /app/html/sites/default/default.settings.php
+          ln -s /etc/opensocial-ci/settings.php /app/html/sites/default/settings.php
+          ln -s /etc/opensocial-ci/settings.docker.php /app/html/sites/default/settings.docker.php
           mkdir /app/files_private
 
           export OPTIONAL=""
@@ -103,7 +112,7 @@ jobs:
             export OPTIONAL="social_module_configure_form.select_all='TRUE'"
           fi
 
-          drush site-install -y social --db-url=mysql://root:root@db:3306/social $OPTIONAL install_configure_form.update_status_module='array(FALSE,FALSE)' --site-name='Open Social';
+          drush site-install -y social $OPTIONAL install_configure_form.update_status_module='array(FALSE,FALSE)' --site-name='Open Social';
 
           # Make sure swiftmailer is configured for our CI.
           drush cset -y swiftmailer.transport transport 'smtp'
@@ -190,6 +199,9 @@ jobs:
 
           cp tmp/tests/composer.json composer.json
 
+          # Make the default folder writable if it exists so our update of composer works.
+          chmod -f +w html/sites/default
+
           # Composer has special handling for "version-like" branch names
           if [[ $BRANCH_NAME =~ [0-9]+\.[0-9]+\.x ]]; then
             composer require goalgorilla/open_social:$BRANCH_NAME-dev
@@ -197,7 +209,8 @@ jobs:
             composer require goalgorilla/open_social:dev-$BRANCH_NAME
           fi
 
-          cp tmp/tests/default.settings.php /app/html/sites/default/default.settings.php
+          ln -s /etc/opensocial-ci/settings.php /app/html/sites/default/settings.php
+          ln -s /etc/opensocial-ci/settings.docker.php /app/html/sites/default/settings.docker.php
           mkdir -p /app/files_private
 
           rm -r tmp/
@@ -223,7 +236,7 @@ jobs:
             export OPTIONAL="social_module_configure_form.select_all='TRUE'"
           fi
 
-          drush site-install -y social --db-url=mysql://root:root@db:3306/social $OPTIONAL install_configure_form.update_status_module='array(FALSE,FALSE)' --site-name='Open Social';
+          drush site-install -y social $OPTIONAL install_configure_form.update_status_module='array(FALSE,FALSE)' --site-name='Open Social';
 
           # Make sure swiftmailer is configured for our CI.
           drush cset -y swiftmailer.transport transport 'smtp'

--- a/.github/workflows/behat.yml
+++ b/.github/workflows/behat.yml
@@ -273,9 +273,6 @@ jobs:
             drush sql:dump > behat-test-output/installation.sql
           fi
 
-      - name: Fix owner of web files
-        run: chown -R www-data:www-data /app
-
       - name: Package up site
         uses: actions/cache@v3
         with:

--- a/.github/workflows/behat.yml
+++ b/.github/workflows/behat.yml
@@ -23,8 +23,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - run: sudo apt-get install jq
-
       - name: Find feature files
         id: set-matrix
         run: |
@@ -39,7 +37,7 @@ jobs:
     name: "Install previous Open Social major version"
     runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/goalgorilla/open-social-dev-php:cli-7.4-3.16
+      image: ghcr.io/goalgorilla/open-social-ci-php:cli-7.4-3.16
       volumes:
         - ${{ github.workspace }}:/var/www
 
@@ -84,7 +82,6 @@ jobs:
         run: |
           set -e
 
-          apt-get install -y jq
           # This gets all version info from composer for Open Social. We then
           # use jq to traverse and manipulate the JSON data to find ourselves
           # the last stable major version before the current stable major
@@ -140,7 +137,7 @@ jobs:
     name: "Install Open Social"
     runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/goalgorilla/open-social-dev-php:cli-8.0-3.16
+      image: ghcr.io/goalgorilla/open-social-ci-php:cli-8.0-3.16
       volumes:
         - ${{ github.workspace }}:/var/www
 
@@ -269,7 +266,7 @@ jobs:
     name: 'Tests'
     runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/goalgorilla/open-social-dev-php:fpm-8.0-3.16
+      image: ghcr.io/goalgorilla/open-social-ci-php:fpm-8.0-3.16
       volumes:
         - ${{ github.workspace }}:/var/www
 
@@ -286,7 +283,7 @@ jobs:
 
     services:
       web:
-        image: ghcr.io/goalgorilla/open-social-dev-router:nginx-1.25.1-3.17
+        image: ghcr.io/goalgorilla/open-social-ci-router:nginx-1.25.1-3.17
         env:
           DRUPAL_SETTINGS: production
         volumes:

--- a/.github/workflows/behat.yml
+++ b/.github/workflows/behat.yml
@@ -215,7 +215,9 @@ jobs:
           cp tmp/tests/composer.json composer.json
 
           # Make the default folder writable if it exists so our update of composer works.
-          chmod -f +w html/sites/default
+          if [ -d "html/sites/default" ]; then
+            chmod -f +w html/sites/default
+          fi
 
           # Composer has special handling for "version-like" branch names
           if [[ $BRANCH_NAME =~ [0-9]+\.[0-9]+\.x ]]; then

--- a/.github/workflows/behat.yml
+++ b/.github/workflows/behat.yml
@@ -49,6 +49,9 @@ jobs:
       volumes:
         - ${{ github.workspace }}:/app
 
+    outputs:
+      previous-major-cache-key: ${{ steps.cache-key.outputs.value }}
+
     strategy:
       matrix:
         with_optional:
@@ -86,18 +89,35 @@ jobs:
         run: |
           cp tmp/tests/composer.json composer.json
 
-      - name: Set-up the previous major version of Open Social
+      - name: Determine previous Open Social version
+        id: previous-major
         run: |
-          set -e
-
           # This gets all version info from composer for Open Social. We then
           # use jq to traverse and manipulate the JSON data to find ourselves
           # the last stable major version before the current stable major
           # version.
           PREVIOUS_MAJOR=`composer info -a --format json goalgorilla/open_social | jq '.versions | map(select(contains("-") == false)) | map(split(".")[0] | tonumber) | unique | reverse | .[1]'`
-          echo "Setting up update test from Open Social $PREVIOUS_MAJOR"
+          echo "version=$PREVIOUS_MAJOR" >> "$GITHUB_OUTPUT"
 
-          composer require goalgorilla/open_social:^$PREVIOUS_MAJOR
+      - name: Cache key
+        id: cache-key
+        run: echo "value=${{ steps.previous-major.outputs.version }}-$_GITHUB_WORKFLOW_SHA-${{ hashFiles('composer.json') }}-previous-version" >> "$GITHUB_OUTPUT"
+
+      - name: Cache previous version
+        id: cache-previous
+        uses: actions/cache@v3
+        with:
+          path: ${{ github.workspace }}
+          key: ${{ steps.cache-key.outputs.value }}-${{ matrix.with_optional }}
+
+      - if: ${{ steps.cache-previous.outputs.cache-hit != 'true' }}
+        name: Set-up the previous major version of Open Social
+        run: |
+          set -e
+
+          echo "Setting up update test from Open Social ${{ steps.previous-major.outputs.version }}"
+
+          composer require goalgorilla/open_social:^${{ steps.previous-major.outputs.version }}
 
           # Installation
           # This is purposefully duplicated because we may change how
@@ -134,11 +154,6 @@ jobs:
       - name: Clean up checkout
         run: rm -r tmp
 
-      - name: Package up previous version
-        uses: actions/cache@v3
-        with:
-          path: ${{ github.workspace }}
-          key: ${{ github.sha }}-previous-version-${{ matrix.with_optional }}
 
   install_open_social:
     needs: [install_previous_open_social]
@@ -183,11 +198,11 @@ jobs:
     steps:
       - name: Retrieve previous version
         if: ${{ matrix.update == 'update' }}
-        uses: actions/cache@v3
+        uses: actions/cache/restore@v3
         with:
           fail-on-cache-miss: true
           path: ${{ github.workspace }}
-          key: ${{ github.sha }}-previous-version-${{ matrix.with_optional }}
+          key: ${{ needs.install_previous_open_social.outputs.previous-major-cache-key }}-${{ matrix.with_optional }}
 
       - uses: actions/checkout@v3
         with:

--- a/tests/behat/behat.yml
+++ b/tests/behat/behat.yml
@@ -56,14 +56,14 @@ default:
     Drupal\DrupalExtension:
       api_driver: 'drupal'
       drupal:
-        drupal_root: '/var/www/html'
+        drupal_root: '/app/html'
       drush:
         # We must specify the binary path because drush launcher outputs its own
         # version before the drush version when queried with `--version` which
         # causes the DrupalDriver to think we're using a version before 9
         # (see DrushDriver::isLegacyDrush).
-        binary: /var/www/vendor/bin/drush
-        root: '/var/www/html'
+        binary: /app/vendor/bin/drush
+        root: '/app/html'
       selectors:
         message_selector: '.alert'
         error_message_selector: '.alert.alert-danger'

--- a/tests/default.settings.php
+++ b/tests/default.settings.php
@@ -805,5 +805,12 @@ if ($drupal_settings === 'development' && file_exists($app_root . '/' . $site_pa
 }
 
 /**
+ * Load docker specific settings provided through environment variables.
+ *
+ * We don't check for an existence because our CI fails if this isn't present.
+ */
+require __DIR__ . '/settings.docker.php';
+
+/**
  * Everything after here is added by the installation process.
  */


### PR DESCRIPTION
## Problem
Our current CI images are difficult to maintain which makes testing different versions of PHP difficult.

## Solution
Use the new dev images that are part of our SaaS build process which provide more versions.

## Issue tracker
Internal CI issue no change.

## How to test
- [ ] Behat CI Should pass

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status
