### PR TITLE
PROD-29431: Change link to Review Open Social

### DIFF
--- a/modules/custom/social_lets_connect/modules/social_lets_connect_contact/social_lets_connect_contact.links.menu.yml
+++ b/modules/custom/social_lets_connect/modules/social_lets_connect_contact/social_lets_connect_contact.links.menu.yml
@@ -7,7 +7,7 @@ social_lets_connect_contact.extensions:
 social_lets_connect_contact.review:
   title: 'Review Open Social'
   parent: social_lets_connect.main
-  url: https://reviews.capterra.com/new/179231
+  url: https://www.g2.com/products/open-social/take_survey
   weight: -5
 
 social_lets_connect_contact.contact:


### PR DESCRIPTION
## Problem
Update the review link now we don't use capterra anymore.

## Solution
Update it to the new link

## Issue tracker
Internal link only; 
https://getopensocial.atlassian.net/browse/PROD-29431

## How to test
- [ ] As a sitemanager
- [ ] See that the review link does not point to capterra anymore but to g2.com
- [ ] Clicking that should open it correctly

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] New features or changes to existing features are covered by tests, either unit (preferably) or behat
- [ ] Update path is tested. New hook_updates should respect update order, right naming convention and consider hook_post_update code
- [ ] Module can be safely uninstalled. Update/implement hook_uninstall and make sure that removed configuration or dependencies are removed/uninstalled
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
![image](https://github.com/goalgorilla/open_social/assets/16667281/ff74a70c-8cd2-4710-91e9-367fb031f632)

## Release notes
Updated the link to Review Open Social.

