### PR TITLE
Issue #3441126: Language configuration create wrong to Original Language at group-type

### DIFF
--- a/modules/custom/social_language/social_language.install
+++ b/modules/custom/social_language/social_language.install
@@ -5,8 +5,8 @@
  * Install, update and uninstall functions for the social_language module.
  */
 
-use Drupal\Core\Database\Database;
 use Drupal\group\Entity\GroupType;
+use Drupal\language\ConfigurableLanguageManagerInterface;
 
 /**
  * Implements hook_install().
@@ -72,15 +72,24 @@ function social_language_update_12201(): string {
  * Removing wrong language configuration for original-language from groups.
  */
 function social_language_update_12301(): void {
-  $group_types = GroupType::loadMultiple();
-  foreach ($group_types as $group_type) {
-    $configuration_name = sprintf('group.type.%s', $group_type->id());
-    $collection_value = sprintf('language.%s', $group_type->language()->getId());
+  $language_manager = \Drupal::languageManager();
+  if (!$language_manager instanceof ConfigurableLanguageManagerInterface) {
+    return;
+  }
 
-    Database::getConnection()
-      ->delete('config')
-      ->condition('collection', $collection_value)
-      ->condition('name', $configuration_name)
-      ->execute();
+  $group_types = GroupType::loadMultiple();
+  $group_configs = [
+    'group_invitation',
+    'group_membership',
+    'group_node-event',
+    'group_node-topic',
+  ];
+  foreach ($group_types as $group_type) {
+    foreach ($group_configs as $group_config) {
+      $configuration_name = sprintf('group.content_type.%s-%s', $group_type->id(), $group_config);
+
+      $config_translation = $language_manager->getLanguageConfigOverride($group_type->language()->getId(), $configuration_name);
+      $config_translation->delete();
+    }
   }
 }

--- a/modules/custom/social_language/social_language.install
+++ b/modules/custom/social_language/social_language.install
@@ -5,6 +5,9 @@
  * Install, update and uninstall functions for the social_language module.
  */
 
+use Drupal\Core\Database\Database;
+use Drupal\group\Entity\GroupType;
+
 /**
  * Implements hook_install().
  *
@@ -63,4 +66,21 @@ function social_language_update_12201(): string {
 
   // Output logged messages to related channel of update execution.
   return $updateHelper->logger()->output();
+}
+
+/**
+ * Removing wrong language configuration for original-language from groups.
+ */
+function social_language_update_12301(): void {
+  $group_types = GroupType::loadMultiple();
+  foreach ($group_types as $group_type) {
+    $configuration_name = sprintf('group.type.%s', $group_type->id());
+    $collection_value = sprintf('language.%s', $group_type->language()->getId());
+
+    Database::getConnection()
+      ->delete('config')
+      ->condition('collection', $collection_value)
+      ->condition('name', $configuration_name)
+      ->execute();
+  }
 }

--- a/modules/social_features/social_group/modules/social_group_invite/social_group_invite.install
+++ b/modules/social_features/social_group/modules/social_group_invite/social_group_invite.install
@@ -95,7 +95,13 @@ function social_group_invite_update_13001(): void {
     $config_name = sprintf('group.content_type.%s-group_invitation', $group);
     $configuration = $config_factory->getEditable($config_name);
 
+    // When the plugin is empty, go to the next.
     $plugin_config_data = $configuration->getOriginal('plugin_config');
+    if (empty($plugin_config_data)) {
+      continue;
+    }
+
+    // Change tokens.
     if (!empty($plugin_config_data['existing_user_invitation_subject'])) {
       $plugin_config_data['existing_user_invitation_subject'] = str_replace('[current-user:display-name]', '[user:display-name]', $plugin_config_data['existing_user_invitation_subject']);
     }

--- a/modules/social_features/social_group/modules/social_group_invite/social_group_invite.install
+++ b/modules/social_features/social_group/modules/social_group_invite/social_group_invite.install
@@ -6,6 +6,7 @@
  */
 
 use Drupal\group\Entity\GroupType;
+use Drupal\language\ConfigurableLanguageManagerInterface;
 
 /**
  * Implements hook_install().
@@ -43,6 +44,67 @@ function social_group_invite_update_dependencies() : array {
  */
 function social_group_invite_update_last_removed() : int {
   return 11503;
+}
+
+/**
+ * Update email invitation messages with new token for the symfony mailer.
+ */
+function social_group_invite_update_12401(): void {
+  $config_factory = \Drupal::configFactory();
+
+  // Groups to look for translation.
+  $groups = [
+    'secret_group',
+    'closed_group',
+    'flexible_group',
+    'open_group',
+    'public_group',
+  ];
+
+  foreach ($groups as $group) {
+    $config_name = sprintf('group.content_type.%s-group_invitation', $group);
+    $configuration = $config_factory->getEditable($config_name);
+
+    $plugin_config_data = $configuration->getOriginal('plugin_config');
+    if (!empty($plugin_config_data['existing_user_invitation_subject'])) {
+      $plugin_config_data['existing_user_invitation_subject'] = str_replace('[current-user:display-name]', '[user:display-name]', $plugin_config_data['existing_user_invitation_subject']);
+    }
+    if (!empty($plugin_config_data['existing_user_invitation_body'])) {
+      $plugin_config_data['existing_user_invitation_body'] = str_replace('[current-user:display-name]', '[user:display-name]', $plugin_config_data['existing_user_invitation_body']);
+    }
+    $configuration->set('plugin_config', $plugin_config_data);
+    $configuration->save();
+
+    // When the Social Language is disabled, go to the next.
+    if (!\Drupal::service('module_handler')->moduleExists('social_language')) {
+      continue;
+    }
+
+    // Change token from email template from languages.
+    $language_manager = \Drupal::languageManager();
+    foreach ($language_manager->getLanguages() as $language) {
+      if (!$language_manager instanceof ConfigurableLanguageManagerInterface) {
+        continue;
+      }
+      $config_translation = $language_manager->getLanguageConfigOverride($language->getId(), $config_name);
+
+      // When the current language don't have translation, go to the next.
+      $plugin_config_data = $config_translation->get('plugin_config');
+      if (empty($plugin_config_data)) {
+        continue;
+      }
+
+      // Change tokens.
+      if (!empty($plugin_config_data['existing_user_invitation_subject'])) {
+        $plugin_config_data['existing_user_invitation_subject'] = str_replace('[current-user:display-name]', '[user:display-name]', $plugin_config_data['existing_user_invitation_subject']);
+      }
+      if (!empty($plugin_config_data['existing_user_invitation_body'])) {
+        $plugin_config_data['existing_user_invitation_body'] = str_replace('[current-user:display-name]', '[user:display-name]', $plugin_config_data['existing_user_invitation_body']);
+      }
+      $config_translation->set('plugin_config', $plugin_config_data);
+      $config_translation->save();
+    }
+  }
 }
 
 /**

--- a/modules/social_features/social_group/modules/social_group_invite/social_group_invite.install
+++ b/modules/social_features/social_group/modules/social_group_invite/social_group_invite.install
@@ -32,8 +32,16 @@ function social_group_invite_update_dependencies() : array {
     'social_group' => 13000,
   ];
 
+  $dependencies['social_group_invite'][13001] = [
+    'social_group' => 13006,
+  ];
+
   $dependencies['social_group'][13001] = [
     'social_group_invite' => 13000,
+  ];
+
+  $dependencies['social_group'][13007] = [
+    'social_group_invite' => 13001,
   ];
 
   return $dependencies;
@@ -47,9 +55,31 @@ function social_group_invite_update_last_removed() : int {
 }
 
 /**
+ * Remove deprecated group types.
+ */
+function social_group_invite_update_13000(): ?string {
+  // Allow platforms to opt out of the group migration, for example if they want
+  // to build it themselves and take more scenario's into account than common
+  // Open Social installations will have.
+  if (\Drupal::state()->get('social_group_group_type_migration_opt_out', FALSE)) {
+    \Drupal::logger('social_group')->info('Platform has opted out of group migration.');
+    return NULL;
+  }
+
+  /** @var \Drupal\update_helper\Updater $updateHelper */
+  $updateHelper = \Drupal::service('update_helper.updater');
+
+  // Execute configuration update definitions with logging of success.
+  $updateHelper->executeUpdate('social_group_invite', __FUNCTION__);
+
+  // Output logged messages to related channel of update execution.
+  return $updateHelper->logger()->output();
+}
+
+/**
  * Update email invitation messages with new token for the symfony mailer.
  */
-function social_group_invite_update_12401(): void {
+function social_group_invite_update_13001(): void {
   $config_factory = \Drupal::configFactory();
 
   // Groups to look for translation.
@@ -105,26 +135,4 @@ function social_group_invite_update_12401(): void {
       $config_translation->save();
     }
   }
-}
-
-/**
- * Remove deprecated group types.
- */
-function social_group_invite_update_13000(): ?string {
-  // Allow platforms to opt out of the group migration, for example if they want
-  // to build it themselves and take more scenario's into account than common
-  // Open Social installations will have.
-  if (\Drupal::state()->get('social_group_group_type_migration_opt_out', FALSE)) {
-    \Drupal::logger('social_group')->info('Platform has opted out of group migration.');
-    return NULL;
-  }
-
-  /** @var \Drupal\update_helper\Updater $updateHelper */
-  $updateHelper = \Drupal::service('update_helper.updater');
-
-  // Execute configuration update definitions with logging of success.
-  $updateHelper->executeUpdate('social_group_invite', __FUNCTION__);
-
-  // Output logged messages to related channel of update execution.
-  return $updateHelper->logger()->output();
 }


### PR DESCRIPTION
## Problem
Some installation has a record at config table to original language and it's wrong, because original language will get data from the content and other language should have a record for they data.
When this record exists, the core never get the right data, because config by translation has priorioty to be selected.

## Solution
Create a hook-update to remove all extra record.

## Issue tracker
<!-- *[Required] Paste a link to the drupal.org issue queue item. If any other issue trackers were used, include links to those too.* -->

## Theme issue tracker
[PROD-27808](https://getopensocial.atlassian.net/browse/PROD-27808)
[#3441126](https://www.drupal.org/project/social/issues/3441126)

## How to test
That error isn't happen for new installation, because probable it was a bug already fixed by community, so to reproduce we need to add a record directly to the database.

- [ ] Install social language
- [ ] Add a second language
- [ ] Go to Group Type configuration
- [ ] Add translate for the groups
- [ ] Go to the table config and look for the translate for each group 'group.type.group_id', change the group id, example: closed_group, flexible_group...
- [ ] Duplicate the record for second language and change the collection column to the original-language
- [ ] With that the code start to get that record created steo before instead of content

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
N/A

## Release notes
This will fix the bug related to group invite, where the user invited as mentioned as invitor.

## Change Record
N/A

## Translations
N/A


[PROD-27808]: https://getopensocial.atlassian.net/browse/PROD-27808?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ