### PR TITLE
Issue #3455464 - Transform GroupMembershipRequestForm to extend the ContentEntityForm, so we can use field API instead of a custom form

### DIFF
--- a/modules/social_features/social_group/modules/social_group_request/config/optional/core.entity_form_display.group_content.group_content_type_7fcb76fdf61a9.default.yml
+++ b/modules/social_features/social_group/modules/social_group_request/config/optional/core.entity_form_display.group_content.group_content_type_7fcb76fdf61a9.default.yml
@@ -1,0 +1,27 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.group_content.group_content_type_7fcb76fdf61a9.grequest_status
+    - field.field.group_content.group_content_type_7fcb76fdf61a9.grequest_updated_by
+    - group.content_type.group_content_type_7fcb76fdf61a9
+id: group_content.group_content_type_7fcb76fdf61a9.default
+targetEntityType: group_content
+bundle: group_content_type_7fcb76fdf61a9
+mode: default
+content:
+  field_grequest_message:
+    type: string_textarea
+    weight: 0
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+hidden:
+  entity_id: true
+  grequest_status: true
+  grequest_updated_by: true
+  langcode: true
+  path: true
+  uid: true

--- a/modules/social_features/social_group/modules/social_group_request/config/optional/field.field.group_content.group_content_type_7fcb76fdf61a9.field_grequest_message.yml
+++ b/modules/social_features/social_group/modules/social_group_request/config/optional/field.field.group_content.group_content_type_7fcb76fdf61a9.field_grequest_message.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.group_content.field_grequest_message
+    - group.content_type.group_content_type_7fcb76fdf61a9
+id: group_content.group_content_type_7fcb76fdf61a9.field_grequest_message
+field_name: field_grequest_message
+entity_type: group_content
+bundle: group_content_type_7fcb76fdf61a9
+label: Message
+description: 'You can leave a message in your request. Only when your request is approved, you will receive a notification via email and notification center.'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string_long

--- a/modules/social_features/social_group/modules/social_group_request/config/static/core.entity_form_display.group_content.group_content_type_7fcb76fdf61a9.default_13003.yml
+++ b/modules/social_features/social_group/modules/social_group_request/config/static/core.entity_form_display.group_content.group_content_type_7fcb76fdf61a9.default_13003.yml
@@ -1,0 +1,27 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.group_content.group_content_type_7fcb76fdf61a9.grequest_status
+    - field.field.group_content.group_content_type_7fcb76fdf61a9.grequest_updated_by
+    - group.content_type.group_content_type_7fcb76fdf61a9
+id: group_content.group_content_type_7fcb76fdf61a9.default
+targetEntityType: group_content
+bundle: group_content_type_7fcb76fdf61a9
+mode: default
+content:
+  field_grequest_message:
+    type: string_textarea
+    weight: 0
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+hidden:
+  entity_id: true
+  grequest_status: true
+  grequest_updated_by: true
+  langcode: true
+  path: true
+  uid: true

--- a/modules/social_features/social_group/modules/social_group_request/config/update/social_group_request_update_13003.yml
+++ b/modules/social_features/social_group/modules/social_group_request/config/update/social_group_request_update_13003.yml
@@ -1,0 +1,16 @@
+core.entity_view_display.group_content.group_content_type_7fcb76fdf61a9.default:
+  expected_config:
+    hidden:
+      field_grequest_message: true
+      langcode: true
+  update_actions:
+    delete:
+      hidden:
+        field_grequest_message: true
+        langcode: true
+field.field.group_content.group_content_type_7fcb76fdf61a9.field_grequest_message:
+  expected_config:
+    description: ''
+  update_actions:
+    change:
+      description: 'You can leave a message in your request. Only when your request is approved, you will receive a notification via email and notification center.'

--- a/modules/social_features/social_group/modules/social_group_request/social_group_request.install
+++ b/modules/social_features/social_group/modules/social_group_request/social_group_request.install
@@ -5,6 +5,8 @@
  * Install/Uninstall/Update hooks for social_group_request module.
  */
 
+use Drupal\Core\Config\FileStorage;
+
 /**
  * Implements hook_install().
  */
@@ -104,4 +106,30 @@ function social_group_request_update_13002(): void {
     ->getStorage('group_role')
     ->load('flexible_group-group_manager');
   $group_manager->grantPermission('administer membership requests')->save();
+}
+
+/**
+ * Apply the config for the grequest_message field.
+ */
+function social_group_request_update_13003(): string {
+  // Add new config.
+  $config_path = \Drupal::service('extension.list.module')->getPath('social_group_request') . '/config/static';
+  $source = new FileStorage($config_path);
+  /** @var \Drupal\Core\Config\StorageInterface $config_storage */
+  $config_storage = \Drupal::service('config.storage');
+
+  $data = $source->read('core.entity_form_display.group_content.group_content_type_7fcb76fdf61a9.default_13003');
+  if (is_array($data)) {
+    $config_storage->write('core.entity_form_display.group_content.group_content_type_7fcb76fdf61a9.default', $data);
+  }
+
+  // Apply updates.
+  /** @var \Drupal\update_helper\Updater $updater */
+  $updater = \Drupal::service('update_helper.updater');
+
+  // Execute configuration update definitions with logging of success.
+  $updater->executeUpdate('social_group_request', __FUNCTION__);
+
+  // Output logged messages to related channel of update execution.
+  return $updater->logger()->output();
 }

--- a/modules/social_features/social_group/modules/social_group_request/social_group_request.module
+++ b/modules/social_features/social_group/modules/social_group_request/social_group_request.module
@@ -66,6 +66,15 @@ function social_group_request_entity_base_field_info(EntityTypeInterface $entity
 }
 
 /**
+ * Implements hook_entity_type_alter().
+ */
+function social_group_request_entity_type_alter(array &$entity_types): void {
+  if (isset($entity_types['group_content'])) {
+    $entity_types['group_content']->setFormClass('request-membership', 'Drupal\social_group_request\Form\GroupRequestMembershipRequestForm');
+  }
+}
+
+/**
  * Implements hook_social_group_join_method_usage().
  */
 function social_group_request_social_group_join_method_usage(): array {

--- a/modules/social_features/social_group/modules/social_group_request/src/Form/GroupRequestMembershipRequestForm.php
+++ b/modules/social_features/social_group/modules/social_group_request/src/Form/GroupRequestMembershipRequestForm.php
@@ -2,90 +2,92 @@
 
 namespace Drupal\social_group_request\Form;
 
+use Drupal\Component\Datetime\TimeInterface;
 use Drupal\Core\Cache\CacheTagsInvalidatorInterface;
+use Drupal\Core\Entity\ContentEntityForm;
+use Drupal\Core\Entity\EntityRepositoryInterface;
+use Drupal\Core\Entity\EntityTypeBundleInfoInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
-use Drupal\Core\Form\FormBase;
+use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Form\FormStateInterface;
-use Drupal\Core\Session\AccountInterface;
-use Drupal\Core\StringTranslation\TranslationInterface;
-use Drupal\grequest\Plugin\Group\Relation\GroupMembershipRequest;
-use Drupal\group\Entity\GroupInterface;
+use Drupal\group\Entity\GroupRelationshipInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Provides a form to request group membership.
  */
-class GroupRequestMembershipRequestForm extends FormBase {
+class GroupRequestMembershipRequestForm extends ContentEntityForm {
 
   /**
-   * Group entity.
-   *
-   * @var \Drupal\group\Entity\GroupInterface
-   */
-  protected $group;
-
-  /**
-   * Group membership request.
-   *
-   * @var \Drupal\group\Entity\GroupRelationshipInterface
-   */
-  protected $groupContent;
-
-  /**
-   * The cache tags invalidator.
+   * The cache invalidator service.
    *
    * @var \Drupal\Core\Cache\CacheTagsInvalidatorInterface
    */
   protected $cacheTagsInvalidator;
 
   /**
-   * The current user.
-   *
-   * @var \Drupal\Core\Session\AccountInterface
-   */
-  protected $currentUser;
-
-  /**
-   * Entity type manger.
+   * The entity type manager.
    *
    * @var \Drupal\Core\Entity\EntityTypeManagerInterface
    */
   protected $entityTypeManager;
 
   /**
-   * GroupRequestMembershipRejectForm constructor.
+   * The module handler service.
    *
+   * @var \Drupal\Core\Extension\ModuleHandlerInterface
+   */
+  protected $moduleHandler;
+
+  /**
+   * Constructs a GroupRequestMembershipRequestForm object.
+   *
+   * @param \Drupal\Core\Entity\EntityRepositoryInterface $entity_repository
+   *   The entity repository.
+   * @param \Drupal\Core\Entity\EntityTypeBundleInfoInterface $entity_type_bundle_info
+   *   The entity type bundle service.
+   * @param \Drupal\Component\Datetime\TimeInterface $time
+   *   The time service.
    * @param \Drupal\Core\Cache\CacheTagsInvalidatorInterface $cache_tags_invalidator
    *   The cache tags invalidator.
-   * @param \Drupal\Core\Session\AccountInterface $current_user
-   *   The current user.
-   * @param \Drupal\Core\StringTranslation\TranslationInterface $string_translation
-   *   The string translation.
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
    *   The entity type manager.
+   * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
+   *   The module handler.
    */
   public function __construct(
+    EntityRepositoryInterface $entity_repository,
+    EntityTypeBundleInfoInterface $entity_type_bundle_info,
+    TimeInterface $time,
     CacheTagsInvalidatorInterface $cache_tags_invalidator,
-    AccountInterface $current_user,
-    TranslationInterface $string_translation,
-    EntityTypeManagerInterface $entity_type_manager
+    EntityTypeManagerInterface $entity_type_manager,
+    ModuleHandlerInterface $module_handler
   ) {
+    parent::__construct($entity_repository, $entity_type_bundle_info, $time);
     $this->cacheTagsInvalidator = $cache_tags_invalidator;
-    $this->currentUser = $current_user;
-    $this->setStringTranslation($string_translation);
     $this->entityTypeManager = $entity_type_manager;
+    $this->moduleHandler = $module_handler;
   }
 
   /**
    * {@inheritdoc}
    */
-  public static function create(ContainerInterface $container) {
+  public static function create(ContainerInterface $container): self {
     return new static(
+      $container->get('entity.repository'),
+      $container->get('entity_type.bundle.info'),
+      $container->get('datetime.time'),
       $container->get('cache_tags.invalidator'),
-      $container->get('current_user'),
-      $container->get('string_translation'),
-      $container->get('entity_type.manager')
+      $container->get('entity_type.manager'),
+      $container->get('module_handler'),
     );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getBaseFormId() {
+    return 'social_group_request_membership_request';
   }
 
   /**
@@ -98,57 +100,35 @@ class GroupRequestMembershipRequestForm extends FormBase {
   /**
    * {@inheritdoc}
    */
-  public function buildForm(array $form, FormStateInterface $form_state, GroupInterface $group = NULL) {
-    $this->group = $group;
-
-    $form['description'] = [
-      '#type' => 'html_tag',
-      '#tag' => 'p',
-      '#value' => $this->t('You can leave a message in your request. Only when your request is approved, you will receive a notification via email and notification center.'),
-    ];
-
-    $form['message'] = [
-      '#type' => 'textarea',
-      '#title' => $this->t('Message'),
-    ];
-
-    $form['actions']['submit'] = [
-      '#type' => 'submit',
-      '#value' => $this->t('Send request'),
-      '#button_type' => 'primary',
-    ];
-
-    return $form;
+  protected function actions(array $form, FormStateInterface $form_state) {
+    $actions = parent::actions($form, $form_state);
+    $actions['submit']['#value'] = $this->t('Send request');
+    return $actions;
   }
 
   /**
    * {@inheritdoc}
    */
   public function submitForm(array &$form, FormStateInterface $form_state) {
-    /** @var \Drupal\group\Entity\Storage\GroupRelationshipTypeStorageInterface $storage */
-    $storage = $this->entityTypeManager->getStorage('group_content_type');
-    $group_type_id = (string) $this->group->getGroupType()->id();
-    $relation_type_id = $storage->getRelationshipTypeId($group_type_id, 'group_membership_request');
+    parent::submitForm($form, $form_state);
 
-    $group_content = $this->entityTypeManager->getStorage('group_content')->create([
-      'type' => $relation_type_id,
-      'gid' => $this->group->id(),
-      'entity_id' => $this->currentUser()->id(),
-      'grequest_status' => GroupMembershipRequest::REQUEST_PENDING,
-      'field_grequest_message' => $form_state->getValue('message'),
-    ]);
-    $result = $group_content->save();
+    $entity = $this->entity;
+    assert($entity instanceof GroupRelationshipInterface);
 
-    if ($result) {
-      $this->messenger()->addMessage($this->t('Your request has been sent successfully'));
-    }
-    else {
-      $this->messenger()->addError($this->t('Error when creating a request to join'));
-    }
+    $this->cacheTagsInvalidator->invalidateTags(['request-membership:' . $entity->get('gid')->target_id]);
 
-    $this->cacheTagsInvalidator->invalidateTags(['request-membership:' . $this->group->id()]);
+    $this->messenger()->addMessage(
+      $this->t(
+        'Your request has been sent successfully'
+      )
+    );
 
-    return $form_state->setRedirect('social_group.stream', ['group' => $this->group->id()]);
+    return $form_state->setRedirect(
+      'social_group.stream',
+      [
+        'group' => $entity->get('gid')->target_id,
+      ]
+    );
   }
 
 }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -8107,7 +8107,7 @@ parameters:
 
 		-
 			message: "#^Method Drupal\\\\Core\\\\Form\\\\FormBuilderInterface\\:\\:getForm\\(\\) invoked with 2 parameters, 1 required\\.$#"
-			count: 2
+			count: 1
 			path: modules/social_features/social_group/modules/social_group_request/src/Controller/GroupRequestController.php
 
 		-
@@ -8201,17 +8201,7 @@ parameters:
 			path: modules/social_features/social_group/modules/social_group_request/src/Form/GroupRequestMembershipRequestAnonymousForm.php
 
 		-
-			message: "#^Method Drupal\\\\social_group_request\\\\Form\\\\GroupRequestMembershipRequestForm\\:\\:create\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: modules/social_features/social_group/modules/social_group_request/src/Form/GroupRequestMembershipRequestForm.php
-
-		-
 			message: "#^Method Drupal\\\\social_group_request\\\\Form\\\\GroupRequestMembershipRequestForm\\:\\:submitForm\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: modules/social_features/social_group/modules/social_group_request/src/Form/GroupRequestMembershipRequestForm.php
-
-		-
-			message: "#^Property Drupal\\\\social_group_request\\\\Form\\\\GroupRequestMembershipRequestForm\\:\\:\\$group \\(Drupal\\\\group\\\\Entity\\\\GroupInterface\\) does not accept Drupal\\\\group\\\\Entity\\\\GroupInterface\\|null\\.$#"
 			count: 1
 			path: modules/social_features/social_group/modules/social_group_request/src/Form/GroupRequestMembershipRequestForm.php
 


### PR DESCRIPTION
## Problem
In issue https://www.drupal.org/project/social/issues/3453509 we discussed removing the hook to automatically add the field_grequest_message. In order for that change to work we also need to remove any "hard-coded" assumptions that this field exist, since the hook will be remove we can no longer assume that the field will always be there. 

This is a breaking change. 

## Solution
In  https://github.com/goalgorilla/open_social/pull/3923 the idea from @Kingdutch  was to refactor and use ContentEntityForm as base. We need to change from FormBase to ContentEntityForm and also update the controller to load the entity form. I also created a new entity form definition since our logic requires a bit of a different flow then the join-group defined by the group_content entity, instead of writing a hook_form_alter for this, I opted to just define a new entity form type and use that in the controller.

## Issue tracker
https://www.drupal.org/project/social/issues/3455464

## Theme issue tracker
<!-- *[Required if applicable] Paste a link to the drupal.org theme issue queue item, either from [socialbase](https://www.drupal.org/project/socialbase) or [socialblue](https://www.drupal.org/project/socialblue). If any other issue trackers were used, include links to those too.* -->

## How to test
1. Create a new group type and set the option to request to join for all users.
2. As a seperate user request the access to join the group and write a request message
3. As the group admin check if any request has been made and verify that the message is present.

## Screenshots
<!-- *[Required if new feature, and if applicable] If this Pull Request makes visual changes then please include some screenshots that show what has changed here. A before and after screenshot helps the reviewer determine what changes were made.* -->

## Release notes
Refactored the GroupMembershipRequestForm to use the ContentEntityForm, this gives us to option to use the field API from core.

## Change Record
<!-- *[Required if applicable] If this Pull Request changes the way that developers should do things or introduces a new API for developers then a change record to document this is needed. Please provide a draft for a change record or a link to an unpublished change record below. Existing change records can be consulted as example. Please provide a draft for a change record or a link to an unpublished change record below. [Existing change records](https://www.drupal.org/list-changes/social) can be consulted as example.* -->

## Translations
<!--
*[Optional]Translatable strings are always extracted from the latest development branch. To ensure translations remain available for platforms running older versions of Open Social the original string should be added to `translations.php` when it's changed or removed.*
- [ ] Changed or removed source strings are added to the `translations.php` file.
-->
