### PR TITLE
Issue #3426460: Error to save Account Settings

### DIFF
--- a/modules/social_features/social_user/config/schema/social_user.schema.yml
+++ b/modules/social_features/social_user/config/schema/social_user.schema.yml
@@ -14,6 +14,9 @@ social_user.settings:
     social_user_profile_landingpage:
       type: string
       label: "A valid route name that is used as default user profile page"
+    show_mail_in_messages:
+      type: boolean
+      label: "The site email address in help messages after failed login, signup or password reset."
 
 social_user.navigation.settings:
   type: config_object

--- a/modules/social_features/social_user/social_user.install
+++ b/modules/social_features/social_user/social_user.install
@@ -146,6 +146,31 @@ function social_user_update_12201(): string {
 }
 
 /**
+ * Copy show-main-in-messages to new structure and delete old structure.
+ */
+function social_user_update_12301(): void {
+  $system_config = \Drupal::configFactory()
+    ->get('system.site');
+
+  // Return early when this configuration is empty.
+  if (empty($system_config->get('show_mail_in_messages'))) {
+    return;
+  }
+
+  // Copy configuration to new structure.
+  \Drupal::configFactory()
+    ->getEditable('social_user.settings')
+    ->set('show_mail_in_messages', (boolean) $system_config->get('show_mail_in_messages'))
+    ->save();
+
+  // Delete old structure.
+  \Drupal::configFactory()
+    ->getEditable('system.site')
+    ->clear('show_mail_in_messages')
+    ->save();
+}
+
+/**
  * Remove deprecated group types.
  */
 function social_user_update_13000(): ?string {

--- a/modules/social_features/social_user/social_user.install
+++ b/modules/social_features/social_user/social_user.install
@@ -146,31 +146,6 @@ function social_user_update_12201(): string {
 }
 
 /**
- * Copy show-main-in-messages to new structure and delete old structure.
- */
-function social_user_update_12301(): void {
-  $system_config = \Drupal::configFactory()
-    ->get('system.site');
-
-  // Return early when this configuration is empty.
-  if (empty($system_config->get('show_mail_in_messages'))) {
-    return;
-  }
-
-  // Copy configuration to new structure.
-  \Drupal::configFactory()
-    ->getEditable('social_user.settings')
-    ->set('show_mail_in_messages', (boolean) $system_config->get('show_mail_in_messages'))
-    ->save();
-
-  // Delete old structure.
-  \Drupal::configFactory()
-    ->getEditable('system.site')
-    ->clear('show_mail_in_messages')
-    ->save();
-}
-
-/**
  * Remove deprecated group types.
  */
 function social_user_update_13000(): ?string {
@@ -190,4 +165,29 @@ function social_user_update_13000(): ?string {
 
   // Output logged messages to a related channel of update execution.
   return $updateHelper->logger()->output();
+}
+
+/**
+ * Copy show-main-in-messages to new structure and delete old structure.
+ */
+function social_user_update_13001(): void {
+  $system_config = \Drupal::configFactory()
+    ->get('system.site');
+
+  // Return early when this configuration is empty.
+  if (empty($system_config->get('show_mail_in_messages'))) {
+    return;
+  }
+
+  // Copy configuration to new structure.
+  \Drupal::configFactory()
+    ->getEditable('social_user.settings')
+    ->set('show_mail_in_messages', (boolean) $system_config->get('show_mail_in_messages'))
+    ->save();
+
+  // Delete old structure.
+  \Drupal::configFactory()
+    ->getEditable('system.site')
+    ->clear('show_mail_in_messages')
+    ->save();
 }

--- a/modules/social_features/social_user/social_user.module
+++ b/modules/social_features/social_user/social_user.module
@@ -570,7 +570,7 @@ function social_user_form_user_admin_settings_submit($form, FormStateInterface $
  * Alter Basic site settings form.
  */
 function social_user_form_system_site_information_settings_alter(&$form, FormStateInterface $form_state) {
-  $config = \Drupal::config('system.site');
+  $config = \Drupal::config('social_user.settings');
 
   $form['site_information']['show_mail_in_messages'] = [
     '#type' => 'checkbox',
@@ -588,8 +588,8 @@ function social_user_form_system_site_information_settings_alter(&$form, FormSta
  */
 function social_user_form_system_site_information_settings_submit($form, FormStateInterface $form_state) {
   $config = \Drupal::configFactory()
-    ->getEditable('system.site');
-  $config->set('show_mail_in_messages', $form_state->getValue("show_mail_in_messages"));
+    ->getEditable('social_user.settings');
+  $config->set('show_mail_in_messages', (boolean) $form_state->getValue("show_mail_in_messages"));
   $config->save();
 }
 

--- a/modules/social_features/social_user/src/Form/SocialUserPasswordForm.php
+++ b/modules/social_features/social_user/src/Form/SocialUserPasswordForm.php
@@ -89,9 +89,10 @@ class SocialUserPasswordForm extends UserPasswordForm {
           ]);
       }
     }
-    $site_config = $this->config('social_user.settings');
+    $site_config = $this->config('system.site');
+    $user_config = $this->config('social_user.settings');
     $site_mail = $site_config->get('mail');
-    $show_mail = $site_config->get('show_mail_in_messages');
+    $show_mail = $user_config->get('show_mail_in_messages');
     $admin_link = ($site_mail && $show_mail) ? Link::fromTextAndUrl(t('site administrator'), Url::fromUri('mailto:' . $site_mail))->toString() : t('site administrator');
     $this->messenger()->addStatus(t('Due to privacy concerns, the identity of registered email addresses will not be disclosed. Therefore, a password reset link has been sent to you only if you have entered a valid email address or username.
 <br>If the email address or username you entered does not exist, you will not get a reset link or a confirmation/warning about that here. Please contact the @admin_link if there are any problems.',

--- a/modules/social_features/social_user/src/Form/SocialUserPasswordForm.php
+++ b/modules/social_features/social_user/src/Form/SocialUserPasswordForm.php
@@ -89,7 +89,7 @@ class SocialUserPasswordForm extends UserPasswordForm {
           ]);
       }
     }
-    $site_config = $this->config('system.site');
+    $site_config = $this->config('social_user.settings');
     $site_mail = $site_config->get('mail');
     $show_mail = $site_config->get('show_mail_in_messages');
     $admin_link = ($site_mail && $show_mail) ? Link::fromTextAndUrl(t('site administrator'), Url::fromUri('mailto:' . $site_mail))->toString() : t('site administrator');


### PR DESCRIPTION
## Problem
When the variable show_mail_in_messages is filled, an error is throwing when the accounts settings is save.

Account Settings page: /admin/config/people
Error: 'show_mail_in_messages' is not a supported key.

## Solution
The show_mail_in_messages should be moved to Social User module and stop to use yaml configuration from core and/or contributte module.

## Issue tracker
[PROD-29296](https://getopensocial.atlassian.net/browse/PROD-29296)
[#3426460](https://www.drupal.org/project/social/issues/3426460)

## Theme issue tracker
N/A

## How to test
- [ ] Go to System -> Basic Information: /admin/config/system/site-information
- [ ] Change the field: 'Show email address in help messages', it will create this value at configuration file
- [ ] Go to People -> Account Settings: /admin/config/people/accounts
- [ ] Try to save this page

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
N/A

## Release notes
The error to save Account Settings will be fixed.

## Change Record
Moved the config variable show_mail_in_messages from system.site to social_users.settings

## Translations
N/A


[PROD-29296]: https://getopensocial.atlassian.net/browse/PROD-29296?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ