### PR TITLE
Issue #3397252: Moved the color module to out of Drupal-Core

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,6 +42,9 @@
             "drupal/ajax_comments": {
                 "Ajax not working when using non-default view mode": "https://www.drupal.org/files/issues/2023-01-30/ajax_comments-ajax_non_default_view_mode-2896916-beta5-60.patch"
             },
+            "drupal/color" : {
+                "Issue #1236098: Notice: Undefined index: 'base' in _color_rewrite_stylesheet()": "https://www.drupal.org/files/issues/2023-10-30/undefined-index-in-_color_rewrite_stylesheet-1236098-59.patch"
+            },
             "drupal/core": {
                 "Issue #3231503 landed in 10.1.x: Cache the result of hook_entity_extra_field_info()": "https://www.drupal.org/files/issues/2023-08-28/3383704-backport-cache-fix-EntityFieldManager-getextrafields.patch",
                 "Restrict images to this site blocks image style derivatives": "https://www.drupal.org/files/issues/2019-05-10/2528214-54.patch",
@@ -57,7 +60,6 @@
                 "Selecting the same day in a date between filter returns no results": "https://www.drupal.org/files/issues/2020-07-06/2842409-15.patch",
                 "Broken title in modal dialog when title is a render array": "https://www.drupal.org/files/issues/2019-10-21/2663316-76.drupal.Broken-title-in-modal-dialog-when-title-is-a-render-array.patch",
                 "Flood MemoryBackend::events[] key of micro time cannot guarantee uniqueness": "https://www.drupal.org/files/issues/2023-04-07/2910000-mr-1451-d95--floodmemorybackend-time-local_0.diff",
-                "Issue #1236098: Notice: Undefined index: 'base' in _color_rewrite_stylesheet()": "https://www.drupal.org/files/issues/undefined-index-in-_color_rewrite_stylesheet-1236098-37.patch",
                 "Issue #3251856: Incorrect typehint for FieldConfig::loadByName": "https://www.drupal.org/files/issues/2021-12-12/drupal9-incorrect_typehint-3251856-7.patch",
                 "Issue #2998390: Cache is not invalidated when comment deleted": "https://www.drupal.org/files/issues/2022-02-07/2998390-8.patch",
                 "Image derivative generation does not work if effect \"Convert\" in use and file stored in private filesystem": "https://www.drupal.org/files/issues/2022-09-23/2786735-39.patch",
@@ -123,6 +125,7 @@
         "drupal/better_exposed_filters": "6.0.3",
         "drupal/block_field": "1.0.0-rc4",
         "drupal/ckeditor": "1.0.2",
+        "drupal/color": "^1.0",
         "drupal/config_modify": "^1",
         "drupal/config_update": "2.0.0-alpha3",
         "drupal/core": "~9.5",

--- a/social.info.yml
+++ b/social.info.yml
@@ -9,12 +9,12 @@ project: social
 dependencies:
   # core
   - drupal:breakpoint
-  - drupal:color
   - drupal:config
   - drupal:node
   - drupal:user
   - drupal:views
   # Contrib
+  - color:color
   - improved_theme_settings:improved_theme_settings
   # Open Social
   - social:social_activity


### PR DESCRIPTION
## Problem
The drupal/color was moved out of drupal-core and it will be removed at Drupal 10.

## Solution
To keep forward to be compatible with Drupal 10, install the drupal/color and change the dependency from drupal-core to the new module.

## Issue tracker
[PROD-27283](https://getopensocial.atlassian.net/browse/PROD-27283)
[#3397252](https://www.drupal.org/project/social/issues/3397252)

## Theme issue tracker
N/A

## How to test
- [ ] Access the Open Social as site-manager
- [ ] Go to the "admin/appearance/settings/socialblue"
- [ ] Change some colors using pick-color and save them

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
N/A

## Release notes
When choosing colors for the Open Social theme you are able to use a color picker. This module has been removed from Drupal 10 core as they use their own interface for this. As we still use the color picker, we moved to the contrib module.
For the end-user nothing will change.

## Change Record
N/A

## Translations
N/A


[PROD-27283]: https://getopensocial.atlassian.net/browse/PROD-27283?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ