### PR TITLE
Issue #3415090 by nkoporec: SocialProfileTagSplitWidget is not being rendered if the #options is empty

### DIFF
--- a/modules/social_features/social_profile/src/Plugin/Field/FieldWidget/SocialProfileTagSplitWidget.php
+++ b/modules/social_features/social_profile/src/Plugin/Field/FieldWidget/SocialProfileTagSplitWidget.php
@@ -57,10 +57,13 @@ class SocialProfileTagSplitWidget extends Select2EntityReferenceWidget {
     // Do not render field if no options or not active.
     if (
       !$this->profileTagService->isActive() ||
-      !$this->profileTagService->hasContent() ||
-      empty($element['#options'])
+      !$this->profileTagService->hasContent()
     ) {
       return [];
+    }
+
+    if (empty($element['#options'])) {
+      return $element;
     }
 
     // Only for fields related to taxonomy terms.


### PR DESCRIPTION
## Problem
We want to programetically render a form that contains that uses the SocialProfileTagSplitWidget widget, the #options array is populated later (after rendering the initial form). The problem is that the field is not being rendered correctly as within the widget we are returning an empty array if there are no #options. I think this should not be the case and the widget should return the basic structure of the element.


## Solution
Don't return an empty array if the #options are empty but rather return the already build element array.

## Issue tracker
https://www.drupal.org/project/social/issues/3415090

## Theme issue tracker
<!-- *[Required if applicable] Paste a link to the drupal.org theme issue queue item, either from [socialbase](https://www.drupal.org/project/socialbase) or [socialblue](https://www.drupal.org/project/socialblue). If any other issue trackers were used, include links to those too.* -->

## How to test
1. Create a form that uses SocialProfileTagSplitWidget
2. Try to render the form programetically but don't populate the #options of the widget.
3. Render the form and check if the widget is rendered.


## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
<!-- *[Required if new feature, and if applicable] If this Pull Request makes visual changes then please include some screenshots that show what has changed here. A before and after screenshot helps the reviewer determine what changes were made.* -->

## Release notes
<!-- *[Required if new feature, and if applicable] A short summary of the changes that were made that can be included in release notes.* -->

## Change Record
Fixed an issue with SocialProfileTagSplitWidget when the widget was not being rendered correctly if the #options were empty.

## Translations
<!--
*[Optional]Translatable strings are always extracted from the latest development branch. To ensure translations remain available for platforms running older versions of Open Social the original string should be added to `translations.php` when it's changed or removed.*
- [ ] Changed or removed source strings are added to the `translations.php` file.
-->
