### PR TITLE
Internal: Fix false positives in CIs

### DIFF
--- a/tests/behat/features/capabilities/administration/check-revoke-or-grant-administrador-roles.feature
+++ b/tests/behat/features/capabilities/administration/check-revoke-or-grant-administrador-roles.feature
@@ -11,6 +11,7 @@ Feature: Revoking or granting roles by permission
     When I select "Site manager" from "role"
       And I press "Filter"
       And I check the box "edit-views-bulk-operations-bulk-form-0"
+      And I wait for "1" seconds
       And I select "Add a role to the selected users" from "Action"
       And I press the "Apply to selected items" button
     Then I should not see the text "Administrator"
@@ -22,6 +23,7 @@ Feature: Revoking or granting roles by permission
     When I select "Administrator" from "role"
       And I press "Filter"
       And I check the box "edit-views-bulk-operations-bulk-form-0"
+      And I wait for "1" seconds
       And I select "Remove a role from the selected users" from "Action"
       And I press the "Apply to selected items" button
     Then I should not see the text "Administrator"

--- a/tests/behat/features/capabilities/groups/groups-create-closed.feature
+++ b/tests/behat/features/capabilities/groups/groups-create-closed.feature
@@ -174,8 +174,8 @@ Feature: Create Closed Group
     And I click "My groups"
     And I click "Test closed group"
     And I click "Edit group"
+    And I wait for "1" seconds
     And I click "Delete"
-    And I wait for "3" seconds
     And I should see "Are you sure you want to delete your group"
     And I should see the button "Cancel"
     And I should see the button "Delete"


### PR DESCRIPTION
## Problem / Solution
We have a known race condition in the way the Chrome driver clicks on buttons. It will first query the page for the position of a button using JavaScript and then send a click event to Chrome for the retrieved coordinates on the page.

It can happen that something is being loaded (e.g. CKEditor or a VBO feedback element) which can caue the page to shift between the determination of the button's component and the actual click. This can cause the test to "misclick" which results in an intermittend test failure.

We add a second delay before we try to click the buttons which we believe are affected by this issue so that the page has time to settle.

## Issue tracker
Internal no issue

## How to test
- [ ] We should see no more false positives in the CI, so all tests should pass in one go and keep passing if we run the CI multiple times

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status
