### PR TITLE
Issue #3380714: Adjust tests for old group types

### DIFF
--- a/tests/behat/features/bootstrap/GroupContext.php
+++ b/tests/behat/features/bootstrap/GroupContext.php
@@ -68,8 +68,8 @@ class GroupContext extends RawMinkContext {
    *
    * Creates group of a given type provided in the form:
    * | author | title      | description     | author   | type        | language | field_group_allowed_visibility |
-   * | user-1 | My title 1 | My description  | username | open_group  | en       | public                         |
-   * | user-1 | My title 2 | My description  | username | open_group  | en       | public,community,group         |
+   * | user-1 | My title 1 | My description  | username | flexible_group  | en       | public                         |
+   * | user-1 | My title 2 | My description  | username | flexible_group  | en       | public,community,group         |
    * | ...    | ...        | ...             | ...      | ...         | ...      | ...                            |
    *
    * @Given groups:
@@ -86,7 +86,7 @@ class GroupContext extends RawMinkContext {
    *
    * Creates group of a given type provided in the form:
    * | title    | description     | author   | type        | language
-   * | My title | My description  | username | open_group  | en
+   * | My title | My description  | username | flexible_group  | en
    * | ...      | ...             | ...      | ...         | ...
    *
    * @Given groups with non-anonymous owner:
@@ -123,7 +123,7 @@ class GroupContext extends RawMinkContext {
    *
    * Creates group of a given type provided in the form:
    * | title    | description     | author   | type        | language
-   * | My title | My description  | username | open_group  | en
+   * | My title | My description  | username | flexible_group  | en
    * | ...      | ...             | ...      | ...         | ...
    *
    * @Given groups owned by current user:
@@ -187,9 +187,6 @@ class GroupContext extends RawMinkContext {
    */
   public function whenICreateAGroupUsingTheForm(string $group_type, TableNode $fields): void {
     $group_types = [
-      'public' => 'public_group',
-      'open' => 'open_group',
-      'closed' => 'closed_group',
       'flexible' => 'flexible_group',
     ];
     $group_type_selector = $group_types[$group_type] ?? NULL;

--- a/tests/behat/features/capabilities/event-management/event-management.feature
+++ b/tests/behat/features/capabilities/event-management/event-management.feature
@@ -1,4 +1,4 @@
-@api @event-management @stability @javascript @DS-1258 @stability-2
+@api @javascript
 Feature: Event Management
   Benefit: In order to organise an event
   Role: As a Verified
@@ -16,13 +16,13 @@ Feature: Event Management
       | event_organiser_1 | eo_1@example.com | GoalGorilla                | 1      | verified |
       | event_organiser_2 | eo_2@example.com | Drupal                     | 1      | verified |
     And groups:
-      | label                                    | field_group_description | author            | type        | langcode |
-      | Springfield local business collaboration | Description text        | event_organiser_1 | open_group  | en       |
+      | label                                    | field_group_description | author            | type           | field_flexible_group_visibility | field_group_allowed_join_method | field_group_allowed_visibility | langcode |
+      | Springfield local business collaboration | Description text        | event_organiser_1 | flexible_group | public                          | direct                          | community                      | en       |
     And I am logged in as an "verified"
     And I am on "user"
     And I click "Events"
     And I click "Create Event"
-    When I fill in the following:
+    And I fill in the following:
       | Title                                  | This is an event with event organisers |
       | edit-field-event-date-0-value-date     | 2025-01-01                             |
       | edit-field-event-date-end-0-value-date | 2025-01-01                             |
@@ -36,20 +36,20 @@ Feature: Event Management
     And I wait for AJAX to finish
     And I fill in "event_organiser_2" for "field_event_managers[1][target_id]"
     And I press "Create event"
-    Then I should see "This is an event with event organisers has been created."
+    And I should see "This is an event with event organisers has been created."
     And I should see "THIS IS AN EVENT WITH EVENT ORGANISERS"
     And I should see "Body description text" in the "Main content"
     And I should see "Organisers"
     And I should not see the link "All Organisers"
 
     # Create event in group.
-    Given I am on "all-groups"
+    And I am on "all-groups"
     And I click "Springfield local business collaboration"
     And I click "Join"
     And I press "Join group"
     And I click "Events"
     And I click "Create Event"
-    When I fill in the following:
+    And I fill in the following:
       | Title                                  | This is an event with event organisers in group |
       | edit-field-event-date-0-value-date     | 2025-01-01                                      |
       | edit-field-event-date-end-0-value-date | 2025-01-01                                      |
@@ -66,37 +66,37 @@ Feature: Event Management
     And I should see "This is an event with event organisers in group"
 
     # Now test with event_organiser_1
-    Given I logout
+    And I logout
     And I am logged in as "event_organiser_1"
     And I open the "event" node with title "This is an event with event organisers"
     And I click "Edit content"
-    Then I should see "Save"
+    And I should see "Save"
     And I should not see "Authoring information"
 
-    Given I open the "event" node with title "This is an event with event organisers in group"
+    And I open the "event" node with title "This is an event with event organisers in group"
     And I click "Edit content"
-    Then I should see "Save"
+    And I should see "Save"
     And I should not see "Authoring information"
 
     # Now test with event_organiser_2
-    Given I logout
+    And I logout
     And I am logged in as "event_organiser_2"
     And I open the "event" node with title "This is an event with event organisers"
     And I click "Edit content"
-    Then I should see "Save"
+    And I should see "Save"
     And I should not see "Authoring information"
 
-    Given I open the "event" node with title "This is an event with event organisers in group"
+    And I open the "event" node with title "This is an event with event organisers in group"
     And I click "Edit content"
-    Then I should see "Save"
+    And I should see "Save"
     And I should not see "Authoring information"
 
     # Regression test for topic
-    Given "topic" content:
+    And "topic" content:
       | title                   | body          |
       | Topic regression test   | Description   |
     And I open the "topic" node with title "Topic regression test"
-    Then I should not see "Organisers"
+    And I should not see "Organisers"
 
 
   Scenario: Ensure, that if we have several translations of the event, the enrollees and organisers are not duplicated
@@ -109,7 +109,7 @@ Feature: Event Management
     And I press "Add language"
     And I wait for AJAX to finish
 
-    Given I am viewing my event:
+    And I am viewing my event:
       | title                    | My awesome event |
       | body                     | Body text        |
       | field_event_date         | +7 days          |
@@ -127,15 +127,15 @@ Feature: Event Management
     And I press "Save"
 
     # Enroll for event
-    When I press the "Enroll" button
+    And I press the "Enroll" button
     And I wait for AJAX to finish
-    Then I should see the text "Meetup: My awesome event" in the "Modal"
+    And I should see the text "Meetup: My awesome event" in the "Modal"
     And I press the "Close" button
 
     # Add translation for this event.
     And I should see "Translate"
-    When I click "Translate"
-    Then I should see "Dutch"
+    And I click "Translate"
+    And I should see "Dutch"
     And I should see "Not translated"
     And I should see "Add"
     And I click "Add"
@@ -143,9 +143,8 @@ Feature: Event Management
 
     # Check if enrollees aren't duplicated.
     And I should see "1 people have enrolled"
-    When I click "Manage enrollments"
-    Then I should see "1 Enrollees"
+    And I click "Manage enrollments"
+    And I should see "1 Enrollees"
     # Check if organisers aren't duplicated.
-    When I click "Organisers"
-    Then I should see "Ryan Gosling" exactly "1" times
-
+    And I click "Organisers"
+    And I should see "Ryan Gosling" exactly "1" times

--- a/tests/behat/features/capabilities/groups/groups-mute-notify.feature
+++ b/tests/behat/features/capabilities/groups/groups-mute-notify.feature
@@ -1,4 +1,4 @@
-@api @notifications @group @DS-7598 @stability @stability-3 @group-mute-group-notifications @no-update
+@api @no-update
 Feature: Mute/Unmute group notifications
   Benefit: In order to be able to get more fine grained control about notifications which I find relative to me
   Role: As a LU
@@ -9,92 +9,93 @@ Feature: Mute/Unmute group notifications
       | name     | pass | mail                 | status | roles       |
       | dude_1st | 1234 | dude_1st@example.com | 1      | verified    |
       | dude_2nd | 1234 | dude_1st@example.com | 1      | sitemanager |
-    Given groups:
-      | label                | field_group_description | author       | type           | langcode |
-      | Ressinel's group 1st | Good nickname, dude!!!  | dude_1st     | open_group     | en       |
-      | Ressinel's group 2nd | Good nickname, dude!!!  | dude_1st     | closed_group   | en       |
+    And groups:
+      | label                | field_group_description | author   | type           | field_flexible_group_visibility | field_group_allowed_join_method | langcode |
+      | Ressinel's group 1st | Good nickname, dude!!!  | dude_1st | flexible_group | public                          | direct                          | en       |
+      | Ressinel's group 2nd | Good nickname, dude!!!  | dude_1st | flexible_group | community                       | added                           | en       |
 
   @group-mute-group-notifications-group-page
   Scenario: LU able to mute/umute group notifications
     Given I am logged in as "dude_1st"
-      And I am on "/my-groups"
-    Then I should see "Ressinel's group 1st" in the "Main content"
-      And I click "Ressinel's group 1st"
-    Then I should see the button "Joined"
-      And I press "Joined"
-      And I should see the link "Mute group"
-    When I click "Mute group"
-      And I wait for AJAX to finish
-    Then I should see "Unmute group"
-    When I click "Unmute group"
-      And I wait for AJAX to finish
-    Then I should see "Mute group"
+    And I am on "/my-groups"
+    And I should see "Ressinel's group 1st" in the "Main content"
+    And I click "Ressinel's group 1st"
+    And I should see the button "Joined"
+    And I press "Joined"
+    And I should see the link "Mute group"
+    And I click "Mute group"
+    And I wait for AJAX to finish
+    And I should see "Unmute group"
+    And I click "Unmute group"
+    And I wait for AJAX to finish
+    And I should see "Mute group"
 
   @group-mute-group-notifications-overview-page
   Scenario: LU able to view all Groups muted
     Given I am logged in as "dude_1st"
-      And I am on "/my-groups"
-    Then I should see "Ressinel's group 1st" in the "Main content"
-      And I click "Ressinel's group 1st"
-    Then I should see the button "Joined"
-      And I press "Joined"
-      And I should see the link "Mute group"
+    And I am on "/my-groups"
+    And I should see "Ressinel's group 1st" in the "Main content"
+    And I click "Ressinel's group 1st"
+    And I should see the button "Joined"
+    And I press "Joined"
+    And I should see the link "Mute group"
+
     When I click "Mute group"
-      And I wait for AJAX to finish
-    Then I should see "Unmute group"
-    When I am on "/my-groups"
-    Then I should see "Ressinel's group 2nd"
-    When I select "My muted groups" from "Muted groups"
-      And I press the "Filter" button
-    Then I should not see "Ressinel's group 2nd"
-      But I should see "Ressinel's group 1st"
-    When I select "My unmuted groups" from "Muted groups"
-      And I press the "Filter" button
-    Then I should not see "Ressinel's group 1st"
-      But I should see "Ressinel's group 2nd"
-    When I press the "Reset" button
-    Then I should see "Ressinel's group 1st"
-      And I should see "Ressinel's group 2nd"
+    And I wait for AJAX to finish
+    And I should see "Unmute group"
+    And I am on "/my-groups"
+    And I should see "Ressinel's group 2nd"
+    And I select "My muted groups" from "Muted groups"
+    And I press the "Filter" button
+    And I should not see "Ressinel's group 2nd"
+    And I should see "Ressinel's group 1st"
+    And I select "My unmuted groups" from "Muted groups"
+    And I press the "Filter" button
+    And I should not see "Ressinel's group 1st"
+    And I should see "Ressinel's group 2nd"
+    And I press the "Reset" button
+    And I should see "Ressinel's group 1st"
+    And I should see "Ressinel's group 2nd"
 
   @email-spool
   Scenario: LU able to receive notifications from the unmuted group
     # Lets first check if sending mail works properly
     Given I am logged in as an "administrator"
-      And I go to "/admin/config/system/mailer/test"
-      And I should see "This page allows you to send a test e-mail to a recipient of your choice."
-    When I fill in the following:
+    And I go to "/admin/config/system/mailer/test"
+    And I should see "This page allows you to send a test e-mail to a recipient of your choice."
+    And I fill in the following:
       | E-mail | site_manager_1@example.com |
-    Then I press "Send"
+    And I press "Send"
     And I should have an email with subject "Social Mailer has been successfully configured!" and in the content:
       | This e-mail has been sent from Open Social by the Social Mailer module. |
 
     # Add content to the group by another user.
-    Given I am logged in as "dude_2nd"
-    When I am on "/all-groups"
-      And I click "Ressinel's group 1st"
-      And I click "Topics"
-      And I click "Create Topic"
-      And I fill in the following:
-        | Title | Topic for unmute notify |
-      And I fill in the "edit-body-0-value" WYSIWYG editor with "Body description text."
-      And I check the box "News"
-      And I press "Create topic"
-    Then I should see "Topic for unmute notify has been created."
-      And I wait for the queue to be empty
+    And I am logged in as "dude_2nd"
+    And I am on "/all-groups"
+    And I click "Ressinel's group 1st"
+    And I click "Topics"
+    And I click "Create Topic"
+    And I fill in the following:
+      | Title | Topic for unmute notify |
+    And I fill in the "edit-body-0-value" WYSIWYG editor with "Body description text."
+    And I check the box "News"
+    And I press "Create topic"
+    And I should see "Topic for unmute notify has been created."
+    And I wait for the queue to be empty
 
     # Log in and check if we have notifications.
-    Given I am logged in as "dude_1st"
+    And I am logged in as "dude_1st"
     # Ensure that group notifications are not muted.
-    When I am on "/my-groups"
-    Then I should see "Ressinel's group 1st"
-      And I click "Ressinel's group 1st"
-    Then I should see the button "Joined"
-      And I press "Joined"
-      And I should see the link "Mute group"
-      And I should see "Mute group"
+    And I am on "/my-groups"
+    And I should see "Ressinel's group 1st"
+    And I click "Ressinel's group 1st"
+    And I should see the button "Joined"
+    And I press "Joined"
+    And I should see the link "Mute group"
+    And I should see "Mute group"
     # There should be notifications.
-    When I am on "/notifications"
-    Then I should see "dude_2nd created a topic Topic for unmute notify in the Ressinel's group 1st group"
+    And I am on "/notifications"
+    And I should see "dude_2nd created a topic Topic for unmute notify in the Ressinel's group 1st group"
     And I should have an email with subject "New content has been added to a group you are in" and in the content:
       | dude_2nd created a topic Topic for unmute notify in the Ressinel's group 1st group |
 
@@ -104,42 +105,44 @@ Feature: Mute/Unmute group notifications
     Given I am logged in as an "administrator"
     And I go to "/admin/config/system/mailer/test"
     And I should see "This page allows you to send a test e-mail to a recipient of your choice."
+
     When I fill in the following:
       | E-mail | site_manager_1@example.com |
+
     Then I press "Send"
     And I should have an email with subject "Social Mailer has been successfully configured!" and in the content:
       | This e-mail has been sent from Open Social by the Social Mailer module. |
 
     # Login and mute group notifications.
-    Given I am logged in as "dude_1st"
-    When I am on "/my-groups"
-    Then I should see "Ressinel's group 1st"
-      And I click "Ressinel's group 1st"
-    Then I should see the button "Joined"
-      And I press "Joined"
-      And I should see the link "Mute group"
-    When I click "Mute group"
-      And I wait for AJAX to finish
-    Then I should see "Unmute group"
+    And I am logged in as "dude_1st"
+    And I am on "/my-groups"
+    And I should see "Ressinel's group 1st"
+    And I click "Ressinel's group 1st"
+    And I should see the button "Joined"
+    And I press "Joined"
+    And I should see the link "Mute group"
+    And I click "Mute group"
+    And I wait for AJAX to finish
+    And I should see "Unmute group"
 
     # Add content to the group by another user.
-    Given I am logged in as "dude_2nd"
-    Then I am on "/all-groups"
-      And I click "Ressinel's group 1st"
-      And I click "Topics"
-      And I click "Create Topic"
-      And I fill in the following:
-        | Title | Topic for mute notify |
-      And I fill in the "edit-body-0-value" WYSIWYG editor with "Body description text."
-      And I check the box "News"
-      And I press "Create topic"
-    Then I should see "Topic for mute notify has been created."
-      And I wait for the queue to be empty
+    And I am logged in as "dude_2nd"
+    And I am on "/all-groups"
+    And I click "Ressinel's group 1st"
+    And I click "Topics"
+    And I click "Create Topic"
+    And I fill in the following:
+      | Title | Topic for mute notify |
+    And I fill in the "edit-body-0-value" WYSIWYG editor with "Body description text."
+    And I check the box "News"
+    And I press "Create topic"
+    And I should see "Topic for mute notify has been created."
+    And I wait for the queue to be empty
 
     # Log in and check if we exactly have no notifications.
-    Given I am logged in as "dude_1st"
+    And I am logged in as "dude_1st"
     # There shouldn't be any notifications.
-    When I am on "/notifications"
-    Then I should not see "dude_2nd created a topic Topic for mute notify in the Ressinel's group 1st group"
-      And I should not have an email with subject "New content has been added to a group you are in" and in the content:
+    And I am on "/notifications"
+    And I should not see "dude_2nd created a topic Topic for mute notify in the Ressinel's group 1st group"
+    And I should not have an email with subject "New content has been added to a group you are in" and in the content:
         | dude_2nd created a topic Topic for mute notify in the Ressinel's group 1st group |

--- a/tests/behat/features/capabilities/search/search-all.feature
+++ b/tests/behat/features/capabilities/search/search-all.feature
@@ -1,4 +1,4 @@
-@api @search @stability @DS-3624 @stability-3 @search-all
+@api
 Feature: Search
   Benefit: In order to find specific content of any type
   Role: As a LU
@@ -8,24 +8,27 @@ Feature: Search
     Given users:
       | name           | status | pass   |
       | tjakka user    | 1      | maxic  |
-    Given groups:
-      | label             | field_group_description | author        | type                  | langcode |
-      | Tjakka group      | Tjakka group            | tjakka user   | closed_group          | en       |
-      | Tjakka group two  | Tjakka group            | tjakka user   | open_group            | en       |
-    Given "event" content:
+    And groups:
+      | label            | field_group_description | author      | type           | field_flexible_group_visibility | field_group_allowed_visibility | field_group_allowed_join_method | langcode |
+      | Tjakka group two | Tjakka group            | tjakka user | flexible_group | community                       | group                          | added                           | en       |
+      | Tjakka group     | Tjakka group            | tjakka user | flexible_group | public                          | public                         | direct                          | en       |
+    And "event" content:
       | title             | body          | status | field_content_visibility |
       | Tjakka event      | Description   | 1      | public                   |
     And "topic" content:
       | title             | body          | status | field_content_visibility |
       | Tjakka topic      | Description   | 1      | public                   |
       | Tjakka topic two  | Description   | 1      | community                |
-    And Search indexes are up to date
+
+    When Search indexes are up to date
     And I am on "search/all/tjakka"
-    Then I should see "Tjakka event"
+    And I should see "Tjakka event"
     And I should see "Tjakka topic"
     And I should not see "Tjakka topic two"
-    When I am logged in as an "authenticated user"
+
+    And I am logged in as an "authenticated user"
     And I am on "search/all/tjakka"
+
     Then I should see "Tjakka group"
     And I should see "Tjakka group two"
     And I should see "Tjakka event"

--- a/tests/behat/features/capabilities/search/search-groups.feature
+++ b/tests/behat/features/capabilities/search/search-groups.feature
@@ -1,4 +1,4 @@
-@api @search @groups @stability @1523 @TB-1690 @stability-3 @search-groups
+@api
 Feature: Search
   Benefit: In order to find specific content
   Role: As a LU
@@ -8,15 +8,16 @@ Feature: Search
     Given users:
       | name             | mail                     | status |
       | Group search One | group_user_1@example.com | 1      |
-    Given groups:
-      | label                    | field_group_description | author           | type        | langcode |
-      | Behat test group title 1 | My Behat description    | Group search One | open_group  | en       |
-      | Behat test group title 2 | My Behat description 2  | Group search One | open_group  | en       |
-      | Behat test group title 3 | No Behat descr          | Group search One | open_group  | en       |
+    And groups:
+      | label                    | field_group_description | author           | type           | field_flexible_group_visibility | field_group_allowed_visibility | field_group_allowed_join_method | langcode |
+      | Behat test group title 1 | My Behat description    | Group search One | flexible_group | public                          | public                         | direct                          | en       |
+      | Behat test group title 2 | My Behat description 2  | Group search One | flexible_group | public                          | public                         | direct                          | en       |
+      | Behat test group title 3 | No Behat descr          | Group search One | flexible_group | public                          | public                         | direct                          | en       |
     And Search indexes are up to date
     And I am logged in as an "authenticated user"
     #@TODO: Change "search/content" to the homepage when search block will be in the header
     And I am on "search/groups"
+
     When I fill in "search_input" with "My Behat description"
     And I press "Search" in the "Hero block" region
     And I should see the heading "Search" in the "Hero block" region


### PR DESCRIPTION
## Problem
⚠️ This should be merged after https://github.com/goalgorilla/open_social/pull/3678
⚠️ This PR is part of a set of stacked commits please do not rebase this PR but instead ping @Kingdutch

## Solution
We’re in the process of removing the old group types which means their tests will start failing. Since we no longer care about the old group types we adjust the test coverage for them.

## Issue tracker
- https://www.drupal.org/project/social/issues/3380714
- https://getopensocial.atlassian.net/browse/PROD-27948

## Theme issue tracker
n/a

## How to test
n/a

## Definition of done
n/a

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
n/a

## Release notes
n/a

## Change Record
n/a

## Translations
n/a
