### PR TITLE
Issue #3438139: Add "Group types" to groups migration

### DIFF
--- a/modules/social_features/social_group/social_group.install
+++ b/modules/social_features/social_group/social_group.install
@@ -289,6 +289,75 @@ function social_group_update_13000() : void {
     ],
   ];
 
+  // Add "Group type" field value to avoid losing groups identity for customers.
+  $taxonomy_storage = \Drupal::entityTypeManager()->getStorage('taxonomy_term');
+  $types_query = \Drupal::database()->select('groups')
+    ->fields('groups', ['type'])
+    ->groupBy('type');
+  $types = (array) $types_query->execute()?->fetchCol();
+  [
+    $has_public_groups,
+    $has_open_groups,
+    $has_closed_groups,
+    $has_secret_groups,
+  ] = [
+    in_array('public_group', $types),
+    in_array('open_group', $types),
+    in_array('closed_group', $types),
+    in_array('secret_group', $types),
+  ];
+
+  $term_names = [
+    'public_group' => $has_public_groups ? 'Public group' : NULL,
+    'open_group' => $has_open_groups ? 'Open group' : NULL,
+    'closed_group' => $has_closed_groups ? 'Closed group' : NULL,
+    'secret_group' => $has_secret_groups ? 'Secret group' : NULL,
+    'default' => 'Flexible group',
+  ];
+
+  foreach ($term_names as $group_type => $name) {
+    if (!$name) {
+      // The platform doesn't have groups of such a type, skip.
+      continue;
+    }
+
+    if (
+      $group_type === 'default' &&
+      !array_filter([
+        $has_public_groups,
+        $has_open_groups,
+        $has_closed_groups,
+        $has_secret_groups,
+      ])
+    ) {
+      // Do not create "Flexible group" term if a platform has
+      // only flexible groups.
+      continue;
+    }
+
+    $tid = $taxonomy_storage->getQuery()
+      ->accessCheck(FALSE)
+      ->condition('name', $name)
+      ->condition('vid', 'group_type')
+      ->execute();
+    $tid = reset($tid);
+
+    if (!$tid) {
+      $term = $taxonomy_storage->create([
+        'name' => $name,
+        'vid' => 'group_type',
+      ]);
+      $term->save();
+      $tid = $term->id();
+    }
+
+    if ($group_type === 'default') {
+      continue;
+    }
+
+    $group_type_mapping[$group_type]['fields']['field_group_type'] = [$tid];
+  }
+
   // If the secret group module isn't enabled we don't need to migrate secret
   // groups.
   if (!\Drupal::moduleHandler()->moduleExists("social_group_secret")) {
@@ -430,7 +499,7 @@ function social_group_update_13000() : void {
             $from->addField("from", "langcode", "langcode");
             $from->addExpression("'flexible_group'", "bundle");
             $from->addExpression($delta, "delta");
-            $from->addExpression("'$value'", $group_table_mapping->getFieldColumnName($field_storage, "value"));
+            $from->addExpression("'$value'", $group_table_mapping->getFieldColumnName($field_storage, $field_name === 'field_group_type' ? 'target_id' : 'value'));
 
             $database->insert($tableName)
               ->from($from)

--- a/tests/behat/features/capabilities/groups/groups-view-overview-filter.feature
+++ b/tests/behat/features/capabilities/groups/groups-view-overview-filter.feature
@@ -6,11 +6,11 @@ Feature: All group overview filters
 
   Scenario: As user I can not filter on the field group type if there are no types added
     Given I am an anonymous user
-    And I set the configuration item "social_group.settings" with key "social_group_type_required" to TRUE
+    And I enable group type settings
 
     When I am viewing the groups overview
-
-    Then I should not see "Type" in the "Sidebar second"
+    # By default we have at least "Flexible group" group type.
+    And I should not see "Type" in the "Sidebar second"
 
   Scenario: As user I can not filter on the field group type if the setting is disabled even if there are options
     Given I am an anonymous user


### PR DESCRIPTION
## Problem
Currently we have 4 types of Groups that we are now migrating to Flexible Groups:
<ul>
  <li>Open Group</li>
  <li>Closed Group</li>
  <li>Secret Group</li>
  <li>Public Group</li>
</ul>

The information about the type of these groups is very valuable and a group is immediately recognisable in teasers search and groups pages.

When moving these groups to Flexible groups we are going to loose this identity.
Everything will be identified as Flexible Groups and this will generate confusion and frustration for customers.

We want to mitigate this problem by creating and assigning "Group type" value to each of the newly migrated groups.

## Solution
Add taxonomy terms in "Group types" vocabulary and assign to group during migration.

## Issue tracker
- https://www.drupal.org/project/social/issues/3438139
- https://getopensocial.atlassian.net/browse/PROD-27578

## Theme issue tracker

## How to test
- [ ] Switch to `goalgorilla/open_social:^12` and install profile
- [ ] Create at least one group by each type: `public`, `open`, `closed` and `secret` groups
- [ ] Switch to `goalgorilla/open_social:dev-main` and run `drush updb -y`
- [ ] On _admin/config/opensocial/social-group_ enable checkbox **"Require group types"**
- [ ] **EB**:  Each group should have "Group type" value according previous group type

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots

## Release notes
Add "Group types" to groups migration to prevent losing groups identity.

## Change Record

## Translations
