### PR TITLE
Issue #3426080: Error to load entity from hook_preprocess_activity on Social Follow Taxonomy

### DIFF
--- a/modules/social_features/social_follow_taxonomy/social_follow_taxonomy.module
+++ b/modules/social_features/social_follow_taxonomy/social_follow_taxonomy.module
@@ -142,6 +142,10 @@ function social_follow_taxonomy_preprocess_activity(&$variables) {
 
   if (in_array($message_template_id, $message_template)) {
     $entity = $activity->getRelatedEntity();
+    // Checking if entity exist to avoid errors.
+    if (empty($entity)) {
+      return;
+    }
 
     if ($entity->getEntityTypeId() === 'node') {
       $storage = \Drupal::entityTypeManager()->getStorage('flagging');


### PR DESCRIPTION
## Problem
When an entity is deleted and it was reference at activity stream, an error happen and activity stream page isn't loading.

## Solution
Add a return early to avoid to load removed entity.

## Issue tracker
[PROD-28459](https://getopensocial.atlassian.net/browse/PROD-28459)
[#3426080](https://www.drupal.org/project/social/issues/3426080)

## Theme issue tracker
N/A

## How to test
* This should be tested locally *
- [ ] Start a new installation with demo data
- [ ] Enable Social Follow Taxonomy
- [ ] Run cron
- [ ] Forcing error: Comment code lines from ActivityCreatorBatchActivityDeletion::bulkDeleteActivities function
- [ ] Delete content: node/1
- [ ] Try to access /explore page

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
N/A

## Release notes
This fix the entity references between contents and activities, the activity page will load without an error.

## Change Record
N/A

## Translations
N/A


[PROD-28459]: https://getopensocial.atlassian.net/browse/PROD-28459?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ