### PR TITLE
Issue #3436013: Fix sidebar blocks display in flexible groups

### DIFF
--- a/tests/behat/features/capabilities/groups/flexible/groups-flexible-sidebar-blocks.feature
+++ b/tests/behat/features/capabilities/groups/flexible/groups-flexible-sidebar-blocks.feature
@@ -1,20 +1,21 @@
-@api @flexible-groups
+@api
 Feature: Flexible groups sidebar blocks are correctly displayed
   Background:
     Given I enable the module "social_group_flexible_group"
 
-  Scenario: Verified user should see all 3 sidebar blocks in a group
+  Scenario: Verified user should see all sidebar blocks in a group
     Given users:
       | name     | status | pass    | roles       |
       | Manager  | 1      | secret  | sitemanager |
       | John     | 1      | secret  | verified    |
-    Given groups:
+    And groups:
       | label              | field_group_description | field_flexible_group_visibility | author  | type            | created  |
       | My Flexible Group  | My Description          | public                          | Manager | flexible_group  | 01/01/01 |
 
     When I am logged in as John
     And I click "All groups"
     And I click "My Flexible Group"
+
     Then I should see "Upcoming events" in the "Sidebar second"
     And I should see "Newest topics" in the "Sidebar second"
     And I should see "Newest Members" in the "Sidebar second"

--- a/tests/behat/features/capabilities/groups/flexible/groups-flexible-sidebar-blocks.feature
+++ b/tests/behat/features/capabilities/groups/flexible/groups-flexible-sidebar-blocks.feature
@@ -1,0 +1,20 @@
+@api @flexible-groups
+Feature: Flexible groups sidebar blocks are correctly displayed
+  Background:
+    Given I enable the module "social_group_flexible_group"
+
+  Scenario: Verified user should see all 3 sidebar blocks in a group
+    Given users:
+      | name     | status | pass    | roles       |
+      | Manager  | 1      | secret  | sitemanager |
+      | John     | 1      | secret  | verified    |
+    Given groups:
+      | label              | field_group_description | field_flexible_group_visibility | author  | type            | created  |
+      | My Flexible Group  | My Description          | public                          | Manager | flexible_group  | 01/01/01 |
+
+    When I am logged in as John
+    And I click "All groups"
+    And I click "My Flexible Group"
+    Then I should see "Upcoming events" in the "Sidebar second"
+    And I should see "Newest topics" in the "Sidebar second"
+    And I should see "Newest Members" in the "Sidebar second"


### PR DESCRIPTION
## Problem

We received a bug report saying that some of our clients using the version <code>12.2.1</code> can't see the sidebar blocks "Upcoming events" and "Newest topics" in flexible groups.

As a result of a extensive investigation, we discovered that the issue is caused by 3 misconfigurations:

1. The visibility settings in the block is restricting it to some group types;
2. The contextual filter in the View has a validation criteria restricting the query to some group types;
3. The `social_course` module is [overriding some of the Views configs](https://git.drupalcode.org/project/social_course/-/blob/5.1.x/src/SocialCourseOverrides.php) affecting the query for those blocks.

We also discovered that this issue does not happen to fresh installations.

## Solution

Since the config overriding (3rd item mentioned above) is already been taken care on another issue ([#3416433](https://www.drupal.org/project/social_course/issues/3416433)), we should write an update script to reset the other two configs: **_block visibility settings_**, and **_contextual filter validation criteria_**, so they will match with the install config state. 

We should also write a Behat test to make sure the blocks appears properly in the flexible group sidebar region.

## Issue tracker
https://www.drupal.org/project/social/issues/3436013

## Theme issue tracker
N/A

## How to test
Run the Behat test `tests/behat/features/capabilities/groups/flexible/groups-flexible-sidebar-blocks.feature`

<img width="1246" alt="image" src="https://github.com/goalgorilla/open_social/assets/197236/6eb1ba4c-f815-42fa-871b-f1159e828835">

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
<!-- *[Required if new feature, and if applicable] If this Pull Request makes visual changes then please include some screenshots that show what has changed here. A before and after screenshot helps the reviewer determine what changes were made.* -->

## Release notes
<!-- *[Required if new feature, and if applicable] A short summary of the changes that were made that can be included in release notes.* -->

## Change Record
<!-- *[Required if applicable] If this Pull Request changes the way that developers should do things or introduces a new API for developers then a change record to document this is needed. Please provide a draft for a change record or a link to an unpublished change record below. Existing change records can be consulted as example. Please provide a draft for a change record or a link to an unpublished change record below. [Existing change records](https://www.drupal.org/list-changes/social) can be consulted as example.* -->

## Translations
<!--
*[Optional]Translatable strings are always extracted from the latest development branch. To ensure translations remain available for platforms running older versions of Open Social the original string should be added to `translations.php` when it's changed or removed.*
- [ ] Changed or removed source strings are added to the `translations.php` file.
-->
