### PR TITLE
Issue #3445981: Solr: Ensure we only run the update hook if the server doesn't exist

### DIFF
--- a/modules/social_features/social_search/social_search.install
+++ b/modules/social_features/social_search/social_search.install
@@ -79,53 +79,56 @@ function social_search_update_last_removed() : int {
 function social_search_update_13000() : void {
   \Drupal::service('module_installer')->install(["search_api_solr"]);
 
-  $new_server = Server::create([
-    'langcode' => 'en',
-    'status' => TRUE,
-    'dependencies' => [
-      'module' => [
-        'search_api_solr',
+  // Create the server if it doesn't exist.
+  if (Server::load('social_solr') === NULL) {
+    $new_server = Server::create([
+      'langcode' => 'en',
+      'status' => TRUE,
+      'dependencies' => [
+        'module' => [
+          'search_api_solr',
+        ],
       ],
-    ],
-    'id' => 'social_solr',
-    'name' => 'Social SOLR',
-    'description' => '',
-    'backend' => 'search_api_solr',
-    'backend_config' => [
-      'connector' => 'standard',
-      'connector_config' => [
-        'scheme' => 'http',
-        'host' => 'solr',
-        'port' => 8983,
-        'path' => '/',
-        'core' => 'drupal',
-        'timeout' => 5,
-        'index_timeout' => 5,
-        'optimize_timeout' => 10,
-        'finalize_timeout' => 30,
-        'commit_within' => 1000,
-        'solr_version' => '',
-        'http_method' => 'AUTO',
-        'jmx' => FALSE,
-        'solr_install_dir' => '/opt/solr',
+      'id' => 'social_solr',
+      'name' => 'Social SOLR',
+      'description' => '',
+      'backend' => 'search_api_solr',
+      'backend_config' => [
+        'connector' => 'standard',
+        'connector_config' => [
+          'scheme' => 'http',
+          'host' => 'solr',
+          'port' => 8983,
+          'path' => '/',
+          'core' => 'drupal',
+          'timeout' => 5,
+          'index_timeout' => 5,
+          'optimize_timeout' => 10,
+          'finalize_timeout' => 30,
+          'commit_within' => 1000,
+          'solr_version' => '',
+          'http_method' => 'AUTO',
+          'jmx' => FALSE,
+          'solr_install_dir' => '/opt/solr',
+        ],
+        'disabled_field_types' => [],
+        'retrieve_data' => FALSE,
+        'highlight_data' => FALSE,
+        'skip_schema_check' => FALSE,
+        'server_prefix' => '',
+        'domain' => 'generic',
+        'optimize' => FALSE,
+        'site_hash' => FALSE,
       ],
-      'disabled_field_types' => [],
-      'retrieve_data' => FALSE,
-      'highlight_data' => FALSE,
-      'skip_schema_check' => FALSE,
-      'server_prefix' => '',
-      'domain' => 'generic',
-      'optimize' => FALSE,
-      'site_hash' => FALSE,
-    ],
-  ]);
-  $new_server->save();
+    ]);
+    $new_server->save();
 
-  // We want to migrate all indices that exist to the new search server.
-  // These are all, content, groups, and users for the distribution but might be
-  // others for SaaS extensions or custom work.
-  foreach (Index::loadMultiple() as $index) {
-    $index->setServer($new_server)->save();
+    // We want to migrate all indices that exist to the new search server.
+    // These are all, content, groups, and users for the distribution but might
+    // be others for SaaS extensions or custom work.
+    foreach (Index::loadMultiple() as $index) {
+      $index->setServer($new_server)->save();
+    }
   }
 }
 


### PR DESCRIPTION
## Problem
In some occassions the solr server already existed, lets make sure we check that before creating.
to prevent

```
    W: >  [error]  'search_api_server' entity with ID 'social_solr' already exists. 
    W: >  [error]  Update failed: social_search_update_13000 
```

## Solution
Check if the server doesn't exist yet.

## Issue tracker
https://www.drupal.org/project/social/issues/3445981

## How to test
Code review will do, the test case happens in our QA checks.

## Release notes
Part of the release notes already, just a fix for 13.0.0 SOLR.
