### PR TITLE
Issue #3408496 - Make sure our flagging has the correct arguments otherwise it will break profile teasers for AN.

### DIFF
--- a/modules/social_features/social_content_report/src/ContentReportService.php
+++ b/modules/social_features/social_content_report/src/ContentReportService.php
@@ -104,7 +104,11 @@ class ContentReportService implements ContentReportServiceInterface {
     $flag = $this->flagService->getFlagById($flag_id);
 
     if ($flag !== NULL) {
-      $flagging = $this->flagService->getFlagging($flag, $entity, $this->currentUser);
+      $session_id = NULL;
+      if ($this->currentUser->isAnonymous()) {
+        $session_id = $this->flagService->getAnonymousSessionId();
+      }
+      $flagging = $this->flagService->getFlagging($flag, $entity, $this->currentUser, $session_id);
     }
 
     // If the user already flagged this, we return a disabled link to nowhere.

--- a/modules/social_features/social_follow_user/src/Service/SocialFollowUserHelper.php
+++ b/modules/social_features/social_follow_user/src/Service/SocialFollowUserHelper.php
@@ -47,7 +47,11 @@ class SocialFollowUserHelper implements SocialFollowUserHelperInterface {
       assert($flag !== NULL, "The 'follow_user' flag type does not exist, this indicates a problem with the social_follow_user module installation.");
       // And display only "Unfollow" button because we should leave the ability
       // to unfollow user.
-      if ($this->flagService->getFlagging($flag, $profile, $this->currentUser)) {
+      $session_id = NULL;
+      if ($this->currentUser->isAnonymous()) {
+        $session_id = $this->flagService->getAnonymousSessionId();
+      }
+      if ($this->flagService->getFlagging($flag, $profile, $this->currentUser, $session_id)) {
         $following_enabled = TRUE;
       }
     }


### PR DESCRIPTION
This is a follow-up as we did not fix this on all places yet.
Original issue: https://www.drupal.org/node/3355315

## Problem
Our socialFollowUser checks all flags for the current user, however, for AN the flag service requires a session id as per:
[https://git.drupalcode.org/project/flag/-/commit/497e170c267780dc314e0f0...](https://git.drupalcode.org/project/flag/-/commit/497e170c267780dc314e0f0ed5962ad5d89dfee7#b6b1c3c70255325ebedd7af4aceb1639bd19829b_129_180)

If not provided, it will trigger the Exception.

## Solution
In our case we can use the same $this->flagService->getAnonymousSessionId to make sure it returns NULL if the user is logged in or provide a/the session ID for AN.

## Issue tracker
https://www.drupal.org/project/social/issues/3408496

## Theme issue tracker
*[Required if applicable] Paste a link to the drupal.org theme issue queue item, either from [socialbase](https://www.drupal.org/project/socialbase) or [socialblue](https://www.drupal.org/project/socialblue). If any other issue trackers were used, include links to those too.*

## How to test
- [ ] Enable social_follow_user
- [ ] Create a flexible group with public permissions, add at least 1 member to it
- [ ] As anonymous go to the group page and navigate to the members tab
- [ ] See it crashes
- [ ] Go to this branch and try again

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
<!-- *[Required if new feature, and if applicable] If this Pull Request makes visual changes then please include some screenshots that show what has changed here. A before and after screenshot helps the reviewer determine what changes were made.* -->

## Release notes
We have fixed an issue where going to the members tab in public groups would result in a page crash.

## Change Record
<!-- *[Required if applicable] If this Pull Request changes the way that developers should do things or introduces a new API for developers then a change record to document this is needed. Please provide a draft for a change record or a link to an unpublished change record below. Existing change records can be consulted as example. Please provide a draft for a change record or a link to an unpublished change record below. [Existing change records](https://www.drupal.org/list-changes/social) can be consulted as example.* -->

## Translations
<!--
*[Optional]Translatable strings are always extracted from the latest development branch. To ensure translations remain available for platforms running older versions of Open Social the original string should be added to `translations.php` when it's changed or removed.*
- [ ] Changed or removed source strings are added to the `translations.php` file.
-->
