### PR TITLE
Issue #3398305 Move view node.book.field_content_visibility:group con…

### DIFF
--- a/modules/social_features/social_book/social_book.install
+++ b/modules/social_features/social_book/social_book.install
@@ -51,6 +51,7 @@ function social_book_install() {
       'edit own book content',
       'view book revisions',
       'view node.book.field_content_visibility:community content',
+      'view node.book.field_content_visibility:group content',
     ]
   );
   user_role_grant_permissions(
@@ -68,6 +69,7 @@ function social_book_install() {
       'view book revisions',
       'administer visibility settings',
       'view node.book.field_content_visibility:community content',
+      'view node.book.field_content_visibility:group content',
     ]
   );
 }

--- a/modules/social_features/social_group/social_group.install
+++ b/modules/social_features/social_group/social_group.install
@@ -91,7 +91,6 @@ function social_group_install() {
       'create public_group group',
       'bypass create group access',
       'manage all groups',
-      'view node.book.field_content_visibility:group content',
       'view node.event.field_content_visibility:group content',
       'view node.topic.field_content_visibility:group content',
       'view node.page.field_content_visibility:group content',
@@ -112,7 +111,6 @@ function social_group_install() {
       'create public_group group',
       'bypass create group access',
       'manage all groups',
-      'view node.book.field_content_visibility:group content',
       'view node.event.field_content_visibility:group content',
       'view node.topic.field_content_visibility:group content',
       'view node.page.field_content_visibility:group content',
@@ -219,7 +217,6 @@ function _social_group_get_permissions($role) {
   $permissions['contentmanager'] = array_merge($permissions['verified'], [
     'bypass create group access',
     'manage all groups',
-    'view node.book.field_content_visibility:group content',
     'view node.event.field_content_visibility:group content',
     'view node.topic.field_content_visibility:group content',
     'view node.page.field_content_visibility:group content',
@@ -1038,4 +1035,34 @@ function social_group_update_12001(): string {
 
   // Output logged messages to related channel of update execution.
   return $updateHelper->logger()->output();
+}
+
+/**
+ * Search for invalid permission(s) and remove them from existing roles.
+ *
+ * Permissions to check:
+ * - "view node.book.field_content_visibility:group content".
+ */
+function social_group_update_12002(): void {
+  $entity_type_manager = \Drupal::entityTypeManager();
+  $all_permissions = array_keys(\Drupal::service('user.permissions')->getPermissions());
+  /** @var \Drupal\user\RoleInterface[] $roles */
+  $roles = $entity_type_manager->getStorage('user_role')->loadMultiple();
+
+  $permissions_to_check = [
+    'view node.book.field_content_visibility:group content',
+  ];
+
+  // If permission is not valid (is not on the list of all permissions),
+  // we need to revoke it from all existing roles.
+  foreach ($permissions_to_check as $permission_to_check) {
+    if (!in_array($permission_to_check, $all_permissions)) {
+      foreach ($roles as $role) {
+        if ($role->hasPermission($permission_to_check)) {
+          $role->revokePermission($permission_to_check);
+          $role->save();
+        }
+      }
+    }
+  }
 }


### PR DESCRIPTION
…tent permission form social_group install to social_book module

## Problem
social_group module on hook_install add permission related to the social_book module that is not enabled yet, so after the social install "view node.book.field_content_visibility:group content" permission becomes undefined.

## Solution
Remove "view node.book.field_content_visibility:group content from" permission form social_group_install, and move it to social_book_install 


## Issue tracker
https://www.drupal.org/project/social/issues/3398305

## Theme issue tracker
N/A

## How to test
- [ ]  Using version 11.11.x of Open Social with the upgrade_status module enabled
- [ ] Go to admin/reports/upgrade-status and check for "Invalid permissions will trigger runtime exceptions in Drupal 10.
- [ ]  Permissions should be defined in a permissions.yml file or a permission callback."

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
<!-- *[Required if new feature, and if applicable] If this Pull Request makes visual changes then please include some screenshots that show what has changed here. A before and after screenshot helps the reviewer determine what changes were made.* -->

## Release notes
Remove "view node.book.field_content_visibility:group content from" permission form social_group_install, and move it to social_book_install

## Change Record
<!-- *[Required if applicable] If this Pull Request changes the way that developers should do things or introduces a new API for developers then a change record to document this is needed. Please provide a draft for a change record or a link to an unpublished change record below. Existing change records can be consulted as example. Please provide a draft for a change record or a link to an unpublished change record below. [Existing change records](https://www.drupal.org/list-changes/social) can be consulted as example.* -->

## Translations
<!--
*[Optional]Translatable strings are always extracted from the latest development branch. To ensure translations remain available for platforms running older versions of Open Social the original string should be added to `translations.php` when it's changed or removed.*
- [ ] Changed or removed source strings are added to the `translations.php` file.
-->
