### PR TITLE
Issue #3442170: Remove outdated patch from Social Blue theme

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -97,9 +97,6 @@
             "drupal/search_api": {
                 "Ensure field definition allowed values callbacks are used for field filter callbacks": "https://www.drupal.org/files/issues/2023-12-26/views_filter_options_callback--2949022-17.patch"
             },
-            "drupal/socialblue": {
-                "Issue #3427426: Custom color being ignored for logged user in Search page": "https://www.drupal.org/files/issues/2024-03-12/socialblue-add-hero-css-file-to-be-overwritten-custom-color-3427426-4.patch"
-            },
             "drupal/url_embed": {
                 "Translate dialog title": "https://www.drupal.org/files/issues/2018-03-16/url_embed_translate_dialog_title-2953591-2.patch",
                 "Issue #2761187/#3386579 Improve how the module deals with non-embeddable URLs & WSODs (See: https://www.drupal.org/project/social/issues/3386579#comment-15225972) 2.x": "https://www.drupal.org/files/issues/2023-09-22/urlembed-non-embeddable-urls-2761187-opensocial-combined-21_2.x_1_ckeditor5.patch",


### PR DESCRIPTION
## Problem
The Social Blue theme has a new Major version and some patch are outdated.

## Solution
Remove outdated patches.

## Issue tracker
[PROD-29367](https://getopensocial.atlassian.net/browse/PROD-29367)
[#3442170](https://www.drupal.org/project/social/issues/3442170)

## Theme issue tracker
N/A

## How to test
N/A

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
N/A

## Release notes
N/A

## Change Record
N/A

## Translations
N/A


[PROD-29367]: https://getopensocial.atlassian.net/browse/PROD-29367?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ