### PR TITLE
Internal: Test hardening: Set a UTC timezone when creating dates in our behat suite

### DIFF
--- a/tests/behat/features/bootstrap/EntityTrait.php
+++ b/tests/behat/features/bootstrap/EntityTrait.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\social\Behat;
 
+use Drupal\Core\Datetime\DrupalDateTime;
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Entity\FieldableEntityInterface;
@@ -88,7 +89,10 @@ trait EntityTrait {
       // Allow date time fields to be provided as an offset to the current day
       // (e.g. "+1 day" or "-5 days").
       if ($field_definition !== NULL && $field_definition->getType() === "datetime") {
-        $values[$field_name] = date('Y-m-d\TH:i:s', strtotime($values[$field_name]));
+        // Make sure we store them as UTC, so we don't have any scenarios where
+        // system time influences behat test.
+        $date = new DrupalDateTime($values[$field_name], 'UTC');
+        $values[$field_name] = $date->format('Y-m-d\TH:i:s');
       }
       // Created and changed fields are stored as a normal timestamp but require
       // the same human-readable input as datetime fields.


### PR DESCRIPTION
## Problem
It seems there are some false negative scenarios when behat is running and dates are being created for entities. So for now we set it to UTC, see if that makes it more stable.

You can see [below tests](https://github.com/goalgorilla/open_social/actions/runs/6650048214/job/18070757980) we're failing for:

```
 Scenario: Successfully use filters for ongoing and upcoming events with today's end date # features/capabilities/event/filter-community-events.feature:29
      Given users:                                                                           # Drupal\social\Behat\SocialDrupalContext::createUsers()
        | name         | mail             | status | timezone | roles    |
        | regular_user | some@example.com | 1      | UTC      | verified |
      And events with non-anonymous author:                                                  # Drupal\social\Behat\EventContext::createEventsWithAuthor()
        | title                                | body        | field_content_visibility | field_event_date | field_event_date_end | field_event_all_day | langcode |
        | My awesome upcoming pepsi-cola party | lorem ipsum | public                   | today            | today                | 1                   | en       |
      And I am logged in as "regular_user"                                                   # Drupal\social\Behat\SocialDrupalContext::assertLoggedInByName()
      When I am on the event overview                                                        # Drupal\social\Behat\EventContext::viewEventOverview()
      And I click radio button "Ongoing and upcoming events"                                 # Drupal\social\Behat\FeatureContext::clickRadioButton()
      And I press "Filter"                                                                   # Drupal\social\Behat\SocialMinkContext::pressButton()
      Then I should see "My awesome upcoming pepsi-cola party"                               # Drupal\social\Behat
```      

![Screenshot 2023-10-26 at 09 54 54](https://github.com/goalgorilla/open_social/assets/16667281/59dcbdc1-66e9-49d4-8fe2-9bf09b92afef)

Which was because, even if it was the 26th of October, the datetime conversion made it the 25th when created.

![Screenshot 2023-10-26 at 09 19 24](https://github.com/goalgorilla/open_social/assets/16667281/e994cf94-d0a3-4726-be8c-5d8faed5a6bf)

## Solution
See if it works better when we force it to be UTC. 

## Issue tracker
None, internal.

## How to test
See test pass.

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status


## Release notes
None, internal.

