### PR TITLE
Issue #3418006: Lock `drupal/dynamic_entity_reference` to make sure patch still applies.

### DIFF
--- a/.github/workflows/behat.yml
+++ b/.github/workflows/behat.yml
@@ -105,10 +105,10 @@ jobs:
           PREVIOUS_MAJOR=`composer info -a --format json goalgorilla/open_social | jq '.versions | map(select(contains("-") == false)) | map(split(".")[0] | tonumber) | unique | reverse | .[0]'`
           echo "Setting up update test from Open Social $PREVIOUS_MAJOR"
 
-          # Also include a hardcoded version for instaclick/php-webdriver
+          # Also include a hardcoded version for instaclick/php-webdriver and drupal/dynamic_entity_reference
           # as we didnt lock the version, and the patch isn't applying on the latest, so we require it
           # specifically to match the version that was installed at that moment in time.
-          composer require goalgorilla/open_social:~$PREVIOUS_MAJOR instaclick/php-webdriver:1.4.16
+          composer require goalgorilla/open_social:~$PREVIOUS_MAJOR instaclick/php-webdriver:1.4.16 drupal/dynamic_entity_reference:3.1.0
 
           # Installation
           # This is purposefully duplicated because we may change how

--- a/composer.json
+++ b/composer.json
@@ -149,7 +149,7 @@
         "drupal/csv_serialization": "2.1.0 || ~3.0 || ~4.0",
         "drupal/ctools": "4.0.4",
         "drupal/data_policy": "2.0.0-beta9",
-        "drupal/dynamic_entity_reference": "^1.16.0 || ^3",
+        "drupal/dynamic_entity_reference": "^1.16.0 || 3.1.0",
         "drupal/editor_advanced_link": "2.2.4",
         "drupal/entity": "1.4.0",
         "drupal/entity_reference_revisions": "1.11.0",


### PR DESCRIPTION
## Problem
https://www.drupal.org/project/dynamic_entity_reference/releases/3.2.0 was just released and now our patch is failing.

## Solution
Lock it, so we can update the module separately and see what we need to do with the patch (and make sure we do our due dilligence on testing the update and it's full impact) this has the least amount of regression impact.

## Issue tracker
https://www.drupal.org/project/social/issues/3418006

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Release notes
Internal. 


