### PR TITLE
Issue #3382821: Remove deprecated hooks

### DIFF
--- a/modules/custom/entity_access_by_field/entity_access_by_field.module
+++ b/modules/custom/entity_access_by_field/entity_access_by_field.module
@@ -250,9 +250,9 @@ function entity_access_by_field_post_presave(PostInterface $post) {
 }
 
 /**
- * Implements hook_field_widget_form_alter().
+ * Implements hook_field_widget_single_element_form_alter().
  */
-function entity_access_by_field_field_widget_form_alter(&$element, FormStateInterface $form_state, $context) {
+function entity_access_by_field_field_widget_single_element_form_alter(&$element, FormStateInterface $form_state, $context) {
   $field_definition = $context['items']->getFieldDefinition();
 
   if ($field_definition->getType() !== 'entity_access_field' && $field_definition->getName() !== 'field_visibility') {

--- a/modules/social_features/social_core/social_core.module
+++ b/modules/social_features/social_core/social_core.module
@@ -711,9 +711,9 @@ function social_core_block_access(Block $block, $operation, AccountInterface $ac
 }
 
 /**
- * Implements hook_field_widget_form_alter().
+ * Implements hook_field_widget_single_element_form_alter().
  */
-function social_core_field_widget_form_alter(&$element, FormStateInterface $form_state, $context) {
+function social_core_field_widget_single_element_form_alter(&$element, FormStateInterface $form_state, $context) {
   $field_definition = $context['items']->getFieldDefinition();
 
   if ($field_definition->getType() === 'path') {

--- a/modules/social_features/social_event/modules/social_event_max_enroll/social_event_max_enroll.module
+++ b/modules/social_features/social_event/modules/social_event_max_enroll/social_event_max_enroll.module
@@ -200,9 +200,9 @@ function social_event_max_enroll_node_presave(EntityInterface $entity) {
 }
 
 /**
- * Implements hook_field_widget_form_alter().
+ * Implements hook_field_widget_single_element_form_alter().
  */
-function social_event_max_enroll_field_widget_form_alter(&$element, FormStateInterface $form_state, $context) {
+function social_event_max_enroll_field_widget_single_element_form_alter(&$element, FormStateInterface $form_state, $context) {
   $field_definition = $context['items']->getFieldDefinition();
   if ($field_definition->getName() === 'field_event_max_enroll_num') {
     $element['value']['#title_display'] = 'none';

--- a/modules/social_features/social_event/social_event.module
+++ b/modules/social_features/social_event/social_event.module
@@ -905,9 +905,9 @@ function social_event_date_validate(&$element, FormStateInterface $form_state, &
 }
 
 /**
- * Implements hook_field_widget_form_alter().
+ * Implements hook_field_widget_single_element_form_alter().
  */
-function social_event_field_widget_form_alter(&$element, FormStateInterface $form_state, $context) {
+function social_event_field_widget_single_element_form_alter(&$element, FormStateInterface $form_state, $context) {
   $field_definition = $context['items']->getFieldDefinition();
   if ($field_definition->getName() == 'field_event_date' || $field_definition->getName() == 'field_event_date_end') {
     $element['value']['#date_time_callbacks'][] = 'social_event_date_all_day_checkbox';

--- a/modules/social_features/social_follow_taxonomy/modules/social_follow_landing_page/social_follow_landing_page.module
+++ b/modules/social_features/social_follow_taxonomy/modules/social_follow_landing_page/social_follow_landing_page.module
@@ -95,9 +95,9 @@ function social_follow_landing_page_preprocess_paragraph(&$variables) {
 }
 
 /**
- * Implements hook_field_widget_WIDGET_TYPE_form_alter().
+ * Implements hook_field_widget_single_element_WIDGET_TYPE_form_alter().
  */
-function social_follow_landing_page_field_widget_entity_reference_paragraphs_form_alter(array &$element, FormStateInterface $form_state, array $context): void {
+function social_follow_landing_page_field_widget_single_element_entity_reference_paragraphs_form_alter(array &$element, FormStateInterface $form_state, array $context): void {
   $subform = FALSE;
   $entity_type_manager = \Drupal::entityTypeManager();
   if (isset($element['subform']['field_tag'])) {

--- a/modules/social_features/social_follow_taxonomy/modules/social_follow_tag/social_follow_tag.module
+++ b/modules/social_features/social_follow_taxonomy/modules/social_follow_tag/social_follow_tag.module
@@ -351,9 +351,9 @@ function social_follow_tag_form_alter(array &$form, FormStateInterface $form_sta
 }
 
 /**
- * Implements hook_field_widget_form_alter().
+ * Implements hook_field_widget_single_element_form_alter().
  */
-function social_follow_tag_field_widget_form_alter(array &$element, FormStateInterface $form_state, array $context): void {
+function social_follow_tag_field_widget_single_element_form_alter(array &$element, FormStateInterface $form_state, array $context): void {
   $field_definition = $context['items']->getFieldDefinition();
 
   if ($field_definition->getName() == 'field_term_page_url') {

--- a/modules/social_features/social_group/modules/social_group_welcome_message/social_group_welcome_message.module
+++ b/modules/social_features/social_group/modules/social_group_welcome_message/social_group_welcome_message.module
@@ -216,9 +216,9 @@ function social_group_welcome_message_group_content_insert(GroupContentInterface
 }
 
 /**
- * Implements hook_field_widget_form_alter().
+ * Implements hook_field_widget_single_element_form_alter().
  */
-function social_group_welcome_message_field_widget_form_alter(&$element, FormStateInterface $form_state, $context) {
+function social_group_welcome_message_field_widget_single_element_form_alter(&$element, FormStateInterface $form_state, $context) {
   // Maps field names to an array containing a single format.
   $map = [
     'private_message_body' => ['basic_html'],

--- a/modules/social_features/social_group/social_group.module
+++ b/modules/social_features/social_group/social_group.module
@@ -1589,9 +1589,9 @@ function _social_group_node_form_submit(array $form, FormStateInterface $form_st
 /**
  * Alter the visibility field within groups.
  *
- * Implements hook_field_widget_form_alter().
+ * Implements hook_field_widget_single_element_form_alter().
  */
-function social_group_field_widget_form_alter(&$element, FormStateInterface $form_state, $context) {
+function social_group_field_widget_single_element_form_alter(&$element, FormStateInterface $form_state, $context) {
   /** @var \Drupal\Core\Field\FieldDefinitionInterface $field_definition */
   $field_definition = $context['items']->getFieldDefinition();
 

--- a/modules/social_features/social_landing_page/social_landing_page.module
+++ b/modules/social_features/social_landing_page/social_landing_page.module
@@ -41,7 +41,7 @@ function social_landing_page_form_views_exposed_form_alter(&$form, FormStateInte
 }
 
 /**
- * Implements hook_field_widget_WIDGET_TYPE_form_alter().
+ * Implements hook_field_widget_single_element_WIDGET_TYPE_form_alter().
  *
  * When rendering the block form inside paragraphs, the #states will not
  * work due to different name parameter, since it's nested inside the paragraph
@@ -49,7 +49,7 @@ function social_landing_page_form_views_exposed_form_alter(&$form, FormStateInte
  * html markup provided by paragraph. We only do this for
  * 'Override title' field.
  */
-function social_landing_page_field_widget_block_field_default_form_alter(&$element, &$form_state, $context) {
+function social_landing_page_field_widget_single_element_block_field_default_form_alter(&$element, &$form_state, $context) {
   // Make sure we are inside a paragraph.
   $form = $context['form'];
   $entity_type = $form['#entity_type'];

--- a/modules/social_features/social_profile/social_profile.module
+++ b/modules/social_features/social_profile/social_profile.module
@@ -39,9 +39,9 @@ const SOCIAL_PROFILE_SUGGESTIONS_FULL_NAME = 'full_name';
 const SOCIAL_PROFILE_SUGGESTIONS_ALL = 'all';
 
 /**
- * Implements hook_field_widget_form_alter().
+ * Implements hook_field_widget_single_element_form_alter().
  */
-function social_profile_field_widget_form_alter(&$element, FormStateInterface $form_state, $context) {
+function social_profile_field_widget_single_element_form_alter(&$element, FormStateInterface $form_state, $context) {
   /** @var \Drupal\Core\Field\FieldDefinitionInterface $field_definition */
   $field_definition = $context['items']->getFieldDefinition();
   switch ($field_definition->getName()) {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1631,17 +1631,17 @@ parameters:
 			path: modules/custom/entity_access_by_field/entity_access_by_field.module
 
 		-
-			message: "#^Function entity_access_by_field_field_widget_form_alter\\(\\) has no return type specified\\.$#"
+			message: "#^Function entity_access_by_field_field_widget_single_element_form_alter\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: modules/custom/entity_access_by_field/entity_access_by_field.module
 
 		-
-			message: "#^Function entity_access_by_field_field_widget_form_alter\\(\\) has parameter \\$context with no type specified\\.$#"
+			message: "#^Function entity_access_by_field_field_widget_single_element_form_alter\\(\\) has parameter \\$context with no type specified\\.$#"
 			count: 1
 			path: modules/custom/entity_access_by_field/entity_access_by_field.module
 
 		-
-			message: "#^Function entity_access_by_field_field_widget_form_alter\\(\\) has parameter \\$element with no type specified\\.$#"
+			message: "#^Function entity_access_by_field_field_widget_single_element_form_alter\\(\\) has parameter \\$element with no type specified\\.$#"
 			count: 1
 			path: modules/custom/entity_access_by_field/entity_access_by_field.module
 
@@ -5506,17 +5506,17 @@ parameters:
 			path: modules/social_features/social_core/social_core.module
 
 		-
-			message: "#^Function social_core_field_widget_form_alter\\(\\) has no return type specified\\.$#"
+			message: "#^Function social_core_field_widget_single_element_form_alter\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: modules/social_features/social_core/social_core.module
 
 		-
-			message: "#^Function social_core_field_widget_form_alter\\(\\) has parameter \\$context with no type specified\\.$#"
+			message: "#^Function social_core_field_widget_single_element_form_alter\\(\\) has parameter \\$context with no type specified\\.$#"
 			count: 1
 			path: modules/social_features/social_core/social_core.module
 
 		-
-			message: "#^Function social_core_field_widget_form_alter\\(\\) has parameter \\$element with no type specified\\.$#"
+			message: "#^Function social_core_field_widget_single_element_form_alter\\(\\) has parameter \\$element with no type specified\\.$#"
 			count: 1
 			path: modules/social_features/social_core/social_core.module
 
@@ -7345,17 +7345,17 @@ parameters:
 			path: modules/social_features/social_event/modules/social_event_max_enroll/social_event_max_enroll.module
 
 		-
-			message: "#^Function social_event_max_enroll_field_widget_form_alter\\(\\) has no return type specified\\.$#"
+			message: "#^Function social_event_max_enroll_field_widget_single_element_form_alter\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: modules/social_features/social_event/modules/social_event_max_enroll/social_event_max_enroll.module
 
 		-
-			message: "#^Function social_event_max_enroll_field_widget_form_alter\\(\\) has parameter \\$context with no type specified\\.$#"
+			message: "#^Function social_event_max_enroll_field_widget_single_element_form_alter\\(\\) has parameter \\$context with no type specified\\.$#"
 			count: 1
 			path: modules/social_features/social_event/modules/social_event_max_enroll/social_event_max_enroll.module
 
 		-
-			message: "#^Function social_event_max_enroll_field_widget_form_alter\\(\\) has parameter \\$element with no type specified\\.$#"
+			message: "#^Function social_event_max_enroll_field_widget_single_element_form_alter\\(\\) has parameter \\$element with no type specified\\.$#"
 			count: 1
 			path: modules/social_features/social_event/modules/social_event_max_enroll/social_event_max_enroll.module
 
@@ -7944,17 +7944,17 @@ parameters:
 			path: modules/social_features/social_event/social_event.module
 
 		-
-			message: "#^Function social_event_field_widget_form_alter\\(\\) has no return type specified\\.$#"
+			message: "#^Function social_event_field_widget_single_element_form_alter\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: modules/social_features/social_event/social_event.module
 
 		-
-			message: "#^Function social_event_field_widget_form_alter\\(\\) has parameter \\$context with no type specified\\.$#"
+			message: "#^Function social_event_field_widget_single_element_form_alter\\(\\) has parameter \\$context with no type specified\\.$#"
 			count: 1
 			path: modules/social_features/social_event/social_event.module
 
 		-
-			message: "#^Function social_event_field_widget_form_alter\\(\\) has parameter \\$element with no type specified\\.$#"
+			message: "#^Function social_event_field_widget_single_element_form_alter\\(\\) has parameter \\$element with no type specified\\.$#"
 			count: 1
 			path: modules/social_features/social_event/social_event.module
 
@@ -10419,17 +10419,17 @@ parameters:
 			path: modules/social_features/social_group/modules/social_group_welcome_message/social_group_welcome_message.module
 
 		-
-			message: "#^Function social_group_welcome_message_field_widget_form_alter\\(\\) has no return type specified\\.$#"
+			message: "#^Function social_group_welcome_message_field_widget_single_element_form_alter\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: modules/social_features/social_group/modules/social_group_welcome_message/social_group_welcome_message.module
 
 		-
-			message: "#^Function social_group_welcome_message_field_widget_form_alter\\(\\) has parameter \\$context with no type specified\\.$#"
+			message: "#^Function social_group_welcome_message_field_widget_single_element_form_alter\\(\\) has parameter \\$context with no type specified\\.$#"
 			count: 1
 			path: modules/social_features/social_group/modules/social_group_welcome_message/social_group_welcome_message.module
 
 		-
-			message: "#^Function social_group_welcome_message_field_widget_form_alter\\(\\) has parameter \\$element with no type specified\\.$#"
+			message: "#^Function social_group_welcome_message_field_widget_single_element_form_alter\\(\\) has parameter \\$element with no type specified\\.$#"
 			count: 1
 			path: modules/social_features/social_group/modules/social_group_welcome_message/social_group_welcome_message.module
 
@@ -10914,17 +10914,17 @@ parameters:
 			path: modules/social_features/social_group/social_group.module
 
 		-
-			message: "#^Function social_group_field_widget_form_alter\\(\\) has no return type specified\\.$#"
+			message: "#^Function social_group_field_widget_single_element_form_alter\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: modules/social_features/social_group/social_group.module
 
 		-
-			message: "#^Function social_group_field_widget_form_alter\\(\\) has parameter \\$context with no type specified\\.$#"
+			message: "#^Function social_group_field_widget_single_element_form_alter\\(\\) has parameter \\$context with no type specified\\.$#"
 			count: 1
 			path: modules/social_features/social_group/social_group.module
 
 		-
-			message: "#^Function social_group_field_widget_form_alter\\(\\) has parameter \\$element with no type specified\\.$#"
+			message: "#^Function social_group_field_widget_single_element_form_alter\\(\\) has parameter \\$element with no type specified\\.$#"
 			count: 1
 			path: modules/social_features/social_group/social_group.module
 
@@ -11784,22 +11784,22 @@ parameters:
 			path: modules/social_features/social_landing_page/social_landing_page.module
 
 		-
-			message: "#^Function social_landing_page_field_widget_block_field_default_form_alter\\(\\) has no return type specified\\.$#"
+			message: "#^Function social_landing_page_field_widget_single_element_block_field_default_form_alter\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: modules/social_features/social_landing_page/social_landing_page.module
 
 		-
-			message: "#^Function social_landing_page_field_widget_block_field_default_form_alter\\(\\) has parameter \\$context with no type specified\\.$#"
+			message: "#^Function social_landing_page_field_widget_single_element_block_field_default_form_alter\\(\\) has parameter \\$context with no type specified\\.$#"
 			count: 1
 			path: modules/social_features/social_landing_page/social_landing_page.module
 
 		-
-			message: "#^Function social_landing_page_field_widget_block_field_default_form_alter\\(\\) has parameter \\$element with no type specified\\.$#"
+			message: "#^Function social_landing_page_field_widget_single_element_block_field_default_form_alter\\(\\) has parameter \\$element with no type specified\\.$#"
 			count: 1
 			path: modules/social_features/social_landing_page/social_landing_page.module
 
 		-
-			message: "#^Function social_landing_page_field_widget_block_field_default_form_alter\\(\\) has parameter \\$form_state with no type specified\\.$#"
+			message: "#^Function social_landing_page_field_widget_single_element_block_field_default_form_alter\\(\\) has parameter \\$form_state with no type specified\\.$#"
 			count: 1
 			path: modules/social_features/social_landing_page/social_landing_page.module
 
@@ -14609,17 +14609,17 @@ parameters:
 			path: modules/social_features/social_profile/social_profile.module
 
 		-
-			message: "#^Function social_profile_field_widget_form_alter\\(\\) has no return type specified\\.$#"
+			message: "#^Function social_profile_field_widget_single_element_form_alter\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: modules/social_features/social_profile/social_profile.module
 
 		-
-			message: "#^Function social_profile_field_widget_form_alter\\(\\) has parameter \\$context with no type specified\\.$#"
+			message: "#^Function social_profile_field_widget_single_element_form_alter\\(\\) has parameter \\$context with no type specified\\.$#"
 			count: 1
 			path: modules/social_features/social_profile/social_profile.module
 
 		-
-			message: "#^Function social_profile_field_widget_form_alter\\(\\) has parameter \\$element with no type specified\\.$#"
+			message: "#^Function social_profile_field_widget_single_element_form_alter\\(\\) has parameter \\$element with no type specified\\.$#"
 			count: 1
 			path: modules/social_features/social_profile/social_profile.module
 


### PR DESCRIPTION
Replace deprecated hook_field_widget_form_alter() with hook_field_widget_single_element_form_alter and
hook_field_widget_WIDGET_TYPE_form_alter() with
hook_field_widget_single_element_WIDGET_TYPE_form_alter

## Problem
Change records: https://www.drupal.org/node/3180429

## Solution
Replace deprecated hooks

## Issue tracker
[3387564](https://www.drupal.org/project/social/issues/3387564)

## Theme issue tracker
N/A

## How to test

### HTT 1
**old**: entity_access_by_field_field_widget_form_alter
**new**: entity_access_by_field_field_widget_single_element_form_alter
- [ ] Go to admin/config/opensocial/visibility and enable "Disable public visibility"
- [ ] Log in as VU (or any role that does not have  permission "Override disabled public visiblility settings")
- [ ] Try to create a post with public visibility
- [ ] If deprecated hook is correctly replaced, you should not be able to see Public visibility option

Expected result:
![htt1_expected_result](https://github.com/goalgorilla/open_social/assets/13753184/fe35609a-1fd7-449e-bffa-945a7b830c03)

Unexpected result:
![htt1_unexpected_result](https://github.com/goalgorilla/open_social/assets/13753184/d5fae090-d2eb-4e07-ad33-a6a8ac4d6179)


### HTT 2
**old**: social_core_field_widget_form_alter
**new**: social_core_field_widget_single_element_form_alter
- [ ] Go to node/add/topic
- [ ] Under "Settings" > "Url Alias" you should see website url, if deprecated hook is correctly replaced.

Expected result:
![htt2_expected_result](https://github.com/goalgorilla/open_social/assets/13753184/af1e2778-9ed4-40ce-b094-2c7b3cb47ba8)

Unexpected result:
![htt2_unexpected_result](https://github.com/goalgorilla/open_social/assets/13753184/060f2edc-260d-49cc-88ba-74c22c303a6a)

### HTT 3
**old**: social_event_max_enroll_field_widget_form_alter
**new**: social_event_max_enroll_field_widget_single_element_form_alter
- [ ] Enable social_event_max_enroll
- [ ] Go to node/add/event
- [ ] Under "Access permissions", enable "Enable event enrollment" and under "Enrollment limit" enable "Set a limit to number of enrollees"
- [ ] If deprecated hook is correctly replaced, "Maximum number of enrollees" title should not be visible

Expected result:
![htt3_expected_result](https://github.com/goalgorilla/open_social/assets/13753184/9a8bd205-4896-4a17-a12a-87434a45f8d8)

Unexpected result:
![htt3_unexpected_result](https://github.com/goalgorilla/open_social/assets/13753184/a32fc504-16c3-434d-b975-cd2303a25c15)


### HTT 4
**old**: social_event_field_widget_form_alter
**new**: social_event_field_widget_single_element_form_alter
- [ ] Go to node/add/event
- [ ] Under "Date and time", there is a checkbox "All day"
- [ ] If deprecated hook is correctly replaced, time field should disappear when 'All day' is checked.

Expected result:
![htt4_expected_result](https://github.com/goalgorilla/open_social/assets/13753184/981d9bbb-3833-4ca4-98a6-50d62e8c89dc)

Unexpected result:
![htt4_unexpected_result](https://github.com/goalgorilla/open_social/assets/13753184/16c4e520-f25e-4da0-a009-786057f998c3)

### HTT 5
**old**: social_follow_landing_page_field_widget_entity_reference_paragraphs_form_alter
**new**: social_follow_landing_page_field_widget_single_element_entity_reference_paragraphs_form_alter
- [ ] Enable social_follow_landing_page
- [ ] Enable field_ui
- [ ] Enable layout_builder
- [ ] Create two follow tags and one of them should be set as child of the other (like on the screenshot)(admin/structure/taxonomy/manage/social_tagging/overview)
![Social tagging](https://github.com/goalgorilla/open_social/assets/13753184/304eddbe-77c4-4704-9700-a393f3352cfa)
- [ ] Go to admin/structure/types/manage/landing_page/display and under "Layout options" enable "Use Layout Builder" and "Allow each content item to have its layout customized."
- [ ] Create landing page (go to node/add/landing_page) and fill in just title
- [ ] After you save the node, edit the layout (node/1/layout)
- [ ] Click on "+Add block" and when the sidebar options are opened click on "+ Create custom block" and select "Follow tags". 
- [ ] Under Tag content you should see only "Example tag" and not "Example category, if deprecated hook is correctly replaced.

Expected result:
![htt5_expected_result](https://github.com/goalgorilla/open_social/assets/13753184/b5e5c538-ef98-4d11-80a9-2492efa2dd7e)

Unexpected result:
![htt5_unexpected_result](https://github.com/goalgorilla/open_social/assets/13753184/0d00430f-9f64-4271-bee9-097b72164e3f)

### HTT 6
**old**: social_follow_tag_field_widget_form_alter
social_follow_tag_field_widget_single_element_form_alter
- [ ] Enable social_follow_tag
- [ ] Go to admin/structure/taxonomy/manage/social_tagging/add 
- [ ]  If deprecated hook is correctly replaced, you should see "URL label" field without any description

Expected result:
![htt6_expected_result](https://github.com/goalgorilla/open_social/assets/13753184/153112f3-e32e-4cfc-8a4a-0da3aa446360)

Unexpected result:
![htt6_unexpected_result](https://github.com/goalgorilla/open_social/assets/13753184/f313487f-7ef6-47fc-8f78-277fc6759c0c)

### HTT 7
**old**: social_group_welcome_message_field_widget_form_alter
**new**: social_group_welcome_message_field_widget_single_element_form_alter
- [ ] Enable social_group_welcome_message
- [ ] Go to group/add/flexible_group, open "Settings" and enable "Send a welcome message to new group members"
- [ ] If deprecated hook is correctly replaced, you should not be able to select text format under message

Expected result:
![htt7_expected_result](https://github.com/goalgorilla/open_social/assets/13753184/790f3a2e-dbb8-4ac7-89b6-e6e40316ce6c)

Unexpected result:
![htt7_unexpected_result](https://github.com/goalgorilla/open_social/assets/13753184/bdae476d-b47b-4b5f-8f88-aea4c818b460)

### HTT 8
**old**: social_group_field_widget_form_alter
**new**: social_group_field_widget_single_element_form_alter
- [ ] Make sure there is no groups on platform
- [ ] Go to node/add/topic
- [ ] If deprecated hook is correctly replaced, "Group members" Visibility options should be inactive under "Access permissions"

Expected result:
![htt8_expected_result](https://github.com/goalgorilla/open_social/assets/13753184/1873a7ab-50a3-4f21-ab7c-318104151f55)

Unexpected result:
![htt8_unexpected_result](https://github.com/goalgorilla/open_social/assets/13753184/37804852-b4e1-4040-9913-f24e67bc3b39)

### HTT 9
**old**: social_landing_page_field_widget_block_field_default_form_alter
**new**: social_landing_page_field_widget_single_element_block_field_default_form_alter
- [ ] Enable social_landing_page module
- [ ] Create a new landing page content type
- [ ] Add a new section
- [ ] Add a block reference
- [ ] For 'Primary' field set 'Complete community activity stream'
- [ ]  If deprecated hook is correctly replaced click the 'Override Title' checkbox and see that additional field is displayed.

Expected result:
![htt9_expected_result](https://user-images.githubusercontent.com/35064680/128164269-21217ffa-0f8e-4ca4-a1d8-0dc4c16459e5.png)

Unexpected result:
![htt9_unexpected_result](https://user-images.githubusercontent.com/35064680/128164249-f8bbe47e-41be-45c5-9777-f9f25bd75334.png)

### HTT 10
**old**: social_profile_field_widget_form_alter
**new**: social_profile_field_widget_single_element_form_alter
- [ ] Go to user/1/profile
- [ ] Inspect First name input field
- [ ] If deprecated hook is correctly replaced `autocomplete="given-name"` should be in the markup

Screenshot:
![Screenshot](https://github.com/goalgorilla/open_social/assets/13753184/dd7ef6d7-2d8e-4502-811c-4ee276c76af6)

Expected result:
`<input class="js-text-full text-full form-text form-control" autocomplete="given-name" data-drupal-selector="edit-field-profile-first-name-0-value" type="text" id="edit-field-profile-first-name-0-value" name="field_profile_first_name[0][value]" value="" size="60" maxlength="255" placeholder="">`

Unexpected result:
`<input class="js-text-full text-full form-text form-control" data-drupal-selector="edit-field-profile-first-name-0-value" type="text" id="edit-field-profile-first-name-0-value" name="field_profile_first_name[0][value]" value="" size="60" maxlength="255" placeholder="">`


## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
N/A

## Release notes
Replace deprecated hook_field_widget_form_alter() with hook_field_widget_single_element_form_alter and
hook_field_widget_WIDGET_TYPE_form_alter() with hook_field_widget_single_element_WIDGET_TYPE_form_alter.

## Change Record
N/A

## Translations
N/A
