### PR TITLE
Issue #3399456: by ronaldtebrake: Update `drupal/update_helper` In order to support Drush 12

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -181,7 +181,7 @@
         "drupal/swiftmailer": "2.3.0",
         "drupal/token": "1.12.0",
         "drupal/ultimate_cron": "2.0.0-alpha6",
-        "drupal/update_helper": "3.0.4",
+        "drupal/update_helper": "^3 || ^4",
         "drupal/url_embed": "2.0.0-alpha1",
         "drupal/views_bulk_operations": "4.2.4",
         "drupal/views_infinite_scroll": "2.0.2",


### PR DESCRIPTION
## Problem
Drush 12 support was added in the 4.0 major branch of `drupal/update_helper`, both version 3 and 4 are Drupal 10 compatible so this way we can help users with Drush, which is not an Open Social Distro requirement but a common Drupal requirement.

## Solution
Make sure both version 3 and 4 are accepted, so composer can figure it out.

## Issue tracker
https://www.drupal.org/project/social/issues/3399456

## How to test
See updates still pass in our behat tests.  

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Release notes
Allow `update_helper` version 3 and 4 for Drush 12 support.


