### PR TITLE
Issue #3436178: Group bulk-action is not enable for everyone

### DIFF
--- a/modules/social_features/social_group/social_group.install
+++ b/modules/social_features/social_group/social_group.install
@@ -100,6 +100,9 @@ function social_group_install(): void {
   // Since we update group related permissions that touch node content we must
   // also rebuild the node access permissions.
   node_access_rebuild();
+
+  // Add group bulk action to people view.
+  _social_group_alter_admin_people_view();
 }
 
 /**
@@ -125,6 +128,29 @@ function social_group_update_dependencies(): array {
  */
 function social_group_update_last_removed() : int {
   return 11902;
+}
+
+/**
+ * Update the user admin view with our custom action.
+ *
+ * Action ID: 'social_group_add_members_to_group_action'.
+ */
+function _social_group_alter_admin_people_view(): void {
+  // Get people view config.
+  $config = \Drupal::configFactory()->getEditable('views.view.user_admin_people');
+  $selected_actions = $config->get('display.default.display_options.fields.views_bulk_operations_bulk_form.selected_actions');
+
+  // Check if already have bulk action.
+  if (in_array('social_group_add_members_to_group_action', array_column(array_values($selected_actions), 'action_id'))) {
+    return;
+  }
+
+  // Add bulk action and save them.
+  $selected_actions[] = [
+    'action_id' => 'social_group_add_members_to_group_action',
+  ];
+  $config->set('display.default.display_options.fields.views_bulk_operations_bulk_form.selected_actions', $selected_actions);
+  $config->save();
 }
 
 /**
@@ -206,6 +232,13 @@ function social_group_update_12301(): void {
   if (!\Drupal::service('module_handler')->moduleExists('flexible_permissions')) {
     \Drupal::service('module_installer')->install(['flexible_permissions']);
   }
+}
+
+/**
+ * Add group bulk action to people view.
+ */
+function social_group_update_12302(): void {
+  _social_group_alter_admin_people_view();
 }
 
 /**


### PR DESCRIPTION
## Problem
The Social Group is enable by default, but, some installation haven't bulk-action on people page to add to a group.
The code enabling the bulk-action was removed a couple version ago.

## Solution
Comeback with the code, but add a validation to ignore installations with bulk-action already be enabled.

## Issue tracker
[PROD-28567](https://getopensocial.atlassian.net/browse/PROD-28567)
[#3436178](https://www.drupal.org/project/social/issues/3436178)

## Theme issue tracker
N/A

## How to test
- [ ] Init a new installation of Open Social
- [ ] Create a couple users
- [ ] Go to people page
- [ ] Select some user and check bulk action to add in a group

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
N/A

## Release notes
Add bulk user to group in be added and will be available for installation missing it.

## Change Record
N/A

## Translations
N/A


[PROD-28567]: https://getopensocial.atlassian.net/browse/PROD-28567?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ