### PR TITLE
Issue #3420101: Remove references to public_group, open_group, closed_group, and secret_group for social_featured_content module

### DIFF
--- a/modules/social_features/social_featured_content/config/install/core.entity_view_display.node.event.featured.yml
+++ b/modules/social_features/social_featured_content/config/install/core.entity_view_display.node.event.featured.yml
@@ -55,30 +55,6 @@ content:
       link: true
     third_party_settings: {  }
     type: entity_reference_label
-  groups_type_closed_group:
-    label: above
-    weight: -5
-    region: content
-    settings:
-      link: true
-    third_party_settings: {  }
-    type: entity_reference_label
-  groups_type_open_group:
-    label: above
-    weight: -5
-    region: content
-    settings:
-      link: true
-    third_party_settings: {  }
-    type: entity_reference_label
-  groups_type_public_group:
-    label: above
-    weight: -5
-    region: content
-    settings:
-      link: true
-    third_party_settings: {  }
-    type: entity_reference_label
 hidden:
   body: true
   field_content_visibility: true

--- a/modules/social_features/social_featured_content/config/install/core.entity_view_display.node.topic.featured.yml
+++ b/modules/social_features/social_featured_content/config/install/core.entity_view_display.node.topic.featured.yml
@@ -44,30 +44,6 @@ content:
       link: true
     third_party_settings: {  }
     type: entity_reference_label
-  groups_type_closed_group:
-    label: above
-    weight: -5
-    region: content
-    settings:
-      link: true
-    third_party_settings: {  }
-    type: entity_reference_label
-  groups_type_open_group:
-    label: above
-    weight: -5
-    region: content
-    settings:
-      link: true
-    third_party_settings: {  }
-    type: entity_reference_label
-  groups_type_public_group:
-    label: above
-    weight: -5
-    region: content
-    settings:
-      link: true
-    third_party_settings: {  }
-    type: entity_reference_label
 hidden:
   body: true
   field_content_visibility: true

--- a/modules/social_features/social_featured_content/config/optional/core.entity_view_display.node.page.featured.yml
+++ b/modules/social_features/social_featured_content/config/optional/core.entity_view_display.node.page.featured.yml
@@ -36,30 +36,6 @@ content:
     settings:
       link: true
     third_party_settings: {  }
-  groups_type_closed_group:
-    type: entity_reference_label
-    weight: 1
-    region: content
-    label: above
-    settings:
-      link: true
-    third_party_settings: {  }
-  groups_type_open_group:
-    type: entity_reference_label
-    weight: 2
-    region: content
-    label: above
-    settings:
-      link: true
-    third_party_settings: {  }
-  groups_type_public_group:
-    type: entity_reference_label
-    weight: 3
-    region: content
-    label: above
-    settings:
-      link: true
-    third_party_settings: {  }
 hidden:
   body: true
   field_content_visibility: true

--- a/modules/social_features/social_featured_content/config/update/social_featured_content_update_13000.yml
+++ b/modules/social_features/social_featured_content/config/update/social_featured_content_update_13000.yml
@@ -1,0 +1,26 @@
+core.entity_view_display.node.event.featured:
+  expected_config: {  }
+  update_actions:
+    delete:
+      content:
+        groups_type_closed_group: {  }
+        groups_type_open_group: {  }
+        groups_type_public_group: {  }
+
+core.entity_view_display.node.page.featured:
+  expected_config: {  }
+  update_actions:
+    delete:
+      content:
+        groups_type_closed_group: {  }
+        groups_type_open_group: {  }
+        groups_type_public_group: {  }
+
+core.entity_view_display.node.topic.featured:
+  expected_config: {  }
+  update_actions:
+    delete:
+      content:
+        groups_type_closed_group: {  }
+        groups_type_open_group: {  }
+        groups_type_public_group: {  }

--- a/modules/social_features/social_featured_content/social_featured_content.install
+++ b/modules/social_features/social_featured_content/social_featured_content.install
@@ -6,8 +6,46 @@
  */
 
 /**
+ * Implements hook_update_dependencies().
+ */
+function social_featured_content_update_dependencies() : array {
+  // Ensure configurations updates runs after the group migration has completed.
+  $dependencies['social_featured_content'][13000] = [
+    'social_group' => 13000,
+  ];
+
+  $dependencies['social_group'][13001] = [
+    'social_featured_content' => 13000,
+  ];
+
+  return $dependencies;
+}
+
+/**
  * Implements hook_update_last_removed().
  */
 function social_featured_content_update_last_removed() : int {
   return 11401;
+}
+
+/**
+ * Remove deprecated group types.
+ */
+function social_featured_content_update_13000(): ?string {
+  // Allow platforms to opt out of the group migration, for example if they want
+  // to build it themselves and take more scenario's into account than common
+  // Open Social installations will have.
+  if (\Drupal::state()->get('social_group_group_type_migration_opt_out', FALSE)) {
+    \Drupal::logger('social_group')->info('Platform has opted out of group migration.');
+    return NULL;
+  }
+
+  /** @var \Drupal\update_helper\Updater $updateHelper */
+  $updateHelper = \Drupal::service('update_helper.updater');
+
+  // Execute configuration update definitions with logging of success.
+  $updateHelper->executeUpdate('social_featured_content', __FUNCTION__);
+
+  // Output logged messages to related channel of update execution.
+  return $updateHelper->logger()->output();
 }


### PR DESCRIPTION
## Problem
We're removing the old group types from Open Social. This module has some references to the old group types which should be removed.

## Solution
Evaluate the references to the old group types. We might be able to remove the functionality that exists around it altogether and remove the dependency on any group type. If that's not possible just remove the references to the old group type. In any case the functionality itself should keep working for flexible groups.

## Issue tracker
https://www.drupal.org/project/social/issues/3420101

## Theme issue tracker

## How to test
- [ ] Social featured content functionality should still work

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots

## Release notes
The references to specific group types have been removed from the user view modes in `social_featured_content`.

## Change Record

## Translations
