### PR TITLE
Issue #3416326: All Enrollments link has broken to Verified User

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -63,7 +63,6 @@
                 "States API doesn't work with multiple select fields": "https://www.drupal.org/files/issues/2023-10-31/states-api-doesnt-work-with-multiselect-fields-1149078-184.patch",
                 "Issue #3395358 - Redirecting a request during delete an entity when the redirect are disabled": "https://www.drupal.org/files/issues/2023-10-19/drupal-redirect-disable-validation-on-delete-entity-3395358-2.patch",
                 "Issue #3414883: [regression] datetime_timestamp widget does not use default field value" : "https://www.drupal.org/files/issues/2024-01-15/3414883-11.patch",
-                "Issue #3416326: All Enrollments link has broken to Verified User" : "https://www.drupal.org/files/issues/2024-01-22/social-revert-drupal-core-view-changes-3416326-2.patch",
                 "Issue #3416251: Drupal 10.1.x revert of modal windows for entity delete operation": "https://www.drupal.org/files/issues/2024-01-22/3416251-3-revert-core-entity-delete-modal-changes.patch",
                 "Issue #3409505: Uncaught TypeError: Cannot read properties of null (reading 'style') (toolbar.js)": "https://www.drupal.org/files/issues/2023-12-20/fix-toolbarjs-null-handling.patch"
             },

--- a/modules/social_features/social_event/config/install/views.view.event_enrollments.yml
+++ b/modules/social_features/social_event/config/install/views.view.event_enrollments.yml
@@ -308,20 +308,7 @@ display:
     display_options:
       display_extenders: {  }
       block_description: 'Enrollments Block'
-      footer:
-        area:
-          id: area
-          table: views
-          field: area
-          relationship: none
-          group_type: group
-          admin_label: ''
-          empty: false
-          tokenize: true
-          content:
-            value: '<a href="/node/{{ raw_arguments.nid }}/enrollments">See all enrollments</a>'
-            format: basic_html
-          plugin_id: text
+      footer: {  }
       defaults:
         footer: false
         style: false
@@ -383,8 +370,8 @@ display:
           entity_type: node
           entity_field: nid
           plugin_id: node_nid
-      link_display: view_enrollments
-      link_url: ''
+      link_display: custom_url
+      link_url: '/node/{{ raw_arguments.nid }}/enrollments'
       use_more: true
       use_more_always: true
       use_more_text: 'All enrollments'

--- a/modules/social_features/social_event/config/update/social_event_update_121001.yml
+++ b/modules/social_features/social_event/config/update/social_event_update_121001.yml
@@ -1,0 +1,169 @@
+views.view.event_enrollments:
+  expected_config:
+    display:
+      event_enrollments:
+        display_plugin: block
+        id: event_enrollments
+        display_title: Block
+        position: 2
+        display_options:
+          display_extenders: {  }
+          block_description: 'Enrollments Block'
+          footer:
+            area:
+              id: area
+              table: views
+              field: area
+              relationship: none
+              group_type: group
+              admin_label: ''
+              empty: false
+              tokenize: true
+              content:
+                value: '<a href="/node/{{ raw_arguments.nid }}/enrollments">See all enrollments</a>'
+                format: basic_html
+              plugin_id: text
+          defaults:
+            footer: false
+            style: false
+            row: false
+            pager: false
+            arguments: false
+            link_display: false
+            link_url: false
+            use_more: false
+            use_more_always: false
+            use_more_text: false
+          style:
+            type: default
+            options: {  }
+          row:
+            type: 'entity:profile'
+            options:
+              relationship: none
+              view_mode: compact
+          pager:
+            type: some
+            options:
+              items_per_page: 12
+              offset: 0
+          arguments:
+            nid:
+              id: nid
+              table: node_field_data
+              field: nid
+              relationship: field_event
+              group_type: group
+              admin_label: ''
+              default_action: default
+              exception:
+                value: all
+                title_enable: false
+                title: All
+              title_enable: false
+              title: ''
+              default_argument_type: node
+              default_argument_options: {  }
+              summary_options:
+                base_path: ''
+                count: true
+                items_per_page: 25
+                override: false
+              summary:
+                sort_order: asc
+                number_of_records: 0
+                format: default_summary
+              specify_validation: false
+              validate:
+                type: none
+                fail: 'not found'
+              validate_options: {  }
+              break_phrase: false
+              not: false
+              entity_type: node
+              entity_field: nid
+              plugin_id: node_nid
+          link_display: view_enrollments
+          link_url: ''
+          use_more: true
+          use_more_always: true
+          use_more_text: 'All enrollments'
+  update_actions:
+    change:
+      display:
+        event_enrollments:
+          display_options:
+            display_extenders: {  }
+            block_description: 'Enrollments Block'
+            footer: {  }
+            defaults:
+              footer: false
+              style: false
+              row: false
+              pager: false
+              arguments: false
+              link_display: false
+              link_url: false
+              use_more: false
+              use_more_always: false
+              use_more_text: false
+            style:
+              type: default
+              options: {  }
+            row:
+              type: 'entity:profile'
+              options:
+                relationship: none
+                view_mode: compact
+            pager:
+              type: some
+              options:
+                items_per_page: 12
+                offset: 0
+            arguments:
+              nid:
+                id: nid
+                table: node_field_data
+                field: nid
+                relationship: field_event
+                group_type: group
+                admin_label: ''
+                default_action: default
+                exception:
+                  value: all
+                  title_enable: false
+                  title: All
+                title_enable: false
+                title: ''
+                default_argument_type: node
+                default_argument_options: {  }
+                default_argument_skip_url: false
+                summary_options:
+                  base_path: ''
+                  count: true
+                  items_per_page: 25
+                  override: false
+                summary:
+                  sort_order: asc
+                  number_of_records: 0
+                  format: default_summary
+                specify_validation: false
+                validate:
+                  type: none
+                  fail: 'not found'
+                validate_options: {  }
+                break_phrase: false
+                not: false
+                entity_type: node
+                entity_field: nid
+                plugin_id: node_nid
+            link_display: custom_url
+            link_url: '/node/{{ raw_arguments.nid }}/enrollments'
+            use_more: true
+            use_more_always: true
+            use_more_text: 'All enrollments'
+    delete:
+      display:
+        event_enrollments:
+          display_options:
+            footer: {  }

--- a/modules/social_features/social_event/social_event.install
+++ b/modules/social_features/social_event/social_event.install
@@ -126,6 +126,20 @@ function social_event_update_last_removed() : int {
 }
 
 /**
+ * Change the More Link from Event Enrollments view.
+ */
+function social_event_update_121001(): string {
+  /** @var \Drupal\update_helper\Updater $updateHelper */
+  $updateHelper = \Drupal::service('update_helper.updater');
+
+  // Execute configuration update definitions with logging of success.
+  $updateHelper->executeUpdate('social_event', __FUNCTION__);
+
+  // Output logged messages to a related channel of update execution.
+  return $updateHelper->logger()->output();
+}
+
+/**
  * Remove deprecated group types.
  */
 function social_event_update_130000(): ?string {


### PR DESCRIPTION
## Problem
The All Enrollments link from an Event page is broken and Verified User isn't be possible to access clicking on it.
That error was found during regression test for Drupal upgrade #3414795.

## Solution
We was used the footer section to save more links and after Drupal upgrade it start to broken, we need to use the custom more link section to save it.

## Issue tracker
[PROD-28086](https://getopensocial.atlassian.net/browse/PROD-28086)
[#3416326](https://www.drupal.org/project/social/issues/3416326)

## Theme issue tracker
N/A

## How to test
- [ ] Create an event
- [ ] Create an verified-user 
- [ ] Enroll to the event created before
- [ ] Access the event page and at left will have a block with link "All enrollments"
- [ ] Click that link and check if will be redirected to right page

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
N/A

## Release notes
Internal:
The Drupal 10.2 removed an variable/feature from View module breaking the read more link in our enrollment view.
This was already fixed in Open Social with a patch, but now fixed in a proper way.

## Change Record
N/A

## Translations
N/A


[PROD-28086]: https://getopensocial.atlassian.net/browse/PROD-28086?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ