### PR TITLE
Issue #3398750 by nkoporec: Can't select a group when creating a content list block and using the event content type

### DIFF
--- a/modules/social_features/social_content_block/modules/social_event_content_block/config/install/field.field.block_content.custom_content_list.field_event_group.yml
+++ b/modules/social_features/social_content_block/modules/social_event_content_block/config/install/field.field.block_content.custom_content_list.field_event_group.yml
@@ -22,6 +22,7 @@ settings:
     target_bundles:
       open_group: open_group
       public_group: public_group
+      flexible_group: flexible_group
     sort:
       field: _none
     auto_create: false

--- a/modules/social_features/social_content_block/modules/social_event_content_block/social_event_content_block.install
+++ b/modules/social_features/social_content_block/modules/social_event_content_block/social_event_content_block.install
@@ -168,3 +168,14 @@ function social_event_content_block_update_11501(): void {
 
   $event_date_storage->set('settings.allowed_values', $allowed_values)->save();
 }
+
+/**
+ * Add "flexible" group type to the field_event_group settings.
+ */
+function social_event_content_block_update_11502(): void {
+  $event_field_group_storage = \Drupal::configFactory()->getEditable('field.field.block_content.custom_content_list.field_event_group');
+  $handler_settings = $event_field_group_storage->get('settings.handler_settings');
+  $handler_settings['target_bundles']['flexible_group'] = "flexible_group";
+
+  $event_field_group_storage->set('settings.handler_settings', $handler_settings)->save();
+}


### PR DESCRIPTION
## Problem
I'm creating a new content list block using the layout builder. I want to select an "event content type" and also limit these event to a specific group. When trying to search for my group it never shows up in the autocomplete options.

## Solution
The issue is that the flexible group type is not set as an option to be referenced for this field, so we need to add it.

## Issue tracker
https://www.drupal.org/project/social/issues/3398750

## Theme issue tracker
*[Required if applicable] Paste a link to the drupal.org theme issue queue item, either from [socialbase](https://www.drupal.org/project/socialbase) or [socialblue](https://www.drupal.org/project/socialblue). If any other issue trackers were used, include links to those too.*

## How to test
1. Enable social_event_content_block module.
2. Create a new flexible group
3. Create a new event that is part of the group created before
4. Go to block/add and select the Custom content list block
5. Select the 'Event' as Type of Content
6. In the "Groups" field try to search for the group created before
7. Group can't be found.

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
<!-- *[Required if new feature, and if applicable] If this Pull Request makes visual changes then please include some screenshots that show what has changed here. A before and after screenshot helps the reviewer determine what changes were made.* -->

## Release notes
Fixed an issue with custom content list block form, where users could not reference a flexible groups.

## Change Record
<!-- *[Required if applicable] If this Pull Request changes the way that developers should do things or introduces a new API for developers then a change record to document this is needed. Please provide a draft for a change record or a link to an unpublished change record below. Existing change records can be consulted as example. Please provide a draft for a change record or a link to an unpublished change record below. [Existing change records](https://www.drupal.org/list-changes/social) can be consulted as example.* -->

## Translations
<!--
*[Optional]Translatable strings are always extracted from the latest development branch. To ensure translations remain available for platforms running older versions of Open Social the original string should be added to `translations.php` when it's changed or removed.*
- [ ] Changed or removed source strings are added to the `translations.php` file.
-->
