### PR TITLE
Issue #3400598 by SV: Content visibility is updated incorrectly in Flexible Groups

### DIFF
--- a/modules/social_features/social_group/modules/social_group_flexible_group/src/FlexibleGroupContentVisibilityUpdate.php
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/src/FlexibleGroupContentVisibilityUpdate.php
@@ -224,6 +224,13 @@ class FlexibleGroupContentVisibilityUpdate {
 
     $visibility = '';
     $option_values = array_column($new_options, 'value');
+
+    // Keep the current visibility of group content items if it's still
+    // available in the group content visibility options.
+    if (in_array($current_visibility, $option_values)) {
+      return $current_visibility;
+    }
+
     // Calculate new options based on what it was before editting.
     switch ($current_visibility) {
       case 'community':

--- a/tests/behat/features/bootstrap/GroupContext.php
+++ b/tests/behat/features/bootstrap/GroupContext.php
@@ -659,6 +659,11 @@ class GroupContext extends RawMinkContext {
     $group['uid'] = $account->id();
     unset($group['author']);
 
+    // Allow using multiple values.
+    if (isset($group['field_group_allowed_visibility']) && str_contains($group['field_group_allowed_visibility'], ',')) {
+      $group['field_group_allowed_visibility'] = explode(',', $group['field_group_allowed_visibility']);
+    }
+
     // Let's create some groups.
     $this->validateEntityFields('group', $group);
     $group_object = Group::create($group);

--- a/tests/behat/features/capabilities/groups/flexible/content/groups-flexible-content-visibility.feature
+++ b/tests/behat/features/capabilities/groups/flexible/content/groups-flexible-content-visibility.feature
@@ -1,0 +1,37 @@
+@api @javascript @flexible-groups @flexible-groups-content-visibility
+Feature: Verify that selected group content visibility applies correctly for content in flexible groups
+
+  Background:
+    Given I enable the module "social_group_flexible_group"
+
+    And groups with non-anonymous owner:
+      | label           | field_group_description      | field_flexible_group_visibility | field_group_allowed_visibility  |type            |
+      | Flexible group  | Description of Flexible group| public                          | public,community,group          |flexible_group  |
+    And "topic_type" terms:
+      | name    |
+      | Blog    |
+    And topics with non-anonymous author:
+      | title           | body         | group          | field_content_visibility | field_topic_type |
+      | Topic public    | Descriptions | Flexible group | public                   | Blog             |
+      | Topic community | Descriptions | Flexible group | community                | Blog             |
+      | Topic group     | Descriptions | Flexible group | group                    | Blog             |
+
+  Scenario: Update group content visibility - so all content items should be updated accordingly
+    # Lets update content visibility and disable "Public" option.
+    Given I am logged in as a user with the sitemanager role
+    When I am editing the group "Flexible group"
+    And I uncheck the box "field_group_allowed_visibility[public]"
+    And I press "Save"
+    And I wait for the batch job to finish
+    And the cache has been cleared
+
+    # Then lets verify all topics visibility.
+    When I am editing the topic "Topic public"
+    And I should see unchecked the box "Public"
+    And I should see checked the box "Community"
+
+    When I am editing the topic "Topic Community"
+    And I should see checked the box "Community"
+
+    When I am editing the topic "Topic group"
+    And I should see checked the box "Group members"


### PR DESCRIPTION
## Problem
When the content visibility of a group is updated, the already existing content is also updated using the new visibility.
Unfortunately in this process, something is going wrong, and not all content gets the correct visibility.

In certain cases, the visibility level is lower than the expected one and this is an issue.

## Solution
Looks like currently, visibility is updating when it's unneeded. So, to prevent such cases need to keep current visibility of group content items if it's available

## Issue tracker
- https://getopensocial.atlassian.net/browse/PROD-27303
- https://www.drupal.org/project/social/issues/3400598

## Theme issue tracker
N/A

## How to test
- [ ] Using the latest version of Open Social with the social_group_flexible_group module enabled
- [ ] As a sitemanager
- [ ] Create a group with content visibility as Public, Community and Group
- [ ] Create 3 topics with different visibility (1- public, 2- community, 3-group) within that group
- [ ] Remove the content visibility as public in the group
- [ ] When saving I expect the result to be: 
T1: Public → Community
T2: remains Community
T3: remains Group
- [ ]  but instead see:
T1: Public → Community (correct)
T2: Community → Group (incorrect)
T3: Group → Community (incorrect)
- [ ] The expected result is attained when repeating the steps with this fix applied.

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
Created a group with content visibility as Public, community and group:
![5e0318db-ef67-4bd4-9c9b-845da66661b4](https://github.com/goalgorilla/open_social/assets/25609390/db3af975-3e71-4b31-9c49-8d65fb3a4661)

Created 3 topics with different visibility:
![a29bea8f-6cdb-4d4d-ac8c-aac63ae62f2c](https://github.com/goalgorilla/open_social/assets/25609390/52ec084b-e54e-4fbc-90bc-b04d80fa3906)

Removed the content visibility as public:
![3e5c3403-9462-49d6-9429-e61174d57da8](https://github.com/goalgorilla/open_social/assets/25609390/6438e2cd-b066-4c39-8147-9418bfa6f899)

## Release notes
Fixes an issue with shifting visibility for group content items.

## Change Record
N/A

## Translations
N/A
