### PR TITLE
Issue #3420020: [13.0.0] Remove  Drupal\social_group\SocialGroupHelperService::getDefaultGroupVisibility

### DIFF
--- a/modules/social_features/social_group/social_group.module
+++ b/modules/social_features/social_group/social_group.module
@@ -1500,12 +1500,6 @@ function social_group_field_widget_single_element_form_alter(&$element, FormStat
     if (!empty($current_group)) {
       $group_type = $current_group->getGroupType();
       $group_type_id = $group_type->id();
-      // If it's an existing entity we don't need to set the default
-      // rather follow the saved one.
-      if (!$entity->id() && $field_cardinality === 1) {
-        $element['#default_value'] = \Drupal::service('social_group.helper_service')
-          ->getDefaultGroupVisibility($group_type_id);
-      }
     }
     else {
       $group_type_id = NULL;

--- a/modules/social_features/social_group/src/SocialGroupHelperService.php
+++ b/modules/social_features/social_group/src/SocialGroupHelperService.php
@@ -191,37 +191,6 @@ class SocialGroupHelperService implements SocialGroupHelperServiceInterface {
   /**
    * {@inheritdoc}
    */
-  public static function getDefaultGroupVisibility(string $type) {
-    $visibility = &drupal_static(__FUNCTION__ . $type);
-
-    if (empty($visibility)) {
-      switch ($type) {
-        case 'closed_group':
-          $visibility = 'group';
-          break;
-
-        case 'open_group':
-          $visibility = 'community';
-          break;
-
-        case 'public_group':
-          $visibility = 'public';
-          break;
-
-        default:
-          $visibility = NULL;
-      }
-
-      \Drupal::moduleHandler()
-        ->alter('social_group_default_visibility', $visibility, $type);
-    }
-
-    return $visibility;
-  }
-
-  /**
-   * {@inheritdoc}
-   */
   public static function getCurrentGroupMembers() {
     $cache = &drupal_static(__FUNCTION__, []);
 

--- a/modules/social_features/social_group/src/SocialGroupHelperServiceInterface.php
+++ b/modules/social_features/social_group/src/SocialGroupHelperServiceInterface.php
@@ -65,21 +65,6 @@ interface SocialGroupHelperServiceInterface {
   public function getGroupFromEntity(array $entity, bool $read_cache = TRUE): ?int;
 
   /**
-   * Returns the default visibility.
-   *
-   * @param string $type
-   *   The Group Type.
-   *
-   * @return string|null
-   *   The default visibility.
-   *
-   * @deprecated in social:12.2.0 and is removed from social:13.0.0. There is no
-   *    replacement.
-   * @see https://www.drupal.org/project/social/issues/3420020
-   */
-  public static function getDefaultGroupVisibility(string $type);
-
-  /**
    * Returns the statically cached group members form the current group.
    *
    * @return array

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -9181,11 +9181,6 @@ parameters:
 			path: modules/social_features/social_group/social_group.module
 
 		-
-			message: "#^Parameter \\#1 \\$type of method Drupal\\\\social_group\\\\SocialGroupHelperService\\:\\:getDefaultGroupVisibility\\(\\) expects string, int\\|string\\|null given\\.$#"
-			count: 1
-			path: modules/social_features/social_group/social_group.module
-
-		-
 			message: "#^Property Drupal\\\\views\\\\ViewExecutable\\:\\:\\$rowPlugin \\(Drupal\\\\views\\\\Plugin\\\\views\\\\row\\\\RowPluginBase\\) in empty\\(\\) is not falsy\\.$#"
 			count: 1
 			path: modules/social_features/social_group/social_group.module

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -68,7 +68,5 @@ parameters:
   ignoreErrors:
       # See - https://github.com/mglaman/drupal-check/pull/187
       - '#Unsafe usage of new static\(\)#'
-      # Until https://www.drupal.org/project/social/issues/3420020.
-      - '#^Call to deprecated method getDefaultGroupVisibility\(\) of class Drupal\\social_group\\SocialGroupHelperService#'
       # Until https://www.drupal.org/project/social/issues/3420070.
       - '#^Fetching class constant class of deprecated class Drupal\\social_group\\Form\\SocialGroupAddForm#'


### PR DESCRIPTION
⚠️ This PR is part of [a set of stacked-PRs](https://newsletter.pragmaticengineer.com/p/stacked-diffs). Do not use the rebase button, but instead rebase the branch of the last PR in the series [using git rebase --update-refs](https://andrewlock.net/working-with-stacked-branches-in-git-is-easier-with-update-refs/) ⚠️

Should be merged after https://github.com/goalgorilla/open_social/pull/3754

## Problem
getDefaultGroupVisibility was used to find the default visibility for the different group types that we have. However, as part of [#3380714: Remove support for public_group, open_group, closed_group, and secret_group and migrate to flexible_group](https://www.drupal.org/project/social/issues/3380714) we're removing all the old group types. This means the function no longer serves a purpose.

## Solution
Remove the function from Open Social 13.0.0.

## Issue tracker
<!-- *[Required] Paste a link to the drupal.org issue queue item. If any other issue trackers were used, include links to those too.* -->

## Theme issue tracker
<!-- *[Required if applicable] Paste a link to the drupal.org theme issue queue item, either from [socialbase](https://www.drupal.org/project/socialbase) or [socialblue](https://www.drupal.org/project/socialblue). If any other issue trackers were used, include links to those too.* -->

## How to test
<!--
*[Required] For example*
- [ ] Using version X.Y.Z of Open Social with the example module enabled
- [ ] As a sitemanager
- [ ] Try to enable the option B on screen c/d/e
- [ ] When saving I expect the result to be F but instead see G.
- [ ] The expected result F is attained when repeating the steps with this fix applied.
-->

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
<!-- *[Required if new feature, and if applicable] If this Pull Request makes visual changes then please include some screenshots that show what has changed here. A before and after screenshot helps the reviewer determine what changes were made.* -->

## Release notes
<!-- *[Required if new feature, and if applicable] A short summary of the changes that were made that can be included in release notes.* -->
`Drupal\social_group\SocialGroupHelperService::getDefaultGroupVisibility` has been removed

## Change Record
<!-- *[Required if applicable] If this Pull Request changes the way that developers should do things or introduces a new API for developers then a change record to document this is needed. Please provide a draft for a change record or a link to an unpublished change record below. Existing change records can be consulted as example. Please provide a draft for a change record or a link to an unpublished change record below. [Existing change records](https://www.drupal.org/list-changes/social) can be consulted as example.* -->
https://www.drupal.org/node/3420125

## Translations
<!--
*[Optional]Translatable strings are always extracted from the latest development branch. To ensure translations remain available for platforms running older versions of Open Social the original string should be added to `translations.php` when it's changed or removed.*
- [ ] Changed or removed source strings are added to the `translations.php` file.
-->
