### PR TITLE
Internal: Set Behat CI install dump names depending on job configuration

### DIFF
--- a/.github/workflows/behat.yml
+++ b/.github/workflows/behat.yml
@@ -248,7 +248,17 @@ jobs:
           drush cset -y swiftmailer.transport smtp_port 1025
 
       - name: Dump Database
-        run: drush sql:dump --result-file=../installation.sql
+        run: |
+          mkdir -p behat-test-output
+          if [[ ! -z "${{ matrix.update }}" ]] && [[ ! -z "${{ matrix.with_optional }}" ]]; then
+            drush sql:dump > behat-test-output/installation-update-with-optional.sql
+          elif [[ ! -z "${{ matrix.update }}" ]]; then
+            drush sql:dump > behat-test-output/installation-update.sql
+          elif [[ ! -z "${{ matrix.with_optional }}" ]]; then
+            drush sql:dump > behat-test-output/installation-with-optional.sql
+          else
+            drush sql:dump > behat-test-output/installation.sql
+          fi
 
       - name: Fix owner of web files
         run: chown -R www-data:www-data /var/www
@@ -336,7 +346,15 @@ jobs:
       # each test runs against a clean database cheaply.
       - name: Run Integration test
         run: |
-          export TEST_DATABASE=`pwd`/installation.sql
+          if [[ ! -z "${{ matrix.update }}" ]] && [[ ! -z "${{ matrix.with_optional }}" ]]; then
+            export TEST_DATABASE=`pwd`/behat-test-output/installation-update-with-optional.sql
+          elif [[ ! -z "${{ matrix.update }}" ]]; then
+            export TEST_DATABASE=`pwd`/behat-test-output/installation-update.sql
+          elif [[ ! -z "${{ matrix.with_optional }}" ]]; then
+            export TEST_DATABASE=`pwd`/behat-test-output/installation-with-optional.sql
+          else
+            export TEST_DATABASE=`pwd`/behat-test-output/installation.sql
+          fi
           vendor/bin/behat --version
           for test in html/profiles/contrib/social/tests/behat/features/capabilities/${{ matrix.feature }}/*.feature; do
             if head -n1 $test | grep -q "@disabled"; then
@@ -387,10 +405,6 @@ jobs:
           if (shopt -s nullglob; f=(html/profiles/contrib/social/tests/behat/logs/*); ((${#f[@]}))); then
             mv html/profiles/contrib/social/tests/behat/logs/* $OUTPUT_FOLDER/
           fi
-
-          # Copy the installation database to the output folder
-          # this makes local reproduction easier.
-          cp `pwd`/installation.sql $OUTPUT_FOLDER/
 
           # Dump the database with the state of the test failure to allow for
           # local inspection.


### PR DESCRIPTION
## Problem / Solution
GitHub is messing up the installation database dumps since #3427.  This deduplicates the installations across jobs and also makes it clearer which is which. An added benefit is that we no longer have the same installation dump in the behat-test-output multiple times :) 

## Issue tracker
Internal no issue

## How to test
- [ ] Behat CI should pass normally again :D 

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status
