### PR TITLE
Issue #3418595: Replace post entity collection with views and show newest posts first

### DIFF
--- a/modules/social_features/social_core/social_core.install
+++ b/modules/social_features/social_core/social_core.install
@@ -5,12 +5,14 @@
  * Install, update and uninstall functions for the social_core module.
  */
 
-use Drupal\Core\File\FileSystemInterface;
+use Drupal\Core\Config\FileStorage;
 use Drupal\Core\Field\FieldItemList;
+use Drupal\Core\File\FileSystemInterface;
+use Drupal\crop\Entity\CropType;
 use Drupal\file\Entity\File;
 use Drupal\menu_link_content\Entity\MenuLinkContent;
-use Drupal\crop\Entity\CropType;
 use Drupal\user\RoleInterface;
+use Drupal\views\Entity\View;
 
 /**
  * Implements hook_requirements().
@@ -246,4 +248,20 @@ function social_core_update_121002(): void {
   // Considering we already assign administer blocks, this seems like a good
   // first iteration.
   user_role_grant_permissions('sitemanager', ['administer block content']);
+}
+
+/**
+ * Create views.view.posts (module social_post).
+ */
+function social_core_update_122001(): void {
+  // Only create if the posts view doesn't exist and views is enabled.
+  if (\Drupal::moduleHandler()->moduleExists('views') && !View::load('posts')) {
+    $config_path = Drupal::service('extension.list.module')->getPath('social_post') . '/config/install';
+    $source = new FileStorage($config_path);
+    $data = $source->read('views.view.posts');
+
+    if (is_array($data)) {
+      \Drupal::entityTypeManager()->getStorage('view')->create($data)->save();
+    }
+  }
 }

--- a/modules/social_features/social_post/config/install/views.view.posts.yml
+++ b/modules/social_features/social_post/config/install/views.view.posts.yml
@@ -1,0 +1,603 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.post.field_post
+  module:
+    - social_post
+    - text
+    - user
+id: posts
+label: Posts
+module: views
+description: ''
+tag: ''
+base_table: post_field_data
+base_field: id
+display:
+  default:
+    id: default
+    display_title: Default
+    display_plugin: default
+    position: 0
+    display_options:
+      title: 'Post list'
+      fields:
+        id:
+          id: id
+          table: post_field_data
+          field: id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: null
+          entity_field: id
+          plugin_id: field
+          label: 'Post ID'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: number_integer
+          settings:
+            thousand_separator: ''
+            prefix_suffix: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        field_post:
+          id: field_post
+          table: post__field_post
+          field: field_post
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: field
+          label: Post
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: text_default
+          settings: {  }
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        user_id:
+          id: user_id
+          table: post_field_data
+          field: user_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: post
+          entity_field: user_id
+          plugin_id: field
+          label: Author
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: true
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        created:
+          id: created
+          table: post_field_data
+          field: created
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: post
+          entity_field: created
+          plugin_id: field
+          label: Created
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: timestamp
+          settings:
+            date_format: medium
+            custom_date_format: ''
+            timezone: ''
+            tooltip:
+              date_format: long
+              custom_date_format: ''
+            time_diff:
+              enabled: false
+              future_format: '@interval hence'
+              past_format: '@interval ago'
+              granularity: 2
+              refresh: 60
+              description: ''
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        status:
+          id: status
+          table: post_field_data
+          field: status
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: post
+          entity_field: status
+          plugin_id: field
+          label: Status
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: boolean
+          settings:
+            format: custom
+            format_custom_false: Unpublished
+            format_custom_true: Published
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        operations:
+          id: operations
+          table: post
+          field: operations
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: post
+          plugin_id: entity_operations
+          label: Actions
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          destination: false
+      pager:
+        type: full
+        options:
+          offset: 0
+          items_per_page: 50
+          total_pages: null
+          id: 0
+          tags:
+            next: 'Next ›'
+            previous: '‹ Previous'
+            first: '« First'
+            last: 'Last »'
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          quantity: 9
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: perm
+        options:
+          perm: 'administer post entities'
+      cache:
+        type: tag
+        options: {  }
+      empty:
+        area_text_custom:
+          id: area_text_custom
+          table: views
+          field: area_text_custom
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: text_custom
+          empty: true
+          content: 'There are no post entities yet.'
+          tokenize: false
+      sorts:
+        created:
+          id: created
+          table: post_field_data
+          field: created
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: post
+          entity_field: created
+          plugin_id: date
+          order: DESC
+          expose:
+            label: ''
+            field_identifier: ''
+          exposed: false
+          granularity: second
+      arguments: {  }
+      filters: {  }
+      style:
+        type: table
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          columns:
+            id: id
+            field_post: field_post
+            user_id: user_id
+            created: created
+            status: status
+            operations: operations
+          default: created
+          info:
+            id:
+              sortable: true
+              default_sort_order: desc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            field_post:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            user_id:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            created:
+              sortable: true
+              default_sort_order: desc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            status:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            operations:
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+          override: true
+          sticky: false
+          summary: ''
+          empty_table: false
+          caption: ''
+          description: ''
+      row:
+        type: fields
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
+      relationships: {  }
+      header:
+        entity_menu_link_content:
+          id: entity_menu_link_content
+          table: views
+          field: entity_menu_link_content
+          plugin_id: entity
+      footer: {  }
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url.query_args
+        - user.permissions
+      tags:
+        - 'config:field.storage.post.field_post'
+  page_admin_content_posts:
+    id: page_admin_content_posts
+    display_title: Page
+    display_plugin: page
+    position: 1
+    display_options:
+      display_extenders:
+        views_ef_fieldset: {  }
+      path: admin/content/post
+      menu:
+        type: tab
+        title: Posts
+        description: 'Administer posts.'
+        weight: 0
+        expanded: false
+        menu_name: admin
+        parent: system.admin_content
+        context: '0'
+      tab_options:
+        type: tab
+        title: Posts
+        description: ''
+        weight: 0
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url.query_args
+        - user.permissions
+      tags:
+        - 'config:field.storage.post.field_post'

--- a/modules/social_features/social_post/social_post.install
+++ b/modules/social_features/social_post/social_post.install
@@ -87,5 +87,5 @@ function social_post_install() {
 
 // IMPORTANT:
 // @see: https://www.drupal.org/project/social/issues/3323713
-// Don't add hook_update_N() implementations here.
-// Add hook_post_update_NAME() implementations to: social_post.post_update.php.
+// Don't add hook_update_N() implementations here!
+// Add hook_update_N() for this module in social_core.install.

--- a/modules/social_features/social_post/social_post.links.action.yml
+++ b/modules/social_features/social_post/social_post.links.action.yml
@@ -2,7 +2,7 @@ entity.post.add_form:
   route_name: 'entity.post.add_page'
   title: 'Add post'
   appears_on:
-    - entity.post.collection
+    - view.posts.page_admin_content_posts
 
 entity.post_type.add_form:
   route_name: 'entity.post_type.add_form'

--- a/modules/social_features/social_post/social_post.links.menu.yml
+++ b/modules/social_features/social_post/social_post.links.menu.yml
@@ -1,7 +1,7 @@
 # Post menu items definition
 entity.post.collection:
   title: 'Posts'
-  route_name: entity.post.collection
+  route_name: view.posts.page_admin_content_posts
   description: 'List and edit post entities'
   parent: system.admin_content
 

--- a/modules/social_features/social_post/src/Entity/Post.php
+++ b/modules/social_features/social_post/src/Entity/Post.php
@@ -56,7 +56,6 @@ use Drupal\user\UserInterface;
  *     "add-form" = "/post/add/{post_type}",
  *     "edit-form" = "/post/{post}/edit",
  *     "delete-form" = "/post/{post}/delete",
- *     "collection" = "/admin/content/post",
  *   },
  *   bundle_entity_type = "post_type",
  *   field_ui_base_route = "entity.post_type.edit_form"


### PR DESCRIPTION
## Problem
The post overview `/admin/content/post` is ordered by oldest first.
This is inconsistent with our other overviews and it is not very handy for site managers.

- As a SM I want to see the latest post first
- Column name “Operations”is renamed “Actions”
- Status options are capital “published” → “Published” , “unpublished” → “Unpublished”

## Solution
The `/admin/content/post` page is an entity collection. So, we need to create a view and use it instead to add any customization.

## Issue tracker
 - https://getopensocial.atlassian.net/browse/PROD-27190
 - https://www.drupal.org/project/social/issues/3418595
 - https://github.com/goalgorilla/cablecar/pull/1065

## Theme issue tracker
n/a

## How to test
- [ ] Login as SM
- [ ] Create a few posts (**/post/add**) (already exist on ECI Demo test env)
- [ ] Go to **/admin/content/post** page
- [ ] The column “Operations” should have the name “Actions”
- [ ] Status options should start with capital: “published” → “Published” , “unpublished” → “Unpublished”

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
![image](https://github.com/goalgorilla/open_social/assets/118297335/b11a7f56-c8f0-4abd-a2f4-7190b994fc34)


## Release notes
Change default order in the post overview to show the newest first.
Also added ability to sort by other columns.

## Change Record
<!-- *[Required if applicable] If this Pull Request changes the way that developers should do things or introduces a new API for developers then a change record to document this is needed. Please provide a draft for a change record or a link to an unpublished change record below. Existing change records can be consulted as example. Please provide a draft for a change record or a link to an unpublished change record below. [Existing change records](https://www.drupal.org/list-changes/social) can be consulted as example.* -->

## Translations
<!--
*[Optional]Translatable strings are always extracted from the latest development branch. To ensure translations remain available for platforms running older versions of Open Social the original string should be added to `translations.php` when it's changed or removed.*
- [ ] Changed or removed source strings are added to the `translations.php` file.
-->
