### PR TITLE
Issue #3417172: Hide revisions tab

### DIFF
--- a/modules/social_features/social_core/social_core.module
+++ b/modules/social_features/social_core/social_core.module
@@ -524,6 +524,16 @@ function social_core_menu_local_tasks_alter(&$data, $route_name) {
     unset($data['tabs'][0]['entity.node.delete_form']);
   }
 
+  // Remove Revisions tab if revisions for the node not exist.
+  $node = \Drupal::routeMatch()->getParameter('node');
+  if ($node instanceof NodeInterface) {
+    $revisions = \Drupal::entityTypeManager()->getStorage('node')->revisionIds($node);
+
+    if ($revisions && count($revisions) === 1) {
+      unset($data['tabs'][0]['entity.node.version_history']);
+    }
+  }
+
 }
 
 /**

--- a/modules/social_features/social_core/src/Routing/RouteSubscriber.php
+++ b/modules/social_features/social_core/src/Routing/RouteSubscriber.php
@@ -69,7 +69,6 @@ class RouteSubscriber extends RouteSubscriberBase {
         );
       }
     }
-
   }
 
 }


### PR DESCRIPTION
## Problem
Content and Site managers see a bar with details and revisions on top of landing pages.
Those blocks should not appear there since they have no use.

## Solution
We agreed to implement fix in `social_core_menu_local_tasks_alter()` and  hide the "Revisions" tab if the node doesn't have any revisions.

The reason why revoking individual permissions is not working is that they are not used in code for access to the revision tab. They are controlled by `View all revisions` permission, but revoking it will still not fix the issue.

Unfortunately `Administer content` permission is responsible for showing the tab. This is a very important permission that we can not remove at the moment but we will do it during the permission epic during the year.

## Issue tracker
- https://getopensocial.atlassian.net/browse/PROD-25225
- https://www.drupal.org/project/social/issues/3417172

## Theme issue tracker
n/a

## How to test
- [ ] Login as CM
- [ ] Create Landing page
- [ ] Go to the page - you shouldn't tab "Revisions"
- [ ] Repeat the steps for Basic page, Book, Topic, Event
- [ ] Repeat the steps for role SM

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
Before:
<img width="1434" alt="image" src="https://github.com/goalgorilla/open_social/assets/2241917/047116a0-03ce-4cd7-b5b0-9b9f7d7142a4">

After:
![image](https://github.com/goalgorilla/open_social/assets/2241917/068ccc00-1251-4a5c-9f9d-07f0efd011a6)


## Release notes
Hide the "Revisions" tab for content if there are no actual revisions.

## Change Record
<!-- *[Required if applicable] If this Pull Request changes the way that developers should do things or introduces a new API for developers then a change record to document this is needed. Please provide a draft for a change record or a link to an unpublished change record below. Existing change records can be consulted as example. Please provide a draft for a change record or a link to an unpublished change record below. [Existing change records](https://www.drupal.org/list-changes/social) can be consulted as example.* -->

## Translations
<!--
*[Optional]Translatable strings are always extracted from the latest development branch. To ensure translations remain available for platforms running older versions of Open Social the original string should be added to `translations.php` when it's changed or removed.*
- [ ] Changed or removed source strings are added to the `translations.php` file.
-->
