### PR TITLE
Internal: PROD-27797 - Improve Behat support for SOLR

### DIFF
--- a/tests/behat/features/bootstrap/SearchContext.php
+++ b/tests/behat/features/bootstrap/SearchContext.php
@@ -3,15 +3,9 @@
 namespace Drupal\social\Behat;
 
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
-use Behat\Gherkin\Node\TableNode;
-use Behat\Mink\Exception\ElementNotFoundException;
 use Behat\MinkExtension\Context\RawMinkContext;
-use Drupal\Component\Plugin\Exception\PluginNotFoundException;
-use Drupal\DrupalExtension\Context\DrupalContext;
-use Drupal\DrupalExtension\Context\MinkContext;
-use Drupal\group\Entity\Group;
-use Drupal\node\Entity\Node;
-use Symfony\Component\Yaml\Yaml;
+use Drupal\Driver\DrushDriver;
+use Drupal\search_api_solr\Plugin\search_api\backend\SearchApiSolrBackend;
 
 /**
  * Defines test steps around the interaction with search.
@@ -19,23 +13,76 @@ use Symfony\Component\Yaml\Yaml;
 class SearchContext extends RawMinkContext {
 
   /**
+   * The driver that allows us to execute drush commands.
+   */
+  private DrushDriver $drushDriver;
+
+  /**
+   * Ensures the drush driver is available in other hooks and steps.
+   *
+   * Should be the first BeforeScenario hook in this class.
+   *
+   * @BeforeScenario
+   */
+  public function getDrushDriver(BeforeScenarioScope $scope) : void {
+    $this->environment= $scope->getEnvironment();
+    $drupal_context = $this->environment->getContext(SocialDrupalContext::class);
+    if (!$drupal_context instanceof SocialDrupalContext) {
+      throw new \RuntimeException("Expected " . SocialDrupalContext::class . " to be configured for Behat.");
+    }
+    // Call getDriver without arguments to boostrap the default driver.
+    $drupal_context->getDriver();
+    $driver = $drupal_context->getDriver("drush");
+    if (!$driver instanceof DrushDriver) {
+      throw new \RuntimeException("Could not load the Drush driver. Make sure the DrupalExtension is configured to enable it.");
+    }
+    $this->drushDriver = $driver;
+  }
+
+  /**
+   * When the database is loaded, delete all data from SOLR.
+   *
+   * The search_api and search_api_solr modules create specific delete queries
+   * for SOLR data based on the indexes. However, the site hash that they use
+   * may change in between databases which can cause old test data not to be
+   * cleaned up. This can cause issues when the data matches and the modules
+   * try to load it.
+   *
+   * See https://www.drupal.org/project/search_api_solr/issues/3218868.
+   */
+  public function onDatabaseLoaded() {
+    /** @var \Drupal\search_api\IndexInterface[] $indexes */
+    $indexes = \Drupal::service("entity_type.manager")
+      ->getStorage('search_api_index')
+      ->loadMultiple();
+
+    foreach ($indexes as $index_id => $index) {
+      /** @var \Drupal\search_api\ServerInterface $server */
+      $server = $index->getServerInstance();
+      $backend = $server->getBackend();
+      if (!$backend instanceof SearchApiSolrBackend) {
+        continue;
+      }
+      $connector = $backend->getSolrConnector();
+      $update_query = $connector->getUpdateQuery();
+      $update_query->addDeleteQuery("*:*");
+      $connector->update($update_query, $backend->getCollectionEndpoint($index));
+    }
+  }
+
+  /**
    * @Given Search indexes are up to date
    */
   public function updateSearchIndexes() {
-    /** @var \Drupal\search_api\Entity\SearchApiConfigEntityStorage $index_storage */
-    $index_storage = \Drupal::service("entity_type.manager")->getStorage('search_api_index');
+    // We use Drush here because it ensures that any settings that are in our
+    // test memory that might be outdated, don't affect what we're indexing.
+    $this->drushDriver->drush("search-api:index");
 
-    $indexes = $index_storage->loadMultiple();
-    if (!$indexes) {
-      return;
-    }
-
-    // Loop over all interfaces and let the Search API index any non-indexed
-    // items.
-    foreach ($indexes as $index) {
-      /** @var \Drupal\search_api\IndexInterface $index */
-      $index->indexItems();
-    }
+    // With the move to SOLR indexing has become asynchronous, so we must wait
+    // a small moment to ensure SOLR has actually settled.
+    // See also search_api_solr's own code in the commits linked for
+    // https://www.drupal.org/project/search_api_solr/issues/2940539.
+    sleep(1);
   }
 
   /**
@@ -45,6 +92,32 @@ class SearchContext extends RawMinkContext {
    */
   public function iSearchIndexForTerm($index, $term) {
     $this->getSession()->visit($this->locatePath('/search/' . $index . '/' . urlencode($term)));
+  }
+
+  /**
+   * Checks, that the search results contains specified text.
+   *
+   * Example: Then I should see "Who is the Batman?" in the search results.
+   * Example: And should see "Who is the Batman?" in the search results.
+   *
+   * @Then I should see :text in the search results
+   * @Then should see :text in the search results
+   */
+  public function assertSearchResultsContainsText($text) : void {
+    $this->assertSession()->elementTextContains("css", "#block-socialblue-content", $text);
+  }
+
+  /**
+   * Checks, that search results don't contain specified text.
+   *
+   * Example: Then I should not see "Who is the Batman?" in the search results.
+   * Example: And should not see "Who is the Batman?" in the search results.
+   *
+   * @Then I should not see :text in the search results
+   * @Then should not see :text in the search results
+   */
+  public function assertSearchResultsNotContainsText($text) {
+    $this->assertSession()->elementTextNotContains("css", "#block-socialblue-content", $text);
   }
 
 }


### PR DESCRIPTION
## Problem / Solution
When running tests backed by SOLR locally you may run into content still being in the SOLR database when the database gets reset. This is because our Behat test doesn’t clear out the SOLR database when a new MariaDB database is loaded, but we can easily do this with onDatabaseLoaded.

It can also be challenging when writing search Behat tests to make sure that text you’re searching for is part of the result set and doesn’t trigger on the search input or on a filter. For this we want to add two steps that actually look inside of the content region to exclude those other sections.

Finally we currently have a “are the search indexes up to date” step which has a custom implementation. However we can get the code for free by invoking Drush instead. That reduces the amount of code we need to maintain and ensures that if indexing changes in the Search API module we get those changes for free (assuming the Drush API doesn’t change).

## Issue tracker
https://getopensocial.atlassian.net/browse/PROD-27797

## Theme issue tracker
*[Required if applicable] Paste a link to the drupal.org theme issue queue item, either from [socialbase](https://www.drupal.org/project/socialbase) or [socialblue](https://www.drupal.org/project/socialblue). If any other issue trackers were used, include links to those too.*

## How to test
<!--
*[Required] For example*
- [ ] Using version X.Y.Z of Open Social with the example module enabled
- [ ] As a sitemanager
- [ ] Try to enable the option B on screen c/d/e
- [ ] When saving I expect the result to be F but instead see G.
- [ ] The expected result F is attained when repeating the steps with this fix applied.
-->

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
<!-- *[Required if new feature, and if applicable] If this Pull Request makes visual changes then please include some screenshots that show what has changed here. A before and after screenshot helps the reviewer determine what changes were made.* -->

## Release notes
<!-- *[Required if new feature, and if applicable] A short summary of the changes that were made that can be included in release notes.* -->

## Change Record
<!-- *[Required if applicable] If this Pull Request changes the way that developers should do things or introduces a new API for developers then a change record to document this is needed. Please provide a draft for a change record or a link to an unpublished change record below. Existing change records can be consulted as example. Please provide a draft for a change record or a link to an unpublished change record below. [Existing change records](https://www.drupal.org/list-changes/social) can be consulted as example.* -->

## Translations
<!--
*[Optional]Translatable strings are always extracted from the latest development branch. To ensure translations remain available for platforms running older versions of Open Social the original string should be added to `translations.php` when it's changed or removed.*
- [ ] Changed or removed source strings are added to the `translations.php` file.
-->
