### PR TITLE
Issue #3423273: Past events isn't be showing at Community Events page

### DIFF
--- a/modules/social_features/social_event/src/Plugin/views/filter/EventDate.php
+++ b/modules/social_features/social_event/src/Plugin/views/filter/EventDate.php
@@ -94,7 +94,7 @@ class EventDate extends InOperator {
 
       case self::PAST_EVENTS:
         $this->query->addWhereExpression($this->options['group'], "
-        (({$now} >= {$field_end}) AND ({$past_midnight} > {$field_end}))
+        (({$now} >= {$field_end}) OR ({$all_day} > 0 AND {$past_midnight} > {$field_end}))
         OR
         ({$field_end} IS NULL AND {$now} >= {$field})");
         break;

--- a/tests/behat/features/capabilities/event/filter-community-events.feature
+++ b/tests/behat/features/capabilities/event/filter-community-events.feature
@@ -4,26 +4,34 @@ Feature: Filter community events
   Role: As a Verified
   Goal/desire: I want to filter events that have all day checkbox activated
 
-  Scenario: Successfully use filters for ongoing and upcoming events with today's end date for different timezones
+  Scenario: Successfully use filters for ongoing and upcoming events with today's end date for timezone 1
     Given users:
       | name            | status | timezone           | roles    |
-      | regular user    | 1      | UTC                | verified |
       | Australian user | 1      | Australia/Victoria | verified |
+    And event content:
+      | title                                              | body        | field_content_visibility | field_event_date    | field_event_date_end  | field_event_all_day | langcode | author       |
+      | My awesome australian and and american pepsi-cola party | lorem ipsum | public                   | today               | today                 | 1                   | en       | regular user |
+
+    When I am logged in as "Australian user"
+    And I am on the event overview
+    And I click radio button "Ongoing and upcoming events"
+    And I press "Filter"
+
+    Then I should see "My awesome australian and and american pepsi-cola party"
+
+  Scenario: Successfully use filters for ongoing and upcoming events with today's end date for timezone 2
+    Given users:
+      | name            | status | timezone           | roles    |
       | American user   | 1      | America/Anchorage  | verified |
     And event content:
       | title                                              | body        | field_content_visibility | field_event_date    | field_event_date_end  | field_event_all_day | langcode | author       |
       | My awesome australian and and american pepsi-cola party | lorem ipsum | public                   | today               | today                 | 1                   | en       | regular user |
-    And I am logged in as "Australian user"
 
-    Given I am on the event overview
-    When I click radio button "Ongoing and upcoming events"
-    And I press "Filter"
-    Then I should see "My awesome australian and and american pepsi-cola party"
-
-    Given I am logged in as "American user"
-    When I am on the event overview
+    When I am logged in as "American user"
+    And I am on the event overview
     And I click radio button "Ongoing and upcoming events"
     And I press "Filter"
+
     Then I should see "My awesome australian and and american pepsi-cola party"
 
   Scenario: Successfully use filters for ongoing and upcoming events with today's end date
@@ -33,10 +41,12 @@ Feature: Filter community events
     And events with non-anonymous author:
       | title                                | body        | field_content_visibility | field_event_date    | field_event_date_end | field_event_all_day | langcode |
       | My awesome upcoming pepsi-cola party | lorem ipsum | public                   | today               | today                | 1                   | en       |
-    And I am logged in as "regular_user"
-    When I am on the event overview
+
+    When I am logged in as "regular_user"
+    And I am on the event overview
     And I click radio button "Ongoing and upcoming events"
     And I press "Filter"
+
     Then I should see "My awesome upcoming pepsi-cola party"
 
   Scenario: Successfully use filters for ongoing and upcoming events
@@ -46,10 +56,12 @@ Feature: Filter community events
     And events with non-anonymous author:
       | title                           | body        | field_content_visibility | field_event_date    | field_event_date_end | field_event_all_day	 | langcode |
       | My awesome upcoming kvass party | lorem ipsum | public                   | + 1 year            | + 1 year             | 1                    | en       |
-    And I am logged in as "regular_user"
-    When I am on the event overview
+
+    When I am logged in as "regular_user"
+    And I am on the event overview
     And I click radio button "Ongoing and upcoming events"
     And I press "Filter"
+
     Then I should see "My awesome upcoming kvass party"
 
   Scenario: Successfully use filters for past events
@@ -58,9 +70,13 @@ Feature: Filter community events
       | regular_user       | some@example.com | 1      | UTC      | verified |
     And events with non-anonymous author:
       | title                                | body              | field_content_visibility | field_event_date    | field_event_date_end | field_event_all_day	 | langcode |
-      | My beautiful last water kvass party  | lorem ipsum       | public                   | - 1 year            | - 1 year             | 1                     | en       |
-    And I am logged in as "regular_user"
-    When I am on the event overview
+      | My beautiful last water kvass party  | lorem ipsum       | public                   | - 5 day             | - 6 day              | 1                     | en       |
+      | Past event finishing same day        | lorem ipsum       | public                   | - 5 hour            | - 6 hour             | 0                     | en       |
+
+    When I am logged in as "regular_user"
+    And I am on the event overview
     And I click radio button "Past events"
     And I press "Filter"
+
     Then I should see "My beautiful last water kvass party"
+    And I should see "Past event finishing same day"


### PR DESCRIPTION
## Problem
Events that started and ended in the same day are not displayed in community events page

## Solution
The custom-filter view isn't built correctly, fix it to return past events.

## Issue tracker
[PROD-28258](https://getopensocial.atlassian.net/browse/PROD-28258)
[#3423273](https://www.drupal.org/project/social/issues/3423273)

## Theme issue tracker
N/A

## How to test
- [ ] Create an event that started and ended today
- [ ] Use 01:00 AM as start time and 02:00 AM as end time
- [ ] Go to /community-events
- [ ] Filter the page to show past events
- [ ] You’d expect this to be a past event

**I advice to create a couple of past events with different dates and using all day as well and check Community Events page.**

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
N/A

## Release notes
We fixed an issue where the past events would not show up in the event overview if the end and start date would be the previous day in combination with different timezones.

## Change Record
N/A

## Translations
N/A


[PROD-28258]: https://getopensocial.atlassian.net/browse/PROD-28258?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ