### PR TITLE
Internal: Ensure Behat test run exits in case of warnings in upgrade path

### DIFF
--- a/.github/workflows/behat.yml
+++ b/.github/workflows/behat.yml
@@ -208,13 +208,30 @@ jobs:
       - name: Update the previous major version to HEAD
         if: ${{ matrix.update == 'update' }}
         run: |
+          set -e
+
           if [[ "${{ matrix.with_optional }}" == "with-optional" ]]; then
             drush sqlc < behat-test-output/pre-update-with-optional.sql
           else
             drush sqlc < behat-test-output/pre-update.sql
           fi
 
-          vendor/bin/drush updb -y
+          vendor/bin/drush updb -y 2> >(tee update.log >&2)
+
+          # Ensure there are no warnings in the update.log
+          if grep -E '^>\s+\[warning\]\s' update.log 1>/dev/null; then
+            # Move the update.log with warnings and status messages to the test output. The text is viewable on GitHub
+            # too but some people might find it easier to just download the artifact and get digging.
+            if [[ "${{ matrix.with_optional }}" == "with-optional" ]]; then
+              mv update.log behat-test-output/update-with-optional.log
+            else
+              mv update.log behat-test-output/update.log
+            fi
+
+            # Abort our testing until the warning is fixed and let our user know why we stopped.
+            echo "The drush output should not contain any warnings"
+            exit 1
+          fi
 
       - name: Set-up a new Open Social installation at HEAD
         if: ${{ matrix.update == '' }}

--- a/modules/social_features/social_content_block/src/SocialContentBlockOverride.php
+++ b/modules/social_features/social_content_block/src/SocialContentBlockOverride.php
@@ -55,7 +55,12 @@ class SocialContentBlockOverride implements ConfigFactoryOverrideInterface {
     if (in_array($config_name, $names)) {
       $config = $this->configFactory->getEditable($config_name);
 
-      $settings = $config->getOriginal('settings', FALSE)['selection_settings']['plugin_ids'];
+      // We initialize to an empty array because this code might run during
+      // updates which changed the block config schema (the selection_settings
+      // nesting didn't exist before). In that case a post-update cache clear
+      // will have the correct config override so there should be no
+      // repercussions for the empty array we're adding here.
+      $settings = $config->getOriginal('settings', FALSE)['selection_settings']['plugin_ids'] ?? [];
 
       // Get all the blocks from this custom block type.
       $storage = self::getBlockContent();

--- a/modules/social_features/social_event/config/update/social_event_update_11902.yml
+++ b/modules/social_features/social_event/config/update/social_event_update_11902.yml
@@ -1,19 +1,14 @@
 message.template.user_was_enrolled_to_event:
   expected_config:
-    text:
-      2:
-        value: "<p>This is to confirm that you've enrolled for the event <em>[social_event:event_iam_organizing]</em>.</p>\r\n\r\n<p>[message:preview]</p>\r\n\r\n<p>[message:cta_button]</p>\r\n"
+    text: { }
   update_actions:
     delete:
       text: { }
     add:
       text:
-        0:
-          value: "<p>This is to confirm that you've enrolled for the event <em>[social_event:event_iam_organizing]</em>.</p>\r\n\r\n<p>[message:preview]</p>\r\n\r\n<p>[message:cta_button]</p>\r\n"
+        - value: "<p>This is to confirm that you've enrolled for the event <em>[social_event:event_iam_organizing]</em>.</p>\r\n\r\n<p>[message:preview]</p>\r\n\r\n<p>[message:cta_button]</p>\r\n"
           format: full_html
-        1:
-          value: "<p>This is to confirm that you've enrolled for the event <em>[social_event:event_iam_organizing]</em>.</p>\r\n\r\n<p>[message:preview]</p>\r\n\r\n<p>[message:cta_button]</p>\r\n"
+        - value: "<p>This is to confirm that you've enrolled for the event <em>[social_event:event_iam_organizing]</em>.</p>\r\n\r\n<p>[message:preview]</p>\r\n\r\n<p>[message:cta_button]</p>\r\n"
           format: full_html
-        2:
-          value: "<p>This is to confirm that you've enrolled for the event <em>[social_event:event_iam_organizing]</em>.</p>\r\n\r\n<p>[message:preview]</p>\r\n\r\n<p>[message:cta_button]</p>\r\n"
+        - value: "<p>This is to confirm that you've enrolled for the event <em>[social_event:event_iam_organizing]</em>.</p>\r\n\r\n<p>[message:preview]</p>\r\n\r\n<p>[message:cta_button]</p>\r\n"
           format: full_html


### PR DESCRIPTION
## Problem
Although people's configuration changes might cause warnings in an upgrade path (for example of upgrade_helper skips a config change to avoid undoing site-builder choices), we do not expect any warnings in the default upgrade path that we build for Open Social.

A warning (like an undefined array key) usually points to a typo and can lead to fatal errors down the line. We want to make sure that there are no warnings in our upgrade path if nothing was changed.

## Solution
Our behat test runs an upgrade from the previous major version. Drush has no good "fail on warning" options, so we'll have to parse the text output of the command and check if any log messages of the warning type were output.

## Also review
This PR required some other fixes to prove it works and those need to be reviewed before merging this
- [ ] https://github.com/goalgorilla/open_social/pull/3496
- [ ] https://github.com/goalgorilla/open_social/pull/3497

## Issue tracker
- CI change
- https://www.drupal.org/project/social/issues/3383956
- https://www.drupal.org/project/social/issues/3383985

## How to test
- This PR should fail due to warnings
- When https://github.com/goalgorilla/open_social/pull/3494, https://github.com/goalgorilla/open_social/pull/3496, and https://github.com/goalgorilla/open_social/pull/3497 are merged, this PR should be green.

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
<!-- *[Required if new feature, and if applicable] If this Pull Request makes visual changes then please include some screenshots that show what has changed here. A before and after screenshot helps the reviewer determine what changes were made.* -->

## Release notes
<!-- *[Required if new feature, and if applicable] A short summary of the changes that were made that can be included in release notes.* -->

## Change Record
<!-- *[Required if applicable] If this Pull Request changes the way that developers should do things or introduces a new API for developers then a change record to document this is needed. Please provide a draft for a change record or a link to an unpublished change record below. Existing change records can be consulted as example. Please provide a draft for a change record or a link to an unpublished change record below. [Existing change records](https://www.drupal.org/list-changes/social) can be consulted as example.* -->

## Translations
<!--
*[Optional]Translatable strings are always extracted from the latest development branch. To ensure translations remain available for platforms running older versions of Open Social the original string should be added to `translations.php` when it's changed or removed.*
- [ ] Changed or removed source strings are added to the `translations.php` file.
-->
