### PR TITLE
PROD-25979: Remove obsolete test for event enrollment

### DIFF
--- a/tests/behat/features/capabilities/event/eventenrollment.feature
+++ b/tests/behat/features/capabilities/event/eventenrollment.feature
@@ -140,15 +140,6 @@ Feature: Enroll for an event
 
     When I am viewing my event:
       | title                    | My Behat Event created |
-      | field_event_date         | -1 days                |
-      | status                   | 1                      |
-      | field_content_visibility | community              |
-
-    Then I should see "No one has enrolled for this event"
-    And I should see the button "Event has passed"
-    And I should see the link "Manage enrollments"
-    And I am viewing my event:
-      | title                    | My Behat Event created |
       | field_event_date         | -3 days                |
       | field_event_date_end     | -2 days                |
       | status                   | 1                      |


### PR DESCRIPTION
## Problem
This test ensures that an event without an end date also properly shows as "passed" but we no longer allow events without end dates. The test step used doesn't validate that the created entity is valid, this is fixed in a future PR.

This is a follow-up to https://github.com/goalgorilla/open_social/pull/3880 which makes end-dates required but didn't remove this test coverage for a now unsupported state.

## Solution
Remove the test steps, the remaining steps cover the scenario with an end date.

## Issue tracker
https://www.drupal.org/project/social/issues/3443501
https://getopensocial.atlassian.net/browse/PROD-25979

## Theme issue tracker
<!-- *[Required if applicable] Paste a link to the drupal.org theme issue queue item, either from [socialbase](https://www.drupal.org/project/socialbase) or [socialblue](https://www.drupal.org/project/socialblue). If any other issue trackers were used, include links to those too.* -->

## How to test
- [x] Behat test should pass

## Screenshots
<!-- *[Required if new feature, and if applicable] If this Pull Request makes visual changes then please include some screenshots that show what has changed here. A before and after screenshot helps the reviewer determine what changes were made.* -->

## Release notes
[Follow-up for existing release notes, no notes needed.]

## Change Record
<!-- *[Required if applicable] If this Pull Request changes the way that developers should do things or introduces a new API for developers then a change record to document this is needed. Please provide a draft for a change record or a link to an unpublished change record below. Existing change records can be consulted as example. Please provide a draft for a change record or a link to an unpublished change record below. [Existing change records](https://www.drupal.org/list-changes/social) can be consulted as example.* -->

## Translations
<!--
*[Optional]Translatable strings are always extracted from the latest development branch. To ensure translations remain available for platforms running older versions of Open Social the original string should be added to `translations.php` when it's changed or removed.*
- [ ] Changed or removed source strings are added to the `translations.php` file.
-->
