### PR TITLE
Issue #3418731: Replace format_size deprecated function

### DIFF
--- a/modules/custom/download_count/src/Plugin/Field/FieldFormatter/FieldDownloadCount.php
+++ b/modules/custom/download_count/src/Plugin/Field/FieldFormatter/FieldDownloadCount.php
@@ -6,6 +6,7 @@ use Drupal\Core\Field\FieldDefinitionInterface;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\File\FileUrlGenerator;
 use Drupal\Core\Session\AccountProxyInterface;
+use Drupal\Core\StringTranslation\ByteSizeMarkup;
 use Drupal\Core\Theme\ThemeManagerInterface;
 use Drupal\file\Plugin\Field\FieldFormatter\GenericFileFormatter;
 use Drupal\Core\Database\Database;
@@ -233,7 +234,7 @@ class FieldDownloadCount extends GenericFileFormatter {
         '#link_text' => $link_text,
         '#classes' => $attributes['class'],
         '#count' => $count,
-        '#file_size' => format_size($file_size),
+        '#file_size' => ByteSizeMarkup::create($file_size),
         '#path_to_socialbase' => $path_to_socialbase,
         '#node_icon' => $node_icon,
         '#attached' => [

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1341,16 +1341,6 @@ parameters:
 			path: modules/custom/download_count/src/Plugin/Field/FieldFormatter/FieldDownloadCount.php
 
 		-
-			message: """
-        #^Call to deprecated function format_size\\(\\)\\:
-        in drupal\\:10\\.2\\.0 and is removed from drupal\\:11\\.0\\.0\\. Use
-          \\\\Drupal\\\\Core\\\\StringTranslation\\\\ByteSizeMarkup\\:\\:create\\(\\$size, \\$langcode\\)
-          instead\\.$#
-			"""
-			count: 1
-			path: modules/custom/download_count/src/Plugin/Field/FieldFormatter/FieldDownloadCount.php
-
-		-
 			message: "#^Function dropdown_help\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: modules/custom/dropdown/dropdown.module


### PR DESCRIPTION
## Problem
In Drupal 10.2 the format_size function was deprecated to be removed on Drupal 11.
https://www.drupal.org/node/2999981

## Solution
Replace the deprecated function, get example at: https://www.drupal.org/node/2999981

## Issue tracker
[PROD-28010](https://getopensocial.atlassian.net/browse/PROD-28010)
[#3418731](https://www.drupal.org/project/social/issues/3418731)

## Theme issue tracker
N/A

## How to test
N/A

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
N/A

## Release notes
N/A

## Change Record
N/A

## Translations
N/A


[PROD-28010]: https://getopensocial.atlassian.net/browse/PROD-28010?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ