### PR TITLE
Issue #3410565: Disable email notification in the Invited to join a group message template

### DIFF
--- a/modules/social_features/social_event/modules/social_event_invite/config/install/message.template.invite_event_enrollment.yml
+++ b/modules/social_features/social_event/modules/social_event_invite/config/install/message.template.invite_event_enrollment.yml
@@ -14,7 +14,6 @@ third_party_settings:
     activity_context: event_invite_activity_context
     activity_destinations:
       notifications: notifications
-      email: email
     activity_create_direct: false
     activity_aggregate: false
     activity_entity_condition: ''

--- a/modules/social_features/social_event/modules/social_event_invite/config/update/social_event_invite_update_12001.yml
+++ b/modules/social_features/social_event/modules/social_event_invite/config/update/social_event_invite_update_12001.yml
@@ -1,0 +1,7 @@
+message.template.invite_event_enrollment:
+  expected_config: { }
+  update_actions:
+    delete:
+      activity_logger:
+        activity_destinations:
+          email: { }

--- a/modules/social_features/social_event/modules/social_event_invite/social_event_invite.install
+++ b/modules/social_features/social_event/modules/social_event_invite/social_event_invite.install
@@ -224,3 +224,17 @@ function social_event_invite_update_11402(): void {
     $configuration->save();
   }
 }
+
+/**
+ * Disable mail notification for message template .
+ */
+function social_event_invite_update_12001(): string {
+  /** @var \Drupal\update_helper\Updater $updateHelper */
+  $updateHelper = \Drupal::service('update_helper.updater');
+
+  // Execute configuration update definitions with logging of success.
+  $updateHelper->executeUpdate('social_event_invite', __FUNCTION__);
+
+  // Output logged messages to related channel of update execution.
+  return $updateHelper->logger()->output();
+}


### PR DESCRIPTION
## Problem
When you invite a user to an event, the user gets 2 e-mails. This looks like a bug, as the user is supposed to only receive one e-mail.
First, the user receives the correct e-mail. Then the user receives a default system e-mail (after running cron).

## Solution
Disable email notification for the event invite message template and keep only one configurable by Site Manager in the Event invite settings.

## Issue tracker
- https://getopensocial.atlassian.net/browse/PROD-26510
- https://www.drupal.org/project/social/issues/3410565

## Theme issue tracker
N/A

## How to test
- [ ] Invite a user to an event using the user name
- [ ] Check emails 


## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
N/A

## Release notes
Disable duplicated email notifications for the event invite message template and keep only one configurable by the Site Manager in the Event invite settings.

## Change Record
N/A

## Translations
N/A
