### PR TITLE
Issue #3432109: Add new route `/my-settings` to redirect users to their settings page

### DIFF
--- a/modules/social_features/social_user/social_user.routing.yml
+++ b/modules/social_features/social_user/social_user.routing.yml
@@ -47,3 +47,10 @@ social_user.stream:
   requirements:
     _user_is_logged_in: 'TRUE'
     _custom_access: '\Drupal\social_user\Controller\SocialUserController::accessUsersPages'
+
+social_user.my_settings:
+  path: '/my-settings'
+  defaults:
+    _controller: '\Drupal\user\Controller\UserController::userEditPage'
+  requirements:
+    _user_is_logged_in: 'TRUE'

--- a/tests/behat/features/capabilities/account/my-settings-page.feature
+++ b/tests/behat/features/capabilities/account/my-settings-page.feature
@@ -1,0 +1,12 @@
+@api
+Feature: Redirect user to their settings page
+  Benefit: To make it easier for users to access their settings page
+  Role: As a Authenticated
+  Goal/desire: I want to be redirected to "/user/*/edit" when I go to "/my-settings"
+
+  Scenario: A user is redirected to their settings page
+    Given I am logged in as a user with the "authenticated" role
+
+    When I go to "/my-settings"
+
+    Then the URL should match "^\/user\/[^\/]+\/edit$"


### PR DESCRIPTION
## Problem

Currently, there is no easy way for users to go to their settings page unless they know their User ID, given that the path to the original route is `/user/{user}/edit`. It makes the UX to be somehow degraded.

## Solution

The solution is to create a custom route `/my-settings` which redirects the users to their settings page, so they don't need to think about it.

The same approach is already applied to other extensions (eg. `/my-invites` and `/my-events`).

## Issue tracker

- https://www.drupal.org/project/social/issues/3432109
- https://getopensocial.atlassian.net/browse/PROD-28573

## Theme issue tracker
N/A

## How to test

- [ ] Checkout branch `feature/3432109-new-route-my-settings` of Open Social
- [ ] As an authenticated user
- [ ] Go to `/my-settings` page
- [ ] The expected result is that the user is redirected to their `/user/{user}/edit` page

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
N/A

## Release notes
N/A

## Change Record
N/A

## Translations
N/A