### PR TITLE
Issue #3374114 - Add patch to prevent duplicate tables created by DB backend

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -94,7 +94,8 @@
             },
             "drupal/search_api": {
                 "Ensure field definition allowed values callbacks are used for field filter callbacks": "https://www.drupal.org/files/issues/2020-06-03/2949022-12--views_filter_options_callback.patch",
-                "Selecting the same day in a date between filter returns no results": "https://www.drupal.org/files/issues/2021-05-05/date_between_2842409_2_d8.patch"
+                "Selecting the same day in a date between filter returns no results": "https://www.drupal.org/files/issues/2021-05-05/date_between_2842409_2_d8.patch",
+                "#3324776 - indexItem can cause database to fill up with duplicated tables for field": "https://www.drupal.org/files/issues/2022-12-01/3324776-search_api-2.patch"
             },
             "drupal/url_embed": {
                 "Translate dialog title": "https://www.drupal.org/files/issues/2018-03-16/url_embed_translate_dialog_title-2953591-2.patch",


### PR DESCRIPTION
## Problem
Within Open Social we've found some scenarios that can cause a table to be created in the database for a field, but the Search API does not properly track that this field was added to the index. This causes the table to be recreated every time a new item is added to the index which can cause the site to break by filling up the database with duplicate tables.

## Solution
Reload $db_info in indexItem after calling fieldsUpdated.

## Issue tracker
https://www.drupal.org/node/3374114

## How to test
- [ ] Enable social_tagging
- [ ] Make sure solr is not enabled
- [ ] Try switching category split in the tagging settings of Open Social
- [ ] Also create multiple content with tags
- [ ] Notice that tables in the database from search_api get duplicated like _1 _2 _3
- [ ] Check out to this branch and try again

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Release notes
We have patched the search_api contrib module with a fix to avoid duplication of search api tables when using social tagging, what can cause if not seen in time overload of tables crashing the database.

