### PR TITLE
During the update to OS-13 we have added a filter with 'flexible_grou…

### DIFF
--- a/modules/social_features/social_group/social_group.install
+++ b/modules/social_features/social_group/social_group.install
@@ -846,3 +846,34 @@ function social_group_update_13008(): string {
   $updateHelper->executeUpdate('social_group', __FUNCTION__);
   return $updateHelper->logger()->output();
 }
+
+/**
+ * Remove redundant flexible group manager filter from views.
+ *
+ * During the update to OS-13 we have added a filter with
+ * 'flexible_group-group_manager' which is redundant as we already have a
+ * '*-group_manager' filter, and this one is also causing issues with the filter
+ * groups, resulting in everyone showing as group manager.
+ */
+function social_group_update_13009(): void {
+  $config = \Drupal::configFactory()
+    ->getEditable('views.view.group_managers');
+
+  $displays = $config->getOriginal('display');
+  foreach ($displays as $key => $display) {
+    // We already have a filter that checks on '*-group_manager', so
+    // remove the flexible_group-group_manager one as it also blocks
+    // other group types.
+    if (!empty($display['display_options']['filters']['group_roles_target_id_3']) && $display['display_options']['filters']['group_roles_target_id_3']['value'] === 'flexible_group-group_manager') {
+      unset($displays[$key]['display_options']['filters']['group_roles_target_id_3']);
+
+      // Remove the filter_groups as it can be the default which is AND.
+      if (!empty($display['display_options']['filter_groups'])) {
+        unset($displays[$key]['display_options']['filter_groups']);
+      }
+    }
+  }
+
+  $config->set('display', $displays);
+  $config->save();
+}


### PR DESCRIPTION
## Problem
During the update to OS-13 we have added a filter with 'flexible_group-group_manager' which is redundant as we already have a '*-group_manager' filter, and this one is also causing issues with the filter groups, resulting in everyone showing as group manager.

## Solution
Remove the flexible_group-group_manager filter and make sure the filter groups are set to default.

## Issue tracker
https://www.drupal.org/project/social/issues/3446480

## Theme issue tracker
<!-- *[Required if applicable] Paste a link to the drupal.org theme issue queue item, either from [socialbase](https://www.drupal.org/project/socialbase) or [socialblue](https://www.drupal.org/project/socialblue). If any other issue trackers were used, include links to those too.* -->

## How to test
- [ ] Create a flexible group and add someone directly to the group. They are now regular member.
- [ ] Enable views_ui and edit the group manager view
- [ ] Do a preview with the group ID and see both are now marked as manager
- [ ] Go to this branch and try again

## Screenshots
<!-- *[Required if new feature, and if applicable] If this Pull Request makes visual changes then please include some screenshots that show what has changed here. A before and after screenshot helps the reviewer determine what changes were made.* -->

## Release notes
Internal (as it's 13-Alpha): We fixed an issue where the group managers block would mark every joined member as manager.

## Change Record
<!-- *[Required if applicable] If this Pull Request changes the way that developers should do things or introduces a new API for developers then a change record to document this is needed. Please provide a draft for a change record or a link to an unpublished change record below. Existing change records can be consulted as example. Please provide a draft for a change record or a link to an unpublished change record below. [Existing change records](https://www.drupal.org/list-changes/social) can be consulted as example.* -->

## Translations
<!--
*[Optional]Translatable strings are always extracted from the latest development branch. To ensure translations remain available for platforms running older versions of Open Social the original string should be added to `translations.php` when it's changed or removed.*
- [ ] Changed or removed source strings are added to the `translations.php` file.
-->
