### PR TITLE
Issue #3445409: Remove expensive entity loads for the event enrollments counter

### DIFF
--- a/modules/social_features/social_event/social_event.tokens.inc
+++ b/modules/social_features/social_event/social_event.tokens.inc
@@ -70,7 +70,7 @@ function social_event_tokens($type, $tokens, array $data, array $options, Bubble
               $count = count($enrollments->getEventEnrollmentsByStatus((int) $node->id(), [
                 EventEnrollmentInterface::INVITE_ACCEPTED_AND_JOINED,
                 EventEnrollmentInterface::REQUEST_APPROVED,
-              ]));
+              ], TRUE));
               $enrollments = \Drupal::translation()->formatPlural(
                 $count,
                 ':count person has enrolled',

--- a/modules/social_features/social_event/src/EventEnrollmentStatusHelper.php
+++ b/modules/social_features/social_event/src/EventEnrollmentStatusHelper.php
@@ -215,6 +215,9 @@ class EventEnrollmentStatusHelper {
    *   Event id to search enrollments.
    * @param array $filter
    *   Event enrollment status to be filtered.
+   * @param bool $ids_only
+   *   (optional) Don't return a list of objects, but just their IDs. Defaults
+   *   to FALSE.
    *
    * @return array
    *   Return an array of EventEnrollmentEntity.
@@ -222,7 +225,7 @@ class EventEnrollmentStatusHelper {
    * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
    * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
    */
-  public function getEventEnrollmentsByStatus(int $event_id, array $filter): array {
+  public function getEventEnrollmentsByStatus(int $event_id, array $filter, bool $ids_only = FALSE): array {
     // Get event-enrollment query.
     $query = $this->entityTypeManager
       ->getStorage('event_enrollment')
@@ -238,6 +241,12 @@ class EventEnrollmentStatusHelper {
       ->condition('field_event', $event_id)
       ->condition($status_group_condition)
       ->execute();
+
+    // If just IDs were requested we can return here without needing to do an
+    // expensive load for the enrollment entities.
+    if ($ids_only) {
+      return $event_nid;
+    }
 
     return $this->entityTypeManager->getStorage('event_enrollment')
       ->loadMultiple($event_nid);


### PR DESCRIPTION
## Problem
The event page has an enrollments block with a counter of how many people enrolled. This counter is loading event enrollment entities which is unnecessary.

<img width="426" alt="Screenshot 2024-05-06 at 10 08 46" src="https://github.com/goalgorilla/open_social/assets/7124754/5ffb9a63-2526-47e5-8cbe-aaa0b7cafc43">

When there are a lot of enrolments to an event the page becomes unnecessarily slow.

## Solution
Add a simple flag loading just the IDs. This way implementations from others will not be affected.

## Issue tracker
https://www.drupal.org/project/social/issues/3445409

## Theme issue tracker
N/a

## How to test
- [ ] Go to an event with enrollments
- [ ] Observe the counter is still correct

## Screenshots
N/a

## Release notes
The counter showing how many people were joining an event was loading an unnecessary amount of data. It now loads only what it needs.

## Change Record
N/a

## Translations
N/a