### PR TITLE
Issue #3428255: Event enrollments block shows incorrect amount of enrollees.

### DIFF
--- a/modules/social_features/social_event/config/install/views.view.event_enrollments.yml
+++ b/modules/social_features/social_event/config/install/views.view.event_enrollments.yml
@@ -172,16 +172,17 @@ display:
       sorts: {  }
       title: Enrollments
       header:
-        result:
-          id: result
-          table: views
-          field: result
-          relationship: none
-          group_type: group
+        area_text_custom:
           admin_label: ''
+          content: '[social_event:enrolled_users_count]'
           empty: true
-          content: '@total people have enrolled'
-          plugin_id: result
+          field: area_text_custom
+          group_type: group
+          id: area_text_custom
+          plugin_id: text_custom
+          relationship: none
+          table: views
+          tokenize: false
       footer:
         area:
           id: area

--- a/modules/social_features/social_event/config/update/social_event_update_121002.yml
+++ b/modules/social_features/social_event/config/update/social_event_update_121002.yml
@@ -1,0 +1,39 @@
+views.view.event_enrollments:
+  expected_config:
+    display:
+      default:
+        display_options:
+          header:
+            result:
+              admin_label: ''
+              content: '@total people have enrolled'
+              empty: true
+              field: result
+              group_type: group
+              id: result
+              plugin_id: result
+              relationship: none
+              table: views
+  update_actions:
+    change:
+      display:
+        default:
+          display_options:
+            header:
+              area_text_custom:
+                admin_label: ''
+                content: '[social_event:enrolled_users_count]'
+                empty: true
+                field: area_text_custom
+                group_type: group
+                id: area_text_custom
+                plugin_id: text_custom
+                relationship: none
+                table: views
+                tokenize: false
+    delete:
+      display:
+        default:
+          display_options:
+            header:
+              result:

--- a/modules/social_features/social_event/modules/social_event_max_enroll/social_event_max_enroll.module
+++ b/modules/social_features/social_event/modules/social_event_max_enroll/social_event_max_enroll.module
@@ -32,7 +32,7 @@ function social_event_max_enroll_views_post_render(ViewExecutable $view, &$outpu
       // Count how many spots left.
       $left = $event_max_enroll_service->getEnrollmentsLeft($node);
       $title_suffix = \Drupal::translation()->formatPlural($left, '(1 spot left)', '(@count spots left)');
-      $view->header['result']->options['content'] .= ' ' . $title_suffix;
+      $view->header['area_text_custom']->options['content'] .= ' ' . $title_suffix;
     }
   }
 }

--- a/modules/social_features/social_event/social_event.install
+++ b/modules/social_features/social_event/social_event.install
@@ -140,6 +140,20 @@ function social_event_update_121001(): string {
 }
 
 /**
+ * Change the event enrollments view header to a token.
+ */
+function social_event_update_121002(): string {
+  /** @var \Drupal\update_helper\Updater $updateHelper */
+  $updateHelper = \Drupal::service('update_helper.updater');
+
+  // Execute configuration update definitions with logging of success.
+  $updateHelper->executeUpdate('social_event', __FUNCTION__);
+
+  // Output logged messages to related channel of update execution.
+  return $updateHelper->logger()->output();
+}
+
+/**
  * Remove deprecated group types.
  */
 function social_event_update_130000(): ?string {

--- a/modules/social_features/social_event/social_event.tokens.inc
+++ b/modules/social_features/social_event/social_event.tokens.inc
@@ -10,6 +10,7 @@ use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\Core\Link;
 use Drupal\Core\Url;
 use Drupal\message\Entity\Message;
+use Drupal\node\NodeInterface;
 use Drupal\social_event\EventEnrollmentInterface;
 
 /**
@@ -37,6 +38,11 @@ function social_event_token_info() {
     'description' => t('Url of the Event a user enrolled to.'),
   ];
 
+  $social_event['enrolled_users_count'] = [
+    'name' => t('Enrolled users count'),
+    'description' => t('The total count of enrolled users to the current event.'),
+  ];
+
   return [
     'types' => ['social_event' => $type],
     'tokens' => [
@@ -50,6 +56,33 @@ function social_event_token_info() {
  */
 function social_event_tokens($type, $tokens, array $data, array $options, BubbleableMetadata $bubbleable_metadata) {
   $replacements = [];
+  if ($type === 'social_event') {
+    foreach ($tokens as $name => $original) {
+      switch ($name) {
+        case 'enrolled_users_count':
+          $nid = Drupal::routeMatch()->getRawParameter('node');
+          if ($nid) {
+            $node = \Drupal::entityTypeManager()
+              ->getStorage('node')
+              ->load($nid);
+            if ($node instanceof NodeInterface && $node->getType() === 'event') {
+              $enrollments = \Drupal::service('social_event.status_helper');
+              $count = count($enrollments->getAllEventEnrollments((int) $node->id(), TRUE));
+              $enrollments = \Drupal::translation()->formatPlural(
+                $count,
+                ':count person has enrolled',
+                ':count people have enrolled',
+                [':count' => $count]
+              );
+              if ($count !== NULL) {
+                $replacements[$original] = $enrollments;
+              }
+            }
+          }
+          break;
+      }
+    }
+  }
   if ($type === 'social_event' && !empty($data['message'])) {
     /** @var Drupal\message\Entity\Message $message */
     $message = $data['message'];

--- a/tests/behat/features/capabilities/event-an-enroll/event-max-enroll.feature
+++ b/tests/behat/features/capabilities/event-an-enroll/event-max-enroll.feature
@@ -37,7 +37,7 @@ Feature: Limitation event enrollments
     And I wait for AJAX to finish
     Then I reload the page
     Then I should not see "0 people have enrolled (2 spots left)"
-    And I should see "1 people have enrolled (1 spot left)"
+    And I should see "1 person has enrolled (1 spot left)"
 
     Given users:
       | name              | mail                     | status | roles    |
@@ -49,7 +49,7 @@ Feature: Limitation event enrollments
     And I press "Enroll"
     And I wait for AJAX to finish
     Then I reload the page
-    Then I should not see "1 people have enrolled (1 spot left)"
+    Then I should not see "1 person has enrolled (1 spot left)"
     And I should see "2 people have enrolled (0 spots left)"
     And I should see the button "Enrolled"
 

--- a/tests/behat/features/capabilities/event-management/event-management.feature
+++ b/tests/behat/features/capabilities/event-management/event-management.feature
@@ -142,7 +142,7 @@ Feature: Event Management
     And I press "Create event (this translation)"
 
     # Check if enrollees aren't duplicated.
-    And I should see "1 people have enrolled"
+    And I should see "1 person has enrolled"
     And I click "Manage enrollments"
     And I should see "1 Enrollees"
     # Check if organisers aren't duplicated.

--- a/tests/behat/features/capabilities/event/eventenrollment.feature
+++ b/tests/behat/features/capabilities/event/eventenrollment.feature
@@ -26,7 +26,7 @@ Feature: Enroll for an event
     And I should see the button "Enrolled"
 
     Then I reload the page
-    And I should see "1 people have enrolled"
+    And I should see "1 person has enrolled"
     And I should see the link "All enrollments"
 
     When I click "All enrollments"
@@ -71,7 +71,7 @@ Feature: Enroll for an event
     And I should see the button "Enrolled"
 
     Then I reload the page
-    And I should see "1 people have enrolled"
+    And I should see "1 person has enrolled"
     And I should see the link "All enrollments"
 
   @verified
@@ -95,7 +95,7 @@ Feature: Enroll for an event
     And I press the "Close" button
     And I should see the button "Enrolled"
     Then I reload the page
-    And I should see "1 people have enrolled"
+    And I should see "1 person has enrolled"
     And I should see the link "All enrollments"
 
     When I press the "Enrolled" button
@@ -111,7 +111,7 @@ Feature: Enroll for an event
     And I wait for AJAX to finish
     And I press the "Close" button
     And I reload the page
-    Then I should see "1 people have enrolled"
+    Then I should see "1 person has enrolled"
     And I should see the link "All enrollments"
 
   @verified @cache

--- a/tests/behat/features/capabilities/event/eventenrollment.feature
+++ b/tests/behat/features/capabilities/event/eventenrollment.feature
@@ -158,3 +158,14 @@ Feature: Enroll for an event
 
     Then I should see "No one has enrolled for this event"
     And I should see the button "Event has passed"
+
+  Scenario: Showing the correct total enrollment count.
+    Given events with non-anonymous author:
+      | title        | body                  | field_content_visibility | field_event_date    | langcode |
+      | Test content | Body description text | community                | 2100-01-01T12:00:00 | en       |
+    And there are 13 event enrollments for the "Test content" event
+
+    When I am logged in as an "verified"
+    And I am viewing the event "Test content"
+
+    Then I should see "13 people have enrolled"


### PR DESCRIPTION
## Problem
In the view for enrollments we show the @total count from the summary result. Because this item amount is set at 12 it will never go higher than 12. 

<img width="387" alt="Screenshot 2024-03-15 at 14 01 57" src="https://github.com/goalgorilla/open_social/assets/19951171/330a3257-6f22-4fc5-8fae-dcd8a880693d">


## Solution
Replace it with another token to get the correct count.

- Add a custom token and use the helper method getAllEventEnrollments to get the enrollment count.
- Also set the translatable text inside the token so we can properly do plural formatting.
- Replace this token in the view.

## Issue tracker
https://www.drupal.org/project/social/issues/3428255

## Theme issue tracker
<!-- *[Required if applicable] Paste a link to the drupal.org theme issue queue item, either from [socialbase](https://www.drupal.org/project/socialbase) or [socialblue](https://www.drupal.org/project/socialblue). If any other issue trackers were used, include links to those too.* -->

## How to test
- [ ] Create an event with open enrollments
- [ ] Enroll more than 12 people
- [ ] Go to the event detail page and see the block keeps stuck at 12 enrollees
- [ ] Check out to this branch and clear the cache
- [ ] See the enrollments are now correct
- [ ] Also try the same with 1 enrollment and see the grammar is now correct.

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
<!-- *[Required if new feature, and if applicable] If this Pull Request makes visual changes then please include some screenshots that show what has changed here. A before and after screenshot helps the reviewer determine what changes were made.* -->

## Release notes
We fixed an issue for events that had more than 12 people enrolled. On the event detail page it would always show 12 enrollments. This should now show correct total amount of enrollees. Also we fixed the plural grammar error when only 1 person has enrolled.

## Change Record
<!-- *[Required if applicable] If this Pull Request changes the way that developers should do things or introduces a new API for developers then a change record to document this is needed. Please provide a draft for a change record or a link to an unpublished change record below. Existing change records can be consulted as example. Please provide a draft for a change record or a link to an unpublished change record below. [Existing change records](https://www.drupal.org/list-changes/social) can be consulted as example.* -->

## Translations
<!--
*[Optional]Translatable strings are always extracted from the latest development branch. To ensure translations remain available for platforms running older versions of Open Social the original string should be added to `translations.php` when it's changed or removed.*
- [ ] Changed or removed source strings are added to the `translations.php` file.
-->
