### PR TITLE
Issue #3445166: Remove outdated patch from Drupal Core

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -56,13 +56,11 @@
                 "Broken title in modal dialog when title is a render array": "https://www.drupal.org/files/issues/2019-10-21/2663316-76.drupal.Broken-title-in-modal-dialog-when-title-is-a-render-array.patch",
                 "Flood MemoryBackend::events[] key of micro time cannot guarantee uniqueness": "https://www.drupal.org/files/issues/2023-04-07/2910000-mr-1451-d95--floodmemorybackend-time-local_0.diff",
                 "Issue #2998390: Cache is not invalidated when comment deleted": "https://www.drupal.org/files/issues/2022-02-07/2998390-8.patch",
-                "Image derivative generation does not work if effect \"Convert\" in use and file stored in private filesystem": "https://www.drupal.org/files/issues/2024-03-06/2786735-64.patch",
                 "Issue #2107455: Image field default value not shown when upload destination set to private file storage": "https://www.drupal.org/files/issues/2024-01-14/2107455-94.10.2.patch",
                 "2924783 - Fatal error on entity autocomplete widget if entity label contains parentheses": "https://www.drupal.org/files/issues/2021-04-18/2924783-18.patch",
                 "Issue #3397494: Revert the runtime exception for permissions until we have fixed them all correctly": "https://www.drupal.org/files/issues/2023-10-29/3397494-revert-runtimeexception-untill-permissions-fixed.patch",
                 "Issue #3395358 - Redirecting a request during delete an entity when the redirect are disabled": "https://www.drupal.org/files/issues/2023-10-19/drupal-redirect-disable-validation-on-delete-entity-3395358-2.patch",
-                "Issue #3416251: Drupal 10.1.x revert of modal windows for entity delete operation": "https://www.drupal.org/files/issues/2024-01-22/3416251-3-revert-core-entity-delete-modal-changes.patch",
-                "Issue #3409505: Uncaught TypeError: Cannot read properties of null (reading 'style') (toolbar.js)": "https://www.drupal.org/files/issues/2023-12-20/fix-toolbarjs-null-handling.patch"
+                "Issue #3416251: Drupal 10.1.x revert of modal windows for entity delete operation": "https://www.drupal.org/files/issues/2024-01-22/3416251-3-revert-core-entity-delete-modal-changes.patch"
             },
             "drupal/dynamic_entity_reference": {
                 "Return the same content list after content type is changed": "https://www.drupal.org/files/issues/2024-02-16/dynamic_entity_reference-the_same_content_list-3230158-7.patch"


### PR DESCRIPTION
## Problem
The Drupal 10.2.6 was released and some patches start to throw error to apply.

## Solution
Removed outdated patches.

## Issue tracker
[PROD-29516](https://getopensocial.atlassian.net/browse/PROD-29516)
[#3445166](https://www.drupal.org/project/social/issues/3445166)

## Theme issue tracker
N/A

## How to test
N/A

## Screenshots
N/A

## Release notes
N/A

## Change Record
N/A

## Translations
N/A


[PROD-29516]: https://getopensocial.atlassian.net/browse/PROD-29516?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ