### PR TITLE
Issue #3411006: Topic and Group type taxonomy permission missing

### DIFF
--- a/modules/social_features/social_group/modules/social_group_flexible_group/config/modify/social_group_flexible_group.authenticated_taxonomy_permissions.yml
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/config/modify/social_group_flexible_group.authenticated_taxonomy_permissions.yml
@@ -1,0 +1,13 @@
+dependencies:
+  module:
+    - taxonomy_access_fix
+items:
+  user.role.authenticated:
+    expected_config:
+      permissions: { }
+    update_actions:
+      add:
+        permissions:
+          - 'view terms in group_type'
+          - 'view term names in group_type'
+          - 'select terms in group_type'

--- a/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.info.yml
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.info.yml
@@ -19,5 +19,6 @@ dependencies:
   - social:social_topic
   - drupal:text
   - drupal:user
+  - config_modify:config_modify
 package: Social
 core_incompatible: false

--- a/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.install
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.install
@@ -41,3 +41,33 @@ function social_group_flexible_group_install() {
 function social_group_flexible_group_update_last_removed() : int {
   return 111103;
 }
+
+/**
+ * Add taxonomy permission with the Taxonomy Access Fix is enabled.
+ */
+function social_group_flexible_group_update_120001(): void {
+  // Nothing to do if the module is not installed.
+  if (!\Drupal::moduleHandler()->moduleExists("taxonomy_access_fix")) {
+    return;
+  }
+
+  // Permission to grant.
+  $taxonomy_permissions = [
+    'view terms in group_type',
+    'view term names in group_type',
+    'select terms in group_type',
+  ];
+
+  // Load the permission.
+  $entity_type_manager = \Drupal::entityTypeManager();
+  /** @var \Drupal\user\RoleInterface $role */
+  $role = $entity_type_manager->getStorage('user_role')->load('authenticated');
+
+  // If the role is not have the permission, grant permission.
+  foreach ($taxonomy_permissions as $taxonomy_permission) {
+    if (!$role->hasPermission($taxonomy_permission)) {
+      $role->grantPermission($taxonomy_permission);
+      $role->save();
+    }
+  }
+}

--- a/modules/social_features/social_topic/config/modify/social_topic.authenticated_taxonomy_permissions.yml
+++ b/modules/social_features/social_topic/config/modify/social_topic.authenticated_taxonomy_permissions.yml
@@ -1,0 +1,13 @@
+dependencies:
+  module:
+    - taxonomy_access_fix
+items:
+  user.role.authenticated:
+    expected_config:
+      permissions: { }
+    update_actions:
+      add:
+        permissions:
+          - 'view terms in topic_types'
+          - 'view term names in topic_types'
+          - 'select terms in topic_types'

--- a/modules/social_features/social_topic/social_topic.info.yml
+++ b/modules/social_features/social_topic/social_topic.info.yml
@@ -24,4 +24,5 @@ dependencies:
   - drupal:text
   - drupal:user
   - drupal:views
+  - config_modify:config_modify
 package: Social

--- a/modules/social_features/social_topic/social_topic.install
+++ b/modules/social_features/social_topic/social_topic.install
@@ -151,3 +151,33 @@ function social_topic_update_120001(): string {
   // Output logged messages to related channel of update execution.
   return $updater->logger()->output();
 }
+
+/**
+ * Add taxonomy permission with the Taxonomy Access Fix is enabled.
+ */
+function social_topic_update_120002(): void {
+  // Nothing to do if the module is not installed.
+  if (!\Drupal::moduleHandler()->moduleExists("taxonomy_access_fix")) {
+    return;
+  }
+
+  // Permission to grant.
+  $taxonomy_permissions = [
+    'view terms in topic_types',
+    'view term names in topic_types',
+    'select terms in topic_types',
+  ];
+
+  // Load the permission.
+  $entity_type_manager = \Drupal::entityTypeManager();
+  /** @var \Drupal\user\RoleInterface $role */
+  $role = $entity_type_manager->getStorage('user_role')->load('authenticated');
+
+  // If the role is not have the permission, grant permission.
+  foreach ($taxonomy_permissions as $taxonomy_permission) {
+    if (!$role->hasPermission($taxonomy_permission)) {
+      $role->grantPermission($taxonomy_permission);
+      $role->save();
+    }
+  }
+}

--- a/modules/social_features/social_topic/social_topic.install
+++ b/modules/social_features/social_topic/social_topic.install
@@ -157,7 +157,7 @@ function social_topic_update_120001(): string {
  */
 function social_topic_update_120002(): void {
   // Nothing to do if the module is not installed.
-  if (!\Drupal::moduleHandler()->moduleExists("taxonomy_access_fix")) {
+  if (!\Drupal::moduleHandler()->moduleExists('taxonomy_access_fix')) {
     return;
   }
 
@@ -174,10 +174,15 @@ function social_topic_update_120002(): void {
   $role = $entity_type_manager->getStorage('user_role')->load('authenticated');
 
   // If the role is not have the permission, grant permission.
+  $roleUpdated = FALSE;
   foreach ($taxonomy_permissions as $taxonomy_permission) {
     if (!$role->hasPermission($taxonomy_permission)) {
       $role->grantPermission($taxonomy_permission);
-      $role->save();
+      $roleUpdated = TRUE;
     }
+  }
+
+  if ($roleUpdated) {
+    $role->save();
   }
 }


### PR DESCRIPTION
## Problem
When the Taxonomy Access Fix module was enabled, the Topic and Group type don't be displayed as expected and this fields is mandatory to create new entities.

## Solution
Created a new configuration modify to add this permission when the Taxonomy Access Fix module are enable.

## Issue tracker
[PROD-27790](https://getopensocial.atlassian.net/browse/PROD-27790)
[#3411006](https://www.drupal.org/project/social/issues/3411006)

## Theme issue tracker
N/A

## How to test
- [ ] Install and enable Taxonomy Access Fix
- [ ] Enable Social Flexible Group
- [ ] Clear cache
- [ ] Try to create a Topic and Group
- [ ] I should be able to see the Type fields and be able to fill them

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
N/A

## Release notes
N/A

## Change Record
N/A

## Translations
N/A


[PROD-27790]: https://getopensocial.atlassian.net/browse/PROD-27790?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ