### PR TITLE
Issue #3444628: Rename iCal to iCalendar

### DIFF
--- a/modules/social_features/social_event/modules/social_event_addtocal/social_event_addtocal.module
+++ b/modules/social_features/social_event/modules/social_event_addtocal/social_event_addtocal.module
@@ -64,7 +64,7 @@ function social_event_addtocal_preprocess_event_enrollment_confirmation_add_to_c
         '#type' => 'html_tag',
         '#tag' => 'span',
         '#value' => Link::fromTextAndUrl(
-          t('@calendar calendar', ['@calendar' => $link['title']]),
+          t('@calendar', ['@calendar' => $link['title']]),
           $link['url']
         )->toString(),
         '#attributes' => [
@@ -111,7 +111,7 @@ function social_event_addtocal_node_view(array &$build, NodeInterface $node, Ent
 
       // Update the 'Add to calendar' field rendering.
       $calendar_link = Link::fromTextAndUrl(
-        t('@calendar calendar', ['@calendar' => $link['title']]),
+        t('@calendar', ['@calendar' => $link['title']]),
         $link['url']
       );
       $build['field_event_addtocal'] = [
@@ -141,7 +141,7 @@ function social_event_addtocal_node_view(array &$build, NodeInterface $node, Ent
             [
               '#type' => 'html_tag',
               '#tag' => 'span',
-              '#value' => t('@cal calendar', ['@cal' => $link['title']]),
+              '#value' => t('@cal', ['@cal' => $link['title']]),
             ],
           ];
 

--- a/modules/social_features/social_event/modules/social_event_addtocal/src/Plugin/SocialAddToCalendar/AddToICal.php
+++ b/modules/social_features/social_event/modules/social_event_addtocal/src/Plugin/SocialAddToCalendar/AddToICal.php
@@ -11,7 +11,7 @@ use Drupal\social_event_addtocal\Plugin\SocialAddToCalendarBase;
  *
  * @SocialAddToCalendar(
  *   id = "ical",
- *   label = @Translation("iCal"),
+ *   label = @Translation("iCalendar"),
  *   url = "social_event_addtocal.add_to_calendar_ics",
  *   dateFormat = "e:Ymd\THis",
  *   utcDateFormat = "e:Ymd\THis"

--- a/tests/behat/features/capabilities/event/add-to-calendar.feature
+++ b/tests/behat/features/capabilities/event/add-to-calendar.feature
@@ -1,4 +1,4 @@
-@api @javascript @event @stability @add-to-calendar
+@api @javascript
 Feature: Add event to calendar
   Benefit: Ability to add event to calendar
   Role: As a Verified
@@ -10,16 +10,16 @@ Feature: Add event to calendar
   Scenario: LU with "UTC" timezone can add event to "iCal" calendar
     Given add to calendar is enabled for "iCal"
 
-    Given users:
+    And users:
       | name               | mail             | status | timezone | roles    |
       | regular_user       | some@example.com | 1      | UTC      |verified |
-    Given events with non-anonymous author:
+    And events with non-anonymous author:
       | title               | body        | field_content_visibility | field_event_date    | field_event_date_end | langcode |
       | Walking in the park | lorem ipsum | public                   | 2100-01-01T10:00:00 | 2100-01-01T12:00:00  | en       |
 
     When I am logged in as "regular_user"
     And I am viewing the event "Walking in the park"
-    And the file downloaded from "iCal calendar" should contain individual lines:
+    And the file downloaded from "iCalendar calendar" should contain individual lines:
       """
       BEGIN:VCALENDAR
       VERSION:2.0
@@ -45,17 +45,18 @@ Feature: Add event to calendar
 
   Scenario: Anonymous enrolled to event can add event to "iCal" calendar
     Given add to calendar is enabled for "iCal"
-    Given I enable the module "social_event_an_enroll"
+    And I enable the module "social_event_an_enroll"
 
-    Given events with non-anonymous author:
+    And events with non-anonymous author:
       | title               | body        | field_content_visibility | field_event_date    | field_event_date_end | langcode | field_event_an_enroll |
       | Walking in the park | lorem ipsum | public                   | 2100-01-01T10:00:00 | 2100-01-01T12:00:00  | en       | 1                     |
 
     And I am viewing the event "Walking in the park"
+
     When I click "Enroll"
     And I wait for AJAX to finish
     And I wait for field: "Enroll as guest" of type: "link" to be rendered
-    When I click "Enroll as guest"
+    And I click "Enroll as guest"
     And I wait for AJAX to finish
     And I wait for field: "field_first_name" of type: "input" to be rendered
     And I fill in the following:
@@ -64,7 +65,7 @@ Feature: Add event to calendar
       | Email address | john@doe.com |
     And I press "Enroll in event" in the "Modal"
     And I wait for AJAX to finish
-    And the file downloaded from "iCal calendar" should contain individual lines:
+    And the file downloaded from "iCalendar calendar" should contain individual lines:
       """
       BEGIN:VCALENDAR
       VERSION:2.0

--- a/tests/behat/features/capabilities/event/add-to-calendar.feature
+++ b/tests/behat/features/capabilities/event/add-to-calendar.feature
@@ -19,7 +19,7 @@ Feature: Add event to calendar
 
     When I am logged in as "regular_user"
     And I am viewing the event "Walking in the park"
-    And the file downloaded from "iCalendar calendar" should contain individual lines:
+    And the file downloaded from "iCalendar" should contain individual lines:
       """
       BEGIN:VCALENDAR
       VERSION:2.0
@@ -65,7 +65,7 @@ Feature: Add event to calendar
       | Email address | john@doe.com |
     And I press "Enroll in event" in the "Modal"
     And I wait for AJAX to finish
-    And the file downloaded from "iCalendar calendar" should contain individual lines:
+    And the file downloaded from "iCalendar" should contain individual lines:
       """
       BEGIN:VCALENDAR
       VERSION:2.0


### PR DESCRIPTION
## Problem
Rename iCal to iCalendar to match the full name and not the file extension.

## Solution

Update copy of each calendar for the users following the copy provided:
- iCal → iCalendar
- Google Calendar → Google
- Office 365 Calendar → Office 365
- Outlook Calendar → Outlook
- Yahoo Calendar → Yahoo

## Issue tracker

- https://www.drupal.org/project/social/issues/3444628
- [PROD-27039](https://getopensocial.atlassian.net/browse/PROD-27039)

## Theme issue tracker
N/A

## How to test

- [ ] Go to /admin/config/opensocial/event-addtocal

## Screenshots
<img width="674" alt="image" src="https://github.com/goalgorilla/open_social/assets/2241917/eb4e9b8a-118f-491e-9246-63e6da511684">


## Release notes
Update copy of calendar levels for the users.

## Change Record
N/A

## Translations
N/A


[PROD-27039]: https://getopensocial.atlassian.net/browse/PROD-27039?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ