### PR TITLE
Internal: Make sure that work that landed in OS 12 also use update hook numbers in this range

### DIFF
--- a/modules/custom/social_gdpr/social_gdpr.install
+++ b/modules/custom/social_gdpr/social_gdpr.install
@@ -52,7 +52,7 @@ function social_gdpr_update_8902() {
  * Permissions to check:
  * - "translate data_policy".
  */
-function social_gdpr_update_111101(): void {
+function social_gdpr_update_120001(): void {
   $entity_type_manager = \Drupal::entityTypeManager();
   $all_permissions = array_keys(\Drupal::service('user.permissions')->getPermissions());
   /** @var \Drupal\user\RoleInterface[] $roles */

--- a/modules/social_features/social_book/social_book.install
+++ b/modules/social_features/social_book/social_book.install
@@ -294,7 +294,7 @@ function social_book_update_11401(): string {
  * Permissions to check:
  * - "translate book node".
  */
-function social_book_update_111101(): void {
+function social_book_update_120001(): void {
   $entity_type_manager = \Drupal::entityTypeManager();
   $all_permissions = array_keys(\Drupal::service('user.permissions')->getPermissions());
   /** @var \Drupal\user\RoleInterface[] $roles */

--- a/modules/social_features/social_core/social_core.install
+++ b/modules/social_features/social_core/social_core.install
@@ -1693,7 +1693,7 @@ function social_core_update_11900() : string {
  * Permissions to check:
  * - "access contextual links".
  */
-function social_core_update_111101(): void {
+function social_core_update_120001(): void {
   $entity_type_manager = \Drupal::entityTypeManager();
   $all_permissions = array_keys(\Drupal::service('user.permissions')->getPermissions());
   /** @var \Drupal\user\RoleInterface[] $roles */
@@ -1720,7 +1720,7 @@ function social_core_update_111101(): void {
 /**
  * Uninstall admin_toolbar_tools if nothing uses it.
  */
-function social_core_update_111201() : void {
+function social_core_update_120002() : void {
   // Nothing to do if the module is not installed.
   if (!\Drupal::moduleHandler()->moduleExists("admin_toolbar_tools")) {
     return;

--- a/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.install
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.install
@@ -641,12 +641,21 @@ function social_group_flexible_group_update_11901(): string {
 }
 
 /**
+ * Disable revisions for flexible group.
+ */
+function social_group_flexible_group_update_111102(): void {
+  $config = \Drupal::configFactory()->getEditable("group.type.flexible_group");
+  $config->set("new_revision", FALSE);
+  $config->save();
+}
+
+/**
  * Search for invalid permission(s) and remove them from existing roles.
  *
  * Permissions to check:
  * - "translate flexible_group group".
  */
-function social_group_flexible_group_update_111101(): void {
+function social_group_flexible_group_update_120001(): void {
   $entity_type_manager = \Drupal::entityTypeManager();
   $all_permissions = array_keys(\Drupal::service('user.permissions')->getPermissions());
   /** @var \Drupal\user\RoleInterface[] $roles */
@@ -668,13 +677,4 @@ function social_group_flexible_group_update_111101(): void {
       }
     }
   }
-}
-
-/**
- * Disable revisions for flexible group.
- */
-function social_group_flexible_group_update_111102(): void {
-  $config = \Drupal::configFactory()->getEditable("group.type.flexible_group");
-  $config->set("new_revision", FALSE);
-  $config->save();
 }

--- a/modules/social_features/social_landing_page/social_landing_page.install
+++ b/modules/social_features/social_landing_page/social_landing_page.install
@@ -780,7 +780,7 @@ function social_landing_page_update_11401(): string {
  * - "override landing_page revision log entry",
  * - "override landing_page promote to front landing_page option".
  */
-function social_landing_page_update_111101(): void {
+function social_landing_page_update_120001(): void {
   $entity_type_manager = \Drupal::entityTypeManager();
   /** @var \Drupal\user\RoleInterface[] $roles */
   $roles = $entity_type_manager->getStorage('user_role')->loadMultiple();
@@ -810,7 +810,7 @@ function social_landing_page_update_111101(): void {
  * Permissions to check:
  * - "translate landing_page node".
  */
-function social_landing_page_update_111102(): void {
+function social_landing_page_update_120002(): void {
   $entity_type_manager = \Drupal::entityTypeManager();
   $all_permissions = array_keys(\Drupal::service('user.permissions')->getPermissions());
   /** @var \Drupal\user\RoleInterface[] $roles */

--- a/modules/social_features/social_page/social_page.install
+++ b/modules/social_features/social_page/social_page.install
@@ -238,7 +238,7 @@ function social_page_update_10302() {
 /**
  * Remove deprecated permission "override page revision log entry".
  */
-function social_page_update_111101(): void {
+function social_page_update_120001(): void {
   $entity_type_manager = \Drupal::entityTypeManager();
   /** @var \Drupal\user\RoleInterface[] $roles */
   $roles = $entity_type_manager->getStorage('user_role')->loadMultiple();
@@ -263,7 +263,7 @@ function social_page_update_111101(): void {
  * Permissions to check:
  * - "translate page node".
  */
-function social_page_update_111102(): void {
+function social_page_update_120002(): void {
   $entity_type_manager = \Drupal::entityTypeManager();
   $all_permissions = array_keys(\Drupal::service('user.permissions')->getPermissions());
   /** @var \Drupal\user\RoleInterface[] $roles */

--- a/modules/social_features/social_profile/social_profile.install
+++ b/modules/social_features/social_profile/social_profile.install
@@ -472,7 +472,7 @@ function social_profile_update_11701(): string {
  * - "view profile",
  * - "add any profile profile".
  */
-function social_profile_update_111101(): void {
+function social_profile_update_120001(): void {
   $entity_type_manager = \Drupal::entityTypeManager();
   /** @var \Drupal\user\RoleInterface[] $roles */
   $roles = $entity_type_manager->getStorage('user_role')->loadMultiple();

--- a/modules/social_features/social_topic/social_topic.install
+++ b/modules/social_features/social_topic/social_topic.install
@@ -501,7 +501,7 @@ function social_topic_update_11401(): string {
 /**
  * Remove deprecated permission "override topic revision log entry".
  */
-function social_topic_update_111101(): void {
+function social_topic_update_120001(): void {
   $entity_type_manager = \Drupal::entityTypeManager();
   /** @var \Drupal\user\RoleInterface[] $roles */
   $roles = $entity_type_manager->getStorage('user_role')->loadMultiple();
@@ -526,7 +526,7 @@ function social_topic_update_111101(): void {
  * Permissions to check:
  * - "translate topic node".
  */
-function social_topic_update_111102(): void {
+function social_topic_update_120002(): void {
   $entity_type_manager = \Drupal::entityTypeManager();
   $all_permissions = array_keys(\Drupal::service('user.permissions')->getPermissions());
   /** @var \Drupal\user\RoleInterface[] $roles */


### PR DESCRIPTION
## Problem
During the release of Open Social 12, there was a PR that was originally written for 11 but changed to 12. 
Update hook were therefore named as 11. To avoid confusion we need to update this to 12 so other developers don't continue on this number.

It should also be no issue that these hooks run again if they already did.

## Solution
Update the hook numbers from 11 to 12.

## Issue tracker
None - Internal

## Theme issue tracker
*[Required if applicable] Paste a link to the drupal.org theme issue queue item, either from [socialbase](https://www.drupal.org/project/socialbase) or [socialblue](https://www.drupal.org/project/socialblue). If any other issue trackers were used, include links to those too.*

## How to test
- [ ] Run drush updb and see that update hooks are still executed properly.

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
<!-- *[Required if new feature, and if applicable] If this Pull Request makes visual changes then please include some screenshots that show what has changed here. A before and after screenshot helps the reviewer determine what changes were made.* -->

## Release notes
Internal: Re-organize the update hook numbers to make sure that work that landed in Open Social 12 also shows this in the code.

## Change Record
<!-- *[Required if applicable] If this Pull Request changes the way that developers should do things or introduces a new API for developers then a change record to document this is needed. Please provide a draft for a change record or a link to an unpublished change record below. Existing change records can be consulted as example. Please provide a draft for a change record or a link to an unpublished change record below. [Existing change records](https://www.drupal.org/list-changes/social) can be consulted as example.* -->

## Translations
<!--
*[Optional]Translatable strings are always extracted from the latest development branch. To ensure translations remain available for platforms running older versions of Open Social the original string should be added to `translations.php` when it's changed or removed.*
- [ ] Changed or removed source strings are added to the `translations.php` file.
-->
