### PR TITLE
Issue #3450914: Prevent fatal error on "Notification center" if flagging entity was accidentally deleted

### DIFF
--- a/modules/custom/activity_creator/src/Entity/Activity.php
+++ b/modules/custom/activity_creator/src/Entity/Activity.php
@@ -9,6 +9,7 @@ use Drupal\Core\Entity\ContentEntityBase;
 use Drupal\Core\Entity\EntityChangedTrait;
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\activity_creator\ActivityInterface;
+use Drupal\Core\Url;
 use Drupal\flag\Entity\Flagging;
 use Drupal\user\UserInterface;
 use Drupal\node\NodeInterface;
@@ -228,10 +229,13 @@ class Activity extends ContentEntityBase implements ActivityInterface {
    * Get related entity url.
    *
    * @return \Drupal\Core\Url|string
-   *   Returns empty string or URL object of related entity canonical url.
+   *   URL object of related entity canonical url or NULL.
+   *
+   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
+   * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
+   * @throws \Drupal\Core\Entity\EntityMalformedException
    */
-  public function getRelatedEntityUrl() {
-    $link = "";
+  public function getRelatedEntityUrl(): string|Url {
     $related_object = $this->get('field_activity_entity')->getValue();
 
     if (!empty($related_object)) {
@@ -268,6 +272,9 @@ class Activity extends ContentEntityBase implements ActivityInterface {
       }
       elseif ($target_type === 'flagging') {
         $flagging = Flagging::load($target_id);
+        if (!$flagging) {
+          return '';
+        }
         $target_type = $flagging->getFlaggableType();
         $target_id = $flagging->getFlaggableId();
       }
@@ -281,7 +288,8 @@ class Activity extends ContentEntityBase implements ActivityInterface {
         $link = $entity->toUrl('canonical');
       }
     }
-    return $link;
+
+    return $link ?? '';
   }
 
   /**

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -431,16 +431,6 @@ parameters:
 			path: modules/custom/activity_creator/src/Controller/NotificationsController.php
 
 		-
-			message: "#^Cannot call method getFlaggableId\\(\\) on Drupal\\\\flag\\\\Entity\\\\Flagging\\|null\\.$#"
-			count: 1
-			path: modules/custom/activity_creator/src/Entity/Activity.php
-
-		-
-			message: "#^Cannot call method getFlaggableType\\(\\) on Drupal\\\\flag\\\\Entity\\\\Flagging\\|null\\.$#"
-			count: 1
-			path: modules/custom/activity_creator/src/Entity/Activity.php
-
-		-
 			message: "#^Method Drupal\\\\activity_creator\\\\Entity\\\\Activity\\:\\:getOwner\\(\\) should return Drupal\\\\user\\\\UserInterface but returns Drupal\\\\Core\\\\Entity\\\\EntityInterface\\.$#"
 			count: 1
 			path: modules/custom/activity_creator/src/Entity/Activity.php


### PR DESCRIPTION
## Problem
One of our client has fatal error on "Notification center" (`/notifications`):
```

Error: Call to a member function getFlaggableType() on null in Drupal\activity_creator\Entity\Activity->getRelatedEntityUrl() (line 279 of profiles/contrib/social/modules/custom/activity_creator/src/Entity/Activity.php).
```

## Solution
Add checks to prevent methods from calling on empty object.

## Issue tracker
- https://www.drupal.org/project/social/issues/3450914
- https://getopensocial.atlassian.net/browse/PROD-29719

## Theme issue tracker

## How to test

## Screenshots

## Release notes
Prevent fatal error on "Notification center" if flagging entity was accidentally deleted.

## Change Record

## Translations
