### PR TITLE
Internal: Fix `Behat\Testwork\Call\Exception\FatalThrowableError`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -99,6 +99,9 @@
             "drupal/search_api": {
                 "Ensure field definition allowed values callbacks are used for field filter callbacks": "https://www.drupal.org/files/issues/2023-12-26/views_filter_options_callback--2949022-17.patch"
             },
+            "drupal/token": {
+                "Ajax call is broken due to token check": "https://www.drupal.org/files/issues/2023-11-10/token-3218969-breaks-some-ajax-forms-3397358-7.patch"
+            },
             "drupal/url_embed": {
                 "Translate dialog title": "https://www.drupal.org/files/issues/2018-03-16/url_embed_translate_dialog_title-2953591-2.patch",
                 "Issue #2761187/#3386579 Improve how the module deals with non-embeddable URLs & WSODs (See: https://www.drupal.org/project/social/issues/3386579#comment-15225972) 2.x": "https://www.drupal.org/files/issues/2023-09-22/urlembed-non-embeddable-urls-2761187-opensocial-combined-21_2.x_1_ckeditor5.patch",

--- a/tests/behat/features/bootstrap/GroupContext.php
+++ b/tests/behat/features/bootstrap/GroupContext.php
@@ -76,14 +76,6 @@ class GroupContext extends RawMinkContext {
    */
   public function createGroups(TableNode $groupsTable) {
     foreach ($groupsTable->getHash() as $groupHash) {
-
-      // @todo We might want to do add more generic approach for multi-value
-      // fields like "field_group_allowed_visibility".
-      if (isset($groupHash['field_group_allowed_visibility'])) {
-        $groupHash['field_group_allowed_visibility'] =
-          explode(',', $groupHash['field_group_allowed_visibility']);
-      }
-
       $group = $this->groupCreate($groupHash);
       $this->groups[$group->id()] = $group;
     }


### PR DESCRIPTION
## Problem
```
Type error: str_contains(): Argument #1 ($haystack) must be of type string, array given in features/bootstrap/GroupContext.php:672
```
In #3712 we added
```
      // @todo We might want to do add more generic approach for multi-value
      // fields like "field_group_allowed_visibility".
      if (isset($groupHash['field_group_allowed_visibility'])) {
        $groupHash['field_group_allowed_visibility'] =
          explode(',', $groupHash['field_group_allowed_visibility']);
      }
```
added as part of `@Given groups:` 

However, we also have it now as part of the `private function groupCreate(array $group) {` which should work for all scenario's using this. This was added as part of the security release, as we couldn't open a public PR tests we're not running and we only noticed this later.

Additional testing uncovered an issue with token, which should be released in a next token release. This could affect behat tests as well and fail randomly for the book in groups test, considering it's a very small patch we decided to add it. See: https://www.drupal.org/i/3397358

## Solution
Use the better placement.

## Issue tracker
Internal.

## How to test
See behat turn green.

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Release notes
None, internal.
