### PR TITLE
Hotfix: inline images converted to secret file system

### DIFF
--- a/modules/social_features/social_core/social_core.install
+++ b/modules/social_features/social_core/social_core.install
@@ -495,3 +495,14 @@ function social_core_update_130004(): void {
 function social_core_update_130005(): void {
   user_role_grant_permissions('sitemanager', ['administer taxonomy']);
 }
+
+/**
+ * Revert inline-images to private file system.
+ */
+function social_core_update_130006(): void {
+  // This does not check if the secret file system was opted in, since in that
+  // case it matches no rows.
+  // The inline-images was omitted from the update hook but the query was not
+  // updated to ignore those files, this causes them to error.
+  \Drupal::database()->query("UPDATE {file_managed} SET uri = REPLACE(uri, 'secret://', 'private://') WHERE uri LIKE 'secret://inline-images/%'");
+}


### PR DESCRIPTION
## Problem / Solution
Due to caching issues in the CKEditor, inline images added through the CKEditor were omitted from using the secret filesystem. However in the update path those images from the `file_managed` table were not excluded. This has caused `social_core_update_130002` to say that inline images that should be served by the private file system should be served by the secret file system. However, this is then invalid, causing issues.

This commit adds an update hook that reverts the incorrectly changed inline images. We can be sure that anything that matches was coming from private, since we didn't touch public images.

## Issue tracker
<!-- *[Required] Paste a link to the drupal.org issue queue item. If any other issue trackers were used, include links to those too.* -->

## Theme issue tracker
<!-- *[Required if applicable] Paste a link to the drupal.org theme issue queue item, either from [socialbase](https://www.drupal.org/project/socialbase) or [socialblue](https://www.drupal.org/project/socialblue). If any other issue trackers were used, include links to those too.* -->

## How to test
<!--
*[Required] For example*
- [ ] Using version X.Y.Z of Open Social with the example module enabled
- [ ] As a sitemanager
- [ ] Try to enable the option B on screen c/d/e
- [ ] When saving I expect the result to be F but instead see G.
- [ ] The expected result F is attained when repeating the steps with this fix applied.
-->

## Screenshots
<!-- *[Required if new feature, and if applicable] If this Pull Request makes visual changes then please include some screenshots that show what has changed here. A before and after screenshot helps the reviewer determine what changes were made.* -->

## Release notes
<!-- *[Required if new feature, and if applicable] A short summary of the changes that were made that can be included in release notes.* -->

## Change Record
<!-- *[Required if applicable] If this Pull Request changes the way that developers should do things or introduces a new API for developers then a change record to document this is needed. Please provide a draft for a change record or a link to an unpublished change record below. Existing change records can be consulted as example. Please provide a draft for a change record or a link to an unpublished change record below. [Existing change records](https://www.drupal.org/list-changes/social) can be consulted as example.* -->

## Translations
<!--
*[Optional]Translatable strings are always extracted from the latest development branch. To ensure translations remain available for platforms running older versions of Open Social the original string should be added to `translations.php` when it's changed or removed.*
- [ ] Changed or removed source strings are added to the `translations.php` file.
-->
