### PR TITLE
Internal: Ensure Behat tests abort if updates fail with requirements errors

### DIFF
--- a/.github/workflows/behat.yml
+++ b/.github/workflows/behat.yml
@@ -247,18 +247,18 @@ jobs:
           drush cset symfony_mailer.mailer_transport.sendmail configuration.host 'mailcatcher' -y
           drush cset symfony_mailer.mailer_transport.sendmail configuration.port '1025' -y
 
-          # Ensure there are no warnings in the update.log
-          if grep -E '^>\s+\[warning\]\s' update.log 1>/dev/null; then
-            # Move the update.log with warnings and status messages to the test output. The text is viewable on GitHub
-            # too but some people might find it easier to just download the artifact and get digging.
+          # Ensure there are no warnings or requirements errors in the update.log
+          if grep -E '^>\s+\[warning\]\s' update.log 1>/dev/null || grep 'Requirements check reports errors. Do you wish to continue?' update.log 1>/dev/null; then
+            # Move the update.log with warnings/errors and status messages to the test output. The text is viewable on
+            # GitHub too but some people might find it easier to just download the artifact and get digging.
             if [[ "${{ matrix.with_optional }}" == "with-optional" ]]; then
               mv update.log behat-test-output/update-with-optional.log
             else
               mv update.log behat-test-output/update.log
             fi
 
-            # Abort our testing until the warning is fixed and let our user know why we stopped.
-            echo "The drush output should not contain any warnings"
+            # Abort our testing until the warning/error is fixed and let our user know why we stopped.
+            echo "The drush output should not contain any warnings or requirements errors"
             exit 1
           fi
 

--- a/tests/behat/features/bootstrap/DatabaseContext.php
+++ b/tests/behat/features/bootstrap/DatabaseContext.php
@@ -193,7 +193,13 @@ class DatabaseContext implements Context {
    * @When I run pending updates
    */
   public function executeUpdates() : void {
-    $this->drushDriver->drush("updatedb", ['-y']);
+    $output = $this->drushDriver->drush("updatedb", ['-y']);
+    // @todo Drush requires -y to continue running updates when the list of updates are presented but -y also bypasses
+    // the question about requirements check errors so we must manually check for the output until a better solutions is
+    // found in https://github.com/drush-ops/drush/issues/5806.
+    if (str_contains($output, "Requirements check reports errors. Do you wish to continue?")) {
+      throw new \Exception("The update showed requirement errors, manually run the updates using drush against the fixture used for the test to find the errors.");
+    }
   }
 
   /**


### PR DESCRIPTION
## Problem
Drush requires the -y flag to run in automated environments because it prompts with the list of available updates. However it also does an update requirements check which gets skipped by the same -y option.

This means that our update path in the CI doesn't fail if there are requirements errors (even though it should, because it causes errors later in tests that are hard to debug) and our tests against fixture dumps for specific update scenarios also don't fail.

## Solution
Until Drush provides a better solution in
https://github.com/drush-ops/drush/issues/5806. We manually go through the update output and errors if the key sentence for requirements errors is spotted.

## Issue tracker
Internal no issue

## Theme issue tracker
*[Required if applicable] Paste a link to the drupal.org theme issue queue item, either from [socialbase](https://www.drupal.org/project/socialbase) or [socialblue](https://www.drupal.org/project/socialblue). If any other issue trackers were used, include links to those too.*

## How to test
<!--
*[Required] For example*
- [ ] Using version X.Y.Z of Open Social with the example module enabled
- [ ] As a sitemanager
- [ ] Try to enable the option B on screen c/d/e
- [ ] When saving I expect the result to be F but instead see G.
- [ ] The expected result F is attained when repeating the steps with this fix applied.
-->

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
<!-- *[Required if new feature, and if applicable] If this Pull Request makes visual changes then please include some screenshots that show what has changed here. A before and after screenshot helps the reviewer determine what changes were made.* -->

## Release notes
<!-- *[Required if new feature, and if applicable] A short summary of the changes that were made that can be included in release notes.* -->

## Change Record
<!-- *[Required if applicable] If this Pull Request changes the way that developers should do things or introduces a new API for developers then a change record to document this is needed. Please provide a draft for a change record or a link to an unpublished change record below. Existing change records can be consulted as example. Please provide a draft for a change record or a link to an unpublished change record below. [Existing change records](https://www.drupal.org/list-changes/social) can be consulted as example.* -->

## Translations
<!--
*[Optional]Translatable strings are always extracted from the latest development branch. To ensure translations remain available for platforms running older versions of Open Social the original string should be added to `translations.php` when it's changed or removed.*
- [ ] Changed or removed source strings are added to the `translations.php` file.
-->
