### PR TITLE
Issue #3368689 by tbsiqueira: Update behat tests to use the new compatible php 8.1 images

### DIFF
--- a/.github/workflows/behat.yml
+++ b/.github/workflows/behat.yml
@@ -140,7 +140,7 @@ jobs:
     name: "Install Open Social"
     runs-on: ubuntu-22.04
     container:
-      image: goalgorilla/open_social_docker:ci
+      image: goalgorilla/open_social_docker:ci-d9.5-php8.1-v1
       volumes:
         - ${{ github.workspace }}:/var/www
 
@@ -269,7 +269,7 @@ jobs:
     name: 'Tests'
     runs-on: ubuntu-22.04
     container:
-      image: goalgorilla/open_social_docker:ci
+      image: goalgorilla/open_social_docker:ci-d9.5-php8.1-v1
       volumes:
         - ${{ github.workspace }}:/var/www
 
@@ -286,7 +286,7 @@ jobs:
 
     services:
       web:
-        image: goalgorilla/open_social_docker:ci
+        image: goalgorilla/open_social_docker:ci-d9.5-php8.1-v1
         env:
           DRUPAL_SETTINGS: production
         volumes:

--- a/.github/workflows/behat.yml
+++ b/.github/workflows/behat.yml
@@ -140,7 +140,7 @@ jobs:
     name: "Install Open Social"
     runs-on: ubuntu-22.04
     container:
-      image: goalgorilla/open_social_docker:ci-d9.5-php8.1-v1
+      image: goalgorilla/open_social_docker:ci-d9.5-php8.1-v2
       volumes:
         - ${{ github.workspace }}:/var/www
 
@@ -269,7 +269,7 @@ jobs:
     name: 'Tests'
     runs-on: ubuntu-22.04
     container:
-      image: goalgorilla/open_social_docker:ci-d9.5-php8.1-v1
+      image: goalgorilla/open_social_docker:ci-d9.5-php8.1-v2
       volumes:
         - ${{ github.workspace }}:/var/www
 
@@ -286,7 +286,7 @@ jobs:
 
     services:
       web:
-        image: goalgorilla/open_social_docker:ci-d9.5-php8.1-v1
+        image: goalgorilla/open_social_docker:ci-d9.5-php8.1-v2
         env:
           DRUPAL_SETTINGS: production
         volumes:

--- a/modules/custom/activity_basics/activity_basics.install
+++ b/modules/custom/activity_basics/activity_basics.install
@@ -55,7 +55,7 @@ function activity_basics_update_8103() : void {
     $activity_bundle_entity = $config->get('third_party_settings.activity_logger.activity_bundle_entity');
     $config->clear('third_party_settings.activity_logger.activity_bundle_entity');
 
-    $bundle_entity = explode('.', $activity_bundle_entity);
+    $bundle_entity = explode('.', $activity_bundle_entity ?? "");
     $activity_bundle_entity_new = $bundle_entity[0] . '-' . $bundle_entity[1];
     $activity_bundle_entities = [$activity_bundle_entity_new => $activity_bundle_entity_new];
 

--- a/modules/custom/download_count/download_count.module
+++ b/modules/custom/download_count/download_count.module
@@ -47,7 +47,7 @@ function download_count_file_access(EntityInterface $entity, $operation, Account
     }
 
     // Validate file has extension that should be counted, if not return.
-    $extensions = explode(' ', mb_strtolower(trim($config->get('download_count_excluded_file_extensions'))));
+    $extensions = explode(' ', mb_strtolower(trim($config->get('download_count_excluded_file_extensions') ?? "")));
     $extension = mb_strtolower(pathinfo($entity->getFilename(), PATHINFO_EXTENSION));
     if (in_array($extension, $extensions, TRUE)) {
       return;

--- a/modules/custom/improved_theme_settings/improved_theme_settings.module
+++ b/modules/custom/improved_theme_settings/improved_theme_settings.module
@@ -252,7 +252,7 @@ function improved_theme_settings_page_attachments(array &$page) {
  */
 function improved_theme_settings_get_setting($setting, $themename) {
   // Fetch setting from the theme.
-  $themevar = Xss::filter(theme_get_setting($setting, $themename));
+  $themevar = Xss::filter(theme_get_setting($setting, $themename) ?? "");
   // In this case '' is something different than 0.
   if ($themevar !== trim((string) ((int) $themevar))) {
     return FALSE;

--- a/modules/custom/social_path_manager/social_path_manager.module
+++ b/modules/custom/social_path_manager/social_path_manager.module
@@ -251,7 +251,7 @@ function _social_path_manager_update_alias(EntityInterface $entity, $op, $bulk =
             $entity_language = $entity->language()->getId();
 
             // Prevent adding alias for default tab.
-            $source_parts = explode('/', $path['source']);
+            $source_parts = explode('/', $path['source'] ?? "");
             if (end($source_parts) === $suffix) {
               continue;
             }

--- a/modules/social_features/social_core/social_core.install
+++ b/modules/social_features/social_core/social_core.install
@@ -160,6 +160,16 @@ function social_core_update_dependencies() {
     'group' => 8020,
   ];
 
+  // Add variationcache hook update from group as required to fix update path.
+  $dependencies['social_core'][11402] = [
+    'group' => 8020,
+  ];
+
+  // Add variationcache hook update from group as required to fix update path.
+  $dependencies['social_core'][11900] = [
+    'group' => 8020,
+  ];
+
   return $dependencies;
 }
 

--- a/modules/social_features/social_core/social_core.install
+++ b/modules/social_features/social_core/social_core.install
@@ -5,7 +5,8 @@
  * Install, update and uninstall functions for the social_core module.
  */
 
-use Drupal\Core\Config\FileStorage;
+use Drupal\Core\Entity\Entity\EntityViewMode;
+use Drupal\Core\Entity\EntityStorageException;
 use Drupal\Core\File\FileSystemInterface;
 use Drupal\block\Entity\Block;
 use Drupal\block_content\Entity\BlockContent;
@@ -1561,10 +1562,18 @@ function social_core_update_11301(): void {
  * Add a new view mode for nodes - Email card.
  */
 function social_core_update_11401(): void {
-  $config_storage = \Drupal::service('config.storage');
-  $config_path = \Drupal::service('extension.list.module')->getPath('social_core') . '/config/static';
-  $source = new FileStorage($config_path);
-  $config_storage->write('core.entity_view_mode.node.email_card', (array) $source->read('core.entity_view_mode.node.email_card_11401'));
+
+  try {
+    $content = file_get_contents(\Drupal::service('extension.list.module')->getPath('social_core') . '/config/static/core.entity_view_mode.node.email_card_11401.yml');
+    if (is_string($content)) {
+      $yml = Yaml::parse($content);
+      EntityViewMode::create($yml)->save();
+    }
+  }
+  catch (EntityStorageException $e) {
+    \Drupal::logger('social_core')->error($e->getMessage());
+  }
+
 }
 
 /**

--- a/modules/social_features/social_core/social_core.install
+++ b/modules/social_features/social_core/social_core.install
@@ -1572,7 +1572,6 @@ function social_core_update_11301(): void {
  * Add a new view mode for nodes - Email card.
  */
 function social_core_update_11401(): void {
-
   try {
     $content = file_get_contents(\Drupal::service('extension.list.module')->getPath('social_core') . '/config/static/core.entity_view_mode.node.email_card_11401.yml');
     if (is_string($content)) {
@@ -1583,7 +1582,6 @@ function social_core_update_11401(): void {
   catch (EntityStorageException $e) {
     \Drupal::logger('social_core')->error($e->getMessage());
   }
-
 }
 
 /**

--- a/modules/social_features/social_event/social_event.install
+++ b/modules/social_features/social_event/social_event.install
@@ -5,7 +5,11 @@
  * Install, update and uninstall functions for the social_event module.
  */
 
+use Drupal\Core\Config\ConfigException;
 use Drupal\Core\Config\FileStorage;
+use Drupal\Core\Entity\Entity\EntityViewDisplay;
+use Drupal\Core\Entity\Entity\EntityViewMode;
+use Drupal\Core\Entity\EntityStorageException;
 use Drupal\Core\Site\Settings;
 use Drupal\field\Entity\FieldConfig;
 use Drupal\field\FieldConfigInterface;
@@ -137,6 +141,10 @@ function social_event_update_dependencies() {
   // New image style change should run after the new image style is imported.
   $dependencies['social_event'][8915] = [
     'social_core' => 8908,
+  ];
+
+  $dependencies['social_event'][11401] = [
+    'social_core' => 11401,
   ];
 
   return $dependencies;
@@ -2112,28 +2120,46 @@ function social_event_update_10311(): string {
  * Add new field to Event node type; Add new message template.
  */
 function social_event_update_11401(): void {
-  $config_files = [
-    'core.entity_view_display.node.event.email_card' => 'core.entity_view_display.node.event.email_card_11401',
-    'message.template.user_was_enrolled_to_event' => 'message.template.user_was_enrolled_to_event_11401',
-  ];
+  try {
+    $content = file_get_contents(\Drupal::service('extension.list.module')->getPath('social_event') . '/config/static/core.entity_view_display.node.event.email_card_11401.yml');
+    if (is_string($content)) {
+      $yml = Yaml::parse($content);
+      EntityViewDisplay::create($yml)->save();
+    }
 
-  $config_storage = \Drupal::service('config.storage');
-  $config_path = \Drupal::service('extension.list.module')->getPath('social_event') . '/config/static';
-  $source = new FileStorage($config_path);
+    // Prepare the path.
+    $path = \Drupal::service('extension.list.module')->getPath('social_event') . '/config/static/message.template.user_was_enrolled_to_event_11401.yml';
 
-  foreach ($config_files as $origin_name => $update_name) {
-    $config_storage->write($origin_name, (array) $source->read($update_name));
+    // Retrieves the configuration factory.
+    $config_factory = \Drupal::configFactory();
+
+    // Create new message template.
+    if (is_file($path)) {
+      $file_content = file_get_contents($path);
+      $settings = Yaml::parse($file_content === FALSE ? '' : $file_content);
+      if (is_array($settings)) {
+        $config = $config_factory->getEditable('message.template.user_was_enrolled_to_event');
+        $config->setData($settings)->save(TRUE);
+      }
+    }
+
+    $source = new FileStorage(\Drupal::service('extension.list.module')->getPath('social_event') . '/config/static');
+
+    // Create a new field from the yaml configuration and save.
+    \Drupal::entityTypeManager()->getStorage('field_storage_config')
+      ->create((array) $source->read('field.storage.node.field_event_send_confirmation_11401'))
+      ->save();
+
+    // Create a new field instance from the yaml configuration and save.
+    \Drupal::entityTypeManager()->getStorage('field_config')
+      ->create((array) $source->read('field.field.node.event.field_event_send_confirmation_11401'))
+      ->save();
+
+  }
+  catch (EntityStorageException $e) {
+    \Drupal::logger('social_event')->error($e->getMessage());
   }
 
-  // Create a new field from the yaml configuration and save.
-  \Drupal::entityTypeManager()->getStorage('field_storage_config')
-    ->create((array) $source->read('field.storage.node.field_event_send_confirmation_11401'))
-    ->save();
-
-  // Create a new field instance from the yaml configuration and save.
-  \Drupal::entityTypeManager()->getStorage('field_config')
-    ->create((array) $source->read('field.field.node.event.field_event_send_confirmation_11401'))
-    ->save();
 }
 
 /**
@@ -2222,4 +2248,40 @@ function social_event_update_11902(): string {
 
   // Output logged messages to related channel of update execution.
   return $updateHelper->logger()->output();
+}
+
+/**
+ * Fix configs that don't have UUIDs.
+ */
+function social_event_update_11903(): void {
+
+  try {
+    /** @var \Drupal\Core\Entity\EntityInterface $email_card_view_display */
+    $email_card_view_display = EntityViewDisplay::load('node.event.email_card');
+    if ($email_card_view_display->uuid() === NULL || empty($email_card_view_display->uuid())) {
+      $site = \Drupal::configFactory()
+        ->getEditable('core.entity_view_display.node.event.email_card');
+      $site->set('uuid', \Drupal::service('uuid')->generate());
+      $site->save(TRUE);
+    }
+
+    /** @var \Drupal\Core\Entity\EntityInterface $email_card_view_mode */
+    $email_card_view_mode = EntityViewMode::load('node.email_card');
+    if ($email_card_view_mode->uuid() === NULL || empty($email_card_view_mode->uuid())) {
+      $site = \Drupal::configFactory()
+        ->getEditable('core.entity_view_mode.node.email_card');
+      $site->set('uuid', \Drupal::service('uuid')->generate());
+      $site->save(TRUE);
+    }
+
+    /** @var \Drupal\Core\Config\Config $config */
+    $config = \Drupal::service('config.factory')->getEditable('message.template.user_was_enrolled_to_event');
+    $config->set('uuid', \Drupal::service('uuid')->generate());
+    $config->save();
+
+  }
+  catch (ConfigException $e) {
+    \Drupal::logger('social_event')->error($e->getMessage());
+  }
+
 }

--- a/modules/social_features/social_event/social_event.install
+++ b/modules/social_features/social_event/social_event.install
@@ -147,6 +147,10 @@ function social_event_update_dependencies() {
     'social_core' => 11401,
   ];
 
+  $dependencies['social_event'][11403] = [
+    'group' => 8020,
+  ];
+
   return $dependencies;
 }
 

--- a/modules/social_features/social_event/social_event.install
+++ b/modules/social_features/social_event/social_event.install
@@ -2163,7 +2163,6 @@ function social_event_update_11401(): void {
   catch (EntityStorageException $e) {
     \Drupal::logger('social_event')->error($e->getMessage());
   }
-
 }
 
 /**
@@ -2258,7 +2257,6 @@ function social_event_update_11902(): string {
  * Fix configs that don't have UUIDs.
  */
 function social_event_update_11903(): void {
-
   try {
     /** @var \Drupal\Core\Entity\EntityInterface $email_card_view_display */
     $email_card_view_display = EntityViewDisplay::load('node.event.email_card');
@@ -2278,14 +2276,22 @@ function social_event_update_11903(): void {
       $site->save(TRUE);
     }
 
-    /** @var \Drupal\Core\Config\Config $config */
-    $config = \Drupal::service('config.factory')->getEditable('message.template.user_was_enrolled_to_event');
-    $config->set('uuid', \Drupal::service('uuid')->generate());
-    $config->save();
+    // List of broken or NULL UUIDs.
+    $config_list = [
+      'message.template.user_was_enrolled_to_event',
+      'views.view.event_manage_enrollments',
+      'views.view.group_manage_members',
+      'views.view.user_admin_people',
+    ];
 
+    foreach ($config_list as $config_name) {
+      /** @var \Drupal\Core\Config\Config $config */
+      $config = \Drupal::service('config.factory')->getEditable($config_name);
+      $config->set('uuid', \Drupal::service('uuid')->generate());
+      $config->save();
+    }
   }
   catch (ConfigException $e) {
     \Drupal::logger('social_event')->error($e->getMessage());
   }
-
 }

--- a/modules/social_features/social_follow_user/social_follow_user.install
+++ b/modules/social_features/social_follow_user/social_follow_user.install
@@ -113,7 +113,7 @@ function social_follow_user_uninstall(): void {
 
     if (!empty($config->getRawData())) {
       $pages = $config->get('visibility.request_path.pages');
-      $pages = explode("\r\n", $pages);
+      $pages = explode("\r\n", $pages ?? "");
 
       foreach ($pages as $delta => $page) {
         if (in_array($page, $paths)) {

--- a/modules/social_features/social_group/modules/social_group_invite/src/Form/SocialBulkGroupInvitation.php
+++ b/modules/social_features/social_group/modules/social_group_invite/src/Form/SocialBulkGroupInvitation.php
@@ -502,7 +502,7 @@ class SocialBulkGroupInvitation extends BulkGroupInvitation {
    *   List of emails to invite .
    */
   private function getSubmittedEmails(FormStateInterface $form_state) {
-    return array_map('trim', array_unique(explode("\r\n", trim($form_state->getValue('email_address')))));
+    return array_map('trim', array_unique(explode("\r\n", trim($form_state->getValue('email_address') ?? ""))));
   }
 
   /**

--- a/modules/social_features/social_landing_page/social_landing_page.module
+++ b/modules/social_features/social_landing_page/social_landing_page.module
@@ -75,7 +75,7 @@ function social_landing_page_field_widget_block_field_default_form_alter(&$eleme
 
   // Grab the id.
   $id = $block_settings['#attributes']['id'];
-  $items = explode('-', $id);
+  $items = explode('-', $id ?? "");
 
   // Generate the new state name.
   // We use block id, to get all the parent names

--- a/modules/social_features/social_post/modules/social_post_album/src/Element/SocialPostAlbumManagedFile.php
+++ b/modules/social_features/social_post/modules/social_post_album/src/Element/SocialPostAlbumManagedFile.php
@@ -24,7 +24,7 @@ class SocialPostAlbumManagedFile extends ManagedFile {
    */
   public static function uploadAjaxCallback(&$form, FormStateInterface &$form_state, Request $request) {
     $response = parent::uploadAjaxCallback($form, $form_state, $request);
-    $parents = explode('/', $request->query->get('element_parents'));
+    $parents = explode('/', $request->query->get('element_parents') ?? "");
 
     return $response->addCommand(new InvokeCommand(
       '#edit-' . str_replace('_', '-', $parents[0]) . '-wrapper',

--- a/modules/social_features/social_profile/social_profile.install
+++ b/modules/social_features/social_profile/social_profile.install
@@ -173,6 +173,11 @@ function social_profile_update_dependencies() {
     'social_core' => 11002,
   ];
 
+  // Add variationcache hook update from group as required to fix update path.
+  $dependencies['social_profile'][11002] = [
+    'group' => 8020,
+  ];
+
   return $dependencies;
 }
 

--- a/modules/social_features/social_profile/src/SocialProfileTrait.php
+++ b/modules/social_features/social_profile/src/SocialProfileTrait.php
@@ -60,7 +60,7 @@ trait SocialProfileTrait {
       case SOCIAL_PROFILE_SUGGESTIONS_FULL_NAME:
       case SOCIAL_PROFILE_SUGGESTIONS_ALL:
         if ($this->useFullName()) {
-          $strings = explode(' ', $name);
+          $strings = explode(' ', $name ?? "");
 
           if (count($strings) > 1) {
             $query->where("CONCAT(TRIM(fn.field_profile_first_name_value), ' ', TRIM(ln.field_profile_last_name_value)) LIKE :full_name", [

--- a/modules/social_features/social_swiftmail/social_swiftmail.module
+++ b/modules/social_features/social_swiftmail/social_swiftmail.module
@@ -30,7 +30,7 @@ function social_swiftmail_preprocess_swiftmailer(array &$variables) {
   $secondary = $colors['brand-secondary'];
   $accent = $colors['brand-accent'];
   $link = $colors['brand-link'];
-  $border_radius = Xss::filter(theme_get_setting('border_radius', $theme_id));
+  $border_radius = Xss::filter(theme_get_setting('border_radius', $theme_id) ?? "");
 
   // Add variables to send to the html template.
   $variables['logo'] = $logo;
@@ -117,7 +117,7 @@ function social_swiftmail_preprocess_swiftmailer(array &$variables) {
     }
 
     $disabled_greeting_keys = $social_swiftmail_config->get("disabled_user_greeting_keys");
-    $disabled_greeting_keys = explode("\r\n", $disabled_greeting_keys);
+    $disabled_greeting_keys = explode("\r\n", $disabled_greeting_keys ?? "");
     $replace = [
       '@display_name' => $display_name,
     ];

--- a/modules/social_features/social_user/social_user.install
+++ b/modules/social_features/social_user/social_user.install
@@ -70,6 +70,11 @@ function social_user_update_dependencies(): array {
     'social_core' => 11002,
   ];
 
+  // Add variationcache hook update from group as required to fix update path.
+  $dependencies['social_user'][11201] = [
+    'group' => 8020,
+  ];
+
   return $dependencies;
 }
 


### PR DESCRIPTION
## :rocket: :fire: Related PRs :fire: :rocket:

This is a PR from a series of 5 PRs that should be merged in the following order: 

1. https://github.com/goalgorilla/open_social_dev/pull/70 
2. https://github.com/goalgorilla/open_social/pull/3460
3. https://github.com/goalgorilla/open_social/pull/3457
4. https://github.com/goalgorilla/drupal_social/pull/392 ( this is just a private repository that we use for development, this will not be available for public users )
5. https://github.com/goalgorilla/open_social/pull/3439

## Problem
We are now officially adding php 8.1 support, but our behat tests are still running on PHP 8.0, this is not an issue because PHPStan guarantees the compatibility, but we want to run our behat tests using PHP 8.1,

After we fixed the behat tests, a couple of issues raised:

`$extensions = explode(' ', mb_strtolower(trim($config->get('download_count_excluded_file_extensions') ?? "")));`

Unresolved variation cache module dependencies during hook updates fixed here and other places, this errors were found during the upgrade path check, and since they are green, they should all be resolved now.

```
 // Add variationcache hook update from group as required to fix update path.
  $dependencies['social_core'][11402] = [
    'group' => 8020,
  ];

  // Add variationcache hook update from group as required to fix update path.
  $dependencies['social_core'][11900] = [
    'group' => 8020,
  ];
```

Missing UUID on configuration created during hook updates, as a result of not using the correct Drupal APIs to generate configs from yml files, [as seen here](https://github.com/goalgorilla/open_social/pull/3439/files#diff-e71c5f38a4b8eb21a16ec516bda780831bf47946fb56a5ea6130e919231a6ae6L1564): 

```
  $config_storage = \Drupal::service('config.storage');
  $config_path = \Drupal::service('extension.list.module')->getPath('social_core') . '/config/static';
  $source = new FileStorage($config_path);
  $config_storage->write('core.entity_view_mode.node.email_card', (array) $source->read('core.entity_view_mode.node.email_card_11401'));
```

This last issue required an update hook, to create a proper for those configuration files, [change is available at this link](https://github.com/goalgorilla/open_social/pull/3439/files#diff-76261ef8588b9c0e238662e1597bf7c1dc0d0db483c3e21fd3fb897e8feb6976R2260)

I also noticed there some `explode()` functions were .... blowing up :boom: ( pun intended ) due to the "string" argument being NULL, so I added checks to avoid that, and they are all verified with PHPStan, the ones that don't have it is because we don't need.


## Solution
Update docker images used for Behat tests to feature PHP 8.1 compatible images

## Issue tracker
https://www.drupal.org/project/social/issues/3368689

## Theme issue tracker
N/A

## How to test
- [ ] Green tests

## Definition of done
### Before merge
- [x] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
<!-- *[Required if new feature, and if applicable] If this Pull Request makes visual changes then please include some screenshots that show what has changed here. A before and after screenshot helps the reviewer determine what changes were made.* -->

## Release notes
<!-- *[Required if new feature, and if applicable] A short summary of the changes that were made that can be included in release notes.* -->

## Change Record
<!-- *[Required if applicable] If this Pull Request changes the way that developers should do things or introduces a new API for developers then a change record to document this is needed. Please provide a draft for a change record or a link to an unpublished change record below. Existing change records can be consulted as example. Please provide a draft for a change record or a link to an unpublished change record below. [Existing change records](https://www.drupal.org/list-changes/social) can be consulted as example.* -->

## Translations
<!--
*[Optional]Translatable strings are always extracted from the latest development branch. To ensure translations remain available for platforms running older versions of Open Social the original string should be added to `translations.php` when it's changed or removed.*
- [ ] Changed or removed source strings are added to the `translations.php` file.
-->
