### PR TITLE
Issue #3404072: PHP error when has comment on page

### DIFF
--- a/modules/custom/social_ajax_comments/social_ajax_comments.module
+++ b/modules/custom/social_ajax_comments/social_ajax_comments.module
@@ -112,9 +112,16 @@ function social_ajax_comments_comment_links_alter(array &$links, CommentInterfac
     $wrapper_id = Html::getId(
       $commented_entity->getEntityTypeId() . '-' . $commented_entity->bundle() . '-' . 'field_post_comments' . '-' . $commented_entity->id()
     );
-    $links['comment']['#links']['comment-edit']['attributes']['data-wrapper-html-id'] = $wrapper_id;
-    $links['comment']['#links']['comment-unpublish']['attributes']['data-wrapper-html-id'] = $wrapper_id;
-    $links['comment']['#links']['comment-delete']['attributes']['data-wrapper-html-id'] = $wrapper_id;
+
+    if (!empty($links['comment']['#links']['comment-edit'])) {
+      $links['comment']['#links']['comment-edit']['attributes']['data-wrapper-html-id'] = $wrapper_id;
+    }
+    if (!empty($links['comment']['#links']['comment-unpublish'])) {
+      $links['comment']['#links']['comment-unpublish']['attributes']['data-wrapper-html-id'] = $wrapper_id;
+    }
+    if (!empty($links['comment']['#links']['comment-delete'])) {
+      $links['comment']['#links']['comment-delete']['attributes']['data-wrapper-html-id'] = $wrapper_id;
+    }
   }
 }
 


### PR DESCRIPTION
## Problem
When a comment is created and the unpublish button isn't be setted, an error message is throwing at page.

## Solution
Before to add the unpublish button, add a validation to avoid an error message

## Issue tracker
[PROD-27528](https://getopensocial.atlassian.net/browse/PROD-27528)
[#3404072](https://www.drupal.org/project/social/issues/3404072)

## Theme issue tracker
N/A

## How to test
Create a comment in a post without unpublish button configuration

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
N/A

## Release notes
N/A

## Change Record
N/A

## Translations
N/A


[PROD-27528]: https://getopensocial.atlassian.net/browse/PROD-27528?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ