### PR TITLE
Issue #3397762: Define entity_access_by_field permissions for all entity types

### DIFF
--- a/modules/custom/entity_access_by_field/src/EntityAccessByFieldPermissions.php
+++ b/modules/custom/entity_access_by_field/src/EntityAccessByFieldPermissions.php
@@ -6,6 +6,7 @@ use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
 use Drupal\Core\Entity\EntityFieldManagerInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\field\Entity\FieldStorageConfig;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -68,33 +69,35 @@ class EntityAccessByFieldPermissions implements ContainerInjectionInterface {
   public function permissions() {
     $permissions = [];
 
-    $contentTypes = $this->getContentTypes();
-    foreach ($contentTypes as $bundle) {
-      $entity_type = 'node';
-      $fields = $this->getEntityAccessFields($entity_type, $bundle);
+    $entity_access_field_map = $this->entityFieldManager->getFieldMapByFieldType('entity_access_field');
 
-      /** @var \Drupal\field\Entity\FieldConfig $field */
-      foreach ($fields as $field) {
-        $field_storage = $field->getFieldStorageDefinition();
+    foreach ($entity_access_field_map as $entity_type => $fields) {
+      foreach ($fields as $field_name => $field) {
+        if (!empty($field['bundles'])) {
+          foreach ($field['bundles'] as $bundle_id) {
+            /** @var \Drupal\field\Entity\FieldConfig $field_storage */
+            $field_storage = FieldStorageConfig::loadByName($entity_type, $field_name);
 
-        // Gets allowed values from function if exists.
-        $function = $field_storage->getSetting('allowed_values_function');
-        if (!empty($function)) {
-          $allowed_values = $function($field_storage);
-        }
-        else {
-          $allowed_values = $field_storage->getSetting('allowed_values');
-        }
+            // Gets allowed values from function if exists.
+            $function = $field_storage->getSetting('allowed_values_function');
+            if (!empty($function)) {
+              $allowed_values = $function($field_storage);
+            }
+            else {
+              $allowed_values = $field_storage->getSetting('allowed_values');
+            }
 
-        if (!empty($allowed_values)) {
-          foreach ($allowed_values as $field_key => $field_label) {
-            if (!in_array($field_key, $this->getIgnoredValues())) {
-              // e.g. label = node.article.field_content_visibility:public.
-              $permission_label = "$entity_type.{$bundle->id()}.{$field->getName()}:$field_key";
-              $permission = 'view ' . $permission_label . ' content';
-              $permissions[$permission] = [
-                'title' => $this->t('View @label content', ['@label' => $permission_label]),
-              ];
+            if (!empty($allowed_values)) {
+              foreach ($allowed_values as $field_key => $field_label) {
+                if (!in_array($field_key, $this->getIgnoredValues())) {
+                  // e.g. label = node.article.field_content_visibility:public.
+                  $permission_label = "$entity_type.{$bundle_id}.{$field_storage->getName()}:$field_key";
+                  $permission = 'view ' . $permission_label . ' content';
+                  $permissions[$permission] = [
+                    'title' => $this->t('View @label content', ['@label' => $permission_label]),
+                  ];
+                }
+              }
             }
           }
         }
@@ -113,36 +116,36 @@ class EntityAccessByFieldPermissions implements ContainerInjectionInterface {
     // If realms is not yet cached, let's populate it now.
     if (!isset($realms)) {
       $realms = [];
-      $contentTypes = $this->getContentTypes();
+      $entity_access_field_map = $this->entityFieldManager->getFieldMapByFieldType('entity_access_field');
 
-      foreach ($contentTypes as $bundle) {
-        $entity_type = 'node';
-        $fields = $this->getEntityAccessFields($entity_type, $bundle);
+      foreach ($entity_access_field_map as $entity_type => $fields) {
+        foreach ($fields as $field_name => $field) {
+          if (!empty($field['bundles'])) {
+            foreach ($field['bundles'] as $bundle_id) {
+              /** @var \Drupal\field\Entity\FieldConfig $field_storage */
+              $field_storage = FieldStorageConfig::loadByName($entity_type, $field_name);
 
-        /** @var \Drupal\field\Entity\FieldConfig $field */
-        foreach ($fields as $field) {
-          $field_storage = $field->getFieldStorageDefinition();
+              // Gets allowed values from function if exists.
+              $function = $field_storage->getSetting('allowed_values_function');
+              if (!empty($function)) {
+                $allowed_values = $function($field_storage);
+              }
+              else {
+                $allowed_values = $field_storage->getSetting('allowed_values');
+              }
 
-          // Gets allowed values from function if exists.
-          $function = $field_storage->getSetting('allowed_values_function');
-          if (!empty($function)) {
-            $allowed_values = $function($field_storage);
-          }
-          else {
-            $allowed_values = $field_storage->getSetting('allowed_values');
-          }
+              if (!empty($allowed_values)) {
+                $op = 'view';
 
-          if (!empty($allowed_values)) {
-            $op = 'view';
-
-            foreach ($allowed_values as $field_key => $field_label) {
-              // e.g. label = node.article.field_content_visibility:public.
-              $permission_label = "$entity_type.{$bundle->id()}.{$field->getName()}:$field_key";
-              $permission = $op . ' ' . $permission_label . ' content';
-              $bundle_id = $bundle->id();
-              $field_name = $field->getName();
-              $realm = $this->getRealmForFieldValue($op, $entity_type, $bundle_id, $field_name, $field_key);
-              $realms[$realm] = $permission;
+                foreach ($allowed_values as $field_key => $field_label) {
+                  // e.g. label = node.article.field_content_visibility:public.
+                  $permission_label = "$entity_type.{$bundle_id}.{$field_storage->getName()}:$field_key";
+                  $permission = $op . ' ' . $permission_label . ' content';
+                  $field_name = $field_storage->getName();
+                  $realm = $this->getRealmForFieldValue($op, $entity_type, $bundle_id, $field_name, $field_key);
+                  $realms[$realm] = $permission;
+                }
+              }
             }
           }
         }


### PR DESCRIPTION
## Problem
The PR [#3109](https://github.com/goalgorilla/open_social/pull/3109) extended functionality of EntityAccessHelper to cover all entity types and rename method to entityAccessCheck(). However, permission definitions in the PR were not updated to apply to this logic.

Starting with Drupal 9.3.0, all permissions in a user role must be defined in a module.permissions.yml file or a permissions callback. Source: https://www.drupal.org/node/3193348

## Solution
Resolve the issue by defining permissions for entity_access_field for all entity types (at the moment, permissions are defined only for node entity type).

## Issue tracker
[3397762](https://www.drupal.org/project/social/issues/3397762)

## Theme issue tracker
N/A

## How to test

### Test case 1 (show permissions on list)

- [x] Install clean open social installation
- [x] Enable Field UI module
- [x] Add an Entity access field to an entity that is not node (example in following steps)
- [x] Go to admin/structure/taxonomy/manage/topic_types/overview/fields and create Entity access field called “Example” <img src="https://github.com/goalgorilla/open_social/assets/13753184/da725df7-04ca-4a81-b6f5-3d3c730696bc" width="70%" height="70%">
- [x] Under “Allowed values list” add for example
```
public|public
community|community
group|group
test|test
```
and save it.
- [x] Go to admin/people/permissions/module/entity_access_by_field and you will see only node related fields here
![Screenshot 2023-11-02 at 16 20 08](https://github.com/goalgorilla/open_social/assets/13753184/15b0aa7e-add6-4b17-955a-88b3a43d39d7)
- [x] The expected result is that nodes permissions remains as they are and we can see additional permissions from other entities as well when the fix is applied
![Screenshot 2023-11-02 at 16 37 12](https://github.com/goalgorilla/open_social/assets/13753184/05cd4d60-2672-40bf-8cca-d79008819366)

### Test case 2 (Make sure that getRealmWithPermission() method was updated correctly and working as it was designed before)

Related to this method: https://github.com/goalgorilla/open_social/blob/1b8ba9974543a5e2b869b1a1460e23f2f07432b2/modules/custom/entity_access_by_field/src/EntityAccessByFieldPermissions.php#L110

- [x] Follow all steps from test case 1 
- [x] Create basic page (node/add/page)
- [x] Set Access permissions field as public
- [x] Anonymous user should see the basic page
- [x] Set Access permissions field as Community
- [x] Anonymous user should not see the basic page
- [x] Feel free to test any other un/happy flow related to this.


## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
N/A

## Release notes
Support entity access checker permissions for any entity type.

## Change Record
N/A

## Translations
N/A
