### PR TITLE
Issue #3427607 by slowflyer, Kingdutch: Variables are incorrectly output in strings causing them to be interpolated as different variables

### DIFF
--- a/modules/custom/social_graphql/src/GraphQL/EntityConnection.php
+++ b/modules/custom/social_graphql/src/GraphQL/EntityConnection.php
@@ -243,7 +243,7 @@ class EntityConnection implements ConnectionInterface {
     if (!is_null($cursor)) {
       $cursor_object = $this->queryHelper->getCursorObject($cursor);
       if (is_null($cursor_object)) {
-        throw new UserError("invalid cursor '${$cursor}'");
+        throw new UserError("invalid cursor '{$cursor}'");
       }
       $pagination_condition = $query->orConditionGroup();
 

--- a/src/Installer/OptionalModuleManager.php
+++ b/src/Installer/OptionalModuleManager.php
@@ -155,7 +155,7 @@ class OptionalModuleManager implements ContainerInjectionInterface {
 
     $contents = file_get_contents($optional_info_file);
     if ($contents === FALSE) {
-      throw new IOException("Could not read '${$optional_info_file}'.");
+      throw new IOException("Could not read '{$optional_info_file}'.");
     }
     // We don't catch the InvalidDataTypeException thrown here because we have
     // no better info to give developers about invalid Yaml files.

--- a/tests/behat/features/bootstrap/AlbumContext.php
+++ b/tests/behat/features/bootstrap/AlbumContext.php
@@ -85,7 +85,7 @@ class AlbumContext extends RawMinkContext {
       elseif ($key === "group") {
         $group_id = $this->getNewestGroupIdFromTitle($value);
         if ($group_id === NULL) {
-          throw new \Exception("Group '${$value}' does not exist.");
+          throw new \Exception("Group '{$value}' does not exist.");
         }
         $page->selectFieldOption($field, $group_id);
         // Changing the group of an album updates the visibility settings so we

--- a/tests/behat/features/bootstrap/BookContext.php
+++ b/tests/behat/features/bootstrap/BookContext.php
@@ -143,7 +143,7 @@ class BookContext extends RawMinkContext {
       elseif ($key === "group") {
         $group_id = $this->getNewestGroupIdFromTitle($value);
         if ($group_id === NULL) {
-          throw new \Exception("Group '${$value}' does not exist.");
+          throw new \Exception("Group '{$value}' does not exist.");
         }
         $page->selectFieldOption($field, $group_id);
         // Changing the group of a book updates the visibility settings so we

--- a/tests/behat/features/bootstrap/TaggingContext.php
+++ b/tests/behat/features/bootstrap/TaggingContext.php
@@ -22,7 +22,7 @@ class TaggingContext extends RawMinkContext {
     $term = \Drupal::entityTypeManager()->getStorage('taxonomy_term')->loadByProperties(['name' => $term_name]);
     $term = reset($term);
     if (!$term instanceof TermInterface) {
-      throw new \Exception("Term '${$term_name}' does not exist.");
+      throw new \Exception("Term '{$term_name}' does not exist.");
     }
     /** @var \Drupal\social_tagging\SocialTaggingServiceInterface $helper */
     $helper = \Drupal::service('social_tagging.tag_service');


### PR DESCRIPTION

<h3 id="summary-problem-motivation">Problem/Motivation</h3>
There's various cases in the codebase where a string is created and a variable is interpolated (e.g. <code>"Something like {$foo}"</code> where this happens incorrectly (i.e. <code>"Something like ${$foo}"</code>) which causes the contents of the variable to be used as name of a different variable that's then interpolated.

After internal investigation we find that none of the 5 occurrences found provide the ability to leak sensitive data and thus we do not consider this a security issue.

Three times in test code.
<ul>
<li>tests/behat/features/bootstrap/TaggingContext.php</li>
<li>tests/behat/features/bootstrap/BookContext.php</li>
<li>tests/behat/features/bootstrap/AlbumContext.php</li>
</ul>

<code>src/Installer/OptionalModuleManager.php</code> which is only run on install and does not use user input.

<code>modules/custom/social_graphql/src/GraphQL/EntityConnection.php</code> which does use user input and was the most likely candidate. However any variables that can be accessed from the particular line of code are deemed to be safe to leak.


<h3 id="summary-proposed-resolution">Proposed resolution</h3>
Fix the string interpolation to use <code>{$variable}</code>

## Issue tracker
https://www.drupal.org/project/social/issues/3427607

## Theme issue tracker
<!-- *[Required if applicable] Paste a link to the drupal.org theme issue queue item, either from [socialbase](https://www.drupal.org/project/socialbase) or [socialblue](https://www.drupal.org/project/socialblue). If any other issue trackers were used, include links to those too.* -->

## How to test
<!--
*[Required] For example*
- [ ] Using version X.Y.Z of Open Social with the example module enabled
- [ ] As a sitemanager
- [ ] Try to enable the option B on screen c/d/e
- [ ] When saving I expect the result to be F but instead see G.
- [ ] The expected result F is attained when repeating the steps with this fix applied.
-->

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
<!-- *[Required if new feature, and if applicable] If this Pull Request makes visual changes then please include some screenshots that show what has changed here. A before and after screenshot helps the reviewer determine what changes were made.* -->

## Release notes
<!-- *[Required if new feature, and if applicable] A short summary of the changes that were made that can be included in release notes.* -->

## Change Record
<!-- *[Required if applicable] If this Pull Request changes the way that developers should do things or introduces a new API for developers then a change record to document this is needed. Please provide a draft for a change record or a link to an unpublished change record below. Existing change records can be consulted as example. Please provide a draft for a change record or a link to an unpublished change record below. [Existing change records](https://www.drupal.org/list-changes/social) can be consulted as example.* -->

## Translations
<!--
*[Optional]Translatable strings are always extracted from the latest development branch. To ensure translations remain available for platforms running older versions of Open Social the original string should be added to `translations.php` when it's changed or removed.*
- [ ] Changed or removed source strings are added to the `translations.php` file.
-->
