### PR TITLE
Issue #3431288 by vnech: Prevent wrong sorting option set on "Custom content list" block

### DIFF
--- a/modules/social_features/social_content_block/src/ContentBuilder.php
+++ b/modules/social_features/social_content_block/src/ContentBuilder.php
@@ -388,6 +388,7 @@ class ContentBuilder implements ContentBuilderInterface {
     }
 
     $element['field_sorting']['widget']['#options'] = $options;
+    $element['field_sorting']['widget']['#process'][] = [static::class, 'processSortOptions'];
 
     $selector = $content_block_manager->getSelector('field_sorting', NULL, $element);
 
@@ -406,10 +407,52 @@ class ContentBuilder implements ContentBuilderInterface {
   }
 
   /**
+   * Helps to rebuild values for "field_sorting" form element.
+   *
+   * @param array $element
+   *   The "field_sorting" form element.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The form state object.
+   * @param array $complete_form
+   *   The form build array.
+   *
+   * @return array
+   *   The element array.
+   */
+  public static function processSortOptions(array $element, FormStateInterface $form_state, array &$complete_form): array {
+    $sort_value = is_array($element['#value'])
+      ? $element['#value'][0] ?? NULL
+      : $element['#value'];
+
+    $options = $element['#options'];
+    // If the current value isn't in the options list, we will have an error on
+    // default value element validation. Here we reassign value with the first
+    // option.
+    /* @see \Drupal\Core\Form\FormValidator::performRequiredValidation() */
+    if ($sort_value === NULL || !isset($options[$sort_value])) {
+      $new_sort_value = is_array($element['#value'])
+        ? [key($options)]
+        : key($options);
+
+      $form_state->setValue($element['#parents'], $new_sort_value);
+      $element['#value'] = $new_sort_value;
+    }
+
+    return $element;
+  }
+
+  /**
    * {@inheritdoc}
    */
   public static function updateFormSortingOptions(array $form, FormStateInterface $form_state): array {
     $parents = ['field_sorting'];
+
+    if (
+      $form_state->has('layout_builder__component') ||
+      str_contains($form_state->getValue('form_id'), 'layout_builder')
+    ) {
+      $parents = array_merge(['settings', 'block_form'], $parents);
+    }
 
     // Check that the currently selected value is valid and change it otherwise.
     $value_parents = array_merge($parents, ['0', 'value']);
@@ -421,13 +464,7 @@ class ContentBuilder implements ContentBuilderInterface {
     );
 
     if ($sort_value === NULL || !isset($options[$sort_value])) {
-      // Unfortunately this has already triggered a validation error.
-      $form_state->clearErrors();
       $form_state->setValue($value_parents, key($options));
-    }
-
-    if ($form_state->has('layout_builder__component')) {
-      $parents = array_merge(['settings', 'block_form'], $parents);
     }
 
     return NestedArray::getValue($form, $parents);


### PR DESCRIPTION
## Problem
When you creating a **Custom content list** block you get an error if switch options in **Sorting** field:

<img width="734" alt="Screenshot 2024-03-18 at 12 19 40" src="https://github.com/goalgorilla/open_social/assets/19921926/bb66e6bf-90db-4008-bd05-ef680883674e">

**Steps to reproduce**:
- Login as admin
- Go to _/block/add/custom_content_list_ page
- Chose "Event" in **Type of content** field
- Chose "Oldest -> Newest" in **Sorting** field
- Chose "Topic" in **Type of content** field
- AB: you will see error in **Sorting** field

## Solution
Add` #process` callback function to `field_sorting` field to reassign values

## Issue tracker
- https://www.drupal.org/project/social/issues/3431288
- https://getopensocial.atlassian.net/browse/PROD-28328

## Theme issue tracker

## How to test
- [ ] Login as admin
- [ ] Go to _/block/add/custom_content_list_ page
- [ ] Chose "Event" in **Type of content** field
- [ ] Chose "Oldest -> Newest" in **Sorting** field
- [ ] Chose "Topic" in **Type of content** field
- [ ] EB: you should not see error in **Sorting** field

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots

## Release notes
Prevent wrong sorting option set on "Custom content list" block.

## Change Record

## Translations
