### PR TITLE
Issue #3420647: Fix $variables['joined'] on preprocess template

### DIFF
--- a/modules/social_features/social_group/social_group.module
+++ b/modules/social_features/social_group/social_group.module
@@ -351,6 +351,9 @@ function social_group_preprocess_group(array &$variables) {
         );
     }
   }
+
+  // Update if user is member of a group.
+  $variables['joined'] = $group->hasMember($account);
 }
 
 /**


### PR DESCRIPTION
## Problem

We must differentiate between group members and non-members at the newly created medium teaser view mode on social_group, added on PR #3748.

Unfortunately `hook_preprocess_group()` implemented at `social_group_preprocess_group()` has a partial implementation of this feature, [where here it defined "joined" as FALSE](https://github.com/goalgorilla/open_social/blob/main/modules/social_features/social_group/social_group.module#L252) but never changes its value. 

This causes our templates to have a "NULL" value thus we cannot verify it in our new teaser template. 

https://git.drupalcode.org/project/socialbase/-/merge_requests/201/diffs#505b7cf7a07a2932a54dbb7c314f900a81672244_0_93

This is also an old bug because [group--teaser.html.twig](https://git.drupalcode.org/project/socialbase/-/blob/2.4.x/templates/group/group--teaser.html.twig#L147) depends on this variable ( joined ) to display a small box at the group overview page. 

This value is altered by the following plugin https://github.com/goalgorilla/open_social/blob/main/modules/social_features/social_group/src/Plugin/Join/SocialGroupAlreadyJoin.php#L41 but this fails at the teaser view mode because `social_group_preprocess` only calls that plugin on [hero, statistics](https://github.com/goalgorilla/open_social/blob/main/modules/social_features/social_group/social_group.module#L224) view modes. 

This variable is also used here https://git.drupalcode.org/project/socialblue/-/blob/2.4.x/templates/group/group--teaser--sky.html.twig#L136

## Solution

We must check if a user is a member of a group at `social_group_preprocess_group()`, and update that variable accordingly. 

## Issue tracker
https://www.drupal.org/project/social/issues/3420647

## Theme issue tracker
https://www.drupal.org/project/socialbase/issues/3420433

## How to test
- [ ] Log in to Open Social as any user
- [ ] Go to group overview page here /all-groups
- [ ] Join any group and go back to the group overview page, you should see a "You have joined" label on the page.

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
### Before change: 
![image](https://github.com/goalgorilla/open_social/assets/11061892/c229e858-b8dc-408c-af47-8bc5fc95543e)

### After change: 
![image](https://github.com/goalgorilla/open_social/assets/11061892/c41a4f88-70d4-4c16-84d6-e1539064bd61)

## Release notes
There should be a visual clue on group overview page informing users that they have joined a group.

## Change Record
N/A

## Translations
N/A
