### PR TITLE
Issue #3450999: Group types translations are not visible in teasers and group page

### DIFF
--- a/modules/social_features/social_group/social_group.module
+++ b/modules/social_features/social_group/social_group.module
@@ -325,7 +325,9 @@ function social_group_preprocess_group(array &$variables) {
     $term = $group->get('field_group_type')->entity;
 
     if ($term instanceof Term) {
-      $variables['group_type'] = $term->getName();
+      /** @var \Drupal\Core\Entity\EntityInterface $entity */
+      $entity = \Drupal::service('entity.repository')->getTranslationFromContext($term);
+      $variables['group_type'] = $entity->label();
       $variables['group_type_icon'] = $term->get('field_group_type_icon')->getString();
     }
   }


### PR DESCRIPTION
## Problem
<!-- *[Required] Describe the problem you're trying to solve, this should motivate why the changes you're proposing are needed.* -->

Group types translations are not visible in teasers and on group page.
Affected pages/view mods:
- teasers, search page, stream, overview, group page

## Solution
<!-- *[Required] Describe the solution you've created, elaborate on any technical choices you've made. Why is this the right solution and is a different solution not the right one? What is the reasoning behind the chosen solution?* -->
In the `social_group_preprocess_group()`:

replace `$variables['group_type'] = $term->getName();`

with `$variables['group_type'] = \Drupal::service('entity.repository')->getTranslationFromContext($term)->label();`


## Issue tracker
<!-- *[Required] Paste a link to the drupal.org issue queue item. If any other issue trackers were used, include links to those too.* -->
- https://www.drupal.org/project/social/issues/3450999
- https://getopensocial.atlassian.net/browse/PROD-29648

## Theme issue tracker
<!-- *[Required if applicable] Paste a link to the drupal.org theme issue queue item, either from [socialbase](https://www.drupal.org/project/socialbase) or [socialblue](https://www.drupal.org/project/socialblue). If any other issue trackers were used, include links to those too.* -->
N/A

## How to test
- [ ] Using the latest version of Open Social with the example module enabled
- [ ] As a sitemanager Create a test group 
- [ ] Add translation of the selected group type (term)
- [ ] Switch your profile language to different then default one
- [ ] And when you open group about page/search/stream the group type displays still untranslated
- [ ] The expected result is attained when repeating the steps with this fix applied.


## Screenshots
<!-- *[Required if new feature, and if applicable] If this Pull Request makes visual changes then please include some screenshots that show what has changed here. A before and after screenshot helps the reviewer determine what changes were made.* -->
<img width="1495" alt="Screenshot 2024-05-30 at 17 09 20" src="https://github.com/goalgorilla/open_social/assets/25609390/e8bc7eec-d6bf-4406-a661-bcc91902eedd">
<img width="1268" alt="Screenshot 2024-05-30 at 17 01 55" src="https://github.com/goalgorilla/open_social/assets/25609390/2bbd53c7-b30c-4200-abc7-b4db89578b2e">

## Release notes
Group types translations are now visible in teasers and group pages.

## Change Record
<!-- *[Required if applicable] If this Pull Request changes the way that developers should do things or introduces a new API for developers then a change record to document this is needed. Please provide a draft for a change record or a link to an unpublished change record below. Existing change records can be consulted as example. Please provide a draft for a change record or a link to an unpublished change record below. [Existing change records](https://www.drupal.org/list-changes/social) can be consulted as example.* -->
N/A
## Translations
<!--
*[Optional]Translatable strings are always extracted from the latest development branch. To ensure translations remain available for platforms running older versions of Open Social the original string should be added to `translations.php` when it's changed or removed.*
- [ ] Changed or removed source strings are added to the `translations.php` file.
-->
N/A