### PR TITLE
Internal: Update tugboat with symfony mailer config in settings.local.php

### DIFF
--- a/.tugboat/config.yml
+++ b/.tugboat/config.yml
@@ -70,11 +70,6 @@ services:
           pmu social_demo
         # Change file owner again because of the way demo content is copied.
         chown -R www-data:www-data $DOCROOT
-        # Ensure SMPT gets created for Symfony mailer, the settings are taken
-        # care off in our settings.local.php, but we need to have the plugin created.
-        ../vendor/bin/drush \
-        --yes \
-        cset symfony_mailer.mailer_transport.sendmail plugin 'smtp'
       build: |
         cd $DOCROOT/..
         export BRANCH_NAME=$([ "$TUGBOAT_PREVIEW_TYPE" = "pullrequest" ] && echo "$TUGBOAT_GITHUB_HEAD" || echo "$TUGBOAT_PREVIEW_REF")

--- a/.tugboat/config.yml
+++ b/.tugboat/config.yml
@@ -70,6 +70,11 @@ services:
           pmu social_demo
         # Change file owner again because of the way demo content is copied.
         chown -R www-data:www-data $DOCROOT
+        # Ensure SMPT gets created for Symfony mailer, the settings are taken
+        # care off in our settings.local.php, but we need to have the plugin created.
+        ../vendor/bin/drush \
+        --yes \
+        cset symfony_mailer.mailer_transport.sendmail plugin 'smtp'
       build: |
         cd $DOCROOT/..
         export BRANCH_NAME=$([ "$TUGBOAT_PREVIEW_TYPE" = "pullrequest" ] && echo "$TUGBOAT_GITHUB_HEAD" || echo "$TUGBOAT_PREVIEW_REF")

--- a/.tugboat/settings.local.php
+++ b/.tugboat/settings.local.php
@@ -27,8 +27,11 @@ $settings['hash_salt'] = hash('sha256', getenv('TUGBOAT_REPO_ID'));
 $settings['deployment_identifier'] = getenv('TUGBOAT_PREVIEW_ID');
 
 // Send e-mail using Tugboat's SMTP server so they are captured.
-$config['swiftmailer.transport']['transport'] = 'smtp';
-$config['swiftmailer.transport']['smtp_host'] = getenv('TUGBOAT_SMTP');
+$config['symfony_mailer.mailer_transport.sendmail']['plugin'] = 'smtp';
+$config['symfony_mailer.mailer_transport.sendmail']['configuration']['user'] = '';
+$config['symfony_mailer.mailer_transport.sendmail']['configuration']['pass'] = '';
+$config['symfony_mailer.mailer_transport.sendmail']['configuration']['port'] = '587';
+$config['symfony_mailer.mailer_transport.sendmail']['configuration']['host'] = getenv('TUGBOAT_SMTP');
 
 // Set a config sync directory to stop Drupal from showing us errors.
 $settings['config_sync_directory'] = "/var/www/config/sync";


### PR DESCRIPTION
## Problem
After moving to symfony mailer we need to make sure the correct settings are also provided for tugboat.

## Solution
Update the config for tugboat and add a similar config object like this:

## Issue tracker
Internal

## How to test
See tugboat catches mail again.

![Screenshot 2024-01-20 at 08 55 12](https://github.com/goalgorilla/open_social/assets/16667281/33befb96-6861-4bd6-bafd-976ca60f9346)


## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

