### PR TITLE
Issue #3402403 - Replying on a Post gives an unexpected error.

### DIFF
--- a/modules/social_features/social_post/src/Controller/PostCommentController.php
+++ b/modules/social_features/social_post/src/Controller/PostCommentController.php
@@ -17,10 +17,6 @@ class PostCommentController extends SocialCommentController {
   public function getReplyForm(Request $request, EntityInterface $entity, $field_name, $pid = NULL) {
     $account = $this->currentUser();
 
-    // The user is not just previewing a comment.
-    $element_parents = \Drupal::request()->request->get('element_parents');
-    assert(is_string($element_parents), new \InvalidArgumentException());
-
     // @phpstan-ignore-next-line
     if ($request->request->get('op') != $this->t('Preview')) {
       // $pid indicates that this is a reply to a comment.

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -12698,7 +12698,7 @@ parameters:
 
 		-
 			message: "#^\\\\Drupal calls should be avoided in classes, use dependency injection instead$#"
-			count: 2
+			count: 1
 			path: modules/social_features/social_post/src/Controller/PostCommentController.php
 
 		-


### PR DESCRIPTION
## Problem
As part of our Drupal 10 work #3578 we've added an assertion to check if the `$element_parents` was a string or not. This because PHPStan started complaining.

## Solution
Actually looking at the file shows the variable is never used so we can safely remove it as it's giving issues with creating a reply on a Post in the stream.

## Test coverage
Should be there, the assertion just didn't fire (see post-comments.feature)

## Issue tracker
https://www.drupal.org/project/social/issues/3402403

## How to test
- [ ] As a LU
- [ ] Create a Post
- [ ] Comment a Reply on that Post
- [ ] When saving You'll notice an unexpected error
- [ ] After checking out this branch that should be gone now.

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Release notes
Replying on a Post should work again, was only broken in Open Social 12.