### PR TITLE
Issue #3422694: Send notification for group content that become published

### DIFF
--- a/modules/custom/activity_basics/activity_basics.module
+++ b/modules/custom/activity_basics/activity_basics.module
@@ -6,23 +6,34 @@
  */
 
 use Drupal\activity_creator\Plugin\ActivityActionInterface;
+use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityPublishedInterface;
 use Drupal\Core\Entity\SynchronizableInterface;
-use Drupal\node\NodeInterface;
 use Drupal\group\Entity\GroupContent;
+use Drupal\group\Entity\GroupContentInterface;
+use Drupal\node\NodeInterface;
 
 /**
  * Implements hook_entity_insert().
  */
 function activity_basics_entity_insert(EntityInterface $entity): void {
+  // Don't trig activity creation for group content entity with
+  // related UNPUBLISHED entity.
+  if ($entity instanceof GroupContentInterface) {
+    $related_entity = $entity->getEntity();
+
+    if ($related_entity instanceof EntityPublishedInterface && !$related_entity->isPublished()) {
+      // Don't do anything.
+      return;
+    }
+  }
+
   _activity_basics_entity_action($entity, 'create_entitiy_action');
 
   // Check if the entity created with "published" status.
-  if ($entity instanceof EntityPublishedInterface) {
-    if ($entity->isPublished()) {
-      _activity_basics_entity_action($entity, 'publish_entity_action');
-    }
+  if ($entity instanceof EntityPublishedInterface && $entity->isPublished()) {
+    _activity_basics_entity_action($entity, 'publish_entity_action');
   }
 }
 

--- a/modules/custom/activity_basics/activity_basics.module
+++ b/modules/custom/activity_basics/activity_basics.module
@@ -18,7 +18,7 @@ use Drupal\node\NodeInterface;
  * Implements hook_entity_insert().
  */
 function activity_basics_entity_insert(EntityInterface $entity): void {
-  // Don't trig activity creation for group content entity with
+  // Don't trigger activity creation for group content entity with
   // related UNPUBLISHED entity.
   if ($entity instanceof GroupContentInterface) {
     $related_entity = $entity->getEntity();
@@ -49,12 +49,29 @@ function activity_basics_entity_update(EntityInterface $entity): void {
  */
 function activity_basics_entity_presave(EntityInterface $entity): void {
   // Check if the entity become published.
-  if ($entity instanceof EntityPublishedInterface && !$entity->isNew()) {
+  if (
+    $entity instanceof EntityPublishedInterface &&
+    !$entity->isNew()
+  ) {
     // Check if entity change state from "unpublished" to "published".
     // @phpstan-ignore-next-line
     $original = $entity->original;
+
     if (!$original->isPublished() && $entity->isPublished()) {
       _activity_basics_entity_action($entity, 'publish_entity_action');
+
+      // Check if entity is instance of content.
+      assert($entity instanceof ContentEntityInterface);
+
+      // Load all of the group content for this entity.
+      // Check if related entity become published then trig activity creation.
+      $group_contents = (array) \Drupal::entityTypeManager()
+        ->getStorage('group_content')
+        ->loadByEntity($entity);
+
+      foreach ($group_contents as $group_content) {
+        _activity_basics_entity_action($group_content, 'create_entitiy_action');
+      }
     }
   }
 }


### PR DESCRIPTION
## Problem
If I create a topic, event, etc. in a group and save it first as a draft (disabling the "published" checkbox), it will not generate a notification for members of the group when it is later updated to be published.

This is also reproducible when using the scheduler extension, no notification is sent when the content inside the group is published later on.

## Solution
- If `entity`, which has relation to `group_content` created unpublished we should not create any activities for message templates that have group_content as trigger entity;
- And vise versa - if `entity` become published (or create as published) we should create activities for message templates that have `group_content` as trigger entity;

## Issue tracker
- https://getopensocial.atlassian.net/browse/PROD-26551
- https://www.drupal.org/project/social/issues/3422694

## Theme issue tracker
n/a

## How to test
- [ ] Login as a SM+
- [ ] Create new VU user
- [ ] Create a group
- [ ] Add a member (created VU user) to the group
- [ ] Create an unpublished Topic inside the group. Save
- [ ] Run cron (/admin/config/system/cron)
- [ ] Go into Mailcatcher through Tugboat Dashboard. You shouldn't see any new emails.
- [ ] Login as a created VU user (in an incognito window). You shouldn't see any new notifications notification about new group content.
- [ ] As an SM+ user edit the created content. Make it published. Save
- [ ] Run cron
- [ ] Go into Mailcatcher. You should see new email
- [ ] As an VU user you also should see a notification about new group content
- [ ] [Optional] Repeat the steps for Event

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
<!-- *[Required if new feature, and if applicable] If this Pull Request makes visual changes then please include some screenshots that show what has changed here. A before and after screenshot helps the reviewer determine what changes were made.* -->

## Release notes
Group members get notifications only if group content becomes published

## Change Record
<!-- *[Required if applicable] If this Pull Request changes the way that developers should do things or introduces a new API for developers then a change record to document this is needed. Please provide a draft for a change record or a link to an unpublished change record below. Existing change records can be consulted as example. Please provide a draft for a change record or a link to an unpublished change record below. [Existing change records](https://www.drupal.org/list-changes/social) can be consulted as example.* -->

## Translations
<!--
*[Optional]Translatable strings are always extracted from the latest development branch. To ensure translations remain available for platforms running older versions of Open Social the original string should be added to `translations.php` when it's changed or removed.*
- [ ] Changed or removed source strings are added to the `translations.php` file.
-->
