### PR TITLE
Issue #3444592: Replace permission `administer taxonomy` with `access taxonomy overview` for SM

### DIFF
--- a/modules/social_features/social_core/social_core.install
+++ b/modules/social_features/social_core/social_core.install
@@ -93,11 +93,14 @@ function social_core_install() {
       'delete all revisions',
       'create url aliases',
       'use text format full_html',
-      'administer taxonomy',
+      'access taxonomy overview',
+      'create terms in expertise',
       'delete terms in expertise',
       'edit terms in expertise',
+      'create terms in interests',
       'delete terms in interests',
       'edit terms in interests',
+      'create terms in topic_types',
       'delete terms in topic_types',
       'edit terms in topic_types',
       'administer site configuration',
@@ -469,4 +472,18 @@ function social_core_update_130002() : void {
  */
 function social_core_update_130003() : void {
   \Drupal::state()->delete("secret_file_system_opt_out");
+}
+
+/**
+ * Replace permission administer taxonomy with access taxonomy overview for SM.
+ */
+function social_core_update_130004(): void {
+  user_role_revoke_permissions('sitemanager', ['administer taxonomy']);
+  $permissions = [
+    'access taxonomy overview',
+    'create terms in expertise',
+    'create terms in interests',
+    'create terms in topic_types',
+  ];
+  user_role_grant_permissions('sitemanager', $permissions);
 }

--- a/modules/social_features/social_event/modules/social_event_type/social_event_type.install
+++ b/modules/social_features/social_event/modules/social_event_type/social_event_type.install
@@ -20,6 +20,7 @@ function social_event_type_install() {
     // Set permission.
     $role->grantPermission('set social event type settings');
     $role->grantPermission('edit terms in event_types');
+    $role->grantPermission('create terms in event_types');
     $role->grantPermission('delete terms in event_types');
     $role->trustData()->save();
   }
@@ -38,6 +39,7 @@ function social_event_type_uninstall() {
     // Set permission.
     $role->revokePermission('set social event type settings');
     $role->revokePermission('edit terms in event_types');
+    $role->revokePermission('create terms in event_types');
     $role->revokePermission('delete terms in event_types');
     $role->trustData()->save();
   }
@@ -54,4 +56,11 @@ function social_event_type_uninstall() {
  */
 function social_event_type_update_last_removed() : int {
   return 11201;
+}
+
+/**
+ * Grant permissions for SM to create terms in event_types vocabulary.
+ */
+function social_event_type_update_130001(): void {
+  user_role_grant_permissions('sitemanager', ['create terms in event_types']);
 }

--- a/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.install
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.install
@@ -26,6 +26,9 @@ function social_group_flexible_group_install() {
     'sitemanager',
     [
       'create flexible_group group',
+      'create terms in group_type',
+      'edit terms in group_type',
+      'delete terms in group_type',
     ]
   );
 
@@ -80,4 +83,16 @@ function social_group_flexible_group_update_130000(): void {
     ->getEditable('social_group.settings')
     ->clear('social_group_type_required')
     ->save();
+}
+
+/**
+ * Grant permissions for site manager to manage terms in group_type vocabulary.
+ */
+function social_group_flexible_group_update_130001(): void {
+  $permissions = [
+    'create terms in group_type',
+    'edit terms in group_type',
+    'delete terms in group_type',
+  ];
+  user_role_grant_permissions('sitemanager', $permissions);
 }

--- a/modules/social_features/social_profile/modules/social_profile_organization_tag/social_profile_organization_tag.install
+++ b/modules/social_features/social_profile/modules/social_profile_organization_tag/social_profile_organization_tag.install
@@ -14,7 +14,8 @@ function social_profile_organization_tag_install() {
     'contentmanager',
     [
       'delete terms in profile_organization_tag',
-      'edit terms in profile_tag',
+      'edit terms in profile_organization_tag',
+      'create terms in profile_organization_tag',
       'edit profile organization tags',
     ]
   );
@@ -22,7 +23,8 @@ function social_profile_organization_tag_install() {
     'sitemanager',
     [
       'delete terms in profile_organization_tag',
-      'edit terms in profile_tag',
+      'edit terms in profile_organization_tag',
+      'create terms in profile_organization_tag',
       'edit profile organization tags',
     ]
   );
@@ -146,4 +148,12 @@ function social_profile_organization_tag_update_121002(): void {
       $role->save();
     }
   }
+}
+
+/**
+ * Grant permissions for SM to create terms in event_types vocabulary.
+ */
+function social_profile_organization_tag_update_130001(): void {
+  user_role_grant_permissions('contentmanager', ['create terms in profile_organization_tag']);
+  user_role_grant_permissions('sitemanager', ['create terms in profile_organization_tag']);
 }

--- a/modules/social_features/social_profile/social_profile.install
+++ b/modules/social_features/social_profile/social_profile.install
@@ -50,6 +50,7 @@ function social_profile_install() {
       'edit profile tags',
       'delete terms in profile_tag',
       'edit terms in profile_tag',
+      'create terms in profile_tag',
       'administer profile settings',
       'view profile email',
       'view profile language',
@@ -193,4 +194,11 @@ function social_profile_update_121001(): void {
       $role->save();
     }
   }
+}
+
+/**
+ * Grant permissions for SM to create terms in profile_tag vocabulary.
+ */
+function social_profile_update_130001(): void {
+  user_role_grant_permissions('sitemanager', ['create terms in profile_tag']);
 }

--- a/modules/social_features/social_tagging/social_tagging.install
+++ b/modules/social_features/social_tagging/social_tagging.install
@@ -19,6 +19,7 @@ function social_tagging_install(): void {
       'administer social_tagging',
       'delete terms in social_tagging',
       'edit terms in social_tagging',
+      'create terms in social_tagging',
     ]
   );
 
@@ -146,4 +147,11 @@ function _social_profile_field_definitions_update(string $field): void {
  */
 function social_tagging_update_last_removed() : int {
   return 11804;
+}
+
+/**
+ * Grant permissions for SM to create terms in social_tagging vocabulary.
+ */
+function social_tagging_update_130001(): void {
+  user_role_grant_permissions('sitemanager', ['create terms in social_tagging']);
 }


### PR DESCRIPTION
## Problem
Currently we allow Site Managers to create, edit and translate taxonomy vocabularies in the taxonomy overview page at `/admin/structure/taxonomy`

These actions are not supported by our frontend  so the changes applied to the vocabularies have no effect in the platform.
This generates confusion and it is hard to explain to Community Managers why this is happening.
We have decided to remove these unused options and present a more functional experience to our customers.

## Solution
- Revoke permission `administer taxonomy` from the site manager.
- Grant permissions to `access taxonomy overview` and `create terms in` vocabularies.

## Issue tracker

- https://www.drupal.org/project/social/issues/3444592
- https://getopensocial.atlassian.net/browse/PROD-27327

## Theme issue tracker
N/A

## How to test

- [ ] As a Site Manager go to `/admin/structure/taxonomy`
- [ ] Site Managers are no longer able to edit or add taxonomy vocabularies
- [ ] Site Manager can still perform all the other actions (Add terms, Edit term, Delete term)

## Screenshots
N/A

## Release notes
Remove unsupported functionality for taxonomy vocabularies.

Currently we allow Site Managers to create, edit and translate taxonomy vocabularies in the taxonomy overview page at `/admin/structure/taxonomy`

These actions are not supported by our frontend  so the changes applied to the vocabularies have no effect in the platform.
This generates confusion and it is hard to explain to Community Managers why this is happening.
We have decided to remove these unused options and present a more functional experience to our customers.

## Change Record
A related change record for Drupal Core:
- https://www.drupal.org/node/2902390

## Translations
N/A
