### PR TITLE
Issue #3380523 by SV: Fix untranslated CTA token in email notifications for multilingual sites

### DIFF
--- a/modules/custom/activity_creator/src/ActivityFactory.php
+++ b/modules/custom/activity_creator/src/ActivityFactory.php
@@ -564,7 +564,11 @@ class ActivityFactory extends ControllerBase {
    * @param array $output
    *   The templated text to be replaced.
    * @param array $options
-   *   Token options.
+   *   A keyed array of token options. Supported options are:
+   *   - langcode: A language code to be used when generating locale-sensitive
+   *     tokens.
+   *   - clear: A boolean flag indicating that tokens should be removed from the
+   *     final text if no replacement value can be generated.
    * @param \Drupal\message\Entity\Message $message
    *   Message object.
    *

--- a/modules/custom/activity_creator/src/ActivityFactory.php
+++ b/modules/custom/activity_creator/src/ActivityFactory.php
@@ -505,8 +505,12 @@ class ActivityFactory extends ControllerBase {
 
     $token_options = $message_template->getSetting('token options', []);
     if (!empty($token_options['token replace'])) {
+      $options = [
+        'langcode' => !empty($langcode) ? $langcode : '',
+        'clear' => !empty($token_options['clear']),
+      ];
       // Token should be processed.
-      $output = $this->processTokens($output, !empty($token_options['clear']), $message);
+      $output = $this->processTokens($output, $options, $message);
     }
 
     return $output;
@@ -559,8 +563,8 @@ class ActivityFactory extends ControllerBase {
    *
    * @param array $output
    *   The templated text to be replaced.
-   * @param bool $clear
-   *   Determine if unused token should be cleared.
+   * @param array $options
+   *   Token options.
    * @param \Drupal\message\Entity\Message $message
    *   Message object.
    *
@@ -568,11 +572,7 @@ class ActivityFactory extends ControllerBase {
    *   The output with placeholders replaced with the token value,
    *   if there are indeed tokens.
    */
-  protected function processTokens(array $output, $clear, Message $message) {
-    $options = [
-      'clear' => $clear,
-    ];
-
+  protected function processTokens(array $output, array $options, Message $message) {
     $bubbleable_metadata = new BubbleableMetadata();
     foreach ($output as $key => $value) {
       if (is_string($value)) {

--- a/modules/custom/activity_creator/src/ActivityFactory.php
+++ b/modules/custom/activity_creator/src/ActivityFactory.php
@@ -564,11 +564,15 @@ class ActivityFactory extends ControllerBase {
    * @param array $output
    *   The templated text to be replaced.
    * @param array $options
-   *   A keyed array of token options. Supported options are:
-   *   - langcode: A language code to be used when generating locale-sensitive
-   *     tokens.
-   *   - clear: A boolean flag indicating that tokens should be removed from the
-   *     final text if no replacement value can be generated.
+   *   A keyed array of settings and flags to control the token
+   *    replacement process. Supported options are:
+   *    - langcode: A language code to be used when generating locale-sensitive
+   *      tokens.
+   *    - callback: A callback function that will be used to post-process the
+   *      array of token replacements after they are generated.
+   *    - clear: A boolean flag indicating that tokens should be removed from
+   *      the final text if no replacement value can be generated.
+   *   This will be passed to \Drupal\Core\Utility\Token::replace().
    * @param \Drupal\message\Entity\Message $message
    *   Message object.
    *

--- a/modules/social_features/social_activity/social_activity.tokens.inc
+++ b/modules/social_features/social_activity/social_activity.tokens.inc
@@ -51,6 +51,11 @@ function social_activity_tokens($type, $tokens, array $data, array $options, Bub
   $replacements = [];
 
   if ($type === 'message' && !empty($data['message'])) {
+    // Translate hook_tokens options to the options for TranslatableMarkup.
+    $translation_options = [
+      'langcode' => $options['langcode'] ?? NULL,
+    ];
+
     /** @var \Drupal\message\Entity\Message $message */
     $message = $data['message'];
 
@@ -78,7 +83,7 @@ function social_activity_tokens($type, $tokens, array $data, array $options, Bub
           $preview_info = $email_token_services->getPostPreview($entity);
 
           // Prepare CTA button information.
-          $cta_button = $email_token_services->getCtaButton($link, new TranslatableMarkup('Leave a comment', [], $options));
+          $cta_button = $email_token_services->getCtaButton($link, new TranslatableMarkup('Leave a comment', [], $translation_options));
 
           // This is for token deprecated token 'additional_information'.
           $additional_information = [
@@ -99,7 +104,7 @@ function social_activity_tokens($type, $tokens, array $data, array $options, Bub
             $link = $node->toUrl('canonical', ['absolute' => TRUE]);
 
             // Prepare the CTA button markup.
-            $cta_button = $email_token_services->getCtaButton($link, new TranslatableMarkup('Read more', [], $options));
+            $cta_button = $email_token_services->getCtaButton($link, new TranslatableMarkup('Read more', [], $translation_options));
 
             // This is for token deprecated token 'additional_information'.
             $additional_information = [

--- a/modules/social_features/social_activity/social_activity.tokens.inc
+++ b/modules/social_features/social_activity/social_activity.tokens.inc
@@ -78,7 +78,7 @@ function social_activity_tokens($type, $tokens, array $data, array $options, Bub
           $preview_info = $email_token_services->getPostPreview($entity);
 
           // Prepare CTA button information.
-          $cta_button = $email_token_services->getCtaButton($link, new TranslatableMarkup('Leave a comment'));
+          $cta_button = $email_token_services->getCtaButton($link, new TranslatableMarkup('Leave a comment', [], $options));
 
           // This is for token deprecated token 'additional_information'.
           $additional_information = [
@@ -99,7 +99,7 @@ function social_activity_tokens($type, $tokens, array $data, array $options, Bub
             $link = $node->toUrl('canonical', ['absolute' => TRUE]);
 
             // Prepare the CTA button markup.
-            $cta_button = $email_token_services->getCtaButton($link, new TranslatableMarkup('Read more'));
+            $cta_button = $email_token_services->getCtaButton($link, new TranslatableMarkup('Read more', [], $options));
 
             // This is for token deprecated token 'additional_information'.
             $additional_information = [

--- a/modules/social_features/social_comment/social_comment.tokens.inc
+++ b/modules/social_features/social_comment/social_comment.tokens.inc
@@ -285,7 +285,7 @@ function social_comment_tokens_alter(array &$replacements, array $context, Bubbl
                 /** @var \Drupal\Core\Entity\EntityInterface $commented_entity */
                 $link = $commented_entity->toUrl('canonical', ['absolute' => TRUE, 'fragment' => 'comment-' . $comment->id()]);
 
-                $cta_button = $email_token_services->getCtaButton($link, new TranslatableMarkup('Reply to this comment'));
+                $cta_button = $email_token_services->getCtaButton($link, new TranslatableMarkup('Reply to this comment', [], $context['options']));
                 $replacements[$context['tokens']['cta_button']] = \Drupal::service('renderer')->renderPlain($cta_button);
               }
 

--- a/modules/social_features/social_comment/social_comment.tokens.inc
+++ b/modules/social_features/social_comment/social_comment.tokens.inc
@@ -259,6 +259,11 @@ function social_comment_tokens($type, $tokens, array $data, array $options, Bubb
  */
 function social_comment_tokens_alter(array &$replacements, array $context, BubbleableMetadata $bubbleable_metadata) {
   if ($context['type'] == 'message' && !empty($context['data']['message'])) {
+    // Translate hook_tokens options to the options for TranslatableMarkup.
+    $translation_options = [
+      'langcode' => $context['options']['langcode'] ?? NULL,
+    ];
+
     /** @var Drupal\message\Entity\Message $message */
     $message = $context['data']['message'];
 
@@ -285,7 +290,7 @@ function social_comment_tokens_alter(array &$replacements, array $context, Bubbl
                 /** @var \Drupal\Core\Entity\EntityInterface $commented_entity */
                 $link = $commented_entity->toUrl('canonical', ['absolute' => TRUE, 'fragment' => 'comment-' . $comment->id()]);
 
-                $cta_button = $email_token_services->getCtaButton($link, new TranslatableMarkup('Reply to this comment', [], $context['options']));
+                $cta_button = $email_token_services->getCtaButton($link, new TranslatableMarkup('Reply to this comment', [], $translation_options));
                 $replacements[$context['tokens']['cta_button']] = \Drupal::service('renderer')->renderPlain($cta_button);
               }
 

--- a/modules/social_features/social_content_report/social_content_report.tokens.inc
+++ b/modules/social_features/social_content_report/social_content_report.tokens.inc
@@ -78,6 +78,11 @@ function social_content_report_tokens($type, $tokens, array $data, array $option
  */
 function social_content_report_tokens_alter(array &$replacements, array $context, BubbleableMetadata $bubbleable_metadata) {
   if ($context['type'] == 'message' && !empty($context['data']['message'])) {
+    // Translate hook_tokens options to the options for TranslatableMarkup.
+    $translation_options = [
+      'langcode' => $context['options']['langcode'] ?? NULL,
+    ];
+
     /** @var Drupal\message\Entity\Message $message */
     $message = $context['data']['message'];
 
@@ -100,7 +105,7 @@ function social_content_report_tokens_alter(array &$replacements, array $context
             // Replace the preview token.
             if (isset($context['tokens']['cta_button'])) {
               $link = Url::fromRoute('view.report_overview.overview');
-              $cta_button = $email_token_services->getCtaButton($link, new TranslatableMarkup('Check the reported contents', [], $context['options']));
+              $cta_button = $email_token_services->getCtaButton($link, new TranslatableMarkup('Check the reported contents', [], $translation_options));
               $replacements[$context['tokens']['cta_button']] = \Drupal::service('renderer')->renderPlain($cta_button);
             }
 

--- a/modules/social_features/social_content_report/social_content_report.tokens.inc
+++ b/modules/social_features/social_content_report/social_content_report.tokens.inc
@@ -100,7 +100,7 @@ function social_content_report_tokens_alter(array &$replacements, array $context
             // Replace the preview token.
             if (isset($context['tokens']['cta_button'])) {
               $link = Url::fromRoute('view.report_overview.overview');
-              $cta_button = $email_token_services->getCtaButton($link, new TranslatableMarkup('Check the reported contents'));
+              $cta_button = $email_token_services->getCtaButton($link, new TranslatableMarkup('Check the reported contents', [], $context['options']));
               $replacements[$context['tokens']['cta_button']] = \Drupal::service('renderer')->renderPlain($cta_button);
             }
 

--- a/modules/social_features/social_event/social_event.tokens.inc
+++ b/modules/social_features/social_event/social_event.tokens.inc
@@ -119,14 +119,14 @@ function social_event_tokens_alter(array &$replacements, array $context, Bubblea
               switch ($message_template_id) {
                 case 'activity_on_events_im_organizing':
                   $link = Url::fromRoute('view.event_manage_enrollments.page_manage_enrollments', ['node' => $event->id()]);
-                  $cta_button = $email_token_services->getCtaButton($link, new TranslatableMarkup('View enrollments'));
+                  $cta_button = $email_token_services->getCtaButton($link, new TranslatableMarkup('View enrollments', [], $context['options']));
                   $replacements[$context['tokens']['cta_button']] = \Drupal::service('renderer')
                     ->renderPlain($cta_button);
                   break;
 
                 case 'request_event_enrollment':
                   $link = Url::fromRoute('view.event_manage_enrollment_requests.page_manage_enrollment_requests', ['node' => $event->id()]);
-                  $cta_button = $email_token_services->getCtaButton($link, new TranslatableMarkup('View enrollment requests'));
+                  $cta_button = $email_token_services->getCtaButton($link, new TranslatableMarkup('View enrollment requests', [], $context['options']));
                   $replacements[$context['tokens']['cta_button']] = \Drupal::service('renderer')
                     ->renderPlain($cta_button);
                   break;
@@ -134,14 +134,14 @@ function social_event_tokens_alter(array &$replacements, array $context, Bubblea
                 case 'member_added_by_event_organiser':
                 case 'event_request_approved':
                   $link = $event->toUrl('canonical');
-                  $cta_button = $email_token_services->getCtaButton($link, new TranslatableMarkup('See the event'));
+                  $cta_button = $email_token_services->getCtaButton($link, new TranslatableMarkup('See the event', [], $context['options']));
                   $replacements[$context['tokens']['cta_button']] = \Drupal::service('renderer')
                     ->renderPlain($cta_button);
                   break;
 
                 case 'user_was_enrolled_to_event':
                   $link = $event->toUrl();
-                  $cta_button = $email_token_services->getCtaButton($link, new TranslatableMarkup('See event details'));
+                  $cta_button = $email_token_services->getCtaButton($link, new TranslatableMarkup('See event details', [], $context['options']));
                   $replacements[$context['tokens']['cta_button']] = \Drupal::service('renderer')
                     ->renderPlain($cta_button);
                   break;

--- a/modules/social_features/social_event/social_event.tokens.inc
+++ b/modules/social_features/social_event/social_event.tokens.inc
@@ -99,6 +99,11 @@ function social_event_tokens($type, $tokens, array $data, array $options, Bubble
  */
 function social_event_tokens_alter(array &$replacements, array $context, BubbleableMetadata $bubbleable_metadata) {
   if ($context['type'] == 'message' && !empty($context['data']['message'])) {
+    // Translate hook_tokens options to the options for TranslatableMarkup.
+    $translation_options = [
+      'langcode' => $context['options']['langcode'] ?? NULL,
+    ];
+
     /** @var Drupal\message\Entity\Message $message */
     $message = $context['data']['message'];
 
@@ -119,14 +124,14 @@ function social_event_tokens_alter(array &$replacements, array $context, Bubblea
               switch ($message_template_id) {
                 case 'activity_on_events_im_organizing':
                   $link = Url::fromRoute('view.event_manage_enrollments.page_manage_enrollments', ['node' => $event->id()]);
-                  $cta_button = $email_token_services->getCtaButton($link, new TranslatableMarkup('View enrollments', [], $context['options']));
+                  $cta_button = $email_token_services->getCtaButton($link, new TranslatableMarkup('View enrollments', [], $translation_options));
                   $replacements[$context['tokens']['cta_button']] = \Drupal::service('renderer')
                     ->renderPlain($cta_button);
                   break;
 
                 case 'request_event_enrollment':
                   $link = Url::fromRoute('view.event_manage_enrollment_requests.page_manage_enrollment_requests', ['node' => $event->id()]);
-                  $cta_button = $email_token_services->getCtaButton($link, new TranslatableMarkup('View enrollment requests', [], $context['options']));
+                  $cta_button = $email_token_services->getCtaButton($link, new TranslatableMarkup('View enrollment requests', [], $translation_options));
                   $replacements[$context['tokens']['cta_button']] = \Drupal::service('renderer')
                     ->renderPlain($cta_button);
                   break;
@@ -134,14 +139,14 @@ function social_event_tokens_alter(array &$replacements, array $context, Bubblea
                 case 'member_added_by_event_organiser':
                 case 'event_request_approved':
                   $link = $event->toUrl('canonical');
-                  $cta_button = $email_token_services->getCtaButton($link, new TranslatableMarkup('See the event', [], $context['options']));
+                  $cta_button = $email_token_services->getCtaButton($link, new TranslatableMarkup('See the event', [], $translation_options));
                   $replacements[$context['tokens']['cta_button']] = \Drupal::service('renderer')
                     ->renderPlain($cta_button);
                   break;
 
                 case 'user_was_enrolled_to_event':
                   $link = $event->toUrl();
-                  $cta_button = $email_token_services->getCtaButton($link, new TranslatableMarkup('See event details', [], $context['options']));
+                  $cta_button = $email_token_services->getCtaButton($link, new TranslatableMarkup('See event details', [], $translation_options));
                   $replacements[$context['tokens']['cta_button']] = \Drupal::service('renderer')
                     ->renderPlain($cta_button);
                   break;

--- a/modules/social_features/social_follow_taxonomy/social_follow_taxonomy.tokens.inc
+++ b/modules/social_features/social_follow_taxonomy/social_follow_taxonomy.tokens.inc
@@ -194,6 +194,11 @@ function social_follow_taxonomy_tokens($type, $tokens, array $data, array $optio
  */
 function social_follow_taxonomy_tokens_alter(array &$replacements, array $context, BubbleableMetadata $bubbleable_metadata) {
   if ($context['type'] == 'message' && !empty($context['data']['message'])) {
+    // Translate hook_tokens options to the options for TranslatableMarkup.
+    $translation_options = [
+      'langcode' => $context['options']['langcode'] ?? NULL,
+    ];
+
     /** @var Drupal\message\Entity\Message $message */
     $message = $context['data']['message'];
 
@@ -212,7 +217,7 @@ function social_follow_taxonomy_tokens_alter(array &$replacements, array $contex
             case 'update_node_following_tag':
               if (isset($context['tokens']['cta_button'])) {
                 $link = $entity->toUrl('canonical', ['absolute' => TRUE]);
-                $cta_button = $email_token_services->getCtaButton($link, new TranslatableMarkup('Read more about it', [], $context['options']));
+                $cta_button = $email_token_services->getCtaButton($link, new TranslatableMarkup('Read more about it', [], $translation_options));
                 $replacements[$context['tokens']['cta_button']] = \Drupal::service('renderer')
                   ->renderPlain($cta_button);
               }

--- a/modules/social_features/social_follow_taxonomy/social_follow_taxonomy.tokens.inc
+++ b/modules/social_features/social_follow_taxonomy/social_follow_taxonomy.tokens.inc
@@ -212,7 +212,7 @@ function social_follow_taxonomy_tokens_alter(array &$replacements, array $contex
             case 'update_node_following_tag':
               if (isset($context['tokens']['cta_button'])) {
                 $link = $entity->toUrl('canonical', ['absolute' => TRUE]);
-                $cta_button = $email_token_services->getCtaButton($link, new TranslatableMarkup('Read more about it'));
+                $cta_button = $email_token_services->getCtaButton($link, new TranslatableMarkup('Read more about it', [], $context['options']));
                 $replacements[$context['tokens']['cta_button']] = \Drupal::service('renderer')
                   ->renderPlain($cta_button);
               }

--- a/modules/social_features/social_group/modules/social_group_request/social_group_request.tokens.inc
+++ b/modules/social_features/social_group/modules/social_group_request/social_group_request.tokens.inc
@@ -98,7 +98,7 @@ function social_group_request_tokens_alter(array &$replacements, array $context,
                 if (isset($context['tokens']['cta_button'])) {
                   $link = Url::fromRoute('view.group_pending_members.membership_requests', ['arg_0' => $group->id()],
                     ['absolute' => TRUE]);
-                  $cta_button = $email_token_services->getCtaButton($link, new TranslatableMarkup('View the requests'));
+                  $cta_button = $email_token_services->getCtaButton($link, new TranslatableMarkup('View the requests', [], $context['options']));
                   $replacements[$context['tokens']['cta_button']] = \Drupal::service('renderer')
                     ->renderPlain($cta_button);
                 }

--- a/modules/social_features/social_group/modules/social_group_request/social_group_request.tokens.inc
+++ b/modules/social_features/social_group/modules/social_group_request/social_group_request.tokens.inc
@@ -76,6 +76,11 @@ function social_group_request_tokens($type, $tokens, array $data, array $options
  */
 function social_group_request_tokens_alter(array &$replacements, array $context, BubbleableMetadata $bubbleable_metadata) {
   if ($context['type'] == 'message' && !empty($context['data']['message'])) {
+    // Translate hook_tokens options to the options for TranslatableMarkup.
+    $translation_options = [
+      'langcode' => $context['options']['langcode'] ?? NULL,
+    ];
+
     /** @var Drupal\message\Entity\Message $message */
     $message = $context['data']['message'];
 
@@ -98,7 +103,7 @@ function social_group_request_tokens_alter(array &$replacements, array $context,
                 if (isset($context['tokens']['cta_button'])) {
                   $link = Url::fromRoute('view.group_pending_members.membership_requests', ['arg_0' => $group->id()],
                     ['absolute' => TRUE]);
-                  $cta_button = $email_token_services->getCtaButton($link, new TranslatableMarkup('View the requests', [], $context['options']));
+                  $cta_button = $email_token_services->getCtaButton($link, new TranslatableMarkup('View the requests', [], $translation_options));
                   $replacements[$context['tokens']['cta_button']] = \Drupal::service('renderer')
                     ->renderPlain($cta_button);
                 }

--- a/modules/social_features/social_group/social_group.tokens.inc
+++ b/modules/social_features/social_group/social_group.tokens.inc
@@ -176,7 +176,7 @@ function social_group_tokens_alter(array &$replacements, array $context, Bubblea
               switch ($message_template_id) {
                 case 'approve_request_join_group':
                   if (isset($context['tokens']['cta_button'])) {
-                    $cta_button = $email_token_services->getCtaButton($link, new TranslatableMarkup('Explore the group'));
+                    $cta_button = $email_token_services->getCtaButton($link, new TranslatableMarkup('Explore the group', [], $context['options']));
                     $replacements[$context['tokens']['cta_button']] = \Drupal::service('renderer')
                       ->renderPlain($cta_button);
                   }

--- a/modules/social_features/social_group/social_group.tokens.inc
+++ b/modules/social_features/social_group/social_group.tokens.inc
@@ -190,7 +190,7 @@ function social_group_tokens_alter(array &$replacements, array $context, Bubblea
                 case 'join_to_group':
                   if (isset($context['tokens']['cta_button'])) {
                     $link = Url::fromRoute('view.group_members.page_group_members', ['group' => $group_content->getGroup()->id()]);
-                    $cta_button = $email_token_services->getCtaButton($link, new TranslatableMarkup('See all members'));
+                    $cta_button = $email_token_services->getCtaButton($link, new TranslatableMarkup('See all members', [], $context['options']));
                     $replacements[$context['tokens']['cta_button']] = \Drupal::service('renderer')
                       ->renderPlain($cta_button);
                   }

--- a/modules/social_features/social_group/social_group.tokens.inc
+++ b/modules/social_features/social_group/social_group.tokens.inc
@@ -156,6 +156,11 @@ function social_group_tokens_alter(array &$replacements, array $context, Bubblea
     // Alter the [message:cta_button] and [message:preview] token, and
     // replace it with the rendered content with new text and link.
     if (isset($context['tokens']['cta_button'])|| isset($context['tokens']['preview'])) {
+      // Translate hook_tokens options to the options for TranslatableMarkup.
+      $translation_options = [
+        'langcode' => $context['options']['langcode'] ?? NULL,
+      ];
+
       /** @var Drupal\message\Entity\Message $message */
       $message = $context['data']['message'];
 
@@ -176,7 +181,7 @@ function social_group_tokens_alter(array &$replacements, array $context, Bubblea
               switch ($message_template_id) {
                 case 'approve_request_join_group':
                   if (isset($context['tokens']['cta_button'])) {
-                    $cta_button = $email_token_services->getCtaButton($link, new TranslatableMarkup('Explore the group', [], $context['options']));
+                    $cta_button = $email_token_services->getCtaButton($link, new TranslatableMarkup('Explore the group', [], $translation_options));
                     $replacements[$context['tokens']['cta_button']] = \Drupal::service('renderer')
                       ->renderPlain($cta_button);
                   }
@@ -190,7 +195,7 @@ function social_group_tokens_alter(array &$replacements, array $context, Bubblea
                 case 'join_to_group':
                   if (isset($context['tokens']['cta_button'])) {
                     $link = Url::fromRoute('view.group_members.page_group_members', ['group' => $group_content->getGroup()->id()]);
-                    $cta_button = $email_token_services->getCtaButton($link, new TranslatableMarkup('See all members', [], $context['options']));
+                    $cta_button = $email_token_services->getCtaButton($link, new TranslatableMarkup('See all members', [], $translation_options));
                     $replacements[$context['tokens']['cta_button']] = \Drupal::service('renderer')
                       ->renderPlain($cta_button);
                   }

--- a/modules/social_features/social_like/social_like.tokens.inc
+++ b/modules/social_features/social_like/social_like.tokens.inc
@@ -141,6 +141,11 @@ function social_like_tokens($type, $tokens, array $data, array $options, Bubblea
  */
 function social_like_tokens_alter(array &$replacements, array $context, BubbleableMetadata $bubbleable_metadata) {
   if ($context['type'] == 'message' && !empty($context['data']['message'])) {
+    // Translate hook_tokens options to the options for TranslatableMarkup.
+    $translation_options = [
+      'langcode' => $context['options']['langcode'] ?? NULL,
+    ];
+
     /** @var Drupal\message\Entity\Message $message */
     $message = $context['data']['message'];
 
@@ -177,7 +182,7 @@ function social_like_tokens_alter(array &$replacements, array $context, Bubbleab
                   $commented_entity = $voted_entity->getCommentedEntity();
                   $link = $commented_entity->toUrl('canonical', $url_options);
                 }
-                $cta_button = $email_token_services->getCtaButton($link, new TranslatableMarkup('See all likes', [], $context['options']));
+                $cta_button = $email_token_services->getCtaButton($link, new TranslatableMarkup('See all likes', [], $translation_options));
                 $replacements[$context['tokens']['cta_button']] = \Drupal::service('renderer')
                   ->renderPlain($cta_button);
               }

--- a/modules/social_features/social_like/social_like.tokens.inc
+++ b/modules/social_features/social_like/social_like.tokens.inc
@@ -177,7 +177,7 @@ function social_like_tokens_alter(array &$replacements, array $context, Bubbleab
                   $commented_entity = $voted_entity->getCommentedEntity();
                   $link = $commented_entity->toUrl('canonical', $url_options);
                 }
-                $cta_button = $email_token_services->getCtaButton($link, new TranslatableMarkup('See all likes'));
+                $cta_button = $email_token_services->getCtaButton($link, new TranslatableMarkup('See all likes', [], $context['options']));
                 $replacements[$context['tokens']['cta_button']] = \Drupal::service('renderer')
                   ->renderPlain($cta_button);
               }

--- a/modules/social_features/social_mentions/social_mentions.tokens.inc
+++ b/modules/social_features/social_mentions/social_mentions.tokens.inc
@@ -175,6 +175,11 @@ function social_mentions_tokens($type, $tokens, array $data, array $options, Bub
  */
 function social_mentions_tokens_alter(array &$replacements, array $context, BubbleableMetadata $bubbleable_metadata) {
   if ($context['type'] == 'message' && !empty($context['data']['message'])) {
+    // Translate hook_tokens options to the options for TranslatableMarkup.
+    $translation_options = [
+      'langcode' => $context['options']['langcode'] ?? NULL,
+    ];
+
     /** @var Drupal\message\Entity\Message $message */
     $message = $context['data']['message'];
 
@@ -240,7 +245,7 @@ function social_mentions_tokens_alter(array &$replacements, array $context, Bubb
                 }
 
                 $link = $entity->toUrl('canonical', $options);
-                $cta_button = $email_token_services->getCtaButton($link, new TranslatableMarkup('Reply to this comment', [], $context['options']));
+                $cta_button = $email_token_services->getCtaButton($link, new TranslatableMarkup('Reply to this comment', [], $translation_options));
                 $replacements[$context['tokens']['cta_button']] = \Drupal::service('renderer')
                   ->renderPlain($cta_button);
               }

--- a/modules/social_features/social_mentions/social_mentions.tokens.inc
+++ b/modules/social_features/social_mentions/social_mentions.tokens.inc
@@ -240,7 +240,7 @@ function social_mentions_tokens_alter(array &$replacements, array $context, Bubb
                 }
 
                 $link = $entity->toUrl('canonical', $options);
-                $cta_button = $email_token_services->getCtaButton($link, new TranslatableMarkup('Reply to this comment'));
+                $cta_button = $email_token_services->getCtaButton($link, new TranslatableMarkup('Reply to this comment', [], $context['options']));
                 $replacements[$context['tokens']['cta_button']] = \Drupal::service('renderer')
                   ->renderPlain($cta_button);
               }

--- a/modules/social_features/social_private_message/social_private_message.tokens.inc
+++ b/modules/social_features/social_private_message/social_private_message.tokens.inc
@@ -43,7 +43,7 @@ function social_private_message_tokens_alter(array &$replacements, array $contex
                   ['private_message_thread' => $thread_id],
                   ['absolute' => TRUE]
                 );
-                $cta_button = $email_token_services->getCtaButton($thread_url, new TranslatableMarkup('Reply to this message'));
+                $cta_button = $email_token_services->getCtaButton($thread_url, new TranslatableMarkup('Reply to this message', [], $context['options']));
                 if (!empty($cta_button)) {
                   $replacements[$context['tokens']['cta_button']] = \Drupal::service('renderer')->renderPlain($cta_button);
                 }

--- a/modules/social_features/social_private_message/social_private_message.tokens.inc
+++ b/modules/social_features/social_private_message/social_private_message.tokens.inc
@@ -14,6 +14,11 @@ use Drupal\Core\Url;
  */
 function social_private_message_tokens_alter(array &$replacements, array $context, BubbleableMetadata $bubbleable_metadata) {
   if ($context['type'] == 'message' && !empty($context['data']['message'])) {
+    // Translate hook_tokens options to the options for TranslatableMarkup.
+    $translation_options = [
+      'langcode' => $context['options']['langcode'] ?? NULL,
+    ];
+
     /** @var Drupal\message\Entity\Message $message */
     $message = $context['data']['message'];
 
@@ -43,7 +48,7 @@ function social_private_message_tokens_alter(array &$replacements, array $contex
                   ['private_message_thread' => $thread_id],
                   ['absolute' => TRUE]
                 );
-                $cta_button = $email_token_services->getCtaButton($thread_url, new TranslatableMarkup('Reply to this message', [], $context['options']));
+                $cta_button = $email_token_services->getCtaButton($thread_url, new TranslatableMarkup('Reply to this message', [], $translation_options));
                 if (!empty($cta_button)) {
                   $replacements[$context['tokens']['cta_button']] = \Drupal::service('renderer')->renderPlain($cta_button);
                 }


### PR DESCRIPTION
## Problem
Currently, on a multilingual site, when the user received a notification (for example "join_to_group") , the "Call to Action" token will be not translated.

## Solution
Check a "Prefered Language" of recipients during processing `cta_button` token:

`new TranslatableMarkup('See all members', [], [langcode])`

## Issue tracker
- https://www.drupal.org/project/social/issues/3380523
- https://getopensocial.atlassian.net/browse/PROD-26247
- https://github.com/goalgorilla/cablecar/pull/563

## Theme issue tracker
N/A

## How to test
- [ ] Using the latest version of the Open Social `social_languages` module enabled
- [ ]  Site should be multilingual and for example with "German" default site language
- [ ] Login under a user with a different preferred language(French) than default one on the site (German)
- [ ] Go to user settings: select "French" user interface and set for related notification to an immediate frequency
- [ ] Create a flexible group
- [ ] Login with a second account and join this group
- [ ] After a cron run I expect to receive a notification email with the correct translated call to action token but instead see it in German.
- [ ] The expected result is attained when repeating the steps with this fix applied.


## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
before applying a patch:
<img width="570" alt="Screenshot 2023-08-31 at 17 47 27" src="https://github.com/goalgorilla/open_social/assets/25609390/ffc51ce7-1b8b-46f0-8f37-62ceea928cc8">

and after:
<img width="572" alt="Screenshot 2023-08-31 at 17 57 24" src="https://github.com/goalgorilla/open_social/assets/25609390/1bacd500-9ba5-4e83-ab0c-30ee2a82ae6e">


## Release notes
Fixes an issue with an untranslated "Call to Action" token in email notifications for multilingual sites

## Change Record
N/A

## Translations
N/A
