### PR TITLE
Revert secret:// to private:// from field_file field

### DIFF
--- a/modules/social_features/social_core/social_core.install
+++ b/modules/social_features/social_core/social_core.install
@@ -506,3 +506,28 @@ function social_core_update_130006(): void {
   // updated to ignore those files, this causes them to error.
   \Drupal::database()->query("UPDATE {file_managed} SET uri = REPLACE(uri, 'secret://', 'private://') WHERE uri LIKE 'secret://inline-images/%'");
 }
+
+/**
+ * Revert field_files to use private:// instead of secret://.
+ */
+function social_core_update_130007(): void {
+  // Change storage uri-scheme to private for file-field.
+  $file_fields = \Drupal::entityTypeManager()
+    ->getStorage('field_storage_config')
+    ->loadByProperties([
+      'type' => 'file',
+    ]);
+
+  foreach ($file_fields as $field_storage) {
+    if (
+      $field_storage->get('field_name') === 'field_files'
+      && $field_storage->getSetting('uri_scheme') === 'secret'
+    ) {
+      $field_storage->setSetting('uri_scheme', 'private');
+      $field_storage->save();
+    }
+  }
+
+  // Change file_managed table only files from field_file field.
+  \Drupal::database()->query("UPDATE {file_managed} SET {file_managed}.uri = REPLACE({file_managed}.uri, 'secret://', 'private://') WHERE fid IN (SELECT {node__field_files}.field_files_target_id FROM {node__field_files})");
+}

--- a/modules/social_features/social_node/config/install/field.storage.node.field_files.yml
+++ b/modules/social_features/social_node/config/install/field.storage.node.field_files.yml
@@ -11,7 +11,7 @@ type: file
 settings:
   display_field: false
   display_default: false
-  uri_scheme: secret
+  uri_scheme: private
   target_type: file
 module: file
 locked: false


### PR DESCRIPTION
## Problem
We have an incident related with secret:// filesystem and it became some unacessible files for all users.

## Solution
Temporary solution is revert secret:// filesystem for field_file field.

## Issue tracker
[PROD-29716](https://getopensocial.atlassian.net/browse/PROD-29716)

## Theme issue tracker
N/A

## How to test
- [ ] Create any content with Attachments;
- [ ] Check this attachments with all users;

## Screenshots
N/A

## Release notes
Fixed access trouble with attachments from contents.

## Change Record
N/A

## Translations
N/A


[PROD-29716]: https://getopensocial.atlassian.net/browse/PROD-29716?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ