### PR TITLE
Issue #3372323 - fix(social_event_managers): GroupEventNode content-enabler declaration

### DIFF
--- a/modules/social_features/social_event/modules/social_event_managers/src/Plugin/GroupContentEnabler/GroupEventNode.php
+++ b/modules/social_features/social_event/modules/social_event_managers/src/Plugin/GroupContentEnabler/GroupEventNode.php
@@ -8,7 +8,7 @@ use Drupal\gnode\Plugin\GroupContentEnabler\GroupNode;
  * Provides a content enabler for Event nodes.
  *
  * @GroupContentEnabler(
- *   id = "group_node",
+ *   id = "group_event_node",
  *   label = @Translation("Group node events"),
  *   description = @Translation("Adds event nodes to groups both publicly and privately."),
  *   entity_type_id = "node",
@@ -16,7 +16,6 @@ use Drupal\gnode\Plugin\GroupContentEnabler\GroupNode;
  *   entity_access = TRUE,
  *   reference_label = @Translation("Title"),
  *   reference_description = @Translation("The title of the node to add to the group"),
- *   deriver = "Drupal\gnode\Plugin\GroupContentEnabler\GroupNodeDeriver",
  *   handlers = {
  *     "access" = "Drupal\social_event_managers\Plugin\EventsGroupContentAccessControlHandler",
  *     "permission_provider" = "Drupal\gnode\Plugin\GroupNodePermissionProvider",


### PR DESCRIPTION
## Problem
When I try to uninstall `social_event_managers` module, I get an error:

```
social_event_managers: The following group content plugins still have content for them: <em class="placeholder">Group node (Article)</em>.
```

It means that group_node:news GroupContentType is attached to a plugin that is wrongly provided by `social_event_managers`.


It is confirmed when I go on my group available-content configuration page:
`/admin/group/types/manage/{myGroupType}/content`
It shows that Group nodes (Article) (and any other GroupNode derivers) are provided by `social_event_managers` module, instead of `group_node`.

## Solution
* Set another id (`group_event_node` instead of `group_node`) for the GroupEventNode plugin.
* Remove the deriver plugin definition since this plugin only concerns nodes with `event` as `entity_bundle`

## Issue tracker
[https://www.drupal.org/project/social/issues/3372323](https://www.drupal.org/project/social/issues/3372323)

## How to test
- [ ] Using version 11.9.x of Open Social with the `social_event_managers` module enabled
- [ ] As a sitemanager
- [ ] When I configure what content is available for a given group type (`/admin/group/types/manage/{group_type}/content`)
- [ ] I'm able to install "Group node (Article)" thanks to the GroupContentEnabler (and its derivers) provided by `group_node` module. (`admin/group/content/install/{group_type}/group_node%3Anews`)
- [ ] I should see on that available content page, that this "Group node (Article)" group content is provided by `group_node`, but it's actually written that `social_event_managers` provides it.
- [ ] As a result, If I post a news in this group, I cannot uninstall `social_event_managers` module anymore since it's considered as provider for a plugin that is concerned by published content.

## Considerations
Since this plugin also declares the same derivers that `GroupNode` plugin. If we only set a different plugin_id in annotation, we get duplications for each node types.

Since this plugin should only take care of `event` node type, removing `deriver` declaration solves this issue.
