### PR TITLE
Issue #3385341 by Kingdutch: Uninstall admin_toolbar_tools and remove from default installation

### DIFF
--- a/modules/social_features/social_core/social_core.info.yml
+++ b/modules/social_features/social_core/social_core.info.yml
@@ -3,7 +3,7 @@ description: 'Provides core components required by other features.'
 type: module
 core_version_requirement: ^9 || ^10
 dependencies:
-  - admin_toolbar_tools:admin_toolbar_tools
+  - admin_toolbar:admin_toolbar
   - drupal:block
   - drupal:block_content
   - config_modify:config_modify

--- a/modules/social_features/social_core/social_core.install
+++ b/modules/social_features/social_core/social_core.install
@@ -1716,3 +1716,23 @@ function social_core_update_111101(): void {
     }
   }
 }
+
+/**
+ * Uninstall admin_toolbar_tools if nothing uses it.
+ */
+function social_core_update_111201() : void {
+  // Nothing to do if the module is not installed.
+  if (!\Drupal::moduleHandler()->moduleExists("admin_toolbar_tools")) {
+    return;
+  }
+
+  // If there are modules depending on admin_toolbar_tools we can't uninstall
+  // it.
+  if (!empty(\Drupal::service('extension.list.module')->get("admin_toolbar_tools")->required_by)) {
+    return;
+  }
+
+  // Uninstall the module (nothing should depend on it but let the module
+  // uninstaller double-check just in case).
+  \Drupal::service("module_installer")->uninstall(["admin_toolbar_tools"], FALSE);
+}

--- a/modules/social_features/social_core/tests/modules/social_core_test/social_core_test.info.yml
+++ b/modules/social_features/social_core/tests/modules/social_core_test/social_core_test.info.yml
@@ -3,7 +3,7 @@ description: 'Support module for module Social Core .'
 type: module
 core_version_requirement: ^9 || ^10
 dependencies:
-  - admin_toolbar_tools:admin_toolbar_tools
+  - admin_toolbar:admin_toolbar
   - drupal:block
   - drupal:block_content
   - crop:crop


### PR DESCRIPTION
<h2 id="summary-problem-motivation">Problem/Motivation</h2>
Open Social requires a lot of modules to function. However, while profiling our installation it was found that <code>admin_toolbar_tools</code> was responsible for over half of the database queries needed during an installation (~85k out of ~125k total).

Looking at the hooks for <code>admin_toolbar_tools</code> the module will also perform this expensive rebuild operation during run-time any time a content entity is created that has bundles.

<h2 id="summary-proposed-resolution">Proposed resolution</h2>
Since the menu rebuild is an expensive operation and almost all of the actions users can take on the platform that are not view will cause an entity to be inserted/updated/deleted, there's a high likely-hood that <code>admin_toolbar_tools</code> triggers this expensive action for a lot of Open Social user actions.

With that in mind my recommendation is to remove the <code>admin_toolbar_tools</code> menu outright by:

<ul>
<li>Changing the dependency in <code>social_core</code> to <code>admin_toolbar</code></li>
<li>Adding an update hook to <code>social_core</code> to uninstall <code>admin_toolbar_tools</code> in case no other modules depend on it</li>
</ul>

For this case we assume that Open Social installations are large active sites and optimise for general member performance over developer convenience (understanding that <code>admin_toolbar_tools</code> provides developer links exclusively). In case a site builder does want the <code>admin_toolbar_tools</code> module on their site they will need to re-install it after the update. In case a user of the Open Social distribution has built on top of the <code>admin_toolbar_tools</code> module we will not uninstall.

## Issue tracker
<!-- *[Required] Paste a link to the drupal.org issue queue item. If any other issue trackers were used, include links to those too.* -->

## Theme issue tracker
*[Required if applicable] Paste a link to the drupal.org theme issue queue item, either from [socialbase](https://www.drupal.org/project/socialbase) or [socialblue](https://www.drupal.org/project/socialblue). If any other issue trackers were used, include links to those too.*

## How to test
<!--
*[Required] For example*
- [ ] Using version X.Y.Z of Open Social with the example module enabled
- [ ] As a sitemanager
- [ ] Try to enable the option B on screen c/d/e
- [ ] When saving I expect the result to be F but instead see G.
- [ ] The expected result F is attained when repeating the steps with this fix applied.
-->

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
<img src="https://www.drupal.org/files/issues/2023-09-05/image%20%282%29.png" alt="" />
Actions such as "Flush", "Index", "Logout" and "Cron" are no longer shown under the logo

<img src="https://www.drupal.org/files/issues/2023-09-05/image%20%283%29.png" alt="" />
Bundle specific developer pages are no longer shown in the admin menu but will require visiting the entity's config page

## Release notes
Open Social will uninstall the `admin_toolbar_tools` module on existing installations (unless a non-Open Social module depends on it) and the module will no longer be installed for new installations. Investigation showed that it performed expensive operations when content was created, updated, or deleted. The `admin_toolbar_tools` provided quick links to developer pages such as cron, search index, caching, and entity bundle configuration for the `admin_toolbar`. The `admin_toolbar` has a much lower performance footprint, further reduced by the `social_admin_menu` module, and will still be enabled.

## Change Record
<!-- *[Required if applicable] If this Pull Request changes the way that developers should do things or introduces a new API for developers then a change record to document this is needed. Please provide a draft for a change record or a link to an unpublished change record below. Existing change records can be consulted as example. Please provide a draft for a change record or a link to an unpublished change record below. [Existing change records](https://www.drupal.org/list-changes/social) can be consulted as example.* -->

## Translations
<!--
*[Optional]Translatable strings are always extracted from the latest development branch. To ensure translations remain available for platforms running older versions of Open Social the original string should be added to `translations.php` when it's changed or removed.*
- [ ] Changed or removed source strings are added to the `translations.php` file.
-->
