### PR TITLE
Issue #3388012: Deprecation reports to be compatible with D10

### DIFF
--- a/modules/custom/activity_basics/activity_basics.info.yml
+++ b/modules/custom/activity_basics/activity_basics.info.yml
@@ -1,7 +1,7 @@
 name: Activity Basics
 type: module
 description: Basic implementation of activites in Open Social
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 package: Custom
 dependencies:
   - social:activity_creator

--- a/modules/custom/activity_creator/activity_creator.info.yml
+++ b/modules/custom/activity_creator/activity_creator.info.yml
@@ -1,7 +1,7 @@
 name: Activity Creator
 type: module
 description: Creates Activity Entities.
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 package: Custom
 dependencies:
   - drupal:block_content

--- a/modules/custom/activity_logger/activity_logger.info.yml
+++ b/modules/custom/activity_logger/activity_logger.info.yml
@@ -1,7 +1,7 @@
 name: Activity Logger
 type: module
 description: Used to log activities based on the message module
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 package: Social
 dependencies:
   - social:activity_creator

--- a/modules/custom/activity_logger/src/Service/ActivityLoggerFactory.php
+++ b/modules/custom/activity_logger/src/Service/ActivityLoggerFactory.php
@@ -311,7 +311,7 @@ class ActivityLoggerFactory {
    *   The data to insert in the field instances.
    */
   protected function createFieldInstances($message_type, array $fields) {
-    @trigger_error(__METHOD__ . ' is deprecated in social:11.7.0 and is removed from social:12.0.0. Create the fields using `config/install` instead. See https://www.drupal.org/node/3232246', E_USER_DEPRECATED);
+    @trigger_error(__METHOD__ . ' is deprecated in social:11.7.0 and is removed from social:13.0.0. Create the fields using `config/install` instead. See https://www.drupal.org/node/3232246', E_USER_DEPRECATED);
     foreach ($fields as $field) {
       $id = 'message.' . $message_type . '.' . $field['name'];
       $config_storage = $this->entityTypeManager

--- a/modules/custom/activity_send/activity_send.info.yml
+++ b/modules/custom/activity_send/activity_send.info.yml
@@ -1,7 +1,7 @@
 name: Activity Send
 type: module
 description: Used to store and manage external notifications
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 package: Social
 configure: activity_send.settings
 dependencies:

--- a/modules/custom/activity_send/modules/activity_send_email/activity_send_email.info.yml
+++ b/modules/custom/activity_send/modules/activity_send_email/activity_send_email.info.yml
@@ -1,7 +1,7 @@
 name: Activity Send Email
 type: module
 description: Used to send activity notifications by Email
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 package: Social
 dependencies:
   - social:activity_send

--- a/modules/custom/activity_send/modules/activity_send_push_notification/activity_send_push_notification.info.yml
+++ b/modules/custom/activity_send/modules/activity_send_push_notification/activity_send_push_notification.info.yml
@@ -1,7 +1,7 @@
 name: Activity Send Push Notification
 type: module
 description: Used to send activity notifications by Push service
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 package: Social
 dependencies:
   - social:activity_send

--- a/modules/custom/activity_viewer/activity_viewer.info.yml
+++ b/modules/custom/activity_viewer/activity_viewer.info.yml
@@ -1,7 +1,7 @@
 name: Activity Viewer
 type: module
 description: Used to display activities with support for views
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 package: Social
 dependencies:
   - social:activity_creator

--- a/modules/custom/alternative_frontpage/alternative_frontpage.info.yml
+++ b/modules/custom/alternative_frontpage/alternative_frontpage.info.yml
@@ -1,7 +1,7 @@
 name: 'Alternative Frontpage'
 description: 'Provides an alternative frontpage option for authenticated users via redirect.'
 type: module
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 configure: entity.alternative_frontpage.collection
 dependencies:
   - drupal:user

--- a/modules/custom/download_count/download_count.info.yml
+++ b/modules/custom/download_count/download_count.info.yml
@@ -4,4 +4,4 @@ description: 'Tracks file downloads for Drupal private core file fields.'
 dependencies:
    - drupal:field
    - drupal:file
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10

--- a/modules/custom/dropdown/dropdown.info.yml
+++ b/modules/custom/dropdown/dropdown.info.yml
@@ -1,7 +1,7 @@
 name: Dropdown
 type: module
 description: Dropdown field.
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 package: Field types
 dependencies:
   - drupal:options

--- a/modules/custom/entity_access_by_field/entity_access_by_field.info.yml
+++ b/modules/custom/entity_access_by_field/entity_access_by_field.info.yml
@@ -1,5 +1,5 @@
 name: Entity Access By Field
 type: module
 description: Enables site-builders to create custom view permissions for entities based on field values in the entity_access field.
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 package: Custom

--- a/modules/custom/grequest/grequest.info.yml
+++ b/modules/custom/grequest/grequest.info.yml
@@ -2,6 +2,6 @@ name: 'Group request'
 type: module
 description: 'Allows users to request access to Groups'
 package: Group
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 dependencies:
   - group:group

--- a/modules/custom/group_core_comments/group_core_comments.info.yml
+++ b/modules/custom/group_core_comments/group_core_comments.info.yml
@@ -1,7 +1,7 @@
 name: Group Core Comments support
 type: module
 description: Enables Group functionality for the Comment module
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 package: Group
 dependencies:
   - drupal:comment

--- a/modules/custom/gvbo/gvbo.info.yml
+++ b/modules/custom/gvbo/gvbo.info.yml
@@ -3,7 +3,7 @@ description: 'Use Views Bulk Operations together with group permission.'
 package: 'Group'
 type: 'module'
 version: 1.0
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 dependencies:
   - 'group'
   - 'views_bulk_operations'

--- a/modules/custom/improved_theme_settings/improved_theme_settings.info.yml
+++ b/modules/custom/improved_theme_settings/improved_theme_settings.info.yml
@@ -1,5 +1,5 @@
 name: Improved Theme Settings
 type: module
 description: Makes the theme pages a bit UI friendly for people with the permissions.
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 package: Custom

--- a/modules/custom/mentions/mentions.info.yml
+++ b/modules/custom/mentions/mentions.info.yml
@@ -1,7 +1,7 @@
 name: Mentions
 type: module
 description: Record, render and react to specified patterns within content.
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 package: Filters
 configure: entity.mentions_type.list
 dependencies:

--- a/modules/custom/sitewide_js/sitewide_js.info.yml
+++ b/modules/custom/sitewide_js/sitewide_js.info.yml
@@ -1,7 +1,7 @@
 name: Sitewide JS
 type: module
 description: Module to insert site wide custom JS.
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 package: Field types
 dependencies:
   - drupal:options

--- a/modules/custom/social_admin_menu/social_admin_menu.info.yml
+++ b/modules/custom/social_admin_menu/social_admin_menu.info.yml
@@ -1,7 +1,7 @@
 name: Social Admin Menu
 type: module
 description: Social Admin Menu enhancements.
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 package: Social
 dependencies:
   - drupal:toolbar

--- a/modules/custom/social_advanced_queue/social_advanced_queue.info.yml
+++ b/modules/custom/social_advanced_queue/social_advanced_queue.info.yml
@@ -1,7 +1,7 @@
 name: Social Advanced Queue
 type: module
 description: Social queue enhancements using the advanced queue modules.
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 package: Social
 dependencies:
   - advancedqueue:advancedqueue

--- a/modules/custom/social_ajax_comments/social_ajax_comments.info.yml
+++ b/modules/custom/social_ajax_comments/social_ajax_comments.info.yml
@@ -1,7 +1,7 @@
 name: Social Ajax Comments
 type: module
 description: Integration with Ajax Comments.
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 package: Social
 dependencies:
   - ajax_comments:ajax_comments

--- a/modules/custom/social_demo/social_demo.info.yml
+++ b/modules/custom/social_demo/social_demo.info.yml
@@ -1,5 +1,5 @@
 name: 'Social Demo'
 type: module
 description: 'Provides demo content.'
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 package: Social

--- a/modules/custom/social_file_private/social_file_private.info.yml
+++ b/modules/custom/social_file_private/social_file_private.info.yml
@@ -4,6 +4,6 @@ description: |
   and be removed in Open Social 13. Starting in Open Social 11.8.0 the private
   file system is the default for sensitive fields and is opt-out.
 type: module
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 dependencies:
   - drupal:file

--- a/modules/custom/social_font/social_font.info.yml
+++ b/modules/custom/social_font/social_font.info.yml
@@ -1,7 +1,7 @@
 name: Social Font
 type: module
 description: Social font module
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 dependencies:
   - drupal:field
   - drupal:file

--- a/modules/custom/social_gdpr/social_gdpr.info.yml
+++ b/modules/custom/social_gdpr/social_gdpr.info.yml
@@ -1,7 +1,7 @@
 name: Social GDPR
 type: module
 description: Integrate Data Policy module.
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 package: Social
 dependencies:
   - data_policy:data_policy

--- a/modules/custom/social_graphql/social_graphql.info.yml
+++ b/modules/custom/social_graphql/social_graphql.info.yml
@@ -1,7 +1,7 @@
 name: 'Social GraphQL'
 description: 'Enables GraphQL support for Open Social features.'
 type: module
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 dependencies:
   - graphql:graphql
 package: Social (Experimental)

--- a/modules/custom/social_language/modules/social_content_translation/social_content_translation.info.yml
+++ b/modules/custom/social_language/modules/social_content_translation/social_content_translation.info.yml
@@ -1,7 +1,7 @@
 name: Social Language - Content Translation
 type: module
 description: Enables translation of static site content (such as Basic Pages, Landing Pages and Book Pages).
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 package: Social (experimental)
 dependencies:
   - social:social_language

--- a/modules/custom/social_language/social_language.info.yml
+++ b/modules/custom/social_language/social_language.info.yml
@@ -1,7 +1,7 @@
 name: Social Language
 type: module
 description: Support for multilingual interface translations.
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 package: Social
 dependencies:
   - drupal:config_translation

--- a/modules/custom/social_lazy_loading/social_lazy_loading.info.yml
+++ b/modules/custom/social_lazy_loading/social_lazy_loading.info.yml
@@ -1,7 +1,7 @@
 name: 'Social Lazy Loading'
 type: module
 description: 'Module for lazy loading content using the blazy library.'
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 package: Social
 dependencies:
   - lazy:lazy

--- a/modules/custom/social_lazy_loading/social_lazy_loading_images/social_lazy_loading_images.info.yml
+++ b/modules/custom/social_lazy_loading/social_lazy_loading_images/social_lazy_loading_images.info.yml
@@ -1,7 +1,7 @@
 name: 'Social Lazy Loading Image'
 type: module
 description: 'Module for lazy loading images using the blazy library.'
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 package: Social
 dependencies:
   - drupal:lazy

--- a/modules/custom/social_lets_connect/modules/social_lets_connect_contact/social_lets_connect_contact.info.yml
+++ b/modules/custom/social_lets_connect/modules/social_lets_connect_contact/social_lets_connect_contact.info.yml
@@ -1,7 +1,7 @@
 name: 'Social Lets Connect Contact'
 type: module
 description: 'Contact the Open Social development team and help us improve the product.'
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 package: 'Social Lets Connect'
 
 dependencies:

--- a/modules/custom/social_lets_connect/modules/social_lets_connect_usage/social_lets_connect_usage.info.yml
+++ b/modules/custom/social_lets_connect/modules/social_lets_connect_usage/social_lets_connect_usage.info.yml
@@ -1,7 +1,7 @@
 name: 'Social Lets Connect Usage'
 type: module
 description: 'Share usage data Open Social development team and help us improve the product.'
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 package: 'Social Lets Connect'
 
 dependencies:

--- a/modules/custom/social_lets_connect/social_lets_connect.info.yml
+++ b/modules/custom/social_lets_connect/social_lets_connect.info.yml
@@ -1,5 +1,5 @@
 name: 'Social Lets Connect'
 type: module
 description: 'Adds a link to https://www.getopensocial.com in the admin menu.'
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 package: 'Social Lets Connect'

--- a/modules/custom/social_magic_login/social_magic_login.info.yml
+++ b/modules/custom/social_magic_login/social_magic_login.info.yml
@@ -1,7 +1,7 @@
 name: 'Social Magic login'
 description: 'Redirect users to a destination while using a magic login link.'
 type: module
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 package: Social (experimental)
 dependencies:
   - token:token

--- a/modules/custom/social_metatag/social_metatag.info.yml
+++ b/modules/custom/social_metatag/social_metatag.info.yml
@@ -1,7 +1,7 @@
 name: 'Social Metatag'
 description: 'Implement defaults for the Metatag module'
 type: module
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 package: Social
 dependencies:
 - metatag:metatag

--- a/modules/custom/social_path_manager/social_path_manager.info.yml
+++ b/modules/custom/social_path_manager/social_path_manager.info.yml
@@ -1,7 +1,7 @@
 name: Social Path Manager
 type: module
 description: Module for managing path aliases. Currently in an experimental stage. NOTE, This module is a work in progress and has some serious peformance issues still.
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 package: Social (experimental)
 dependencies:
   - pathauto:pathauto

--- a/modules/custom/social_queue_storage/social_queue_storage.info.yml
+++ b/modules/custom/social_queue_storage/social_queue_storage.info.yml
@@ -1,7 +1,7 @@
 name: 'Social Queue item Storage'
 type: module
 description: 'Storage for queue item data to be used in processes that run in the background with a long duration.'
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 package: Social (experimental)
 dependencies:
   - social:activity_logger

--- a/modules/custom/social_react/social_react.info.yml
+++ b/modules/custom/social_react/social_react.info.yml
@@ -8,5 +8,5 @@ description: >-
   should depend on the React library contained in this module to ensure React is
   properly loaded.
 type: module
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 package: Social

--- a/modules/custom/template_suggestions_extra/template_suggestions_extra.info.yml
+++ b/modules/custom/template_suggestions_extra/template_suggestions_extra.info.yml
@@ -1,5 +1,5 @@
 name: template_suggestions_extra
 type: module
 description: Add extra useful template suggestsions
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 package: Custom

--- a/modules/social_features/social_activity/modules/social_activity_filter/social_activity_filter.info.yml
+++ b/modules/social_features/social_activity/modules/social_activity_filter/social_activity_filter.info.yml
@@ -1,7 +1,7 @@
 name: 'Social Activity Filter'
 description: 'Provides filters for activity streams used for example on landing pages, it allows you to filter by taxonomy terms.'
 type: module
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 package: Social (experimental)
 configure: social_activity_filter.settings
 dependencies:

--- a/modules/social_features/social_activity/social_activity.info.yml
+++ b/modules/social_features/social_activity/social_activity.info.yml
@@ -1,7 +1,7 @@
 name: 'Social Activity'
 description: 'Provides activity stream for Open Social.'
 type: module
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 dependencies:
   - social:activity_basics
   - social:activity_send_email

--- a/modules/social_features/social_album/social_album.info.yml
+++ b/modules/social_features/social_album/social_album.info.yml
@@ -1,7 +1,7 @@
 name: 'Social Album'
 description: 'Provides Album content type and related configuration.'
 type: module
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 package: Social (experimental)
 dependencies:
   - social:social_event

--- a/modules/social_features/social_album/social_album.install
+++ b/modules/social_features/social_album/social_album.install
@@ -71,7 +71,7 @@ function social_album_install() {
  * @param array $paths
  *   List of blocks which should be updated and paths which should be added.
  *
- * @deprecated in social:11.4.0 and is removed from social:12.0.0. Use
+ * @deprecated in social:11.4.0 and is removed from social:13.0.0. Use
  *   _social_core_blocks_paths instead.
  *
  * @see https://www.drupal.org/node/3291491

--- a/modules/social_features/social_book/modules/social_book_featured/social_book_featured.info.yml
+++ b/modules/social_features/social_book/modules/social_book_featured/social_book_featured.info.yml
@@ -1,7 +1,7 @@
 name: 'Social Book on Landing pages'
 description: 'Provides a book featured view mode for use on landing pages.'
 type: module
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 dependencies:
   - social:social_book
   - social:social_landing_page

--- a/modules/social_features/social_book/social_book.info.yml
+++ b/modules/social_features/social_book/social_book.info.yml
@@ -1,7 +1,7 @@
 name: 'Social Book'
 description: 'Provides book feature.'
 type: module
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 dependencies:
   - drupal:block
   - drupal:book

--- a/modules/social_features/social_branding/social_branding.info.yml
+++ b/modules/social_features/social_branding/social_branding.info.yml
@@ -1,7 +1,7 @@
 name: 'Social Branding'
 description: 'Extends the GraphQL API with branding information for this Open Social platform.'
 type: module
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 dependencies:
   # Remove this dependency when we have an accessible test environment.
   - social:social_graphql

--- a/modules/social_features/social_branding/tests/modules/social_branding_test/social_branding_test.info.yml
+++ b/modules/social_features/social_branding/tests/modules/social_branding_test/social_branding_test.info.yml
@@ -1,7 +1,7 @@
 name: 'Social Branding Test'
 description: 'Support module for module Social Branding for testing.'
 type: module
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 dependencies:
   - social:social_branding
 package: Testing

--- a/modules/social_features/social_comment/social_comment.info.yml
+++ b/modules/social_features/social_comment/social_comment.info.yml
@@ -1,7 +1,7 @@
 name: 'Social Comment'
 description: 'Provides default comment type and related configuration'
 type: module
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 dependencies:
   - drupal:comment
   - group:group

--- a/modules/social_features/social_comment_upload/social_comment_upload.info.yml
+++ b/modules/social_features/social_comment_upload/social_comment_upload.info.yml
@@ -1,7 +1,7 @@
 name: 'Social Comment Upload'
 description: 'Provides ability to upload files in comments'
 type: module
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 package: Social
 dependencies:
   - drupal:comment

--- a/modules/social_features/social_content_block/modules/social_book_content_block/social_book_content_block.info.yml
+++ b/modules/social_features/social_content_block/modules/social_book_content_block/social_book_content_block.info.yml
@@ -1,7 +1,7 @@
 name: 'Social Book Content Block'
 description: 'Provides a content block for books.'
 type: module
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 dependencies:
   - social:social_content_block
   - social:social_book

--- a/modules/social_features/social_content_block/modules/social_content_block_landing_page/social_content_block_landing_page.info.yml
+++ b/modules/social_features/social_content_block/modules/social_content_block_landing_page/social_content_block_landing_page.info.yml
@@ -1,7 +1,7 @@
 name: 'Social Content Block on Landing pages'
 description: 'Provides "Custom content list block" paragraphs type for landing pages.'
 type: module
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 dependencies:
   - social:social_content_block
   - social:social_landing_page

--- a/modules/social_features/social_content_block/modules/social_event_content_block/social_event_content_block.info.yml
+++ b/modules/social_features/social_content_block/modules/social_event_content_block/social_event_content_block.info.yml
@@ -1,7 +1,7 @@
 name: 'Social Event Content Block'
 description: 'Provides a content block for events.'
 type: module
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 dependencies:
   - social:social_content_block
   - social:social_event

--- a/modules/social_features/social_content_block/modules/social_group_content_block/social_group_content_block.info.yml
+++ b/modules/social_features/social_content_block/modules/social_group_content_block/social_group_content_block.info.yml
@@ -1,7 +1,7 @@
 name: 'Social Group Content Block'
 description: 'Provides a content block for groups.'
 type: module
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 dependencies:
   - social:social_content_block
   - social:social_group

--- a/modules/social_features/social_content_block/modules/social_page_content_block/social_page_content_block.info.yml
+++ b/modules/social_features/social_content_block/modules/social_page_content_block/social_page_content_block.info.yml
@@ -1,7 +1,7 @@
 name: 'Social Page Content Block'
 description: 'Provides a content block for pages.'
 type: module
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 dependencies:
   - social:social_content_block
   - social:social_page

--- a/modules/social_features/social_content_block/social_content_block.api.php
+++ b/modules/social_features/social_content_block/social_content_block.api.php
@@ -16,7 +16,7 @@ use Drupal\Core\Database\Query\SelectInterface;
  * @param \Drupal\block_content\BlockContentInterface $block_content
  *   The current block content.
  *
- * @deprecated in social:11.1.0 and is removed from social:12.0.0. Use
+ * @deprecated in social:11.1.0 and is removed from social:13.0.0. Use
  *   hook_query_social_content_block_alter instead.
  *
  * @see https://www.drupal.org/node/3258202

--- a/modules/social_features/social_content_block/social_content_block.info.yml
+++ b/modules/social_features/social_content_block/social_content_block.info.yml
@@ -1,7 +1,7 @@
 name: Social Content Block
 type: module
 description: A custom block to generate a list of content dynamically according to specific filters.
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 package: Social
 dependencies:
   - drupal:block

--- a/modules/social_features/social_content_report/social_content_report.info.yml
+++ b/modules/social_features/social_content_report/social_content_report.info.yml
@@ -1,7 +1,7 @@
 name: 'Social Content Report'
 description: 'Provides the ability to report inappropriate content.'
 type: module
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 package: Social
 configure: social_content_report.settings
 dependencies:

--- a/modules/social_features/social_core/social_core.api.php
+++ b/modules/social_features/social_core/social_core.api.php
@@ -72,7 +72,7 @@ function hook_social_core_title_alter(array &$titles) {
  * @param array $node_types
  *   The filter format that is default.
  *
- * @deprecated in social:11.4.0 and is removed from social:12.0.0. Use
+ * @deprecated in social:11.4.0 and is removed from social:13.0.0. Use
  *   hook_social_core_title_alter instead.
  *
  * @see https://www.drupal.org/node/3285045

--- a/modules/social_features/social_core/social_core.info.yml
+++ b/modules/social_features/social_core/social_core.info.yml
@@ -1,7 +1,7 @@
 name: 'Social Core'
 description: 'Provides core components required by other features.'
 type: module
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 dependencies:
   - admin_toolbar_tools:admin_toolbar_tools
   - drupal:block

--- a/modules/social_features/social_core/src/Controller/SocialCoreController.php
+++ b/modules/social_features/social_core/src/Controller/SocialCoreController.php
@@ -244,7 +244,7 @@ class SocialCoreController extends ControllerBase {
       }
 
       $this->moduleHandler()->alterDeprecated(
-        'Deprecated in social:11.4.0 and is removed from social:12.0.0. Use hook_social_core_title_alter instead. See https://www.drupal.org/node/3285045',
+        'Deprecated in social:11.4.0 and is removed from social:13.0.0. Use hook_social_core_title_alter instead. See https://www.drupal.org/node/3285045',
         'social_node_title_prefix_articles',
         $titles['node']['bundles'],
       );

--- a/modules/social_features/social_core/src/Routing/RouteSubscriber.php
+++ b/modules/social_features/social_core/src/Routing/RouteSubscriber.php
@@ -57,7 +57,7 @@ class RouteSubscriber extends RouteSubscriberBase {
       }
 
       $this->moduleHandler->alterDeprecated(
-        'Deprecated in social:11.4.0 and is removed from social:12.0.0. Use hook_social_core_title_alter instead. See https://www.drupal.org/node/3285045',
+        'Deprecated in social:11.4.0 and is removed from social:13.0.0. Use hook_social_core_title_alter instead. See https://www.drupal.org/node/3285045',
         'social_node_title_prefix_articles',
         $titles['node']['bundles'],
       );

--- a/modules/social_features/social_core/tests/modules/social_core_test/social_core_test.info.yml
+++ b/modules/social_features/social_core/tests/modules/social_core_test/social_core_test.info.yml
@@ -1,7 +1,7 @@
 name: 'Social Core Test'
 description: 'Support module for module Social Core .'
 type: module
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 dependencies:
   - admin_toolbar_tools:admin_toolbar_tools
   - drupal:block

--- a/modules/social_features/social_download_count/social_download_count.info.yml
+++ b/modules/social_features/social_download_count/social_download_count.info.yml
@@ -1,7 +1,7 @@
 name: 'Social Download Count'
 description: 'Tracks file downloads for Drupal private core file fields for Open Social.'
 type: module
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 dependencies:
   - social:download_count
 package: Social

--- a/modules/social_features/social_editor/social_editor.info.yml
+++ b/modules/social_features/social_editor/social_editor.info.yml
@@ -1,7 +1,7 @@
 name: 'Social Editor'
 description: 'Provides site editor components.'
 type: module
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 dependencies:
   - drupal:ckeditor
   - drupal:editor

--- a/modules/social_features/social_embed/social_embed.info.yml
+++ b/modules/social_features/social_embed/social_embed.info.yml
@@ -1,7 +1,7 @@
 name: Social Embed
 type: module
 description: Module for embedding social media links. Currently in an experimental stage. NOTE, This module is a work in progress and has some serious peformance issues still.
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 package: Social
 dependencies:
   - embed:embed

--- a/modules/social_features/social_emoji/social_emoji.info.yml
+++ b/modules/social_features/social_emoji/social_emoji.info.yml
@@ -1,6 +1,6 @@
 name: 'Social Emoji'
 description: 'Provides an emoji picker functionality for Open Social.'
 type: module
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 package: Social (experimental)
 lifecycle: experimental

--- a/modules/social_features/social_event/modules/social_event_addtocal/social_event_addtocal.info.yml
+++ b/modules/social_features/social_event/modules/social_event_addtocal/social_event_addtocal.info.yml
@@ -1,6 +1,6 @@
 name: Social Event Add To Calendar
 description: Provides the ability to add Open Social events to the third party calendars
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 type: module
 dependencies:
   - social:social_event

--- a/modules/social_features/social_event/modules/social_event_an_enroll/social_event_an_enroll.info.yml
+++ b/modules/social_features/social_event/modules/social_event_an_enroll/social_event_an_enroll.info.yml
@@ -1,7 +1,7 @@
 name: 'Social Event Anonymous Enrolments'
 description: 'Provides ability to enroll to an event without having to create an account.'
 type: module
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 package: Social
 dependencies:
   - social:social_editor

--- a/modules/social_features/social_event/modules/social_event_an_enroll_enrolments_export/social_event_an_enroll_enrolments_export.info.yml
+++ b/modules/social_features/social_event/modules/social_event_an_enroll_enrolments_export/social_event_an_enroll_enrolments_export.info.yml
@@ -1,7 +1,7 @@
 name: 'Social Event Anonymous Enrolments Export'
 description: 'Adds ability to export event enrolments (include guests) to a CSV.'
 type: module
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 package: Social
 dependencies:
   - social:social_event_an_enroll

--- a/modules/social_features/social_event/modules/social_event_enrolments_export/social_event_enrolments_export.info.yml
+++ b/modules/social_features/social_event/modules/social_event_enrolments_export/social_event_enrolments_export.info.yml
@@ -1,7 +1,7 @@
 name: 'Social Event Enrolments Export'
 description: 'Adds ability to export event enrolments to a CSV.'
 type: module
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 package: Social
 dependencies:
   - social:social_event

--- a/modules/social_features/social_event/modules/social_event_invite/social_event_invite.info.yml
+++ b/modules/social_features/social_event/modules/social_event_invite/social_event_invite.info.yml
@@ -1,7 +1,7 @@
 name: 'Social Event Invite Enrolments'
 description: 'Provides ability to invite enroll to an event.'
 type: module
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 package: Social
 dependencies:
   - social:social_event

--- a/modules/social_features/social_event/modules/social_event_managers/social_event_managers.info.yml
+++ b/modules/social_features/social_event/modules/social_event_managers/social_event_managers.info.yml
@@ -1,7 +1,7 @@
 name: 'Social Event Organisers'
 type: module
 description: 'Social Event Organisers'
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 package: Social
 dependencies:
   - drupal:block

--- a/modules/social_features/social_event/modules/social_event_max_enroll/social_event_max_enroll.info.yml
+++ b/modules/social_features/social_event/modules/social_event_max_enroll/social_event_max_enroll.info.yml
@@ -1,7 +1,7 @@
 name: 'Social Event Max Enroll'
 description: 'Allow setting the maximum participant number for events.'
 type: module
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 configure: social_event_max_enroll.settings
 dependencies:
   - social:social_event

--- a/modules/social_features/social_event/modules/social_event_type/social_event_type.info.yml
+++ b/modules/social_features/social_event/modules/social_event_type/social_event_type.info.yml
@@ -1,7 +1,7 @@
 name: 'Social Event Type'
 description: 'Provides and event types taxonomy for the event content type.'
 type: module
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 dependencies:
   - social:social_event
 package: Social

--- a/modules/social_features/social_event/social_event.info.yml
+++ b/modules/social_features/social_event/social_event.info.yml
@@ -1,7 +1,7 @@
 name: 'Social Event'
 description: 'Provides Event content type and related configuration. '
 type: module
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 configure: social_event.settings
 dependencies:
   - address:address

--- a/modules/social_features/social_event/social_event.services.yml
+++ b/modules/social_features/social_event/social_event.services.yml
@@ -19,7 +19,7 @@ services:
     class: Drupal\social_event\Service\SocialEventEnrollService
     arguments:
       - '@config.factory'
-    deprecated: The "%service_id%" service is deprecated in social:11.5.0 and is removed from social:12.0.0. See https://www.drupal.org/project/social/issues/3306568
+    deprecated: The "%service_id%" service is deprecated in social:11.5.0 and is removed from social:13.0.0. See https://www.drupal.org/project/social/issues/3306568
   social_event.enrollments_access:
     class: Drupal\social_event\Access\EventEnrollmentsAccessCheck
     tags:

--- a/modules/social_features/social_event/src/Service/SocialEventEnrollService.php
+++ b/modules/social_features/social_event/src/Service/SocialEventEnrollService.php
@@ -34,7 +34,7 @@ class SocialEventEnrollService implements SocialEventEnrollServiceInterface {
    * {@inheritdoc}
    */
   public function isEnabled(NodeInterface $node) {
-    @trigger_error(__METHOD__ . '() is deprecated in social:11.5.0 and is removed from social:12.0.0. Use bundled node object itself `$event->isEnrollmentEnabled()` instead. See https://www.drupal.org/project/social/issues/3306568', E_USER_DEPRECATED);
+    @trigger_error(__METHOD__ . '() is deprecated in social:11.5.0 and is removed from social:13.0.0. Use bundled node object itself `$event->isEnrollmentEnabled()` instead. See https://www.drupal.org/project/social/issues/3306568', E_USER_DEPRECATED);
     return $node instanceof Event &&
       $node->isEnrollmentEnabled();
   }

--- a/modules/social_features/social_event/src/Service/SocialEventEnrollServiceInterface.php
+++ b/modules/social_features/social_event/src/Service/SocialEventEnrollServiceInterface.php
@@ -20,7 +20,7 @@ interface SocialEventEnrollServiceInterface {
    * @return bool
    *   TRUE if enrollment is allowed.
    *
-   * @deprecated in social:11.5.0 and is removed from social:12.0.0. Use
+   * @deprecated in social:11.5.0 and is removed from social:13.0.0. Use
    *   bundled node object itself `$event->isEnrollmentEnabled()` instead.
    * @see https://www.drupal.org/project/social/issues/3306568
    */

--- a/modules/social_features/social_featured_content/social_featured_content.info.yml
+++ b/modules/social_features/social_featured_content/social_featured_content.info.yml
@@ -1,7 +1,7 @@
 name: 'Social Featured Content'
 description: 'Provides "Featured Content" paragraphs type for landing pages.'
 type: module
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 dependencies:
   - drupal:block_content
   - entity_reference_revisions:entity_reference_revisions

--- a/modules/social_features/social_featured_items/social_featured_items.info.yml
+++ b/modules/social_features/social_featured_items/social_featured_items.info.yml
@@ -1,7 +1,7 @@
 name: 'Social Featured Items'
 type: module
 description: 'Provides a shared paragraphs type for landing pages and dashboards.'
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 dependencies:
   - paragraphs:paragraphs
   - drupal:block_content

--- a/modules/social_features/social_follow_content/social_follow_content.info.yml
+++ b/modules/social_features/social_follow_content/social_follow_content.info.yml
@@ -1,7 +1,7 @@
 name: 'Social Follow Content'
 description: 'Provides "Follow Content" flag type and related functionality.'
 type: module
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 dependencies:
   - social:activity_logger
   - drupal:block

--- a/modules/social_features/social_follow_taxonomy/modules/social_follow_landing_page/social_follow_landing_page.info.yml
+++ b/modules/social_features/social_follow_taxonomy/modules/social_follow_landing_page/social_follow_landing_page.info.yml
@@ -1,7 +1,7 @@
 name: 'Social Follow Landing Page'
 description: 'Provide the possibility to add the Follow tag block on the landing pages.'
 type: module
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 dependencies:
   - social_follow_taxonomy:social_follow_taxonomy
   - social_tagging:social_tagging

--- a/modules/social_features/social_follow_taxonomy/modules/social_follow_tag/social_follow_tag.info.yml
+++ b/modules/social_features/social_follow_taxonomy/modules/social_follow_tag/social_follow_tag.info.yml
@@ -1,7 +1,7 @@
 name: 'Social Follow Tag'
 description: 'Provide follow functionality for the social_tagging vocabulary and create activities related to followed tag.'
 type: module
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 dependencies:
   - social_follow_taxonomy:social_follow_taxonomy
   - social_tagging:social_tagging

--- a/modules/social_features/social_follow_taxonomy/modules/social_follow_tag/social_follow_tag.install
+++ b/modules/social_features/social_follow_taxonomy/modules/social_follow_tag/social_follow_tag.install
@@ -161,7 +161,7 @@ function _social_follow_tag_update_existing_messages(array &$sandbox): void {
     $query = $message_storage->getQuery()
       ->condition('template', 'create_node_following_tag_stream');
     $mids = $query
-      ->accessCheck()
+      ->accessCheck(TRUE)
       ->execute();
     if (empty($mids)) {
       $sandbox['#finished'] = 1;
@@ -171,7 +171,7 @@ function _social_follow_tag_update_existing_messages(array &$sandbox): void {
     // Set default params.
     $sandbox['total'] = $query
       ->count()
-      ->accessCheck()
+      ->accessCheck(TRUE)
       ->execute();
     $sandbox['processed'] = 0;
     $sandbox['mids'] = $mids;

--- a/modules/social_features/social_follow_taxonomy/modules/social_follow_tag/social_follow_tag.install
+++ b/modules/social_features/social_follow_taxonomy/modules/social_follow_tag/social_follow_tag.install
@@ -160,14 +160,19 @@ function _social_follow_tag_update_existing_messages(array &$sandbox): void {
     // Get all message IDs than should be updated.
     $query = $message_storage->getQuery()
       ->condition('template', 'create_node_following_tag_stream');
-    $mids = $query->execute();
+    $mids = $query
+      ->accessCheck()
+      ->execute();
     if (empty($mids)) {
       $sandbox['#finished'] = 1;
       return;
     }
 
     // Set default params.
-    $sandbox['total'] = $query->count()->execute();
+    $sandbox['total'] = $query
+      ->count()
+      ->accessCheck()
+      ->execute();
     $sandbox['processed'] = 0;
     $sandbox['mids'] = $mids;
   }

--- a/modules/social_features/social_follow_taxonomy/modules/social_follow_tag/social_follow_tag.install
+++ b/modules/social_features/social_follow_taxonomy/modules/social_follow_tag/social_follow_tag.install
@@ -161,7 +161,7 @@ function _social_follow_tag_update_existing_messages(array &$sandbox): void {
     $query = $message_storage->getQuery()
       ->condition('template', 'create_node_following_tag_stream');
     $mids = $query
-      ->accessCheck(TRUE)
+      ->accessCheck(FALSE)
       ->execute();
     if (empty($mids)) {
       $sandbox['#finished'] = 1;
@@ -171,7 +171,7 @@ function _social_follow_tag_update_existing_messages(array &$sandbox): void {
     // Set default params.
     $sandbox['total'] = $query
       ->count()
-      ->accessCheck(TRUE)
+      ->accessCheck(FALSE)
       ->execute();
     $sandbox['processed'] = 0;
     $sandbox['mids'] = $mids;

--- a/modules/social_features/social_follow_taxonomy/social_follow_taxonomy.info.yml
+++ b/modules/social_features/social_follow_taxonomy/social_follow_taxonomy.info.yml
@@ -1,7 +1,7 @@
 name: 'Social Follow Taxonomy Term'
 description: 'Provides "Follow Term" flag type and related functionality.'
 type: module
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 dependencies:
   - social:activity_logger
   - social:social_user

--- a/modules/social_features/social_follow_taxonomy/social_follow_taxonomy.module
+++ b/modules/social_features/social_follow_taxonomy/social_follow_taxonomy.module
@@ -295,7 +295,7 @@ function social_follow_taxonomy_related_entity_count(TermInterface $term, $field
         ->addTag('node_access')
         ->addMetaData('base_table', 'node')
         ->addMetaData('op', 'view')
-        ->accessCheck()
+        ->accessCheck(TRUE)
         ->execute();
       break;
 
@@ -304,7 +304,7 @@ function social_follow_taxonomy_related_entity_count(TermInterface $term, $field
         ->getStorage('group')
         ->getQuery()
         ->condition($field_id, $term->id())
-        ->accessCheck()
+        ->accessCheck(TRUE)
         ->execute();
       break;
 

--- a/modules/social_features/social_follow_taxonomy/social_follow_taxonomy.module
+++ b/modules/social_features/social_follow_taxonomy/social_follow_taxonomy.module
@@ -295,6 +295,7 @@ function social_follow_taxonomy_related_entity_count(TermInterface $term, $field
         ->addTag('node_access')
         ->addMetaData('base_table', 'node')
         ->addMetaData('op', 'view')
+        ->accessCheck()
         ->execute();
       break;
 
@@ -303,6 +304,7 @@ function social_follow_taxonomy_related_entity_count(TermInterface $term, $field
         ->getStorage('group')
         ->getQuery()
         ->condition($field_id, $term->id())
+        ->accessCheck()
         ->execute();
       break;
 

--- a/modules/social_features/social_follow_taxonomy/src/Plugin/views/filter/FollowTaxonomyViewsFilter.php
+++ b/modules/social_features/social_follow_taxonomy/src/Plugin/views/filter/FollowTaxonomyViewsFilter.php
@@ -173,7 +173,7 @@ class FollowTaxonomyViewsFilter extends TaxonomyIndexTid {
           ->getStorage('taxonomy_term')
           ->loadMultiple(
             $query
-              ->accessCheck()
+              ->accessCheck(TRUE)
               ->execute()
           );
 

--- a/modules/social_features/social_follow_taxonomy/src/Plugin/views/filter/FollowTaxonomyViewsFilter.php
+++ b/modules/social_features/social_follow_taxonomy/src/Plugin/views/filter/FollowTaxonomyViewsFilter.php
@@ -171,7 +171,11 @@ class FollowTaxonomyViewsFilter extends TaxonomyIndexTid {
         }
         $terms = $this->entityTypeManager
           ->getStorage('taxonomy_term')
-          ->loadMultiple($query->execute());
+          ->loadMultiple(
+            $query
+              ->accessCheck()
+              ->execute()
+          );
 
         foreach ($terms as $term) {
           $options[$term->id()] = $this->entityRepository

--- a/modules/social_features/social_follow_user/social_follow_user.info.yml
+++ b/modules/social_features/social_follow_user/social_follow_user.info.yml
@@ -1,7 +1,7 @@
 name: 'Social Follow User'
 description: 'Provides "Follow User" flag type and related functionality.'
 type: module
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 package: Social (Experimental)
 configure: social_follow_user.settings
 dependencies:

--- a/modules/social_features/social_footer/social_footer.info.yml
+++ b/modules/social_features/social_footer/social_footer.info.yml
@@ -1,7 +1,7 @@
 name: Social Footer
 type: module
 description: 'Provides block based on the "Powered by Drupal" block from Drupal core.'
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 package: Social
 dependencies:
   - drupal:file

--- a/modules/social_features/social_group/modules/social_group_default_route/social_group_default_route.info.yml
+++ b/modules/social_features/social_group/modules/social_group_default_route/social_group_default_route.info.yml
@@ -1,7 +1,7 @@
 name: Social Group Default Route
 type: module
 description: This module allows group managers to set the default routes on a group for member and non-members.
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 package: Social
 dependencies:
   - social:social_group

--- a/modules/social_features/social_group/modules/social_group_flexible_group/modules/social_flexible_group_book/social_flexible_group_book.info.yml
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/modules/social_flexible_group_book/social_flexible_group_book.info.yml
@@ -1,7 +1,7 @@
 name: 'Social Flexible Group - Book pages'
 description: 'Provides an ability to have Book Page node type in flexible groups.'
 type: module
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 package: Social (Experimental)
 lifecycle: experimental
 dependencies:

--- a/modules/social_features/social_group/modules/social_group_flexible_group/modules/social_flexible_group_featured/social_flexible_group_featured.info.yml
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/modules/social_flexible_group_featured/social_flexible_group_featured.info.yml
@@ -1,7 +1,7 @@
 name: 'Social Flexible Group on Landing pages'
 description: 'Provides a flexible Group featured view mode for use on landing pages.'
 type: module
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 dependencies:
   - social:social_group_flexible_group
   - social:social_landing_page

--- a/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.api.php
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.api.php
@@ -30,7 +30,7 @@ function hook_social_group_flexible_group_content_routes_alter(array &$content_r
  * @param string $description
  *   An explanation of a visibility option as HTML markup text.
  *
- * @deprecated in social:11.5.0 and is removed from social:12.0.0. Use
+ * @deprecated in social:11.5.0 and is removed from social:13.0.0. Use
  *   hook_social_group_group_visibility_description_alter instead.
  *
  * @see https://www.drupal.org/node/3302921

--- a/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.info.yml
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.info.yml
@@ -1,7 +1,7 @@
 name: 'Social Flexible Group'
 description: 'Provides a flexible Group feature allowing members to configure the group to their liking.'
 type: module
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 dependencies:
   - address:address
   - drupal:field

--- a/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.install
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.install
@@ -547,10 +547,10 @@ function social_group_flexible_group_update_11402(): string {
 function social_group_flexible_group_update_11701(array &$sandbox): string {
   if (!isset($sandbox['total'])) {
     $sandbox['total'] = \Drupal::entityQuery('group')
-      ->accessCheck(FALSE)
       ->condition('type', 'flexible_group')
       ->notExists('field_group_posts_enabled')
       ->count()
+      ->accessCheck(FALSE)
       ->execute();
 
     if (!$sandbox['total']) {
@@ -572,12 +572,12 @@ function social_group_flexible_group_update_11701(array &$sandbox): string {
   }
 
   $entity_ids = \Drupal::entityQuery('group')
-    ->accessCheck(FALSE)
     ->condition('type', 'flexible_group')
     ->condition('id', $sandbox['current_id'], '>')
     ->notExists('field_group_posts_enabled')
     ->sort('id')
     ->range(0, $sandbox['limit'])
+    ->accessCheck(FALSE)
     ->execute();
 
   $storage = \Drupal::entityTypeManager()->getStorage('group');

--- a/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.module
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.module
@@ -43,7 +43,7 @@ function social_group_flexible_group_social_group_types_alter(array &$social_gro
 /**
  * Implements hook_views_data_alter().
  *
- * @deprecated in social:11.9.0 and is removed from social:12.0.0.
+ * @deprecated in social:11.9.0 and is removed from social:13.0.0.
  *   Use views filter "node_access" from "node" module instead.
  * @see https://www.drupal.org/project/social/issues/3358489
  */

--- a/modules/social_features/social_group/modules/social_group_flexible_group/src/Plugin/views/filter/FlexibleGroupNodeAccess.php
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/src/Plugin/views/filter/FlexibleGroupNodeAccess.php
@@ -13,7 +13,7 @@ use Drupal\views\Views;
  *
  * @ViewsFilter("flexible_group_node_access")
  *
- * @deprecated in social:11.9.0 and is removed from social:12.0.0.
+ * @deprecated in social:11.9.0 and is removed from social:13.0.0.
  *   Use views filter "node_access" from "node" module instead.
  * @see https://www.drupal.org/project/social/issues/3358489
  */

--- a/modules/social_features/social_group/modules/social_group_gvbo/social_group_gvbo.info.yml
+++ b/modules/social_features/social_group/modules/social_group_gvbo/social_group_gvbo.info.yml
@@ -1,7 +1,7 @@
 name: 'Social Group VBO integration with Groups and Open Social'
 description: 'Adds ability to act on Group Content.'
 type: module
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 package: Social
 dependencies:
   - social:social_group

--- a/modules/social_features/social_group/modules/social_group_invite/social_group_invite.info.yml
+++ b/modules/social_features/social_group/modules/social_group_invite/social_group_invite.info.yml
@@ -1,7 +1,7 @@
 name: 'Social Group Invite'
 description: 'Provides Group Invite member feature.'
 type: module
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 dependencies:
   - group:group
   - group:ginvite

--- a/modules/social_features/social_group/modules/social_group_members_export/social_group_members_export.info.yml
+++ b/modules/social_features/social_group/modules/social_group_members_export/social_group_members_export.info.yml
@@ -1,7 +1,7 @@
 name: 'Social Group Members Export'
 description: 'Adds ability to export group members to a CSV.'
 type: module
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 package: Social
 dependencies:
   - social:social_group

--- a/modules/social_features/social_group/modules/social_group_quickjoin/social_group_quickjoin.info.yml
+++ b/modules/social_features/social_group/modules/social_group_quickjoin/social_group_quickjoin.info.yml
@@ -1,7 +1,7 @@
 name: 'Social Group Quickjoin'
 description: 'Allows users to skip confirmation when joining a group.'
 type: module
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 dependencies:
 - social:social_group
 package: Social

--- a/modules/social_features/social_group/modules/social_group_request/social_group_request.api.php
+++ b/modules/social_features/social_group/modules/social_group_request/social_group_request.api.php
@@ -16,7 +16,7 @@
  * @param array $group_types
  *   List of group types used in open social.
  *
- * @deprecated in social:11.4.0 and is removed from social:12.0.0. Use
+ * @deprecated in social:11.4.0 and is removed from social:13.0.0. Use
  *   hook_social_group_join_method_usage instead.
  *
  * @see https://www.drupal.org/node/3254715

--- a/modules/social_features/social_group/modules/social_group_request/social_group_request.info.yml
+++ b/modules/social_features/social_group/modules/social_group_request/social_group_request.info.yml
@@ -2,7 +2,7 @@ name: 'Social Group request'
 type: module
 description: 'Allows users to request access to Groups'
 package: Social
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 dependencies:
   - group:group
   - grequest:grequest

--- a/modules/social_features/social_group/modules/social_group_request/social_group_request.module
+++ b/modules/social_features/social_group/modules/social_group_request/social_group_request.module
@@ -360,8 +360,8 @@ function social_group_request_preprocess_page_title(&$variables) {
     ->condition('type', $contentTypeConfigId)
     ->condition('gid', $group->id())
     ->condition('grequest_status', GroupMembershipRequest::REQUEST_PENDING)
-    ->accessCheck()
     ->count()
+    ->accessCheck(TRUE)
     ->execute();
 
   $title_singular = '1 membership request to group: :group_title';

--- a/modules/social_features/social_group/modules/social_group_secret/modules/social_secret_group_featured/social_secret_group_featured.info.yml
+++ b/modules/social_features/social_group/modules/social_group_secret/modules/social_secret_group_featured/social_secret_group_featured.info.yml
@@ -1,7 +1,7 @@
 name: 'Social Secret Group on Landing pages'
 description: 'Provides a Secret Group featured view mode for use on landing pages.'
 type: module
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 dependencies:
   - social:social_group_secret
   - social:social_landing_page

--- a/modules/social_features/social_group/modules/social_group_secret/social_group_secret.info.yml
+++ b/modules/social_features/social_group/modules/social_group_secret/social_group_secret.info.yml
@@ -1,7 +1,7 @@
 name: 'Social Secret Group'
 description: 'Adds Secret Group as a group type.'
 type: module
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 dependencies:
   - social:social_group
 package: Social

--- a/modules/social_features/social_group/modules/social_group_welcome_message/social_group_welcome_message.info.yml
+++ b/modules/social_features/social_group/modules/social_group_welcome_message/social_group_welcome_message.info.yml
@@ -1,7 +1,7 @@
 name: 'Social Group Welcome Message'
 description: 'Implements group welcome message functionality.'
 type: module
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 dependencies:
   - social:social_editor
   - social:social_group

--- a/modules/social_features/social_group/social_group.info.yml
+++ b/modules/social_features/social_group/social_group.info.yml
@@ -1,7 +1,7 @@
 name: 'Social Group'
 description: 'Provides Group feature.'
 type: module
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 dependencies:
   - address:address
   - better_exposed_filters:better_exposed_filters

--- a/modules/social_features/social_group/social_group.module
+++ b/modules/social_features/social_group/social_group.module
@@ -1276,7 +1276,7 @@ function _social_group_cross_posting_group_type_validate(array $element, FormSta
  * @param array $complete_form
  *   The complete form structure.
  *
- * @deprecated in social:11.1.0 and is removed from social:12.0.0. Use
+ * @deprecated in social:11.1.0 and is removed from social:13.0.0. Use
  *   \Drupal\social_group\Element\SocialGroupEntityAutocomplete::validateEntityAutocompleteSelect2()
  *   instead.
  *

--- a/modules/social_features/social_group/src/JoinManager.php
+++ b/modules/social_features/social_group/src/JoinManager.php
@@ -61,7 +61,7 @@ class JoinManager extends DefaultPluginManager implements JoinManagerInterface {
       $old_types = $new_types = array_unique($old_types);
 
       $this->moduleHandler->alterDeprecated(
-        'Deprecated in social:11.2.0 and is removed from social:12.0.0. Use hook_social_group_join_method_usage instead. See https://www.drupal.org/node/3254715',
+        'Deprecated in social:11.2.0 and is removed from social:13.0.0. Use hook_social_group_join_method_usage instead. See https://www.drupal.org/node/3254715',
         'social_group_request',
         $new_types,
       );

--- a/modules/social_features/social_landing_page/social_landing_page.info.yml
+++ b/modules/social_features/social_landing_page/social_landing_page.info.yml
@@ -1,7 +1,7 @@
 name: 'Social Landing Page'
 type: module
 description: 'Provides landing page content type for dynamic content, such as a home page.'
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 dependencies:
   - activity_creator:activity_creator
   - activity_creator:activity_viewer

--- a/modules/social_features/social_like/social_like.info.yml
+++ b/modules/social_features/social_like/social_like.info.yml
@@ -1,7 +1,7 @@
 name: 'Social Like'
 description: 'Provides Like voting functionality for Open Social.'
 type: module
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 dependencies:
   - social:activity_logger
   - drupal:block

--- a/modules/social_features/social_mentions/social_mentions.info.yml
+++ b/modules/social_features/social_mentions/social_mentions.info.yml
@@ -1,7 +1,7 @@
 name: 'Social Mentions'
 description: 'Provide mentions feature for Open Social.'
 type: module
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 dependencies:
   - social:activity_logger
   - dynamic_entity_reference:dynamic_entity_reference

--- a/modules/social_features/social_node/social_node.info.yml
+++ b/modules/social_features/social_node/social_node.info.yml
@@ -1,7 +1,7 @@
 name: 'Social Node'
 description: 'Provides core functionality around Nodes.'
 type: module
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 dependencies:
   - drupal:node
   - social:activity_creator

--- a/modules/social_features/social_page/social_page.info.yml
+++ b/modules/social_features/social_page/social_page.info.yml
@@ -1,7 +1,7 @@
 name: 'Social Page'
 description: 'Provide basic pages content type for your static content, such as an About us page.'
 type: module
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 dependencies:
   - drupal:comment
   - social:entity_access_by_field

--- a/modules/social_features/social_post/modules/social_post_album/social_post_album.info.yml
+++ b/modules/social_features/social_post/modules/social_post_album/social_post_album.info.yml
@@ -1,7 +1,7 @@
 name: 'Social Post Album'
 description: 'Provides the ability to use the Album feature in a post.'
 type: module
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 dependencies:
   - social:social_post_photo
   - social:social_comment_upload

--- a/modules/social_features/social_post/modules/social_post_photo/social_post_photo.info.yml
+++ b/modules/social_features/social_post/modules/social_post_photo/social_post_photo.info.yml
@@ -1,7 +1,7 @@
 name: 'Social Post Photo'
 description: 'Provides an new post type bundle.'
 type: module
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 dependencies:
   - drupal:comment
   - social:dropdown

--- a/modules/social_features/social_post/social_post.info.yml
+++ b/modules/social_features/social_post/social_post.info.yml
@@ -1,7 +1,7 @@
 name: 'Social Post'
 description: 'Provides Post functionality for Open Social.'
 type: module
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 dependencies:
   - drupal:block
   - drupal:comment

--- a/modules/social_features/social_private_message/social_private_message.info.yml
+++ b/modules/social_features/social_private_message/social_private_message.info.yml
@@ -1,7 +1,7 @@
 name: Social Private Message
 type: module
 description: Allow users to send private messages to each other
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 package: Social
 dependencies:
   - private_message:private_message

--- a/modules/social_features/social_profile/modules/social_profile_fields/social_profile_fields.info.yml
+++ b/modules/social_features/social_profile/modules/social_profile_fields/social_profile_fields.info.yml
@@ -1,7 +1,7 @@
 name: 'Social Profile Fields'
 description: 'Provides hiding fields on a per profile_type basis'
 type: module
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 package: Social
 configure: social_profile_fields.settings
 dependencies:

--- a/modules/social_features/social_profile/modules/social_profile_manager_notes/social_profile_manager_notes.info.yml
+++ b/modules/social_features/social_profile/modules/social_profile_manager_notes/social_profile_manager_notes.info.yml
@@ -1,7 +1,7 @@
 name: 'Social Profile Manager Notes'
 description: 'Provides profile notes that can created by Managers'
 type: module
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 package: Social (experimental)
 dependencies:
   - drupal:user

--- a/modules/social_features/social_profile/modules/social_profile_organization_tag/social_profile_organization_tag.info.yml
+++ b/modules/social_features/social_profile/modules/social_profile_organization_tag/social_profile_organization_tag.info.yml
@@ -1,7 +1,7 @@
 name: 'Social Profile Organization Tag'
 description: 'Provides Profile Organization Tag field and vocabulary'
 type: module
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 package: Social
 dependencies:
   - social:social_profile

--- a/modules/social_features/social_profile/modules/social_profile_preview/social_profile_preview.info.yml
+++ b/modules/social_features/social_profile/modules/social_profile_preview/social_profile_preview.info.yml
@@ -1,7 +1,7 @@
 name: 'Social Profile Preview'
 description: 'Provides a modal window to display profile details.'
 type: module
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 package: Social (experimental)
 dependencies:
   - social:social_profile

--- a/modules/social_features/social_profile/modules/social_profile_privacy/social_profile_privacy.info.yml
+++ b/modules/social_features/social_profile/modules/social_profile_privacy/social_profile_privacy.info.yml
@@ -1,7 +1,7 @@
 name: 'Social Profile Privacy'
 description: 'Provides ability to set visibility of profile fields'
 type: module
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 package: Social
 configure: social_profile.settings
 dependencies:

--- a/modules/social_features/social_profile/social_profile.info.yml
+++ b/modules/social_features/social_profile/social_profile.info.yml
@@ -1,7 +1,7 @@
 name: 'Social Profile'
 description: 'Provides user profiles.'
 type: module
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 configure: social_profile.settings
 dependencies:
   - address:address

--- a/modules/social_features/social_search/social_search.info.yml
+++ b/modules/social_features/social_search/social_search.info.yml
@@ -1,7 +1,7 @@
 name: 'Social Search'
 description: 'Provide Search API configuration and Search Views.'
 type: module
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 dependencies:
   - better_exposed_filters:better_exposed_filters
   - drupal:block

--- a/modules/social_features/social_sharing/social_sharing.info.yml
+++ b/modules/social_features/social_sharing/social_sharing.info.yml
@@ -1,7 +1,7 @@
 name: 'Social Sharing'
 description: 'Provides sharing of content to social media.'
 type: module
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 dependencies:
   - drupal:shariff
   - drupal:block

--- a/modules/social_features/social_swiftmail/social_swiftmail.info.yml
+++ b/modules/social_features/social_swiftmail/social_swiftmail.info.yml
@@ -1,7 +1,7 @@
 name: Social Swiftmailer
 type: module
 description: Social Swiftmailer implementation
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 package: Social
 dependencies:
   - swiftmailer:swiftmailer

--- a/modules/social_features/social_tagging/social_tagging.info.yml
+++ b/modules/social_features/social_tagging/social_tagging.info.yml
@@ -1,7 +1,7 @@
 name: Social Tagging
 type: module
 description: Content tagging module
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 package: Social
 configure: social_tagging.settings
 dependencies:

--- a/modules/social_features/social_tagging/social_tagging.module
+++ b/modules/social_features/social_tagging/social_tagging.module
@@ -596,13 +596,13 @@ function social_tagging_form_views_exposed_form_alter(&$form, FormStateInterface
  * @return mixed|string
  *   A machine name so it can be used programmatically.
  *
- * @deprecated in social:11.3.10 and is removed from social:12.0.0. Use
+ * @deprecated in social:11.3.10 and is removed from social:13.0.0. Use
  *   \Drupal::service('social_core.machine_name')->transform() instead.
  *
  * @see https://www.drupal.org/node/3306214
  */
 function social_tagging_to_machine_name($text) {
-  @trigger_error('social_tagging_to_machine_name() is deprecated in social:11.3.10 and is removed from social:12.0.0. Use "\Drupal::service(\'social_core.machine_name\')->transform()" instead. See https://www.drupal.org/node/3306214', E_USER_DEPRECATED);
+  @trigger_error('social_tagging_to_machine_name() is deprecated in social:11.3.10 and is removed from social:13.0.0. Use "\Drupal::service(\'social_core.machine_name\')->transform()" instead. See https://www.drupal.org/node/3306214', E_USER_DEPRECATED);
   return preg_replace('@[^a-z0-9-]+@', '_', strtolower($text));
 }
 

--- a/modules/social_features/social_topic/social_topic.info.yml
+++ b/modules/social_features/social_topic/social_topic.info.yml
@@ -1,7 +1,7 @@
 name: 'Social Topic'
 description: 'Provides Topic content type and related configuration. '
 type: module
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 dependencies:
   - drupal:block
   - drupal:comment

--- a/modules/social_features/social_user/social_user.info.yml
+++ b/modules/social_features/social_user/social_user.info.yml
@@ -1,7 +1,7 @@
 name: 'Social User'
 description: 'Provides User related configuration.'
 type: module
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 dependencies:
   - drupal:block
   - drupal:user

--- a/modules/social_features/social_user_export/social_user_export.info.yml
+++ b/modules/social_features/social_user_export/social_user_export.info.yml
@@ -1,7 +1,7 @@
 name: 'Social User Export'
 description: 'Adds ability to export users to a CSV.'
 type: module
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 package: Social
 dependencies:
   - drupal:user

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -8809,11 +8809,6 @@ parameters:
 			path: modules/social_features/social_follow_taxonomy/modules/social_follow_tag/social_follow_tag.install
 
 		-
-			message: "#^Relying on entity queries to check access by default is deprecated in drupal\\:9\\.2\\.0 and an error will be thrown from drupal\\:10\\.0\\.0\\. Call \\\\Drupal\\\\Core\\\\Entity\\\\Query\\\\QueryInterface\\:\\:accessCheck\\(\\) with TRUE or FALSE to specify whether access should be checked\\.$#"
-			count: 2
-			path: modules/social_features/social_follow_taxonomy/modules/social_follow_tag/social_follow_tag.install
-
-		-
 			message: "#^Function social_follow_tag_entity_update\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: modules/social_features/social_follow_taxonomy/modules/social_follow_tag/social_follow_tag.module
@@ -8979,11 +8974,6 @@ parameters:
 			path: modules/social_features/social_follow_taxonomy/social_follow_taxonomy.module
 
 		-
-			message: "#^Relying on entity queries to check access by default is deprecated in drupal\\:9\\.2\\.0 and an error will be thrown from drupal\\:10\\.0\\.0\\. Call \\\\Drupal\\\\Core\\\\Entity\\\\Query\\\\QueryInterface\\:\\:accessCheck\\(\\) with TRUE or FALSE to specify whether access should be checked\\.$#"
-			count: 2
-			path: modules/social_features/social_follow_taxonomy/social_follow_taxonomy.module
-
-		-
 			message: "#^Function social_follow_taxonomy_token_info\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: modules/social_features/social_follow_taxonomy/social_follow_taxonomy.tokens.inc
@@ -9065,11 +9055,6 @@ parameters:
 
 		-
 			message: "#^Method Drupal\\\\social_follow_taxonomy\\\\Plugin\\\\views\\\\filter\\\\FollowTaxonomyViewsFilter\\:\\:valueForm\\(\\) has parameter \\$form with no type specified\\.$#"
-			count: 1
-			path: modules/social_features/social_follow_taxonomy/src/Plugin/views/filter/FollowTaxonomyViewsFilter.php
-
-		-
-			message: "#^Relying on entity queries to check access by default is deprecated in drupal\\:9\\.2\\.0 and an error will be thrown from drupal\\:10\\.0\\.0\\. Call \\\\Drupal\\\\Core\\\\Entity\\\\Query\\\\QueryInterface\\:\\:accessCheck\\(\\) with TRUE or FALSE to specify whether access should be checked\\.$#"
 			count: 1
 			path: modules/social_features/social_follow_taxonomy/src/Plugin/views/filter/FollowTaxonomyViewsFilter.php
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -6651,7 +6651,7 @@ parameters:
 			path: modules/social_features/social_event/modules/social_event_invite/src/Form/EnrollInviteEmailForm.php
 
 		-
-			message: "#^The \"social_event\\.enroll\" service is deprecated in social\\:11\\.5\\.0 and is removed from social\\:12\\.0\\.0\\. See https\\://www\\.drupal\\.org/project/social/issues/3306568$#"
+			message: "#^The \"social_event\\.enroll\" service is deprecated in social\\:11\\.5\\.0 and is removed from social\\:13\\.0\\.0\\. See https\\://www\\.drupal\\.org/project/social/issues/3306568$#"
 			count: 1
 			path: modules/social_features/social_event/modules/social_event_invite/src/Form/EnrollInviteEmailForm.php
 
@@ -6673,7 +6673,7 @@ parameters:
 		-
 			message: """
 				#^Call to deprecated method isEnabled\\(\\) of class Drupal\\\\social_event\\\\Service\\\\SocialEventEnrollServiceInterface\\:
-				in social\\:11\\.5\\.0 and is removed from social\\:12\\.0\\.0\\. Use
+				in social\\:11\\.5\\.0 and is removed from social\\:13\\.0\\.0\\. Use
 				  bundled node object itself `\\$event\\-\\>isEnrollmentEnabled\\(\\)` instead\\.$#
 			"""
 			count: 1
@@ -7417,7 +7417,7 @@ parameters:
 		-
 			message: """
 				#^Call to deprecated method isEnabled\\(\\) of class Drupal\\\\social_event\\\\Service\\\\SocialEventEnrollServiceInterface\\:
-				in social\\:11\\.5\\.0 and is removed from social\\:12\\.0\\.0\\. Use
+				in social\\:11\\.5\\.0 and is removed from social\\:13\\.0\\.0\\. Use
 				  bundled node object itself `\\$event\\-\\>isEnrollmentEnabled\\(\\)` instead\\.$#
 			"""
 			count: 1
@@ -8294,7 +8294,7 @@ parameters:
 			path: modules/social_features/social_event/src/Form/EnrollActionForm.php
 
 		-
-			message: "#^The \"social_event\\.enroll\" service is deprecated in social\\:11\\.5\\.0 and is removed from social\\:12\\.0\\.0\\. See https\\://www\\.drupal\\.org/project/social/issues/3306568$#"
+			message: "#^The \"social_event\\.enroll\" service is deprecated in social\\:11\\.5\\.0 and is removed from social\\:13\\.0\\.0\\. See https\\://www\\.drupal\\.org/project/social/issues/3306568$#"
 			count: 1
 			path: modules/social_features/social_event/src/Form/EnrollActionForm.php
 

--- a/social.info.yml
+++ b/social.info.yml
@@ -1,7 +1,7 @@
 name: Social
 type: profile
 description: 'Open Social distribution profile.'
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 version: '11.10.x-dev'
 project: social
 

--- a/tests/behat/features/bootstrap/EntityTrait.php
+++ b/tests/behat/features/bootstrap/EntityTrait.php
@@ -73,6 +73,7 @@ trait EntityTrait {
               $term_ids = $taxonomy_storage->getQuery()
                 ->condition("vid", $allowed_bundles, "IN")
                 ->condition("name", $id_or_name)
+                ->accessCheck()
                 ->execute();
 
               if (!is_array($term_ids) || empty($term_ids)) {

--- a/tests/behat/features/bootstrap/EntityTrait.php
+++ b/tests/behat/features/bootstrap/EntityTrait.php
@@ -73,7 +73,7 @@ trait EntityTrait {
               $term_ids = $taxonomy_storage->getQuery()
                 ->condition("vid", $allowed_bundles, "IN")
                 ->condition("name", $id_or_name)
-                ->accessCheck()
+                ->accessCheck(TRUE)
                 ->execute();
 
               if (!is_array($term_ids) || empty($term_ids)) {

--- a/tests/behat/features/bootstrap/FeatureContext.php
+++ b/tests/behat/features/bootstrap/FeatureContext.php
@@ -602,7 +602,7 @@ class FeatureContext extends RawMinkContext {
       $query = \Drupal::entityQuery('user')
         ->condition('name', $username);
       $uid = $query
-        ->accessCheck()
+        ->accessCheck(TRUE)
         ->execute();
 
       if (!empty($uid) && count($uid) === 1) {
@@ -653,7 +653,7 @@ class FeatureContext extends RawMinkContext {
       $query = \Drupal::entityQuery('user')
         ->condition('name', $username);
       $uid = $query
-        ->accessCheck()
+        ->accessCheck(TRUE)
         ->execute();
 
       if (!empty($uid) && count($uid) === 1) {

--- a/tests/behat/features/bootstrap/FeatureContext.php
+++ b/tests/behat/features/bootstrap/FeatureContext.php
@@ -601,7 +601,9 @@ class FeatureContext extends RawMinkContext {
 
       $query = \Drupal::entityQuery('user')
         ->condition('name', $username);
-      $uid = $query->execute();
+      $uid = $query
+        ->accessCheck()
+        ->execute();
 
       if (!empty($uid) && count($uid) === 1) {
         $uid = reset($uid);
@@ -650,7 +652,9 @@ class FeatureContext extends RawMinkContext {
 
       $query = \Drupal::entityQuery('user')
         ->condition('name', $username);
-      $uid = $query->execute();
+      $uid = $query
+        ->accessCheck()
+        ->execute();
 
       if (!empty($uid) && count($uid) === 1) {
         $uid = reset($uid);


### PR DESCRIPTION
## Problem
The [Upgrade Status](https://www.drupal.org/project/upgrade_status) module, gave to us a report with all issues to be fixed to make the Open Social compatible with Drupal 10.

## Solution
**Social deprecation-function:**
The major version 12 will be used to upgrade the Drupal to version 10, so all deprecation function from Social should be changed to be removed at major version 13.

**Drupal deprecation-function:**
Update all deprecated function from Drupal to the new function.

**Sub-modules core version:**
Update the drupal-core-version at info files from sub-modules.

## Issue tracker
- https://www.drupal.org/project/social/issues/3388012

## Theme issue tracker
N/A

## How to test
- [ ] Smoke test in the system

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
N/A

## Release notes
Open Social version 12 will only contain a Drupal 10 upgrade as its scope; this is why we are changing the deprecation of this method from version 12 to 13.

Files with deprecated message update:
- modules/social_features/social_event/src/Service/SocialEventEnrollService.php
- modules/social_features/social_event/src/Service/SocialEventEnrollServiceInterface.php
- modules/social_features/social_event/social_event.services.yml
- modules/custom/activity_logger/src/Service/ActivityLoggerFactory.php
- modules/social_features/social_album/social_album.install
- modules/social_features/social_content_block/social_content_block.api.php
- modules/social_features/social_core/social_core.api.php
- modules/social_features/social_core/src/Controller/SocialCoreController.php
- modules/social_features/social_core/src/Routing/RouteSubscriber.php
- modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.api.php
- modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.module
- modules/social_features/social_group/modules/social_group_flexible_group/src/Plugin/views/filter/FlexibleGroupNodeAccess.php
- modules/social_features/social_group/modules/social_group_request/social_group_request.api.php
- modules/social_features/social_group/social_group.module
- modules/social_features/social_group/src/JoinManager.php
- modules/social_features/social_tagging/social_tagging.module

## Change Record
N/A

## Translations
N/A
