### PR TITLE
Issue #3452477: Change the title of the Likes pop-up for posts

### DIFF
--- a/modules/social_features/social_like/social_like.module
+++ b/modules/social_features/social_like/social_like.module
@@ -88,5 +88,12 @@ function social_like_preprocess_like_and_dislike_icons(&$variables) {
       }
     }
   }
-  $variables['modal_title'] = t('Members who liked this @content', ['@content' => $bundle]);
+  $variables['modal_title'] = t('Members who like this @content', ['@content' => $bundle]);
+
+  // Title of a pop-up for post is not always correct in case
+  // we have only text posts without images.
+  // See https://www.drupal.org/project/social/issues/3452477
+  if ($variables['entity_type'] == 'post') {
+    $variables['modal_title'] = t('Liked by');
+  }
 }


### PR DESCRIPTION
## Problem
The title of this pop-up reads "Members who liked this Photo", it's not always correct in case we have only text posts without images.

## Solution
Change the title of the Likes pop-up on posts to "Liked by", so it's more generic for all cases.

## Issue tracker
- https://getopensocial.atlassian.net/browse/PROD-26545
- https://www.drupal.org/project/social/issues/3452477

## Theme issue tracker
N/A

## How to test
- [ ] Open some content
- [ ] Click on the text 'like(s)' at the bottom of the page
- [ ] Check the title of the popup

## Screenshots
N/A

## Release notes
Change the title of the Likes pop-up on posts to "Liked by", so it's more generic for all cases.

## Change Record
N/A

## Translations
N/A
