### PR TITLE
Issue #3445024: Change labels of invitations to join a Group

### DIFF
--- a/modules/social_features/social_group/modules/social_group_invite/src/Form/SocialBulkGroupInvitation.php
+++ b/modules/social_features/social_group/modules/social_group_invite/src/Form/SocialBulkGroupInvitation.php
@@ -221,9 +221,9 @@ class SocialBulkGroupInvitation extends BulkGroupInvitation {
     ];
 
     $form['users_fieldset']['user'] = [
-      '#title' => $this->t('Find people by name or email address'),
+      '#title' => $this->t('Invite any person inside or outside your community using their name or email'),
       '#type' => 'select2',
-      '#description' => $this->t('You can enter or paste multiple entries separated by comma or semicolon'),
+      '#description' => $this->t('For multiple invitees separate each name or email with a comma'),
       '#multiple' => TRUE,
       '#tags' => TRUE,
       '#autocomplete' => TRUE,

--- a/translations.php
+++ b/translations.php
@@ -181,3 +181,7 @@ new TranslatableMarkup('Resend invites for group members');
 
 // String added because original one was changed due to #3439386 issue.
 new TranslatableMarkup('Are you sure you want to send your email to to the following %count enrollees?');
+
+// String added because original one was changed due to #3445024 issue.
+new TranslatableMarkup('Find people by name or email address');
+new TranslatableMarkup('You can enter or paste multiple entries separated by comma or semicolon');


### PR DESCRIPTION
## Problem
In the 'Invite members to group' page: `group/ID/invite-members`
The copy for the Invite members feature in a group needs to be updated.


## Solution
Change labels:
- Find people by name or email address → Invite any person inside or outside your community using their name or email

- You can enter or paste multiple entries separated by comma or semicolon → For multiple invitees separate each name or email with a comma

## Issue tracker
- https://www.drupal.org/project/social/issues/3445024
- https://getopensocial.atlassian.net/browse/PROD-25814

## Theme issue tracker
N/A

## How to test
- [ ] Go to /group/[id]/invite-members

## Screenshots
Before:
![image](https://github.com/goalgorilla/open_social/assets/2241917/c27212e1-2a82-4c68-8dbe-8d97cd7433c4)

After:
![image](https://github.com/goalgorilla/open_social/assets/2241917/09929fb4-1b68-4b5a-a882-c979f029c420)


## Release notes
Change labels of invitations to join a Group

## Change Record
N/A

## Translations
N/A
