### PR TITLE
Internal: Lock `drupal/search_api_solr`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -174,7 +174,7 @@
         "drupal/redirect": "1.9.0",
         "drupal/role_delegation": "1.2.0",
         "drupal/search_api": "1.35.0",
-        "drupal/search_api_solr": "~4.3.1",
+        "drupal/search_api_solr": "4.3.3",
         "drupal/select2": "1.15.0",
         "drupal/shariff": "2.0.0",
         "drupal/socialblue": "~2.5.6",


### PR DESCRIPTION
## Problem & Solution
Lock `drupal/search_api_solr` as we've now added a patch that fails on the next update https://www.drupal.org/project/search_api_solr/releases/4.3.4.

Instead of updating and removing the patch, that could cause quite some regression,  we are first locking it. 
This way we can unblock our PR's which are failing and we can perform the update later. 

That patch is released here: https://www.drupal.org/files/issues/2024-04-22/3434394-6--drupal_11_compatibility.patch 

## Issue tracker
https://getopensocial.atlassian.net/browse/PROD-29910

## How to test
See that patches apply and everything is green. Considering we're using the same version no regression should take place.

## Release notes
None, internal.