### PR TITLE
Issue #3443004: Error to apply patch at Ultimate Cron module

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -105,9 +105,6 @@
                 "Issue #2761187/#3386579 Improve how the module deals with non-embeddable URLs & WSODs (See: https://www.drupal.org/project/social/issues/3386579#comment-15225972) 2.x": "https://www.drupal.org/files/issues/2023-09-22/urlembed-non-embeddable-urls-2761187-opensocial-combined-21_2.x_1_ckeditor5.patch",
                 "Issue #3386590: preg_split in _filter_url breaks for long html tags": "https://www.drupal.org/files/issues/2023-09-11/3382821-url_embed-preg-split_2.x_1.patch"
             },
-            "drupal/ultimate_cron": {
-                "Issue #3334805: apply entity query access check": "https://www.drupal.org/files/issues/2023-10-31/ultime-cron-entity-query-3334805-5.patch"
-            },
             "drupal/views_infinite_scroll" : {
                 "Headers in table format repeat on load more instead of adding rows (v1.8)": "https://www.drupal.org/files/issues/2021-02-11/2899705-35.patch"
             },


### PR DESCRIPTION
## Problem
The Ultimate Cron module has a old patch and it is not applying any more.

## Solution
Execute composer-install at 12.4.0 version.

## Issue tracker
[#3443004](https://www.drupal.org/project/social/issues/3443004)

## Theme issue tracker
N/A

## How to test
- [ ] Execute composer-install

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
N/A

## Release notes
Fix the problem with composer install.

## Change Record
N/A

## Translations
N/A
