### PR TITLE
Internal: Add Configuration to influence the order of branding features

### DIFF
--- a/modules/social_features/social_branding/config/schema/social_branding.schema.yml
+++ b/modules/social_features/social_branding/config/schema/social_branding.schema.yml
@@ -1,0 +1,16 @@
+social_branding.settings:
+  type: config_object
+  label: "Features configured for Branding"
+  mapping:
+    features:
+      type: sequence
+      label: "List of configured features"
+      sequence:
+        type: mapping
+        mapping:
+          weight:
+            type: integer
+            label: 'Weight'
+          name:
+            type: string
+            label: 'Machine name'

--- a/modules/social_features/social_branding/social_branding.api.php
+++ b/modules/social_features/social_branding/social_branding.api.php
@@ -38,11 +38,14 @@ function hook_social_branding_preferred_features() {
  * @ingroup social_branding_api
  */
 function hook_social_branding_preferred_features_alter(array &$preferred_features) {
+  // Set individual weight.
   foreach ($preferred_features as $preferred_feature) {
     if ($preferred_feature->getName() === 'first_feature') {
       $preferred_feature->setWeight(3);
     }
   }
+  // Or empty the features.
+  $preferred_features = [];
 }
 
 /**

--- a/modules/social_features/social_branding/social_branding.info.yml
+++ b/modules/social_features/social_branding/social_branding.info.yml
@@ -2,6 +2,7 @@ name: 'Social Branding'
 description: 'Extends the GraphQL API with branding information for this Open Social platform.'
 type: module
 core_version_requirement: ^9 || ^10
+configure: social_branding.settings
 dependencies:
   # Remove this dependency when we have an accessible test environment.
   - social:social_graphql

--- a/modules/social_features/social_branding/social_branding.links.menu.yml
+++ b/modules/social_features/social_branding/social_branding.links.menu.yml
@@ -1,0 +1,11 @@
+social_branding.settings:
+  title: 'App feature settings'
+  description: 'Settings for the bottom bar features.'
+  route_name: social_branding.settings
+  parent: social_core.admin.config.social
+  weight: 80
+social_branding.social_core.dashboard.configuration.settings:
+  title: 'App feature settings'
+  parent: social_core.dashboard.appearance
+  route_name: social_branding.settings
+  weight: -20

--- a/modules/social_features/social_branding/social_branding.module
+++ b/modules/social_features/social_branding/social_branding.module
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * @file
+ * The Social Branding module.
+ */
+
+use Drupal\social_branding\PreferredFeature;
+
+/**
+ * Implements hook_social_branding_preferred_features().
+ */
+function social_branding_social_branding_preferred_features(): array {
+  return [
+    new PreferredFeature('home', 0),
+    new PreferredFeature('events', 1),
+    new PreferredFeature('groups', 2),
+    new PreferredFeature('search', 3),
+    new PreferredFeature('topics', 5),
+  ];
+}

--- a/modules/social_features/social_branding/social_branding.permissions.yml
+++ b/modules/social_features/social_branding/social_branding.permissions.yml
@@ -1,0 +1,3 @@
+administer social branding settings:
+  title: 'Access branding settings'
+  description: 'Allows configuring the branding features.'

--- a/modules/social_features/social_branding/social_branding.routing.yml
+++ b/modules/social_features/social_branding/social_branding.routing.yml
@@ -1,0 +1,7 @@
+social_branding.settings:
+  path: 'admin/config/opensocial/branding-features'
+  defaults:
+    _form: '\Drupal\social_branding\Form\SocialBrandingFeaturesForm'
+    _title: 'Branding features configuration'
+  requirements:
+    _permission: 'administer social branding settings'

--- a/modules/social_features/social_branding/src/Form/SocialBrandingFeaturesForm.php
+++ b/modules/social_features/social_branding/src/Form/SocialBrandingFeaturesForm.php
@@ -1,0 +1,199 @@
+<?php
+
+namespace Drupal\social_branding\Form;
+
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Extension\ModuleHandlerInterface;
+use Drupal\Core\Form\ConfigFormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Class SocialBrandingFeaturesForm.
+ *
+ * @package Drupal\social_branding\Form
+ */
+class SocialBrandingFeaturesForm extends ConfigFormBase {
+
+  /**
+   * The module handler.
+   *
+   * @var \Drupal\Core\Extension\ModuleHandlerInterface
+   */
+  protected $moduleHandler;
+
+  /**
+   * Constructs a new DataPolicyRevisionDeleteForm.
+   *
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   The factory for configuration objects.
+   * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
+   *   The module handler.
+   */
+  public function __construct(ConfigFactoryInterface $config_factory, ModuleHandlerInterface $module_handler) {
+    parent::__construct($config_factory);
+    $this->moduleHandler = $module_handler;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) : SocialBrandingFeaturesForm {
+    return new static(
+      $container->get('config.factory'),
+      $container->get('module_handler')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getEditableConfigNames() {
+    return [
+      'social_branding.settings',
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'social_branding_settings_form';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    // Show a list of features.
+    $form['features'] = [
+      '#type' => 'table',
+      '#header' => [
+        '',
+        $this->t('Weight'),
+        $this->t('Feature'),
+      ],
+      '#attributes' => [
+        'id' => 'branding-table',
+      ],
+      '#tabledrag' => [
+        [
+          'action' => 'order',
+          'relationship' => 'sibling',
+          'group' => 'draggable-weight',
+        ],
+      ],
+      '#caption' => $this->t('Keep in mind, only the first four features will be shown in the app.'),
+    ];
+
+    // Get all features created through existing hooks.
+    $features = $this->getFeatures();
+
+    foreach ($features as $feature) {
+      // By default we use the Plugin weight.
+      $weight = $feature->getWeight();
+
+      $form['features'][$feature->getName()] = [
+        'data' => [],
+        '#attributes' => [
+          'class' => [
+            'draggable',
+          ],
+        ],
+        'weight' => [
+          '#type' => 'weight',
+          '#title' => t('Weight'),
+          '#title_display' => '',
+          '#default_value' => $weight,
+          '#attributes' => [
+            'class' => [
+              'draggable-weight',
+            ],
+          ],
+        ],
+        'label' => [
+          '#markup' => $feature->getName(),
+        ],
+      ];
+    }
+
+    return parent::buildForm($form, $form_state);
+  }
+
+  /**
+   * Get all preferred features.
+   *
+   * @return array
+   *   Array containing all preferred features.
+   */
+  private function getFeatures() : array {
+    $preferred_features =& drupal_static(__METHOD__, []);
+
+    if (empty($preferred_features)) {
+      // Grab the features defined by the hook, this is used
+      // as default for our form.
+      $preferred_features = $this->moduleHandler->invokeAll('social_branding_preferred_features');
+
+      // Grab the saved config, if there is config already saved.
+      $config = $this->config('social_branding.settings');
+      $features = $config->get('features');
+      if (!empty($features)) {
+        foreach ($features as $name => $weight) {
+          $weight = $weight['weight'];
+          // If we have saved the weight before, lets grab that instead.
+          // this way the configuration is more important than the plugin,
+          // but just for the weight.
+          // We don't add / remove features based on existing config, as
+          // the hook with $defined_features is leading, and new
+          // PreferredFeatures can be added or old ones removed.
+          $preferred_features = $this->updateDefinedFeature($name, $weight, $preferred_features);
+        }
+      }
+
+      // Order our features ascending by weight.
+      // So we render our form based on weight.
+      usort($preferred_features, function ($item1, $item2) {
+        return $item1->getWeight() <=> $item2->getWeight();
+      });
+    }
+
+    return $preferred_features;
+  }
+
+  /**
+   * Update the preferred feature with the updated weight.
+   *
+   * @param string $name
+   *   The preferred feature name.
+   * @param int $weight
+   *   The new weight.
+   * @param array $defined_features
+   *   The initially defined features.
+   *
+   * @return array
+   *   The preferred features.
+   */
+  private function updateDefinedFeature(string $name, int $weight, array $defined_features) : array {
+    // Loop through the defined features.
+    foreach ($defined_features as &$feature) {
+      // If we have a matching one, update the weight.
+      if ($feature->getName() === $name) {
+        $feature->setWeight($weight);
+      }
+    }
+
+    return $defined_features;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) : void {
+    parent::submitForm($form, $form_state);
+
+    $this->config('social_branding.settings')
+      ->set('features', $form_state->getValue('features'))
+      ->save();
+  }
+
+}

--- a/modules/social_features/social_branding/src/Plugin/GraphQL/DataProducer/PreferredFeatures.php
+++ b/modules/social_features/social_branding/src/Plugin/GraphQL/DataProducer/PreferredFeatures.php
@@ -2,9 +2,11 @@
 
 namespace Drupal\social_branding\Plugin\GraphQL\DataProducer;
 
+use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\graphql\Plugin\GraphQL\DataProducer\DataProducerPluginBase;
+use Drupal\social_branding\PreferredFeature;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -23,20 +25,24 @@ class PreferredFeatures extends DataProducerPluginBase implements ContainerFacto
 
   /**
    * The module handler.
-   *
-   * @var \Drupal\Core\Extension\ModuleHandlerInterface
    */
-  protected $moduleHandler;
+  protected ModuleHandlerInterface $moduleHandler;
+
+  /**
+   * The config factory.
+   */
+  protected ConfigFactoryInterface $config;
 
   /**
    * {@inheritdoc}
    */
-  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition): PreferredFeatures|ContainerFactoryPluginInterface|static {
     return new static(
       $configuration,
       $plugin_id,
       $plugin_definition,
-      $container->get('module_handler')
+      $container->get('module_handler'),
+      $container->get('config.factory')
     );
   }
 
@@ -51,10 +57,13 @@ class PreferredFeatures extends DataProducerPluginBase implements ContainerFacto
    *   The plugin implementation definition.
    * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
    *   The module handler.
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config
+   *   The config factory.
    */
-  public function __construct(array $configuration, string $plugin_id, array $plugin_definition, ModuleHandlerInterface $module_handler) {
+  public function __construct(array $configuration, string $plugin_id, array $plugin_definition, ModuleHandlerInterface $module_handler, ConfigFactoryInterface $config,) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
     $this->moduleHandler = $module_handler;
+    $this->config = $config;
   }
 
   /**
@@ -65,6 +74,21 @@ class PreferredFeatures extends DataProducerPluginBase implements ContainerFacto
    */
   public function resolve() : array {
     $preferred_features = $this->moduleHandler->invokeAll('social_branding_preferred_features');
+    // Grab the saved config, if there is config already saved.
+    $config = $this->config->getEditable('social_branding.settings');
+    $features = $config->get('features');
+    if (!empty($features)) {
+      // If we have saved the config, this means at this moment in time,
+      // even if there are things provided in the hook, we expect the
+      // form to have been submitted so that will take priority.
+      $preferred_features = [];
+      foreach ($features as $name => $weight) {
+        $weight = $weight['weight'];
+        $preferred_features[] = new PreferredFeature($name, $weight);
+      }
+    }
+
+    // Make sure the alter hook still works.
     $this->moduleHandler->alter('social_branding_preferred_features', $preferred_features);
 
     // Order ascending by weight.

--- a/modules/social_features/social_branding/tests/modules/social_branding_default_test/social_branding_default_test.info.yml
+++ b/modules/social_features/social_branding/tests/modules/social_branding_default_test/social_branding_default_test.info.yml
@@ -1,0 +1,8 @@
+name: 'Social Branding Test'
+description: 'Support module for module Social Branding for testing and removing preferred features.'
+type: module
+core_version_requirement: ^9 || ^10
+dependencies:
+  - social:social_branding
+package: Testing
+hidden: true

--- a/modules/social_features/social_branding/tests/modules/social_branding_default_test/social_branding_default_test.install
+++ b/modules/social_features/social_branding/tests/modules/social_branding_default_test/social_branding_default_test.install
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * @file
+ * Install functions for the social_branding_default_test module.
+ */
+
+/**
+ * Implements hook_install().
+ *
+ * Perform installation of social_branding_default_test.
+ */
+function social_branding_default_test_install(): void {
+  // Set some default config.
+  $features = [
+    'home' => [
+      'weight' => 0,
+    ],
+    'events' => [
+      'weight' => 1,
+    ],
+    'topics' => [
+      'weight' => 2,
+    ],
+    'groups' => [
+      'weight' => 3,
+    ],
+    'search' => [
+      'weight' => 4,
+    ],
+  ];
+
+  \Drupal::configFactory()->getEditable('social_branding.settings')
+    ->set('features', $features)
+    ->save();
+}

--- a/modules/social_features/social_branding/tests/modules/social_branding_default_test/social_branding_default_test.module
+++ b/modules/social_features/social_branding/tests/modules/social_branding_default_test/social_branding_default_test.module
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * @file
+ * Social Branding Test.
+ */
+
+use Drupal\social_branding\PreferredFeature;
+
+/**
+ * Implements hook_social_branding_preferred_features().
+ */
+function social_branding_default_test_social_branding_preferred_features(): array {
+  // Will not be taken into account, as the default settings doesn't have
+  // discussion saved through the form.
+  return [
+    new PreferredFeature('discussion', 10),
+  ];
+}
+
+/**
+ * Implements hook_social_branding_preferred_features_alter().
+ */
+function social_branding_default_test_social_branding_preferred_features_alter(array &$preferred_features): void {
+  // Will not be taken into account, as the default settings doesn't have
+  // discussion saved through the form.
+  foreach ($preferred_features as $preferred_feature) {
+    if ($preferred_feature->getName() === 'discussion') {
+      $preferred_feature->setWeight(-10);
+    }
+  }
+  // Will be taken in to account, just to prove this alter hook does run.
+  $preferred_features[] = new PreferredFeature('cheese', -20);
+}

--- a/modules/social_features/social_branding/tests/modules/social_branding_empty_test/social_branding_empty_test.info.yml
+++ b/modules/social_features/social_branding/tests/modules/social_branding_empty_test/social_branding_empty_test.info.yml
@@ -1,0 +1,8 @@
+name: 'Social Branding Test'
+description: 'Support module for module Social Branding for testing and removing preferred features.'
+type: module
+core_version_requirement: ^9 || ^10
+dependencies:
+  - social:social_branding
+package: Testing
+hidden: true

--- a/modules/social_features/social_branding/tests/modules/social_branding_empty_test/social_branding_empty_test.module
+++ b/modules/social_features/social_branding/tests/modules/social_branding_empty_test/social_branding_empty_test.module
@@ -1,0 +1,14 @@
+<?php
+
+/**
+ * @file
+ * Social Branding Test.
+ */
+
+/**
+ * Implements hook_social_branding_preferred_features_alter().
+ */
+function social_branding_empty_test_social_branding_preferred_features_alter(array &$preferred_features): void {
+  // This shows how we can override the features and empty them.
+  $preferred_features = [];
+}

--- a/modules/social_features/social_branding/tests/modules/social_branding_test/social_branding_test.module
+++ b/modules/social_features/social_branding/tests/modules/social_branding_test/social_branding_test.module
@@ -10,7 +10,7 @@ use Drupal\social_branding\PreferredFeature;
 /**
  * Implements hook_social_branding_preferred_features().
  */
-function social_branding_test_social_branding_preferred_features() {
+function social_branding_test_social_branding_preferred_features(): array {
   return [
     new PreferredFeature('feature0', 0),
     new PreferredFeature('feature1', 1),
@@ -21,10 +21,10 @@ function social_branding_test_social_branding_preferred_features() {
 /**
  * Implements hook_social_branding_preferred_features_alter().
  */
-function social_branding_test_social_branding_preferred_features_alter(&$preferred_features) {
+function social_branding_test_social_branding_preferred_features_alter(array &$preferred_features): void {
   foreach ($preferred_features as $preferred_feature) {
     if ($preferred_feature->getName() === 'feature0') {
-      $preferred_feature->setWeight(3);
+      $preferred_feature->setWeight(2);
     }
   }
 }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -3686,21 +3686,6 @@ parameters:
 			path: modules/social_features/social_branding/src/Plugin/GraphQL/SchemaExtension/AppSchemaExtension.php
 
 		-
-			message: "#^Function social_branding_test_social_branding_preferred_features\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: modules/social_features/social_branding/tests/modules/social_branding_test/social_branding_test.module
-
-		-
-			message: "#^Function social_branding_test_social_branding_preferred_features_alter\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: modules/social_features/social_branding/tests/modules/social_branding_test/social_branding_test.module
-
-		-
-			message: "#^Function social_branding_test_social_branding_preferred_features_alter\\(\\) has parameter \\$preferred_features with no type specified\\.$#"
-			count: 1
-			path: modules/social_features/social_branding/tests/modules/social_branding_test/social_branding_test.module
-
-		-
 			message: "#^Function social_comment_install\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: modules/social_features/social_comment/social_comment.install


### PR DESCRIPTION
## Problem
Right now we don't have an easy way to influence the bottom bar features, while we do promise that.
This was done by implementing a patch, per environment which uses 

```
function hook_social_branding_preferred_features(): array {
  return [
    new PreferredFeature('home', 0),
    new PreferredFeature('events', 1),
    new PreferredFeature('groups', 2),
    new PreferredFeature('search', 3),
    new PreferredFeature('topics', 5),
  ];
}
```
But than changing that per environment.

## Solution
We now provide a new admin form, currently no permissions are set, as it's for now Admin only (until we know every business requirement we need to provide it for SM, e.g. which preferred features are available, mandatory, how many etc)

So this form gives admins a way to deal with the bottom bar features for the App. 

Right now we use the existing hook as input for the ConfigForm which preferred features are available. 
We add a draggable table to the form, which shows all available features. 
And we change the place where the hook is invoked, for GraphQl, to the configuration from the form submitted.

## Notes
- We don't provide default configuration, this ensures we don't break existing platforms, by default still the ones provided by the hook `hook_social_branding_preferred_features()` are available and used
- Once the Form is saved however, that will take presedence, this to ensure we don't have duplicate weights from the Hook and the Form
- The hook_social_branding_preferred_features_alter is still leading, this allows people to always add or remove preferred features.

## Issue tracker
https://getopensocial.atlassian.net/browse/PROD-28762
https://www.drupal.org/project/social/issues/3442499

## How to test
- [ ] Enable `social_branding`, see that it works (unit tests also provide this proof)
- [ ] As a sitemanager see you can't reach the page
- [ ] As admin go to `admin/config/opensocial/branding-features`
- [ ] When saving I expect the Form to have the order you saved it in
- [ ] Querying the API clearly shows the new order

## Screenshots
![Screenshot 2024-04-22 at 11 44 30](https://github.com/goalgorilla/open_social/assets/16667281/833755be-3ae7-407a-97ee-11ff25d1b9cf)

## Release notes
We have added an Admin form for the Branding features which are used through GraphQL.