### PR TITLE
Issue #3409546: Missing permission to taxonomies for all users

### DIFF
--- a/modules/social_features/social_profile/config/modify/social_profile.anonymous_taxonomy_permissions.yml
+++ b/modules/social_features/social_profile/config/modify/social_profile.anonymous_taxonomy_permissions.yml
@@ -1,0 +1,20 @@
+dependencies:
+  module:
+    - social_registration_fields
+    - taxonomy_access_fix
+items:
+  user.role.anonymous:
+    expected_config:
+      permissions: { }
+    update_actions:
+      add:
+        permissions:
+          - 'view terms in interests'
+          - 'view term names in interests'
+          - 'select terms in interests'
+          - 'view terms in expertise'
+          - 'view term names in expertise'
+          - 'select terms in expertise'
+          - 'view terms in profile_tag'
+          - 'view term names in profile_tag'
+          - 'select terms in profile_tag'

--- a/modules/social_features/social_profile/config/modify/social_profile.authenticated_taxonomy_permissions.yml
+++ b/modules/social_features/social_profile/config/modify/social_profile.authenticated_taxonomy_permissions.yml
@@ -1,0 +1,49 @@
+dependencies:
+  module:
+    - taxonomy_access_fix
+items:
+  user.role.sitemanager:
+    expected_config:
+      permissions: { }
+    update_actions:
+      add:
+        permissions:
+          - 'view terms in interests'
+          - 'view term names in interests'
+          - 'select terms in interests'
+          - 'view terms in expertise'
+          - 'view term names in expertise'
+          - 'select terms in expertise'
+          - 'view terms in profile_tag'
+          - 'view term names in profile_tag'
+          - 'select terms in profile_tag'
+  user.role.verified:
+    expected_config:
+      permissions: { }
+    update_actions:
+      add:
+        permissions:
+          - 'view terms in interests'
+          - 'view term names in interests'
+          - 'select terms in interests'
+          - 'view terms in expertise'
+          - 'view term names in expertise'
+          - 'select terms in expertise'
+          - 'view terms in profile_tag'
+          - 'view term names in profile_tag'
+          - 'select terms in profile_tag'
+  user.role.contentmanager:
+    expected_config:
+      permissions: { }
+    update_actions:
+      add:
+        permissions:
+          - 'view terms in interests'
+          - 'view term names in interests'
+          - 'select terms in interests'
+          - 'view terms in expertise'
+          - 'view term names in expertise'
+          - 'select terms in expertise'
+          - 'view terms in profile_tag'
+          - 'view term names in profile_tag'
+          - 'select terms in profile_tag'

--- a/modules/social_features/social_profile/modules/social_profile_fields/config/modify/social_profile_fields.anonymous_taxonomy_permissions.yml
+++ b/modules/social_features/social_profile/modules/social_profile_fields/config/modify/social_profile_fields.anonymous_taxonomy_permissions.yml
@@ -1,0 +1,14 @@
+dependencies:
+  module:
+    - social_registration_fields
+    - taxonomy_access_fix
+items:
+  user.role.anonymous:
+    expected_config:
+      permissions: { }
+    update_actions:
+      add:
+        permissions:
+          - 'view terms in nationality'
+          - 'view term names in nationality'
+          - 'select terms in nationality'

--- a/modules/social_features/social_profile/modules/social_profile_fields/config/modify/social_profile_fields.authenticated_taxonomy_permissions.yml
+++ b/modules/social_features/social_profile/modules/social_profile_fields/config/modify/social_profile_fields.authenticated_taxonomy_permissions.yml
@@ -1,0 +1,31 @@
+dependencies:
+  module:
+    - taxonomy_access_fix
+items:
+  user.role.sitemanager:
+    expected_config:
+      permissions: { }
+    update_actions:
+      add:
+        permissions:
+          - 'view terms in nationality'
+          - 'view term names in nationality'
+          - 'select terms in nationality'
+  user.role.verified:
+    expected_config:
+      permissions: { }
+    update_actions:
+      add:
+        permissions:
+          - 'view terms in nationality'
+          - 'view term names in nationality'
+          - 'select terms in nationality'
+  user.role.contentmanager:
+    expected_config:
+      permissions: { }
+    update_actions:
+      add:
+        permissions:
+          - 'view terms in nationality'
+          - 'view term names in nationality'
+          - 'select terms in nationality'

--- a/modules/social_features/social_profile/modules/social_profile_fields/social_profile_fields.install
+++ b/modules/social_features/social_profile/modules/social_profile_fields/social_profile_fields.install
@@ -85,3 +85,59 @@ function _social_profile_fields_nationalities() {
 function social_profile_fields_update_last_removed() : int {
   return 11201;
 }
+
+/**
+ * Add new permissions for taxonomies.
+ */
+function social_profile_fields_update_121001(): void {
+  // Nothing to do if the module is not installed.
+  if (!\Drupal::moduleHandler()->moduleExists("taxonomy_access_fix")) {
+    return;
+  }
+
+  // Permission to grant.
+  $taxonomy_permissions = [
+    'view terms in nationality',
+    'view term names in nationality',
+    'select terms in nationality',
+  ];
+
+  // Authenticated roles.
+  $authenticated_roles = [
+    'sitemanager',
+    'verified',
+    'contentmanager',
+  ];
+
+  // Load the permission.
+  $entity_type_manager = \Drupal::entityTypeManager();
+  foreach ($authenticated_roles as $role) {
+    /** @var \Drupal\user\RoleInterface $role */
+    $role = $entity_type_manager->getStorage('user_role')->load($role);
+
+    // If the role does not have the permission, grant permission.
+    foreach ($taxonomy_permissions as $taxonomy_permission) {
+      if (!$role->hasPermission($taxonomy_permission)) {
+        $role->grantPermission($taxonomy_permission);
+        $role->save();
+      }
+    }
+  }
+
+  // For anonymous role, we need to check the if Registration Fields is enabled.
+  if (!\Drupal::moduleHandler()->moduleExists("social_registration_fields")) {
+    return;
+  }
+
+  // Load anonymous role.
+  /** @var \Drupal\user\RoleInterface $role */
+  $role = $entity_type_manager->getStorage('user_role')->load('anonymous');
+
+  // If the role does not have the permission, grant permission.
+  foreach ($taxonomy_permissions as $taxonomy_permission) {
+    if (!$role->hasPermission($taxonomy_permission)) {
+      $role->grantPermission($taxonomy_permission);
+      $role->save();
+    }
+  }
+}

--- a/modules/social_features/social_profile/modules/social_profile_organization_tag/config/modify/social_profile_organization_tag.anonymous_taxonomy_permissions.yml
+++ b/modules/social_features/social_profile/modules/social_profile_organization_tag/config/modify/social_profile_organization_tag.anonymous_taxonomy_permissions.yml
@@ -1,0 +1,14 @@
+dependencies:
+  module:
+    - social_registration_fields
+    - taxonomy_access_fix
+items:
+  user.role.anonymous:
+    expected_config:
+      permissions: { }
+    update_actions:
+      add:
+        permissions:
+          - 'view terms in profile_organization_tag'
+          - 'view term names in profile_organization_tag'
+          - 'select terms in profile_organization_tag'

--- a/modules/social_features/social_profile/modules/social_profile_organization_tag/config/modify/social_profile_organization_tag.authenticated_taxonomy_permissions.yml
+++ b/modules/social_features/social_profile/modules/social_profile_organization_tag/config/modify/social_profile_organization_tag.authenticated_taxonomy_permissions.yml
@@ -1,0 +1,31 @@
+dependencies:
+  module:
+    - taxonomy_access_fix
+items:
+  user.role.sitemanager:
+    expected_config:
+      permissions: { }
+    update_actions:
+      add:
+        permissions:
+          - 'view terms in profile_organization_tag'
+          - 'view term names in profile_organization_tag'
+          - 'select terms in profile_organization_tag'
+  user.role.verified:
+    expected_config:
+      permissions: { }
+    update_actions:
+      add:
+        permissions:
+          - 'view terms in profile_organization_tag'
+          - 'view term names in profile_organization_tag'
+          - 'select terms in profile_organization_tag'
+  user.role.contentmanager:
+    expected_config:
+      permissions: { }
+    update_actions:
+      add:
+        permissions:
+          - 'view terms in profile_organization_tag'
+          - 'view term names in profile_organization_tag'
+          - 'select terms in profile_organization_tag'

--- a/modules/social_features/social_profile/modules/social_profile_organization_tag/social_profile_organization_tag.install
+++ b/modules/social_features/social_profile/modules/social_profile_organization_tag/social_profile_organization_tag.install
@@ -37,3 +37,59 @@ function social_profile_organization_tag_install() {
 function social_profile_organization_tag_update_last_removed() : int {
   return 11201;
 }
+
+/**
+ * Add new permissions for taxonomies.
+ */
+function social_profile_organization_tag_update_121001(): void {
+  // Nothing to do if the module is not installed.
+  if (!\Drupal::moduleHandler()->moduleExists("taxonomy_access_fix")) {
+    return;
+  }
+
+  // Permission to grant.
+  $taxonomy_permissions = [
+    'view terms in profile_organization_tag',
+    'view term names in profile_organization_tag',
+    'select terms in profile_organization_tag',
+  ];
+
+  // Authenticated roles.
+  $authenticated_roles = [
+    'sitemanager',
+    'verified',
+    'contentmanager',
+  ];
+
+  // Load the permission.
+  $entity_type_manager = \Drupal::entityTypeManager();
+  foreach ($authenticated_roles as $role) {
+    /** @var \Drupal\user\RoleInterface $role */
+    $role = $entity_type_manager->getStorage('user_role')->load($role);
+
+    // If the role is not have the permission, grant permission.
+    foreach ($taxonomy_permissions as $taxonomy_permission) {
+      if (!$role->hasPermission($taxonomy_permission)) {
+        $role->grantPermission($taxonomy_permission);
+        $role->save();
+      }
+    }
+  }
+
+  // For anonymous role, we need to check the if Registration Fields is enabled.
+  if (!\Drupal::moduleHandler()->moduleExists("social_registration_fields")) {
+    return;
+  }
+
+  // Load anonymous role.
+  /** @var \Drupal\user\RoleInterface $role */
+  $role = $entity_type_manager->getStorage('user_role')->load('anonymous');
+
+  // If the role is not have the permission, grant permission.
+  foreach ($taxonomy_permissions as $taxonomy_permission) {
+    if (!$role->hasPermission($taxonomy_permission)) {
+      $role->grantPermission($taxonomy_permission);
+      $role->save();
+    }
+  }
+}

--- a/modules/social_features/social_profile/social_profile.info.yml
+++ b/modules/social_features/social_profile/social_profile.info.yml
@@ -21,4 +21,5 @@ dependencies:
   - drupal:user
   - drupal:views
   - select2:select2
+  - config_modify:config_modify
 package: Social

--- a/modules/social_features/social_profile/social_profile.install
+++ b/modules/social_features/social_profile/social_profile.install
@@ -132,3 +132,65 @@ function social_profile_uninstall() {
 function social_profile_update_last_removed() : int {
   return 111101;
 }
+
+/**
+ * Add new permissions for taxonomies.
+ */
+function social_profile_update_121001(): void {
+  // Nothing to do if the module is not installed.
+  if (!\Drupal::moduleHandler()->moduleExists("taxonomy_access_fix")) {
+    return;
+  }
+
+  // Permission to grant.
+  $taxonomy_permissions = [
+    'view terms in interests',
+    'view term names in interests',
+    'select terms in interests',
+    'view terms in expertise',
+    'view term names in expertise',
+    'select terms in expertise',
+    'view terms in profile_tag',
+    'view term names in profile_tag',
+    'select terms in profile_tag',
+  ];
+
+  // Authenticated roles.
+  $authenticated_roles = [
+    'sitemanager',
+    'verified',
+    'contentmanager',
+  ];
+
+  // Load the permission.
+  $entity_type_manager = \Drupal::entityTypeManager();
+  foreach ($authenticated_roles as $role) {
+    /** @var \Drupal\user\RoleInterface $role */
+    $role = $entity_type_manager->getStorage('user_role')->load($role);
+
+    // If the role is not have the permission, grant permission.
+    foreach ($taxonomy_permissions as $taxonomy_permission) {
+      if (!$role->hasPermission($taxonomy_permission)) {
+        $role->grantPermission($taxonomy_permission);
+        $role->save();
+      }
+    }
+  }
+
+  // For anonymous role, we need to check the if Registration Fields is enabled.
+  if (!\Drupal::moduleHandler()->moduleExists("social_registration_fields")) {
+    return;
+  }
+
+  // Load anonymous role.
+  /** @var \Drupal\user\RoleInterface $role */
+  $role = $entity_type_manager->getStorage('user_role')->load('anonymous');
+
+  // If the role is not have the permission, grant permission.
+  foreach ($taxonomy_permissions as $taxonomy_permission) {
+    if (!$role->hasPermission($taxonomy_permission)) {
+      $role->grantPermission($taxonomy_permission);
+      $role->save();
+    }
+  }
+}


### PR DESCRIPTION
## Problem
The taxonomy fields from Registration page isn't working as expected.

## Solution
Created a configuration-modify to add the permission when some modules is enabled.

## Issue tracker
[PROD-27744](https://getopensocial.atlassian.net/browse/PROD-27744)
[#3409546](https://www.drupal.org/project/social/issues/3409546)

## Theme issue tracker
N/A

## How to test
- [ ] Enable the modules: Social Registration Fields and Taxonomy Access Fix
- [ ] Clear cache
- [ ] Enable Social Profile, Social Profile Fields and Social Profile Organization Tag
- [ ] The last 3 modules will add some fields at Registration Page, so enable than at: /admin/config/people/social-registration-fields
- [ ] Check all new fields at Registration Page

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
N/A

## Release notes
Internal: For the SaaS version of Open Social we are having some issues with permissions for a registration module in combination with taxonomy. Because there is at the moment no better place where the code can live we have added it to the Distro. 

This should not affect your installation unless you also have added the drupal/taxonomy_access_fix as a dependency.

## Change Record
N/A

## Translations
N/A


[PROD-27744]: https://getopensocial.atlassian.net/browse/PROD-27744?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ