### PR TITLE
Issue #3370936 by ronaldtebrake: Allow users to filter on the Flexible Group types on the `/all-groups` overview

### DIFF
--- a/modules/social_features/social_group/modules/social_group_flexible_group/config/modify/social_group_flexible_group.field_group_type_overview_filter.yml
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/config/modify/social_group_flexible_group.field_group_type_overview_filter.yml
@@ -1,0 +1,62 @@
+dependencies:
+  config:
+    - field.field.group.flexible_group.field_group_type
+items:
+  views.view.newest_groups:
+    expected_config: { }
+    update_actions:
+      add:
+        display:
+          page_all_groups:
+            display_options:
+              filters:
+                field_group_type_target_id:
+                  id: field_group_type_target_id
+                  table: group__field_group_type
+                  field: field_group_type_target_id
+                  relationship: none
+                  group_type: group
+                  admin_label: ''
+                  plugin_id: taxonomy_index_tid
+                  operator: or
+                  value: { }
+                  group: 1
+                  exposed: true
+                  expose:
+                    operator_id: field_group_type_target_id_op
+                    label: 'Type'
+                    description: ''
+                    use_operator: false
+                    operator: field_group_type_target_id_op
+                    operator_limit_selection: false
+                    operator_list: { }
+                    identifier: field_group_type_target_id
+                    required: false
+                    remember: false
+                    multiple: false
+                    remember_roles:
+                      authenticated: authenticated
+                      anonymous: '0'
+                      administrator: '0'
+                      contentmanager: '0'
+                      verified: '0'
+                      sitemanager: '0'
+                    reduce: false
+                  is_grouped: false
+                  group_info:
+                    label: ''
+                    description: ''
+                    identifier: ''
+                    optional: true
+                    widget: select
+                    multiple: false
+                    remember: false
+                    default_group: All
+                    default_group_multiple: { }
+                    group_items: { }
+                  reduce_duplicates: false
+                  vid: group_type
+                  type: select
+                  hierarchy: false
+                  limit: true
+                  error_message: true

--- a/modules/social_features/social_group/modules/social_group_flexible_group/config/update/social_group_flexible_group_update_11901.yml
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/config/update/social_group_flexible_group_update_11901.yml
@@ -1,0 +1,61 @@
+views.view.newest_groups:
+  expected_config: {  }
+  update_actions:
+    change:
+      display:
+        page_all_groups:
+          display_options:
+            defaults:
+              filter_groups: true
+              filters: true
+            filters:
+              field_group_type_target_id:
+                id: field_group_type_target_id
+                table: group__field_group_type
+                field: field_group_type_target_id
+                relationship: none
+                group_type: group
+                admin_label: ''
+                plugin_id: taxonomy_index_tid
+                operator: or
+                value: { }
+                group: 1
+                exposed: true
+                expose:
+                  operator_id: field_group_type_target_id_op
+                  label: 'Type'
+                  description: ''
+                  use_operator: false
+                  operator: field_group_type_target_id_op
+                  operator_limit_selection: false
+                  operator_list: { }
+                  identifier: field_group_type_target_id
+                  required: false
+                  remember: false
+                  multiple: false
+                  remember_roles:
+                    authenticated: authenticated
+                    anonymous: '0'
+                    administrator: '0'
+                    contentmanager: '0'
+                    verified: '0'
+                    sitemanager: '0'
+                  reduce: false
+                is_grouped: false
+                group_info:
+                  label: ''
+                  description: ''
+                  identifier: ''
+                  optional: true
+                  widget: select
+                  multiple: false
+                  remember: false
+                  default_group: All
+                  default_group_multiple: { }
+                  group_items: { }
+                reduce_duplicates: false
+                vid: group_type
+                type: select
+                hierarchy: false
+                limit: true
+                error_message: true

--- a/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.install
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.install
@@ -631,7 +631,7 @@ function social_group_flexible_group_update_11801(): void {
 /**
  * Add field_group_type filter to the all-groups overview.
  */
-function social_group_flexible_group_update_11901() {
+function social_group_flexible_group_update_11901(): string {
   /** @var \Drupal\update_helper\Updater $updater */
   $updater = \Drupal::service('update_helper.updater');
 

--- a/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.install
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.install
@@ -627,3 +627,17 @@ function social_group_flexible_group_update_11801(): void {
     $config->save();
   }
 }
+
+/**
+ * Add field_group_type filter to the all-groups overview.
+ */
+function social_group_flexible_group_update_11901() {
+  /** @var \Drupal\update_helper\Updater $updater */
+  $updater = \Drupal::service('update_helper.updater');
+
+  // Execute configuration update definitions with logging of success.
+  $updater->executeUpdate('social_group_flexible_group', 'social_group_flexible_group_update_11901');
+
+  // Output logged messages to related channel of update execution.
+  return $updater->logger()->output();
+}

--- a/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.module
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.module
@@ -97,6 +97,29 @@ function social_group_flexible_group_form_alter(&$form, FormStateInterface $form
         ],
       ];
     }
+    if (!empty($form['field_group_type_target_id']) &&
+      !empty($form['type']['#options']) &&
+      $form['type']['#type'] !== 'hidden') {
+      $form['field_group_type_target_id']['#states'] = [
+        'visible' => [
+          ':input[name="type"]' => ['value' => 'flexible_group'],
+        ],
+      ];
+    }
+    // Hide the flexible group field group type if the setting for it to be
+    // required is disabled even if there are values in the vocabulary.
+    if (!empty($form['field_group_type_target_id']) &&
+      !\Drupal::config('social_group.settings')->get('social_group_type_required')) {
+      $form['field_group_type_target_id']['#type'] = 'hidden';
+    }
+    // Hide the flexible group field group type if there is only the
+    // "All / any" option we hide it as well.
+    if (!empty($form['field_group_type_target_id']) &&
+      !empty($form['field_group_type_target_id']['#options']) &&
+      count($form['field_group_type_target_id']['#options']) === 1 &&
+      array_key_exists('All', $form['field_group_type_target_id']['#options'])) {
+      $form['field_group_type_target_id']['#type'] = 'hidden';
+    }
   }
   // For adding or editing a flexible group, we alter the visibility fields.
   if ($form['#id'] === 'group-flexible-group-add-form' ||

--- a/modules/social_features/social_group/social_group.module
+++ b/modules/social_features/social_group/social_group.module
@@ -1194,6 +1194,14 @@ function social_group_form_alter(&$form, FormStateInterface $form_state, $form_i
           unset($form['type']['#options'][$type]);
         }
       }
+      // If we determined the user can only see the All / Any option
+      // And perhaps one more group type, like flexible groups.
+      // this filter doesn't make sense, and we hide it.
+      // This also allows other filters, depending on the options to show up.
+      if (count($form['type']['#options']) === 2 &&
+        array_key_exists('All', $form['type']['#options'])) {
+        $form['type']['#type'] = 'hidden';
+      }
     }
   }
 

--- a/modules/social_features/social_group/social_group.module
+++ b/modules/social_features/social_group/social_group.module
@@ -1184,6 +1184,10 @@ function social_group_form_alter(&$form, FormStateInterface $form_state, $form_i
     $form['#id'] === 'views-exposed-form-search-groups-page') {
     $account = \Drupal::currentUser();
     if (!empty($form['type']['#options'])) {
+      // Make sure we add cache tags so whenever a type is added/removed in the
+      // vocabulary this gets cleared.
+      $form['#cache']['tags'][] = 'taxonomy_term_list:group_type';
+
       foreach ($form['type']['#options'] as $type => $label) {
         // All / Any we can skip they are optional translatable options
         // and not group types.

--- a/modules/social_features/social_group/src/Form/SocialGroupSettings.php
+++ b/modules/social_features/social_group/src/Form/SocialGroupSettings.php
@@ -233,6 +233,10 @@ class SocialGroupSettings extends ConfigFormBase {
     $config->set('social_group_type_required', $form_state->getValue('social_group_type_required'));
     $config->save();
 
+    if ($form['social_group_type_required']['#default_value'] !== (bool) $form_state->getValue('social_group_type_required')) {
+      Cache::invalidateTags(['config:block.block.exposed_form_newest_groups_page_all_groups']);
+    }
+
     Cache::invalidateTags(['group_view']);
   }
 

--- a/tests/behat/features/bootstrap/GroupContext.php
+++ b/tests/behat/features/bootstrap/GroupContext.php
@@ -13,6 +13,7 @@ use Drupal\group\Entity\Group;
 use Drupal\group\Entity\GroupContentType;
 use Drupal\group\Entity\GroupInterface;
 use Drupal\group\Entity\GroupRole;
+use Drupal\group\Entity\GroupType;
 use Drupal\user\Entity\User;
 use Drupal\user\UserInterface;
 

--- a/tests/behat/features/bootstrap/SocialMinkContext.php
+++ b/tests/behat/features/bootstrap/SocialMinkContext.php
@@ -264,4 +264,45 @@ class SocialMinkContext extends MinkContext {
     return TRUE;
   }
 
+  /**
+   * Ensure a select field does not contain the following options.
+   *
+   * @Given /^the "(?P<locator>[^"]+)" select field should not contain the following options:$/
+   */
+  public function theSelectFieldShouldNotContainTheFollowingOptions(string $locator, TableNode $options): void {
+    $field = $this->getSession()->getPage()->findField($locator);
+
+    if (NULL === $field) {
+      throw new ElementNotFoundException($this->getSession()->getDriver(), 'form field', 'id|name|label|value', $locator);
+    }
+
+    foreach ($options->getHash() as $value) {
+      $option = $field->find('named', ['option', $value['options']]);
+
+      if ($option !== NULL) {
+        throw new \Exception("The field was supposed to not contain '$option' but it was an option in the select field.");
+      }
+    }
+  }
+
+  /**
+   * Ensure a select field does contain the following options.
+   *
+   * @Given /^the "(?P<locator>[^"]+)" select field should contain the following options:$/
+   */
+  public function theSelectFieldShouldContainTheFollowingOptions(string $locator, TableNode $options): void {
+    $field = $this->getSession()->getPage()->findField($locator);
+
+    if (NULL === $field) {
+      throw new ElementNotFoundException($this->getSession()->getDriver(), 'form field', 'id|name|label|value', $locator);
+    }
+
+    foreach ($options->getHash() as $value) {
+      $option = $field->find('named', ['option', $value['options']]);
+
+      if ($option === NULL) {
+        throw new \Exception("The field was supposed to contain '$option' but it was not an option in the select field.");
+      }
+    }
+  }
 }

--- a/tests/behat/features/bootstrap/SocialMinkContext.php
+++ b/tests/behat/features/bootstrap/SocialMinkContext.php
@@ -5,6 +5,7 @@ namespace Drupal\social\Behat;
 
 use Behat\Mink\Exception\ElementNotFoundException;
 use Drupal\DrupalExtension\Context\MinkContext;
+use Behat\Gherkin\Node\TableNode;
 
 /**
  * Defines application features from the specific context.

--- a/tests/behat/features/capabilities/groups/groups-view-overview-filter.feature
+++ b/tests/behat/features/capabilities/groups/groups-view-overview-filter.feature
@@ -1,0 +1,82 @@
+@api @javascript @group @group-overview
+Feature: All group overview filters
+
+  Background:
+    Given I enable the module "social_group_flexible_group"
+
+  Scenario: As user I can filter on the available group types on the group overview
+    Given I am an anonymous user
+
+    When I am viewing the groups overview
+
+    Then the "Group type" select field should not contain the following options:
+      | options         |
+      | Secret group    |
+      | Community group |
+    And the "Group type" select field should contain the following options:
+      | options         |
+      | Flexible group  |
+      | Public group    |
+      | - Any -         |
+
+#  @TODO when Flexible groups is our only group type this should work. For now it doesnt, as we have public and flexible
+#  as group types enabled by default. In order to create a setup step for this test to run we would either need to
+#  uninstall a group type, or remove permissions for AN / outsiders to not be able to view published group of type as
+#  group permission. This doesn't help us in our confidence to do the group migration, so we can revisit this later.
+#
+#  Scenario: As user I can not filter on group types on the group overview if there is only one group type
+#    Given I am an anonymous user
+#
+#    When I am viewing the groups overview
+#
+#    Then I should not see "Group type" in the "Sidebar second"
+
+  Scenario: As user I can not filter on the field group type if there are no types added
+    Given I am an anonymous user
+    And I set the configuration item "social_group.settings" with key "social_group_type_required" to TRUE
+
+    When I am viewing the groups overview
+
+    Then I should not see "Type" in the "Sidebar second"
+
+  Scenario: As user I can not filter on the field group type if the setting is disabled even if there are options
+    Given I am an anonymous user
+    And I set the configuration item "social_group.settings" with key "social_group_type_required" to FALSE
+    And "group_type" terms:
+      | name |
+      | Local Group |
+
+    When I am viewing the groups overview
+
+    Then I should not see "Type" in the "Sidebar second"
+
+  Scenario: As user I can filter on the field group type if flexible groups is selected as filter option
+    Given I am an anonymous user
+    And I set the configuration item "social_group.settings" with key "social_group_type_required" to TRUE
+    And "group_type" terms:
+      | name |
+      | Local Group |
+
+    When I am viewing the groups overview
+    And I select "Flexible group" from "Group type"
+
+    Then I should see "Type" in the "Sidebar second"
+
+  Scenario: As user I can filter on the field group type and the right group(s) are shown
+    Given I am an anonymous user
+    And I set the configuration item "social_group.settings" with key "social_group_type_required" to TRUE
+    And "group_type" terms:
+      | name |
+      | Local Group |
+    And groups with non-anonymous owner:
+      | label                   | field_group_description   | field_flexible_group_visibility | type            | created  | field_group_type |
+      | This is a local group   | This is a local group     | public                          | flexible_group  | 01/01/01 | Local Group      |
+      | This is not a local one | Just an ordinary on       | public                          | flexible_group  | 01/01/01 |                  |
+
+    When I am viewing the groups overview
+    And I select "Flexible group" from "Group type"
+    And I select "Local Group" from "Type"
+    And I press "Filter"
+
+    Then I should see "This is a local group"
+    And I should not see "This is not a local one"


### PR DESCRIPTION
## Problem
In Open Social version 10 we have introduced a new taxonomy vocabulary called Group types where a user is able to categorise a flexible group using this taxonomy term reference field. At the moment we do not expose this as a filter anyway so its use is limited.

Scope of this story will be to expose the filter in the /all-groups overview.

## Solution
Add the filter to the overview and follow the following business rules:

1. If there are no values in the vocabulary referenced by the new type filter, we hide the filter.
2. If the setting in the Group settings to require the new type field on flexible groups is disabled, we hide the filter.

3. Whenever flexible group is the only Group type option we hide the old Group type filter.
4. Whenever flexible group is the only Group type option and the Group type filter is hidden, we do show the new type filter.
5. Whenever flexible group is not the only Group type option, we hide the new type filter, unless Flexible group is chosen as Group type select option.

This should ensure that it works for even where users might have created other Group types or in the scenario's whenever we migrate to only Flexible groups and no other group types exist.

## Issue tracker
https://www.drupal.org/project/social/issues/3370936

## How to test
Do the below in install and update.

1. As AN
- [x] Go to the /all-groups overview
- [x] See nothing changes by default

2. Create some items in the new Type vocabulary
As AN
- [x] Go to the /all-groups overview
- [x] See nothing changes by default, because the setting is not enabled to require this new type

3. Create some items in the new Type vocabulary
Enable the setting on the Group settings form to enable the type for flexible groups
As AN
- [x] Go to the /all-groups overview
- [x] See nothing changes by default as Flexible group isn't chosen
- [x] Select "Flexible group" as group type
- [x] See the new type field shows up with the right options

4. Login as Admin and go to `admin/group/types/manage/public_group/permissions`
Remove the "view published group" permission for AN
As AN
- [x] Go to the /all-groups overview
- [x] See the Group type filter is hidden
- [x] See the new type field shows immediately with the right options

Now create groups with Group types and see the filter actually works accordingly 😄 

## Definition of done
### Before merge
- [x] Code/peer review is completed
- [x] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [x] All acceptance criteria were met
- [x] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [x] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [x] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [x] This pull request has all required labels (team/type/priority)
- [x] This pull request has a milestone
- [x] This pull request has an assignee (if applicable)
- [x] Any front end changes are tested on all major browsers
- [x] New UI elements, or changes on UI elements are approved by the design team
- [x] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Release notes
We have added a filter for the added Type field on Flexible Groups. This should allow your users to filter on the actual Types of flexible groups they have.
