### PR TITLE
Issue #3452643: Change uri_scheme of field_media_file to secret

### DIFF
--- a/modules/custom/social_media_system/config/install/field.storage.media.field_media_file.yml
+++ b/modules/custom/social_media_system/config/install/field.storage.media.field_media_file.yml
@@ -12,7 +12,7 @@ settings:
   target_type: file
   display_field: false
   display_default: false
-  uri_scheme: private
+  uri_scheme: secret
 module: file
 locked: false
 cardinality: 1

--- a/modules/custom/social_media_system/config/update/social_media_system_update_12103.yml
+++ b/modules/custom/social_media_system/config/update/social_media_system_update_12103.yml
@@ -1,0 +1,8 @@
+field.storage.media.field_media_file:
+  expected_config:
+    settings:
+      uri_scheme: private
+  update_actions:
+    change:
+      settings:
+        uri_scheme: secret

--- a/modules/custom/social_media_system/social_media_system.install
+++ b/modules/custom/social_media_system/social_media_system.install
@@ -34,3 +34,17 @@ function social_media_system_update_12102(): string {
   // Output logged messages to related channel of update execution.
   return $updater->logger()->output();
 }
+
+/**
+ * Change uri_scheme of field_media_file from private to secret.
+ */
+function social_media_system_update_12103(): string {
+  /** @var \Drupal\update_helper\Updater $updater */
+  $updater = \Drupal::service('update_helper.updater');
+
+  // Execute configuration update definitions with logging of success.
+  $updater->executeUpdate('social_media_system', 'social_media_system_update_12103');
+
+  // Output logged messages to related channel of update execution.
+  return $updater->logger()->output();
+}


### PR DESCRIPTION
## Problem
In version 12.0.0 `social_media_system` module was added as a helper module for all the default media configurations.
This module provides `field_media_file` which by default uses public uri_scheme.
This module provides field_media_file which by default uses public uri_scheme.
Later with https://github.com/goalgorilla/open_social/pull/3727 visibility was changed from public to private uri_scheme.

Summary of decision:
Out of the box, access to files is granted based on configuration - users have access to all media files.
Media items don't inherit access control from parents (https://www.drupal.org/project/drupal/issues/2984093) so 
this is why we want to use secret file system instead, so the URL isn't guessable and it's only provided if the media entity is rendered.

Complete discussions why this was needed (private slack)
- https://opensocial.slack.com/archives/C1AUZQTKR/p1717520071505409
- https://opensocial.slack.com/archives/C05NPE17D42/p1717426831522599

## Solution
Change uri_scheme of field_media_file from private to secret.

## Issue tracker
[3452643](https://www.drupal.org/project/social/issues/3452643)

## Theme issue tracker
N/A

## How to test
- [ ] Install social_media_system
- [ ] Go to field storage settings of the field_media_file
- [ ] You should see upload destination is set to secret   

## Screenshots
N/A

## Release notes
Change uri_scheme of field_media_file from private to public by default for better flexibility.


## Change Record
N/A

## Translations
N/A
