### PR TITLE
Issue #3418896: Replace EntityTranslationRenderTrait::getEntityTranslation deprecated function

### DIFF
--- a/modules/social_features/social_event/modules/social_event_invite/src/Plugin/views/field/SocialEventInviteRecipientField.php
+++ b/modules/social_features/social_event/modules/social_event_invite/src/Plugin/views/field/SocialEventInviteRecipientField.php
@@ -99,7 +99,7 @@ class SocialEventInviteRecipientField extends FieldPluginBase {
       $entity = $this->getEntity($values);
       if ($entity && $profile) {
         $build = [];
-        $entity = $this->getEntityTranslation($entity, $values);
+        $entity = $this->getEntityTranslationByRelationship($entity, $values);
         $view_builder = $this->entityTypeManager->getViewBuilder('profile');
         $build += $view_builder->view($profile, 'table', $entity->language()->getId());
         return $build;

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -5636,16 +5636,6 @@ parameters:
 			path: modules/social_features/social_event/modules/social_event_invite/src/Plugin/views/field/SocialEventInviteRecipientField.php
 
 		-
-			message: """
-        #^Call to deprecated method getEntityTranslation\\(\\) of class Drupal\\\\social_event_invite\\\\Plugin\\\\views\\\\field\\\\SocialEventInviteRecipientField\\:
-        in drupal\\:10\\.1\\.0 and is removed from drupal\\:11\\.0\\.0\\. Use
-          \\\\Drupal\\\\views\\\\Entity\\\\Render\\\\EntityTranslationRenderTrait\\:\\:getEntityTranslationByRelationship
-          instead\\.$#
-			"""
-			count: 1
-			path: modules/social_features/social_event/modules/social_event_invite/src/Plugin/views/field/SocialEventInviteRecipientField.php
-
-		-
 			message: "#^Method Drupal\\\\social_event_invite\\\\Routing\\\\RouteSubscriber\\:\\:alterRoutes\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: modules/social_features/social_event/modules/social_event_invite/src/Routing/RouteSubscriber.php


### PR DESCRIPTION
## Problem
n Drupal 10.1 the format_size function was deprecated to be removed on Drupal 11.
https://www.drupal.org/node/3311862

## Solution
Replace the deprecated function, get example at: https://www.drupal.org/node/3311862

## Issue tracker
[PROD-28011](https://getopensocial.atlassian.net/browse/PROD-28011)

## Theme issue tracker
N/A

## How to test
N/A

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
N/A

## Release notes
N/A

## Change Record
N/A

## Translations
N/A


[PROD-28011]: https://getopensocial.atlassian.net/browse/PROD-28011?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ