### PR TITLE
Issue #3383704: cache improvements for `hook_entity_extra_field_info()` and `EntityFieldManager::getExtraFields()`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,6 +43,7 @@
                 "Ajax not working when using non-default view mode": "https://www.drupal.org/files/issues/2023-01-30/ajax_comments-ajax_non_default_view_mode-2896916-beta5-60.patch"
             },
             "drupal/core": {
+                "Issue #3231503 landed in 10.1.x: Cache the result of hook_entity_extra_field_info()": "https://www.drupal.org/files/issues/2023-08-28/3383704-backport-cache-fix-EntityFieldManager-getextrafields.patch",
                 "Restrict images to this site blocks image style derivatives": "https://www.drupal.org/files/issues/2019-05-10/2528214-54.patch",
                 "Optimize getCommentedEntity()": "https://www.drupal.org/files/issues/2018-12-28/2580551-72.patch",
                 "Multiple usages of FieldPluginBase::getEntity do not check for NULL, leading to WSOD": "https://www.drupal.org/files/issues/2023-01-05/3007424-146-9.5.x.patch",


### PR DESCRIPTION
## Problem
As this patch only lands in 10.1.x (which is when we can remove this patch) we backport it as it could have significant performance impact, especially on pages layout builder or paragraphs driven (or even views with many fields).
This way we can get the benefits already from the work done there, and remove it once we do our update towards 10.1.x, which is not yet planned at the time or writing.

## Solution
Backport the issue from Drupal Core issue [3231503](https://www.drupal.org/project/drupal/issues/3231503)

## Issue tracker
[3383704](https://www.drupal.org/project/social/issues/3383704)

## How to test
- [ ] Enable `social_landing_page` 
- [ ] See that it works like expected

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Release notes
Performance improvement for `hook_entity_extra_field_info()` and `EntityFieldManager::getExtraFields()`
