### PR TITLE
Issue #3424659: Change cron to get translation to run one time per day

### DIFF
--- a/modules/custom/social_language/config/update/social_language_update_12201.yml
+++ b/modules/custom/social_language/config/update/social_language_update_12201.yml
@@ -1,0 +1,10 @@
+ultimate_cron.job.locale_cron:
+  expected_config:
+    scheduler:
+      id: simple
+  update_actions:
+    add:
+      scheduler:
+        configuration:
+          rules:
+            - '0+@ 0 * * *'

--- a/modules/custom/social_language/social_language.install
+++ b/modules/custom/social_language/social_language.install
@@ -36,6 +36,12 @@ function social_language_install() {
   \Drupal::configFactory()->getEditable('locale.settings')
     ->set('translation.path', '/tmp')
     ->save();
+
+  // Changing the schedule for locale cron.
+  \Drupal::service('ultimate_cron.discovery')->discoverCronJobs();
+  \Drupal::configFactory()->getEditable('ultimate_cron.job.locale_cron')
+    ->set('scheduler.configuration.rules', ['0+@ 0 * * *'])
+    ->save();
 }
 
 /**
@@ -43,4 +49,18 @@ function social_language_install() {
  */
 function social_language_update_last_removed() : int {
   return 10302;
+}
+
+/**
+ * Changing the schedule for locale cron.
+ */
+function social_language_update_12201(): string {
+  /** @var \Drupal\update_helper\Updater $updateHelper */
+  $updateHelper = \Drupal::service('update_helper.updater');
+
+  // Execute configuration update definitions with logging of success.
+  $updateHelper->executeUpdate('social_language', __FUNCTION__);
+
+  // Output logged messages to related channel of update execution.
+  return $updateHelper->logger()->output();
 }


### PR DESCRIPTION
## Problem
Currently we have a cron to get new translation and it's ran each 15 minutes, looking to improve our performance we can change it to run 1 time per day.

## Solution
Created a hook-update to change the frequency in installed system and added a logic to change it when the Social Language i will enable in new installation.

## Issue tracker
[PROD-28138](https://getopensocial.atlassian.net/browse/PROD-28138)
[#3424659](https://www.drupal.org/project/social/issues/3424659)

## Theme issue tracker
N/A

## How to test
- [ ] Enable the Social Language
- [ ] Go to cron page and check frequency from locale cron

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
N/A

## Release notes
We have changed the fetching of new translations from 15 minutes to 1 day when you have the multilingual module enabled. 15 min creates unnecessary stress on the cron-jobs and in practice 1 day is more then enough to keep a site up to date with the latest translations.

## Change Record
N/A

## Translations
N/A


[PROD-28138]: https://getopensocial.atlassian.net/browse/PROD-28138?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ