### PR TITLE
Issue #3418502: Add setPreferredLanguage and addTopicTranslations steps for testing multi-language

### DIFF
--- a/tests/behat/features/bootstrap/SocialDrupalContext.php
+++ b/tests/behat/features/bootstrap/SocialDrupalContext.php
@@ -528,4 +528,29 @@ class SocialDrupalContext extends DrupalContext {
     }
   }
 
+  /**
+   * Set the preferred language for the current user if this language exists.
+   *
+   * Can be used for testing multi-language.
+   *
+   * @Given My preferred language is :preferred_language
+   */
+  public function setPreferredLanguageForCurrentUser(string $preferred_language) {
+    if (!$preferred_language) {
+      throw new \Exception("You need to specify the langcode for set preferred language for the current user.");
+    }
+    $language_manager = \Drupal::service('language_manager');
+    $all_enabled_languages = $language_manager->getLanguages();
+    $current_language = array_filter($all_enabled_languages, fn($language): bool => $language->getName() === $preferred_language);
+    if (empty($current_language)) {
+      throw new \Exception("The language '${$preferred_language}' you specified does not exist or is not enabled");
+    }
+    $current_language = reset($current_language);
+    $current_language_lg = $current_language->getId();
+    $current_user = $this->getUserManager()->getCurrentUser();
+    $current_user = User::load($current_user->uid);
+    $current_user->set('preferred_langcode', $current_language_lg);
+    $current_user->save();
+  }
+
 }


### PR DESCRIPTION
## Problem
Now, we don't have any steps to be able to test multi-language for topics.

## Solution
Add the setPreferredLanguage step in SocialDrupalContext to set the preferred language for the current user
Add the addTopicTranslations step in TopicContext for being able to create translations for specific topics

## Issue tracker
https://www.drupal.org/project/social/issues/3418502

## Theme issue tracker
N/A

## How to test
N/A


## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
N/A

## Release notes
Add steps for testing multi-language in behat test.

## Change Record
N/A

## Translations
N/A
