### PR TITLE
Internal: Restructure EmailContext to provide better debug information

### DIFF
--- a/tests/behat/features/bootstrap/EmailContext.php
+++ b/tests/behat/features/bootstrap/EmailContext.php
@@ -1,5 +1,4 @@
 <?php
-// @codingStandardsIgnoreFile
 
 namespace Drupal\social\Behat;
 
@@ -8,8 +7,18 @@ use Behat\Gherkin\Node\TableNode;
 use Drupal\ultimate_cron\Entity\CronJob;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;
+use Symfony\Component\Finder\SplFileInfo;
 use Symfony\Component\HttpFoundation\File\File;
 
+/**
+ * Provides helpful test steps around the handling of e-mails.
+ *
+ * To enable email collection for one or more scenario's add the @email-spool
+ * annotation to the scenario or to an entire feature. Email collection in the
+ * mail-spool directory will automatically happen for annotated tests.
+ *
+ * Steps exist to check that a certain email was or was not sent.
+ */
 class EmailContext implements Context {
 
   /**
@@ -17,7 +26,7 @@ class EmailContext implements Context {
    *
    * @BeforeScenario @email-spool
    */
-  public function enableEmailSpool() {
+  public function enableEmailSpool() : void {
     // Update Drupal configuration.
     $swiftmailer_config = \Drupal::configFactory()->getEditable('swiftmailer.transport');
     $swiftmailer_config->set('transport', 'spool');
@@ -33,7 +42,7 @@ class EmailContext implements Context {
    *
    * @AfterScenario @email-spool
    */
-  public function disableEmailSpool() {
+  public function disableEmailSpool() : void {
     // Update Drupal configuration.
     $swiftmailer_config = \Drupal::configFactory()->getEditable('swiftmailer.transport');
     $swiftmailer_config->set('transport', 'native');
@@ -41,130 +50,11 @@ class EmailContext implements Context {
   }
 
   /**
-   * Get a list of spooled emails.
-   *
-   * @return Finder|null
-   *   Returns a Finder if the directory exists.
-   * @throws Exception
-   */
-  public function getSpooledEmails() {
-    $finder = new Finder();
-    $spoolDir = $this->getSpoolDir();
-
-    if(empty($spoolDir)) {
-      throw new \Exception('Could not retrieve the spool directory, or the directory does not exist.');
-    }
-
-    try {
-      $finder->files()->in($spoolDir);
-      return $finder;
-    }
-    catch (InvalidArgumentException $exception) {
-      return NULL;
-    }
-  }
-
-  /**
-   * Get content of email.
-   *
-   * @param string $file
-   *   Path to the file.
-   *
-   * @return string
-   *   An unserialized email.
-   */
-  public function getEmailContent($file) {
-    return unserialize(file_get_contents($file));
-  }
-
-  /**
-   * Get the path where the spooled emails are stored.
-   *
-   * @return string
-   *   The path where the spooled emails are stored.
-   */
-  protected function getSpoolDir() {
-    $path = \Drupal::service('extension.list.profile')->getPath('social') . '/tests/behat/mail-spool';
-    if (!file_exists($path)) {
-      mkdir($path, 0777, true);
-    }
-
-    return $path;
-  }
-
-  /**
-   * Purge the messages in the spool.
-   */
-  protected function purgeSpool() {
-    $filesystem = new Filesystem();
-    $finder = $this->getSpooledEmails();
-
-    if ($finder) {
-      /** @var File $file */
-      foreach ($finder as $file) {
-        $filesystem->remove($file->getRealPath());
-      }
-    }
-  }
-
-  /**
-   * Find an email with the given subject and body.
-   *
-   * @param string $subject
-   *   The subject of the email.
-   * @param array $body
-   *   Text that should be in the email.
-   *
-   * @return bool
-   *   Email was found or not.
-   * @throws Exception
-   */
-  protected function findSubjectAndBody($subject, $body) {
-    $finder = $this->getSpooledEmails();
-
-    $found_email = FALSE;
-
-    if ($finder) {
-      /** @var File $file */
-      foreach ($finder as $file) {
-        /** @var Swift_Message $email */
-        $email = $this->getEmailContent($file);
-        $email_subject = $email->getSubject();
-        $email_body = $email->getBody();
-
-        // Make it a traversable HTML doc.
-        $doc = new \DOMDocument();
-        @$doc->loadHTML($email_body);
-        $xpath = new \DOMXPath($doc);
-        // Find the post header and email content in the HTML file.
-        $content = $xpath->evaluate('string(//*[contains(@class,"postheader")])');
-        $content .= $xpath->evaluate('string(//*[contains(@class,"main")])');
-        $content_found = 0;
-
-        foreach ($body as $string) {
-          if (strpos($content, $string)) {
-            $content_found++;
-          }
-        }
-
-        if ($email_subject == $subject && $content_found === count($body)) {
-          $found_email = TRUE;
-        }
-      }
-    }
-    else {
-      throw new \Exception('There are no email messages.');
-    }
-
-    return $found_email;
-  }
-
-  /**
    * I run the digest cron.
    *
    * @Then I run the :arg1 digest cron
    */
-  public function iRunTheDigestCron($frequency) {
+  public function iRunTheDigestCron(string $frequency) : void {
     // Update the timings in the digest table.
     $query =  \Drupal::database()->update('user_activity_digest');
     $query->fields(['timestamp' => 1]);
@@ -191,12 +81,8 @@ class EmailContext implements Context {
    *
    * @Then /^(?:|I )should have an email with subject "([^"]*)" and "([^"]*)" in the body$/
    */
-  public function iShouldHaveAnEmailWithTitleAndBody($subject, $body) {
-    $found_email = $this->findSubjectAndBody($subject, [$body]);
-
-    if (!$found_email) {
-      throw new \Exception('There is no email with that subject and body.');
-    }
+  public function iShouldHaveAnEmailWithTitleAndBody(string $subject, string $body) : void {
+    $this->assertEmailWithSubjectAndBody($subject, [$body]);
   }
 
   /**
@@ -204,17 +90,44 @@ class EmailContext implements Context {
    *
    * @Then I should have an email with subject :arg1 and in the content:
    */
-  public function iShouldHaveAnEmailWithTitleAndBodyMulti($subject, TableNode $table) {
+  public function iShouldHaveAnEmailWithTitleAndBodyMulti(string $subject, TableNode $table) : void {
     $body = [];
     $hash = $table->getHash();
     foreach ($hash as $row) {
       $body[] = $row['content'];
     }
 
-    $found_email = $this->findSubjectAndBody($subject, $body);
+    $this->assertEmailWithSubjectAndBody($subject, $body);
+  }
 
-    if (!$found_email) {
-      throw new \Exception('There is no email with that subject and body.');
+  /**
+   * No emails have been sent.
+   *
+   * @Then no emails have been sent
+   */
+  public function noEmailsHaveBeenSent() : void {
+    $finder = $this->getSpooledEmails();
+
+    $count = $finder->count();
+    if ($count !== 0) {
+      throw new \Exception("No email messages should have been sent, but found $count.");
+    }
+  }
+
+  /**
+   * I do not have an email with a specific subject.
+   *
+   * Can be used in case you don't want an email to be sent regardless of the
+   * body.
+   *
+   * @Then should not have an email with subject :subject
+   * @Then I should not have an email with subject :subject
+   */
+  public function iShouldNotHaveAnEmailWithSubject(string $subject) : void {
+    $emails = $this->findEmailsWithSubject($subject);
+    $email_count = count($emails);
+    if ($email_count !== 0) {
+      throw new \Exception("Expected no emails with subject '$subject' but found $email_count");
     }
   }
 
@@ -223,12 +136,8 @@ class EmailContext implements Context {
    *
    * @Then /^(?:|I )should not have an email with subject "([^"]*)" and "([^"]*)" in the body$/
    */
-  public function iShouldNotHaveAnEmailWithTitleAndBody($subject, $body) {
-    $found_email = $this->findSubjectAndBody($subject, [$body]);
-
-    if ($found_email) {
-      throw new \Exception('There is an email with that subject and body.');
-    }
+  public function iShouldNotHaveAnEmailWithTitleAndBody(string $subject, string $body) : void {
+    $this->assertNoEmailWithSubjectAndBody($subject, [$body]);
   }
 
   /**
@@ -236,17 +145,231 @@ class EmailContext implements Context {
    *
    * @Then I should not have an email with subject :arg1 and in the content:
    */
-  public function iShouldNotHaveAnEmailWithTitleAndBodyMulti($subject, TableNode $table) {
+  public function iShouldNotHaveAnEmailWithTitleAndBodyMulti(string $subject, TableNode $table) : void {
     $body = [];
     $hash = $table->getHash();
     foreach ($hash as $row) {
       $body[] = $row['content'];
     }
 
-    $found_email = $this->findSubjectAndBody($subject, $body);
+    $this->assertNoEmailWithSubjectAndBody($subject, $body);
+  }
 
-    if ($found_email) {
-      throw new \Exception('There is an email with that subject and body.');
+  /**
+   * Ensure at least one email exists matching the provided subject and body.
+   *
+   * @param string $subject
+   *   The exact subject the email should have.
+   *
+   * @param list<string> $expected_lines
+   *   A list of lines that should all be present in the body of the e-mail.
+   *
+   * @throws \Exception
+   *   An exception that details to the developer what was wrong (e.g. no
+   *   matching subject, no matching lines, or missing a specific line match).
+   */
+  protected function assertEmailWithSubjectAndBody(string $subject, array $expected_lines) : void {
+    $emails = $this->findEmailsWithSubject($subject);
+
+    // If no emails with the subject exist then we want to report that so a
+    // developer knows that may be the cause of their failure.
+    $subject_match_count = count($emails);
+    if ($subject_match_count === 0) {
+      throw new \Exception("No emails with subject '$subject' were found.");
+    }
+
+    $partial_matches = [];
+    $count_expected = count($expected_lines);
+    foreach ($emails as $email) {
+      $matched_lines = $this->getMatchingLinesForEmail($expected_lines, $email);
+
+      $count_matched = count($matched_lines);
+      // If we have a complete match then we're done.
+      if ($count_matched === $count_expected) {
+        return;
+      }
+
+      if ($count_matched > 0) {
+        $partial_matches[] = $matched_lines;
+      }
+    }
+
+    $partial_match_count = count($partial_matches);
+    // If we had no partial matches then we can provide a simplified error message.
+    if ($partial_match_count === 0) {
+      $message = $subject_match_count === 1
+        ? "One email with the subject '$subject' was found but none of the expected lines were found in the body of the email."
+        : "$subject_match_count emails with the subject '$subject' were found but none of the expected lines were found in the body of the email.";
+      throw new \Exception($message);
+    }
+    // If we had a single partial match then we tell the developer and there's
+    // probably a simple typo in the email or test.
+    if ($partial_match_count === 1) {
+      $missing_lines = array_diff($expected_lines, $partial_matches[0]);
+      $message = "One email was found which matched the subject and some lines but the following lines were missing from the e-mail: \n  " . implode("\n  ", $missing_lines);
+      throw new \Exception($message);
+    }
+    // With multiple partial matches we want to provide the developer as much
+    // information as possible.
+    $message = "$partial_match_count emails were found that matched the subject but all of them were missing some expected lines from the email:\n";
+    foreach ($partial_matches as $i => $partial_match) {
+      $missing_lines = array_diff($expected_lines, $partial_match);
+      $message .= "------- Partial match $i --------\n  " . implode("\n  ", $missing_lines);
+    }
+    throw new \Exception($message);
+  }
+
+  /**
+   * Ensure there's no emails with the specified subject and body.
+   *
+   * @param string $subject
+   *   The subject to match against.
+   * @param list<string> $expected_lines
+   *   An array of strings that match the body's contents. For an email to be
+   *   considered a match, all lines in the array must match.
+   *
+   * @throws \Exception
+   *   In case an email was found matching the subject and all expected lines of
+   *   text.
+   */
+  protected function assertNoEmailWithSubjectAndBody(string $subject, array $expected_lines) : void {
+    $emails = $this->findEmailsWithSubject($subject);
+
+    $count_expected = count($expected_lines);
+    foreach ($emails as $email) {
+      $matched_lines = $this->getMatchingLinesForEmail($expected_lines, $email);
+
+      $count_matched = count($matched_lines);
+      if ($count_matched === $count_expected) {
+        throw new \Exception("An email exists with the specified subject and body.");
+      }
     }
   }
+
+  /**
+   * Purge the messages in the spool.
+   */
+  protected function purgeSpool() : void {
+    $filesystem = new Filesystem();
+    $finder = $this->getSpooledEmails();
+
+    /** @var File $file */
+    foreach ($finder as $file) {
+      $filesystem->remove($file->getRealPath());
+    }
+  }
+
+  /**
+   * Find all emails that were sent with a given subject.
+   *
+   * @param string $subject
+   *   The subject to search for.
+   *
+   * @return array
+   *   An array of matching emails.
+   * @throws \Exception
+   *   An exception in case no emails were sent or email collection is
+   *   incorrectly configured.
+   */
+  protected function findEmailsWithSubject(string $subject) : array {
+    $finder = $this->getSpooledEmails();
+
+    if ($finder->count() === 0) {
+      throw new \Exception('No email messages have been sent in the test.');
+    }
+
+    $emails = [];
+    foreach ($finder as $file) {
+      $email = $this->getEmailContent($file);
+      assert($email instanceof \Swift_Message);
+
+      if ($email->getSubject() === $subject) {
+        $emails[] = $email;
+      }
+    }
+
+    return $emails;
+  }
+
+  /**
+   * Get a list of spooled emails.
+   *
+   * @return Finder
+   *   Returns a Finder if the directory exists.
+   * @throws \Exception
+   *   An exception is thrown in case the configured directory does not exist.
+   */
+  protected function getSpooledEmails() : Finder {
+    $finder = new Finder();
+    $spoolDir = $this->getSpoolDir();
+
+    try {
+      return $finder->files()->name("*.message")->in($spoolDir);
+    }
+    catch (\InvalidArgumentException $exception) {
+      throw new \Exception("The e-mail spool directory does not exist or is incorrectly configured, expected '{$spoolDir}' to exist.");
+    }
+  }
+
+  /**
+   * Get the path where the spooled emails are stored.
+   *
+   * @return string
+   *   The path where the spooled emails are stored.
+   */
+  protected function getSpoolDir() : string {
+    // This path should exist within the repository and have a .gitignore file
+    // that ignores all e-mails so developers don't accidentally commit them.
+    return \Drupal::service('extension.list.profile')->getPath('social') . '/tests/behat/mail-spool';
+  }
+
+  /**
+   * Get content of email.
+   *
+   * @param \Symfony\Component\Finder\SplFileInfo $file
+   *   The .message file to get content for.
+   *
+   * @return
+   *   A deserialized email.
+   */
+  protected function getEmailContent(SplFileInfo $file) {
+    assert($file->getExtension() === "message", "File passed to " . __FUNCTION__ . " must be a serialized .message file.");
+    return unserialize($file->getContents());
+  }
+
+  /**
+   * Find the matching lines in a specific email.
+   *
+   * @param list<string> $expected_lines
+   *   The list of lines of text that is expected to be in the email.
+   * @param $email
+   *   The email to check.
+   *
+   * @return list<string>
+   *   A list of lines from $expected_lines that was found in the body of
+   *   $email.
+   */
+  protected function getMatchingLinesForEmail(array $expected_lines, $email) : array {
+    $body = $email->getBody();
+
+    // Make it a traversable HTML doc.
+    $doc = new \DOMDocument();
+    @$doc->loadHTML($body);
+    $xpath = new \DOMXPath($doc);
+    // Find the post header and email content in the HTML file.
+    $content = $xpath->evaluate('string(//*[contains(@class,"postheader")])');
+    $content .= $xpath->evaluate('string(//*[contains(@class,"main")])');
+
+    $matched_lines = [];
+
+    foreach ($expected_lines as $string) {
+      if (str_contains($content, $string)) {
+        $matched_lines[] = $string;
+      }
+    }
+
+    return $matched_lines;
+  }
+
+
 }

--- a/tests/behat/mail-spool/.gitignore
+++ b/tests/behat/mail-spool/.gitignore
@@ -1,1 +1,5 @@
+*.html
 *.message
+*.txt
+*.metadata
+*.unknown


### PR DESCRIPTION
## Problem/Solution

The EmailContext mail handling was created quite some years ago. In case an email in a test didn't match, the developer only got information that there was no match, there was no useful information about what didn't match (for example that a subject wasn't found, or that a specific line didn't match).

The test steps are rewritten so that the developer gets as much actionable information as possible. This can be that a specific subject wasn't found, or that one or more lines of the body did not match. This makes it easier for the developer based on just the test output and the changes they may have made to determine where the error comes from.

Providing this information in the test output requires some new functions to be rewritten. This opportunity is used to also restructure the other functions of the file and provide PHPStan output:

- Behat hooks are placed at the top
- Followed by developer usable test steps
- Followed by protected functions which are used to support the test steps, in the order in which they were first called.

## Issue tracker
Test infrastructure change only, no issue.

## How to test
- [ ] Write an email test that fails for different reasons and inspect the output.
- [ ] The changes should not break any tests already in the CI, so Behat for this PR should be green without test changes.

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
<!-- *[Required if new feature, and if applicable] If this Pull Request makes visual changes then please include some screenshots that show what has changed here. A before and after screenshot helps the reviewer determine what changes were made.* -->

## Release notes
<!-- *[Required if new feature, and if applicable] A short summary of the changes that were made that can be included in release notes.* -->

## Change Record
<!-- *[Required if applicable] If this Pull Request changes the way that developers should do things or introduces a new API for developers then a change record to document this is needed. Please provide a draft for a change record or a link to an unpublished change record below. Existing change records can be consulted as example. Please provide a draft for a change record or a link to an unpublished change record below. [Existing change records](https://www.drupal.org/list-changes/social) can be consulted as example.* -->

## Translations
<!--
*[Optional]Translatable strings are always extracted from the latest development branch. To ensure translations remain available for platforms running older versions of Open Social the original string should be added to `translations.php` when it's changed or removed.*
- [ ] Changed or removed source strings are added to the `translations.php` file.
-->
