### PR TITLE
Issue #3446480: Group manager block marking every joined member as manager

### DIFF
--- a/modules/social_features/social_group/config/optional/views.view.group_managers.yml
+++ b/modules/social_features/social_group/config/optional/views.view.group_managers.yml
@@ -238,8 +238,7 @@ display:
       filter_groups:
         operator: AND
         groups:
-          1: OR
-          2: AND
+          1: AND
     cache_metadata:
       max-age: -1
       contexts:

--- a/modules/social_features/social_group/config/update/social_group_update_13007.yml
+++ b/modules/social_features/social_group/config/update/social_group_update_13007.yml
@@ -1,0 +1,10 @@
+views.view.group_managers:
+  expected_config: {}
+  update_actions:
+    change:
+      display:
+        default:
+          display_options:
+            filter_groups:
+              groups:
+                1: AND

--- a/modules/social_features/social_group/social_group.install
+++ b/modules/social_features/social_group/social_group.install
@@ -820,3 +820,19 @@ function social_group_update_13004() : string {
 function social_group_update_13006() : void {
   \Drupal::state()->delete("social_group_group_type_migration_opt_out");
 }
+
+/**
+ * Adjust the group managers view AND/OR filter.
+ *
+ * They need to have group manager role AND a profile.
+ */
+function social_group_update_13007(): string {
+  /** @var \Drupal\update_helper\Updater $updateHelper */
+  $updateHelper = \Drupal::service('update_helper.updater');
+
+  // Execute configuration update definitions with logging of success.
+  $updateHelper->executeUpdate('social_group', __FUNCTION__);
+
+  // Output logged messages to related channel of update execution.
+  return $updateHelper->logger()->output();
+}


### PR DESCRIPTION
## Problem
In the new 13.0.0 update the group migration has taken place so some views have been altered to remove the open-closed group types.
But in the group managers block the filter has been changed incorrectly, now requiring only to have a profile to be group manager.
This is only for the block view and does not actually give them group manager permissions/role.

## Solution
Change the filter from "or" to "and".

## Issue tracker
https://www.drupal.org/project/social/issues/3446480

## Theme issue tracker
<!-- *[Required if applicable] Paste a link to the drupal.org theme issue queue item, either from [socialbase](https://www.drupal.org/project/socialbase) or [socialblue](https://www.drupal.org/project/socialblue). If any other issue trackers were used, include links to those too.* -->

## How to test
- [ ] Create a flexible group and add someone directly to the group. They are now regular member.
- [ ] Enable views_ui and edit the group manager view
- [ ] Do a preview with the group ID and see both are now marked as manager
- [ ] Go to this branch and try again

## Screenshots
<!-- *[Required if new feature, and if applicable] If this Pull Request makes visual changes then please include some screenshots that show what has changed here. A before and after screenshot helps the reviewer determine what changes were made.* -->

## Release notes
Internal (as it's 13-Alpha): We fixed an issue where the group managers block would mark every joined member as manager.

## Change Record
<!-- *[Required if applicable] If this Pull Request changes the way that developers should do things or introduces a new API for developers then a change record to document this is needed. Please provide a draft for a change record or a link to an unpublished change record below. Existing change records can be consulted as example. Please provide a draft for a change record or a link to an unpublished change record below. [Existing change records](https://www.drupal.org/list-changes/social) can be consulted as example.* -->

## Translations
<!--
*[Optional]Translatable strings are always extracted from the latest development branch. To ensure translations remain available for platforms running older versions of Open Social the original string should be added to `translations.php` when it's changed or removed.*
- [ ] Changed or removed source strings are added to the `translations.php` file.
-->
