### PR TITLE
Issue #3403776 by SV: "Unique nicknames" setting should result in error message instead of "unexpected error" during registration

### DIFF
--- a/modules/social_features/social_profile/modules/social_profile_fields/src/Plugin/Validation/Constraint/UniqueNickname.php
+++ b/modules/social_features/social_profile/modules/social_profile_fields/src/Plugin/Validation/Constraint/UniqueNickname.php
@@ -20,6 +20,6 @@ class UniqueNickname extends Constraint {
    *
    * @var string
    */
-  public $notUnique = '%value is already taken.';
+  public $notUnique = 'This name is already taken, please try another one.';
 
 }

--- a/modules/social_features/social_profile/modules/social_profile_fields/src/Plugin/Validation/Constraint/UniqueNicknameValidator.php
+++ b/modules/social_features/social_profile/modules/social_profile_fields/src/Plugin/Validation/Constraint/UniqueNicknameValidator.php
@@ -46,7 +46,7 @@ class UniqueNicknameValidator extends ConstraintValidator implements ContainerIn
     foreach ($items as $item) {
       // Next check if the value is unique.
       if (!$this->isUnique($item->value)) {
-        $this->context->addViolation($constraint->notUnique, ['%value' => $item->value]);
+        $this->context->addViolation($constraint->notUnique);
       }
     }
   }
@@ -65,13 +65,17 @@ class UniqueNicknameValidator extends ConstraintValidator implements ContainerIn
     // Get all profiles with the provided nickname.
     $profiles = $this->profileStorage->loadByProperties(['field_profile_nick_name' => $value]);
 
-    // Remove current profile from profiles.
-    foreach ($profiles as $key => $profile) {
-      // Get the profile we're performing actions on.
-      $current_profile = _social_profile_get_profile_from_route();
+    // Check if this is a new user just trying to sign up.
+    $new_profile = $this->context->getRoot()->getValue()->isNew();
 
-      if ($profile->id() === $current_profile->get('profile_id')->value) {
-        unset($profiles[$key]);
+    if (!$new_profile) {
+      foreach ($profiles as $key => $profile) {
+        // Get the profile we're performing actions on.
+        $current_profile = _social_profile_get_profile_from_route();
+
+        if ($profile->id() === $current_profile->get('profile_id')->value) {
+          unset($profiles[$key]);
+        }
       }
     }
 

--- a/tests/behat/features/capabilities/profile/unique-nickname.feature
+++ b/tests/behat/features/capabilities/profile/unique-nickname.feature
@@ -31,7 +31,7 @@ Feature: I want to be able to make nick names unique
 
     When I fill in "Nickname" with "Susan"
     And I press "Save"
-    Then I should see the error message "Susan is already taken."
+    Then I should see the error message "This name is already taken, please try another one."
 
     When I fill in "Nickname" with "Carl"
     And I press "Save"


### PR DESCRIPTION
## Problem
When a new user tries to register using a "Nickname" that already exists in the system, the registration fails and the user gets shown:
<img width="1247" alt="Screenshot 2023-11-23 at 16 47 29" src="https://github.com/goalgorilla/open_social/assets/25609390/65fc4d48-3ed2-4657-9e1d-69d9d8a85ce8">
<!-- *[Required] Describe the problem you're trying to solve, this should motivate why the changes you're proposing are needed.* -->

## Solution
- Add check to prevent issue on user register page. 
- Update text of the waring message: “This name is already taken, please try another one”

<!-- *[Required] Describe the solution you've created, elaborate on any technical choices you've made. Why is this the right solution and is a different solution not the right one? What is the reasoning behind the chosen solution?* -->

## Issue tracker
<!-- *[Required] Paste a link to the drupal.org issue queue item. If any other issue trackers were used, include links to those too.* -->
- https://www.drupal.org/project/social/issues/3403776
- https://getopensocial.atlassian.net/browse/PROD-26459

## Theme issue tracker
N/A

## How to test

- [ ] Using the latest version of Open Social with the social_profile_fields module enabled
- [ ] And "Unique nicknames" option enabled
- [ ] As a AN
- [ ] Try to register on the site but use nicknames that already exist
- [ ] When saving I expect to see provided warning message but instead i see WSOD page
- [ ] The expected result is attained when repeating the steps with this fix applied.


## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
<!-- *[Required if new feature, and if applicable] If this Pull Request makes visual changes then please include some screenshots that show what has changed here. A before and after screenshot helps the reviewer determine what changes were made.* -->
N/A

## Release notes
<!-- *[Required if new feature, and if applicable] A short summary of the changes that were made that can be included in release notes.* -->
Fixes the issue with "Unique nicknames" on the user register page

## Change Record
<!-- *[Required if applicable] If this Pull Request changes the way that developers should do things or introduces a new API for developers then a change record to document this is needed. Please provide a draft for a change record or a link to an unpublished change record below. Existing change records can be consulted as example. Please provide a draft for a change record or a link to an unpublished change record below. [Existing change records](https://www.drupal.org/list-changes/social) can be consulted as example.* -->
N/A

## Translations
<!--
*[Optional]Translatable strings are always extracted from the latest development branch. To ensure translations remain available for platforms running older versions of Open Social the original string should be added to `translations.php` when it's changed or removed.*
- [ ] Changed or removed source strings are added to the `translations.php` file.
-->
N/A
