### PR TITLE
Issue #3427532 by vnech: As a developer I should be able to decorate "social_content_block.content_builder" service

### DIFF
--- a/modules/social_features/social_content_block/src/ContentBuilder.php
+++ b/modules/social_features/social_content_block/src/ContentBuilder.php
@@ -69,7 +69,24 @@ class ContentBuilder implements ContentBuilderInterface {
   protected TimeInterface $time;
 
   /**
-   * {@inheritdoc}
+   * ContentBuilder constructor.
+   *
+   * @param \Drupal\Core\Session\AccountInterface $account
+   *   User account entity.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager.
+   * @param \Drupal\Core\Database\Connection $connection
+   *   The current active database's master connection.
+   * @param \Drupal\Core\StringTranslation\TranslationInterface $string_translation
+   *   The string translation.
+   * @param \Drupal\Core\Language\LanguageManagerInterface $language_manager
+   *   The language manager.
+   * @param \Drupal\social_content_block\ContentBlockManagerInterface $content_block_manager
+   *   The content block manager.
+   * @param \Drupal\Core\Entity\EntityRepositoryInterface $entity_repository
+   *   The entity repository.
+   * @param \Drupal\Component\Datetime\TimeInterface $time
+   *   The time service.
    */
   public function __construct(
     AccountInterface $account,

--- a/modules/social_features/social_content_block/src/ContentBuilderInterface.php
+++ b/modules/social_features/social_content_block/src/ContentBuilderInterface.php
@@ -2,15 +2,8 @@
 
 namespace Drupal\social_content_block;
 
-use Drupal\Component\Datetime\TimeInterface;
-use Drupal\Core\Database\Connection;
-use Drupal\Core\Entity\EntityRepositoryInterface;
-use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\FormStateInterface;
-use Drupal\Core\Language\LanguageManagerInterface;
 use Drupal\Core\Security\TrustedCallbackInterface;
-use Drupal\Core\Session\AccountInterface;
-use Drupal\Core\StringTranslation\TranslationInterface;
 
 /**
  * Provides an interface for the content builder service.
@@ -18,37 +11,6 @@ use Drupal\Core\StringTranslation\TranslationInterface;
  * @package Drupal\social_content_block
  */
 interface ContentBuilderInterface extends TrustedCallbackInterface {
-
-  /**
-   * ContentBuilder constructor.
-   *
-   * @param \Drupal\Core\Session\AccountInterface $account
-   *   User account entity.
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
-   *   The entity type manager.
-   * @param \Drupal\Core\Database\Connection $connection
-   *   The current active database's master connection.
-   * @param \Drupal\Core\StringTranslation\TranslationInterface $string_translation
-   *   The string translation.
-   * @param \Drupal\Core\Language\LanguageManagerInterface $language_manager
-   *   The language manager.
-   * @param \Drupal\social_content_block\ContentBlockManagerInterface $content_block_manager
-   *   The content block manager.
-   * @param \Drupal\Core\Entity\EntityRepositoryInterface $entity_repository
-   *   The entity repository.
-   * @param \Drupal\Component\Datetime\TimeInterface $time
-   *   The time service.
-   */
-  public function __construct(
-    AccountInterface $account,
-    EntityTypeManagerInterface $entity_type_manager,
-    Connection $connection,
-    TranslationInterface $string_translation,
-    LanguageManagerInterface $language_manager,
-    ContentBlockManagerInterface $content_block_manager,
-    EntityRepositoryInterface $entity_repository,
-    TimeInterface $time
-  );
 
   /**
    * Function to get all the entities based on the filters.


### PR DESCRIPTION
## Problem
In distro we have a `social_content_block.content_builder `service used in "Custom content list block" feature.

Unfortunately, if I want to decorate the service behaviour (for example, add a custom entity to "Custom content list block") I can't do it because `__construct() `method is declared in `\Drupal\social_content_block\ContentBuilderInterface` rather then in `\Drupal\social_content_block\ContentBuilder`

## Solution
- Remove `\Drupal\social_content_block\ContentBuilderInterface::__construct()`

## Issue tracker
- https://www.drupal.org/project/social/issues/3427532
- https://getopensocial.atlassian.net/browse/PROD-28503

## Theme issue tracker

## How to test
- [ ] Make sure that the Content List block works without regression (automated tests pass)

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots

## Release notes
For developers:
- The service 'social_content_block.content_builder' is open for decoration.

## Change Record

## Translations
