### PR TITLE
Internal: PROD-27796 - Add Behat test steps around profile management

### DIFF
--- a/tests/behat/behat.yml
+++ b/tests/behat/behat.yml
@@ -33,6 +33,7 @@ default:
         - Drupal\social\Behat\FileContext
         - Drupal\social\Behat\LogContext
         - Drupal\social\Behat\ModuleContext
+        - Drupal\social\Behat\ProfileContext
         - Drupal\social\Behat\SearchContext
         - Drupal\social\Behat\SocialDrupalContext
         - Drupal\social\Behat\SocialMessageContext

--- a/tests/behat/features/bootstrap/ProfileContext.php
+++ b/tests/behat/features/bootstrap/ProfileContext.php
@@ -1,0 +1,236 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\social\Behat;
+
+use Behat\Behat\Hook\Scope\BeforeScenarioScope;
+use Behat\Gherkin\Node\TableNode;
+use Behat\MinkExtension\Context\RawMinkContext;
+use Drupal\DrupalExtension\Context\DrupalContext;
+use Drupal\profile\Entity\Profile;
+use Drupal\profile\Entity\ProfileInterface;
+use Drupal\user\Entity\User;
+
+/**
+ * Defines test steps around user profiles and profile management.
+ */
+class ProfileContext extends RawMinkContext {
+
+  use EntityTrait;
+
+  /**
+   * The Drupal context which gives us access to user management.
+   */
+  private DrupalContext $drupalContext;
+
+  /**
+   * Make some contexts available here, so we can delegate steps.
+   *
+   * @BeforeScenario
+   */
+  public function gatherContexts(BeforeScenarioScope $scope) {
+    $environment = $scope->getEnvironment();
+
+    $this->drupalContext = $environment->getContext(SocialDrupalContext::class);
+  }
+
+  /**
+   * Go to the profile page for the current user.
+   *
+   * @When I am viewing my profile
+   */
+  public function amViewingMyProfile() : void {
+    $user_id = $this->drupalContext->getUserManager()->getCurrentUser()->uid;
+    $this->visitPath("/user/$user_id");
+    $this->assertSession()->statusCodeEquals(200);
+  }
+
+  /**
+   * Try to view a specific profile even if you might not have access.
+   *
+   * @When I try to view the profile of :user
+   */
+  public function attemptViewingProfile(string $user) : void {
+    if ($user === 'anonymous') {
+      $user_ids = [0];
+    }
+    else {
+      $user_ids = \Drupal::entityQuery('user')
+        ->accessCheck(FALSE)
+        ->condition('name', $user)
+        ->execute();
+
+      if (count($user_ids) !== 1) {
+        throw new \InvalidArgumentException("Could not find user with username `$user'.");
+      }
+    }
+
+    $user_id = reset($user_ids);
+    $this->visitPath("/user/$user_id");
+  }
+
+  /**
+   * Create or update the profile for a user with a specific nickname.
+   *
+   * Updates a profile in the form:
+   * | field_profile_first_name | John |
+   * | field_profile_last_name  | Doe  |
+   *
+   * @Given user :username has a profile filled with:
+   */
+  public function userHasProfile(string $username, TableNode $profileTable) : void {
+    $profile = $profileTable->getRowsHash();
+    $profile['owner'] = $username;
+    $this->profileUpdate($profile);
+  }
+
+  /**
+   * Create or update the profile for the current user.
+   *
+   * Updates a profile in the form:
+   * | field_profile_first_name | John |
+   * | field_profile_last_name  | Doe  |
+   *
+   * @Given I have a profile filled with:
+   * @Given have a profile filled with:
+   */
+  public function iHaveProfile(TableNode $profileTable) : void {
+    $profile = $profileTable->getRowsHash();
+    if (isset($profile['uid'])) {
+      throw new \InvalidArgumentException("Should not set `uid` for profile, use 'user :username has a profile filled with' instead.");
+    }
+    if (isset($profile['owner'])) {
+      throw new \InvalidArgumentException("Should not set `owner` for profile, use 'user :username has a profile filled with' instead.");
+    }
+    $this->profileUpdate($profile);
+  }
+
+  /**
+   * Go to the profile edit page for the current user.
+   *
+   * @When I am editing my profile
+   */
+  public function amEditingMyProfile() : void {
+    $user_id = $this->drupalContext->getUserManager()->getCurrentUser()->uid;
+    $this->visitPath("/user/$user_id/profile");
+    $this->assertSession()->statusCodeEquals(200);
+  }
+
+  /**
+   * Go to the profile edit page for the specified user.
+   *
+   * @When I try to edit the profile of :user
+   * @When I try to edit my profile
+   */
+  public function amEditingProfileOf(?string $user = NULL) : void {
+    if ($user === NULL) {
+      $user_id = $this->drupalContext->getUserManager()->getCurrentUser()->uid;
+    }
+    elseif ($user === 'anonymous') {
+      $user_id = 0;
+    }
+    else {
+      $user_ids = \Drupal::entityQuery('user')
+        ->accessCheck(FALSE)
+        ->condition('name', $user)
+        ->execute();
+
+      if (count($user_ids) !== 1) {
+        throw new \InvalidArgumentException("Could not find user with username `$user'.");
+      }
+
+      $user_id = reset($user_ids);
+    }
+
+    $this->visitPath("/user/$user_id/profile");
+  }
+
+  /**
+   * Manage whether unique nicknames are enforced.
+   *
+   * @param string $state
+   *   Either enabled or disabled.
+   *
+   * @Given unique nicknames for users is :state
+   */
+  public function setUniqueNicknames(string $state) : void {
+    assert($state === "enabled" || $state === "disabled", ":state must be one of 'enabled' or 'disabled' (got '$state')");
+
+    \Drupal::configFactory()->getEditable("social_profile_fields.settings")->set("nickname_unique_validation", $state === "enabled")->save();
+    \Drupal::service("entity_field.manager")->clearCachedFieldDefinitions();
+  }
+
+  /**
+   * Check the state of unique nicknames enforcement.
+   *
+   * @param string $state
+   *   Either enabled or disabled.
+   *
+   * @Then unique nicknames for users should be :state
+   */
+  public function assertUniqueNicknames(string $state) : void {
+    assert($state === "enabled" || $state === "disabled", ":state must be one of 'enabled' or 'disabled' (got '$state')");
+    // For some reason the way Drupal Extension runs Drupal the permissions get
+    // cached in our runtime, so we need to cache bust to ensure we can actually
+    // see the result of the form save.
+    \Drupal::configFactory()->clearStaticCache();
+
+    $expectedState = $state === "enabled";
+    $actualState = \Drupal::config("social_profile_fields.settings")->get("nickname_unique_validation");
+    if ($expectedState !== $actualState) {
+      throw new \RuntimeException("Expected unique nicknames to be $state but got '" . ($actualState ? "enabled" : "disabled") . "'");
+    }
+  }
+
+  /**
+   * Update a profile for a user.
+   *
+   * @param array $profile
+   *   The field values for the profile.
+   *
+   * @return \Drupal\profile\Entity\Profile
+   *   The updated profile.
+   */
+  private function profileUpdate(array $profile) : Profile {
+    if (!isset($profile['owner'])) {
+      $current_user = $this->drupalContext->getUserManager()->getCurrentUser();
+      $profile['uid'] ??= is_object($current_user) ? $current_user->uid ?? 0 : 0;
+    }
+    else {
+      $account = user_load_by_name($profile['owner']);
+      if ($account->id() !== 0) {
+        $profile['uid'] ??= $account->id();
+      }
+      else {
+        throw new \Exception(sprintf("User with username '%s' does not exist.", $profile['owner']));
+      }
+      unset($profile['owner']);
+    }
+
+    if ($profile['uid'] === 0) {
+      throw new \InvalidArgumentException("Can not update the profile of the anonymous user");
+    }
+
+    $profile['type'] = 'profile';
+    $this->validateEntityFields("profile", $profile);
+    $profile_object = \Drupal::entityTypeManager()->getStorage('profile')->loadByUser(User::load($profile['uid']), 'profile');
+    if ($profile_object instanceof ProfileInterface) {
+      foreach ($profile as $field => $value) {
+        $profile_object->set($field, $value);
+      }
+    }
+    else {
+      $profile_object = Profile::create($profile);
+    }
+
+    $violations = $profile_object->validate();
+    if ($violations->count() !== 0) {
+      throw new \Exception("The profile you tried to update is invalid: $violations");
+    }
+    $profile_object->save();
+
+    return $profile_object;
+  }
+
+}


### PR DESCRIPTION
## Problem / Solution
As part of the profile refactor we added [quite comprehensive test steps around profiles](https://github.com/goalgorilla/open_social/blob/2b640208df7b05c79fc22c1b573e5d2aba7821b8/tests/behat/features/bootstrap/ProfileContext.php). We want to bring those into the distribution ahead of the profile refactor because they can be useful already.

All the steps that are not directly related to the new field management system are included:

-  When I am viewing my profile
-  When I try to view the profile of :user
-  Given user :username has a profile filled with:
-  Given I have a profile filled with:
-  Given have a profile filled with:
-  When I am editing my profile
-  When I try to edit the profile of :user
-  Given unique nickname for users is :state
-  Then unique nicknames for users should be :state

## Issue tracker
https://getopensocial.atlassian.net/browse/PROD-27796

## Theme issue tracker
*[Required if applicable] Paste a link to the drupal.org theme issue queue item, either from [socialbase](https://www.drupal.org/project/socialbase) or [socialblue](https://www.drupal.org/project/socialblue). If any other issue trackers were used, include links to those too.*

## How to test
<!--
*[Required] For example*
- [ ] Using version X.Y.Z of Open Social with the example module enabled
- [ ] As a sitemanager
- [ ] Try to enable the option B on screen c/d/e
- [ ] When saving I expect the result to be F but instead see G.
- [ ] The expected result F is attained when repeating the steps with this fix applied.
-->

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
<!-- *[Required if new feature, and if applicable] If this Pull Request makes visual changes then please include some screenshots that show what has changed here. A before and after screenshot helps the reviewer determine what changes were made.* -->

## Release notes
<!-- *[Required if new feature, and if applicable] A short summary of the changes that were made that can be included in release notes.* -->

## Change Record
<!-- *[Required if applicable] If this Pull Request changes the way that developers should do things or introduces a new API for developers then a change record to document this is needed. Please provide a draft for a change record or a link to an unpublished change record below. Existing change records can be consulted as example. Please provide a draft for a change record or a link to an unpublished change record below. [Existing change records](https://www.drupal.org/list-changes/social) can be consulted as example.* -->

## Translations
<!--
*[Optional]Translatable strings are always extracted from the latest development branch. To ensure translations remain available for platforms running older versions of Open Social the original string should be added to `translations.php` when it's changed or removed.*
- [ ] Changed or removed source strings are added to the `translations.php` file.
-->
