### PR TITLE
Revert "Issue #3388607: Remove social_tour from distribution."

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -155,6 +155,7 @@
         "drupal/search_api": "1.29.0",
         "drupal/select2": "1.15.0",
         "drupal/shariff": "2.0.0",
+        "drupal/social_tour": "1.0.0-alpha2",
         "drupal/socialblue": "~2.5.0",
         "drupal/swiftmailer": "2.3.0",
         "drupal/token": "1.12.0",


### PR DESCRIPTION
## Problem
Changes that were released as 12.0.0-alpha1 were built as if they were going in a minor version which causes issues in our update hook numbering. All changes in 12.0.0-alpha1 are backwards compatible, so to fix this we can also release those as 11.11.0.

This was also merged as part of 12.0.0-alpha2, however is also BC breaking, so we need to remove it from main.

## Solution
This reverts commit bb95d45730c8f0d9bb3e5d267d59b2a3d571b915.

