### PR TITLE
Issue #3383956: Fix upgrade path warning in SocialContentBlockOverride

### DIFF
--- a/modules/social_features/social_content_block/src/SocialContentBlockOverride.php
+++ b/modules/social_features/social_content_block/src/SocialContentBlockOverride.php
@@ -55,7 +55,12 @@ class SocialContentBlockOverride implements ConfigFactoryOverrideInterface {
     if (in_array($config_name, $names)) {
       $config = $this->configFactory->getEditable($config_name);
 
-      $settings = $config->getOriginal('settings', FALSE)['selection_settings']['plugin_ids'];
+      // We initialize to an empty array because this code might run during
+      // updates which changed the block config schema (the selection_settings
+      // nesting didn't exist before). In that case a post-update cache clear
+      // will have the correct config override so there should be no
+      // repercussions for the empty array we're adding here.
+      $settings = $config->getOriginal('settings', FALSE)['selection_settings']['plugin_ids'] ?? [];
 
       // Get all the blocks from this custom block type.
       $storage = self::getBlockContent();


### PR DESCRIPTION
## Problem
The class reads existing config, but in the upgrade path from Open
Social 10 to 11 the config schema is changed, so the array element we're
trying to read might not exist. This causes warnings in the upgrade
path.

## Solution
We ignore the setting if it doesn't exist because it means we're working with the old config. The config override will be reloaded after the post-update cache-clear which ensures the proper override is applied.


## Issue tracker
https://www.drupal.org/project/social/issues/3383956

## Theme issue tracker
*[Required if applicable] Paste a link to the drupal.org theme issue queue item, either from [socialbase](https://www.drupal.org/project/socialbase) or [socialblue](https://www.drupal.org/project/socialblue). If any other issue trackers were used, include links to those too.*

## How to test
<!--
*[Required] For example*
- [ ] Using version X.Y.Z of Open Social with the example module enabled
- [ ] As a sitemanager
- [ ] Try to enable the option B on screen c/d/e
- [ ] When saving I expect the result to be F but instead see G.
- [ ] The expected result F is attained when repeating the steps with this fix applied.
-->

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
<!-- *[Required if new feature, and if applicable] If this Pull Request makes visual changes then please include some screenshots that show what has changed here. A before and after screenshot helps the reviewer determine what changes were made.* -->

## Release notes
<!-- *[Required if new feature, and if applicable] A short summary of the changes that were made that can be included in release notes.* -->

## Change Record
<!-- *[Required if applicable] If this Pull Request changes the way that developers should do things or introduces a new API for developers then a change record to document this is needed. Please provide a draft for a change record or a link to an unpublished change record below. Existing change records can be consulted as example. Please provide a draft for a change record or a link to an unpublished change record below. [Existing change records](https://www.drupal.org/list-changes/social) can be consulted as example.* -->

## Translations
<!--
*[Optional]Translatable strings are always extracted from the latest development branch. To ensure translations remain available for platforms running older versions of Open Social the original string should be added to `translations.php` when it's changed or removed.*
- [ ] Changed or removed source strings are added to the `translations.php` file.
-->
