### PR TITLE
Internal: Allow debugging mail spool for failed tests

### DIFF
--- a/.github/workflows/behat.yml
+++ b/.github/workflows/behat.yml
@@ -392,6 +392,11 @@ jobs:
             mv html/profiles/contrib/social/tests/behat/logs/* $OUTPUT_FOLDER/
           fi
 
+          # Move files from the mail spool to the output folder if they exist
+          if (shopt -s nullglob; f=(html/profiles/contrib/social/tests/behat/mail-spool/*); ((${#f[@]}))); then
+            mv html/profiles/contrib/social/tests/behat/mail-spool/* $OUTPUT_FOLDER/
+          fi
+
           # Dump the database with the state of the test failure to allow for
           # local inspection.
           drush sql-dump > $OUTPUT_FOLDER/at-test-failure.sql


### PR DESCRIPTION

## Problem / Solution
It can be difficult to debug failed tests for e-mails because we are not able to look at the files that are in the mail-spool. This commit changes the Behat failure scenario to also copy any e-mail messages from the mail-spool on a test failure.

## Issue tracker
Internal change no ticket

## How to test
- [ ] Fail a behat email test in the CI and see its output in the attachment

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

