### PR TITLE
Issue #3444432: Always display "Type" field on group add/edit pages

### DIFF
--- a/modules/social_features/social_group/config/schema/social_group.schema.yml
+++ b/modules/social_features/social_group/config/schema/social_group.schema.yml
@@ -11,9 +11,6 @@ social_group.settings:
     address_visibility_settings:
       type: boolean
       label: 'Only show the group address to the group members'
-    social_group_type_required:
-      type: boolean
-      label: 'Enable and require a group type'
 
 views.access.group_managers_only:
   type: mapping

--- a/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.install
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.install
@@ -71,3 +71,13 @@ function social_group_flexible_group_update_120001(): void {
     }
   }
 }
+
+/**
+ * Remove redundant "social_group_type_required" settings.
+ */
+function social_group_flexible_group_update_130000(): void {
+  \Drupal::configFactory()
+    ->getEditable('social_group.settings')
+    ->clear('social_group_type_required')
+    ->save();
+}

--- a/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.module
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.module
@@ -97,12 +97,7 @@ function social_group_flexible_group_form_alter(&$form, FormStateInterface $form
         ],
       ];
     }
-    // Hide the flexible group field group type if the setting for it to be
-    // required is disabled even if there are values in the vocabulary.
-    if (!empty($form['field_group_type_target_id']) &&
-      !\Drupal::config('social_group.settings')->get('social_group_type_required')) {
-      $form['field_group_type_target_id']['#type'] = 'hidden';
-    }
+
     // Hide the flexible group field group type if there is only the
     // "All / any" option we hide it as well.
     if (!empty($form['field_group_type_target_id']) &&
@@ -182,20 +177,14 @@ function social_group_flexible_group_form_alter(&$form, FormStateInterface $form
       }
     }
 
-    // Disable type field if there are no terms added in 'Group type' vocab.
-    // Also, check for settings by SM for enabling this field.
-    $group_type_settings = \Drupal::config('social_group.settings')->get('social_group_type_required');
-    if ($group_type_settings
-      && isset($form['field_group_type'])
-      && !empty(\Drupal::entityTypeManager()->getStorage('taxonomy_term')->loadTree('group_type'))) {
-      $form['field_group_type']['widget']['#required'] = TRUE;
+    if (!empty($form['field_group_type'])) {
       // Unset the group type label for none.
       if (isset($form['field_group_type']['widget']['#options']['_none'])) {
         unset($form['field_group_type']['widget']['#options']['_none']);
       }
-    }
-    else {
-      $form['field_group_type']['#access'] = FALSE;
+
+      // Disable type field if there are no terms added in 'Group type' vocab.
+      $form['field_group_type']['#access'] = !empty($form['field_group_type']['widget']['#options']);
     }
 
     // Disable the public visibility option on group create/edit content option.

--- a/modules/social_features/social_group/src/Form/SocialGroupSettings.php
+++ b/modules/social_features/social_group/src/Form/SocialGroupSettings.php
@@ -8,9 +8,7 @@ use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Form\ConfigFormBase;
 use Drupal\Core\Form\FormStateInterface;
-use Drupal\Core\Link;
 use Drupal\Core\Render\Element\Checkboxes;
-use Drupal\Core\Url;
 use Drupal\crop\Entity\CropType;
 use Drupal\group\Plugin\GroupContentEnablerManagerInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -168,22 +166,6 @@ class SocialGroupSettings extends ConfigFormBase {
       ],
     ];
 
-    // Add an option for site manager to enable/disable option to choose group
-    // type on page to add flexible groups.
-    if (\Drupal::moduleHandler()->moduleExists('social_group_flexible_group')) {
-      $form['social_group_type_required'] = [
-        '#type' => 'checkbox',
-        '#title' => $this->t('Require group types'),
-        '#description' => $this->t('When checked, a new option will appear on
-          the flexible group form which requires group creators to select a
-          group type, this allows for a better categorisation of groups in your
-          community. You can add or edit the available group types @link', [
-            '@link' => Link::fromTextAndUrl('here.', Url::fromUserInput('/admin/structure/taxonomy/manage/group_type/overview'))->toString(),
-          ]),
-        '#default_value' => $config->get('social_group_type_required'),
-      ];
-    }
-
     return parent::buildForm($form, $form_state);
   }
 
@@ -230,12 +212,8 @@ class SocialGroupSettings extends ConfigFormBase {
       ]))
       : []
     );
-    $config->set('social_group_type_required', $form_state->getValue('social_group_type_required'));
-    $config->save();
 
-    if ($form['social_group_type_required']['#default_value'] !== (bool) $form_state->getValue('social_group_type_required')) {
-      Cache::invalidateTags(['config:block.block.exposed_form_newest_groups_page_all_groups']);
-    }
+    $config->save();
 
     Cache::invalidateTags(['group_view']);
   }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -9254,11 +9254,6 @@ parameters:
 			path: modules/social_features/social_group/src/Form/SocialGroupSettings.php
 
 		-
-			message: "#^\\\\Drupal calls should be avoided in classes, use dependency injection instead$#"
-			count: 1
-			path: modules/social_features/social_group/src/Form/SocialGroupSettings.php
-
-		-
 			message: "#^Cannot call method fetchField\\(\\) on Drupal\\\\Core\\\\Database\\\\StatementInterface\\|null\\.$#"
 			count: 1
 			path: modules/social_features/social_group/src/GroupStatistics.php

--- a/tests/behat/features/bootstrap/GroupContext.php
+++ b/tests/behat/features/bootstrap/GroupContext.php
@@ -702,22 +702,4 @@ class GroupContext extends RawMinkContext {
     }
   }
 
-  /**
-   * Switch "group type" settings.
-   *
-   * @param string $switch
-   *   Should be either "enable" or "disable".
-   *
-   * @Given I :switch group type settings
-   */
-  public function iSwitchGroupTypeSettings(string $switch): void {
-     if (!in_array($switch, ['enable', 'disable'])) {
-       throw new \InvalidArgumentException('Invalid parameter $switch');
-     }
-
-    \Drupal::configFactory()
-      ->getEditable('social_group.settings')
-      ->set('social_group_type_required', $switch === 'enable')
-      ->save();
-  }
 }

--- a/tests/behat/features/capabilities/groups/groups-view-overview-filter.feature
+++ b/tests/behat/features/capabilities/groups/groups-view-overview-filter.feature
@@ -6,26 +6,22 @@ Feature: All group overview filters
 
   Scenario: As user I can not filter on the field group type if there are no types added
     Given I am an anonymous user
-    And I enable group type settings
 
     When I am viewing the groups overview
-    # By default we have at least "Flexible group" group type.
     And I should not see "Type" in the "Sidebar second"
 
   Scenario: As user I can not filter on the field group type if the setting is disabled even if there are options
     Given I am an anonymous user
-    And I disable group type settings
     And "group_type" terms:
       | name |
       | Local Group |
 
     When I am viewing the groups overview
 
-    Then I should not see "Type" in the "Sidebar second"
+    Then I should see "Type" in the "Sidebar second"
 
   Scenario: As user I can filter on the field group type if flexible groups is selected as filter option
     Given I am an anonymous user
-    And I enable group type settings
     And "group_type" terms:
       | name |
       | Local Group |
@@ -36,7 +32,6 @@ Feature: All group overview filters
 
   Scenario: As user I can filter on the field group type and the right group(s) are shown
     Given I am an anonymous user
-    And I set the configuration item "social_group.settings" with key "social_group_type_required" to TRUE
     And "group_type" terms:
       | name |
       | Local Group |


### PR DESCRIPTION
## Problem
During the migration from old groups to "Flexible group" we have enable the field "Group type” for everyone.
In the backend we have a settings page _/admin/config/opensocial/social-group_ where we allow for SM to enable/disable group types:
<img width="654" alt="Screenshot 2024-04-05 at 15 20 28-20240405-122034" src="https://github.com/goalgorilla/open_social/assets/19921926/87a094fa-4213-4b30-9ef9-6023437fae92">

In Open Social 13 we want to make Group types a default for everyone and we want to remove the option for SM to disable it.

## Solution
- Remove redundant `social_group_type_required` setting from `social_group.settings`
- Always display "Type" field on group add/edit pages

## Issue tracker
- https://www.drupal.org/project/social/issues/3444432
- https://getopensocial.atlassian.net/browse/PROD-28732

## Theme issue tracker

## How to test
- [x] Login as admin
- [x] Enable "Social Flexible Group" extension
- [x] Visit _/admin/config/opensocial/social-group_ 
  - [x] **EB**: make sure the "Require group type" settings is not exist
- [x] Visit _/group/add/flexible_group_ page
  - [x] **EB**: make sure the field "Type" is not visible
- [x]  Visit _/all-groups_  page
  - [x] **EB**: make sure there are no "Type" filter on right sidebar
- [x] On _admin/structure/taxonomy/manage/group_type/overview_ add at least one term
- [x] Visit _/group/add/flexible_group_ page
  - [ ] **EB**: make sure the field "Type" is visible
- [x]  Visit _/all-groups_  page
  - [x] **EB**: make sure the "Type" filter is visible on right sidebar

## Screenshots
n/a

## Release notes
Always display "Type" field on group add/edit pages

## Change Record
The setting  `social_group_type_required` is removed from `social_group.settings` configuration, no replacement.

## Translations
