### PR TITLE
Internal: There is a new version of `instaclick/php-webdriver` and the patch doesn't apply

### DIFF
--- a/.github/workflows/behat.yml
+++ b/.github/workflows/behat.yml
@@ -98,7 +98,10 @@ jobs:
           # recommended/support version before all our D10 efforts started. We can
           # remove it later when we have a new major out.
           PREVIOUS_MAJOR=11.9.0
-          composer require goalgorilla/open_social:~$PREVIOUS_MAJOR
+          # Also include a hardcoded version for instaclick/php-webdriver
+          # as we didnt lock the version, and the patch isn't applying on the latest, so we require it
+          # specifically to match the version that was installed at that moment in time.
+          composer require goalgorilla/open_social:~$PREVIOUS_MAJOR instaclick/php-webdriver:1.4.16
 
           # Installation
           # This is purposefully duplicated because we may change how

--- a/composer.json
+++ b/composer.json
@@ -30,9 +30,6 @@
     "extra": {
         "enable-patching": true,
         "patches": {
-            "instaclick/php-webdriver": {
-                "Curl_exec errors on behat (1.4.11)": "https://www.drupal.org/files/issues/2022-03-30/social-instaclick-webdriver-3272386-2.patch"
-            },
             "embed/embed": {
                 "Issue #3110341: Embedded Vimeo videos are sometimes blocked when hosted on cloud hosting": "https://www.drupal.org/files/issues/2020-01-31/3110341-vendor-fix-vimeo-adapter.patch"
             },

--- a/tests/composer.json
+++ b/tests/composer.json
@@ -76,13 +76,6 @@
                 "type:drupal-drush"
             ]
         },
-        "enable-patching": true,
-        "patches-ignore": {
-            "goalgorilla/open_social": {
-                "instaclick/php-webdriver": {
-                    "Curl_exec errors on behat (1.4.10)": "https://www.drupal.org/files/issues/2021-10-17/social-instaclick-webdriver-3226058-8.patch"
-                }
-            }
-        }
+        "enable-patching": true
     }
 }


### PR DESCRIPTION
## Problem
There is a new version of `instaclick/php-webdriver` and the patch doesn't apply

Lets see if we still get CURL issues, if so we need to lock the version for now as it's blocking main and we can create a follow up to properly fix this, also with an issue in the actual instaclick/php-webdriver repo.

## Issue tracker
Internal.

## How to test
Behat shouldn't get any curl issues.

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status
