### PR TITLE
Issue #3412327 by nkoporec: Uncaught PHP Exception Error: "Call to a member function access() on null"

### DIFF
--- a/modules/custom/activity_creator/src/ActivityAccessControlHandler.php
+++ b/modules/custom/activity_creator/src/ActivityAccessControlHandler.php
@@ -105,12 +105,16 @@ class ActivityAccessControlHandler extends EntityAccessControlHandler implements
       $ref_entity_type = $related_object['0']['target_type'];
       $ref_entity_id = $related_object['0']['target_id'];
       try {
-        /** @var \Drupal\Core\Entity\EntityInterface $ref_entity */
+        /** @var \Drupal\Core\Entity\EntityInterface|null $ref_entity */
         $ref_entity = $this->entityTypeManager->getStorage($ref_entity_type)
           ->load($ref_entity_id);
       }
       catch (InvalidPluginDefinitionException | PluginNotFoundException $e) {
         return AccessResult::neutral(sprintf('No opinion on access due to: %s', $e->getMessage()));
+      }
+
+      if (!$ref_entity) {
+        return AccessResult::neutral('No opinion on access due to: no related entity found');
       }
 
       return AccessResult::allowedIf($ref_entity->access($operation, $account));


### PR DESCRIPTION
## Problem
We have encountered a WSOD page when visiting a regular members profile as a SM. The error was

```
Uncaught PHP Exception Error: "Call to a member function access() on null" at /app/html/profiles/contrib/social/modules/custom/activity_creator/src/ActivityAccessControlHandler.php line 116
```
## Solution
Currently activity_creator/src/ActivityAccessControlHandler.php we not gracefully handling if the related entity does not exist. We always assume that it is there, so we should add a check that verifies that the related entity indeed exists before calling a method.


## Issue tracker
https://www.drupal.org/project/social/issues/3412327

## Theme issue tracker
*[Required if applicable] Paste a link to the drupal.org theme issue queue item, either from [socialbase](https://www.drupal.org/project/socialbase) or [socialblue](https://www.drupal.org/project/socialblue). If any other issue trackers were used, include links to those too.*

## How to test
I don't have an exact steps to reproduce, but the issue should occur if a certain reference activity is deleted and thus the access check throws an errror.

Test that there is no WSOD when visiting users profiles.

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
<!-- *[Required if new feature, and if applicable] If this Pull Request makes visual changes then please include some screenshots that show what has changed here. A before and after screenshot helps the reviewer determine what changes were made.* -->

## Release notes
<!-- *[Required if new feature, and if applicable] A short summary of the changes that were made that can be included in release notes.* -->

## Change Record
Fixed an issue when visiting a members profile would throw a WSOD.

## Translations
<!--
*[Optional]Translatable strings are always extracted from the latest development branch. To ensure translations remain available for platforms running older versions of Open Social the original string should be added to `translations.php` when it's changed or removed.*
- [ ] Changed or removed source strings are added to the `translations.php` file.
-->
