### PR TITLE
Issue #3428454: Email subject with <em> html tag

### DIFF
--- a/modules/custom/activity_send/modules/activity_send_email/src/Plugin/EmailBuilder/ActivitySendEmailBuilder.php
+++ b/modules/custom/activity_send/modules/activity_send_email/src/Plugin/EmailBuilder/ActivitySendEmailBuilder.php
@@ -70,8 +70,8 @@ class ActivitySendEmailBuilder extends EmailBuilderBase implements ContainerFact
     }
     else {
       $site_name = $this->configFactory->get('system.site')->get('name');
-      $email->setSubject($this->t('Notification from %site_name', [
-        '%site_name' => $site_name,
+      $email->setSubject($this->t('Notification from @site_name', [
+        '@site_name' => $site_name,
       ], [
         'langcode' => $email->getLangcode(),
       ]));

--- a/modules/social_features/social_event/modules/social_event_managers/src/Form/SocialEventManagersAddEnrolleeForm.php
+++ b/modules/social_features/social_event/modules/social_event_managers/src/Form/SocialEventManagersAddEnrolleeForm.php
@@ -221,7 +221,7 @@ class SocialEventManagersAddEnrolleeForm extends FormBase {
     ];
 
     $variables = [
-      '%site_name' => \Drupal::config('system.site')->get('name'),
+      '@site_name' => \Drupal::config('system.site')->get('name'),
     ];
 
     // Load event invite configuration.
@@ -281,7 +281,7 @@ class SocialEventManagersAddEnrolleeForm extends FormBase {
       '#theme' => 'invite_email_preview',
       '#title' => $this->t('Message'),
       '#logo' => $logo,
-      '#subject' => $this->t('Notification from %site_name', $variables),
+      '#subject' => $this->t('Notification from @site_name', $variables),
       '#body' => $body,
       '#helper' => $this->token->replace($invite_config->get('invite_helper'), $params),
     ];


### PR DESCRIPTION
## Problem
When processing activities such as creating a post in the stream it will send out emails. When there is no subject pre-defined it will will use the default `Notification from %site_name`, but the % placeholder when processed will surround the text with the HTML` <em class="placeholder">`. Since email subject html rendering can be different per email provider it can happen that this will show the HTML as raw.

## Solution
Change the placeholder % to @ as this is similar to % but without the rendering of the HTML tag.

## Issue tracker
[PROD-28384](https://getopensocial.atlassian.net/browse/PROD-28384)
[#3428454](https://www.drupal.org/project/social/issues/3428454)

## Theme issue tracker
N/A

## How to test
- [ ] Create two diferent users with email
- [ ] Access with user 1 and create a post
- [ ] Access with user 2 and comment post created by user 1
- [ ] Run cron
- [ ] Check the email

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
N/A

## Release notes
The Notification emails will stop to send <em> html tag at subject.

## Change Record
N/A

## Translations
Notification from %site_name -> Notification from @site_name


[PROD-28384]: https://getopensocial.atlassian.net/browse/PROD-28384?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ