### PR TITLE
Internal: Remove socialbase patches after release of 2.5.11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -98,10 +98,6 @@
                 "Ensure field definition allowed values callbacks are used for field filter callbacks": "https://www.drupal.org/files/issues/2020-06-03/2949022-12--views_filter_options_callback.patch",
                 "Selecting the same day in a date between filter returns no results": "https://www.drupal.org/files/issues/2021-05-05/date_between_2842409_2_d8.patch"
             },
-            "drupal/socialbase": {
-                "Ensure lazy_builders work": "https://git.drupalcode.org/project/socialbase/-/merge_requests/175.patch",
-                "Issue #3398140: CKEditor 5 isn't respecting width limit": "https://www.drupal.org/files/issues/2023-10-31/socialbase-ckeditor-width-is-not-respecting-3398140-2.patch"
-            },
             "drupal/url_embed": {
                 "Translate dialog title": "https://www.drupal.org/files/issues/2018-03-16/url_embed_translate_dialog_title-2953591-2.patch",
                 "Issue #3316376 - CKEditor 5 Support": "https://www.drupal.org/files/issues/2023-05-18/url_embed_ckeditor5_support.patch",


### PR DESCRIPTION
## Problem
We added some patches, which are now released as part of https://www.drupal.org/project/socialbase/releases/2.5.11
As we didn't lock our theme(s) they are automatically added and patches are failing builds.

## Solution
Remove them.

## Issue tracker
None - internal. 

## How to test
None - internal. 

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
<!-- *[Required if new feature, and if applicable] If this Pull Request makes visual changes then please include some screenshots that show what has changed here. A before and after screenshot helps the reviewer determine what changes were made.* -->

## Release notes
None - internal. 
