### PR TITLE
Issue #3410322 by SV: Impossible to translate "ago" on the list of private messages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -65,7 +65,8 @@
                 "2924783 - Fatal error on entity autocomplete widget if entity label contains parentheses": "https://www.drupal.org/files/issues/2021-04-18/2924783-18.patch",
                 "Issue #3397494: Revert the runtime exception for permissions until we have fixed them all correctly": "https://www.drupal.org/files/issues/2023-10-29/3397494-revert-runtimeexception-untill-permissions-fixed.patch",
                 "States API doesn't work with multiple select fields": "https://www.drupal.org/files/issues/2023-10-31/states-api-doesnt-work-with-multiselect-fields-1149078-184.patch",
-                "Issue #3395358 - Redirecting a request during delete an entity when the redirect are disabled": "https://www.drupal.org/files/issues/2023-10-19/drupal-redirect-disable-validation-on-delete-entity-3395358-2.patch"
+                "Issue #3395358 - Redirecting a request during delete an entity when the redirect are disabled": "https://www.drupal.org/files/issues/2023-10-19/drupal-redirect-disable-validation-on-delete-entity-3395358-2.patch",
+                "Issue #3410322 - Impossible to translate 'ago' on the list of private messages": "https://www.drupal.org/files/issues/2023-12-20/translate-timestamp-ago-formatter-3410052-2.patch"
             },
             "drupal/dynamic_entity_reference": {
                 "Return the same content list after content type is changed": "https://www.drupal.org/files/issues/2021-08-27/dynamic_entity_reference-the_same_content_list-3230158-2.patch"


### PR DESCRIPTION
## Problem
<!-- *[Required] Describe the problem you're trying to solve, this should motivate why the changes you're proposing are needed.* -->
Currently, when we have a multilingual site we can't translate "Future format/Past format" for timestamp_ago formatter on the preview page of the private message list

## Solution
<!-- *[Required] Describe the solution you've created, elaborate on any technical choices you've made. Why is this the right solution and is a different solution not the right one? What is the reasoning behind the chosen solution?* -->
- Add a patch where FormattableMarkup is replaced with TranslatableMarkup that fixes the issue

## Issue tracker
<!-- *[Required] Paste a link to the drupal.org issue queue item. If any other issue trackers were used, include links to those too.* -->
- https://getopensocial.atlassian.net/browse/PROD-27560
- https://www.drupal.org/project/social/issues/3410322
- https://www.drupal.org/project/drupal/issues/3410052

## Theme issue tracker
<!--*[Required if applicable] Paste a link to the drupal.org theme issue queue item, either from [socialbase](https://www.drupal.org/project/socialbase) or [socialblue](https://www.drupal.org/project/socialblue). If any other issue trackers were used, include links to those too.*
-->
N/A

## How to test
- [ ] Using the latest version of Open Social with the social_private_message module enabled and added a few languages on the site
- [ ] As a sitemanager try to find and add translations for: "@interval hence" and "@interval ago"
- [ ] Log in as LU with different prefered language as default one
- [ ] When I open "/user/inbox" I expect to see translated "ago" and "hence" but instead see them in English.
- [ ] The expected result is attained when repeating the steps with this fix applied.

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
<!-- *[Required if new feature, and if applicable] If this Pull Request makes visual changes then please include some screenshots that show what has changed here. A before and after screenshot helps the reviewer determine what changes were made.* -->
Before:
<img width="1042" alt="Screenshot 2023-12-20 at 18 37 02" src="https://github.com/goalgorilla/open_social/assets/25609390/66a32c77-241c-4b39-85bd-6abc964e1864">

After:
<img width="1196" alt="Screenshot 2023-12-21 at 17 44 37" src="https://github.com/goalgorilla/open_social/assets/25609390/f13ca55a-bd8a-422f-b398-d0888389caea">
<img width="805" alt="Screenshot 2023-12-21 at 17 44 49" src="https://github.com/goalgorilla/open_social/assets/25609390/f86d560d-b8ca-486d-bd4c-91703da5ab97">

## Release notes
<!-- *[Required if new feature, and if applicable] A short summary of the changes that were made that can be included in release notes.* -->
Fixes the issue with untranslated "ago" on the private message list page

## Change Record
<!-- *[Required if applicable] If this Pull Request changes the way that developers should do things or introduces a new API for developers then a change record to document this is needed. Please provide a draft for a change record or a link to an unpublished change record below. Existing change records can be consulted as example. Please provide a draft for a change record or a link to an unpublished change record below. [Existing change records](https://www.drupal.org/list-changes/social) can be consulted as example.* -->
N/A

## Translations
<!--
*[Optional]Translatable strings are always extracted from the latest development branch. To ensure translations remain available for platforms running older versions of Open Social the original string should be added to `translations.php` when it's changed or removed.*
- [ ] Changed or removed source strings are added to the `translations.php` file.
-->
N/A
