### PR TITLE
Issue #3444422: Display group types taxonomy terms on group teasers

### DIFF
--- a/modules/social_features/social_group/modules/social_group_request/social_group_request.module
+++ b/modules/social_features/social_group/modules/social_group_request/social_group_request.module
@@ -21,7 +21,6 @@ use Drupal\group\Entity\GroupContentTypeInterface;
 use Drupal\group\Entity\GroupContentInterface;
 use Drupal\views\ViewExecutable;
 use Drupal\message\Entity\Message;
-use Drupal\taxonomy\Entity\Term;
 
 /**
  * Implements hook_ENTITY_TYPE_insert() for group_content_type.
@@ -131,58 +130,6 @@ function social_group_request_module_implements_alter(&$implementations, $hook) 
     // Remove the grequest implementation, we have a fallback in our hook.
     if (isset($implementations['grequest'])) {
       unset($implementations['grequest']);
-    }
-  }
-}
-
-/**
- * Implements hook_theme_registry_alter().
- */
-function social_group_request_theme_registry_alter(&$theme_registry) {
-  // Unfortunately the preprocess functions aren't ordered by module weight.
-  // Changing module weight doesn't work, also with dependency set to
-  // social_group this should be dealt with but isn't.
-  // So we enforce our preprocess after social_group.
-  if (!empty($theme_registry['group']['preprocess functions'])) {
-    $current_key = array_search('social_group_request_preprocess_group', $theme_registry['group']['preprocess functions'], FALSE);
-    unset($theme_registry['group']['preprocess functions'][$current_key]);
-    // Give it a new key all the way at the end.
-    $theme_registry['group']['preprocess functions'][] = 'social_group_request_preprocess_group';
-  }
-}
-
-/**
- * Implements hook_preprocess_HOOK().
- */
-function social_group_request_preprocess_group(array &$variables): void {
-  if (!\Drupal::config('social_group.settings')->get('social_group_type_required')) {
-    return;
-  }
-
-  /** @var \Drupal\social_group\SocialGroupInterface $group */
-  $group = $variables['group'];
-
-  if (!$group->hasField('field_group_type')) {
-    return;
-  }
-
-  /** @var \Drupal\social_group\JoinManagerInterface $manager */
-  $manager = \Drupal::service('plugin.manager.social_group.join');
-
-  /** @var string $bundle */
-  $bundle = $group->getGroupType()->id();
-
-  if ($manager->hasMethod($bundle, 'request')) {
-    $field = $group->field_group_type;
-
-    if (!$field->isEmpty()) {
-      /** @var \Drupal\taxonomy\TermInterface $term */
-      $term = $field->entity;
-
-      if ($term instanceof Term) {
-        $variables['group_type'] = $term->getName();
-        $variables['group_type_icon'] = $term->field_group_type_icon->value;
-      }
     }
   }
 }

--- a/modules/social_features/social_group/social_group.module
+++ b/modules/social_features/social_group/social_group.module
@@ -43,6 +43,7 @@ use Drupal\social_group\Element\SocialGroupEntityAutocomplete;
 use Drupal\social_group\Entity\Access\SocialGroupAccessControlHandler;
 use Drupal\social_group\Entity\Group;
 use Drupal\social_group\SocialGroupInterface;
+use Drupal\taxonomy\Entity\Term;
 use Drupal\user\Entity\User;
 use Drupal\user\UserInterface;
 use Drupal\views\Plugin\views\cache\CachePluginBase;
@@ -314,6 +315,19 @@ function social_group_preprocess_group(array &$variables) {
 
   // Update if user is member of a group.
   $variables['joined'] = $group->hasMember($account);
+
+  if (
+    $group->hasField('field_group_type') &&
+    !$group->get('field_group_type')->isEmpty()
+  ) {
+    /** @var \Drupal\taxonomy\TermInterface $term */
+    $term = $group->get('field_group_type')->entity;
+
+    if ($term instanceof Term) {
+      $variables['group_type'] = $term->getName();
+      $variables['group_type_icon'] = $term->get('field_group_type_icon')->getString();
+    }
+  }
 }
 
 /**

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -8244,16 +8244,6 @@ parameters:
 			path: modules/social_features/social_group/modules/social_group_request/social_group_request.module
 
 		-
-			message: "#^Function social_group_request_theme_registry_alter\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: modules/social_features/social_group/modules/social_group_request/social_group_request.module
-
-		-
-			message: "#^Function social_group_request_theme_registry_alter\\(\\) has parameter \\$theme_registry with no type specified\\.$#"
-			count: 1
-			path: modules/social_features/social_group/modules/social_group_request/social_group_request.module
-
-		-
 			message: "#^Function social_group_request_views_pre_view\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: modules/social_features/social_group/modules/social_group_request/social_group_request.module


### PR DESCRIPTION
## Problem
Field `field_group_type` in `flexible group` contains the taxonomy terms that could represent the group type (like in topics or events). If group have this taxonomy then it should be displayed instead of default group type.

## Solution
Refactor code.

## Issue tracker
- https://www.drupal.org/project/social/issues/3444422
- https://getopensocial.atlassian.net/browse/PROD-29292

## Theme issue tracker

## How to test
- [ ] Login as SM
- [ ] Allow group types on _/admin/config/opensocial/social-group_
- [ ] Create a few group types on _admin/structure/taxonomy/manage/group_type/overview_
- [ ] Create a flexible group with any group type 
- [ ] Visit pages and make sure the group type is displayed instead "Flexible group":
  - [ ] _/search/all_
  - [ ] _/search/groups_
  - [ ] _/all-groups_

## Screenshots
_Before:_
<img width="668" alt="Screenshot 2024-04-30 at 17 08 11" src="https://github.com/goalgorilla/open_social/assets/19921926/90e319ba-0bc2-46ee-97fa-11bdebbae409">

_After:_
<img width="671" alt="Screenshot 2024-04-30 at 17 09 01" src="https://github.com/goalgorilla/open_social/assets/19921926/0a65e3ec-3c9e-4c6e-9a57-4fbdd0e1442a">


## Release notes
Display group types on group teasers

## Change Record

## Translations