### PR TITLE
Issue #3423900: Set default cache maximum age with 1 hour

### DIFF
--- a/modules/social_features/social_core/config/modify/social_core.system_performance_maximum_age.yml
+++ b/modules/social_features/social_core/config/modify/social_core.system_performance_maximum_age.yml
@@ -1,0 +1,11 @@
+items:
+  system.performance:
+    expected_config:
+      cache:
+        page:
+          max_age: 0
+    update_actions:
+      change:
+        cache:
+          page:
+            max_age: 3600

--- a/modules/social_features/social_core/social_core.install
+++ b/modules/social_features/social_core/social_core.install
@@ -300,3 +300,17 @@ function social_core_update_123001() : void {
 function social_core_update_123002(): void {
   user_role_grant_permissions('sitemanager', ['administer site configuration']);
 }
+
+/**
+ * Set cache maximum age with 1 hour.
+ */
+function social_core_update_123003(): void {
+  // Get cache configuration.
+  $config = \Drupal::service('config.factory')->getEditable('system.performance');
+
+  // When the max-age is empty, set 1 hour.
+  if (empty($config->get('cache.page.max_age'))) {
+    $config->set('cache.page.max_age', 3600)
+      ->save();
+  }
+}

--- a/tests/behat/features/bootstrap/Chrome/ChromeDriver.php
+++ b/tests/behat/features/bootstrap/Chrome/ChromeDriver.php
@@ -16,6 +16,11 @@ class ChromeDriver extends ChromeDriverBase {
    */
   public function visit($url) {
     parent::visit($url);
+    // We need an additional reload after we implemented a default page cache.
+    // A reload seems to do a hard refresh, ensuring we don't run in to pages
+    // being served from cache when we visit the URL's.
+    // @todo: find a better way of dealing with this scenario.
+    parent::reload();
     // We overwrite the visit method because Open Social uses the CKEditor on
     // some pages. The editor waits until the page is loaded similarly to our
     // Behat driver. This can cause a race condition between the CKEditor and

--- a/tests/behat/features/bootstrap/Chrome/ChromeDriver.php
+++ b/tests/behat/features/bootstrap/Chrome/ChromeDriver.php
@@ -16,11 +16,6 @@ class ChromeDriver extends ChromeDriverBase {
    */
   public function visit($url) {
     parent::visit($url);
-    // We need an additional reload after we implemented a default page cache.
-    // A reload seems to do a hard refresh, ensuring we don't run in to pages
-    // being served from cache when we visit the URL's.
-    // @todo: find a better way of dealing with this scenario.
-    parent::reload();
     // We overwrite the visit method because Open Social uses the CKEditor on
     // some pages. The editor waits until the page is loaded similarly to our
     // Behat driver. This can cause a race condition between the CKEditor and

--- a/tests/behat/features/bootstrap/FeatureContext.php
+++ b/tests/behat/features/bootstrap/FeatureContext.php
@@ -40,6 +40,14 @@ class FeatureContext extends RawMinkContext {
      * @param \Behat\Behat\Hook\Scope\BeforeScenarioScope $scope
      */
     public function before(BeforeScenarioScope $scope) {
+      // Restart the session in that case, this means
+      // the browser cache is cleared and not shared between
+      // scenario's. This is necessary due to enabling cache.page.max_age
+      // which adds the Cache Control header and allows the browser
+      // to cache things between scenario's.
+      // See: https://github.com/goalgorilla/open_social/actions/runs/8188710546/job/22392267853.
+      $this->getSession()->restart();
+
       // Start a session if not already done.
       // Needed since https://github.com/minkphp/Mink/pull/705
       // Otherwise resizeWindow will throw an error.

--- a/tests/behat/features/bootstrap/TopicContext.php
+++ b/tests/behat/features/bootstrap/TopicContext.php
@@ -398,6 +398,9 @@ class TopicContext extends RawMinkContext {
     if ($violations->count() !== 0) {
       throw new \Exception("The topic you tried to create is invalid: $violations");
     }
+    if (!$topic_object->body->format) {
+      $topic_object->body->format = 'basic_html';
+    }
     $topic_object->save();
 
     // Adding to group usually happens in a form handler so for initialization

--- a/tests/behat/features/capabilities/contentmanagement/default-visibility.feature
+++ b/tests/behat/features/capabilities/contentmanagement/default-visibility.feature
@@ -1,0 +1,35 @@
+@api @javascript
+Feature: Default Content Visibility
+  Benefit: In order to control the distribution of information and to secure my privacy
+  Role: As a Verified and Anonymous
+  Goal/desire: I want to see the visibility of content created with a default visibility
+
+  Scenario: Default content visibility public as VU on the homepage
+    Given I set the configuration item "entity_access_by_field.settings" with key "default_visibility" to "public"
+    And I am logged in as an "sitemanager"
+    And I create a topic using its creation page:
+      | Title        | Behat Topic public   |
+      | Description  | Testing  visibility  |
+      | Type         | News                 |
+      | Published    | True                 |
+
+    When I am logged in as an "verified"
+    And I am on the homepage
+
+    Then I should see "All topics"
+    And I should see "Behat Topic public"
+
+  Scenario: Default content visibility community as VU on the homepage
+    Given I set the configuration item "entity_access_by_field.settings" with key "default_visibility" to "community"
+    And I am logged in as an "sitemanager"
+    And I create a topic using its creation page:
+      | Title        | Behat Topic public   |
+      | Description  | Testing  visibility  |
+      | Type         | News                 |
+      | Published    | True                 |
+
+    When I am logged in as an "verified"
+    And I am on the homepage
+
+    Then I should see "All topics"
+    And I should not see "Behat Topic community"

--- a/tests/behat/features/capabilities/contentmanagement/node-visibility.feature
+++ b/tests/behat/features/capabilities/contentmanagement/node-visibility.feature
@@ -1,68 +1,60 @@
-@api @contentmanagement @stability @perfect @critical @DS-158 @stability-1 @node-visibility
+@api
 Feature: Visibility
   Benefit: In order to control the distribution of information and to secure my privacy
   Role: As a Verified
   Goal/desire: I want to set the visibility of content I create
 
-  Scenario: Successfully create topic visible for community and public
-    Given I am logged in as an "verified"
-    And I am on "node/add/topic"
-    When I fill in "Title" with "This is a topic for community"
-    And I fill in the "edit-body-0-value" WYSIWYG editor with "This is a topic for community"
-    And I click radio button "Community"
-    And I check the box "News"
-    And I press "Create topic"
-    Then I should see "Topic This is a topic for community has been created."
-    And I am on "node/add/topic"
-    When I fill in "Title" with "This is a topic for public"
-    And I fill in the "edit-body-0-value" WYSIWYG editor with "This is a topic for public"
-    And I click radio button "Public"
-    And I check the box "News"
-    And I press "Create topic"
-    Then I should see "Topic This is a topic for public has been created."
+  Background:
+    Given topics with non-anonymous author:
+      | title                         | field_topic_type | status | field_content_visibility | body                         |
+      | This is a topic for public    | Blog             | 1      | public                   | Testing public visibility    |
+      | This is a topic for community | Blog             | 1      | community                | Testing community visibility |
 
-    # Now visit the pages as authenticated user.
+  Scenario: As authenticated user view public topic with zero user permission settings
     Given I disable that the registered users to be verified immediately
-      And I am logged in as an "authenticated user"
-      And I open the "topic" node with title "This is a topic for public"
-    Then I should see "This is a topic for public"
-    When I open the "topic" node with title "This is a topic for community"
-    Then I should not see "This is a topic for community"
-      And I should see "Access denied"
-      And I should see "You are not authorized to access this page."
-      And I enable that the registered users to be verified immediately
+    And I am logged in as an "authenticated user"
 
-    # Now visit the pages as anonymous user.
-    When I logout
-    Given I open the "topic" node with title "This is a topic for public"
+    When I open the "topic" node with title "This is a topic for public"
+
     Then I should see "This is a topic for public"
-    Given I open the "topic" node with title "This is a topic for community"
+
+  Scenario: As authenticated user view community topic with zero user permission settings
+    Given I disable that the registered users to be verified immediately
+    And I am logged in as an "authenticated user"
+
+    When I open the "topic" node with title "This is a topic for community"
+
+    Then I should not see "This is a topic for community"
+    And I should see "Access denied"
+    And I should see "You are not authorized to access this page."
+
+  Scenario: As anonymous user I can view a public topic
+    Given I am an anonymous user
+
+    When I open the "topic" node with title "This is a topic for public"
+
+    Then I should see "This is a topic for public"
+
+  Scenario: As anonymous user I cant view a topic with community visibility
+    Given I am an anonymous user
+
+    When I open the "topic" node with title "This is a topic for community"
+
     Then I should not see "This is a topic for community"
     And I should see "Access denied."
 
-  # Check visibility on content overview pages.
+  Scenario: Content visibility community as AN on topic overview
+    Given I am an anonymous user
+
+    When I am on the topic overview
+
+    Then I should see "This is a topic for public"
+    And I should not see "This is a topic for community"
+
+  Scenario: As verified user I can view public and community topics on the topic overview
     Given I am logged in as an "verified"
-      And I am on the topic overview
-    Then I should see "This is a topic for public"
-      And I should see "This is a topic for community"
-    Given I logout
-      And I am on the topic overview
-    Then I should see "This is a topic for public"
-      And I should not see "This is a topic for community"
 
-    # Check default visibility
-    Given I set the configuration item "entity_access_by_field.settings" with key "default_visibility" to "public"
-    Given topic content:
-      | title              | field_topic_type | status |
-      | Behat Topic public | Blog             | 1      |
-    Given I am on the homepage
-    Then I should see "All topics"
-    And I should see "Behat Topic public"
+    When I am on the topic overview
 
-    Given I set the configuration item "entity_access_by_field.settings" with key "default_visibility" to "community"
-    Given topic content:
-      | title                 | field_topic_type | status |
-      | Behat Topic community | Blog             | 1      |
-    Given I am on the homepage
-    Then I should see "All topics"
-    And I should not see "Behat Topic community"
+    Then I should see "This is a topic for public"
+    And I should see "This is a topic for community"

--- a/tests/behat/features/capabilities/embed/embed-consent.feature
+++ b/tests/behat/features/capabilities/embed/embed-consent.feature
@@ -1,4 +1,4 @@
-@api @embed @embed-consent @stability @perfect @critical @TB-5671 @stability-4
+@api
 Feature: Embed
   Benefit: Provides user feature allow/disallow embedded content
   Role: As a SM
@@ -6,104 +6,54 @@ Feature: Embed
 
   Background:
     Given I enable the module "social_embed"
+    And topics with non-anonymous author:
+      | title          | field_topic_type | body                                               | field_content_visibility |
+      | Embed consent  | News             | <p>https://www.youtube.com/watch?v=fv2nWEXKSf4</p> | public                   |
 
-  @LU
-  Scenario: Check the working of consent settings for LU
-    Given I am logged in as a user with the "administer social embed settings" permission
-    And I am on "admin/config/opensocial/embed-consent"
-    When I check the box "edit-embed-consent-settings-lu"
-    And I press the "Save configuration" button
-    Then I should see the text "The configuration options have been saved."
-    And I logout
-    Then the cache has been cleared
-
-    # Create a topic with embedded content.
-    Given I am logged in as an "authenticated user"
+  Scenario: As AU I want to configure my consent to see all embedded content immediately
+    Given I set the configuration item "social_embed.settings" with key "embed_consent_settings_lu" to 1
+    And I am logged in as an "authenticated user"
     And I click the xth "0" element with the css ".navbar-nav .profile"
     And I click "Settings"
-    Then I should see "Enforce consent for all embedded content"
-    And I check the box "Enforce consent for all embedded content"
+    And I uncheck the box "Enforce consent for all embedded content"
     And I press "Save"
-    Given I am on "node/add/topic"
-    And I check the box "News"
-    When I fill in the following:
-      | Title | Embed consent |
-    And I click on the embed icon in the WYSIWYG editor
-    And I wait for AJAX to finish
-    And I fill in "URL" with "https://www.youtube.com/watch?v=ojafuCcUZzU"
-    And I press the "Embed" button
-    # Temporary comment next step since it will fails because of the Embed
-    # module new release https://www.drupal.org/project/embed/releases/8.x-1.5
-    # @see https://git.drupalcode.org/project/embed/-/commit/89b249e4da8f5b39fdfa3e97960107c850427469
-    # @todo Uncomment it out when a solution will found
-    # And I wait for AJAX to finish
-    And I wait for "3" seconds
-    And I press "Create topic"
-    Then I should see "Topic Embed consent has been created."
+
+    When I open the "topic" node with title "Embed consent"
+
+    Then The iframe in the body description should have the src "https://www.youtube.com/embed/fv2nWEXKSf4?feature=oembed"
+
+  Scenario: As AU I want to be able to give my consent to individual video's
+    Given I set the configuration item "social_embed.settings" with key "embed_consent_settings_lu" to 1
+
+    When I am logged in as an "authenticated user"
+    And I open the "topic" node with title "Embed consent"
     And I click "Show content"
     And I wait for AJAX to finish
     And I wait for "3" seconds
-    And The embedded content in the body description should have the src "https://www.youtube.com/embed/ojafuCcUZzU"
-    And I logout
 
-    # Restore the settings
-    Given I am logged in as a user with the "administer social embed settings" permission
-    And I am on "admin/config/opensocial/embed-consent"
-    When I uncheck the box "edit-embed-consent-settings-lu"
-    And I press the "Save configuration" button
-    Then I should see the text "The configuration options have been saved."
-    And I logout
+    Then The embedded content in the body description should have the src "https://www.youtube.com/embed/fv2nWEXKSf4?feature=oembed"
 
-    # Check the content as LU again
-    Then the cache has been cleared
+  Scenario: As AU I want to see embedded content
     Given I am logged in as an "authenticated user"
-    And I am on the homepage
-    And I click "Embed consent"
-    And The iframe in the body description should have the src "https://www.youtube.com/embed/ojafuCcUZzU"
 
-  @AN
-  Scenario: Check the working of consent settings for AN
-    Given I am logged in as a user with the "administer social embed settings" permission
-    And I am on "admin/config/opensocial/embed-consent"
-    When I check the box "edit-embed-consent-settings-an"
-    And I press the "Save configuration" button
-    Then I should see the text "The configuration options have been saved."
+    When I open the "topic" node with title "Embed consent"
 
-    # Create a topic with embedded content.
-    Given I am on "node/add/topic"
-    And I check the box "News"
-    And I click radio button "Public"
-    When I fill in the following:
-      | Title | Embed consent (AN) |
-    And I click on the embed icon in the WYSIWYG editor
-    And I wait for AJAX to finish
-    And I fill in "URL" with "https://www.youtube.com/watch?v=ojafuCcUZzU"
-    And I press the "Embed" button
-    # Temporary comment next step since it will fails because of the Embed
-    # module new release https://www.drupal.org/project/embed/releases/8.x-1.5
-    # @see https://git.drupalcode.org/project/embed/-/commit/89b249e4da8f5b39fdfa3e97960107c850427469
-    # @todo Uncomment it out when a solution will found
-    # And I wait for AJAX to finish
-    And I wait for "3" seconds
-    And I press "Create topic"
-    Then I should see "Topic Embed consent (AN) has been created."
-    And I logout
+    Then The iframe in the body description should have the src "https://www.youtube.com/embed/fv2nWEXKSf4?feature=oembed"
 
-    # Check the content as AN
-    And I open the "topic" node with title "Embed consent (AN)"
+  Scenario: As AN I want to be able to give my consent to individual video's when that is configured
+    Given I set the configuration item "social_embed.settings" with key "embed_consent_settings_an" to 1
+
+    When I am an anonymous user
+    And I open the "topic" node with title "Embed consent"
     And I click "Show content"
     And I wait for AJAX to finish
     And I wait for "3" seconds
-    And The embedded content in the body description should have the src "https://www.youtube.com/embed/ojafuCcUZzU"
 
-    # Restore the settings
-    Given I am logged in as a user with the "administer social embed settings" permission
-    And I am on "admin/config/opensocial/embed-consent"
-    When I uncheck the box "edit-embed-consent-settings-an"
-    And I press the "Save configuration" button
-    Then I should see the text "The configuration options have been saved."
-    And I logout
+    Then The embedded content in the body description should have the src "https://www.youtube.com/embed/fv2nWEXKSf4?feature=oembed"
 
-    # Check the content as AN again
-    And I open the "topic" node with title "Embed consent (AN)"
-    And The iframe in the body description should have the src "https://www.youtube.com/embed/ojafuCcUZzU"
+  Scenario: As AN I want to see embedded content
+    Given I am an anonymous user
+
+    When I open the "topic" node with title "Embed consent"
+
+    Then The iframe in the body description should have the src "https://www.youtube.com/embed/fv2nWEXKSf4?feature=oembed"

--- a/tests/behat/features/capabilities/topic/newest-topics.feature
+++ b/tests/behat/features/capabilities/topic/newest-topics.feature
@@ -1,44 +1,52 @@
-@api @topic @stability @perfect @community @newest @overview @block @verified @critical @DS-1057 @stability-3 @newest-topics
+@api
 Feature: See newest topics in the community
   Benefit: In order to discover content
   Role: As a Verified
   Goal/desire: I want to see newest topics block and overview
 
-  Scenario: Successfully show my upcoming events as a Verified
-#    TODO: Test visibility settings (Public, Community)
-
+  Background:
     Given "topic_types" terms:
       | name          |
       | Blog          |
       | News          |
       | Article       |
 
-    Given I am on "/stream"
-    Then I should not see "Behat Topic 1"
-    And I should not see "Behat Topic 2"
-
-    Given "topic" content:
+    And "topic" content:
       | title         | field_topic_type | status | field_content_visibility |
       | Behat Topic 1 | Blog             | 1      | public                   |
       | Behat Topic 2 | News             | 1      | public                   |
 
-    Given I am on "/stream"
+  Scenario: Successfully show upcoming events as a AN on the stream
+    Given I am an anonymous user
+
+    When I am on "/stream"
 
     Then I should see "All topics"
     And I should see "Behat Topic 1"
     And I should see "Behat Topic 2"
 
-    When I am on "all-topics"
+  Scenario: Successfully show upcoming events as a AN on the overview
+    Given I am an anonymous user
+
+    When I am on the topic overview
+
     Then I should see "Behat Topic 1"
     And I should see "Behat Topic 2"
     And I should see "All topics"
 
+  Scenario: Successfully show my upcoming events as a Verified on the stream
     Given I am logged in as an "verified"
-    And I am on "/stream"
+
+    When I am on "/stream"
+
     Then I should see "Behat Topic 1"
     And I should see "Behat Topic 2"
 
-    When I am on "all-topics"
+  Scenario: Successfully show my upcoming events as a Verified on the overview
+    Given I am logged in as an "verified"
+
+    When I am on the topic overview
+
     Then I should see "All topics"
     And I should see "Behat Topic 1"
     And I should see "Behat Topic 2"


### PR DESCRIPTION
## Problem
The default `cache.page.max_age` isn't configured and the default value is 0, change it to 1 hour to increase our performance.

## Solution
1. Create a hook-update to set 1 hour for cache maximum age when it's empty and create a configuration modify to new installation being with 1 hour as default cache maximum age.
2. Fix behat tests

Expanding on that a bit more, as you can see it's quite the change.
The biggest issue is that we currently have a lot of places where we now encounter browser cache.

This is because `FinishResponseSubscriber`


```
    if ($is_cacheable && $this->config->get('cache.page.max_age') > 0) {
      if (!$this->isCacheControlCustomized($response)) {
        // Only add the default Cache-Control header if the controller did not
        // specify one on the response.
        $this->setResponseCacheable($response, $request);
      }
    }

.....

  protected function setResponseCacheable(Response $response, Request $request) {
    // HTTP/1.0 proxies do not support the Vary header, so prevent any caching
    // by sending an Expires date in the past. HTTP/1.1 clients ignore the
    // Expires header if a Cache-Control: max-age directive is specified (see
    // RFC 2616, section 14.9.3).
    if (!$response->headers->has('Expires')) {
      $this->setExpiresNoCache($response);
    }

    $max_age = $this->config->get('cache.page.max_age');
    $response->headers->set('Cache-Control', 'public, max-age=' . $max_age);
```

Adds the Cache-Control header, which is used by the browser to base it's cache on (obviously, it has other things like last modified, ETAG and more headers that influence it)

But, because we're not using Scenario's across the board in our behat tests, we will see that browser cache is used incorrectly. In a sense that the caching is correct, but we're not clearing it correctly.

For that we have introduce an additional reset in the existing BeforeScenario, which means the browser cache is cleared between scenario's. I've also left other examples which we've tried but which weren't succesfull in clearing it correctly.

Having a browser cache clear between scenario's allows us to now split up some tasks in different scenario's. Something we want to do anyway considering it's best practice. So we took the time to rewrite the failing scenario's which had issues with browser cache in place fully, to also make behat linting green. Eventhough it wasn't the entire scenario failing, but this way it's easier to trace back and get a lot of value along with it.

But also when you think about it, you can now create scenarios using the arrange / act / assert way, with caches being tested in between your scenario. The whole goal of asserting (and background) is to setup your test in such a way you can act and arrange on it and not have to deal with other scenarios. 

## Issue tracker
[PROD-28382](https://getopensocial.atlassian.net/browse/PROD-28382)
[#3423900](https://www.drupal.org/project/social/issues/3423900)

## Theme issue tracker
N/A

## How to test
N/A

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
N/A

## Release notes
N/A

## Change Record
N/A

## Translations
N/A


[PROD-28382]: https://getopensocial.atlassian.net/browse/PROD-28382?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ