### PR TITLE
Issue #3421348: Remove redundant "Group type" filter

### DIFF
--- a/modules/social_features/social_group/config/install/views.view.newest_groups.yml
+++ b/modules/social_features/social_group/config/install/views.view.newest_groups.yml
@@ -355,51 +355,6 @@ display:
             default_group_multiple: { }
             group_items: { }
           plugin_id: list_field
-        type:
-          id: type
-          table: groups_field_data
-          field: type
-          relationship: none
-          group_type: group
-          admin_label: ''
-          operator: in
-          value: {  }
-          group: 1
-          exposed: true
-          expose:
-            operator_id: type_op
-            label: 'Group type'
-            description: ''
-            use_operator: false
-            operator: type_op
-            identifier: type
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-              anonymous: '0'
-              administrator: '0'
-              contentmanager: '0'
-              sitemanager: '0'
-            reduce: false
-            operator_limit_selection: false
-            operator_list: {  }
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
-          entity_type: group
-          entity_field: type
-          plugin_id: bundle
       defaults:
         filters: false
         filter_groups: false

--- a/modules/social_features/social_group/config/update/social_group_update_13008.yml
+++ b/modules/social_features/social_group/config/update/social_group_update_13008.yml
@@ -1,0 +1,9 @@
+views.view.newest_groups:
+  expected_config: { }
+  update_actions:
+    delete:
+      display:
+        page_all_groups:
+          display_options:
+            filters:
+              type: { }

--- a/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.module
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.module
@@ -78,28 +78,6 @@ function social_group_flexible_group_form_alter(&$form, FormStateInterface $form
   if ($form['#id'] === 'views-exposed-form-newest-groups-page-all-groups' ||
     $form['#id'] === 'views-exposed-form-search-groups-page-no-value' ||
     $form['#id'] === 'views-exposed-form-search-groups-page') {
-    // Add states so this is only available when flexible groups is checked.
-    // Could be hidden when only flexible groups is enabled, so check that.
-    // @todo remove this once everything is migrated to flexible groups.
-    if (!empty($form['field_group_allowed_join_method']) &&
-      !empty($form['type']['#options']) &&
-      $form['type']['#type'] !== 'hidden') {
-      $form['field_group_allowed_join_method']['#states'] = [
-        'visible' => [
-          ':input[name="type"]' => ['value' => 'flexible_group'],
-        ],
-      ];
-    }
-    if (!empty($form['field_group_type_target_id']) &&
-      !empty($form['type']['#options']) &&
-      $form['type']['#type'] !== 'hidden') {
-      $form['field_group_type_target_id']['#states'] = [
-        'visible' => [
-          ':input[name="type"]' => ['value' => 'flexible_group'],
-        ],
-      ];
-    }
-
     // Hide the flexible group field group type if there is only the
     // "All / any" option we hide it as well.
     if (!empty($form['field_group_type_target_id']) &&

--- a/modules/social_features/social_group/social_group.install
+++ b/modules/social_features/social_group/social_group.install
@@ -836,3 +836,13 @@ function social_group_update_13007(): string {
   // Output logged messages to related channel of update execution.
   return $updateHelper->logger()->output();
 }
+
+/**
+ * Remove redundant "Group types" filter from views.
+ */
+function social_group_update_13008(): string {
+  /** @var \Drupal\update_helper\Updater $updateHelper */
+  $updateHelper = \Drupal::service('update_helper.updater');
+  $updateHelper->executeUpdate('social_group', __FUNCTION__);
+  return $updateHelper->logger()->output();
+}

--- a/modules/social_features/social_group/social_group.module
+++ b/modules/social_features/social_group/social_group.module
@@ -1018,35 +1018,15 @@ function social_group_form_alter(&$form, FormStateInterface $form_state, $form_i
     }
   }
 
-  // Exposed Filter block on the all-groups overview.
-  if ($form['#id'] === 'views-exposed-form-newest-groups-page-all-groups' ||
+  // Exposed Filter block on the "all-groups" overview.
+  if (
+    $form['#id'] === 'views-exposed-form-newest-groups-page-all-groups' ||
     $form['#id'] === 'views-exposed-form-search-groups-page-no-value' ||
-    $form['#id'] === 'views-exposed-form-search-groups-page') {
-    $account = \Drupal::currentUser();
-    if (!empty($form['type']['#options'])) {
-      // Make sure we add cache tags so whenever a type is added/removed in the
-      // vocabulary this gets cleared.
-      $form['#cache']['tags'][] = 'taxonomy_term_list:group_type';
-
-      foreach ($form['type']['#options'] as $type => $label) {
-        // All / Any we can skip they are optional translatable options
-        // and not group types.
-        if ($label instanceof TranslatableMarkup) {
-          continue;
-        }
-        if (!social_group_can_view_groups_of_type($type, $account)) {
-          unset($form['type']['#options'][$type]);
-        }
-      }
-      // If we determined the user can only see the All / Any option
-      // And perhaps one more group type, like flexible groups.
-      // this filter doesn't make sense, and we hide it.
-      // This also allows other filters, depending on the options to show up.
-      if (count($form['type']['#options']) === 2 &&
-        array_key_exists('All', $form['type']['#options'])) {
-        $form['type']['#type'] = 'hidden';
-      }
-    }
+    $form['#id'] === 'views-exposed-form-search-groups-page'
+  ) {
+    // Make sure we add cache tags, so whenever a type is added/removed
+    // in the vocabulary, this gets cleared.
+    $form['#cache']['tags'][] = 'taxonomy_term_list:group_type';
   }
 
   // Add custom validation for "group_type" group field.


### PR DESCRIPTION
## Problem
Follow up #3763

## Solution
Remove redundant "Group type" filter on "/all-groups" page.

## Issue tracker
- https://www.drupal.org/project/social/issues/3421348
- https://getopensocial.atlassian.net/browse/PROD-29583

## Theme issue tracker

## How to test
- [ ] Login as SM
- [ ] Enable "Social Flexible Group" module
- [ ] On _/admin/structure/taxonomy/manage/group_type/overview_ add at least one term
- [ ] Visit _/all-group_ page and make sure the filter "Group type" doesn't exist

## Screenshots

## Release notes
Remove redundant "Group type" filter on group overview.

## Change Record
## Translations
