### PR TITLE
Internal: Automatically cancel PR workflows on new code pushes

### DIFF
--- a/.github/workflows/behat.yml
+++ b/.github/workflows/behat.yml
@@ -10,6 +10,14 @@ on:
       - main
       - "[0-9]+.[0-9]+.x"
 
+# We use the default concurrency grouping of allowing a single workflow per branch/PR/tag to run at the same time.
+# In case of PRs we only care about the results for the last workflow run, so we cancel workflows already in progress
+# when new code is pushed, in all other cases (branches/tags) we want to have a history for commits so it's easier to
+# find breakages when they occur (head_ref is non-empty only when the workflow is triggered from a PR).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.head_ref != '' }}
+
 # github.head_ref is only set when the workflow was triggered by a pull_request and it contains the value of the source branch of the PR.
 # github.ref_name will than only be used if the workflow was not triggered by a pull_request and it also just contains the branch name.
 env:

--- a/.github/workflows/bestPractices.yml
+++ b/.github/workflows/bestPractices.yml
@@ -7,6 +7,14 @@ name: Best practices
 on:
   pull_request: { }
 
+# We use the default concurrency grouping of allowing a single workflow per branch/PR/tag to run at the same time.
+# In case of PRs we only care about the results for the last workflow run, so we cancel workflows already in progress
+# when new code is pushed, in all other cases (branches/tags) we want to have a history for commits so it's easier to
+# find breakages when they occur (head_ref is non-empty only when the workflow is triggered from a PR).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.head_ref != '' }}
+
 defaults:
   run:
     shell: bash

--- a/.github/workflows/qualityChecks.yml
+++ b/.github/workflows/qualityChecks.yml
@@ -8,6 +8,14 @@ on:
       - main
       - "[0-9]+.[0-9]+.x"
 
+# We use the default concurrency grouping of allowing a single workflow per branch/PR/tag to run at the same time.
+# In case of PRs we only care about the results for the last workflow run, so we cancel workflows already in progress
+# when new code is pushed, in all other cases (branches/tags) we want to have a history for commits so it's easier to
+# find breakages when they occur (head_ref is non-empty only when the workflow is triggered from a PR).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.head_ref != '' }}
+
 jobs:
   setup:
     name: Project Setup


### PR DESCRIPTION
## Problem / Solution
If someone is rapidly iterating on a PR (e.g. because they're trying to fix a workflow) then the action queue can be filled with workflows for the same PR where we no longer care about any results except the last one.

This commit uses the default GitHub concurrency of 1 workflow per ref (branch/pr/tag). The concurrency group must be specified even though it's the default, otherwise cancel-in-progress would cancel all workflow runs rather than only the ones in the current group. In case the change is for a PR (head_ref is not empty) we cancel previous in progress workflows in the group.

See https://docs.github.com/en/actions/using-jobs/using-concurrency See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency

## Issue tracker
Internal CI change no issue

## Theme issue tracker
*[Required if applicable] Paste a link to the drupal.org theme issue queue item, either from [socialbase](https://www.drupal.org/project/socialbase) or [socialblue](https://www.drupal.org/project/socialblue). If any other issue trackers were used, include links to those too.*

## How to test
- [ ] Create a PR and push changes, see that the previous workflow runs for that PR are cancelled
- [ ] Push multiple commits separately to `main` or an `\d.\d.x` branch and see all workflows are executed sequentially.

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
<img width="1149" alt="image" src="https://github.com/goalgorilla/open_social/assets/327697/48bd1181-693c-406e-ab5e-885035ec583d">

Pushed a `git commit --amend` without changes to this PR to show that the cancelling works (Best practices finished before I could push).

## Release notes
<!-- *[Required if new feature, and if applicable] A short summary of the changes that were made that can be included in release notes.* -->

## Change Record
<!-- *[Required if applicable] If this Pull Request changes the way that developers should do things or introduces a new API for developers then a change record to document this is needed. Please provide a draft for a change record or a link to an unpublished change record below. Existing change records can be consulted as example. Please provide a draft for a change record or a link to an unpublished change record below. [Existing change records](https://www.drupal.org/list-changes/social) can be consulted as example.* -->

## Translations
<!--
*[Optional]Translatable strings are always extracted from the latest development branch. To ensure translations remain available for platforms running older versions of Open Social the original string should be added to `translations.php` when it's changed or removed.*
- [ ] Changed or removed source strings are added to the `translations.php` file.
-->
