### PR TITLE
Issue #3420072: Deprecate Drupal\social_group\Form\SocialGroupAddForm

### DIFF
--- a/modules/social_features/social_group/src/Form/SocialGroupAddForm.php
+++ b/modules/social_features/social_group/src/Form/SocialGroupAddForm.php
@@ -14,6 +14,10 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *
  * GroupAddForm.
  *
+ * @deprecated in social:12.2.0 and is removed from social:13.0.0. There is no
+ *      replacement.
+ * @see https://www.drupal.org/node/3420122
+ *
  * @package Drupal\social_group\Form
  */
 class SocialGroupAddForm extends FormBase {
@@ -136,7 +140,7 @@ class SocialGroupAddForm extends FormBase {
 
     // Add help text if the user can't edit group types.
     if (!$user->hasPermission('edit group types')) {
-      $element['#description'] = $this->t('In order to change the group type, 
+      $element['#description'] = $this->t('In order to change the group type,
         please contact the content or site managers.');
     }
 
@@ -174,7 +178,7 @@ class SocialGroupAddForm extends FormBase {
         ],
         'widget' => [
           '#title' => $this->t('Group type'),
-          '#description' => $this->t('In order to change the group type, 
+          '#description' => $this->t('In order to change the group type,
           please contact the content or site managers.'),
           '#field_parents' => [],
           '#required' => TRUE,

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -72,3 +72,7 @@ parameters:
       - '#^Call to deprecated method getDefaultGroupVisibility\(\) of class Drupal\\social_group\\SocialGroupHelperService#'
       # Until https://www.drupal.org/project/social/issues/3420069.
       - '#^Call to method batchUpdateGroupContentVisibility\(\) of deprecated class Drupal\\social_group\\GroupContentVisibilityUpdate#'
+      # Until https://www.drupal.org/project/social/issues/3420070.
+      - '#^Call to method create\(\) of deprecated class Drupal\\social_group\\Form\\SocialGroupAddForm#'
+      # Until https://www.drupal.org/project/social/issues/3420070.
+      - '#^Fetching class constant class of deprecated class Drupal\\social_group\\Form\\SocialGroupAddForm#'


### PR DESCRIPTION
⚠️ This PR is part of [a set of stacked-PRs](https://newsletter.pragmaticengineer.com/p/stacked-diffs). *Do not* use the rebase button, but instead rebase the branch of the last PR in the series [using `git rebase --update-refs`](https://andrewlock.net/working-with-stacked-branches-in-git-is-easier-with-update-refs/) ⚠️ 

Should be merged after #3752

## Problem
The class will be removed in [#3420070: [13.0.0] Remove Drupal\social_group\Form\SocialGroupAddForm](https://www.drupal.org/project/social/issues/3420070)

## Solution
Deprecate the class in a minor version before its removal.

## Issue tracker
<!-- *[Required] Paste a link to the drupal.org issue queue item. If any other issue trackers were used, include links to those too.* -->
https://www.drupal.org/project/social/issues/3420072

## Theme issue tracker
<!-- *[Required if applicable] Paste a link to the drupal.org theme issue queue item, either from [socialbase](https://www.drupal.org/project/socialbase) or [socialblue](https://www.drupal.org/project/socialblue). If any other issue trackers were used, include links to those too.* -->

## How to test
<!--
*[Required] For example*
- [ ] Using version X.Y.Z of Open Social with the example module enabled
- [ ] As a sitemanager
- [ ] Try to enable the option B on screen c/d/e
- [ ] When saving I expect the result to be F but instead see G.
- [ ] The expected result F is attained when repeating the steps with this fix applied.
-->

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
<!-- *[Required if new feature, and if applicable] If this Pull Request makes visual changes then please include some screenshots that show what has changed here. A before and after screenshot helps the reviewer determine what changes were made.* -->

## Release notes
<!-- *[Required if new feature, and if applicable] A short summary of the changes that were made that can be included in release notes.* -->
`Drupal\social_group\Form\SocialGroupAddForm` is deprecated and will be removed in Open Social 13.0.0

## Change Record
<!-- *[Required if applicable] If this Pull Request changes the way that developers should do things or introduces a new API for developers then a change record to document this is needed. Please provide a draft for a change record or a link to an unpublished change record below. Existing change records can be consulted as example. Please provide a draft for a change record or a link to an unpublished change record below. [Existing change records](https://www.drupal.org/list-changes/social) can be consulted as example.* -->
https://www.drupal.org/node/3420122

## Translations
<!--
*[Optional]Translatable strings are always extracted from the latest development branch. To ensure translations remain available for platforms running older versions of Open Social the original string should be added to `translations.php` when it's changed or removed.*
- [ ] Changed or removed source strings are added to the `translations.php` file.
-->
