### PR TITLE
Issue #3440298: Deprecate Social Lazy Loading module

### DIFF
--- a/cspell.baseline.txt
+++ b/cspell.baseline.txt
@@ -637,6 +637,7 @@ iefix
 ieiunius
 ielunior
 iframe
+iframes
 igitur
 ignorat
 ignorecase

--- a/modules/custom/social_lazy_loading/social_lazy_loading.info.yml
+++ b/modules/custom/social_lazy_loading/social_lazy_loading.info.yml
@@ -1,7 +1,7 @@
-name: 'Social Lazy Loading'
+name: 'Deprecated - Social Lazy Loading'
 type: module
 description: 'Module for lazy loading content using the blazy library.'
+lifecycle: deprecated
+lifecycle_link: 'https://www.drupal.org/project/social/issues/3440298'
 core_version_requirement: ^9 || ^10
 package: Social
-dependencies:
-  - lazy:lazy

--- a/modules/social_features/social_core/social_core.install
+++ b/modules/social_features/social_core/social_core.install
@@ -358,3 +358,63 @@ function social_core_update_123004(): void {
     }
   }
 }
+
+/**
+ * Uninstall Social Lazy Loading module.
+ */
+function social_core_update_124000(): void {
+  // Nothing to do if the module is not installed.
+  if (!\Drupal::moduleHandler()->moduleExists('social_lazy_loading')) {
+    return;
+  }
+
+  // If there are modules depending on admin_toolbar_tools, and it is enabled
+  // we can't uninstall it.
+  $module_dependencies = \Drupal::service('extension.list.module')->get('social_lazy_loading')->required_by ?? [];
+  $has_dependency_enabled = FALSE;
+  foreach ($module_dependencies as $module_name => $module_dependency) {
+    if (\Drupal::moduleHandler()->moduleExists($module_name)) {
+      $has_dependency_enabled = TRUE;
+      break;
+    }
+  }
+  if ($has_dependency_enabled) {
+    return;
+  }
+
+  // Uninstall the module (nothing should depend on it but let the module
+  // uninstaller double-check just in case).
+  \Drupal::service('module_installer')->uninstall(['social_lazy_loading'], FALSE);
+}
+
+/**
+ * Uninstall Lazy module.
+ */
+function social_core_update_124001(): void {
+  // Nothing to do if the module is not installed.
+  if (!\Drupal::moduleHandler()->moduleExists('lazy')) {
+    return;
+  }
+
+  // If there are modules depending on admin_toolbar_tools, and it is enabled
+  // we can't uninstall it.
+  $module_dependencies = \Drupal::service('extension.list.module')->get('lazy')->required_by ?? [];
+  $has_dependency_enabled = FALSE;
+  foreach ($module_dependencies as $module_name => $module_dependency) {
+    if (\Drupal::moduleHandler()->moduleExists($module_name)) {
+      $has_dependency_enabled = TRUE;
+      break;
+    }
+  }
+  if ($has_dependency_enabled) {
+    return;
+  }
+
+  // Uninstall the module (nothing should depend on it but let the module
+  // uninstaller double-check just in case).
+  \Drupal::service('module_installer')->uninstall(['lazy'], FALSE);
+
+  // Remove configuration.
+  $config = \Drupal::service('config.factory')->getEditable('lazy.settings');
+  $config->delete()->save();
+}

--- a/modules/social_features/social_embed/social_embed.install
+++ b/modules/social_features/social_embed/social_embed.install
@@ -127,3 +127,41 @@ function social_embed_uninstall() :void {
 function social_embed_update_last_removed() : int {
   return 11005;
 }
+
+/**
+ * Change lazy-filter to use the social lazy-filter.
+ */
+function social_embed_update_124001(): void {
+  $config_factory = \Drupal::configFactory();
+  $text_formats = [
+    'filter.format.full_html',
+    'filter.format.basic_html',
+    'filter.format.plain_text',
+    'filter.format.simple_text',
+    'filter.format.restricted_html',
+    'filter.format.mail_html',
+  ];
+
+  foreach ($text_formats as $text_format) {
+    $configuration = $config_factory->getEditable($text_format);
+    $filters = $configuration->get('filters');
+
+    // Removing old plugin when is enabled.
+    if (isset($filters['lazy_filter'])) {
+      unset($filters['lazy_filter']);
+    }
+
+    // Adding the lazy filter for all.
+    $filters['social_embed_lazy_filter'] = [
+      'id' => 'social_embed_lazy_filter',
+      'provider' => 'social_embed',
+      'status' => TRUE,
+      'weight' => 999,
+      'settings' => [],
+    ];
+
+    // Saving new filters.
+    $configuration->set('filters', $filters)
+      ->save();
+  }
+}

--- a/modules/social_features/social_embed/src/Plugin/Filter/SocialEmbedLazyFilter.php
+++ b/modules/social_features/social_embed/src/Plugin/Filter/SocialEmbedLazyFilter.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Drupal\social_embed\Plugin\Filter;
+
+use Drupal\Component\Utility\Html;
+use Drupal\filter\FilterProcessResult;
+use Drupal\filter\Plugin\FilterBase;
+
+/**
+ * Provides a filter to lazy-load iframes.
+ *
+ * @Filter(
+ *   id = "social_embed_lazy_filter",
+ *   title = @Translation("Lazy-load for iframes"),
+ *   description = @Translation("Only selected tags will be lazy-loaded in activated text-formats."),
+ *   type = Drupal\filter\Plugin\FilterInterface::TYPE_TRANSFORM_REVERSIBLE,
+ *   settings = { },
+ *   weight = 999
+ * )
+ */
+class SocialEmbedLazyFilter extends FilterBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function process($text, $langcode): FilterProcessResult {
+    $result = new FilterProcessResult($text);
+
+    if ($this->status) {
+      $html_dom = Html::load($text);
+      $xpath = new \DOMXPath($html_dom);
+
+      // Return early when the query-result is false/empty.
+      $query_result = $xpath->query('//iframe');
+      if (!$query_result) {
+        return $result;
+      }
+
+      /** @var \DOMElement $node */
+      foreach ($query_result as $node) {
+        // When is an iframe, set loading has lazy.
+        if ($node->tagName === 'iframe') {
+          $node->setAttribute('loading', 'lazy');
+        }
+      }
+
+      $result->setProcessedText(Html::serialize($html_dom));
+    }
+
+    return $result;
+  }
+
+}


### PR DESCRIPTION
## Problem
We will remove the Social Lazy and Lazy module at Open Social 13, so we will add deprecated lifecycle to it.

## Solution
We already use Drupal Core's native one for images (see https://github.com/goalgorilla/open_social/pull/3555) however we still have a way to lazy load iframes, using the embed module.

So we migrate the functionality from lazy to a new plugin within Social Embed.
The interesting part is the native browser `loading=lazy` attribute 
But we don't need a contrib module to have that, we just implement it ourselves.

Important note is that we set the weight to 999 to ensure this runs after the actual embed content.
Embed creates a different wrapper which will be replaced with an iframe, so we can't run it before, otherwise there is no iframe rendered yet.

It also works with the consent itself, this is lazy loaded by a user having to press a button.

## Issue tracker
[PROD-28024](https://getopensocial.atlassian.net/browse/PROD-28042)
[#3440298](https://www.drupal.org/project/social/issues/3440298)

## Theme issue tracker
N/A

## How to test
- [ ] Enable Social Embed module
- [ ] Go to Text Format CKEditor configuration: /admin/config/content/formats
- [ ] Configure Basic HTML and Full HTML
- [ ] Enable "Lazy-load images and iframes" option for both
- [ ] Create basic page and add some image and iframe and check if everything continue working

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
N/A

## Release notes
We are deprecated the Social Lazy Loading module to be removed at Open Social 13, it shouldn't impact any feature.

## Change Record
N/A

## Translations
N/A


[PROD-28024]: https://getopensocial.atlassian.net/browse/PROD-28024?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ