### PR TITLE
Issue #3398146: CKEditor 5 isn't respecting width limit

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -99,7 +99,8 @@
                 "Selecting the same day in a date between filter returns no results": "https://www.drupal.org/files/issues/2021-05-05/date_between_2842409_2_d8.patch"
             },
             "drupal/socialbase": {
-                "Ensure lazy_builders work": "https://git.drupalcode.org/project/socialbase/-/merge_requests/175.patch"
+                "Ensure lazy_builders work": "https://git.drupalcode.org/project/socialbase/-/merge_requests/175.patch",
+                "Issue #3398140: CKEditor 5 isn't respecting width limit": "https://www.drupal.org/files/issues/2023-10-31/socialbase-ckeditor-width-is-not-respecting-3398140-2.patch"
             },
             "drupal/url_embed": {
                 "Translate dialog title": "https://www.drupal.org/files/issues/2018-03-16/url_embed_translate_dialog_title-2953591-2.patch",


### PR DESCRIPTION
## Problem
The Social Base is customize the CKEditor 5 layout and currently it will impacting the width limit from entity create page.

## Solution
Apply a patch to fix the width layout bug.

## Issue tracker
Social issue: [#3398146](https://www.drupal.org/project/social/issues/3398146)
Social Base issue: [#3398140](https://www.drupal.org/project/socialbase/issues/3398140)

## Theme issue tracker
N/A

## How to test
- [ ] Try to create any content and check CKEditor 5 width is respecting the page limit.
 
## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
![image](https://github.com/goalgorilla/open_social/assets/6049862/e5110ec0-25fc-4d2c-8b93-7db3f7a77500)


## Release notes
N/A

## Change Record
N/A

## Translations
N/A
