### PR TITLE
Issue #3455025: Fix type error when users directly goes to `social_group_request.anonymous_request_membership`

### DIFF
--- a/modules/social_features/social_group/modules/social_group_request/social_group_request.services.yml
+++ b/modules/social_features/social_group/modules/social_group_request/social_group_request.services.yml
@@ -12,3 +12,8 @@ services:
     class: Drupal\social_group_request\Routing\SocialGroupRequestRouteSubscriber
     tags:
       - { name: event_subscriber }
+  social_group_request.redirect_subscriber:
+    class: Drupal\social_group_request\EventSubscriber\RedirectSubscriber
+    arguments: [ '@current_route_match', '@request_stack', '@entity_type.manager' ]
+    tags:
+      - { name: event_subscriber }

--- a/modules/social_features/social_group/modules/social_group_request/src/EventSubscriber/RedirectSubscriber.php
+++ b/modules/social_features/social_group/modules/social_group_request/src/EventSubscriber/RedirectSubscriber.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Drupal\social_group_request\EventSubscriber;
+
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Routing\CurrentRouteMatch;
+use Drupal\Core\Url;
+use Drupal\group\Entity\Group;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * Implements the group request RedirectSubscriber.
+ *
+ * @package Drupal\social_group_request\EventSubscriber
+ */
+class RedirectSubscriber implements EventSubscriberInterface {
+
+  /**
+   * The current route.
+   *
+   * @var \Drupal\Core\Routing\CurrentRouteMatch
+   */
+  protected $currentRoute;
+
+  /**
+   * Entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * Request stack.
+   *
+   * @var \Symfony\Component\HttpFoundation\RequestStack
+   */
+  protected $requestStack;
+
+  /**
+   * RedirectSubscriber construct.
+   *
+   * @param \Drupal\Core\Routing\CurrentRouteMatch $route_match
+   *   The current route.
+   * @param \Symfony\Component\HttpFoundation\RequestStack $request_stack
+   *   The current user.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   Entity type manager.
+   */
+  public function __construct(CurrentRouteMatch $route_match, RequestStack $request_stack, EntityTypeManagerInterface $entity_type_manager) {
+    $this->currentRoute = $route_match;
+    $this->requestStack = $request_stack;
+    $this->entityTypeManager = $entity_type_manager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents(): array {
+    $events[KernelEvents::REQUEST][] = ['anRequestMembershipPage'];
+    return $events;
+  }
+
+  /**
+   * Redirect users to the group page to start the AN Membership flow.
+   *
+   * @param \Symfony\Component\HttpKernel\Event\RequestEvent $event
+   *   The event.
+   */
+  public function anRequestMembershipPage(RequestEvent $event): void {
+    // First check if the current route is the AN request membership.
+    $routeMatch = $this->currentRoute->getRouteName();
+    if ($routeMatch !== 'social_group_request.anonymous_request_membership') {
+      return;
+    }
+
+    // We need a referer, otherwise we land directly on the route which
+    // isn't supported, see GroupRequestMembershipRequestAnonymousForm
+    // this is opened in a Modal on the group page so we can redirect
+    // after the user joins / registers.
+    if (!$this->requestStack->getCurrentRequest()) {
+      return;
+    }
+    if ($this->requestStack->getCurrentRequest()->headers->get('referer')) {
+      return;
+    }
+
+    // Fetch the group parameter and check if's an actual group.
+    $group = $this->currentRoute->getParameter('group');
+    // Not group, then we leave.
+    if (!$group instanceof Group) {
+      return;
+    }
+
+    // Redirect to the entity group canonical instead, so they can click
+    // join there and start the flow.
+    $event->setResponse(new RedirectResponse(Url::fromRoute('entity.group.canonical', ['group' => $group->id()])->toString()));
+  }
+
+}

--- a/modules/social_features/social_group/modules/social_group_request/src/Form/GroupRequestMembershipRequestAnonymousForm.php
+++ b/modules/social_features/social_group/modules/social_group_request/src/Form/GroupRequestMembershipRequestAnonymousForm.php
@@ -72,9 +72,18 @@ class GroupRequestMembershipRequestAnonymousForm extends FormBase {
       '#value' => $this->t('In order to send your request, please first sign up or log in.'),
     ];
 
-    $previous_url = $this->requestStack->getCurrentRequest()->headers->get('referer');
-    $request = Request::create($previous_url);
-    $referer_path = $request->getRequestUri();
+    $destination = [];
+
+    // By default, we use the current (group canonical) url.
+    if ($this->requestStack->getCurrentRequest()) {
+      $referer_path = $this->requestStack->getCurrentRequest()->getRequestUri();
+      if ($this->requestStack->getCurrentRequest()->headers->get('referer')) {
+        $request = Request::create($this->requestStack->getCurrentRequest()->headers->get('referer'));
+        $referer_path = $request->getRequestUri();
+      }
+
+      $destination = ['destination' => $referer_path . '?requested-membership=' . $this->group->id()];
+    }
 
     $form['actions']['#type'] = 'actions';
     $form['actions']['sign_up'] = [
@@ -88,9 +97,7 @@ class GroupRequestMembershipRequestAnonymousForm extends FormBase {
           'waves-btn',
         ],
       ],
-      '#url' => Url::fromRoute('user.register', [
-        'destination' => $referer_path . '?requested-membership=' . $this->group->id(),
-      ]),
+      '#url' => Url::fromRoute('user.register', $destination),
     ];
 
     $form['actions']['log_in'] = [
@@ -104,9 +111,7 @@ class GroupRequestMembershipRequestAnonymousForm extends FormBase {
           'waves-btn',
         ],
       ],
-      '#url' => Url::fromRoute('user.login', [
-        'destination' => $referer_path . '?requested-membership=' . $this->group->id(),
-      ]),
+      '#url' => Url::fromRoute('user.login', $destination),
     ];
 
     return $form;

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1616,9 +1616,39 @@ parameters:
 			path: modules/custom/grequest/src/Form/GroupRequestMembershipRejectForm.php
 
 		-
+			message: "#^Property Drupal\\\\grequest\\\\Form\\\\GroupRequestMembershipRejectForm\\:\\:\\$groupContent \\(Drupal\\\\group\\\\Entity\\\\GroupRelationshipInterface\\) does not accept Drupal\\\\group\\\\Entity\\\\GroupRelationshipInterface\\|null\\.$#"
+			count: 1
+			path: modules/custom/grequest/src/Form/GroupRequestMembershipRejectForm.php
+
+		-
 			message: "#^\\\\Drupal calls should be avoided in classes, use dependency injection instead$#"
 			count: 1
 			path: modules/custom/grequest/src/Form/GroupRequestMembershipRejectForm.php
+
+		-
+			message: "#^Cannot call method configureField\\(\\) on Drupal\\\\group\\\\Plugin\\\\Group\\\\RelationHandler\\\\RelationHandlerInterface\\|null\\.$#"
+			count: 1
+			path: modules/custom/grequest/src/Plugin/Group/RelationHandler/GroupMembershipRequestEntityReference.php
+
+		-
+			message: "#^Cannot call method getGroupOperations\\(\\) on Drupal\\\\group\\\\Plugin\\\\Group\\\\RelationHandler\\\\RelationHandlerInterface\\|null\\.$#"
+			count: 1
+			path: modules/custom/grequest/src/Plugin/Group/RelationHandler/GroupMembershipRequestOperationProvider.php
+
+		-
+			message: "#^Cannot call method buildPermissions\\(\\) on Drupal\\\\group\\\\Plugin\\\\Group\\\\RelationHandler\\\\RelationHandlerInterface\\|null\\.$#"
+			count: 1
+			path: modules/custom/grequest/src/Plugin/Group/RelationHandler/GroupMembershipRequestPermissionProvider.php
+
+		-
+			message: "#^Cannot call method getPermission\\(\\) on Drupal\\\\group\\\\Plugin\\\\Group\\\\RelationHandler\\\\RelationHandlerInterface\\|null\\.$#"
+			count: 1
+			path: modules/custom/grequest/src/Plugin/Group/RelationHandler/GroupMembershipRequestPermissionProvider.php
+
+		-
+			message: "#^Cannot call method getInstallTasks\\(\\) on Drupal\\\\group\\\\Plugin\\\\Group\\\\RelationHandler\\\\RelationHandlerInterface\\|null\\.$#"
+			count: 1
+			path: modules/custom/grequest/src/Plugin/Group/RelationHandler/GroupMembershipRequestPostInstall.php
 
 		-
 			message: "#^Function group_core_comments_install\\(\\) has no return type specified\\.$#"
@@ -5910,6 +5940,11 @@ parameters:
 			path: modules/social_features/social_event/modules/social_event_managers/src/Plugin/Action/SocialEventManagersSendEmail.php
 
 		-
+			message: "#^Cannot call method entityAccess\\(\\) on Drupal\\\\group\\\\Plugin\\\\Group\\\\RelationHandler\\\\RelationHandlerInterface\\|null\\.$#"
+			count: 3
+			path: modules/social_features/social_event/modules/social_event_managers/src/Plugin/Group/RelationHandler/EventsGroupContentAccessControl.php
+
+		-
 			message: "#^Method Drupal\\\\social_event_managers\\\\Plugin\\\\views\\\\access\\\\ManageByOrganizersOnlyAccess\\:\\:alterRouteDefinition\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: modules/social_features/social_event/modules/social_event_managers/src/Plugin/views/access/ManageByOrganizersOnlyAccess.php
@@ -7389,6 +7424,11 @@ parameters:
 			path: modules/social_features/social_group/modules/social_group_default_route/social_group_default_route.module
 
 		-
+			message: "#^Constant Drupal\\\\social_group_default_route\\\\EventSubscriber\\\\RedirectSubscriber\\:\\:DEFAULT_CLOSED_ROUTE is unused\\.$#"
+			count: 1
+			path: modules/social_features/social_group/modules/social_group_default_route/src/EventSubscriber/RedirectSubscriber.php
+
+		-
 			message: "#^Method Drupal\\\\social_group_default_route\\\\EventSubscriber\\\\RedirectSubscriber\\:\\:groupLandingPage\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: modules/social_features/social_group/modules/social_group_default_route/src/EventSubscriber/RedirectSubscriber.php
@@ -7412,6 +7452,16 @@ parameters:
 			message: "#^Not allowed to call private function _social_group_get_current_group from module social_flexible_group_book\\.$#"
 			count: 2
 			path: modules/social_features/social_group/modules/social_group_flexible_group/modules/social_flexible_group_book/src/Plugin/Block/GroupAddBookBlock.php
+
+		-
+			message: "#^Cannot call method fetchAllAssoc\\(\\) on Drupal\\\\Core\\\\Database\\\\StatementInterface\\|null\\.$#"
+			count: 1
+			path: modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.install
+
+		-
+			message: "#^Cannot call method getMember\\(\\) on Drupal\\\\social_group\\\\Entity\\\\Group\\|null\\.$#"
+			count: 1
+			path: modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.install
 
 		-
 			message: "#^Function social_group_flexible_group_install\\(\\) has no return type specified\\.$#"
@@ -7530,6 +7580,16 @@ parameters:
 
 		-
 			message: "#^Function social_group_flexible_group_social_group_types_alter\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.module
+
+		-
+			message: "#^Function social_group_flexible_group_social_user_account_header_create_links\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.module
+
+		-
+			message: "#^Function social_group_flexible_group_social_user_account_header_create_links\\(\\) has parameter \\$context with no type specified\\.$#"
 			count: 1
 			path: modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.module
 
@@ -7914,6 +7974,15 @@ parameters:
 			path: modules/social_features/social_group/modules/social_group_invite/src/Form/SocialBulkGroupInvitation.php
 
 		-
+			message: """
+				#^Parameter \\$group_membership_loader of method Drupal\\\\social_group_invite\\\\Form\\\\SocialBulkGroupInvitation\\:\\:__construct\\(\\) has typehint with deprecated interface Drupal\\\\group\\\\GroupMembershipLoaderInterface\\:
+				in group\\:3\\.2\\.0 and is removed from group\\:4\\.0\\.0\\. Use the static
+				  methods on \\\\Drupal\\\\group\\\\Entity\\\\GroupMembership instead\\.$#
+			"""
+			count: 1
+			path: modules/social_features/social_group/modules/social_group_invite/src/Form/SocialBulkGroupInvitation.php
+
+		-
 			message: "#^Property Drupal\\\\social_group_invite\\\\Form\\\\SocialBulkGroupInvitation\\:\\:\\$configFactory \\(Drupal\\\\Core\\\\Config\\\\ConfigFactory\\) does not accept Drupal\\\\Core\\\\Config\\\\ConfigFactoryInterface\\.$#"
 			count: 1
 			path: modules/social_features/social_group/modules/social_group_invite/src/Form/SocialBulkGroupInvitation.php
@@ -7949,7 +8018,17 @@ parameters:
 			path: modules/social_features/social_group/modules/social_group_invite/src/Plugin/Block/SocialInviteLocalActionsBlock.php
 
 		-
+			message: "#^Cannot call method relationshipAccess\\(\\) on Drupal\\\\group\\\\Plugin\\\\Group\\\\RelationHandler\\\\RelationHandlerInterface\\|null\\.$#"
+			count: 1
+			path: modules/social_features/social_group/modules/social_group_invite/src/Plugin/Group/RelationHandler/SocialGroupInviteAccessControl.php
+
+		-
 			message: "#^Method Drupal\\\\social_group_invite\\\\Plugin\\\\Join\\\\SocialGroupInviteJoin\\:\\:create\\(\\) should return static\\(Drupal\\\\social_group_invite\\\\Plugin\\\\Join\\\\SocialGroupInviteJoin\\) but returns Drupal\\\\social_group_invite\\\\Plugin\\\\Join\\\\SocialGroupInviteJoin\\.$#"
+			count: 1
+			path: modules/social_features/social_group/modules/social_group_invite/src/Plugin/Join/SocialGroupInviteJoin.php
+
+		-
+			message: "#^Negated boolean expression is always false\\.$#"
 			count: 1
 			path: modules/social_features/social_group/modules/social_group_invite/src/Plugin/Join/SocialGroupInviteJoin.php
 
@@ -8204,13 +8283,13 @@ parameters:
 			path: modules/social_features/social_group/modules/social_group_request/src/Form/GroupRequestMembershipRejectForm.php
 
 		-
-			message: "#^Cannot access property \\$headers on Symfony\\\\Component\\\\HttpFoundation\\\\Request\\|null\\.$#"
+			message: "#^Property Drupal\\\\social_group_request\\\\Form\\\\GroupRequestMembershipRejectForm\\:\\:\\$groupContent \\(Drupal\\\\group\\\\Entity\\\\GroupRelationshipInterface\\) does not accept Drupal\\\\group\\\\Entity\\\\GroupRelationshipInterface\\|null\\.$#"
 			count: 1
-			path: modules/social_features/social_group/modules/social_group_request/src/Form/GroupRequestMembershipRequestAnonymousForm.php
+			path: modules/social_features/social_group/modules/social_group_request/src/Form/GroupRequestMembershipRejectForm.php
 
 		-
 			message: "#^Cannot call method id\\(\\) on Drupal\\\\group\\\\Entity\\\\GroupInterface\\|null\\.$#"
-			count: 2
+			count: 1
 			path: modules/social_features/social_group/modules/social_group_request/src/Form/GroupRequestMembershipRequestAnonymousForm.php
 
 		-
@@ -8220,11 +8299,6 @@ parameters:
 
 		-
 			message: "#^Method Drupal\\\\social_group_request\\\\Form\\\\GroupRequestMembershipRequestAnonymousForm\\:\\:submitForm\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: modules/social_features/social_group/modules/social_group_request/src/Form/GroupRequestMembershipRequestAnonymousForm.php
-
-		-
-			message: "#^Parameter \\#1 \\$uri of static method Symfony\\\\Component\\\\HttpFoundation\\\\Request\\:\\:create\\(\\) expects string, string\\|null given\\.$#"
 			count: 1
 			path: modules/social_features/social_group/modules/social_group_request/src/Form/GroupRequestMembershipRequestAnonymousForm.php
 
@@ -8804,16 +8878,6 @@ parameters:
 			path: modules/social_features/social_group/social_group.module
 
 		-
-			message: "#^Function social_group_flexible_group_social_user_account_header_create_links\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.module
-
-		-
-			message: "#^Function social_group_flexible_group_social_user_account_header_create_links\\(\\) has parameter \\$context with no type specified\\.$#"
-			count: 1
-			path: modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.module
-
-		-
 			message: "#^Function social_group_social_user_account_header_items\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: modules/social_features/social_group/social_group.module
@@ -8849,6 +8913,11 @@ parameters:
 			path: modules/social_features/social_group/social_group.module
 
 		-
+			message: "#^Function template_preprocess_group_settings_help\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: modules/social_features/social_group/social_group.module
+
+		-
 			message: "#^Parameter \\#1 \\$account of method Drupal\\\\group\\\\Entity\\\\GroupInterface\\:\\:addMember\\(\\) expects Drupal\\\\user\\\\UserInterface, Drupal\\\\user\\\\Entity\\\\User\\|null given\\.$#"
 			count: 1
 			path: modules/social_features/social_group/social_group.module
@@ -8861,11 +8930,6 @@ parameters:
 		-
 			message: "#^Parameter \\#1 \\$group_type_id of function social_group_get_allowed_visibility_options_per_group_type expects string\\|null, int\\|string\\|null given\\.$#"
 			count: 2
-			path: modules/social_features/social_group/social_group.module
-
-		-
-			message: "#^Function template_preprocess_group_settings_help\\(\\) has no return type specified\\.$#"
-			count: 1
 			path: modules/social_features/social_group/social_group.module
 
 		-
@@ -13356,77 +13420,3 @@ parameters:
 			message: "#^\\\\Drupal calls should be avoided in classes, use dependency injection instead$#"
 			count: 2
 			path: modules/social_features/social_user_export/src/Plugin/Action/ExportUser.php
-		-
-
-			message: "#^Property Drupal\\\\grequest\\\\Form\\\\GroupRequestMembershipRejectForm\\:\\:\\$groupContent \\(Drupal\\\\group\\\\Entity\\\\GroupRelationshipInterface\\) does not accept Drupal\\\\group\\\\Entity\\\\GroupRelationshipInterface\\|null\\.$#"
-			count: 1
-			path: modules/custom/grequest/src/Form/GroupRequestMembershipRejectForm.php
-
-		-
-			message: "#^Constant Drupal\\\\social_group_default_route\\\\EventSubscriber\\\\RedirectSubscriber\\:\\:DEFAULT_CLOSED_ROUTE is unused.$#"
-			count: 1
-			path: modules/social_features/social_group/modules/social_group_default_route/src/EventSubscriber/RedirectSubscriber.php
-
-		-
-			message: "#^Negated boolean expression is always false.$#"
-			count: 1
-			path: modules/social_features/social_group/modules/social_group_invite/src/Plugin/Join/SocialGroupInviteJoin.php
-
-		-
-			message: "#^Property Drupal\\\\social_group_request\\\\Form\\\\GroupRequestMembershipRejectForm\\:\\:\\$groupContent \\(Drupal\\\\group\\\\Entity\\\\GroupRelationshipInterface\\) does not accept Drupal\\\\group\\\\Entity\\\\GroupRelationshipInterface\\|null\\.$#"
-			count: 1
-			path: modules/social_features/social_group/modules/social_group_request/src/Form/GroupRequestMembershipRejectForm.php
-
-		-
-			message: "#^Cannot call method configureField\\(\\) on Drupal\\\\group\\\\Plugin\\\\Group\\\\RelationHandler\\\\RelationHandlerInterface\\|null\\.$#"
-			count: 1
-			path: modules/custom/grequest/src/Plugin/Group/RelationHandler/GroupMembershipRequestEntityReference.php
-
-		-
-			message: "#^Cannot call method entityAccess\\(\\) on Drupal\\\\group\\\\Plugin\\\\Group\\\\RelationHandler\\\\RelationHandlerInterface\\|null\\.$#"
-			count: 3
-			path: modules/social_features/social_event/modules/social_event_managers/src/Plugin/Group/RelationHandler/EventsGroupContentAccessControl.php
-
-		-
-			message: "#^Cannot call method getInstallTasks\\(\\) on Drupal\\\\group\\\\Plugin\\\\Group\\\\RelationHandler\\\\RelationHandlerInterface\\|null\\.$#"
-			count: 1
-			path: modules/custom/grequest/src/Plugin/Group/RelationHandler/GroupMembershipRequestPostInstall.php
-
-		-
-			message: "#^Cannot call method getPermission\\(\\) on Drupal\\\\group\\\\Plugin\\\\Group\\\\RelationHandler\\\\RelationHandlerInterface\\|null\\.$#"
-			count: 1
-			path: modules/custom/grequest/src/Plugin/Group/RelationHandler/GroupMembershipRequestPermissionProvider.php
-
-		-
-			message: "#^Cannot call method buildPermissions\\(\\) on Drupal\\\\group\\\\Plugin\\\\Group\\\\RelationHandler\\\\RelationHandlerInterface\\|null\\.$#"
-			count: 1
-			path: modules/custom/grequest/src/Plugin/Group/RelationHandler/GroupMembershipRequestPermissionProvider.php
-
-		-
-			message: "#^Cannot call method getGroupOperations\\(\\) on Drupal\\\\group\\\\Plugin\\\\Group\\\\RelationHandler\\\\RelationHandlerInterface\\|null\\.$#"
-			count: 1
-			path: modules/custom/grequest/src/Plugin/Group/RelationHandler/GroupMembershipRequestOperationProvider.php
-
-		-
-			message: """
-				#^Parameter \\$group_membership_loader of method Drupal\\\\social_group_invite\\\\Form\\\\SocialBulkGroupInvitation\\:\\:__construct\\(\\) has typehint with deprecated interface Drupal\\\\group\\\\GroupMembershipLoaderInterface\\:
-				in group\\:3\\.2\\.0 and is removed from group\\:4\\.0\\.0\\. Use the static
-				  methods on \\\\Drupal\\\\group\\\\Entity\\\\GroupMembership instead\\.$#
-			"""
-			count: 1
-			path: modules/social_features/social_group/modules/social_group_invite/src/Form/SocialBulkGroupInvitation.php
-
-		-
-			message: "#^Cannot call method relationshipAccess\\(\\) on Drupal\\\\group\\\\Plugin\\\\Group\\\\RelationHandler\\\\RelationHandlerInterface\\|null\\.$#"
-			count: 1
-			path: modules/social_features/social_group/modules/social_group_invite/src/Plugin/Group/RelationHandler/SocialGroupInviteAccessControl.php
-
-		-
-			message: "#^Cannot call method fetchAllAssoc\\(\\) on Drupal\\\\Core\\\\Database\\\\StatementInterface\\|null\\.$#"
-			count: 1
-			path: modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.install
-
-		-
-			message: "#^Cannot call method getMember\\(\\) on Drupal\\\\social_group\\\\Entity\\\\Group\\|null\\.$#"
-			count: 1
-			path: modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.install

--- a/tests/behat/features/capabilities/groups/flexible/groups-flexible-view-outsider-anonymous.feature
+++ b/tests/behat/features/capabilities/groups/flexible/groups-flexible-view-outsider-anonymous.feature
@@ -1,19 +1,29 @@
-@api @javascript @flexible-groups
+@api @javascript
 Feature: Flexible groups view access for anonymous users
   Background:
     Given I enable the module "social_group_flexible_group"
     And I disable that the registered users to be verified immediately
 
-#  @todo Broken by https://www.drupal.org/project/social/issues/3314447
-#  Scenario: As anonymous user view a public group
-#    Given groups with non-anonymous owner:
-#      | label      | field_group_description | type           | langcode | field_flexible_group_visibility |
-#      | Test group | Public visibility       | flexible_group | en       | public                          |
-#    And I am an anonymous user
-#
-#    When I am viewing the group "Test group"
-#
-#    Then I should see "Test group"
+  Scenario: As anonymous user view a public group
+    Given groups with non-anonymous owner:
+      | label      | field_group_description | type           | langcode | field_flexible_group_visibility | field_group_allowed_join_method |
+      | Test group | Public visibility       | flexible_group | en       | public                          | direct                          |
+    And I am an anonymous user
+
+    When I am viewing the "stream" page of group "Test group"
+
+    Then I should see "Test group"
+
+  Scenario: As anonymous redirect to the group when visiting the request membership
+    Given groups with non-anonymous owner:
+      | label      | field_group_description | type           | langcode | field_flexible_group_visibility | field_group_allowed_join_method |
+      | Test group | Public visibility       | flexible_group | en       | public                          | request                         |
+    And I am an anonymous user
+
+    When I am viewing the "anonymous-request-membership" page of group "Test group"
+
+    Then I should see "Test group"
+    And I should see "Request to join"
 
   Scenario: As anonymous user I can't view a community group
     Given groups with non-anonymous owner:


### PR DESCRIPTION
## Problem & Solution
The intention of this route is that it's a callback for the join button, which works well. 
We never figured out what would happen if the user directly goes to the route. In this case, we will ensure that the flow gets started through the join button by
- Ensuring that we will redirect them to the group page if they go to the route directly.
- Write a fall back for the error, if the referer isn't there.

## Issue tracker
https://www.drupal.org/project/social/issues/3455025

## How to test
- [ ] Create a group with public settings and the request to join as join method
- [ ] As an visit `/group/{group}/anonymous-request-membership`
- [ ] See that it breaks
- [ ] Checkout this branch and do the same
- [ ] See that it now redirects to the group page, so the AN user can click the Request to join button
- [ ] See that you are being redirected to user register / join accordingly
- [ ] See that when you login with, lets see chris hall, you get directed to the Group page and the request flow starts (by popping up the request to join message)

## Release notes
We ensured the AN Group Request membership flow is fixed for the scenario that the modal frame URL is opened directly.