### PR TITLE
Issue #3406311: Form State is empty at Ajax Comment hook_batch_alter

### DIFF
--- a/modules/custom/social_ajax_comments/social_ajax_comments.module
+++ b/modules/custom/social_ajax_comments/social_ajax_comments.module
@@ -268,7 +268,7 @@ function social_ajax_comments_form_comment_form_alter(array &$form, FormStateInt
  */
 function social_ajax_comments_batch_alter(array &$batch): void {
   /** @var \Drupal\Core\Form\FormStateInterface|null $form_state */
-  $form_state = $batch['form_state'];
+  $form_state = $batch['form_state'] ?? NULL;
 
   if (empty($form_state) || $form_state->getValue('form_id') != 'comment_comment_delete_form' || !empty($batch['batch_redirect'])) {
     return;


### PR DESCRIPTION
## Problem
The Social Ajax Comments module has an hook_batch_alter and thier isn't have a treatment to batch without form-state and it is throwing a php error.

## Solution
Add a nullable default value to form-state variable and the form-state validation will return early.

## Issue tracker
[PROD-27607](https://getopensocial.atlassian.net/browse/PROD-27607)
[#3406311](https://www.drupal.org/project/social/issues/3406311)

## Theme issue tracker
N/A

## How to test
- [ ] Enable the Social Ajax Comments module
- [ ] Try to execute a mass change on entities content

**This error is happen at Enterprise environment**

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
N/A

## Release notes
N/A

## Change Record
N/A

## Translations
N/A


[PROD-27607]: https://getopensocial.atlassian.net/browse/PROD-27607?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ