### PR TITLE
Internal: Fix translation extraction after updating to Drupal 10.2

### DIFF
--- a/yaml_translation_patterns.yml
+++ b/yaml_translation_patterns.yml
@@ -10,3 +10,9 @@ translation_patterns:
     translatable_keys:
       - name
       - description
+  # Can be removed as part of a new potx version, see #3411529 which was not
+  # tagged and released yet in potx:1.0
+  - matches: '*.field_type_categories.yml'
+    translatable_keys:
+      - label
+      - description


### PR DESCRIPTION
## Problem
We have an issue with translation extraction in our Github Actions.

## Solution
In [#3411529](https://www.drupal.org/i/3411529) (after/on D10.2) `field_type_categories.yml` 
translatable strings we're marked as missing from potx.

Because we're using a tagged version and this isn't released yet, we also need to make sure our yaml_translation_patterns are aware. This can be removed once we can update potx with a new released version.

## Issue tracker
TBD.

## How to test
TBD. 

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Release notes
Internal.

