### PR TITLE
Issue #3454972: Enrolment & Invite pages in Manage Members in Events and Groups does show selected users

### DIFF
--- a/modules/social_features/social_group/modules/social_group_invite/src/Plugin/views/field/SocialGroupInviteViewsBulkOperationsBulkForm.php
+++ b/modules/social_features/social_group/modules/social_group_invite/src/Plugin/views/field/SocialGroupInviteViewsBulkOperationsBulkForm.php
@@ -82,15 +82,15 @@ class SocialGroupInviteViewsBulkOperationsBulkForm extends ViewsBulkOperationsBu
       }
       // Add the Group ID to the data.
       $tempstoreData['group_id'] = $group->id();
+      $this->setTempstoreData($tempstoreData, $this->view->id(), $this->view->current_display);
     }
 
-    /** @var array $tempstoreData */
-    $this->setTempstoreData($tempstoreData, $this->view->id(), $this->view->current_display);
-
     // Reorder the form array.
-    $multipage = $form['header'][$this->options['id']]['multipage'];
-    unset($form['header'][$this->options['id']]['multipage']);
-    $form['header'][$this->options['id']]['multipage'] = $multipage;
+    if (!empty($form['header'])) {
+      $multipage = $form['header'][$this->options['id']]['multipage'];
+      unset($form['header'][$this->options['id']]['multipage']);
+      $form['header'][$this->options['id']]['multipage'] = $multipage;
+    }
 
     // Render proper classes for the header in VBO form.
     $wrapper = &$form['header'][$this->options['id']];
@@ -102,33 +102,35 @@ class SocialGroupInviteViewsBulkOperationsBulkForm extends ViewsBulkOperationsBu
     // Add some JS for altering titles and switches.
     $form['#attached']['library'][] = 'social_group/views_bulk_operations.frontUi';
 
-    // Render select all results checkbox.
+    // Render select all result checkboxes.
     if (!empty($wrapper['select_all'])) {
-      $total_results = is_array($this->tempStoreData) ? $this->tempStoreData['total_results'] : 0;
+      $total_results = $this->tempStoreData['total_results'] ?? 0;
       $wrapper['select_all']['#title'] = $this->t('Select / unselect all @count invites across all the pages', [
         '@count' => ' ' . $total_results,
       ]);
       // Styling attributes for the select box.
       $form['header'][$this->options['id']]['select_all']['#attributes']['class'][] = 'form-no-label';
       $form['header'][$this->options['id']]['select_all']['#attributes']['class'][] = 'checkbox';
-    }
 
-    /** @var \Drupal\Core\StringTranslation\TranslatableMarkup $title */
-    $title = $wrapper['multipage']['#title'];
-    $arguments = $title->getArguments();
-    $count = empty($arguments['%count']) ? 0 : $arguments['%count'];
+      // Initialize the count.
+      $count = 0;
+      if (isset($this->tempStoreData['list'])) {
+        // Set the count for selected enrollees.
+        $count = empty($this->tempStoreData['exclude_mode']) ? \count($this->tempStoreData['list']) : $this->tempStoreData['total_results'] - \count($this->tempStoreData['list']);
+      }
 
-    $title = $this->formatPlural($count, '<b><em class="placeholder">@count</em> Invite</b> is selected', '<b><em class="placeholder">@count</em> Invites</b> are selected');
-    $wrapper['multipage']['#title'] = [
-      '#type' => 'html_tag',
-      '#tag' => 'div',
-      '#value' => $title,
-      '#attributes' => [
-        'class' => [
-          'vbo-info-list-wrapper',
+      $title = $this->formatPlural($count, '<b><em class="placeholder">@count</em> Invite</b> is selected', '<b><em class="placeholder">@count</em> Invites</b> are selected');
+      $wrapper['multipage']['#title'] = [
+        '#type' => 'html_tag',
+        '#tag' => 'div',
+        '#value' => $title,
+        '#attributes' => [
+          'class' => [
+            'vbo-info-list-wrapper',
+          ],
         ],
-      ],
-    ];
+      ];
+    }
 
     // Add selector so the JS of VBO applies correctly.
     $wrapper['multipage']['#attributes']['class'][] = 'vbo-multipage-selector';
@@ -161,23 +163,24 @@ class SocialGroupInviteViewsBulkOperationsBulkForm extends ViewsBulkOperationsBu
 
     // Actions are not a select list but a dropbutton list.
     $actions = &$wrapper['actions'];
+    if (!empty($actions) && !empty($wrapper['action'])) {
+      $actions['#theme'] = 'links__dropbutton__operations__actions';
+      $actions['#label'] = $this->t('Actions');
+      $actions['#type'] = 'dropbutton';
 
-    $actions['#theme'] = 'links__dropbutton__operations__actions';
-    $actions['#label'] = $this->t('Actions');
-    $actions['#type'] = 'dropbutton';
-
-    $items = [];
-    foreach ($wrapper['action']['#options'] as $key => $value) {
-      if ($key !== '' && array_key_exists($key, $this->bulkOptions)) {
-        $items[] = [
-          '#type' => 'submit',
-          '#value' => $value,
-        ];
+      $items = [];
+      foreach ($wrapper['action']['#options'] as $key => $value) {
+        if ($key !== '' && array_key_exists($key, $this->bulkOptions)) {
+          $items[] = [
+            '#type' => 'submit',
+            '#value' => $value,
+          ];
+        }
       }
-    }
 
-    // Add our links to the dropdown buttondrop type.
-    $actions['#links'] = $items;
+      // Add our links to the dropdown buttondrop type.
+      $actions['#links'] = $items;
+    }
 
     // Remove the Views select list and submit button.
     $form['actions']['#type'] = 'hidden';

--- a/modules/social_features/social_group/src/Plugin/views/field/SocialGroupViewsBulkOperationsBulkForm.php
+++ b/modules/social_features/social_group/src/Plugin/views/field/SocialGroupViewsBulkOperationsBulkForm.php
@@ -115,15 +115,15 @@ class SocialGroupViewsBulkOperationsBulkForm extends ViewsBulkOperationsBulkForm
       }
       // Add the Group ID to the data.
       $tempstoreData['group_id'] = $group->id();
+      $this->setTempstoreData($tempstoreData, $this->view->id(), $this->view->current_display);
     }
 
-    /** @var array $tempstoreData */
-    $this->setTempstoreData($tempstoreData, $this->view->id(), $this->view->current_display);
-
     // Reorder the form array.
-    $multipage = $form['header'][$this->options['id']]['multipage'];
-    unset($form['header'][$this->options['id']]['multipage']);
-    $form['header'][$this->options['id']]['multipage'] = $multipage;
+    if (!empty($form['header'])) {
+      $multipage = $form['header'][$this->options['id']]['multipage'];
+      unset($form['header'][$this->options['id']]['multipage']);
+      $form['header'][$this->options['id']]['multipage'] = $multipage;
+    }
 
     // Render proper classes for the header in VBO form.
     $wrapper = &$form['header'][$this->options['id']];
@@ -135,33 +135,35 @@ class SocialGroupViewsBulkOperationsBulkForm extends ViewsBulkOperationsBulkForm
     // Add some JS for altering titles and switches.
     $form['#attached']['library'][] = 'social_group/views_bulk_operations.frontUi';
 
-    // Render select all results checkbox.
+    // Render select all result checkboxes.
     if (!empty($wrapper['select_all'])) {
-      $total_results = is_array($this->tempStoreData) ? $this->tempStoreData['total_results'] : 0;
+      $total_results = $this->tempStoreData['total_results'] ?? 0;
       $wrapper['select_all']['#title'] = $this->t('Select / unselect all @count members across all the pages', [
         '@count' => ' ' . $total_results,
       ]);
       // Styling attributes for the select box.
       $form['header'][$this->options['id']]['select_all']['#attributes']['class'][] = 'form-no-label';
       $form['header'][$this->options['id']]['select_all']['#attributes']['class'][] = 'checkbox';
-    }
 
-    /** @var \Drupal\Core\StringTranslation\TranslatableMarkup $title */
-    $title = $wrapper['multipage']['#title'];
-    $arguments = $title->getArguments();
-    $count = empty($arguments['%count']) ? 0 : $arguments['%count'];
+      // Initialize the count.
+      $count = 0;
+      if (isset($this->tempStoreData['list'])) {
+        // Set the count for selected enrollees.
+        $count = empty($this->tempStoreData['exclude_mode']) ? \count($this->tempStoreData['list']) : $this->tempStoreData['total_results'] - \count($this->tempStoreData['list']);
+      }
 
-    $title = $this->formatPlural($count, '<b><em class="placeholder">@count</em> Member</b> is selected', '<b><em class="placeholder">@count</em> Members</b> are selected');
-    $wrapper['multipage']['#title'] = [
-      '#type' => 'html_tag',
-      '#tag' => 'div',
-      '#value' => $title,
-      '#attributes' => [
-        'class' => [
-          'vbo-info-list-wrapper',
+      $title = $this->formatPlural($count, '<b><em class="placeholder">@count</em> Member</b> is selected', '<b><em class="placeholder">@count</em> Members</b> are selected');
+      $wrapper['multipage']['#title'] = [
+        '#type' => 'html_tag',
+        '#tag' => 'div',
+        '#value' => $title,
+        '#attributes' => [
+          'class' => [
+            'vbo-info-list-wrapper',
+          ],
         ],
-      ],
-    ];
+      ];
+    }
 
     // Add selector so the JS of VBO applies correctly.
     $wrapper['multipage']['#attributes']['class'][] = 'vbo-multipage-selector';
@@ -194,22 +196,25 @@ class SocialGroupViewsBulkOperationsBulkForm extends ViewsBulkOperationsBulkForm
 
     // Actions are not a select list but a dropbutton list.
     $actions = &$wrapper['actions'];
-    $actions['#theme'] = 'links__dropbutton__operations__actions';
-    $actions['#label'] = $this->t('Actions');
-    $actions['#type'] = 'dropbutton';
+    if (!empty($actions) && !empty($wrapper['action'])) {
+      $actions['#theme'] = 'links__dropbutton__operations__actions';
+      $actions['#label'] = $this->t('Actions');
+      $actions['#type'] = 'dropbutton';
 
-    $items = [];
-    foreach ($wrapper['action']['#options'] as $key => $value) {
-      if ($key !== '' && array_key_exists($key, $this->bulkOptions)) {
-        $items[] = [
-          '#type' => 'submit',
-          '#value' => $value,
-        ];
+      $items = [];
+      foreach ($wrapper['action']['#options'] as $key => $value) {
+        if ($key !== '' && array_key_exists($key, $this->bulkOptions)) {
+          $items[] = [
+            '#type' => 'submit',
+            '#value' => $value,
+          ];
+        }
       }
+
+      // Add our links to the dropdown buttondrop type.
+      $actions['#links'] = $items;
     }
 
-    // Add our links to the dropdown buttondrop type.
-    $actions['#links'] = $items;
     // Remove the Views select list and submit button.
     $form['actions']['#type'] = 'hidden';
     $form['header']['social_views_bulk_operations_bulk_form_group']['action']['#access'] = FALSE;

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -5935,11 +5935,6 @@ parameters:
 			path: modules/social_features/social_event/modules/social_event_managers/src/Plugin/views/field/SocialEventManagersViewsBulkOperationsBulkForm.php
 
 		-
-			message: "#^Variable \\$title in PHPDoc tag @var does not exist\\.$#"
-			count: 1
-			path: modules/social_features/social_event/modules/social_event_managers/src/Plugin/views/field/SocialEventManagersViewsBulkOperationsBulkForm.php
-
-		-
 			message: "#^\\\\Drupal calls should be avoided in classes, use dependency injection instead$#"
 			count: 1
 			path: modules/social_features/social_event/modules/social_event_managers/src/Plugin/views/field/SocialEventManagersViewsBulkOperationsBulkForm.php


### PR DESCRIPTION
## Problem
On an event's or group's "Manage members" tabs, when we select users in an event, it does not show how many users are selected. Also, count remained 0 on selections as well as on page refresh.

## Solution
This was happening because we were calculating the total count is indifferent logic from VBO's own parent class. So, we are abopting the same solution across all the VBOForms used in Open Social.

## Issue tracker
https://getopensocial.atlassian.net/browse/PROD-29405

## Theme issue tracker
N.A

## How to test
- [ ] Setup Open Social with Social Events Manager, Social Group modules enabled
- [ ] As a sitemanager
- [ ] Go to "Manage Members" tab of both a Group and Event with minimum 2 enrollments
- [ ] Select the members using the checkbox
- [ ] You should see a list of selected members in "Items selected" list
- [ ] When you refresh the same page, you should see number of enrolees selected

## Screenshots
**Before**
Both _On selection_ and _On refresh_
<img width="1205" alt="Screenshot 2024-06-17 at 12 22 08 PM" src="https://github.com/goalgorilla/open_social/assets/8435994/79837321-2552-4acc-856b-686ec58bad8c">


**After**
_On selection_
<img width="1159" alt="Screenshot 2024-06-17 at 12 21 31 PM" src="https://github.com/goalgorilla/open_social/assets/8435994/d6a3fb5a-efad-4643-a137-80e5204d648f">

_On refresh_
<img width="1167" alt="Screenshot 2024-06-17 at 12 21 38 PM" src="https://github.com/goalgorilla/open_social/assets/8435994/5ce4f893-d957-4e0a-ac99-ed267606e89e">



## Release notes
We have fixed a bug where the list of selected members in an Event or Group's "Manage Members" tab was not showing as well as not updating the count. Now, when you select a member, you will see in "Items selected" list and the count will also reflect the number of members selected.

## Change Record
N.A

## Translations
N.A