### PR TITLE
Issue #3383079: Hotfix: Fix view name for groups search

### DIFF
--- a/modules/social_features/social_search/social_search.install
+++ b/modules/social_features/social_search/social_search.install
@@ -307,7 +307,6 @@ function social_search_update_11403() : void {
   $views = [
     "views.view.search_all",
     "views.view.search_content",
-    "views.view.search_group",
   ];
 
   foreach ($views as $view) {
@@ -321,5 +320,35 @@ function social_search_update_11403() : void {
 
     $config->set('display', $display);
     $config->save(TRUE);
+  }
+}
+
+/**
+ * Revert search_api_language filter name/id change for groups view.
+ */
+function social_search_update_11404() : void {
+  // There was a typo in the view name of social_search_update_11403 which
+  // caused the groups view not to be updated, so we must do it again here.
+  $views = [
+    "views.view.search_groups",
+  ];
+
+  foreach ($views as $view) {
+    $config = \Drupal::configFactory()->getEditable($view);
+    $display = $config->get("display");
+
+    $filter = $display['default']['display_options']['filters']['language_with_fallback'];
+    $filter['id'] = "search_api_language";
+    $display['default']['display_options']['filters']["search_api_language"] = $filter;
+    unset($display['default']['display_options']['filters']['language_with_fallback']);
+
+    $config->set('display', $display);
+    $config->save(TRUE);
+  }
+
+  // Clean up the config created in our erroneous version of 11403.
+  $incorrect_view = \Drupal::configFactory()->getEditable("views.view.search_group");
+  if (!$incorrect_view->isNew()) {
+    $incorrect_view->delete();
   }
 }


### PR DESCRIPTION
## Problem
A typo in `social_search_update_11403` leaves sites in an indeterminate state which causes a fatal error for admins. Additionally it means that the view configuration is not properly updated.

## Solution
We can't just fix the change in `social_search_update_11403` because we would leave sites that had already executed the update in an indeterminate state.

There's two scenarios:

1) The update has already run. In this case the change for the groups view hasn't happened due to the type, the new update hook will be executed and now all views are correct.

2) The update hook hasn't run already. In this case we do the correct 2 views (that sites from scenario 1 don't need help changing) in 11403 and we fix groups in 11404.


## Issue tracker
https://www.drupal.org/project/social/issues/3383079

## How to test
- [x] Upgrade path from 10.x should have no warnings
- [ ] Login as admin on an upgraded platform should work without errors

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Release notes
A typo in an upgrade hook caused a search view to not be updated which could cause a fatal error for users with access to the views UI.