### PR TITLE
Issue #3397613 - Replace the ckeditor4 core modules with the contrib one

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -124,6 +124,7 @@
         "drupal/ajax_comments": "1.0.0-beta5",
         "drupal/better_exposed_filters": "6.0.3",
         "drupal/block_field": "1.0.0-rc4",
+        "drupal/ckeditor": "1.0.2",
         "drupal/config_modify": "^1",
         "drupal/config_update": "^1.7 || 2.0.0-alpha3",
         "drupal/core": "~9.5",

--- a/modules/social_features/social_editor/social_editor.info.yml
+++ b/modules/social_features/social_editor/social_editor.info.yml
@@ -3,7 +3,7 @@ description: 'Provides site editor components.'
 type: module
 core_version_requirement: ^9 || ^10
 dependencies:
-  - drupal:ckeditor
+  - ckeditor:ckeditor
   - drupal:editor
   - drupal:filter
   - editor_advanced_link:editor_advanced_link


### PR DESCRIPTION
## Problem
Ckeditor4 will be deprecated from core in favor of Ckeditor5. Open Social will be moving to Ckeditor5 in the version 12, but to give the community some time in moving from 11 to 12, we can move to the contrib ckeditor which will be supported until the end of the year.

## Solution
Move to contrib Ckeditor4

## Issue tracker
https://www.drupal.org/project/social/issues/3397613

## Theme issue tracker
*[Required if applicable] Paste a link to the drupal.org theme issue queue item, either from [socialbase](https://www.drupal.org/project/socialbase) or [socialblue](https://www.drupal.org/project/socialblue). If any other issue trackers were used, include links to those too.*

## How to test
- [ ] Install open_social like your are used to.
- [ ] Create content and see the ckeditor is still functioning like expected
- [ ] Install the social_embed module
- [ ] See there is a url embed (media) icon and use it to include videos, see that this also still works like normal.

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
<!-- *[Required if new feature, and if applicable] If this Pull Request makes visual changes then please include some screenshots that show what has changed here. A before and after screenshot helps the reviewer determine what changes were made.* -->

## Release notes
We moved the ckeditor4 module from Drupal core to the contrib one. This will be supported until the end of the year and will give people some extra time in moving to Open Social 12.

## Change Record
<!-- *[Required if applicable] If this Pull Request changes the way that developers should do things or introduces a new API for developers then a change record to document this is needed. Please provide a draft for a change record or a link to an unpublished change record below. Existing change records can be consulted as example. Please provide a draft for a change record or a link to an unpublished change record below. [Existing change records](https://www.drupal.org/list-changes/social) can be consulted as example.* -->

## Translations
<!--
*[Optional]Translatable strings are always extracted from the latest development branch. To ensure translations remain available for platforms running older versions of Open Social the original string should be added to `translations.php` when it's changed or removed.*
- [ ] Changed or removed source strings are added to the `translations.php` file.
-->
