### PR TITLE
Issue #3382816: Revert search_api_language filter ID change in search views

### DIFF
--- a/modules/social_features/social_search/config/install/search_api.index.social_all.yml
+++ b/modules/social_features/social_search/config/install/search_api.index.social_all.yml
@@ -245,6 +245,7 @@ processor_settings:
   ignorecase:
     all_fields: true
     fields:
+      - language_with_fallback
       - field_group_description
       - field_group_location
       - field_profile_first_name
@@ -332,6 +333,7 @@ processor_settings:
   transliteration:
     all_fields: true
     fields:
+      - language_with_fallback
       - field_group_description
       - field_group_location
       - field_profile_first_name

--- a/modules/social_features/social_search/config/install/views.view.search_all.yml
+++ b/modules/social_features/social_search/config/install/views.view.search_all.yml
@@ -153,14 +153,13 @@ display:
             link_to_item: false
             multi_separator: ', '
       filters:
-        language_with_fallback:
-          id: language_with_fallback
+        search_api_language:
+          id: search_api_language
           table: search_api_index_social_all
           field: language_with_fallback
           relationship: none
           group_type: group
           admin_label: ''
-          plugin_id: search_api_language
           operator: in
           value:
             '***LANGUAGE_language_interface***': '***LANGUAGE_language_interface***'
@@ -193,6 +192,7 @@ display:
             default_group: All
             default_group_multiple: { }
             group_items: { }
+          plugin_id: search_api_language
       sorts:
         search_api_relevance:
           id: search_api_relevance

--- a/modules/social_features/social_search/config/install/views.view.search_content.yml
+++ b/modules/social_features/social_search/config/install/views.view.search_content.yml
@@ -280,14 +280,13 @@ display:
                   min: ''
                   max: ''
           plugin_id: search_api_date
-        language_with_fallback:
-          id: language_with_fallback
+        search_api_language:
+          id: search_api_language
           table: search_api_index_social_content
           field: language_with_fallback
           relationship: none
           group_type: group
           admin_label: ''
-          plugin_id: search_api_language
           operator: in
           value:
             '***LANGUAGE_language_interface***': '***LANGUAGE_language_interface***'
@@ -300,7 +299,7 @@ display:
             use_operator: false
             operator: ''
             operator_limit_selection: false
-            operator_list: { }
+            operator_list: {  }
             identifier: ''
             required: false
             remember: false
@@ -318,8 +317,9 @@ display:
             multiple: false
             remember: false
             default_group: All
-            default_group_multiple: { }
-            group_items: { }
+            default_group_multiple: {  }
+            group_items: {  }
+          plugin_id: search_api_language
       sorts:
         search_api_relevance:
           id: search_api_relevance

--- a/modules/social_features/social_search/config/install/views.view.search_groups.yml
+++ b/modules/social_features/social_search/config/install/views.view.search_groups.yml
@@ -172,14 +172,13 @@ display:
             group_items: {  }
           reduce_duplicates: false
           plugin_id: search_api_options
-        language_with_fallback:
-          id: language_with_fallback
+        search_api_language:
+          id: search_api_language
           table: search_api_index_social_groups
           field: language_with_fallback
           relationship: none
           group_type: group
           admin_label: ''
-          plugin_id: search_api_language
           operator: in
           value:
             '***LANGUAGE_language_interface***': '***LANGUAGE_language_interface***'
@@ -192,7 +191,7 @@ display:
             use_operator: false
             operator: ''
             operator_limit_selection: false
-            operator_list: { }
+            operator_list: {  }
             identifier: ''
             required: false
             remember: false
@@ -210,8 +209,9 @@ display:
             multiple: false
             remember: false
             default_group: All
-            default_group_multiple: { }
-            group_items: { }
+            default_group_multiple: {  }
+            group_items: {  }
+          plugin_id: search_api_language
       sorts:
         search_api_relevance:
           id: search_api_relevance

--- a/modules/social_features/social_search/social_search.install
+++ b/modules/social_features/social_search/social_search.install
@@ -291,3 +291,35 @@ function social_search_update_11402(): string {
   // Output logged messages to related channel of update execution.
   return $updateHelper->logger()->output();
 }
+
+/**
+ * Revert search_api_language filter name/id change.
+ */
+function social_search_update_11403() : void {
+  // In social_search_update_11402
+  // (https://github.com/goalgorilla/open_social/pull/3470/) we changed the
+  // search_api_language filter to a language_with_fallback filter to ensure
+  // that users could find matching content in different languages if no version
+  // in their own language was available. However, this also changed the IDs of
+  // the filter which can break existing sites that might rely on that filter.
+  // Below we go through the views and change the filter back to the ID it had,
+  // just with the new field added to the index.
+  $views = [
+    "views.view.search_all",
+    "views.view.search_content",
+    "views.view.search_group",
+  ];
+
+  foreach ($views as $view) {
+    $config = \Drupal::configFactory()->getEditable($view);
+    $display = $config->get("display");
+
+    $filter = $display['default']['display_options']['filters']['language_with_fallback'];
+    $filter['id'] = "search_api_language";
+    $display['default']['display_options']['filters']["search_api_language"] = $filter;
+    unset($display['default']['display_options']['filters']['language_with_fallback']);
+
+    $config->set('display', $display);
+    $config->save(TRUE);
+  }
+}


### PR DESCRIPTION
# Problem / Solution
In #3470 we changed the search_api_language filter to a language_with_fallback filter to ensure that users could find matching content in different languages if no version in their own language was available. However, this also changed the IDs of the filter which can break existing sites that might rely on that filter.

In this commit we revert the ID/name change and only change the field used. We also revert any formatting changes made to the views.* files to make fixing merge conflicts in our search rework easier.

## Issue tracker
https://www.drupal.org/project/social/issues/3382816

## How to test


## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Release notes
In Open Social 11.9.10 the name and ID of the language filter were changed along with its type. If you relied on this name this may cause you issues. We've reverted the change to the name and ID so existing code can keep working. The type has still been changed to `language_with_fallback` for the new behaviour.

## Change of install configuration

As we're reverting changes that were made in another PR to our install configuration. The difference with the pre-11.9.10 social_search config is as follows (update hooks omitted for brevity). Generated with ` git diff 9e0c12e48^ -- modules/social_features/social_search/config/install`.

```diff
diff --git a/modules/social_features/social_search/config/install/search_api.index.social_all.yml b/modules/social_features/social_search/config/install/search_api.index.social_all.yml
index 2b0b35afe..52bc1afff 100644
--- a/modules/social_features/social_search/config/install/search_api.index.social_all.yml
+++ b/modules/social_features/social_search/config/install/search_api.index.social_all.yml
@@ -109,6 +109,10 @@ field_settings:
     dependencies:
       module:
         - group
+  language_with_fallback:
+    label: 'Language (with fallback)'
+    property_path: language_with_fallback
+    type: string
   name:
     label: 'Owner » User » Name'
     datasource_id: 'entity:profile'
@@ -241,6 +245,7 @@ processor_settings:
   ignorecase:
     all_fields: true
     fields:
+      - language_with_fallback
       - field_group_description
       - field_group_location
       - field_profile_first_name
@@ -328,6 +333,7 @@ processor_settings:
   transliteration:
     all_fields: true
     fields:
+      - language_with_fallback
       - field_group_description
       - field_group_location
       - field_profile_first_name
diff --git a/modules/social_features/social_search/config/install/search_api.index.social_content.yml b/modules/social_features/social_search/config/install/search_api.index.social_content.yml
index c2a43e628..df35a665b 100644
--- a/modules/social_features/social_search/config/install/search_api.index.social_content.yml
+++ b/modules/social_features/social_search/config/install/search_api.index.social_content.yml
@@ -39,6 +39,10 @@ field_settings:
     dependencies:
       config:
         - field.storage.node.field_event_date_end
+  language_with_fallback:
+    label: 'Language (with fallback)'
+    property_path: language_with_fallback
+    type: string
   node_grants:
     label: 'Node access information'
     property_path: search_api_node_grants
@@ -114,6 +118,7 @@ processor_settings:
     plugin_id: ignorecase
     all_fields: true
     fields:
+      - language_with_fallback
       - rendered_item
       - title
       - type
@@ -193,6 +198,7 @@ processor_settings:
     plugin_id: transliteration
     all_fields: true
     fields:
+      - language_with_fallback
       - rendered_item
       - title
       - type
diff --git a/modules/social_features/social_search/config/install/search_api.index.social_groups.yml b/modules/social_features/social_search/config/install/search_api.index.social_groups.yml
index 4d56c5f17..d8ad9367c 100644
--- a/modules/social_features/social_search/config/install/search_api.index.social_groups.yml
+++ b/modules/social_features/social_search/config/install/search_api.index.social_groups.yml
@@ -39,6 +39,10 @@ field_settings:
     dependencies:
       module:
         - group
+  language_with_fallback:
+    label: 'Language (with fallback)'
+    property_path: language_with_fallback
+    type: string
   name:
     label: 'Group creator » User » Name'
     datasource_id: 'entity:group'
@@ -83,6 +87,7 @@ processor_settings:
     fields:
       - field_group_description
       - label
+      - language_with_fallback
       - name
       - rendered_item
       - type
@@ -189,6 +194,7 @@ processor_settings:
     fields:
       - field_group_description
       - label
+      - language_with_fallback
       - name
       - rendered_item
       - type
diff --git a/modules/social_features/social_search/config/install/views.view.search_all.yml b/modules/social_features/social_search/config/install/views.view.search_all.yml
index 302302aec..512346c48 100644
--- a/modules/social_features/social_search/config/install/views.view.search_all.yml
+++ b/modules/social_features/social_search/config/install/views.view.search_all.yml
@@ -156,14 +156,13 @@ display:
         search_api_language:
           id: search_api_language
           table: search_api_index_social_all
-          field: search_api_language
+          field: language_with_fallback
           relationship: none
           group_type: group
           admin_label: ''
           operator: in
           value:
             '***LANGUAGE_language_interface***': '***LANGUAGE_language_interface***'
-            und: und
           group: 1
           exposed: false
           expose:
diff --git a/modules/social_features/social_search/config/install/views.view.search_content.yml b/modules/social_features/social_search/config/install/views.view.search_content.yml
index 1702a98d2..4bb47a094 100644
--- a/modules/social_features/social_search/config/install/views.view.search_content.yml
+++ b/modules/social_features/social_search/config/install/views.view.search_content.yml
@@ -283,7 +283,7 @@ display:
         search_api_language:
           id: search_api_language
           table: search_api_index_social_content
-          field: search_api_language
+          field: language_with_fallback
           relationship: none
           group_type: group
           admin_label: ''
diff --git a/modules/social_features/social_search/config/install/views.view.search_groups.yml b/modules/social_features/social_search/config/install/views.view.search_groups.yml
index e5376d8ad..8df90fefd 100644
--- a/modules/social_features/social_search/config/install/views.view.search_groups.yml
+++ b/modules/social_features/social_search/config/install/views.view.search_groups.yml
@@ -175,7 +175,7 @@ display:
         search_api_language:
           id: search_api_language
           table: search_api_index_social_groups
-          field: search_api_language
+          field: language_with_fallback
           relationship: none
           group_type: group
           admin_label: ''
```