### PR TITLE
Issue #3406164: Make sure we add `socialbase` as defaul theme for our mailer policy after moving to syfmony mailer.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -103,7 +103,8 @@
             },
             "drupal/socialbase": {
                 "Ensure lazy_builders work": "https://git.drupalcode.org/project/socialbase/-/merge_requests/175.patch",
-                "Issue #3398140: CKEditor 5 isn't respecting width limit": "https://www.drupal.org/files/issues/2023-10-31/socialbase-ckeditor-width-is-not-respecting-3398140-2.patch"
+                "Issue #3398140: CKEditor 5 isn't respecting width limit": "https://www.drupal.org/files/issues/2023-10-31/socialbase-ckeditor-width-is-not-respecting-3398140-2.patch",
+                "Inline CSS for email templates the symfony mailer way": "https://git.drupalcode.org/project/socialbase/-/merge_requests/191.patch"
             },
             "drupal/url_embed": {
                 "Translate dialog title": "https://www.drupal.org/files/issues/2018-03-16/url_embed_translate_dialog_title-2953591-2.patch",

--- a/modules/social_features/social_swiftmail/social_swiftmail.install
+++ b/modules/social_features/social_swiftmail/social_swiftmail.install
@@ -152,3 +152,14 @@ function social_swiftmail_update_11003(): void {
     }
   }
 }
+
+/**
+ * Update default theme for symfony mailer policy.
+ */
+function social_swiftmail_update_11004(): void {
+  // Set our theme to socialbase, as that is where our email template and
+  // styling live.
+  $config_factory = \Drupal::configFactory();
+  $config = $config_factory->getEditable('symfony_mailer.mailer_policy._');
+  $config->set('configuration.email_theme.theme', 'socialbase')->save();
+}


### PR DESCRIPTION
## Problem
As per https://www.drupal.org/project/socialbase/issues/3406149 we're going to implement a library for our inline CSS. However, as the template and the CSS live in socialbase we also need to update our default theme when emails are being sent. So the correct theming is used.

## Solution
Write an update hook, see below the before and after update hook config:

```
root@8338f9e32eac:/var/www# vendor/bin/drush cget symfony_mailer.mailer_policy._
langcode: en
status: true
dependencies: {  }
id: _
configuration:
  mailer_inline_css: {  }
  email_theme:
    theme: _default
  mailer_url_to_absolute: {  }
  mailer_wrap_and_convert:
    plain: false
    swiftmailer: false

root@8338f9e32eac:/var/www# vendor/bin/drush updb -y
 ------------------ ----------- --------------- ------------------------------ 
  Module             Update ID   Type            Description                   
 ------------------ ----------- --------------- ------------------------------ 
  social_swiftmail   11004       hook_update_n   11004 - Update default theme  
                                                 for symfony mailer policy.    
 ------------------ ----------- --------------- ------------------------------ 


 // Do you wish to run the specified pending updates?: yes.                                                             

>  [notice] Update started: social_swiftmail_update_11004
>  [notice] Update completed: social_swiftmail_update_11004
 [success] Finished performing updates.
root@8338f9e32eac:/var/www# vendor/bin/drush cget symfony_mailer.mailer_policy._configuration:email_theme
langcode: en
status: true
dependencies: {  }
id: _
configuration:
  mailer_inline_css: {  }
  email_theme:
    theme: socialbase
  mailer_url_to_absolute: {  }
  mailer_wrap_and_convert:
    plain: false
    swiftmailer: false

root@8338f9e32eac:/var/www#
```

## Issue tracker
https://www.drupal.org/project/social/issues/3406164 

## Theme issue tracker
https://www.drupal.org/project/socialbase/issues/3406149 (will be released and merged later)

## How to test
- [ ] Checkout this branch
- [ ] Run update hooks
- [ ] Test emails, see the theme applies.

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
I've tried adding it to socialblue:
![socialblue](https://github.com/goalgorilla/open_social/assets/16667281/c9e9fa86-5522-473f-bf1f-5d64b9da3fcc)

I've decided to for now do it in socialbase, as that was least chance of regression:
![socialbase](https://github.com/goalgorilla/open_social/assets/16667281/8b221e44-8f8d-43c3-a730-8d8c6aadaf5f)

## Release notes
Internal - As the email theming is used as it was before.