### PR TITLE
Issue #3437440: Block with enrollments from Event page is showing wrong count

### DIFF
--- a/modules/social_features/social_event/modules/social_event_max_enroll/social_event_max_enroll.module
+++ b/modules/social_features/social_event/modules/social_event_max_enroll/social_event_max_enroll.module
@@ -31,8 +31,16 @@ function social_event_max_enroll_views_post_render(ViewExecutable $view, &$outpu
     if ($event_max_enroll_service->isEnabled($node)) {
       // Count how many spots left.
       $left = $event_max_enroll_service->getEnrollmentsLeft($node);
-      $title_suffix = \Drupal::translation()->formatPlural($left, '(1 spot left)', '(@count spots left)');
-      $view->header['area_text_custom']->options['content'] .= ' ' . $title_suffix;
+      $title_suffix = \Drupal::translation()
+        ->formatPlural($left, '(1 spot left)', '(@count spots left)');
+      // Social_event_update_121001 changed 'result' to 'area_text_custom'
+      // Add backwards compatibility, in case of update hook failure.
+      if (isset($view->header['area_text_custom'])) {
+        $view->header['area_text_custom']->options['content'] .= ' ' . $title_suffix;
+      }
+      if (isset($view->header['result'])) {
+        $view->header['result']->options['content'] .= ' ' . $title_suffix;
+      }
     }
   }
 }

--- a/modules/social_features/social_event/social_event.tokens.inc
+++ b/modules/social_features/social_event/social_event.tokens.inc
@@ -67,7 +67,10 @@ function social_event_tokens($type, $tokens, array $data, array $options, Bubble
               ->load($nid);
             if ($node instanceof NodeInterface && $node->getType() === 'event') {
               $enrollments = \Drupal::service('social_event.status_helper');
-              $count = count($enrollments->getAllEventEnrollments((int) $node->id(), TRUE));
+              $count = count($enrollments->getEventEnrollmentsByStatus((int) $node->id(), [
+                EventEnrollmentInterface::INVITE_ACCEPTED_AND_JOINED,
+                EventEnrollmentInterface::REQUEST_APPROVED,
+              ]));
               $enrollments = \Drupal::translation()->formatPlural(
                 $count,
                 ':count person has enrolled',

--- a/modules/social_features/social_event/src/EventEnrollmentStatusHelper.php
+++ b/modules/social_features/social_event/src/EventEnrollmentStatusHelper.php
@@ -208,4 +208,39 @@ class EventEnrollmentStatusHelper {
       ->loadByProperties($conditions);
   }
 
+  /**
+   * Get event-enrollment without request-invite-status and filtering by it too.
+   *
+   * @param int $event_id
+   *   Event id to search enrollments.
+   * @param array $filter
+   *   Event enrollment status to be filtered.
+   *
+   * @return array
+   *   Return an array of EventEnrollmentEntity.
+   *
+   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
+   * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
+   */
+  public function getEventEnrollmentsByStatus(int $event_id, array $filter): array {
+    // Get event-enrollment query.
+    $query = $this->entityTypeManager
+      ->getStorage('event_enrollment')
+      ->getQuery()
+      ->accessCheck(FALSE);
+
+    // Get event-enrollment with field_request_or_invite_status or filter by
+    // array parameter.
+    $status_group_condition = $query->orConditionGroup()
+      ->notExists('field_request_or_invite_status')
+      ->condition('field_request_or_invite_status', $filter, 'IN');
+    $event_nid = $query
+      ->condition('field_event', $event_id)
+      ->condition($status_group_condition)
+      ->execute();
+
+    return $this->entityTypeManager->getStorage('event_enrollment')
+      ->loadMultiple($event_nid);
+  }
+
 }


### PR DESCRIPTION
## Problem
The enrollments count from Event page is showing all enrollments without check the status for invite or pending request.

## Solution
Removed parameters to ignore status from events

## Issue tracker
<!-- *[Required] Paste a link to the drupal.org issue queue item. If any other issue trackers were used, include links to those too.* -->

## Theme issue tracker
[PROD-28692](https://getopensocial.atlassian.net/browse/PROD-28692)
[#3437440](https://www.drupal.org/project/social/issues/3437440)

## How to test
- [ ] Create an event
- [ ] Add an enrollee to the event
- [ ] Invite another user to the event
- [ ] Check the event page
- [ ] The Enrollees block states that the event has two enrollees on the event when there is only one displayed

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
N/A

## Release notes
Fixed the enrollments count from event page.

## Change Record
N/A

## Translations
N/A


[PROD-28692]: https://getopensocial.atlassian.net/browse/PROD-28692?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ