### PR TITLE
Issue #3419770 - Remove our custom views bulk operations update selection callback

### DIFF
--- a/modules/social_features/social_core/src/Controller/SocialCoreController.php
+++ b/modules/social_features/social_core/src/Controller/SocialCoreController.php
@@ -117,6 +117,11 @@ class SocialCoreController extends ControllerBase {
    *   The display ID of the current view.
    * @param \Symfony\Component\HttpFoundation\Request $request
    *   The request object.
+   *
+   * @deprecated in open_social:12.1.0 and is removed from open_social:14.0.0. Use
+   *   'views_bulk_operations.update_selection' instead.
+   *
+   * @see https://www.drupal.org/node/3419770
    */
   public function updateSelection(
     string $view_id,

--- a/modules/social_features/social_core/src/Routing/RouteSubscriber.php
+++ b/modules/social_features/social_core/src/Routing/RouteSubscriber.php
@@ -18,9 +18,6 @@ class RouteSubscriber extends RouteSubscriberBase {
    */
   private const CALLBACKS = [
     'system.entity_autocomplete' => EntityAutocompleteController::class . '::handleAutocomplete',
-
-    // Write our own VBO update selection for validation on AJAX request.
-    'views_bulk_operations.update_selection' => SocialCoreController::class . '::updateSelection',
   ];
 
   /**


### PR DESCRIPTION
## Problem
After updating to views_bulk_operations 4.2.6, we noticed the actual selection wasn't updating anymore correctly this blocked the bulk operations action button. On top of that we have a selection message which talks about members but this callback is used for every bulk operations, including content and more. We need beter ways of fixing it. 

## Solution
Deprecate this callback, and move to ViewsBulkOperationsController's variant. This fixes the blocking updateSelection issue (see screenshot of how the button and selection isn't matching)
![Screenshot 2024-02-07 at 14 01 02](https://github.com/goalgorilla/open_social/assets/16667281/3d688b57-b296-4a97-9719-0efc56cff164)

## Issue tracker
https://www.drupal.org/project/social/issues/3419770

## How to test
- [ ] Enable user_export
- [ ] Make sure you have over 50 users
- [ ] See that you can make a selection across multiple pages (it is by design that he left selector shows the count for the current page, and the right for the overal)
- [ ] See that you can export correctly

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
![Screenshot 2024-02-07 at 16 05 41](https://github.com/goalgorilla/open_social/assets/16667281/431eb4b6-1348-4ab5-94da-8c8a25ae1041)

## Release notes
All bulk operations should work again.

## Change Record
https://www.drupal.org/node/3419810


