### PR TITLE
Issue #3387060 by vnech: Remove hardcoded "access denied" result for events

### DIFF
--- a/modules/social_features/social_event/modules/social_event_an_enroll/src/Controller/EventAnEnrollController.php
+++ b/modules/social_features/social_event/modules/social_event_an_enroll/src/Controller/EventAnEnrollController.php
@@ -151,7 +151,7 @@ class EventAnEnrollController extends ControllerBase {
    * @param \Drupal\Core\Session\AccountInterface $account
    *   Run access checks for this account.
    *
-   * @return \Drupal\Core\Access\AccessResult
+   * @return \Drupal\Core\Access\AccessResultInterface
    *   Check standard and custom permissions.
    */
   public function enrollManageAccess(AccountInterface $account) {

--- a/modules/social_features/social_event/modules/social_event_managers/src/SocialEventManagersAccessHelper.php
+++ b/modules/social_features/social_event/modules/social_event_managers/src/SocialEventManagersAccessHelper.php
@@ -17,17 +17,17 @@ class SocialEventManagersAccessHelper {
   /**
    * Neutral status.
    */
-  const NEUTRAL = 0;
+  protected const NEUTRAL = 0;
 
   /**
    * Forbidden status.
    */
-  const FORBIDDEN = 1;
+  protected const FORBIDDEN = 1;
 
   /**
    * Allowed status.
    */
-  const ALLOW = 2;
+  protected const ALLOW = 2;
 
   /**
    * NodeAccessCheck for given operation, node and user account.

--- a/modules/social_features/social_event/modules/social_event_managers/src/SocialEventManagersAccessHelper.php
+++ b/modules/social_features/social_event/modules/social_event_managers/src/SocialEventManagersAccessHelper.php
@@ -2,7 +2,6 @@
 
 namespace Drupal\social_event_managers;
 
-use Drupal\Core\Access\AccessResultInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\Access\AccessResult;
 use Drupal\node\NodeInterface;
@@ -75,7 +74,7 @@ class SocialEventManagersAccessHelper {
   /**
    * Gets the Entity access for the given node.
    */
-  public static function getEntityAccessResult(NodeInterface $node, $op, AccountInterface $account): AccessResultInterface {
+  public static function getEntityAccessResult(NodeInterface $node, $op, AccountInterface $account): AccessResult {
     $access = self::nodeAccessCheck($node, $op, $account);
 
     switch ($access) {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -7255,17 +7255,7 @@ parameters:
 			path: modules/social_features/social_event/modules/social_event_managers/src/Plugin/views/field/SocialEventManagersViewsBulkOperationsBulkForm.php
 
 		-
-			message: "#^Method Drupal\\\\social_event_managers\\\\SocialEventManagersAccessHelper\\:\\:getEntityAccessResult\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: modules/social_features/social_event/modules/social_event_managers/src/SocialEventManagersAccessHelper.php
-
-		-
 			message: "#^Method Drupal\\\\social_event_managers\\\\SocialEventManagersAccessHelper\\:\\:getEntityAccessResult\\(\\) has parameter \\$op with no type specified\\.$#"
-			count: 1
-			path: modules/social_features/social_event/modules/social_event_managers/src/SocialEventManagersAccessHelper.php
-
-		-
-			message: "#^Method Drupal\\\\social_event_managers\\\\SocialEventManagersAccessHelper\\:\\:nodeAccessCheck\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: modules/social_features/social_event/modules/social_event_managers/src/SocialEventManagersAccessHelper.php
 


### PR DESCRIPTION
## Problem
The `Social Event Organisers` module has hardcoded `access denied` access result to event edit page if event don't have any organisers.
This breaks access results counting chain for other modules and non-organisers don't have ability to edit event.

## Solution
Replace `AccessResult::forbidden()` with `AccessResult::neutral()`

## Issue tracker
- https://getopensocial.atlassian.net/browse/PROD-26652
- https://www.drupal.org/project/social/issues/3387060

## Theme issue tracker
n/a

## How to test
- [ ] Login as admin
- [ ] Enable `Social Event Organisers` module
- [ ] Assign to LU role a permission `edit any event content`
- [ ] Create an event
- [ ] Login as LU
- [ ] Try to edit created event

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
n/a

## Release notes
Removed hardcoded `access denied` access result for events.

## Change Record
n/a

## Translations
n/a
