### PR TITLE
Issue #3454115: Deny access to unpublished events for enrolled users

### DIFF
--- a/modules/custom/entity_access_by_field/src/EntityAccessHelper.php
+++ b/modules/custom/entity_access_by_field/src/EntityAccessHelper.php
@@ -216,7 +216,7 @@ class EntityAccessHelper {
           ->getStorage('event_enrollment')
           ->load(reset($ids));
 
-        if ($enrollment !== NULL) {
+        if ($enrollment !== NULL && (isset($entity->status) && $entity->status->value)) {
           $status = (int) $enrollment->field_request_or_invite_status->value;
 
           if (


### PR DESCRIPTION
## Problem
Unpublished events are visible to enrolled VU via URL.

## Solution
Add check for enrolled users if the event is published or not.

## Issue tracker

- https://www.drupal.org/project/social/issues/3454115
- https://getopensocial.atlassian.net/browse/PROD-27870


## Theme issue tracker
N/A

## How to test

- [ ] Create an event
- [ ]  Enroll user to this event
- [ ]  Unpublish this event
- [ ]  Go the event via the direct URL

## Screenshots
N/A

## Release notes
User should not be able to access an unpublished event even if he is enrolled in it.

## Change Record
N/A

## Translations
N/A
