### PR TITLE
Issue #3386579: Update url_embed to 2.0.0-alpha1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -99,10 +99,8 @@
             },
             "drupal/url_embed": {
                 "Translate dialog title": "https://www.drupal.org/files/issues/2018-03-16/url_embed_translate_dialog_title-2953591-2.patch",
-                "Improve how the module deals with non-embeddable URLs & WSODs (See: https://www.drupal.org/project/social/issues/2930457#comment-13973067)": "https://www.drupal.org/files/issues/2021-01-22/urlembed-non-embeddable-urls-2761187-opensocial-combined-21.patch",
-                "Support for Facebook/Instagram API changes - add access token settings": "https://www.drupal.org/files/issues/2021-07-14/url_embed-add-facebook-access-token-config-3177860-opensocial-2.patch",
-                "Embed Preview throws 403 forbidden": "https://www.drupal.org/files/issues/2023-03-17/url_embed-preview-403-3285139-10.patch",
-                "Issue #3382821: preg_split in _filter_url breaks for long html tags (improvement for issue 3360661)" :"https://www.drupal.org/files/issues/2023-08-23/3382821-url_embed-preg-split.patch.diff"
+                "Issue #2761187/#3386579 Improve how the module deals with non-embeddable URLs & WSODs (See: https://www.drupal.org/project/social/issues/3386579#comment-15225972) 2.x": "https://www.drupal.org/files/issues/2023-09-11/urlembed-non-embeddable-urls-2761187-opensocial-combined-21_2.x_1.patch",
+                "Issue #3386590: preg_split in _filter_url breaks for long html tags": "https://www.drupal.org/files/issues/2023-09-11/3382821-url_embed-preg-split_2.x_1.patch"
             },
             "drupal/views_infinite_scroll" : {
                 "Headers in table format repeat on load more instead of adding rows (v1.8)": "https://www.drupal.org/files/issues/2021-02-11/2899705-35.patch"
@@ -167,7 +165,7 @@
         "drupal/token": "1.12.0",
         "drupal/ultimate_cron": "2.0.0-alpha6",
         "drupal/update_helper": "3.0.4",
-        "drupal/url_embed": "1.0-beta1",
+        "drupal/url_embed": "2.0.0-alpha1",
         "drupal/views_bulk_operations": "4.1.4",
         "drupal/views_infinite_scroll": "2.0.2",
         "drupal/votingapi": "3.0.0-beta4",


### PR DESCRIPTION
Update url_embed to provide Drupal 10 compatibility including related patches. Issues related with update: #2930457, #3386579.

## Problem
We are currently running 8.x-1.0-beta1 which is not compatible with Drupal 10

## Solution
Update url_embed to 2.0.0-alpha1 which is compatible with Drupal 10 and update all related patches.

**Remove patch:** 
"Embed Preview throws 403 forbidden": "https://www.drupal.org/files/issues/2023-03-17/url_embed-preview-403-3285139-10.patch" 
Fixed <a href="https://git.drupalcode.org/project/url_embed/-/commit/64596b7">here</a>.

**Remove patch:** 
"Support for Facebook/Instagram API changes - add access token settings": "https://www.drupal.org/files/issues/2021-07-14/url_embed-add-facebook-access-token-config-3177860-opensocial-2.patch"
Fixed <a href="https://git.drupalcode.org/project/url_embed/-/commit/63f8d03">here</a>.

**Update patch:**
"Improve how the module deals with non-embeddable URLs & WSODs"
Old issue <a href="https://www.drupal.org/project/social/issues/2930457#comment-13973067">2930457</a> => new issue <a href="https://www.drupal.org/project/social/issues/3386579#comment-15225972">3386579</a>

**Update patch:**
"preg_split in _filter_url breaks for long html tags"
Old issue <a href="https://www.drupal.org/project/social/issues/3382821#comment-15203041">3382821</a> => new issue <a href="https://www.drupal.org/project/social/issues/3386590#comment-15226004">3386590</a>

## Issue tracker
Main issue: [3386591](https://www.drupal.org/project/social/issues/3386591)
Issues related with patches: [3386579](https://www.drupal.org/project/social/issues/3386579), [3386590](https://www.drupal.org/project/social/issues/3386590)

## Theme issue tracker
N/A

## How to test
- [ ] HTT 1: Follow the steps to reproduce of https://www.drupal.org/project/social/issues/3360661 and confirm that expected result is provided.
- [ ] HTT 2: Follow the steps to reproduce of https://www.drupal.org/project/social/issues/3382821

HTT3:
- [ ] Install clean version of Open Social (11.9.x)
- [ ] enable social_embed module
- [ ] Create a post by visiting post/add/post and insert content: "Broken link example: http://example/idontexist and working Youtube embed example: https://youtu.be/ojafuCcUZzU"
- [ ] Go to homepage and check the expected result (screenshot).


## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
![image](https://github.com/goalgorilla/open_social/assets/13753184/20f9ceb0-3304-48d2-9891-aa06dadedf1f)

## Release notes
Update url_embed to 2.0.0-alpha1 which is compatible with Drupal 10 and update all related patches.

## Change Record
N/A

## Translations
N/A
