### PR TITLE
Issue #3410068: Behat tests falling during git-checks

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -98,10 +98,6 @@
                 "Ensure field definition allowed values callbacks are used for field filter callbacks": "https://www.drupal.org/files/issues/2020-06-03/2949022-12--views_filter_options_callback.patch",
                 "Selecting the same day in a date between filter returns no results": "https://www.drupal.org/files/issues/2021-05-05/date_between_2842409_2_d8.patch"
             },
-            "drupal/socialbase": {
-                "Ensure lazy_builders work": "https://git.drupalcode.org/project/socialbase/-/merge_requests/175.patch",
-                "Issue #3398140: CKEditor 5 isn't respecting width limit": "https://www.drupal.org/files/issues/2023-10-31/socialbase-ckeditor-width-is-not-respecting-3398140-2.patch"
-            },
             "drupal/url_embed": {
                 "Translate dialog title": "https://www.drupal.org/files/issues/2018-03-16/url_embed_translate_dialog_title-2953591-2.patch",
                 "Issue #3316376 - CKEditor 5 Support": "https://www.drupal.org/files/issues/2023-05-18/url_embed_ckeditor5_support.patch",

--- a/cspell.words.txt
+++ b/cspell.words.txt
@@ -9,6 +9,9 @@ behat
 dtstamp
 langcode
 langcodes
+TZNAME
+TZOFFSETTO
+TZOFFSETFROM
 # Behat EmailContext to define the host to catch mails.
 mailcatcher
 # Product ID attribute for the add to iCal (ICS) feature.

--- a/tests/behat/features/bootstrap/SocialDrupalContext.php
+++ b/tests/behat/features/bootstrap/SocialDrupalContext.php
@@ -496,22 +496,35 @@ class SocialDrupalContext extends DrupalContext {
     }
   }
 
-
   /**
-   * I wait (seconds) seconds for (field_name) (field_type) be rendered.
+   * I wait for (field_name) (field_type) be rendered.
    *
-   * @When /^(?:|I )wait "([^"]*)" seconds for "([^"]*)" "([^"]*)" field be rendered$/
+   * @When /^(?:|I )wait for "([^"]*)" "([^"]*)" field be rendered$/
    */
-  public function iWaitForTheFieldBeRender(string $seconds, string $field_name, string $field_type): void {
+  public function iWaitForTheFieldBeRender(string $field_name, string $field_type): void {
 
+    // Type of field accepted to be found.
     $types = [
       'link' => 'a[title',
       'input' => 'input[name',
     ];
 
+    // To avoid loop an infinite loop we create a countable and try to keep
+    // this function to be executed in max 60 seconds.
+    $check_count = 0;
+
+    // Field query-element to be found.
     $condition = sprintf("document.querySelectorAll('%s=\"%s\"]').length > 0", $types[$field_type], $field_name);
-    if (!$this->getSession()->getDriver()->wait(1000 * (int) $seconds, $condition)) {
-      throw new \Exception(sprintf("The %s field did not render within %s seconds.", $field_name, $seconds));
+
+    while (!$this->getSession()->getDriver()->wait(500, $condition)) {
+      // Each loop will wait 500 milliseconds, so when the countable arrived at
+      // 120 probably the script take about 60 seconds and this check will throw
+      // an exception with error.
+      if ($check_count === 120) {
+        throw new \Exception(sprintf("The %s field did not render within 60 seconds.", $field_name));
+      }
+
+      $check_count++;
     }
   }
 

--- a/tests/behat/features/bootstrap/SocialDrupalContext.php
+++ b/tests/behat/features/bootstrap/SocialDrupalContext.php
@@ -498,15 +498,20 @@ class SocialDrupalContext extends DrupalContext {
 
 
   /**
-   * I Wait for (field_name) field be rendered.
+   * I wait (seconds) seconds for (field_name) (field_type) be rendered.
    *
-   * @When /^(?:|I )wait for "([^"]*)" field be rendered$/
-   */  public function iWaitForTheFieldBeRender(string $field_name): void {
+   * @When /^(?:|I )wait "([^"]*)" seconds for "([^"]*)" "([^"]*)" field be rendered$/
+   */
+  public function iWaitForTheFieldBeRender(string $seconds, string $field_name, string $field_type): void {
 
-    $ajax_timeout = $this->getMinkParameter('ajax_timeout');
-    $condition = sprintf("document.querySelectorAll('[name=\"%s\"').length > 0", $field_name);
-    if (!$this->getSession()->getDriver()->wait(1000 * $ajax_timeout, $condition)) {
-      throw new \Exception(sprintf("The %s field did not render within $ajax_timeout seconds.", $field_name));
+    $types = [
+      'link' => 'a[title',
+      'input' => 'input[name',
+    ];
+
+    $condition = sprintf("document.querySelectorAll('%s=\"%s\"]').length > 0", $types[$field_type], $field_name);
+    if (!$this->getSession()->getDriver()->wait(1000 * (int) $seconds, $condition)) {
+      throw new \Exception(sprintf("The %s field did not render within %s seconds.", $field_name, $seconds));
     }
   }
 

--- a/tests/behat/features/bootstrap/SocialDrupalContext.php
+++ b/tests/behat/features/bootstrap/SocialDrupalContext.php
@@ -496,4 +496,18 @@ class SocialDrupalContext extends DrupalContext {
     }
   }
 
+
+  /**
+   * I Wait for (field_name) field be rendered.
+   *
+   * @When /^(?:|I )wait for "([^"]*)" field be rendered$/
+   */  public function iWaitForTheFieldBeRender(string $field_name): void {
+
+    $ajax_timeout = $this->getMinkParameter('ajax_timeout');
+    $condition = sprintf("document.querySelectorAll('[name=\"%s\"').length > 0", $field_name);
+    if (!$this->getSession()->getDriver()->wait(1000 * $ajax_timeout, $condition)) {
+      throw new \Exception(sprintf("The %s field did not render within $ajax_timeout seconds.", $field_name));
+    }
+  }
+
 }

--- a/tests/behat/features/capabilities/event/add-to-calendar.feature
+++ b/tests/behat/features/capabilities/event/add-to-calendar.feature
@@ -56,6 +56,7 @@ Feature: Add event to calendar
     And I wait for AJAX to finish
     When I click "Enroll as guest"
     And I wait for AJAX to finish
+    And I wait for "field_first_name" field be rendered
     And I fill in the following:
       | First name    | John         |
       | Last name     | Doe          |

--- a/tests/behat/features/capabilities/event/add-to-calendar.feature
+++ b/tests/behat/features/capabilities/event/add-to-calendar.feature
@@ -54,9 +54,10 @@ Feature: Add event to calendar
     And I am viewing the event "Walking in the park"
     When I click "Enroll"
     And I wait for AJAX to finish
+    And I wait "60" seconds for "Enroll as guest" "link" field be rendered
     When I click "Enroll as guest"
     And I wait for AJAX to finish
-    And I wait for "field_first_name" field be rendered
+    And I wait "60" seconds for "field_first_name" "input" field be rendered
     And I fill in the following:
       | First name    | John         |
       | Last name     | Doe          |

--- a/tests/behat/features/capabilities/event/add-to-calendar.feature
+++ b/tests/behat/features/capabilities/event/add-to-calendar.feature
@@ -54,10 +54,10 @@ Feature: Add event to calendar
     And I am viewing the event "Walking in the park"
     When I click "Enroll"
     And I wait for AJAX to finish
-    And I wait "60" seconds for "Enroll as guest" "link" field be rendered
+    And I wait for "Enroll as guest" "link" field be rendered
     When I click "Enroll as guest"
     And I wait for AJAX to finish
-    And I wait "60" seconds for "field_first_name" "input" field be rendered
+    And I wait for "field_first_name" "input" field be rendered
     And I fill in the following:
       | First name    | John         |
       | Last name     | Doe          |


### PR DESCRIPTION
## Problem
The behat tests related to anonymous-user enrolling to an event and downloading the calendar file is falling at git-checks and locally works perfectly.
The logs show the script trying to run before the modal/form be rendered.

## Solution
Create a new function to wait a field be rendered and throw an error when this fields isn't be rendered.

## Issue tracker
[PROD-27550](https://getopensocial.atlassian.net/browse/PROD-27550)
[#3410068](https://www.drupal.org/project/social/issues/3410068)

## Theme issue tracker
N/A

## How to test
This error is hardest to reproduce locally, usually it happen at git-checks probably because is a lazy environment.

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
N/A

## Release notes
N/A

## Change Record
N/A

## Translations
N/A


[PROD-27550]: https://getopensocial.atlassian.net/browse/PROD-27550?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ