### PR TITLE
Issue #3453946: Add alternative token with capitalized entity bundle label

### DIFF
--- a/modules/social_features/social_comment/social_comment.tokens.inc
+++ b/modules/social_features/social_comment/social_comment.tokens.inc
@@ -190,8 +190,11 @@ function social_comment_tokens($type, $tokens, array $data, array $options, Bubb
             break;
 
           case 'commented_content_type':
+          case 'commented_content_type:capitalized':
           case 'commented_entity_link':
+          case 'commented_entity_link:capitalized':
           case 'commented_entity_link_html':
+          case 'commented_entity_link_html:capitalized':
 
             if (!$message->get('field_message_related_object')->isEmpty()) {
               $target_type = $message->getFieldValue('field_message_related_object', 'target_type');
@@ -218,15 +221,19 @@ function social_comment_tokens($type, $tokens, array $data, array $options, Bubb
                     }
                   }
 
-                  if ($name === 'commented_content_type') {
+                  if (isset($commented_content_type) && str_ends_with($name, ':capitalized')) {
+                    $commented_content_type = ucfirst($commented_content_type);
+                  }
+
+                  if (str_starts_with($name, 'commented_content_type')) {
                     if (!empty($commented_content_type)) {
                       $replacements[$original] = $commented_content_type;
                     }
                   }
-                  if ($name === 'commented_entity_link') {
+                  if (str_starts_with($name, 'commented_entity_link')) {
                     $replacements[$original] = $entity->toUrl('canonical', ['absolute' => TRUE])->toString();
                   }
-                  if ($name === 'commented_entity_link_html') {
+                  if (str_starts_with($name, 'commented_entity_link_html')) {
                     $url_options = ['absolute' => TRUE];
                     $link = $entity->toUrl('canonical', $url_options)->toString();
 
@@ -238,6 +245,7 @@ function social_comment_tokens($type, $tokens, array $data, array $options, Bubb
                     else {
                       $entity_link_html = '<a href="' . $link . '">' . $commented_content_type . '</a>';
                     }
+
                     $replacements[$original] = Markup::create($entity_link_html);
                   }
                 }
@@ -245,7 +253,6 @@ function social_comment_tokens($type, $tokens, array $data, array $options, Bubb
             }
 
             break;
-
         }
       }
     }

--- a/modules/social_features/social_follow_taxonomy/social_follow_taxonomy.tokens.inc
+++ b/modules/social_features/social_follow_taxonomy/social_follow_taxonomy.tokens.inc
@@ -67,7 +67,9 @@ function social_follow_taxonomy_tokens($type, $tokens, array $data, array $optio
     foreach ($tokens as $name => $original) {
       switch ($name) {
         case 'content_type':
+        case 'content_type:capitalized':
         case 'indefinite_article':
+        case 'indefinite_article:capitalized':
         case 'taxonomy_i_follow':
           /** @var \Drupal\message\Entity\Message $message */
           $message = $data['message'];
@@ -121,11 +123,15 @@ function social_follow_taxonomy_tokens($type, $tokens, array $data, array $optio
             }
           }
 
-          if ($name === 'content_type') {
+          if ($display_name && str_ends_with($name, ':capitalized')) {
+            $display_name = ucfirst($display_name);
+          }
+
+          if (str_starts_with($name, 'content_type')) {
             $replacements[$original] = $display_name;
           }
 
-          if ($name === 'indefinite_article') {
+          if (str_starts_with($name, 'indefinite_article')) {
             if (!empty($display_name)) {
               // Prepares a replacement token: content name.
               // When a name of content name starts from a vowel letter then
@@ -136,6 +142,7 @@ function social_follow_taxonomy_tokens($type, $tokens, array $data, array $optio
               else {
                 $indefinite_article = t('a');
               }
+
               $replacements[$original] = $indefinite_article;
             }
             else {
@@ -143,7 +150,7 @@ function social_follow_taxonomy_tokens($type, $tokens, array $data, array $optio
             }
           }
 
-          if ($name === 'taxonomy_i_follow' && !empty($term_names)) {
+          if (str_starts_with($name, 'taxonomy_i_follow') && !empty($term_names)) {
             // Prepares a replacement token: a string with term names.
             // Wrap the names in quotation marks and separate it with commas.
             $replacement_string = "'" . implode("', '", $term_names) . "'";

--- a/modules/social_features/social_group/social_group.tokens.inc
+++ b/modules/social_features/social_group/social_group.tokens.inc
@@ -63,9 +63,11 @@ function social_group_tokens($type, $tokens, array $data, array $options, Bubble
       foreach ($tokens as $name => $original) {
         switch ($name) {
 
-          case 'content_type':
           case 'content_url':
+          case 'content_type':
+          case 'content_type:capitalized':
           case 'created_entity_link_html':
+          case 'created_entity_link_html:capitalized':
 
             // Get the related entity.
             if (!$message->get('field_message_related_object')->isEmpty()) {
@@ -104,6 +106,10 @@ function social_group_tokens($type, $tokens, array $data, array $options, Bubble
                   );
                 }
 
+                if (isset($display_name) && str_ends_with($name, ':capitalized')) {
+                  $display_name = ucfirst($display_name);
+                }
+
                 // When a name of content name starts from a vowel letter then
                 // will be added "an" before this name. For example "an
                 // event".
@@ -121,12 +127,12 @@ function social_group_tokens($type, $tokens, array $data, array $options, Bubble
                     $replacements[$original] = $content_url->toString();
                   }
                 }
-                elseif ($name === 'content_type') {
+                elseif (str_starts_with($name, 'content_type')) {
                   if (isset($display_name)) {
                     $replacements[$original] = $display_name;
                   }
                 }
-                elseif ($name === 'created_entity_link_html' && isset($display_name)) {
+                elseif (str_starts_with($name, 'created_entity_link_html') && isset($display_name)) {
                   // We should only use the label of entities who have a label.
                   if ($link_label = $entity->label()) {
                     $entity_link_html = $display_name . ' <a href="' . $content_url->toString() . '">' . $link_label . '</a>';

--- a/modules/social_features/social_like/social_like.tokens.inc
+++ b/modules/social_features/social_like/social_like.tokens.inc
@@ -62,10 +62,11 @@ function social_like_tokens($type, $tokens, array $data, array $options, Bubblea
     ) {
       foreach ($tokens as $name => $original) {
         switch ($name) {
-
           case 'liked_entity':
           case 'liked_content_type':
+          case 'liked_content_type:capitalized':
           case 'liked_entity_link_html':
+          case 'liked_entity_link_html:capitalized':
             /** @var \Drupal\votingapi\Entity\Vote $vote */
             $storage = \Drupal::entityTypeManager()->getStorage($vote->getVotedEntityType());
             $entity = $storage->load($vote->getVotedEntityId());
@@ -87,11 +88,14 @@ function social_like_tokens($type, $tokens, array $data, array $options, Bubblea
             if ($content_type === 'post' || $content_type === 'photo' || $content_type === 'comment') {
               $content_type_label = mb_strtolower($entity->getEntityType()->getLabel());
             }
-            if ($name === 'liked_content_type') {
+            if (str_ends_with($name, ':capitalized')) {
+              $content_type_label = ucfirst($content_type_label);
+            }
+            if (str_starts_with($name, 'liked_content_type')) {
               $replacements[$original] = $content_type_label;
             }
 
-            if ($name === 'liked_entity_link_html') {
+            if (str_starts_with($name, 'liked_entity_link_html')) {
               // We should only use the label of entities who have a label.
               if ($content_type !== 'comment' && $link_label = $entity->label()) {
                 $liked_entity_link_html = $content_type_label . ' <a href="' . $link . '">' . $link_label . '</a>';
@@ -116,10 +120,18 @@ function social_like_tokens($type, $tokens, array $data, array $options, Bubblea
                     else {
                       $commented_content_type = $commented_entity->bundle();
                     }
+
+                    if ($commented_content_type && str_ends_with($name, ':capitalized')) {
+                      $commented_content_type = ucfirst($commented_content_type);
+                    }
                     $liked_entity_link_html .= ' ' . t('on the') . ' ' . $commented_content_type . ' <a href="' . $ref_link . '">' . $ref_link_label . '</a>';
                   }
                   else {
                     $commented_content_type = mb_strtolower($commented_entity->getEntityType()->getLabel());
+
+                    if (str_ends_with($name, ':capitalized')) {
+                      $commented_content_type = ucfirst($commented_content_type);
+                    }
                     $liked_entity_link_html .= ' ' . t('on a') . ' <a href="' . $ref_link . '">' . $commented_content_type . '</a>';
                   }
                 }
@@ -133,6 +145,7 @@ function social_like_tokens($type, $tokens, array $data, array $options, Bubblea
       }
     }
   }
+
   return $replacements;
 }
 

--- a/modules/social_features/social_mentions/social_mentions.tokens.inc
+++ b/modules/social_features/social_mentions/social_mentions.tokens.inc
@@ -109,6 +109,7 @@ function social_mentions_tokens($type, $tokens, array $data, array $options, Bub
             break;
 
           case 'commented_entity_link_html':
+          case 'commented_entity_link_html:capitalized':
 
             if (!$message->get('field_message_related_object')->isEmpty()) {
               $target_type = $message->getFieldValue('field_message_related_object', 'target_type');
@@ -144,7 +145,10 @@ function social_mentions_tokens($type, $tokens, array $data, array $options, Bub
                 case 'comment':
                   $content_type_label = mb_strtolower($entity->getEntityType()->getLabel());
                   break;
+              }
 
+              if (isset($content_type_label) && str_ends_with($name, ':capitalized')) {
+                $content_type_label = ucfirst($content_type_label);
               }
 
               $url_options = ['absolute' => TRUE];


### PR DESCRIPTION
## Problem

Currently in several notifications we use placeholders to show the entity bundle (Topic, Event, Comment etc). We force this placeholders to always be lowercase. This works well in english and most languages, but not in German for example where those terms should be displayed uppercase.

## Solution
Add an alternative version of the same tokens with capitalized entity bundle label, so it can be used in German. The original tokens are kept the same.

Added variations for the tokens:

- [social_mentions:commented_entity_link_html:capitalized]
- [social_group:content_type:capitalized]
- [social_group:created_entity_link_html:capitalized]
- [social_comment:commented_content_type:capitalized]
- [social_comment:commented_entity_link:capitalized]
- [social_comment:commented_entity_link_html:capitalized]
- [social_taxonomy_follow:content_type:capitalized]
- [social_taxonomy_follow:indefinite_article:capitalized]

## Issue tracker

- https://www.drupal.org/project/social/issues/3453946
- https://getopensocial.atlassian.net/browse/PROD-29353


## How to test

- [ ] Find a message template that uses tokens we changed
- [ ] Edit related message templates and add new variations there
- [ ] For example `admin/structure/message/manage/create_content_in_joined_group`
- [ ] Create new topic/event in a Group
- [ ] Run cron
- [ ] Go to `admin/content/message` and check output there

## Screenshots
![image](https://github.com/goalgorilla/open_social/assets/2241917/0159a65e-92c3-4dd7-9129-9f9d15ad8c71)

![image](https://github.com/goalgorilla/open_social/assets/2241917/b58cd17e-df56-4246-b648-542bb5258469)

![image](https://github.com/goalgorilla/open_social/assets/2241917/29bc276e-b22c-472d-87fa-47ed80b40fc1)


## Release notes
Add variations to transform the output of some tokens to make a string's first character uppercase.
