### PR TITLE
Issue #3445957: Organization field doesn't appear on registration field settings

### DIFF
--- a/modules/social_features/social_profile/social_profile.module
+++ b/modules/social_features/social_profile/social_profile.module
@@ -1065,12 +1065,3 @@ function social_profile_social_core_default_main_menu_links_alter(array &$links)
 function social_profile_social_tagging_type(): string {
   return 'profile';
 }
-
-/**
- * Remove the organization from the options to use in the user registration.
- */
-function social_profile_social_registration_fields_list_alter(array &$fields): void {
-  if (($key = array_search('field_profile_organization', $fields, TRUE)) !== FALSE) {
-    unset($fields[$key]);
-  }
-}


### PR DESCRIPTION
## Problem
In PR #3799, we added a hook api from the registration module to not allow these organization fields to beadded to the registration.

## Solution
We are reverting the same logic in this PR and it will be moved social_organization module.

## Issue tracker
https://www.drupal.org/project/social/issues/3445957

## Theme issue tracker

## How to test
- [ ] Enable the modules: Social Registration Fields
- [ ] Clear cache
- [ ] Go to: /admin/config/people/social-registration-fields
- [ ] The Organization field should be showing up.

## Screenshots
**Before**
<img width="1221" alt="Screenshot 2024-05-08 at 1 00 02 PM" src="https://github.com/goalgorilla/open_social/assets/8435994/8e7b7db5-af49-40c4-9a84-d052937c3f07">

**After**
<img width="1286" alt="Screenshot 2024-05-08 at 1 00 13 PM" src="https://github.com/goalgorilla/open_social/assets/8435994/58bf1b87-a0cb-43f2-b2de-fde69ffb66e7">


## Release notes
We added the organizations profile fields to be used for the user registration page.

## Change Record
N.A

## Translations
N.A