### PR TITLE
Issue #3416247: Add optional string and phone number GraphQL input types

### DIFF
--- a/modules/custom/social_graphql/graphql/open_social.graphqls
+++ b/modules/custom/social_graphql/graphql/open_social.graphqls
@@ -325,3 +325,27 @@ The base GraphQL Response class
 interface Response {
   errors: [Violation]
 }
+
+"""
+An optional string.
+
+Used on input fields that require discerning between not-updating the field value and setting the field to NULL.
+"""
+# This type should only be used as a last resort in case you're building system-to-system APIs where a partial update is important.
+# You most likely want a simple nullable scalar, or to implement multiple more focused mutations.
+input OptionalString {
+  value: String
+}
+
+"""
+An optional phone number.
+
+Must be a valid phone number in the format `[+country-prefix]<number>`.
+
+Used on input fields that require discerning between not-updating the field value and setting the field to NULL.
+"""
+# This type should only be used as a last resort in case you're building system-to-system APIs where a partial update is important.
+# You most likely want a simple nullable scalar, or to implement multiple more focused mutations.
+input OptionalPhoneNumber {
+  value: PhoneNumber
+}


### PR DESCRIPTION
## Problem
For system-to-system APIs an external system will usually want to push some kind of update for data it knows has changed (e.g. perhaps it manages address information for users) without changing anything else. 

These changes should happen as a single efficient transaction to ensure data doesn’t end up in an unknown state, this excludes splitting mutations on a per-field level, since they’re executed independently. Additionally it’s not feasible for external systems to first request existing data because this might cause race conditions (whether those race conditions are a problem for user-facing applications is feature/application specific but because it’s a user initiated action this is much less likely a problem because the user sees the info they intend to submit).

To meet these design criteria we introduce an Optional* input type that wraps another scalar type (e.g. String or PhoneNumber) which can be NULL. This custom input type can then be used in mutations intended for system-to-system interaction and distinguish between “I don’t care about this field” omitting the Optional* type or “I want to set this field to empty”: sending an Optional* type input containing NULL.

## Solution
These types can be used in system to system API design to distinguish between a field that a system doesn't want to change or a field that should be changed to the empty value (NULL).

For now we only need String and PhoneNumber, we don't have this need for other scalar or more complex types yet.

## Issue tracker
https://getopensocial.atlassian.net/browse/PROD-28057
Drupal.org issue: https://www.drupal.org/project/social/issues/3416247
## Theme issue tracker
<!-- *[Required if applicable] Paste a link to the drupal.org theme issue queue item, either from [socialbase](https://www.drupal.org/project/socialbase) or [socialblue](https://www.drupal.org/project/socialblue). If any other issue trackers were used, include links to those too.* -->

## How to test
- [ ] Schema should validate

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
<!-- *[Required if new feature, and if applicable] If this Pull Request makes visual changes then please include some screenshots that show what has changed here. A before and after screenshot helps the reviewer determine what changes were made.* -->

## Release notes
Open Social has introduced two GraphQL input types in the form of `OptionalPhoneNumber` and `OptionalString` which can be used when designing system-to-system mutations in GraphQL where it's important to distinguish between "Don't want to update" and "Should update to NULL". These types are not yet used in any public schemas.

## Change Record
<!-- *[Required if applicable] If this Pull Request changes the way that developers should do things or introduces a new API for developers then a change record to document this is needed. Please provide a draft for a change record or a link to an unpublished change record below. Existing change records can be consulted as example. Please provide a draft for a change record or a link to an unpublished change record below. [Existing change records](https://www.drupal.org/list-changes/social) can be consulted as example.* -->

## Translations
<!--
*[Optional]Translatable strings are always extracted from the latest development branch. To ensure translations remain available for platforms running older versions of Open Social the original string should be added to `translations.php` when it's changed or removed.*
- [ ] Changed or removed source strings are added to the `translations.php` file.
-->
