### PR TITLE
Issue #3451029: Display "followers counter" only for the followers_count view mode

### DIFF
--- a/modules/social_features/social_follow_taxonomy/modules/social_follow_tag/social_follow_tag.module
+++ b/modules/social_features/social_follow_taxonomy/modules/social_follow_tag/social_follow_tag.module
@@ -401,12 +401,12 @@ function social_follow_tag_taxonomy_term_view_alter(array &$build, TermInterface
   $flag_count = \Drupal::service('flag.count');
   $follower_count = !empty($result = $flag_count->getEntityFlagCounts($term)) ?
     (float) $result['follow_term'] : 0;
-  $build['follower_count'] = [
-    '#type' => 'markup',
-    '#markup' => number_format($follower_count),
-  ];
 
   if ($build['#view_mode'] === 'followers_count') {
+    $build['follower_count'] = [
+      '#type' => 'markup',
+      '#markup' => number_format($follower_count),
+    ];
     $build['#cache']['tags'][] = "flagging_list:follow_term";
   }
 }


### PR DESCRIPTION
## Problem
We could see "followers count" in different views related to taxonomy, which is not correct.

## Solution
Display "followers count" only for the followers count view mode.

## Issue tracker

- https://getopensocial.atlassian.net/browse/PROD-27339
- https://www.drupal.org/project/social/issues/3451029


## Theme issue tracker
N/A

## How to test

- [ ] Enable social_follow_tag module
- [ ] Check that the followers counter is displayed as before.

## Screenshots
N/A

## Release notes
Before this change, we could see "followers count" in different views related to taxonomy
Now, the "followers count" number is displayed only for the followers count view mode.

## Change Record
N/A

## Translations
N/A
