### PR TITLE
Internal: Remove fixed errors from baseline

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -531,16 +531,6 @@ parameters:
 			path: modules/custom/activity_creator/src/Controller/NotificationsController.php
 
 		-
-			message: "#^Call to an undefined method Drupal\\\\Core\\\\Entity\\\\EntityInterface\\:\\:getVotedEntityId\\(\\)\\.$#"
-			count: 1
-			path: modules/custom/activity_creator/src/Entity/Activity.php
-
-		-
-			message: "#^Call to an undefined method Drupal\\\\Core\\\\Entity\\\\EntityInterface\\:\\:getVotedEntityType\\(\\)\\.$#"
-			count: 1
-			path: modules/custom/activity_creator/src/Entity/Activity.php
-
-		-
 			message: "#^Cannot call method getFlaggableId\\(\\) on Drupal\\\\flag\\\\Entity\\\\Flagging\\|null\\.$#"
 			count: 1
 			path: modules/custom/activity_creator/src/Entity/Activity.php


### PR DESCRIPTION
## Problem
Our PHPStan is failing in main.
Seems to be because of a recent phpstan update, which we don't lock.

## Solution
Removed the ignored errors.

## Issue tracker
None: internal.

## How to test
See PHPStan pass.

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Release notes
Fix PHPStan, removing from baseline is always nice!

