### PR TITLE
Issue #3445775: validateEntityFields is not correctly transforming date

### DIFF
--- a/tests/behat/features/bootstrap/EntityTrait.php
+++ b/tests/behat/features/bootstrap/EntityTrait.php
@@ -92,7 +92,12 @@ trait EntityTrait {
         // Make sure we store them as UTC, so we don't have any scenarios where
         // system time influences behat test.
         $date = new DrupalDateTime($values[$field_name], 'UTC');
-        $values[$field_name] = $date->format('Y-m-d\TH:i:s');
+        if ($field_definition->getSetting('datetime_type') === 'date') {
+          $values[$field_name] = $date->format('Y-m-d');
+        }
+        else {
+          $values[$field_name] = $date->format('Y-m-d\TH:i:s');
+        }
       }
       // Created and changed fields are stored as a normal timestamp but require
       // the same human-readable input as datetime fields.


### PR DESCRIPTION
## Problem
validateEntityFields() is not correctly transforming date field values for datetime type "date" fields (it works as designed for "datetime" type only). To fix the issue correct date format is applied for date only fields.

## Solution
<!-- *[Required] Describe the solution you've created, elaborate on any technical choices you've made. Why is this the right solution and is a different solution not the right one? What is the reasoning behind the chosen solution?* -->

## Issue tracker
[3445775](https://www.drupal.org/project/social/issues/3445775) (PROD-29315)

## Theme issue tracker
N/A

## How to test
Create behat test step, that uses validateEntityFields method and validate date only field. 
Created entity will have empty date field as an result of wrong date format applied.
With this fix applied date field will be correctly transformed.

## Screenshots
N/A

## Release notes
Improve tests.

## Change Record
N/A

## Translations
N/A