### PR TITLE
Internal: Improve test fixture creation for group references

### DIFF
--- a/tests/behat/features/bootstrap/EntityTrait.php
+++ b/tests/behat/features/bootstrap/EntityTrait.php
@@ -99,6 +99,43 @@ trait EntityTrait {
       if ($field_definition !== NULL && in_array($field_definition->getType(), ["created", "changed"], TRUE)) {
         $values[$field_name] = strtotime($values[$field_name]);
       }
+      // Allow group fields to be a comma separated list of IDs or labels.
+      // We can only do this for the default handler because other handlers
+      // might have a different settings format so we can't know the target
+      // bundles.
+      if ($field_definition !== NULL && $field_definition->getType() === "entity_reference" && $field_definition->getSetting("target_type") === "group") {
+        $group_storage = $entity_type_manager->getStorage("group");
+        if ($field_definition->getSetting("handler") === "default:group") {
+          assert(is_string($field_value), "The group value for '$field_name' has already been converted to entities but this isn't needed.");
+          if (trim($field_value) === "") {
+            unset($values[$field_name]);
+            continue;
+          }
+          $allowed_bundles = $field_definition->getSetting("handler_settings")["target_bundles"];
+          // Split 0,1 to [0, 1] and convert 2,someLabel to [2, 4], making a
+          // lookup of the group id by name.
+          $values[$field_name] = array_map(
+            function ($id_or_name) use ($group_storage, $allowed_bundles) {
+              $id_or_name = trim($id_or_name);
+              if (is_numeric($id_or_name)) {
+                return ["target_id" => $id_or_name];
+              }
+
+              $group_ids = $group_storage->getQuery()
+                ->condition("type", $allowed_bundles, "IN")
+                ->condition("label", $id_or_name)
+                ->accessCheck(TRUE)
+                ->execute();
+
+              if (!is_array($group_ids) || empty($group_ids)) {
+                throw new \InvalidArgumentException("Group $id_or_name does not exist" . implode(", ", $allowed_bundles));
+              }
+              return ["target_id" => (int) reset($group_ids)];
+            },
+            explode(",", $field_value)
+          );
+        }
+      }
     }
   }
 


### PR DESCRIPTION
## Problem / Solution
This commit allows group reference data to be provided as a comma separated list of IDs or term names (mixing is allowed). This can now be used in tables for e.g. groups, topics and events. By putting this in the validate method we can use this everywhere.

This ensures we deduplicate the group title lookup so that we don't break on a pre-fetched value. Since we now do it by field type we no longer need to do it by field name.

## Example usage

```cucumber
    Given groups:
      | label |
      | Cats  |
      | Birds |
    And groups:
      | label   | field_related_groups |
      | Dogs    | 1,Birds              |
      | Snakes  | 1,2                  |
      | Rabbits | Cats,Birds           |
```

Inspired by: [3394](https://github.com/goalgorilla/open_social/pull/3394)

## Issue tracker
[3436789](https://www.drupal.org/project/social/issues/3436789#)

## Theme issue tracker
N/A

## How to test
- [ ] Tests should pass :)

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
<!-- *[Required if new feature, and if applicable] If this Pull Request makes visual changes then please include some screenshots that show what has changed here. A before and after screenshot helps the reviewer determine what changes were made.* -->

## Release notes
<!-- *[Required if new feature, and if applicable] A short summary of the changes that were made that can be included in release notes.* -->

## Change Record
<!-- *[Required if applicable] If this Pull Request changes the way that developers should do things or introduces a new API for developers then a change record to document this is needed. Please provide a draft for a change record or a link to an unpublished change record below. Existing change records can be consulted as example. Please provide a draft for a change record or a link to an unpublished change record below. [Existing change records](https://www.drupal.org/list-changes/social) can be consulted as example.* -->

## Translations
<!--
*[Optional]Translatable strings are always extracted from the latest development branch. To ensure translations remain available for platforms running older versions of Open Social the original string should be added to `translations.php` when it's changed or removed.*
- [ ] Changed or removed source strings are added to the `translations.php` file.
-->
