### PR TITLE
Issue #3444592 - Revert removal of administer taxonomy permission for SM.

### DIFF
--- a/modules/social_features/social_core/social_core.install
+++ b/modules/social_features/social_core/social_core.install
@@ -86,6 +86,7 @@ function social_core_install() {
       'access toolbar',
       'administer nodes',
       'administer menu',
+      'administer taxonomy',
       'access site reports',
       'access administration pages',
       'view all revisions',
@@ -486,4 +487,11 @@ function social_core_update_130004(): void {
     'create terms in topic_types',
   ];
   user_role_grant_permissions('sitemanager', $permissions);
+}
+
+/**
+ * Add administer taxonomy back again, this had side effects we need to fix.
+ */
+function social_core_update_130005(): void {
+  user_role_grant_permissions('sitemanager', ['administer taxonomy']);
 }


### PR DESCRIPTION
## Problem
In #3885 we removed the administer taxonomy permission for SM.
This had some unwanted side effects.
Considering it already has been released we do it in another update hook to be kind to the community who are apparantly already using it. (From historical purposes probably also a good reference)

After fixing all the occurrences (like nationality / report reason) of taxonomy creation in the individual modules we can revoke this permission in the product again.

## Solution
For now the PR #3885 still is fine, the added permissions aren't a problem, it's the removal of the administer taxonomy and us forgetting some of the vocabularies that we're relying on this permission for SM to be able to CRUD the terms in there. 

Once we have fixed all the individual vocabulary & term permissions for SM we can revoke this permission.

## Issue tracker
[#3444592: Replace permission administer taxonomy with access taxonomy overview for SM](https://www.drupal.org/project/social/issues/3444592)

## How to test
- [ ] As a sitemanager
- [ ] You should be able to manage the nationality list when `social_profile_extra` is Enabled

## Release notes
None, removed the linked issue from release notes as we partially reverted this.