### PR TITLE
Issue #3439600: Update hook social_event update hook 121001 and 121002 not executed because of language issues

### DIFF
--- a/modules/social_features/social_event/config/update/social_event_update_121003.yml
+++ b/modules/social_features/social_event/config/update/social_event_update_121003.yml
@@ -1,0 +1,81 @@
+views.view.event_enrollments:
+  expected_config: {}
+  update_actions:
+    change:
+      display:
+        event_enrollments:
+          display_options:
+            display_extenders: {  }
+            block_description: 'Enrollments Block'
+            footer: {  }
+            defaults:
+              footer: false
+              style: false
+              row: false
+              pager: false
+              arguments: false
+              link_display: false
+              link_url: false
+              use_more: false
+              use_more_always: false
+              use_more_text: false
+            style:
+              type: default
+              options: {  }
+            row:
+              type: 'entity:profile'
+              options:
+                relationship: none
+                view_mode: compact
+            pager:
+              type: some
+              options:
+                items_per_page: 12
+                offset: 0
+            arguments:
+              nid:
+                id: nid
+                table: node_field_data
+                field: nid
+                relationship: field_event
+                group_type: group
+                admin_label: ''
+                default_action: default
+                exception:
+                  value: all
+                  title_enable: false
+                  title: All
+                title_enable: false
+                title: ''
+                default_argument_type: node
+                default_argument_options: {  }
+                default_argument_skip_url: false
+                summary_options:
+                  base_path: ''
+                  count: true
+                  items_per_page: 25
+                  override: false
+                summary:
+                  sort_order: asc
+                  number_of_records: 0
+                  format: default_summary
+                specify_validation: false
+                validate:
+                  type: none
+                  fail: 'not found'
+                validate_options: {  }
+                break_phrase: false
+                not: false
+                entity_type: node
+                entity_field: nid
+                plugin_id: node_nid
+            link_display: custom_url
+            link_url: '/node/{{ raw_arguments.nid }}/enrollments'
+            use_more: true
+            use_more_always: true
+            use_more_text: 'All enrollments'
+    delete:
+      display:
+        event_enrollments:
+          display_options:
+            footer: {  }

--- a/modules/social_features/social_event/config/update/social_event_update_121004.yml
+++ b/modules/social_features/social_event/config/update/social_event_update_121004.yml
@@ -1,0 +1,25 @@
+views.view.event_enrollments:
+  expected_config: {}
+  update_actions:
+    change:
+      display:
+        default:
+          display_options:
+            header:
+              area_text_custom:
+                admin_label: ''
+                content: '[social_event:enrolled_users_count]'
+                empty: true
+                field: area_text_custom
+                group_type: group
+                id: area_text_custom
+                plugin_id: text_custom
+                relationship: none
+                table: views
+                tokenize: false
+    delete:
+      display:
+        default:
+          display_options:
+            header:
+              result:

--- a/modules/social_features/social_event/social_event.install
+++ b/modules/social_features/social_event/social_event.install
@@ -154,6 +154,40 @@ function social_event_update_121002(): string {
 }
 
 /**
+ * Re-run: Change the More Link from Event Enrollments view.
+ *
+ * Due to an issue with expected config vs actual config
+ * having translated strings in it.
+ */
+function social_event_update_121003(): string {
+  /** @var \Drupal\update_helper\Updater $updateHelper */
+  $updateHelper = \Drupal::service('update_helper.updater');
+
+  // Execute configuration update definitions with logging of success.
+  $updateHelper->executeUpdate('social_event', __FUNCTION__);
+
+  // Output logged messages to a related channel of update execution.
+  return $updateHelper->logger()->output();
+}
+
+/**
+ * Re-run: Change the event enrollments view header to a token.
+ *
+ * Due to an issue with expected config vs actual config
+ * having translated strings in it.
+ */
+function social_event_update_121004(): string {
+  /** @var \Drupal\update_helper\Updater $updateHelper */
+  $updateHelper = \Drupal::service('update_helper.updater');
+
+  // Execute configuration update definitions with logging of success.
+  $updateHelper->executeUpdate('social_event', __FUNCTION__);
+
+  // Output logged messages to related channel of update execution.
+  return $updateHelper->logger()->output();
+}
+
+/**
  * Remove deprecated group types.
  */
 function social_event_update_130000(): ?string {


### PR DESCRIPTION
## Problem
The social event update hook 121001 and 121002 are bugfixes to the view enrollments, but inside the expected config it contains some strings like use_more_text: 'All enrollments'

In some cases it can be that multilingual platform have this string in a different language. This causes the update to not be executed and the bug persists on the platform. Even though base strings should be english we should take this into account.

## Solution
Remove the expected config to make sure they get executed.
Given this being an issue with language, config and update helper we acknowledge this won't run on 13.0.0, but given people need to first move to the latest 12.x version before going to 13 that should be acceptable. The fresh installed config, on 13, is already correct so it's merely the update hooks that didn't ran.

## Issue tracker
https://www.drupal.org/project/social/issues/3439600

## Theme issue tracker
<!-- *[Required if applicable] Paste a link to the drupal.org theme issue queue item, either from [socialbase](https://www.drupal.org/project/socialbase) or [socialblue](https://www.drupal.org/project/socialblue). If any other issue trackers were used, include links to those too.* -->

## How to test
- [ ]  Make sure social_event is enabled
- [ ]  Make sure to add multiple language where it causes the base view to be non english
- [ ]  Run the mentioned social_event update hooks and see they fail
- [ ] Checkout to this branch and try again, see they now are updated correctly.

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
<!-- *[Required if new feature, and if applicable] If this Pull Request makes visual changes then please include some screenshots that show what has changed here. A before and after screenshot helps the reviewer determine what changes were made.* -->

## Release notes
Internal: We had to re-run social_event update hook 121001 and 121002 to make sure those fixes landed for client where multilingual maybe configured incorrectly.

## Change Record
<!-- *[Required if applicable] If this Pull Request changes the way that developers should do things or introduces a new API for developers then a change record to document this is needed. Please provide a draft for a change record or a link to an unpublished change record below. Existing change records can be consulted as example. Please provide a draft for a change record or a link to an unpublished change record below. [Existing change records](https://www.drupal.org/list-changes/social) can be consulted as example.* -->

## Translations
<!--
*[Optional]Translatable strings are always extracted from the latest development branch. To ensure translations remain available for platforms running older versions of Open Social the original string should be added to `translations.php` when it's changed or removed.*
- [ ] Changed or removed source strings are added to the `translations.php` file.
-->
