### PR TITLE
Issue #3377397 by Kovalskiy266: Fix duplication of event enrollees and organizers

### DIFF
--- a/modules/social_features/social_event/config/install/views.view.event_enrollments.yml
+++ b/modules/social_features/social_event/config/install/views.view.event_enrollments.yml
@@ -35,7 +35,7 @@ display:
         type: views_query
         options:
           disable_sql_rewrite: false
-          distinct: false
+          distinct: true
           replica: false
           query_comment: ''
           query_tags: {  }

--- a/modules/social_features/social_event/config/install/views.view.event_manage_enrollment_requests.yml
+++ b/modules/social_features/social_event/config/install/views.view.event_manage_enrollment_requests.yml
@@ -38,7 +38,7 @@ display:
         type: views_query
         options:
           disable_sql_rewrite: false
-          distinct: false
+          distinct: true
           replica: false
           query_comment: ''
           query_tags: {  }

--- a/modules/social_features/social_event/modules/social_event_an_enroll/config/install/views.view.manage_enrollments.yml
+++ b/modules/social_features/social_event/modules/social_event_an_enroll/config/install/views.view.manage_enrollments.yml
@@ -32,7 +32,7 @@ display:
         type: views_query
         options:
           disable_sql_rewrite: false
-          distinct: false
+          distinct: true
           replica: false
           query_comment: ''
           query_tags: {  }

--- a/modules/social_features/social_event/modules/social_event_invite/config/install/views.view.event_manage_enrollment_invites.yml
+++ b/modules/social_features/social_event/modules/social_event_invite/config/install/views.view.event_manage_enrollment_invites.yml
@@ -38,7 +38,7 @@ display:
         type: views_query
         options:
           disable_sql_rewrite: false
-          distinct: false
+          distinct: true
           replica: false
           query_comment: ''
           query_tags: {  }

--- a/modules/social_features/social_event/modules/social_event_managers/config/install/views.view.event_manage_enrollments.yml
+++ b/modules/social_features/social_event/modules/social_event_managers/config/install/views.view.event_manage_enrollments.yml
@@ -37,7 +37,7 @@ display:
         type: views_query
         options:
           disable_sql_rewrite: false
-          distinct: false
+          distinct: true
           replica: false
           query_comment: ''
           query_tags: {  }

--- a/modules/social_features/social_event/modules/social_event_managers/config/install/views.view.managers.yml
+++ b/modules/social_features/social_event/modules/social_event_managers/config/install/views.view.managers.yml
@@ -34,7 +34,7 @@ display:
         type: views_query
         options:
           disable_sql_rewrite: false
-          distinct: false
+          distinct: true
           replica: false
           query_comment: ''
           query_tags: {  }

--- a/modules/social_features/social_event/social_event.install
+++ b/modules/social_features/social_event/social_event.install
@@ -2295,3 +2295,32 @@ function social_event_update_11903(): void {
     \Drupal::logger('social_event')->error($e->getMessage());
   }
 }
+
+/**
+ * Update the views that are associated with enrolling in an event.
+ *
+ * To prevent duplication of users.
+ */
+function social_event_update_11904(): void {
+  $configs = [
+    'event_enrollments',
+    'event_manage_enrollments',
+    'manage_enrollments',
+    'event_manage_enrollment_invites',
+    'event_manage_enrollment_requests',
+    'managers',
+  ];
+
+  // Updating views that are responsible for receiving users,
+  // who have enrolled for an event or are the organisers of this event.
+  foreach ($configs as $config_name) {
+    $config_value = \Drupal::configFactory()->getEditable('views.view.' . $config_name);
+    if ($config_value !== NULL) {
+      $data = $config_value->getRawData();
+      if (isset($data['display']['default']['display_options']['query']['options']['distinct'])) {
+        $data['display']['default']['display_options']['query']['options']['distinct'] = TRUE;
+        $config_value->setData($data)->save();
+      }
+    }
+  }
+}

--- a/tests/behat/features/bootstrap/SocialMinkContext.php
+++ b/tests/behat/features/bootstrap/SocialMinkContext.php
@@ -306,4 +306,15 @@ class SocialMinkContext extends MinkContext {
       }
     }
   }
+
+  /**
+   * @Then /^I should see "([^"]*)" exactly "([^"]*)" times$/
+   */
+  public function iShouldSeeTheTextCertainNumberTimes($text, $expectedNumber): void {
+    $allText = $this->getSession()->getPage()->getText();
+    $numberText = substr_count($allText, $text);
+    if ($expectedNumber != $numberText) {
+      throw new \Exception('Found '.$numberText.' times of "'.$text.'" when expecting '.$expectedNumber);
+    }
+  }
 }


### PR DESCRIPTION
## Problem
If you add a translation to an event, it leads to duplicate enrollees and event organisers. This also applies to invitations and requests.

## Solution
Update the configurations of the views that are responsible for this, namely, enable the distinct option to prevent duplication.

## Issue tracker

- https://getopensocial.atlassian.net/browse/PROD-22011
- https://www.drupal.org/project/social/issues/3377397

## Theme issue tracker
N/A

## How to test
- [ ] As a sitemanager
- [ ] Create a new event and add translations to this event
- [ ] Enrol for this event
- [ ] Go to "Manage enrollments" page
- [ ] You will see that enrollees are duplicated
- [ ]  Also go to organisers page
- [ ] You will see that organisers are duplicated

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
![image](https://github.com/goalgorilla/open_social/assets/85495223/846ac28a-a5c7-4a4c-aadb-5c0f40195ff9)
![image](https://github.com/goalgorilla/open_social/assets/85495223/8ad96e94-9574-49e7-807b-92efdb372aaf)

## Release notes
Fixes issue with duplication event enrollees and organisers, when event has several translations.

## Change Record
N/A

## Translations
N/A
