### PR TITLE
Issue #3381157: Deprecate SocialProfileTrait ahead of removal

### DIFF
--- a/modules/social_features/social_profile/src/SocialProfileTrait.php
+++ b/modules/social_features/social_profile/src/SocialProfileTrait.php
@@ -8,6 +8,8 @@ use Drupal\Core\Database\Query\SelectInterface;
  * Trait SocialProfileTrait.
  *
  * @package Drupal\social_profile
+ * @deprecated SocialProfileTrait is deprecated in 11.10.0 and will be marked as internal in 12.0.0. After 12.0.0 is might be removed without warning.
+ * @see https://www.drupal.org/project/social/issues/3381156.
  */
 trait SocialProfileTrait {
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -12184,6 +12184,14 @@ parameters:
 			path: modules/social_features/social_mentions/src/Controller/AutocompleteController.php
 
 		-
+			message: """
+				#^Usage of deprecated trait Drupal\\\\social_profile\\\\SocialProfileTrait in class Drupal\\\\social_mentions\\\\Controller\\\\AutocompleteController\\:
+				SocialProfileTrait is deprecated in 11\\.10\\.0 and will be marked as internal in 12\\.0\\.0\\. After 12\\.0\\.0 is might be removed without warning\\.$#
+			"""
+			count: 1
+			path: modules/social_features/social_mentions/src/Controller/AutocompleteController.php
+
+		-
 			message: "#^Method Drupal\\\\social_mentions\\\\Plugin\\\\ActivityEntityCondition\\\\MentionCommentActivityEntityCondition\\:\\:isValidEntityCondition\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: modules/social_features/social_mentions/src/Plugin/ActivityEntityCondition/MentionCommentActivityEntityCondition.php
@@ -13729,6 +13737,14 @@ parameters:
 			path: modules/social_features/social_private_message/src/Mapper/PrivateMessageMapper.php
 
 		-
+			message: """
+				#^Usage of deprecated trait Drupal\\\\social_profile\\\\SocialProfileTrait in class Drupal\\\\social_private_message\\\\Mapper\\\\PrivateMessageMapper\\:
+				SocialProfileTrait is deprecated in 11\\.10\\.0 and will be marked as internal in 12\\.0\\.0\\. After 12\\.0\\.0 is might be removed without warning\\.$#
+			"""
+			count: 1
+			path: modules/social_features/social_private_message/src/Mapper/PrivateMessageMapper.php
+
+		-
 			message: "#^Cannot call method hasPermission\\(\\) on Drupal\\\\user\\\\Entity\\\\Role\\|null\\.$#"
 			count: 1
 			path: modules/social_features/social_private_message/src/Plugin/EntityReferenceSelection/UserSelection.php
@@ -14825,6 +14841,14 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$name of method Drupal\\\\social_profile\\\\Plugin\\\\EntityReferenceSelection\\\\UserSelection\\:\\:getUserIdsFromName\\(\\) expects string, string\\|null given\\.$#"
+			count: 1
+			path: modules/social_features/social_profile/src/Plugin/EntityReferenceSelection/UserSelection.php
+
+		-
+			message: """
+				#^Usage of deprecated trait Drupal\\\\social_profile\\\\SocialProfileTrait in class Drupal\\\\social_profile\\\\Plugin\\\\EntityReferenceSelection\\\\UserSelection\\:
+				SocialProfileTrait is deprecated in 11\\.10\\.0 and will be marked as internal in 12\\.0\\.0\\. After 12\\.0\\.0 is might be removed without warning\\.$#
+			"""
 			count: 1
 			path: modules/social_features/social_profile/src/Plugin/EntityReferenceSelection/UserSelection.php
 


### PR DESCRIPTION
## Problem
The SocialProfileTrait is doing too many things that should probably be a specific service to fulfill a goal rather than something that performs a lot of query alters.

## Solution
In the profile refactor we'll be removing most of its use, but we're not quite ready to remove it yet. We want to deprecate it in 11.x so we can work on it in [#3381156: Remove usage of SocialProfileTrait ](https://www.drupal.org/project/social/issues/3381156)and remove it in any version after 12.0.0 when we're ready for it.

## Issue tracker
https://www.drupal.org/project/social/issues/3381157

## How to test
Documentation change, no tests.

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
<!-- *[Required if new feature, and if applicable] If this Pull Request makes visual changes then please include some screenshots that show what has changed here. A before and after screenshot helps the reviewer determine what changes were made.* -->

## Release notes
Usage of `SocialProfileTrait` has been deprecated. The trait was for code-sharing in internal code and will be marked as `@internal` in 12.0.0 so that it can be refactored. There is no replacement.
