### PR TITLE
Issue #3384622 by zanvidmar: Permission must exist (D10)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -129,7 +129,7 @@
         "drupal/crop": "2.3.0",
         "drupal/csv_serialization": "2.1.0",
         "drupal/ctools": "3.11",
-        "drupal/data_policy": "2.0.0-beta3",
+        "drupal/data_policy": "2.0.0-beta4",
         "drupal/dynamic_entity_reference": "1.16.0",
         "drupal/editor_advanced_link": "2.2.4",
         "drupal/entity": "1.4.0",

--- a/composer.json
+++ b/composer.json
@@ -60,7 +60,6 @@
                 "Issue #1236098: Notice: Undefined index: 'base' in _color_rewrite_stylesheet()": "https://www.drupal.org/files/issues/undefined-index-in-_color_rewrite_stylesheet-1236098-37.patch",
                 "Issue #3251856: Incorrect typehint for FieldConfig::loadByName": "https://www.drupal.org/files/issues/2021-12-12/drupal9-incorrect_typehint-3251856-7.patch",
                 "Issue #2998390: Cache is not invalidated when comment deleted": "https://www.drupal.org/files/issues/2022-02-07/2998390-8.patch",
-                "Issue #3282073: Comment the \"user_post_update_update_roles\" that was added in Drupal 9.3": "https://www.drupal.org/files/issues/2023-04-07/social-comment_the_user_post_update_update_roles-3282073_d95.diff",
                 "Image derivative generation does not work if effect \"Convert\" in use and file stored in private filesystem": "https://www.drupal.org/files/issues/2022-09-23/2786735-39.patch",
                 "Issue #2107455: Image field default value not shown when upload destination set to private file storage": "https://www.drupal.org/files/issues/2022-06-24/2107455-75.patch",
                 "Issue #3052115: Mark an entity as 'syncing' during a migration update": "https://www.drupal.org/files/issues/2023-02-01/3052115-59.patch",

--- a/modules/custom/social_gdpr/social_gdpr.install
+++ b/modules/custom/social_gdpr/social_gdpr.install
@@ -52,7 +52,7 @@ function social_gdpr_update_8902() {
  * Permissions to check:
  * - "translate data_policy".
  */
-function social_gdpr_update_111201(): void {
+function social_gdpr_update_111101(): void {
   $entity_type_manager = \Drupal::entityTypeManager();
   $all_permissions = array_keys(\Drupal::service('user.permissions')->getPermissions());
   /** @var \Drupal\user\RoleInterface[] $roles */

--- a/modules/custom/social_gdpr/social_gdpr.install
+++ b/modules/custom/social_gdpr/social_gdpr.install
@@ -47,8 +47,10 @@ function social_gdpr_update_8902() {
 }
 
 /**
- * Search for invalid permission(s) and remove them from existing roles:
- * "translate data_policy".
+ * Search for invalid permission(s) and remove them from existing roles.
+ *
+ * Permissions to check:
+ * - "translate data_policy".
  */
 function social_gdpr_update_111201(): void {
   $entity_type_manager = \Drupal::entityTypeManager();

--- a/modules/custom/social_gdpr/social_gdpr.install
+++ b/modules/custom/social_gdpr/social_gdpr.install
@@ -24,7 +24,6 @@ function social_gdpr_install() {
       'overview inform and consent settings',
       'administer inform and consent settings',
       'change inform and consent setting status',
-      'translate data_policy',
     ]
   );
 
@@ -45,4 +44,32 @@ function social_gdpr_update_8901() {
  */
 function social_gdpr_update_8902() {
   user_role_grant_permissions('sitemanager', ['translate data_policy']);
+}
+
+/**
+ * Search for invalid permission(s) and remove them from existing roles:
+ * "translate data_policy".
+ */
+function social_gdpr_update_111201(): void {
+  $entity_type_manager = \Drupal::entityTypeManager();
+  $all_permissions = array_keys(\Drupal::service('user.permissions')->getPermissions());
+  /** @var \Drupal\user\RoleInterface[] $roles */
+  $roles = $entity_type_manager->getStorage('user_role')->loadMultiple();
+
+  $permissions_to_check = [
+    'translate data_policy',
+  ];
+
+  // If permission is not valid (is not on the list of all permissions),
+  // we need to revoke it from all existing roles.
+  foreach ($permissions_to_check as $permission_to_check) {
+    if (!in_array($permission_to_check, $all_permissions)) {
+      foreach ($roles as $role) {
+        if ($role->hasPermission($permission_to_check)) {
+          $role->revokePermission($permission_to_check);
+          $role->save();
+        }
+      }
+    }
+  }
 }

--- a/modules/social_features/social_book/social_book.install
+++ b/modules/social_features/social_book/social_book.install
@@ -294,7 +294,7 @@ function social_book_update_11401(): string {
  * Permissions to check:
  * - "translate book node".
  */
-function social_book_update_111201(): void {
+function social_book_update_111101(): void {
   $entity_type_manager = \Drupal::entityTypeManager();
   $all_permissions = array_keys(\Drupal::service('user.permissions')->getPermissions());
   /** @var \Drupal\user\RoleInterface[] $roles */

--- a/modules/social_features/social_book/social_book.install
+++ b/modules/social_features/social_book/social_book.install
@@ -50,7 +50,6 @@ function social_book_install() {
       'edit any book content',
       'edit own book content',
       'view book revisions',
-      'translate book node',
       'view node.book.field_content_visibility:community content',
     ]
   );
@@ -67,7 +66,6 @@ function social_book_install() {
       'edit any book content',
       'edit own book content',
       'view book revisions',
-      'translate book node',
       'administer visibility settings',
       'view node.book.field_content_visibility:community content',
     ]
@@ -288,4 +286,32 @@ function social_book_update_11401(): string {
 
   // Output logged messages to related channel of update execution.
   return $updateHelper->logger()->output();
+}
+
+/**
+ * Search for invalid permission(s) and remove them from existing roles:
+ * "translate book node".
+ */
+function social_book_update_111201(): void {
+  $entity_type_manager = \Drupal::entityTypeManager();
+  $all_permissions = array_keys(\Drupal::service('user.permissions')->getPermissions());
+  /** @var \Drupal\user\RoleInterface[] $roles */
+  $roles = $entity_type_manager->getStorage('user_role')->loadMultiple();
+
+  $permissions_to_check = [
+    'translate book node',
+  ];
+
+  // If permission is not valid (is not on the list of all permissions),
+  // we need to revoke it from all existing roles.
+  foreach ($permissions_to_check as $permission_to_check) {
+    if (!in_array($permission_to_check, $all_permissions)) {
+      foreach ($roles as $role) {
+        if ($role->hasPermission($permission_to_check)) {
+          $role->revokePermission($permission_to_check);
+          $role->save();
+        }
+      }
+    }
+  }
 }

--- a/modules/social_features/social_book/social_book.install
+++ b/modules/social_features/social_book/social_book.install
@@ -289,8 +289,10 @@ function social_book_update_11401(): string {
 }
 
 /**
- * Search for invalid permission(s) and remove them from existing roles:
- * "translate book node".
+ * Search for invalid permission(s) and remove them from existing roles.
+ *
+ * Permissions to check:
+ * - "translate book node".
  */
 function social_book_update_111201(): void {
   $entity_type_manager = \Drupal::entityTypeManager();

--- a/modules/social_features/social_core/config/modify/social_core.access_contextual_links_permissions.yml
+++ b/modules/social_features/social_core/config/modify/social_core.access_contextual_links_permissions.yml
@@ -1,0 +1,18 @@
+dependencies:
+  module:
+    - contextual
+items:
+  user.role.contentmanager:
+    expected_config:
+      permissions: { }
+    update_actions:
+      add:
+        permissions:
+          - 'access contextual links'
+  user.role.sitemanager:
+    expected_config:
+      permissions: { }
+    update_actions:
+      add:
+        permissions:
+          - 'access contextual links'

--- a/modules/social_features/social_core/social_core.install
+++ b/modules/social_features/social_core/social_core.install
@@ -1693,7 +1693,7 @@ function social_core_update_11900() : string {
  * Permissions to check:
  * - "access contextual links".
  */
-function social_core_update_111201(): void {
+function social_core_update_111101(): void {
   $entity_type_manager = \Drupal::entityTypeManager();
   $all_permissions = array_keys(\Drupal::service('user.permissions')->getPermissions());
   /** @var \Drupal\user\RoleInterface[] $roles */

--- a/modules/social_features/social_core/social_core.install
+++ b/modules/social_features/social_core/social_core.install
@@ -120,7 +120,6 @@ function social_core_install() {
       'administer account settings',
       'administer themes',
       'administer blocks',
-      'access contextual links',
       'access social_core dashboard',
     ]
   );
@@ -250,7 +249,6 @@ function _social_core_get_permissions($role) {
     'administer account settings',
     'administer themes',
     'administer blocks',
-    'access contextual links',
   ]);
 
   return $permissions[$role] ?? [];
@@ -1687,4 +1685,32 @@ function social_core_update_11900() : string {
 
   // Output logged messages to related channel of update execution.
   return $update_helper->logger()->output();
+}
+
+/**
+ * Search for invalid permission(s) and remove them from existing roles:
+ * "access contextual links".
+ */
+function social_core_update_111201(): void {
+  $entity_type_manager = \Drupal::entityTypeManager();
+  $all_permissions = array_keys(\Drupal::service('user.permissions')->getPermissions());
+  /** @var \Drupal\user\RoleInterface[] $roles */
+  $roles = $entity_type_manager->getStorage('user_role')->loadMultiple();
+
+  $permissions_to_check = [
+    'access contextual links',
+  ];
+
+  // If permission is not valid (is not on the list of all permissions),
+  // we need to revoke it from all existing roles.
+  foreach ($permissions_to_check as $permission_to_check) {
+    if (!in_array($permission_to_check, $all_permissions)) {
+      foreach ($roles as $role) {
+        if ($role->hasPermission($permission_to_check)) {
+          $role->revokePermission($permission_to_check);
+          $role->save();
+        }
+      }
+    }
+  }
 }

--- a/modules/social_features/social_core/social_core.install
+++ b/modules/social_features/social_core/social_core.install
@@ -1688,8 +1688,10 @@ function social_core_update_11900() : string {
 }
 
 /**
- * Search for invalid permission(s) and remove them from existing roles:
- * "access contextual links".
+ * Search for invalid permission(s) and remove them from existing roles.
+ *
+ * Permissions to check:
+ * - "access contextual links".
  */
 function social_core_update_111201(): void {
   $entity_type_manager = \Drupal::entityTypeManager();

--- a/modules/social_features/social_event/social_event.install
+++ b/modules/social_features/social_event/social_event.install
@@ -59,7 +59,6 @@ function social_event_install() {
       'view node.event.field_content_visibility:community content',
       'view events on my profile',
       'view events on other profiles',
-      'translate event node',
       'delete any event content',
       'edit any event content',
       'revert event revisions',
@@ -82,7 +81,6 @@ function social_event_install() {
       'view node.event.field_content_visibility:community content',
       'view events on my profile',
       'view events on other profiles',
-      'translate event node',
       'delete any event content',
       'edit any event content',
       'revert event revisions',
@@ -2340,6 +2338,34 @@ function social_event_update_111201(): void {
       if ($role->hasPermission($deprecated_permission)) {
         $role->revokePermission($deprecated_permission);
         $role->save();
+      }
+    }
+  }
+}
+
+/**
+ * Search for invalid permission(s) and remove them from existing roles:
+ * "translate event node".
+ */
+function social_event_update_111202(): void {
+  $entity_type_manager = \Drupal::entityTypeManager();
+  $all_permissions = array_keys(\Drupal::service('user.permissions')->getPermissions());
+  /** @var \Drupal\user\RoleInterface[] $roles */
+  $roles = $entity_type_manager->getStorage('user_role')->loadMultiple();
+
+  $permissions_to_check = [
+    'translate event node',
+  ];
+
+  // If permission is not valid (is not on the list of all permissions),
+  // we need to revoke it from all existing roles.
+  foreach ($permissions_to_check as $permission_to_check) {
+    if (!in_array($permission_to_check, $all_permissions)) {
+      foreach ($roles as $role) {
+        if ($role->hasPermission($permission_to_check)) {
+          $role->revokePermission($permission_to_check);
+          $role->save();
+        }
       }
     }
   }

--- a/modules/social_features/social_event/social_event.install
+++ b/modules/social_features/social_event/social_event.install
@@ -2324,7 +2324,7 @@ function social_event_update_11904(): void {
 /**
  * Remove deprecated permission "override event revision log entry".
  */
-function social_event_update_111201(): void {
+function social_event_update_111101(): void {
   $entity_type_manager = \Drupal::entityTypeManager();
   /** @var \Drupal\user\RoleInterface[] $roles */
   $roles = $entity_type_manager->getStorage('user_role')->loadMultiple();
@@ -2349,7 +2349,7 @@ function social_event_update_111201(): void {
  * Permissions to check:
  * - "translate event node".
  */
-function social_event_update_111202(): void {
+function social_event_update_111102(): void {
   $entity_type_manager = \Drupal::entityTypeManager();
   $all_permissions = array_keys(\Drupal::service('user.permissions')->getPermissions());
   /** @var \Drupal\user\RoleInterface[] $roles */

--- a/modules/social_features/social_event/social_event.install
+++ b/modules/social_features/social_event/social_event.install
@@ -65,7 +65,6 @@ function social_event_install() {
       'revert event revisions',
       'delete event revisions',
       'view event revisions',
-      'override event revision log entry',
       'override event authored by option',
       'override event authored on option',
       'override event promote to front page option',
@@ -89,7 +88,6 @@ function social_event_install() {
       'revert event revisions',
       'delete event revisions',
       'view event revisions',
-      'override event revision log entry',
       'override event authored by option',
       'override event authored on option',
       'override event promote to front page option',
@@ -2320,6 +2318,28 @@ function social_event_update_11904(): void {
       if (isset($data['display']['default']['display_options']['query']['options']['distinct'])) {
         $data['display']['default']['display_options']['query']['options']['distinct'] = TRUE;
         $config_value->setData($data)->save();
+      }
+    }
+  }
+}
+
+/**
+ * Remove deprecated permission "override event revision log entry".
+ */
+function social_event_update_111201(): void {
+  $entity_type_manager = \Drupal::entityTypeManager();
+  /** @var \Drupal\user\RoleInterface[] $roles */
+  $roles = $entity_type_manager->getStorage('user_role')->loadMultiple();
+
+  $deprecated_permissions = [
+    'override event revision log entry',
+  ];
+
+  foreach ($deprecated_permissions as $deprecated_permission) {
+    foreach ($roles as $role) {
+      if ($role->hasPermission($deprecated_permission)) {
+        $role->revokePermission($deprecated_permission);
+        $role->save();
       }
     }
   }

--- a/modules/social_features/social_event/social_event.install
+++ b/modules/social_features/social_event/social_event.install
@@ -2344,8 +2344,10 @@ function social_event_update_111201(): void {
 }
 
 /**
- * Search for invalid permission(s) and remove them from existing roles:
- * "translate event node".
+ * Search for invalid permission(s) and remove them from existing roles.
+ *
+ * Permissions to check:
+ * - "translate event node".
  */
 function social_event_update_111202(): void {
   $entity_type_manager = \Drupal::entityTypeManager();

--- a/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.install
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.install
@@ -641,8 +641,10 @@ function social_group_flexible_group_update_11901(): string {
 }
 
 /**
- * Search for invalid permission(s) and remove them from existing roles:
- * "translate flexible_group group".
+ * Search for invalid permission(s) and remove them from existing roles.
+ *
+ * Permissions to check:
+ * - "translate flexible_group group".
  */
 function social_group_flexible_group_update_111201(): void {
   $entity_type_manager = \Drupal::entityTypeManager();

--- a/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.install
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.install
@@ -646,7 +646,7 @@ function social_group_flexible_group_update_11901(): string {
  * Permissions to check:
  * - "translate flexible_group group".
  */
-function social_group_flexible_group_update_111201(): void {
+function social_group_flexible_group_update_111101(): void {
   $entity_type_manager = \Drupal::entityTypeManager();
   $all_permissions = array_keys(\Drupal::service('user.permissions')->getPermissions());
   /** @var \Drupal\user\RoleInterface[] $roles */

--- a/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.install
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.install
@@ -28,14 +28,12 @@ function social_group_flexible_group_install() {
     'contentmanager',
     [
       'create flexible_group group',
-      'translate flexible_group group',
     ]
   );
   user_role_grant_permissions(
     'sitemanager',
     [
       'create flexible_group group',
-      'translate flexible_group group',
     ]
   );
 
@@ -640,4 +638,32 @@ function social_group_flexible_group_update_11901(): string {
 
   // Output logged messages to related channel of update execution.
   return $updater->logger()->output();
+}
+
+/**
+ * Search for invalid permission(s) and remove them from existing roles:
+ * "translate flexible_group group".
+ */
+function social_group_flexible_group_update_111201(): void {
+  $entity_type_manager = \Drupal::entityTypeManager();
+  $all_permissions = array_keys(\Drupal::service('user.permissions')->getPermissions());
+  /** @var \Drupal\user\RoleInterface[] $roles */
+  $roles = $entity_type_manager->getStorage('user_role')->loadMultiple();
+
+  $permissions_to_check = [
+    'translate flexible_group group',
+  ];
+
+  // If permission is not valid (is not on the list of all permissions),
+  // we need to revoke it from all existing roles.
+  foreach ($permissions_to_check as $permission_to_check) {
+    if (!in_array($permission_to_check, $all_permissions)) {
+      foreach ($roles as $role) {
+        if ($role->hasPermission($permission_to_check)) {
+          $role->revokePermission($permission_to_check);
+          $role->save();
+        }
+      }
+    }
+  }
 }

--- a/modules/social_features/social_landing_page/social_landing_page.install
+++ b/modules/social_features/social_landing_page/social_landing_page.install
@@ -50,11 +50,9 @@ function social_landing_page_install() {
       'view landing_page revisions',
       'delete landing_page revisions',
       'revert landing_page revisions',
-      'override landing_page revision log entry',
       'override landing_page authored by option',
       'override landing_page published option',
       'override landing_page authored on option',
-      'override landing_page promote to front landing_page option',
       'override landing_page revision option',
       'override landing_page sticky option',
       'view node.landing_page.field_content_visibility:group content',
@@ -73,11 +71,9 @@ function social_landing_page_install() {
       'view landing_page revisions',
       'delete landing_page revisions',
       'revert landing_page revisions',
-      'override landing_page revision log entry',
       'override landing_page authored by option',
       'override landing_page published option',
       'override landing_page authored on option',
-      'override landing_page promote to front landing_page option',
       'override landing_page revision option',
       'override landing_page sticky option',
       'view node.landing_page.field_content_visibility:group content',
@@ -777,4 +773,33 @@ function social_landing_page_update_11401(): string {
 
   // Output logged messages to related channel of update execution.
   return $updateHelper->logger()->output();
+}
+
+/**
+ * Remove deprecated permissions:
+ * "override landing_page revision log entry",
+ * "override landing_page promote to front landing_page option".
+ */
+function social_landing_page_update_111201(): void {
+  $entity_type_manager = \Drupal::entityTypeManager();
+  /** @var \Drupal\user\RoleInterface[] $roles */
+  $roles = $entity_type_manager->getStorage('user_role')->loadMultiple();
+
+  $deprecated_permissions = [
+    'override landing_page revision log entry',
+    // Permission below does not exist because it has a typo. It should be
+    // 'override landing_page promote to front page option'. The permission
+    // with typo is not replaced with correct one, because we want to remove
+    // the permission anyway.
+    'override landing_page promote to front landing_page option',
+  ];
+
+  foreach ($deprecated_permissions as $deprecated_permission) {
+    foreach ($roles as $role) {
+      if ($role->hasPermission($deprecated_permission)) {
+        $role->revokePermission($deprecated_permission);
+        $role->save();
+      }
+    }
+  }
 }

--- a/modules/social_features/social_landing_page/social_landing_page.install
+++ b/modules/social_features/social_landing_page/social_landing_page.install
@@ -774,9 +774,11 @@ function social_landing_page_update_11401(): string {
 }
 
 /**
- * Remove deprecated permissions:
- * "override landing_page revision log entry",
- * "override landing_page promote to front landing_page option".
+ * Remove deprecated permissions.
+ *
+ * Deprecated permissions:
+ * - "override landing_page revision log entry",
+ * - "override landing_page promote to front landing_page option".
  */
 function social_landing_page_update_111201(): void {
   $entity_type_manager = \Drupal::entityTypeManager();
@@ -803,8 +805,10 @@ function social_landing_page_update_111201(): void {
 }
 
 /**
- * Search for invalid permission(s) and remove them from existing roles:
- * "translate landing_page node".
+ * Search for invalid permission(s) and remove them from existing roles.
+ *
+ * Permissions to check:
+ * - "translate landing_page node".
  */
 function social_landing_page_update_111202(): void {
   $entity_type_manager = \Drupal::entityTypeManager();

--- a/modules/social_features/social_landing_page/social_landing_page.install
+++ b/modules/social_features/social_landing_page/social_landing_page.install
@@ -780,7 +780,7 @@ function social_landing_page_update_11401(): string {
  * - "override landing_page revision log entry",
  * - "override landing_page promote to front landing_page option".
  */
-function social_landing_page_update_111201(): void {
+function social_landing_page_update_111101(): void {
   $entity_type_manager = \Drupal::entityTypeManager();
   /** @var \Drupal\user\RoleInterface[] $roles */
   $roles = $entity_type_manager->getStorage('user_role')->loadMultiple();
@@ -810,7 +810,7 @@ function social_landing_page_update_111201(): void {
  * Permissions to check:
  * - "translate landing_page node".
  */
-function social_landing_page_update_111202(): void {
+function social_landing_page_update_111102(): void {
   $entity_type_manager = \Drupal::entityTypeManager();
   $all_permissions = array_keys(\Drupal::service('user.permissions')->getPermissions());
   /** @var \Drupal\user\RoleInterface[] $roles */

--- a/modules/social_features/social_landing_page/social_landing_page.install
+++ b/modules/social_features/social_landing_page/social_landing_page.install
@@ -46,7 +46,6 @@ function social_landing_page_install() {
       'delete own landing_page content',
       'edit any landing_page content',
       'edit own landing_page content',
-      'translate landing_page node',
       'view landing_page revisions',
       'delete landing_page revisions',
       'revert landing_page revisions',
@@ -67,7 +66,6 @@ function social_landing_page_install() {
       'delete own landing_page content',
       'edit any landing_page content',
       'edit own landing_page content',
-      'translate landing_page node',
       'view landing_page revisions',
       'delete landing_page revisions',
       'revert landing_page revisions',
@@ -799,6 +797,34 @@ function social_landing_page_update_111201(): void {
       if ($role->hasPermission($deprecated_permission)) {
         $role->revokePermission($deprecated_permission);
         $role->save();
+      }
+    }
+  }
+}
+
+/**
+ * Search for invalid permission(s) and remove them from existing roles:
+ * "translate landing_page node".
+ */
+function social_landing_page_update_111202(): void {
+  $entity_type_manager = \Drupal::entityTypeManager();
+  $all_permissions = array_keys(\Drupal::service('user.permissions')->getPermissions());
+  /** @var \Drupal\user\RoleInterface[] $roles */
+  $roles = $entity_type_manager->getStorage('user_role')->loadMultiple();
+
+  $permissions_to_check = [
+    'translate landing_page node',
+  ];
+
+  // If permission is not valid (is not on the list of all permissions),
+  // we need to revoke it from all existing roles.
+  foreach ($permissions_to_check as $permission_to_check) {
+    if (!in_array($permission_to_check, $all_permissions)) {
+      foreach ($roles as $role) {
+        if ($role->hasPermission($permission_to_check)) {
+          $role->revokePermission($permission_to_check);
+          $role->save();
+        }
       }
     }
   }

--- a/modules/social_features/social_page/social_page.install
+++ b/modules/social_features/social_page/social_page.install
@@ -238,7 +238,7 @@ function social_page_update_10302() {
 /**
  * Remove deprecated permission "override page revision log entry".
  */
-function social_page_update_111201(): void {
+function social_page_update_111101(): void {
   $entity_type_manager = \Drupal::entityTypeManager();
   /** @var \Drupal\user\RoleInterface[] $roles */
   $roles = $entity_type_manager->getStorage('user_role')->loadMultiple();
@@ -263,7 +263,7 @@ function social_page_update_111201(): void {
  * Permissions to check:
  * - "translate page node".
  */
-function social_page_update_111202(): void {
+function social_page_update_111102(): void {
   $entity_type_manager = \Drupal::entityTypeManager();
   $all_permissions = array_keys(\Drupal::service('user.permissions')->getPermissions());
   /** @var \Drupal\user\RoleInterface[] $roles */

--- a/modules/social_features/social_page/social_page.install
+++ b/modules/social_features/social_page/social_page.install
@@ -258,8 +258,10 @@ function social_page_update_111201(): void {
 }
 
 /**
- * Search for invalid permission(s) and remove them from existing roles:
- * "translate page node".
+ * Search for invalid permission(s) and remove them from existing roles.
+ *
+ * Permissions to check:
+ * - "translate page node".
  */
 function social_page_update_111202(): void {
   $entity_type_manager = \Drupal::entityTypeManager();

--- a/modules/social_features/social_page/social_page.install
+++ b/modules/social_features/social_page/social_page.install
@@ -47,7 +47,6 @@ function social_page_install() {
       'view page revisions',
       'delete page revisions',
       'revert page revisions',
-      'override page revision log entry',
       'override page authored by option',
       'override page published option',
       'override page authored on option',
@@ -69,7 +68,6 @@ function social_page_install() {
       'view page revisions',
       'delete page revisions',
       'revert page revisions',
-      'override page revision log entry',
       'override page authored by option',
       'override page published option',
       'override page authored on option',
@@ -237,4 +235,26 @@ function social_page_update_10301() {
 function social_page_update_10302() {
   $config = \Drupal::configFactory()->getEditable('core.entity_view_display.node.page.small_teaser');
   $config->set('third_party_settings', [])->save();
+}
+
+/**
+ * Remove deprecated permission "override page revision log entry".
+ */
+function social_page_update_111201(): void {
+  $entity_type_manager = \Drupal::entityTypeManager();
+  /** @var \Drupal\user\RoleInterface[] $roles */
+  $roles = $entity_type_manager->getStorage('user_role')->loadMultiple();
+
+  $deprecated_permissions = [
+    'override page revision log entry',
+  ];
+
+  foreach ($deprecated_permissions as $deprecated_permission) {
+    foreach ($roles as $role) {
+      if ($role->hasPermission($deprecated_permission)) {
+        $role->revokePermission($deprecated_permission);
+        $role->save();
+      }
+    }
+  }
 }

--- a/modules/social_features/social_page/social_page.install
+++ b/modules/social_features/social_page/social_page.install
@@ -43,7 +43,6 @@ function social_page_install() {
       'delete own page content',
       'edit any page content',
       'edit own page content',
-      'translate page node',
       'view page revisions',
       'delete page revisions',
       'revert page revisions',
@@ -64,7 +63,6 @@ function social_page_install() {
       'delete own page content',
       'edit any page content',
       'edit own page content',
-      'translate page node',
       'view page revisions',
       'delete page revisions',
       'revert page revisions',
@@ -254,6 +252,34 @@ function social_page_update_111201(): void {
       if ($role->hasPermission($deprecated_permission)) {
         $role->revokePermission($deprecated_permission);
         $role->save();
+      }
+    }
+  }
+}
+
+/**
+ * Search for invalid permission(s) and remove them from existing roles:
+ * "translate page node".
+ */
+function social_page_update_111202(): void {
+  $entity_type_manager = \Drupal::entityTypeManager();
+  $all_permissions = array_keys(\Drupal::service('user.permissions')->getPermissions());
+  /** @var \Drupal\user\RoleInterface[] $roles */
+  $roles = $entity_type_manager->getStorage('user_role')->loadMultiple();
+
+  $permissions_to_check = [
+    'translate page node',
+  ];
+
+  // If permission is not valid (is not on the list of all permissions),
+  // we need to revoke it from all existing roles.
+  foreach ($permissions_to_check as $permission_to_check) {
+    if (!in_array($permission_to_check, $all_permissions)) {
+      foreach ($roles as $role) {
+        if ($role->hasPermission($permission_to_check)) {
+          $role->revokePermission($permission_to_check);
+          $role->save();
+        }
       }
     }
   }

--- a/modules/social_features/social_profile/social_profile.install
+++ b/modules/social_features/social_profile/social_profile.install
@@ -477,10 +477,12 @@ function social_profile_update_11701(): string {
 }
 
 /**
- * Remove deprecated permissions:
- * "add own profile profile",
- * "view profile",
- * "add any profile profile".
+ * Remove deprecated permissions.
+ *
+ * Deprecated permissions:
+ * - "add own profile profile",
+ * - "view profile",
+ * - "add any profile profile".
  */
 function social_profile_update_111201(): void {
   $entity_type_manager = \Drupal::entityTypeManager();

--- a/modules/social_features/social_profile/social_profile.install
+++ b/modules/social_features/social_profile/social_profile.install
@@ -32,10 +32,8 @@ function social_profile_install() {
   user_role_grant_permissions(
     RoleInterface::AUTHENTICATED_ID,
     [
-      'add own profile profile',
       'update own profile profile',
       'view own profile profile',
-      'view profile',
     ]
   );
   user_role_grant_permissions(
@@ -48,7 +46,6 @@ function social_profile_install() {
     'contentmanager',
     [
       'view any profile profile',
-      'add any profile profile',
       'update any profile profile',
       'edit profile tags',
     ]
@@ -57,7 +54,6 @@ function social_profile_install() {
     'sitemanager',
     [
       'view any profile profile',
-      'add any profile profile',
       'update any profile profile',
       'edit profile tags',
       'delete terms in profile_tag',
@@ -478,4 +474,31 @@ function social_profile_update_11701(): string {
 
   // Output logged messages to related channel of update execution.
   return $updateHelper->logger()->output();
+}
+
+/**
+ * Remove deprecated permissions:
+ * "add own profile profile",
+ * "view profile",
+ * "add any profile profile".
+ */
+function social_profile_update_111201(): void {
+  $entity_type_manager = \Drupal::entityTypeManager();
+  /** @var \Drupal\user\RoleInterface[] $roles */
+  $roles = $entity_type_manager->getStorage('user_role')->loadMultiple();
+
+  $deprecated_permissions = [
+    'add own profile profile',
+    'view profile',
+    'add any profile profile',
+  ];
+
+  foreach ($deprecated_permissions as $deprecated_permission) {
+    foreach ($roles as $role) {
+      if ($role->hasPermission($deprecated_permission)) {
+        $role->revokePermission($deprecated_permission);
+        $role->save();
+      }
+    }
+  }
 }

--- a/modules/social_features/social_profile/social_profile.install
+++ b/modules/social_features/social_profile/social_profile.install
@@ -484,7 +484,7 @@ function social_profile_update_11701(): string {
  * - "view profile",
  * - "add any profile profile".
  */
-function social_profile_update_111201(): void {
+function social_profile_update_111101(): void {
   $entity_type_manager = \Drupal::entityTypeManager();
   /** @var \Drupal\user\RoleInterface[] $roles */
   $roles = $entity_type_manager->getStorage('user_role')->loadMultiple();

--- a/modules/social_features/social_topic/social_topic.install
+++ b/modules/social_features/social_topic/social_topic.install
@@ -514,7 +514,7 @@ function social_topic_update_11401(): string {
 /**
  * Remove deprecated permission "override topic revision log entry".
  */
-function social_topic_update_111201(): void {
+function social_topic_update_111101(): void {
   $entity_type_manager = \Drupal::entityTypeManager();
   /** @var \Drupal\user\RoleInterface[] $roles */
   $roles = $entity_type_manager->getStorage('user_role')->loadMultiple();
@@ -539,7 +539,7 @@ function social_topic_update_111201(): void {
  * Permissions to check:
  * - "translate topic node".
  */
-function social_topic_update_111202(): void {
+function social_topic_update_111102(): void {
   $entity_type_manager = \Drupal::entityTypeManager();
   $all_permissions = array_keys(\Drupal::service('user.permissions')->getPermissions());
   /** @var \Drupal\user\RoleInterface[] $roles */

--- a/modules/social_features/social_topic/social_topic.install
+++ b/modules/social_features/social_topic/social_topic.install
@@ -62,7 +62,6 @@ function social_topic_install() {
       'revert topic revisions',
       'delete topic revisions',
       'view topic revisions',
-      'override topic revision log entry',
       'override topic authored by option',
       'override topic authored on option',
       'override topic promote to front page option',
@@ -86,7 +85,6 @@ function social_topic_install() {
       'revert topic revisions',
       'delete topic revisions',
       'view topic revisions',
-      'override topic revision log entry',
       'override topic authored by option',
       'override topic authored on option',
       'override topic promote to front page option',
@@ -513,4 +511,26 @@ function social_topic_update_11401(): string {
 
   // Output logged messages to related channel of update execution.
   return $updateHelper->logger()->output();
+}
+
+/**
+ * Remove deprecated permission "override topic revision log entry".
+ */
+function social_topic_update_111201(): void {
+  $entity_type_manager = \Drupal::entityTypeManager();
+  /** @var \Drupal\user\RoleInterface[] $roles */
+  $roles = $entity_type_manager->getStorage('user_role')->loadMultiple();
+
+  $deprecated_permissions = [
+    'override topic revision log entry',
+  ];
+
+  foreach ($deprecated_permissions as $deprecated_permission) {
+    foreach ($roles as $role) {
+      if ($role->hasPermission($deprecated_permission)) {
+        $role->revokePermission($deprecated_permission);
+        $role->save();
+      }
+    }
+  }
 }

--- a/modules/social_features/social_topic/social_topic.install
+++ b/modules/social_features/social_topic/social_topic.install
@@ -56,7 +56,6 @@ function social_topic_install() {
       'view node.topic.field_content_visibility:community content',
       'view topics on my profile',
       'view topics on other profiles',
-      'translate topic node',
       'delete any topic content',
       'edit any topic content',
       'revert topic revisions',
@@ -79,7 +78,6 @@ function social_topic_install() {
       'view node.topic.field_content_visibility:community content',
       'view topics on my profile',
       'view topics on other profiles',
-      'translate topic node',
       'delete any topic content',
       'edit any topic content',
       'revert topic revisions',
@@ -530,6 +528,34 @@ function social_topic_update_111201(): void {
       if ($role->hasPermission($deprecated_permission)) {
         $role->revokePermission($deprecated_permission);
         $role->save();
+      }
+    }
+  }
+}
+
+/**
+ * Search for invalid permission(s) and remove them from existing roles:
+ * "translate topic node".
+ */
+function social_topic_update_111202(): void {
+  $entity_type_manager = \Drupal::entityTypeManager();
+  $all_permissions = array_keys(\Drupal::service('user.permissions')->getPermissions());
+  /** @var \Drupal\user\RoleInterface[] $roles */
+  $roles = $entity_type_manager->getStorage('user_role')->loadMultiple();
+
+  $permissions_to_check = [
+    'translate topic node',
+  ];
+
+  // If permission is not valid (is not on the list of all permissions),
+  // we need to revoke it from all existing roles.
+  foreach ($permissions_to_check as $permission_to_check) {
+    if (!in_array($permission_to_check, $all_permissions)) {
+      foreach ($roles as $role) {
+        if ($role->hasPermission($permission_to_check)) {
+          $role->revokePermission($permission_to_check);
+          $role->save();
+        }
       }
     }
   }

--- a/modules/social_features/social_topic/social_topic.install
+++ b/modules/social_features/social_topic/social_topic.install
@@ -534,8 +534,10 @@ function social_topic_update_111201(): void {
 }
 
 /**
- * Search for invalid permission(s) and remove them from existing roles:
- * "translate topic node".
+ * Search for invalid permission(s) and remove them from existing roles.
+ *
+ * Permissions to check:
+ * - "translate topic node".
  */
 function social_topic_update_111202(): void {
   $entity_type_manager = \Drupal::entityTypeManager();

--- a/tests/behat/features/bootstrap/LogContext.php
+++ b/tests/behat/features/bootstrap/LogContext.php
@@ -155,6 +155,8 @@ class LogContext implements Context {
       // Ignore an existing bug.
       // @todo https://www.drupal.org/project/social/issues/3320117
       || ($row->type === 'php' && (int) $row->severity === RfcLogLevel::WARNING && (str_contains($row->variables, 'Undefined array key "#comment_display_mode"') || str_contains($row->variables, 'Undefined array key "#comment_type"')))
+      // Ignore update notices.
+      || ($row->type === 'update' && (int) $row->severity === RfcLogLevel::NOTICE)
       ;
   }
 


### PR DESCRIPTION
## Problem
Starting with Drupal 9.3.0, all permissions in a user role must be defined in a module.permissions.yml file or a permissions callback. Other permissions are now considered invalid. This includes permissions from uninstalled modules, permissions that depend on configuration that has been removed (such as a content type), and permissions of obscure origin.

In Drupal 9.3.0 or later, saving a role with an invalid permission will trigger a E_USER_DEPRECATED error. In Drupal 10, it will throw a runtime exception.

Since Drupal 8.0, modules are supposed to remove their data from the database when they are uninstalled. See [Modules cannot be in a disabled state anymore, only installed and uninstalled](https://www.drupal.org/node/2193013). One exception has been that uninstalled modules did not remove the permissions they defined from user roles. Before Drupal 9.3.0, a site administrator could uninstall a module, then install it again, and the permissions previously assigned to user roles would be in effect. Starting with Drupal 9.3.0, the administrator must configure permissions again when re-installing the module.

An update function is provided to remove invalid permissions from existing roles. The update function logs the permissions removed from each role.

Source [Permissions must exist](https://www.drupal.org/node/3193348)

## Solution
- Remove deprecated permissions
- Remove granting conditional permissions on module install

## Issue tracker
[3384622](https://www.drupal.org/project/social/issues/3384622), PROD-26030
[data_policy 3384271](https://www.drupal.org/project/data_policy/issues/3384271)

## Theme issue tracker
N/A

## How to test

### General steps
- [ ] Using version 11.11.x of Open Social with the upgrade_status module enabled
- [ ] Go to admin/reports/upgrade-status and check for "[Invalid permissions will trigger runtime exceptions in Drupal 10.](https://www.drupal.org/node/3193348) Permissions should be defined in a permissions.yml file or a permission callback."

### Test cases 1

**Permissions:**
`add own profile profile`
`view profile`
`add any profile profile`
`override event revision log entry`
`override landing_page revision log entry`
`override page revision log entry`
`override topic revision log entry`
`override landing_page promote to front landing_page option`

#### Test case 1A (upgrade)
- [ ] Follow general steps
- [ ] Enable `social_landing_page`
- [ ] On upgrade status you will see all this permissions are marked as invalid.
- [ ] Apply the fix and trigger update hooks - invalid permissions from list above should be removed from upgrade status report.

#### Test case 1B (clean install)
- [ ] Apply the fix
- [ ] Enable social_landing_page
- [ ] Follow general steps
- [ ] Expected result is that on upgrade status you don't see any permission from list above marked as invalid.

### Test cases 2

**Permissions:**
`translate book node`
`translate event node`
`translate flexible_group group`
`translate landing_page node`
`translate page node`
`translate topic node`

#### Test case 2A (upgrade, with permissions removal)
- [ ] Follow general steps
- [ ] Enable `social_landing_page`
- [ ] Enable `social_book`
- [ ] On upgrade status you will see all this permissions are marked as invalid.
- [ ] Apply the fix and trigger update hooks - invalid permissions from list above should be removed from upgrade status report.

#### Test case 2B (upgrade, without permissions removal)
- [ ] Follow general steps
- [ ] Enable `social_landing_page`
- [ ] Enable `social_book`
- [ ] Enable `social_content_translation`
- [ ] Expected result is that on upgrade status you don't see any permission from list above marked as invalid.
- [ ] Apply the fix and trigger update hooks - no permission from list above should be revoked.

#### Test case 2C (clean install)
- [ ] Apply the fix
- [ ] Enable `social_landing_page`
- [ ] Enable `social_book`
- [ ] Confirm that `social_content_translation` and `content_translation` modules are disabled
- [ ] Follow general steps
- [ ] Expected result is that on upgrade status you don't see any permission from list above marked as invalid when.

### Test cases 3

**Permissions:**
`access contextual links`

#### Test case 3A (upgrade, without permissions removal)
- [ ] Follow general steps
- [ ] On upgrade status you will see all this permissions are marked as invalid.
- [ ] Apply the fix and trigger update hooks - invalid permissions from list above should be removed from upgrade status report.

#### Test case 3B (upgrade, with permissions removal)
- [ ] Follow general steps
- [ ] Enable `contextual`
- [ ] Expected result is that on upgrade status you don't see any permission from list above marked as invalid.
- [ ] Apply the fix and trigger update hooks - no permission from list above should be revoked.

#### Test case 3C (clean install)
- [ ] Apply the fix
- [ ] Confirm that `contextual` module is disabled
- [ ] Follow general steps
- [ ] Expected result is that on upgrade status you don't see any permission from list above marked as invalid.

### Test cases 4

**Permissions:**
`access data policy revisions`
~~MR: https://www.drupal.org/project/data_policy/issues/3384271~~ Released: [2.0.0-beta4](https://www.drupal.org/project/data_policy/releases/2.0.0-beta4)

~~_Note: Test case 4A step 3 is temporary. Once MR above will be released, we need to update privacy_policy dependency to require changes in OS. Step 3 can be removed after that_~~

#### Test case 4A
- [ ] Follow general steps
- [ ] On upgrade status you will see all this permissions are marked as invalid.
- [ ] ~~Apply the changes from MR~~
- [ ] Expected result is that on upgrade status you don't see any permission from list above marked as invalid.

### Test cases 5 
_Note: this test cases are very similar to test cases 2_

**Permissions:**
`translate data_policy`

#### Test case 5A (upgrade, with permissions removal)
- [ ] Follow general steps
- [ ] Enable `social_gdpr`
- [ ] On upgrade status you will see all this permissions are marked as invalid.
- [ ] Apply the fix and trigger update hooks - invalid permissions from list above should be removed from upgrade status report.

#### Test case 5B (upgrade, without permissions removal)
- [ ] Follow general steps
- [ ] Enable `social_gdpr`
- [ ] Enable `social_content_translation`
- [ ] Expected result is that on upgrade status you don't see any permission from list above marked as invalid.
- [ ] Apply the fix and trigger update hooks - no permission from list above should be revoked.

#### Test case 5C (clean install)
- [ ] Apply the fix
- [ ] Enable `social_gdpr`
- [ ] Confirm that `social_content_translation` and `content_translation` modules are disabled
- [ ] Follow general steps
- [ ] Expected result is that on upgrade status you don't see any permission from list above marked as invalid when.

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
N/A

## Release notes
Clean up deprecated permissions in case they are granted on any role.
- `add own profile profile`
- `view profile`
- `add any profile profile`
- `override event revision log entry`
- `override landing_page revision log entry`
- `override page revision log entry`
- `override topic revision log entry`
- `override landing_page promote to front landing_page option`

Clean up unused permissions in case they are granted on any role.
- `translate book node`
- `translate event node`
- `translate flexible_group group`
- `translate landing_page node`
- `translate page node`
- `translate topic node`
- `translate data_policy`

## Change Record
<!-- *[Required if applicable] If this Pull Request changes the way that developers should do things or introduces a new API for developers then a change record to document this is needed. Please provide a draft for a change record or a link to an unpublished change record below. Existing change records can be consulted as example. Please provide a draft for a change record or a link to an unpublished change record below. [Existing change records](https://www.drupal.org/list-changes/social) can be consulted as example.* -->

When installing Open Social, permissions listed below should be granted manually (before they were granted automatically).
- `translate book node`
- `translate event node`
- `translate flexible_group group`
- `translate landing_page node`
- `translate page node`
- `translate topic node`
- `translate data_policy`

## Translations
N/A
