### PR TITLE
Issue #3452925: Fix issue with preview popup element on the group pages

### DIFF
--- a/modules/social_features/social_core/assets/css/preview-el.css
+++ b/modules/social_features/social_core/assets/css/preview-el.css
@@ -38,7 +38,11 @@
 .hero__banner .metainfo__content span.preview-popup-link,
 .hero__banner .metainfo__content a.preview-popup-link,
 .message span.preview-popup-link,
-.message a.preview-popup-link {
+.message a.preview-popup-link,
+.view--group-managers .list-item__text span.preview-popup-link,
+.view--group-managers .list-item__text a.preview-popup-link,
+.view-group-pending-members span.preview-popup-link,
+.view-group-pending-members a.preview-popup-link {
   display: inline;
   width: auto;
   height: auto;
@@ -54,8 +58,30 @@
 .hero__banner .metainfo__content span.preview-popup-link:before,
 .hero__banner .metainfo__content a.preview-popup-link:before,
 .message span.preview-popup-link:before,
-.message a.preview-popup-link:before {
+.message a.preview-popup-link:before,
+.view--group-managers .list-item__text span.preview-popup-link:before,
+.view--group-managers .list-item__text a.preview-popup-link:before,
+.view-group-pending-members span.preview-popup-link:before,
+.view-group-pending-members a.preview-popup-link:before {
   display: none;
+}
+.teaser--small span.preview-popup-link:hover,
+.teaser--small a.preview-popup-link:hover,
+.card--stream .media-body span.preview-popup-link:hover,
+.card--stream .media-body a.preview-popup-link:hover,
+.comment .comment__content span.preview-popup-link:hover,
+.comment .comment__content a.preview-popup-link:hover,
+.teaser span.preview-popup-link:hover,
+.teaser a.preview-popup-link:hover,
+.hero__banner .metainfo__content span.preview-popup-link:hover,
+.hero__banner .metainfo__content a.preview-popup-link:hover,
+.message span.preview-popup-link:hover,
+.message a.preview-popup-link:hover,
+.view--group-managers .list-item__text span.preview-popup-link:hover,
+.view--group-managers .list-item__text a.preview-popup-link:hover,
+.view-group-pending-members span.preview-popup-link:hover,
+.view-group-pending-members a.preview-popup-link:hover {
+  text-decoration: underline;
 }
 
 .img-grid a.preview-popup-link {

--- a/modules/social_features/social_core/assets/css/preview-el.scss
+++ b/modules/social_features/social_core/assets/css/preview-el.scss
@@ -38,7 +38,9 @@
 .comment .comment__content,
 .teaser,
 .hero__banner .metainfo__content,
-.message {
+.message,
+.view--group-managers .list-item__text,
+.view-group-pending-members {
   span.preview-popup-link,
   a.preview-popup-link {
     display: inline;
@@ -47,6 +49,10 @@
 
     &:before {
       display: none;
+    }
+
+    &:hover {
+      text-decoration: underline;
     }
   }
 }


### PR DESCRIPTION
## Problem
The user preview element on the group pages does not have a correct hover behavior.

## Solution
Should reset styles that were added for avatar images and add an underline effect to the simple text.

## Issue tracker

- https://www.drupal.org/project/social/issues/3452925
- https://getopensocial.atlassian.net/browse/PROD-29773

## Theme issue tracker
<!-- *[Required if applicable] Paste a link to the drupal.org theme issue queue item, either from [socialbase](https://www.drupal.org/project/socialbase) or [socialblue](https://www.drupal.org/project/socialblue). If any other issue trackers were used, include links to those too.* -->

## How to test
Steps to reproduce 1
- [ ] Create a course/group
- [ ] Go to course’s or group’s about tab
- [ ] Check Course/Group Leaders block and see that the user link is, wrongly, displaying a blue circle highlight

Steps to reproduce 2
- [ ] Create a group where users have to request to join
- [ ] Log out ad log in with another user 
- [ ] Request to join the group created on first step
- [ ] Log ou and login with the first user
- [ ] Check first group members ship requests page (/group/<group ID>/membership-requests)
- [ ] Hover the requesting user username link and see that it is, wrongly, displaying a blue circle highlight

## Screenshots
Before:
![Screenshot 2024-06-06 at 09 25 05](https://github.com/goalgorilla/open_social/assets/16086340/d0859e49-1672-4fc9-a829-f4d22a5b359e)

After:
![Screenshot 2024-06-06 at 13 42 08](https://github.com/goalgorilla/open_social/assets/16086340/2089e7b8-3f8a-4adc-9445-dd6c9bc03034)

## Release notes
Improve hover behavior for the user preview element on the group pages.
