### PR TITLE
Issue #3398931: Grant content translate permissions

### DIFF
--- a/modules/custom/social_language/modules/social_content_translation/config/modify/social_content_translation.book_translation_permissions.yml
+++ b/modules/custom/social_language/modules/social_content_translation/config/modify/social_content_translation.book_translation_permissions.yml
@@ -1,0 +1,20 @@
+dependencies:
+  module:
+    - content_translation
+    - social_content_translation
+    - social_book
+items:
+  user.role.contentmanager:
+    expected_config:
+      permissions: { }
+    update_actions:
+      add:
+        permissions:
+          - 'translate book node'
+  user.role.sitemanager:
+    expected_config:
+      permissions: { }
+    update_actions:
+      add:
+        permissions:
+          - 'translate book node'

--- a/modules/custom/social_language/modules/social_content_translation/config/modify/social_content_translation.data_policy_translation_permissions.yml
+++ b/modules/custom/social_language/modules/social_content_translation/config/modify/social_content_translation.data_policy_translation_permissions.yml
@@ -1,0 +1,13 @@
+dependencies:
+  module:
+    - content_translation
+    - social_content_translation
+    - data_policy
+items:
+  user.role.sitemanager:
+    expected_config:
+      permissions: { }
+    update_actions:
+      add:
+        permissions:
+          - 'translate data_policy'

--- a/modules/custom/social_language/modules/social_content_translation/config/modify/social_content_translation.event_translation_permissions.yml
+++ b/modules/custom/social_language/modules/social_content_translation/config/modify/social_content_translation.event_translation_permissions.yml
@@ -1,0 +1,20 @@
+dependencies:
+  module:
+    - content_translation
+    - social_content_translation
+    - social_event
+items:
+  user.role.contentmanager:
+    expected_config:
+      permissions: { }
+    update_actions:
+      add:
+        permissions:
+          - 'translate event node'
+  user.role.sitemanager:
+    expected_config:
+      permissions: { }
+    update_actions:
+      add:
+        permissions:
+          - 'translate event node'

--- a/modules/custom/social_language/modules/social_content_translation/config/modify/social_content_translation.flexible_group_translation_permissions.yml
+++ b/modules/custom/social_language/modules/social_content_translation/config/modify/social_content_translation.flexible_group_translation_permissions.yml
@@ -1,0 +1,20 @@
+dependencies:
+  module:
+    - content_translation
+    - social_content_translation
+    - social_group_flexible_group
+items:
+  user.role.contentmanager:
+    expected_config:
+      permissions: { }
+    update_actions:
+      add:
+        permissions:
+          - 'translate flexible_group group'
+  user.role.sitemanager:
+    expected_config:
+      permissions: { }
+    update_actions:
+      add:
+        permissions:
+          - 'translate flexible_group group'

--- a/modules/custom/social_language/modules/social_content_translation/config/modify/social_content_translation.landing_page_translation_permissions.yml
+++ b/modules/custom/social_language/modules/social_content_translation/config/modify/social_content_translation.landing_page_translation_permissions.yml
@@ -1,0 +1,20 @@
+dependencies:
+  module:
+    - content_translation
+    - social_content_translation
+    - social_landing_page
+items:
+  user.role.contentmanager:
+    expected_config:
+      permissions: { }
+    update_actions:
+      add:
+        permissions:
+          - 'translate landing_page node'
+  user.role.sitemanager:
+    expected_config:
+      permissions: { }
+    update_actions:
+      add:
+        permissions:
+          - 'translate landing_page node'

--- a/modules/custom/social_language/modules/social_content_translation/config/modify/social_content_translation.page_translation_permissions.yml
+++ b/modules/custom/social_language/modules/social_content_translation/config/modify/social_content_translation.page_translation_permissions.yml
@@ -1,0 +1,20 @@
+dependencies:
+  module:
+    - content_translation
+    - social_content_translation
+    - social_page
+items:
+  user.role.contentmanager:
+    expected_config:
+      permissions: { }
+    update_actions:
+      add:
+        permissions:
+          - 'translate page node'
+  user.role.sitemanager:
+    expected_config:
+      permissions: { }
+    update_actions:
+      add:
+        permissions:
+          - 'translate page node'

--- a/modules/custom/social_language/modules/social_content_translation/config/modify/social_content_translation.topic_translation_permissions.yml
+++ b/modules/custom/social_language/modules/social_content_translation/config/modify/social_content_translation.topic_translation_permissions.yml
@@ -1,0 +1,20 @@
+dependencies:
+  module:
+    - content_translation
+    - social_content_translation
+    - social_topic
+items:
+  user.role.contentmanager:
+    expected_config:
+      permissions: { }
+    update_actions:
+      add:
+        permissions:
+          - 'translate topic node'
+  user.role.sitemanager:
+    expected_config:
+      permissions: { }
+    update_actions:
+      add:
+        permissions:
+          - 'translate topic node'

--- a/modules/custom/social_language/modules/social_content_translation/social_content_translation.info.yml
+++ b/modules/custom/social_language/modules/social_content_translation/social_content_translation.info.yml
@@ -4,4 +4,5 @@ description: Enables translation of static site content (such as Basic Pages, La
 core_version_requirement: ^9 || ^10
 package: Social (experimental)
 dependencies:
+  - drupal:config_modify
   - social:social_language


### PR DESCRIPTION
## Problem
In Issue #3384622 with PR #3499 we remove the assignment of the translate permissions because these permissions don’t exist when the content translation module is not enabled and having non-existent permissions assigned is disallowed in Drupal 10.

However, from a product perspective this is problematic because when enabling features we don’t want manual work of adding permissions. The PR itself does not add any code to automatically re-assign these permissions when they exist.

Permissions:
translate book node
translate event node
translate flexible_group group
translate landing_page node
translate page node
translate topic node
translate data_policy

## Solution
Automatically grant permissions listed above in the same way as before [3384622](https://www.drupal.org/project/social/issues/3384622) with PR #3499 was introduced.

## Issue tracker
[3398931](https://www.drupal.org/project/social/issues/3398931)

## Theme issue tracker
N/A

## How to test

### How to test 1
- [ ] Install Open Social
- [ ] Enable `social_content_translation`
- [ ]  Add at least one additional language
- [ ] As a content manager and as a site manager try to translate:
     - basic page
     - event
     - topic
     - flexible group
- [ ] As an admin go to admin/people/permissions and check if
     - "Translate Basic page content item"
     - "Translate Event content item"
     - "Translate Topic content item"
    - "Translate Flexible group group"
    are granted for content manager and site manager
- [ ] The expected result is attained when repeating the steps with this fix applied


### How to test 2
- [ ] Install Open Social
- [ ] Enable `social_content_translation`
- [ ] Enable `social_landing_page`
- [ ]  Add at least one additional language
- [ ] As a content manager and as a site manager try to translate:
     - landing page
- [ ] As an admin go to admin/people/permissions and check if
     - "Translate Landing page content item"
     is granted for content manager and site manager
- [ ] The expected result is attained when repeating the steps with this fix applied

### How to test 3
- [ ] Install Open Social
- [ ] Enable `social_content_translation`
- [ ] Enable `data_policy`
- [ ]  Add at least one additional language
- [ ] As a site manager try to translate:
     - data policy
- [ ] As an admin go to admin/people/permissions and check if
     - "Translate data policy"
     is granted for site manager
- [ ] The expected result is attained when repeating the steps with this fix applied
     
### How to test 4
- [ ] Install Open Social
- [ ] Enable `social_content_translation`
- [ ] Enable `social_book`
- [ ]  Add at least one additional language
- [ ] As a content manager and as a site manager try to translate:
     - book
- [ ] As an admin go to admin/people/permissions and check if
     - "Translate Book content item"
     is granted for content manager and site manager
- [ ] The expected result is attained when repeating the steps with this fix applied


## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
N/A

## Release notes
Automatically grant permissions listed below to revert the changes introduced in OS 11.10.3:
- translate book node
- translate event node
- translate flexible_group group
- translate landing_page node
- translate page node
- translate topic node
- translate data_policy

## Change Record
N/A

## Translations
N/A
