### PR TITLE
Issue #3452660: Grequest compatibility with group v2

### DIFF
--- a/modules/custom/grequest/grequest.services.yml
+++ b/modules/custom/grequest/grequest.services.yml
@@ -1,26 +1,26 @@
 services:
   # Specific group relation handlers.
-  group.relation_handler.operation_provider.grequest:
+  group.relation_handler.operation_provider.group_membership_request:
     class: 'Drupal\grequest\Plugin\Group\RelationHandler\GroupMembershipRequestOperationProvider'
     arguments: [ '@group.relation_handler.operation_provider', '@current_user', '@string_translation' ]
     shared: false
 
-  group.relation_handler.permission_provider.grequest:
+  group.relation_handler.permission_provider.group_membership_request:
     class: 'Drupal\grequest\Plugin\Group\RelationHandler\GroupMembershipRequestPermissionProvider'
     arguments: [ '@group.relation_handler.permission_provider' ]
     shared: false
 
-  group.relation_handler.post_install.grequest:
+  group.relation_handler.post_install.group_membership_request:
     class: 'Drupal\grequest\Plugin\Group\RelationHandler\GroupMembershipRequestPostInstall'
     arguments: [ '@group.relation_handler.post_install', '@entity_type.manager', '@string_translation' ]
     shared: false
 
-  group.relation_handler.access_control.grequest:
+  group.relation_handler.access_control.group_membership_request:
     class: 'Drupal\grequest\Plugin\Group\RelationHandler\GroupMembershipRequestAccessControl'
     arguments: [ '@group.relation_handler.access_control' ]
     shared: false
 
-  group.relation_handler.entity_reference.grequest:
+  group.relation_handler.entity_reference.group_membership_request:
     class: 'Drupal\grequest\Plugin\Group\RelationHandler\GroupMembershipRequestEntityReference'
     arguments: [ '@group.relation_handler.entity_reference' ]
     shared: false

--- a/modules/custom/grequest/src/Plugin/Group/RelationHandler/GroupMembershipRequestPermissionProvider.php
+++ b/modules/custom/grequest/src/Plugin/Group/RelationHandler/GroupMembershipRequestPermissionProvider.php
@@ -55,14 +55,6 @@ class GroupMembershipRequestPermissionProvider implements PermissionProviderInte
       'allowed for' => ['outsider'],
     ];
 
-    // These are handled by 'administer members'.
-    unset($permissions['update own group_membership_request content']);
-    unset($permissions['view group_membership_request content']);
-    unset($permissions['create group_membership_request content']);
-    unset($permissions['update any group_membership_request content']);
-    unset($permissions['delete any group_membership_request content']);
-    unset($permissions['delete own group_membership_request content']);
-
     return $permissions;
   }
 


### PR DESCRIPTION
## Problem
When looking at the code of the grequest module in the latest alpha we see there are still issues for it to work with groups v2.
- Services are not correctly defined.
- Still reference to old group content relation

## Solution
- Add the correct services definition for the relation.
- Remove the old unset of permissions as they don't exist anymore in that part.

Note: Even though we don't use all the services such as group operations (we have our own button there) it's good to have it in there for when we want to convert to the contrib grequest.

## Issue tracker
https://www.drupal.org/node/3452660

## Theme issue tracker
<!-- *[Required if applicable] Paste a link to the drupal.org theme issue queue item, either from [socialbase](https://www.drupal.org/project/socialbase) or [socialblue](https://www.drupal.org/project/socialblue). If any other issue trackers were used, include links to those too.* -->

## How to test
- [ ] Functional: Go to admin/group/types/manage/flexible_group/permissions and search for the word "Administer membership request" and see it cannot find anything.
- [ ] Set breakpoint in the RelationHandler PermissionProvider and see it won't reach there when going to the url above.
- [ ] Check out to this branch and try again.
- [ ] Also set a breakpoint in the buildPermissions method and see that they unset permissions are not showing because they don't exist there.

## Screenshots
<!-- *[Required if new feature, and if applicable] If this Pull Request makes visual changes then please include some screenshots that show what has changed here. A before and after screenshot helps the reviewer determine what changes were made.* -->

## Release notes
Internal: Fix for group v2 compatibility for the submodule grequest.

## Change Record
<!-- *[Required if applicable] If this Pull Request changes the way that developers should do things or introduces a new API for developers then a change record to document this is needed. Please provide a draft for a change record or a link to an unpublished change record below. Existing change records can be consulted as example. Please provide a draft for a change record or a link to an unpublished change record below. [Existing change records](https://www.drupal.org/list-changes/social) can be consulted as example.* -->

## Translations
<!--
*[Optional]Translatable strings are always extracted from the latest development branch. To ensure translations remain available for platforms running older versions of Open Social the original string should be added to `translations.php` when it's changed or removed.*
- [ ] Changed or removed source strings are added to the `translations.php` file.
-->
