### PR TITLE
Issue #3402109 by SV: As a GM I want to choose how many users I can see in the Manage members overview page

### DIFF
--- a/modules/social_features/social_group/config/install/views.view.group_manage_members.yml
+++ b/modules/social_features/social_group/config/install/views.view.group_manage_members.yml
@@ -9,6 +9,7 @@ dependencies:
     - group.content_type.open_group-group_membership
     - group.content_type.public_group-group_membership
   module:
+    - better_exposed_filters
     - group
     - profile
     - social_group
@@ -43,7 +44,7 @@ display:
           query_comment: ''
           query_tags: {  }
       exposed_form:
-        type: basic
+        type: bef
         options:
           submit_button: Filter
           reset_button: false
@@ -52,10 +53,21 @@ display:
           expose_sort_order: true
           sort_asc_label: Asc
           sort_desc_label: Desc
+          text_input_required_format: basic_html
+          bef:
+            general:
+              autosubmit: true
+              autosubmit_exclude_textfield: false
+              autosubmit_hide: true
+              allow_secondary: false
+            pager:
+              plugin_id: default
+              advanced:
+                is_secondary: false
       pager:
         type: full
         options:
-          items_per_page: 10
+          items_per_page: 25
           offset: 0
           id: 0
           total_pages: null
@@ -65,9 +77,9 @@ display:
             first: '« First'
             last: 'Last »'
           expose:
-            items_per_page: false
+            items_per_page: true
             items_per_page_label: 'Items per page'
-            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options: '25, 50, 100'
             items_per_page_options_all: false
             items_per_page_options_all_label: '- All -'
             offset: false

--- a/modules/social_features/social_group/config/update/social_group_update_12101.yml
+++ b/modules/social_features/social_group/config/update/social_group_update_12101.yml
@@ -1,0 +1,27 @@
+views.view.group_manage_members:
+  expected_config: {  }
+  update_actions:
+    change:
+      display:
+        default:
+          display_options:
+            exposed_form:
+              type: bef
+              options:
+                text_input_required_format: basic_html
+                bef:
+                  general:
+                    autosubmit: true
+                    autosubmit_exclude_textfield: false
+                    autosubmit_hide: true
+                    allow_secondary: false
+                  pager:
+                    plugin_id: default
+                    advanced:
+                      is_secondary: false
+            pager:
+              options:
+                items_per_page: 25
+                expose:
+                  items_per_page: true
+                  items_per_page_options: '25, 50, 100'

--- a/modules/social_features/social_group/social_group.install
+++ b/modules/social_features/social_group/social_group.install
@@ -1080,3 +1080,17 @@ function social_group_update_12003(): string {
   // Output logged messages to related channel of update execution.
   return $updater->logger()->output();
 }
+
+/**
+ * Enable pager limit on the manage members page.
+ */
+function social_group_update_12101(): string {
+  /** @var \Drupal\update_helper\Updater $updateHelper */
+  $updateHelper = \Drupal::service('update_helper.updater');
+
+  // Execute configuration update definitions with logging of success.
+  $updateHelper->executeUpdate('social_group', __FUNCTION__);
+
+  // Output logged messages to related channel of update execution.
+  return $updateHelper->logger()->output();
+}

--- a/modules/social_features/social_group/social_group.module
+++ b/modules/social_features/social_group/social_group.module
@@ -3272,3 +3272,51 @@ function social_group_social_core_title(): array {
 function social_group_social_tagging_type(): string {
   return 'group';
 }
+
+/**
+ * Implements hook_form_form_ID_alter().
+ */
+function social_group_form_views_exposed_form_alter(array &$form, FormStateInterface $form_state, string $form_id): void {
+  if ($form['#id'] === 'views-exposed-form-group-manage-members-page-group-manage-members') {
+    $form['actions']['submit']['#submit'][] = '_views_manage_members_exposed_form_submit';
+  }
+}
+
+/**
+ * Submission handler for social_group_form_views_exposed_form_alter().
+ */
+function _views_manage_members_exposed_form_submit(array $form, FormStateInterface $form_state): void {
+  // Currently, only user input includes actual items_per_page value.
+  $values = $form_state->getUserInput();
+
+  // Check if items_per_page value has been changed.
+  if (isset($values['items_per_page'])) {
+    $items_per_page = $values['items_per_page'];
+
+    /** @var  \Drupal\user\UserDataInterface $userData */
+    $userData = \Drupal::service('user.data');
+
+    // Save selected specific number of items on the page for current user.
+    $userData->set('social_group', \Drupal::currentUser()->id(), 'items_per_page', $items_per_page);
+  }
+}
+
+/**
+ * Implements hook_views_pre_view().
+ */
+function social_group_views_pre_view(ViewExecutable $view, string $display_id, array &$args): void {
+  if ($display_id === 'page_group_manage_members') {
+    // Get default pager options.
+    $default_pager_options = $view->display_handler->getOption('pager');
+
+    /** @var  \Drupal\user\UserDataInterface $userData */
+    $userData = \Drupal::service('user.data');
+
+    // Check if user selected specific number of items on the page and override
+    // default one.
+    if ($items_per_page = $userData->get('social_group', \Drupal::currentUser()->id(), 'items_per_page')) {
+      $default_pager_options['options']['items_per_page'] = $items_per_page;
+      $view->display_handler->setOption('pager', $default_pager_options);
+    }
+  }
+}

--- a/tests/behat/features/capabilities/groups/flexible/content/groups-flexible-manage-members-page-limit.feature
+++ b/tests/behat/features/capabilities/groups/flexible/content/groups-flexible-manage-members-page-limit.feature
@@ -1,0 +1,86 @@
+@api @javascript
+Feature: Items per page limit on the Manage members overview page
+
+  Background:
+    Given I enable the module "social_group_flexible_group"
+
+    And groups with non-anonymous owner:
+      | label           | field_group_description      | field_flexible_group_visibility | field_group_allowed_visibility  |type            |
+      | Flexible group  | Description of Flexible group| public                          | public                          |flexible_group  |
+    And users:
+      | name    | mail                     | status | roles    |
+      | member1   | mail_user1@example.com | 1      | verified |
+      | member2   | mail_user2@example.com | 1      | verified |
+      | member3   | mail_user3@example.com | 1      | verified |
+      | member4   | mail_user4@example.com | 1      | verified |
+      | member5   | mail_user5@example.com | 1      | verified |
+      | member6   | mail_user6@example.com | 1      | verified |
+      | member7   | mail_user7@example.com | 1      | verified |
+      | member8   | mail_user8@example.com | 1      | verified |
+      | member9   | mail_user9@example.com | 1      | verified |
+      | member10   | mail_user10@example.com | 1      | verified |
+      | member11   | mail_user11@example.com | 1      | verified |
+      | member12   | mail_user12@example.com | 1      | verified |
+      | member13   | mail_user13@example.com | 1      | verified |
+      | member14   | mail_user14@example.com | 1      | verified |
+      | member15   | mail_user15@example.com | 1      | verified |
+      | member16   | mail_user16@example.com | 1      | verified |
+      | member17   | mail_user17@example.com | 1      | verified |
+      | member18   | mail_user18@example.com | 1      | verified |
+      | member19   | mail_user19@example.com | 1      | verified |
+      | member20   | mail_user20@example.com | 1      | verified |
+      | member21   | mail_user21@example.com | 1      | verified |
+      | member22   | mail_user22@example.com | 1      | verified |
+      | member23   | mail_user23@example.com | 1      | verified |
+      | member24   | mail_user24@example.com | 1      | verified |
+      | member25   | mail_user25@example.com | 1      | verified |
+      | member26   | mail_user26@example.com | 1      | verified |
+    And group members:
+      |  group          | user    |
+      | Flexible group  | member1 |
+      | Flexible group  | member2 |
+      | Flexible group  | member3 |
+      | Flexible group  | member4 |
+      | Flexible group  | member5 |
+      | Flexible group  | member6 |
+      | Flexible group  | member7 |
+      | Flexible group  | member8 |
+      | Flexible group  | member9 |
+      | Flexible group  | member10 |
+      | Flexible group  | member11 |
+      | Flexible group  | member12 |
+      | Flexible group  | member13 |
+      | Flexible group  | member14 |
+      | Flexible group  | member15 |
+      | Flexible group  | member16 |
+      | Flexible group  | member17 |
+      | Flexible group  | member18 |
+      | Flexible group  | member19 |
+      | Flexible group  | member20 |
+      | Flexible group  | member21 |
+      | Flexible group  | member22 |
+      | Flexible group  | member23 |
+      | Flexible group  | member24 |
+      | Flexible group  | member25 |
+      | Flexible group  | member26 |
+
+  Scenario: User can control the number of items displayed on the Manage members overview page
+
+    Given I am logged in as a user with the sitemanager role
+
+    When I am viewing the group "Flexible group"
+
+    And I click "Manage members"
+    And I should see "27 members"
+    And I select "50" from "items_per_page"
+
+    # Should be displayed all items without page.
+    Then I should not see the link "Next"
+    And I should not see the link "Last"
+
+    # Check that selected number of items now is permanent for the current user.
+    And I click "About"
+    And I click "Manage members"
+    And should see "50" selected in the "items_per_page" select field
+    And I should not see the link "Next"
+    And I should not see the link "Last"


### PR DESCRIPTION
## Problem
<!-- *[Required] Describe the problem you're trying to solve, this should motivate why the changes you're proposing are needed.* -->
A filter should be added to the Group members overview where GM can choose how many users are displayed
As part of this story, we also want to increase the default number from 10 to 25 users.

## Solution
<!-- *[Required] Describe the solution you've created, elaborate on any technical choices you've made. Why is this the right solution and is a different solution not the right one? What is the reasoning behind the chosen solution?* -->
Add a pager limit option on the manage member group page.

## Issue tracker
<!-- *[Required] Paste a link to the drupal.org issue queue item. If any other issue trackers were used, include links to those too.* -->

- https://www.drupal.org/project/social/issues/3402109
- https://getopensocial.atlassian.net/browse/PROD-26201

## Theme issue tracker
- https://www.drupal.org/project/socialbase/issues/3402180

## How to test
- [ ] Using the latest version of Open Social with the example module enabled
- [ ] As a sitemanager
- [ ] Try to open any flexible groups with members
- [ ] Go to Manage Members page 
- [ ] And you should see a dropdown with "25, 50, 100" (to control the number of items displayed on the Manage members) overview page


## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
![image](https://github.com/goalgorilla/open_social/assets/2241917/b3f6227a-5f1d-4ace-9c9d-71e9b8e8b4fe)


## Release notes
Group Managers can choose how many users are shown on the Manage members overview page.

## Change Record
<!-- *[Required if applicable] If this Pull Request changes the way that developers should do things or introduces a new API for developers then a change record to document this is needed. Please provide a draft for a change record or a link to an unpublished change record below. Existing change records can be consulted as example. Please provide a draft for a change record or a link to an unpublished change record below. [Existing change records](https://www.drupal.org/list-changes/social) can be consulted as example.* -->

## Translations
<!--
*[Optional]Translatable strings are always extracted from the latest development branch. To ensure translations remain available for platforms running older versions of Open Social the original string should be added to `translations.php` when it's changed or removed.*
- [ ] Changed or removed source strings are added to the `translations.php` file.
-->
