### PR TITLE
Issue #3450163: Activity "created" field value is wrong

### DIFF
--- a/modules/custom/activity_creator/src/ActivityFactory.php
+++ b/modules/custom/activity_creator/src/ActivityFactory.php
@@ -139,7 +139,6 @@ class ActivityFactory extends ControllerBase {
 
     // Initialize fields for new activity entity.
     $activity_fields = [
-      'created' => $this->getCreated($message),
       'field_activity_destinations' => $this->getFieldDestinations($data),
       'field_activity_entity' => $this->getFieldEntity($data),
       'field_activity_message' => $this->getFieldMessage($data),


### PR DESCRIPTION
## Problem
[Activity](https://github.com/goalgorilla/open_social/blob/main/modules/custom/activity_creator/src/Entity/Activity.php#L187) entity has `created` field that should contain the time when the entity was created. Instead, the field contain the time creation of the entity from `field_activity_entity` own field.

This leads to a few common problems:
- If the `field_activity_entity` entity created as unpublished a long time ago, after publishing related notification can be lost among others notifications (instead appearing on the top of the notifications list)
- `created` date of activity could have unexpected displaying (for example, if related entity is profile that created a few years ago

## Solution
Make `created` field contain real "Activity" creation time rather then related entity.

## Issue tracker
- https://www.drupal.org/project/social/issues/3450163
- https://getopensocial.atlassian.net/browse/PROD-28587

## Theme issue tracker

## How to test
- [ ] Login as admin
- [ ] Create a flexible group
- [ ] Add a LU as group member
- [ ] Login as LU in a separate browser window
- [ ] As admin create an UNPUBLISHED topic in a group
- [ ] Change created date (for example, make it created a few months ago)
- [ ] Make the topic published and save 
- [ ] Run cron
- [ ] As LU visit _/notifications_ page
  - [ ] LU should get notification that should not contain the text "... months ago"

## Screenshots

## Release notes
Make `created` field contain real "Activity" creation time rather then related entity.

## Change Record

## Translations
