### PR TITLE
Issue #3424719: Add 'administer site configuration' permission to site-manager role

### DIFF
--- a/modules/social_features/social_core/social_core.install
+++ b/modules/social_features/social_core/social_core.install
@@ -293,3 +293,10 @@ function social_core_update_123001() : void {
   // uninstaller double-check just in case).
   \Drupal::service('module_installer')->uninstall(['admin_toolbar_tools'], FALSE);
 }
+
+/**
+ * Add permission for SM to administer site configuration.
+ */
+function social_core_update_123002(): void {
+  user_role_grant_permissions('sitemanager', ['administer site configuration']);
+}


### PR DESCRIPTION
## Problem
The 'administer site configuration' permission should granted to site-manager role to manage DNS information.
For new installation already have a function to be granted, but, we need to guaranteed to all old installation.

## Solution
Create a hook-update to grant 'administer site configuration' permission to site-manager role.

## Issue tracker
[PROD-28386](https://getopensocial.atlassian.net/browse/PROD-28386)
[#3424719](https://www.drupal.org/project/social/issues/3424719)

## Theme issue tracker
N/A

## How to test
- [ ] Access the system with administrator user
- [ ] Check if Site Manager role has: 'adminiter site configuration'

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
N/A

## Release notes
We fixed an issue to make sure the site-managers have the permissions "administer site configuration". This was already working for new installations but not existing ones.

## Change Record
N/A

## Translations
N/A


[PROD-28386]: https://getopensocial.atlassian.net/browse/PROD-28386?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ