### PR TITLE
Issue #3453509: Make modules responsible for their own message request fields

### DIFF
--- a/modules/social_features/social_group/modules/social_group_request/social_group_request.module
+++ b/modules/social_features/social_group/modules/social_group_request/social_group_request.module
@@ -14,31 +14,10 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Link;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\Url;
-use Drupal\field\Entity\FieldConfig;
-use Drupal\field\Entity\FieldStorageConfig;
 use Drupal\grequest\Plugin\Group\Relation\GroupMembershipRequest;
-use Drupal\group\Entity\GroupRelationshipTypeInterface;
 use Drupal\group\Entity\GroupRelationshipInterface;
 use Drupal\views\ViewExecutable;
 use Drupal\message\Entity\Message;
-
-/**
- * Implements hook_ENTITY_TYPE_insert() for group_content_type.
- */
-function social_group_request_group_content_type_insert(GroupRelationshipTypeInterface $group_content_type) {
-  if ($group_content_type->getPluginId() === 'group_membership_request') {
-    // Add Message field.
-    FieldConfig::create([
-      'field_storage' => FieldStorageConfig::loadByName('group_content', 'field_grequest_message'),
-      'bundle' => $group_content_type->id(),
-      'label' => t('Message'),
-      'description' => '',
-      'required' => FALSE,
-      'settings' => [],
-      'field_type' => 'string_long',
-    ])->save();
-  }
-}
 
 /**
  * Implements hook_entity_base_field_info().

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -8049,11 +8049,6 @@ parameters:
 			path: modules/social_features/social_group/modules/social_group_request/social_group_request.module
 
 		-
-			message: "#^Function social_group_request_group_content_type_insert\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: modules/social_features/social_group/modules/social_group_request/social_group_request.module
-
-		-
 			message: "#^Function social_group_request_module_implements_alter\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: modules/social_features/social_group/modules/social_group_request/social_group_request.module


### PR DESCRIPTION
## Related PRs

https://github.com/goalgorilla/open_social/pull/3937
https://github.com/goalgorilla/open_social/pull/3928

## Problem
We currently have a hook in `social_group_request` which adds a field to all group types that use the "Request Access" plugin. This creates problems for group types where a different request flow is needed and where we don't want the "Message" field.

We tried to be clever in the past because we initially had 4 group bundles that were different group types and we wanted to share behavior between them.


Since then we've understood that that's not a maintainable solution and we want to have these kind of functionalities be opt-in (our only "group" type is now also `flexible_group` rather than open/public/closed/secret)

The automatic generation also creates other problems because it creates config in an install hook that other modules might depend on. This works if we install modules one-by-one using Drush but it doesn't work well if we install the module during tests because these hooks may not fire before the config is attempted to be imported from `config/install` folders.

## Solution
The solution is to remove the magic hook here and instead add the config files to config/optional in the different modules that support group requests (e.g. `social_group_flexible_group`, `social_course`, etc.). That way if `social_group_request` is enabled Drupal will automatically install the config at the right moment.

So, we put field_request_message into the optional folder where it is needed. So, we have a list of these modules, which have their own group type:
 1. `social_discussion_group` - has own group type, but doesn't have `group_membership_request` plugin, which means we don't need to put `field_request_message `field
2. `social_course_advanced_request` - has `social_group_request` module in dependencies and field config in `/install`
3. `social_course_basic_request` - has `social_group_request` module in dependencies and field config in `/install`
4. `social_discussion_secret_group` - has own group type, but doesn't have `group_membership_request` plugin, which means we don't need to put `field_request_message` field
5. `social_flexible_group` - put field in `/optional`, since this module doesn't have `social_group_request` in dependencies


## Issue tracker
https://www.drupal.org/project/social/issues/3453509

## Theme issue tracker
N/A

## How to test
- [ ] Install `social_group module`
- [ ] Install `social_group_flexible_group`
- [ ] Install the `social_group_request` module
- [ ] Everything should work as previously 
It would be better to test also for social courses

## Screenshots
N/A

## Release notes
<!-- *[Required if new feature, and if applicable] A short summary of the changes that were made that can be included in release notes.* -->

## Change Record
N/A

## Translations
N/A
