### PR TITLE
Issue #26669: As a SM I want to decide where a content tag category should be displayed

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -64,7 +64,8 @@
                 "Issue #2107455: Image field default value not shown when upload destination set to private file storage": "https://www.drupal.org/files/issues/2022-06-24/2107455-75.patch",
                 "Issue #3052115: Mark an entity as 'syncing' during a migration update": "https://www.drupal.org/files/issues/2023-02-01/3052115-59.patch",
                 "Issue #3332546: CommentSelection::entityQueryAlter() fails on validate when referencing entity is not a comment": "https://www.drupal.org/files/issues/2023-01-11/3332546-6-comment_selection_entityqueryalter.patch",
-                "2924783 - Fatal error on entity autocomplete widget if entity label contains parentheses": "https://www.drupal.org/files/issues/2021-04-18/2924783-18.patch"
+                "2924783 - Fatal error on entity autocomplete widget if entity label contains parentheses": "https://www.drupal.org/files/issues/2021-04-18/2924783-18.patch",
+                "States API doesn't work with multiple select fields": "https://www.drupal.org/files/issues/2023-06-27/drupal-n1149078-172-95x.patch"
             },
             "drupal/dynamic_entity_reference": {
                 "Return the same content list after content type is changed": "https://www.drupal.org/files/issues/2021-08-27/dynamic_entity_reference-the_same_content_list-3230158-2.patch"

--- a/modules/social_features/social_tagging/config/install/core.entity_form_display.taxonomy_term.social_tagging.default.yml
+++ b/modules/social_features/social_tagging/config/install/core.entity_form_display.taxonomy_term.social_tagging.default.yml
@@ -2,12 +2,12 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.taxonomy_term.social_tagging.field_category_usage
     - field.field.taxonomy_term.social_tagging.field_term_page_url
     - taxonomy.vocabulary.social_tagging
   module:
     - link
-    - path
-    - text
+    - social_tagging
   enforced:
     module:
       - social_tagging
@@ -16,41 +16,35 @@ targetEntityType: taxonomy_term
 bundle: social_tagging
 mode: default
 content:
-  description:
-    type: text_textfield
+  field_category_usage:
+    type: social_tagging_usage
+    weight: 1
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_term_page_url:
+    type: link_default
+    weight: 2
+    region: content
+    settings:
+      placeholder_url: ''
+      placeholder_title: ''
+    third_party_settings: {  }
+  name:
+    type: string_textfield
     weight: 0
     region: content
     settings:
       size: 60
       placeholder: ''
     third_party_settings: {  }
-  field_term_page_url:
-    weight: 1
-    settings:
-      placeholder_url: ''
-      placeholder_title: ''
-    third_party_settings: {  }
-    type: link_default
-    region: content
-  name:
-    type: string_textfield
-    weight: -5
-    region: content
-    settings:
-      size: 60
-      placeholder: ''
-    third_party_settings: {  }
-  path:
-    type: path
-    weight: 30
-    region: content
-    settings: {  }
-    third_party_settings: {  }
   status:
     type: boolean_checkbox
+    weight: 3
+    region: content
     settings:
       display_label: true
-    weight: 100
-    region: content
     third_party_settings: {  }
-hidden: {  }
+hidden:
+  description: true
+  path: true

--- a/modules/social_features/social_tagging/config/install/core.entity_view_display.taxonomy_term.social_tagging.default.yml
+++ b/modules/social_features/social_tagging/config/install/core.entity_view_display.taxonomy_term.social_tagging.default.yml
@@ -2,11 +2,11 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.taxonomy_term.social_tagging.field_category_usage
     - field.field.taxonomy_term.social_tagging.field_term_page_url
     - taxonomy.vocabulary.social_tagging
   module:
-    - link
-    - text
+    - social_tagging
   enforced:
     module:
       - social_tagging
@@ -15,24 +15,14 @@ targetEntityType: taxonomy_term
 bundle: social_tagging
 mode: default
 content:
-  description:
-    label: hidden
-    type: text_default
-    weight: 0
-    region: content
+  field_category_usage:
+    type: social_tagging_usage_formatter
+    label: above
     settings: {  }
     third_party_settings: {  }
-  field_term_page_url:
-    weight: 1
-    label: hidden
-    settings:
-      trim_length: 80
-      url_only: false
-      url_plain: false
-      rel: ''
-      target: ''
-    third_party_settings: {  }
-    type: link
+    weight: 0
     region: content
 hidden:
+  description: true
+  field_term_page_url: true
   search_api_excerpt: true

--- a/modules/social_features/social_tagging/config/install/field.field.taxonomy_term.social_tagging.field_category_usage.yml
+++ b/modules/social_features/social_tagging/config/install/field.field.taxonomy_term.social_tagging.field_category_usage.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_category_usage
+    - taxonomy.vocabulary.social_tagging
+id: taxonomy_term.social_tagging.field_category_usage
+field_name: field_category_usage
+entity_type: taxonomy_term
+bundle: social_tagging
+label: Placement
+description: 'Where this term will be available within the platform'
+required: false
+translatable: false
+default_value:
+  -
+    value: ''
+default_value_callback: ''
+settings: {  }
+field_type: string_long

--- a/modules/social_features/social_tagging/config/install/field.storage.taxonomy_term.field_category_usage.yml
+++ b/modules/social_features/social_tagging/config/install/field.storage.taxonomy_term.field_category_usage.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - taxonomy
+id: taxonomy_term.field_category_usage
+field_name: field_category_usage
+entity_type: taxonomy_term
+type: string_long
+settings:
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/social_features/social_tagging/config/static/field.field.taxonomy_term.social_tagging.field_category_usage_11802.yml
+++ b/modules/social_features/social_tagging/config/static/field.field.taxonomy_term.social_tagging.field_category_usage_11802.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_category_usage
+    - taxonomy.vocabulary.social_tagging
+id: taxonomy_term.social_tagging.field_category_usage
+field_name: field_category_usage
+entity_type: taxonomy_term
+bundle: social_tagging
+label: Placement
+description: 'Where this term will be available within the platform'
+required: false
+translatable: false
+default_value:
+  -
+    value: ''
+default_value_callback: ''
+settings: {  }
+field_type: string_long

--- a/modules/social_features/social_tagging/config/static/field.storage.taxonomy_term.field_category_usage_11802.yml
+++ b/modules/social_features/social_tagging/config/static/field.storage.taxonomy_term.field_category_usage_11802.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - taxonomy
+id: taxonomy_term.field_category_usage
+field_name: field_category_usage
+entity_type: taxonomy_term
+type: string_long
+settings:
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/social_features/social_tagging/config/update/social_tagging_update_11803.yml
+++ b/modules/social_features/social_tagging/config/update/social_tagging_update_11803.yml
@@ -1,0 +1,38 @@
+core.entity_form_display.taxonomy_term.social_tagging.default:
+  expected_config: {  }
+  update_actions:
+    change:
+      content:
+        field_category_usage:
+          type: social_tagging_usage
+          weight: 1
+          region: content
+          settings: { }
+          third_party_settings: { }
+    add:
+      dependencies:
+        config:
+          - field.field.taxonomy_term.social_tagging.field_category_usage
+      hidden:
+        description: true
+        path: true
+    delete:
+      content:
+        description: {}
+        path: {}
+core.entity_view_display.taxonomy_term.social_tagging.default:
+  expected_config: {  }
+  update_actions:
+    change:
+      content:
+        field_category_usage:
+          type: social_tagging_usage_formatter
+          label: above
+          settings: { }
+          third_party_settings: { }
+          weight: 0
+          region: content
+    add:
+      dependencies:
+        config:
+          - field.field.taxonomy_term.social_tagging.field_category_usage

--- a/modules/social_features/social_tagging/social_tagging.install
+++ b/modules/social_features/social_tagging/social_tagging.install
@@ -344,3 +344,63 @@ function social_tagging_update_11801(): void {
     }
   }
 }
+
+/**
+ * Add Placement field to Content tags.
+ */
+function social_tagging_update_11802(): void {
+  $config_path = \Drupal::service('extension.list.module')->getPath('social_tagging') . '/config/static';
+  $source = new FileStorage($config_path);
+  $entity_type_manager = \Drupal::entityTypeManager();
+
+  // Create field storages.
+  /** @var \Drupal\Core\Config\Entity\ConfigEntityStorageInterface $field_storage_config_storage */
+  $field_storage_config_storage = $entity_type_manager->getStorage('field_storage_config');
+  $data = $source->read('field.storage.taxonomy_term.field_category_usage_11802');
+  if (!is_array($data)) {
+    throw new \Exception('Could not load config file: field.storage.taxonomy_term.field_category_usage_11802');
+  }
+  $field_storage_config_storage->create($data)->save();
+
+  // Create field settings.
+  /** @var \Drupal\Core\Config\Entity\ConfigEntityStorageInterface $field_config_storage */
+  $field_config_storage = $entity_type_manager->getStorage('field_config');
+  $data = $source->read('field.field.taxonomy_term.social_tagging.field_category_usage_11802');
+  if (!is_array($data)) {
+    throw new \Exception('Could not load config file: field.field.taxonomy_term.social_tagging.field_category_usage_11802');
+  }
+  $field_config_storage->create($data)->save();
+}
+
+/**
+ * Update a form and view display for the 'Social tagging' terms.
+ */
+function social_tagging_update_11803(): string {
+  /** @var \Drupal\update_helper\Updater $updater */
+  $updater = \Drupal::service('update_helper.updater');
+
+  // Execute configuration update definitions with logging of success.
+  $updater->executeUpdate('social_tagging', __FUNCTION__);
+
+  // Output logged messages to related channel of update execution.
+  return $updater->logger()->output();
+}
+
+/**
+ * Fill content to field_category_usage field.
+ */
+function social_tagging_update_11804(): void {
+  /** @var \Drupal\social_tagging\SocialTaggingServiceInterface $helper */
+  $helper = \Drupal::service('social_tagging.tag_service');
+  $options = $helper->getKeyValueOptions();
+  // Option contains key=>value array where values are a label.
+  // Get keys, and serialize like in TaggingUsageWidget.
+  $values = array_keys($options);
+  $terms = \Drupal::entityTypeManager()->getStorage('taxonomy_term')->loadByProperties([
+    'vid' => 'social_tagging',
+    'parent' => '0',
+  ]);
+  foreach ($terms as $term) {
+    $term->set('field_category_usage', serialize($values))->save();
+  }
+}

--- a/modules/social_features/social_tagging/social_tagging.module
+++ b/modules/social_features/social_tagging/social_tagging.module
@@ -55,9 +55,7 @@ function social_tagging_form_taxonomy_term_social_tagging_form_alter(&$form, For
   $tag_service = Drupal::getContainer()->get('social_tagging.tag_service');
 
   // Remove these fields.
-  $form['path']['#access'] = FALSE;
   $form['relations']['#access'] = FALSE;
-  $form['description']['#access'] = FALSE;
 
   // Move it outside the details.
   $form['parent'] = $form['relations']['parent'];
@@ -65,17 +63,36 @@ function social_tagging_form_taxonomy_term_social_tagging_form_alter(&$form, For
 
   // Make some changes.
   $form['weight']['#access'] = FALSE;
-  $form['parent']['#title'] = t('Placement');
+  $form['parent']['#title'] = t('Location');
+  $form['parent']['#required'] = TRUE;
+  $form['parent']['#description'] = t('Integrate this term into an existing category or establish new one');
+  $form['parent']['#description_display'] = 'before';
 
   // Fetch all top level items.
   $options = $tag_service->getCategories();
   // Add the 0 option for a new toplevel item.
-  $options[0] = t('Main category');
+  $options[0] = t('New category');
   // Sort the array.
   ksort($options);
   // Add it to the select.
   $form['parent']['#options'] = $options;
 
+  // Add states for tagging usage.
+  $form['field_category_usage']['#states'] = [
+    'visible' => [
+      'select[name="parent[]"]' => ['value' => ['0']],
+    ],
+  ];
+  $form['actions']['submit']['#submit'][] = '_social_tagging_form_taxonomy_term_social_tagging_submit';
+}
+
+/**
+ * Custom submit for social tagging form.
+ */
+function _social_tagging_form_taxonomy_term_social_tagging_submit(array $form, FormStateInterface $form_state): void {
+  // Clear cache to see updated lists.
+  \Drupal::service('cache.render')->invalidateAll();
+  \Drupal::service('plugin.cache_clearer')->clearCachedDefinitions();
 }
 
 /**
@@ -499,24 +516,24 @@ function social_tagging_theme($existing, $type, $theme, $path) {
  * Implements hook_form_FORM_ID_alter().
  */
 function social_tagging_form_views_exposed_form_alter(&$form, FormStateInterface $form_state, $form_id) {
-  $form_ids = [
-    'views-exposed-form-search-content-page-no-value',
-    'views-exposed-form-search-content-page',
-    'views-exposed-form-search-groups-page-no-value',
-    'views-exposed-form-search-groups-page',
-    'views-exposed-form-search-users-page-no-value',
-    'views-exposed-form-search-users-page',
-    'views-exposed-form-latest-topics-page-latest-topics',
-    'views-exposed-form-upcoming-events-page-community-events',
-    'views-exposed-form-topics-page-profile',
-    'views-exposed-form-events-events-overview',
-    'views-exposed-form-group-topics-page-group-topics',
-    'views-exposed-form-group-events-page-group-events',
-    'views-exposed-form-group-books-page-group-books',
-    'views-exposed-form-newest-groups-page-all-groups',
-    'views-exposed-form-newest-users-page-newest-users',
+  $keys = [
+    'views-exposed-form-search-content-page-no-value' => ['node_page', 'node_event', 'node_topic'],
+    'views-exposed-form-search-content-page' => ['node_page', 'node_event', 'node_topic'],
+    'views-exposed-form-search-groups-page-no-value' => ['group'],
+    'views-exposed-form-search-groups-page' => ['group'],
+    'views-exposed-form-search-users-page-no-value' => ['profile'],
+    'views-exposed-form-search-users-page' => ['profile'],
+    'views-exposed-form-latest-topics-page-latest-topics' => ['node_topic'],
+    'views-exposed-form-upcoming-events-page-community-events' => ['node_event'],
+    'views-exposed-form-topics-page-profile' => ['node_topic'],
+    'views-exposed-form-events-events-overview' => ['node_event'],
+    'views-exposed-form-group-topics-page-group-topics' => ['node_topic'],
+    'views-exposed-form-group-events-page-group-events' => ['node_event'],
+    'views-exposed-form-group-books-page-group-books' => ['node_topic'],
+    'views-exposed-form-newest-groups-page-all-groups' => ['group'],
+    'views-exposed-form-newest-users-page-newest-users' => ['profile'],
   ];
-
+  $form_ids = array_keys($keys);
   // Must be either one of these form_ids.
   if (!in_array($form['#id'], $form_ids)) {
     return;
@@ -532,7 +549,10 @@ function social_tagging_form_views_exposed_form_alter(&$form, FormStateInterface
     foreach ($tag_service->getCategories() as $tid => $term_name) {
       $label = \Drupal::service('social_core.machine_name')->transform($term_name);
 
-      if (isset($form[$label])) {
+      if (!isset($form[$label])) {
+        continue;
+      }
+      if ($tag_service->termIsVisibleForEntities($term_name, $keys[$form['#id']])) {
         $form[$label]['#options'] = [];
         $form[$label]['#options'][''] = t('- Any -');
 
@@ -562,7 +582,10 @@ function social_tagging_form_views_exposed_form_alter(&$form, FormStateInterface
         if ($query->has($label)) {
           $form[$label]['#value'] = $query->get($label);
         }
-
+      }
+      else {
+        // Otherwise, we should not see tag on a form.
+        $form[$label]['#access'] = FALSE;
       }
     }
   }

--- a/modules/social_features/social_tagging/src/Form/SocialTaggingSettingsForm.php
+++ b/modules/social_features/social_tagging/src/Form/SocialTaggingSettingsForm.php
@@ -16,7 +16,7 @@ use Drupal\taxonomy\TermInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
- * Class SocialTaggingSettingsForm.
+ * Class Social Tagging Settings Form.
  *
  * @package Drupal\social_tagging\Form
  */

--- a/modules/social_features/social_tagging/src/Plugin/Field/FieldFormatter/TaggingUsageFormatter.php
+++ b/modules/social_features/social_tagging/src/Plugin/Field/FieldFormatter/TaggingUsageFormatter.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Drupal\social_tagging\Plugin\Field\FieldFormatter;
+
+use Drupal\Core\Field\FieldDefinitionInterface;
+use Drupal\Core\Field\FormatterBase;
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\social_tagging\SocialTaggingServiceInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Plugin implementation of the 'social_tagging_usage_formatter' formatter.
+ *
+ * @FieldFormatter(
+ *   id = "social_tagging_usage_formatter",
+ *   label = @Translation("Social tagging usage"),
+ *   field_types = {
+ *     "string_long",
+ *   }
+ * )
+ */
+class TaggingUsageFormatter extends FormatterBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct($plugin_id, $plugin_definition, FieldDefinitionInterface $field_definition, array $settings, $label, $view_mode, array $third_party_settings, private SocialTaggingServiceInterface $taggingService) {
+    parent::__construct($plugin_id, $plugin_definition, $field_definition, $settings, $label, $view_mode, $third_party_settings);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $plugin_id,
+      $plugin_definition,
+      $configuration['field_definition'],
+      $configuration['settings'],
+      $configuration['label'],
+      $configuration['view_mode'],
+      $configuration['third_party_settings'],
+      $container->get('social_tagging.tag_service')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function viewElements(FieldItemListInterface $items, $langcode) {
+    $elements = [];
+    foreach ($items as $delta => $item) {
+      $keys = $this->taggingService->getKeyValueOptions();
+      $values = unserialize($items[$delta]->value ?? '');
+      foreach ($values as $value) {
+        // Skip not selected items.
+        if (empty($value) || empty($keys[$value])) {
+          continue;
+        }
+        $elements[$delta][] = [
+          '#type' => 'html_tag',
+          '#tag' => 'div',
+          '#value' => $keys[$value],
+        ];
+      }
+    }
+
+    return $elements;
+  }
+
+}

--- a/modules/social_features/social_tagging/src/Plugin/Field/FieldWidget/TaggingUsageWidget.php
+++ b/modules/social_features/social_tagging/src/Plugin/Field/FieldWidget/TaggingUsageWidget.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Drupal\social_tagging\Plugin\Field\FieldWidget;
+
+use Drupal\Component\Utility\NestedArray;
+use Drupal\Core\Field\FieldDefinitionInterface;
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Field\WidgetBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\social_tagging\SocialTaggingServiceInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Plugin implementation of the 'social_tagging_usage' widget.
+ *
+ * @FieldWidget(
+ *   id = "social_tagging_usage",
+ *   label = @Translation("Social tagging usage"),
+ *   field_types = {
+ *     "string_long"
+ *   }
+ * )
+ */
+class TaggingUsageWidget extends WidgetBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct($plugin_id, $plugin_definition, FieldDefinitionInterface $field_definition, array $settings, array $third_party_settings, private SocialTaggingServiceInterface $taggingService) {
+    parent::__construct($plugin_id, $plugin_definition, $field_definition, $settings, $third_party_settings);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $plugin_id,
+      $plugin_definition,
+      $configuration['field_definition'],
+      $configuration['settings'],
+      $configuration['third_party_settings'],
+      $container->get('social_tagging.tag_service'),
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function formElement(FieldItemListInterface $items, $delta, array $element, array &$form, FormStateInterface $form_state): array {
+    $value = unserialize($items[$delta]->value ?? '');
+    $options = $this->taggingService->getKeyValueOptions();
+    $element['#type'] = 'checkboxes';
+    $element['#options'] = $options;
+    $element['#default_value'] = empty($value) ? [] : $value;
+    $element['#description_display'] = 'before';
+    return $element;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function extractFormValues(FieldItemListInterface $items, array $form, FormStateInterface $form_state): void {
+    // Check parent value.
+    $parent = $form_state->getValue('parent') ?? [];
+    $parent = reset($parent);
+    // If parent is set, no usage value is needed.
+    if (!empty($parent)) {
+      $items->setValue('');
+      return;
+    }
+    $field_name = $this->fieldDefinition->getName();
+    // Extract the values from $form_state->getValues().
+    $path = array_merge($form['#parents'], [$field_name]);
+    $form_values = $form_state->getValues();
+    $values = NestedArray::getValue($form_values, $path);
+    $values = reset($values);
+    $values = array_values($values);
+    $values = array_filter($values, fn($value) => !empty($value));
+    // We have dynamic amount of items.
+    // Save as string.
+    $items->setValue(serialize($values));
+  }
+
+}

--- a/modules/social_features/social_tagging/src/SocialTaggingServiceInterface.php
+++ b/modules/social_features/social_tagging/src/SocialTaggingServiceInterface.php
@@ -132,6 +132,11 @@ interface SocialTaggingServiceInterface {
   public function getCategories(): array;
 
   /**
+   * Check if given term is allowed to use and see for given entities.
+   */
+  public function termIsVisibleForEntities(string $term_name, array $placement_filter_keys): bool;
+
+  /**
    * Returns the children of any level term items.
    *
    * @param int $category
@@ -172,5 +177,13 @@ interface SocialTaggingServiceInterface {
    *   The keys are entity type identifiers. The values are arrays of bundles.
    */
   public function types(bool $short = FALSE): array;
+
+  /**
+   * Get key values array.
+   *
+   * @return array
+   *   Where key is unique and value is a label.
+   */
+  public function getKeyValueOptions(): array;
 
 }

--- a/tests/behat/behat.yml
+++ b/tests/behat/behat.yml
@@ -40,6 +40,7 @@ default:
         - Drupal\social\Behat\ThemeContext
         - Drupal\social\Behat\TopicContext
         - Drupal\social\Behat\UserContext
+        - Drupal\social\Behat\TaggingContext
   extensions:
     Drupal\social\Behat\Chrome\ChromeExtension: ~
     Drupal\MinkExtension:
@@ -53,6 +54,7 @@ default:
           chrome:
             api_url: "http://chrome:9222"
             validate_certificate: false
+            socket_timeout: 60
     Drupal\DrupalExtension:
       api_driver: 'drupal'
       drupal:

--- a/tests/behat/features/bootstrap/TaggingContext.php
+++ b/tests/behat/features/bootstrap/TaggingContext.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Drupal\social\Behat;
+
+use Behat\MinkExtension\Context\RawMinkContext;
+use Drupal\Core\Database\Query\PagerSelectExtender;
+use Drupal\Core\Database\Query\TableSortExtender;
+use Drupal\Core\Database\StatementWrapper;
+use Drupal\taxonomy\TermInterface;
+
+/**
+ * Defines test steps around the usage of user.
+ */
+class TaggingContext extends RawMinkContext {
+
+  /**
+   * Fill placement data to show tag for entities.
+   *
+   * @Given I enable content tag :term_name for all entities
+   */
+  public function enableContentTagForAllEntities(string $term_name): void {
+    $term = \Drupal::entityTypeManager()->getStorage('taxonomy_term')->loadByProperties(['name' => $term_name]);
+    $term = reset($term);
+    if (!$term instanceof TermInterface) {
+      throw new \Exception("Term '${$term_name}' does not exist.");
+    }
+    /** @var \Drupal\social_tagging\SocialTaggingServiceInterface $helper */
+    $helper = \Drupal::service('social_tagging.tag_service');
+    $options = $helper->getKeyValueOptions();
+    // Option contains key=>value array where values are a label.
+    // Get keys, and serialize like in TaggingUsageWidget.
+    $values = array_keys($options);
+    $term->set('field_category_usage', serialize($values))->save();
+  }
+
+}

--- a/tests/behat/features/capabilities/follow-taxonomy/follow-tags.feature
+++ b/tests/behat/features/capabilities/follow-taxonomy/follow-tags.feature
@@ -17,6 +17,8 @@ Feature: Follow Tags
       | Category 2   |            |
       | Category 2.1 | Category 2 |
       | Category 2.2 | Category 2 |
+    And I enable content tag "Category 1" for all entities
+    And I enable content tag "Category 2" for all entities
     And users:
       | name            | mail                      | status | roles          | field_profile_first_name | field_profile_last_name |
       | follower        | follower@test.user        | 1      | verified       | Jack                     | Richer                  |


### PR DESCRIPTION
## Problem
Currently we give flexibility to SM to add content tags categories.
Each category is displayed and separate field in the entity creation page and used as filter  in overviews and search.

Currently every entity that supports content tags uses the same set of categories.
When a new category is added, it becomnes available for every entity.

This has a big limitation. It is very common that a tag is relevant for events but makes no sense for Groups and the other way around.

Because of this limitation, in the past we had to create ad hoc vocabularies for some projects in order to support their migration.

We want to introduce the possibility of choosing in which entity a certain category should be displayed. 
The available options are all the entities that are available and that are enabled in the tagging settings here `admin/config/opensocial/tagging-settings`


## Solution
- Add a new field `field_category_usage` to the `social_tagging` taxonomy.
- Allow SM to can choose for which entity a content tag category is available on the taxonomy create/edit page.

## Issue tracker
- https://getopensocial.atlassian.net/browse/PROD-26669

## Theme issue tracker
None.

## How to test
- [ ] Enable Social Tagging module
- [ ] Add tags and select placement where to use them
- [ ] Check entity creation forms
- [ ] Check filter pages


## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
![Screenshot 2023-09-15 at 16 54 18](https://github.com/goalgorilla/open_social/assets/15105499/6a7ba8ed-3ae0-48be-84b6-b3a3807be36c)
![Screenshot 2023-09-22 at 16 25 39](https://github.com/goalgorilla/open_social/assets/15105499/19330de7-54bf-49ce-bb1c-97e126c520f0)
![Screenshot 2023-09-22 at 16 26 49](https://github.com/goalgorilla/open_social/assets/15105499/ef578ee0-809c-4e0d-ab0c-f82146bfd019)


## Release notes
Added possibility for Site Managers to decide where a content tag category should be displayed.

## Change Record
None.

## Translations
None.
