### PR TITLE
Issue #3420022: Deprecate Drupal\social_group\SocialGroupHelperService::getDefaultGroupVisibility

### DIFF
--- a/modules/social_features/social_group/social_group.api.php
+++ b/modules/social_features/social_group/social_group.api.php
@@ -47,6 +47,10 @@ function hook_social_group_hide_types_alter(array &$hidden_types) {
  *   The group type we alter the visibility setting for.
  *
  * @ingroup social_group_api
+ *
+ * @deprecated in social:12.2.0 and is removed from social:13.0.0. There is no
+ *     replacement.
+ * @see https://www.drupal.org/project/social/issues/3420020
  */
 function hook_social_group_default_visibility_alter(&$visibility, $group_type_id) {
   switch ($group_type_id) {

--- a/modules/social_features/social_group/src/SocialGroupHelperServiceInterface.php
+++ b/modules/social_features/social_group/src/SocialGroupHelperServiceInterface.php
@@ -72,6 +72,10 @@ interface SocialGroupHelperServiceInterface {
    *
    * @return string|null
    *   The default visibility.
+   *
+   * @deprecated in social:12.2.0 and is removed from social:13.0.0. There is no
+   *    replacement.
+   * @see https://www.drupal.org/project/social/issues/3420020
    */
   public static function getDefaultGroupVisibility(string $type);
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -68,3 +68,5 @@ parameters:
   ignoreErrors:
       # See - https://github.com/mglaman/drupal-check/pull/187
       - '#Unsafe usage of new static\(\)#'
+      # Until https://www.drupal.org/project/social/issues/3420020.
+      - '#^Call to deprecated method getDefaultGroupVisibility\(\) of class Drupal\\social_group\\SocialGroupHelperService#'


### PR DESCRIPTION
⚠️ This PR is part of [a set of stacked-PRs](https://newsletter.pragmaticengineer.com/p/stacked-diffs). *Do not* use the rebase button, but instead rebase the branch of the last PR in the series [using `git rebase --update-refs`](https://andrewlock.net/working-with-stacked-branches-in-git-is-easier-with-update-refs/) ⚠️ 

## Problem
We'll be removing the function as part of [#3420020: [13.0.0] Remove Drupal\social_group\SocialGroupHelperService::getDefaultGroupVisibility](https://www.drupal.org/project/social/issues/3420020) but want to make sure people are aware that it will disappear.

## Solution
Deprecate the function in the next minor version to inform people of its pending removal.

## Issue tracker
https://www.drupal.org/project/social/issues/3420022

## Theme issue tracker
<!-- *[Required if applicable] Paste a link to the drupal.org theme issue queue item, either from [socialbase](https://www.drupal.org/project/socialbase) or [socialblue](https://www.drupal.org/project/socialblue). If any other issue trackers were used, include links to those too.* -->

## How to test
<!--
*[Required] For example*
- [ ] Using version X.Y.Z of Open Social with the example module enabled
- [ ] As a sitemanager
- [ ] Try to enable the option B on screen c/d/e
- [ ] When saving I expect the result to be F but instead see G.
- [ ] The expected result F is attained when repeating the steps with this fix applied.
-->

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
<!-- *[Required if new feature, and if applicable] If this Pull Request makes visual changes then please include some screenshots that show what has changed here. A before and after screenshot helps the reviewer determine what changes were made.* -->

## Release notes
`Drupal\social_group\SocialGroupHelperService::getDefaultGroupVisibility` is deprecated and will be removed from Open Social 13.0.0

## Change Record
https://www.drupal.org/node/3420125

## Translations
<!--
*[Optional]Translatable strings are always extracted from the latest development branch. To ensure translations remain available for platforms running older versions of Open Social the original string should be added to `translations.php` when it's changed or removed.*
- [ ] Changed or removed source strings are added to the `translations.php` file.
-->
