### PR TITLE
Issue #3454117: use a post update hook to fix base field override references to GroupContent which is updated in v2 of Groups

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -77,7 +77,8 @@
             "drupal/group": {
                 "Missing config schema for condition.plugin.group_type": "https://www.drupal.org/files/issues/2018-12-14/group-group_type_condition_plugin_config_schema-3020554-2.patch",
                 "Ability to use group tokens in node context": "https://www.drupal.org/files/issues/2023-02-17/group-2774827-93.patch",
-                "Issue #15543144 Ability to use gnode access checks": "https://www.drupal.org/files/issues/2024-04-09/3439568-gnode_grant_access-2.patch"
+                "Issue #15543144 Ability to use gnode access checks": "https://www.drupal.org/files/issues/2024-04-09/3439568-gnode_grant_access-2.patch",
+                "Issue #3454117 base field override not updated": "https://www.drupal.org/files/issues/2024-06-12/106.diff"
             },
             "drupal/paragraphs": {
                 "Integrity constraint violation: 1048 Column 'langcode' cannot be null": "https://www.drupal.org/files/issues/2019-07-10/paragraphs-set_langcode_widgets-2901390-29.patch"


### PR DESCRIPTION
## Problem
We've noticed there are still some references in the database with base field overrides these were coming from group_update_8022 and should be tackled in the group module accordingly.

## Solution
Patch group and apply that patch here - issue at https://www.drupal.org/project/group/issues/3322761

## Issue tracker
https://www.drupal.org/project/social/issues/3454117

## How to test
It's not easily reproducable, we have some existing sites.

## Release notes
Fixed an issue with CRUD of Group related entities (memberships / nodes)