### PR TITLE
Issue #3409033 - Add an update hook to remove leftsovers of the embed_button for the ckeditor 4 to 5 migration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -100,7 +100,7 @@
             },
             "drupal/url_embed": {
                 "Translate dialog title": "https://www.drupal.org/files/issues/2018-03-16/url_embed_translate_dialog_title-2953591-2.patch",
-                "Issue #3316376 - CKEditor 5 Support": "https://www.drupal.org/files/issues/2023-05-18/url_embed_ckeditor5_support.patch",
+                "Issue #3316376 - CKEditor 5 Support": "https://www.drupal.org/files/issues/2023-11-20/url_embed-ckeditor5-support-3316376-37.patch",
                 "Issue #2761187/#3386579 Improve how the module deals with non-embeddable URLs & WSODs (See: https://www.drupal.org/project/social/issues/3386579#comment-15225972) 2.x": "https://www.drupal.org/files/issues/2023-09-22/urlembed-non-embeddable-urls-2761187-opensocial-combined-21_2.x_1_ckeditor5.patch",
                 "Issue #3386590: preg_split in _filter_url breaks for long html tags": "https://www.drupal.org/files/issues/2023-09-11/3382821-url_embed-preg-split_2.x_1.patch"
             },

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -5926,6 +5926,11 @@ parameters:
 			path: modules/social_features/social_embed/social_embed.install
 
 		-
+			message: "#^Parameter \\#1 \\$format_id of function editor_load expects int, string given\\.$#"
+			count: 1
+			path: modules/social_features/social_embed/social_embed.post_update.php
+
+		-
 			message: "#^Function social_embed_update_10301\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: modules/social_features/social_embed/social_embed.install


### PR DESCRIPTION
## Problem
When going to the Drupal status page you will see an error message like in the screenshot below.
![url_embed](https://github.com/goalgorilla/open_social/assets/19951171/c51f3ca1-f1a9-4da7-a0d7-1561ee6f2415)

## Solution
The url embed module did not migrate the old plugin to the new ckeditor5 but added a new plugin. This causes the old button still being available on admin/config/content/embed which is not compatible with ckeditor5. This will not create any issues but does pollute the status page.

To solve this we can remove this old button as we don't use it anymore and replaced it with the new one.

Only remove it when no text-formats are using ckeditor4 with this plugin

## Issue tracker
https://www.drupal.org/project/social/issues/3409033

## Theme issue tracker
*[Required if applicable] Paste a link to the drupal.org theme issue queue item, either from [socialbase](https://www.drupal.org/project/socialbase) or [socialblue](https://www.drupal.org/project/socialblue). If any other issue trackers were used, include links to those too.*

## How to test
Scenario 1
- [ ] Enable social_embed
- [ ] Go to the status page and see the error message
- [ ] Check out to this branch and run drush updb
- [ ] See it now is gone

Scenario 2
- [ ] Enable social_embed
- [ ] add the embed button to a text format on admin/config/content/formats with the ckeditor4 (you can create a new text format if you want)
- [ ] Check out to this branch  and run drush updb
- [ ] Notice it will keep the button (also the error message) as we dont want to remove it when people still use the button for ckeditor 4 text formats
- [ ] Now remove the button again from the text format, and change in the code social_embed.post_update the social_embed_post_update_12001_remove_old_social_embed_button to social_embed_post_update_12002 remove_old_social_embed_button
- [ ] run drush updb again and see it will get removed now, as its no longer active anymore in any text format.

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
<!-- *[Required if new feature, and if applicable] If this Pull Request makes visual changes then please include some screenshots that show what has changed here. A before and after screenshot helps the reviewer determine what changes were made.* -->

## Release notes
During the migration from ckeditor4 to 5 there we still some leftovers in the code that caused a warning on the Drupal status page. This has been fixed now.

## Change Record
<!-- *[Required if applicable] If this Pull Request changes the way that developers should do things or introduces a new API for developers then a change record to document this is needed. Please provide a draft for a change record or a link to an unpublished change record below. Existing change records can be consulted as example. Please provide a draft for a change record or a link to an unpublished change record below. [Existing change records](https://www.drupal.org/list-changes/social) can be consulted as example.* -->

## Translations
<!--
*[Optional]Translatable strings are always extracted from the latest development branch. To ensure translations remain available for platforms running older versions of Open Social the original string should be added to `translations.php` when it's changed or removed.*
- [ ] Changed or removed source strings are added to the `translations.php` file.
-->
