### PR TITLE
Issue #3396251 by ronaldtebrake: PHP 8.1 will be required, so remove PHP 8.0 checks

### DIFF
--- a/.github/workflows/qualityChecks.yml
+++ b/.github/workflows/qualityChecks.yml
@@ -15,7 +15,6 @@ jobs:
     strategy:
       matrix:
         php:
-          - 8.0
           - 8.1
     steps:
       # We want to reuse our project setup to run different jobs at once.
@@ -70,7 +69,6 @@ jobs:
     strategy:
       matrix:
         php:
-          - 8.0
           - 8.1
     steps:
       - uses: actions/cache/restore@v3
@@ -137,7 +135,6 @@ jobs:
     strategy:
       matrix:
         php:
-          - 8.0
           - 8.1
     steps:
       - uses: actions/cache/restore@v3


### PR DESCRIPTION
## Problem
Currently we still have parts of our automation testing PHP 8.0 and running on PHP 8.0. While we have D10 requirements that need PHP 8.1.

With Drupal 10 and updates like [#3384177: Update drupal/bootstrap from 3.26 to 3.29](https://www.drupal.org/project/socialbase/issues/3384177) requiring PHP 8.1 we are going to drop support for PHP 8.0, we will do so softly as our code is still fine on PHP 8.0 however our dependencies will require it.

## Solution
We are going to stop checking for PHP 8.0 support in our test suite, so we can safely require the updates that have an actual PHP 8.1 requirement.

## Issue tracker
https://www.drupal.org/project/social/issues/3396251

## How to test
Check if everything is running on PHP 8.1 

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Release notes
Open Social will be running on PHP 8.1 as other dependencies require it, we've been PHP 8.1 ready for a long time but now there is no other way than having it running on PHP 8.1