### PR TITLE
PROD-29703: Provide external identifier field

### DIFF
--- a/modules/social_features/social_core/config/schema/social_core.schema.yml
+++ b/modules/social_features/social_core/config/schema/social_core.schema.yml
@@ -12,3 +12,28 @@ field.formatter.settings.comment_node:
     always_show_all_comments:
       type: boolean
       label: 'Always show all comments'
+
+field.value.social_external_identifier:
+  type: mapping
+  label: Default value
+  mapping:
+    external_id:
+      type: string
+      label: External ID
+    external_owner_target_type:
+      type: string
+      label: External Owner Target type
+    external_owner_id:
+      type: integer
+      label: External Owner ID
+
+field.storage_settings.social_external_identifier:
+  type: mapping
+  label: "Social External Identifier field storage settings"
+  mapping:
+    target_types:
+      type: sequence
+      label: 'Target entity types'
+      sequence:
+        type: string
+        label: 'Target entity type'

--- a/modules/social_features/social_core/src/Plugin/Field/FieldFormatter/ExternalIdentifierDefaultFormatter.php
+++ b/modules/social_features/social_core/src/Plugin/Field/FieldFormatter/ExternalIdentifierDefaultFormatter.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\social_core\Plugin\Field\FieldFormatter;
+
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Field\FormatterBase;
+
+/**
+ * Plugin implementation of the 'External Identifier Default' formatter.
+ *
+ * @FieldFormatter(
+ *   id = "social_external_identifier_default_formatter",
+ *   label = @Translation("External Identifier Default"),
+ *   field_types = {"social_external_identifier"},
+ * )
+ */
+final class ExternalIdentifierDefaultFormatter extends FormatterBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function viewElements(FieldItemListInterface $items, $langcode): array {
+    $element = [];
+    foreach ($items as $delta => $item) {
+      $element[$delta] = [
+        '#theme' => 'external_id_formatter',
+        '#external_id' => $item->external_id,
+        '#external_owner_target_type' => $item->external_owner_target_type,
+        '#external_owner_id' => $item->external_owner_id,
+      ];
+    }
+    return $element;
+  }
+
+}

--- a/modules/social_features/social_core/src/Plugin/Field/FieldType/ExternalIdentifierItem.php
+++ b/modules/social_features/social_core/src/Plugin/Field/FieldType/ExternalIdentifierItem.php
@@ -1,0 +1,227 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\social_core\Plugin\Field\FieldType;
+
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Entity\EntityTypeInterface;
+use Drupal\Core\Field\FieldItemBase;
+use Drupal\Core\Field\FieldStorageDefinitionInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\Core\TypedData\DataDefinition;
+use Drupal\Core\TypedData\DataReferenceTargetDefinition;
+
+/**
+ * Defines the 'social_external_identifier' field type.
+ *
+ * Supported settings (below the definition's 'settings' key) are:
+ * - target_type: The entity type to reference. Required.
+ *
+ * @FieldType(
+ *   id = "social_external_identifier",
+ *   label = @Translation("External Identifier"),
+ *   description = @Translation("Define external Identifier and external Owner/Consumer."),
+ *   default_widget = "social_external_identifier_default_widget",
+ *   default_formatter = "social_external_identifier_default_formatter",
+ *   constraints = {
+ *     "ExternalIdentifierEmptySubfieldsConstraint" = {},
+ *     "ExternalIdentifierExternalOwnerTargetTypeConstraint" = {},
+ *     "ExternalIdentifierExternalOwnerIdConstraint" = {},
+ *     "ComplexData" = {
+ *       "external_id" = {
+ *         "Length" = {"max" = 225}
+ *        }
+ *      }
+ *   }
+ * )
+ */
+final class ExternalIdentifierItem extends FieldItemBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function isEmpty(): bool {
+    // Business rules:
+    // - Field is considered empty if all subfield values are empty.
+    // - Field is considered invalid (by constraints) if subfield values are
+    // just partly provided (except if all subfield values are empty).
+    // - Field is considered valid if all subfield values are provided (but it
+    // is also valid if none of the subfield value is provided)
+    //
+    // Subfields:
+    // - external_id,
+    // - external_owner_target_type
+    // - external_owner_id
+    //
+    // Note, even that external_owner_id is int, we are checking is as string
+    // because of some Drupal bugs that int values ane not matching type hints.
+    // See: https://www.drupal.org/project/drupal/issues/3441689
+    // See: https://www.drupal.org/project/drupal/issues/3224376
+    //
+    // Also note that the ExternalIdentifierEmptySubfieldsConstraintValidator
+    // prevents the field from being saved if all subfields do not have set
+    // values.
+    foreach ($this->getValue() as $value) {
+      if ($value !== '' && $value !== NULL) {
+        return FALSE;
+      }
+    }
+
+    return TRUE;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function propertyDefinitions(FieldStorageDefinitionInterface $field_definition): array {
+    $properties['external_id'] = DataDefinition::create('string')
+      ->setLabel(t('External ID'))
+      ->setRequired(TRUE);
+    $properties['external_owner_target_type'] = DataReferenceTargetDefinition::create('string')
+      ->setLabel(t('Target Entity Type'))
+      ->setRequired(TRUE);
+    $properties['external_owner_id'] = DataDefinition::create('integer')
+      ->setLabel(t('External Owner'))
+      ->setRequired(TRUE);
+
+    return $properties;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function storageSettingsSummary(FieldStorageDefinitionInterface $storage_definition): array {
+    $summary = [];
+    $target_types = $storage_definition->getSetting('target_types');
+    if (!empty($target_types)) {
+      $entity_type_labels = [];
+      foreach ($target_types as $target_type) {
+        $target_type_info = \Drupal::entityTypeManager()->getDefinition($target_type);
+        if (!empty($target_type_info)) {
+          $entity_type_labels[] = $target_type_info->getLabel();
+        }
+      }
+      $summary[] = new TranslatableMarkup('Reference type: @entity_type_labels', [
+        '@entity_type_labels' => implode(', ', $entity_type_labels),
+      ]);
+
+    }
+
+    return $summary;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function schema(FieldStorageDefinitionInterface $field_definition): array {
+    return [
+      'columns' => [
+        'external_id' => [
+          'type' => 'varchar',
+          'description' => 'External ID',
+          'length' => 255,
+          'not null' => TRUE,
+        ],
+        'external_owner_target_type' => [
+          'type' => 'varchar',
+          'description' => 'External Owner Target Type',
+          'length' => 255,
+          'not null' => TRUE,
+        ],
+        'external_owner_id' => [
+          'type' => 'int',
+          'description' => 'External Owner ID',
+          'unsigned' => TRUE,
+          'not null' => TRUE,
+        ],
+      ],
+      'indexes' => [
+        'external_id' => ['external_id'],
+        'external_owner_target_type' => ['external_owner_target_type'],
+        'external_owner_id' => ['external_owner_id'],
+      ],
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setValue($values, $notify = TRUE): void {
+    if (is_array($values)) {
+      $this->set('external_id', $values['external_id'] ?? NULL);
+      $this->set('external_owner_target_type', $values['external_owner_target_type'] ?? NULL);
+      $this->set('external_owner_id', $values['external_owner_id'] ?? NULL);
+    }
+    else {
+      parent::setValue($values, $notify);
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function defaultStorageSettings() {
+    return [
+      'target_types' => [],
+    ] + parent::defaultStorageSettings();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function storageSettingsForm(array &$form, FormStateInterface $form_state, $has_data) {
+    $element['target_types'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Allowed external owner target types'),
+      '#description' => $this->t('Entity type of item to reference (Example: consumer)'),
+      '#default_value' => $this->getSetting('target_types'),
+      '#multiple' => TRUE,
+      // For field to work properly, at least one target type must be available,
+      // as this is hard requirement, If requirement can not be fulfilled, field
+      // will return an error if non-empty value will try to be applied.
+      // Despite all those facts, we still keep this option as optional, because
+      // by default, no target types are predefined.
+      '#required' => FALSE,
+      '#disabled' => $has_data,
+      '#size' => 10,
+    ];
+
+    // Only allow the field to target entity types that have an ID key. This
+    // is enforced in ::propertyDefinitions().
+    $entity_type_manager = \Drupal::entityTypeManager();
+    $filter = function (string $entity_type_id) use ($entity_type_manager): bool {
+      /** @var \Drupal\Core\Entity\EntityTypeInterface $entity_type */
+      $entity_type = $entity_type_manager->getDefinition($entity_type_id);
+      assert($entity_type instanceof EntityTypeInterface, "EntityTypeManager::getDefinition should throw an exception if the entity type does not exist rather than returning NULL");
+      return $entity_type->hasKey('id');
+    };
+    $options = \Drupal::service('entity_type.repository')->getEntityTypeLabels(TRUE);
+    foreach ($options as $group_name => $group) {
+      $element['target_types']['#options'][$group_name] = array_filter($group, $filter, ARRAY_FILTER_USE_KEY);
+    }
+    return $element;
+  }
+
+  /**
+   * Loads the external owner entity.
+   *
+   * @return \Drupal\Core\Entity\EntityInterface|null
+   *   Returns external owner entity if exists.
+   *
+   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
+   * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
+   * @throws \Drupal\Core\TypedData\Exception\MissingDataException
+   */
+  public function getExternalOwnerEntity(): ?EntityInterface {
+    $entity_type = $this->get('external_owner_target_type')->getValue();
+    $entity_id = $this->get('external_owner_id')->getValue();
+
+    if ($entity_type && $entity_id) {
+      return \Drupal::entityTypeManager()->getStorage($entity_type)->load($entity_id);
+    }
+    return NULL;
+  }
+
+}

--- a/modules/social_features/social_core/src/Plugin/Field/FieldWidget/ExternalIdentifierDefaultWidget.php
+++ b/modules/social_features/social_core/src/Plugin/Field/FieldWidget/ExternalIdentifierDefaultWidget.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\social_core\Plugin\Field\FieldWidget;
+
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Field\FieldDefinitionInterface;
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Field\WidgetBase;
+use Drupal\Core\Form\FormStateInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Defines the 'social_external_identifier_default_widget' field widget.
+ *
+ * @FieldWidget(
+ *   id = "social_external_identifier_default_widget",
+ *   label = @Translation("External Identifier Default"),
+ *   field_types = {"social_external_identifier"},
+ * )
+ */
+final class ExternalIdentifierDefaultWidget extends WidgetBase {
+
+  /**
+   * Constructs a new ExternalIdentifierDefaultWidget object.
+   *
+   * @param string $plugin_id
+   *   The plugin_id for the widget.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   * @param \Drupal\Core\Field\FieldDefinitionInterface $field_definition
+   *   The definition of the field to which the widget is associated.
+   * @param array $settings
+   *   The widget settings.
+   * @param array $third_party_settings
+   *   Any third party settings.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
+   *   The entity type manager service.
+   */
+  public function __construct(
+    $plugin_id,
+    $plugin_definition,
+    FieldDefinitionInterface $field_definition,
+    array $settings,
+    array $third_party_settings,
+    protected EntityTypeManagerInterface $entityTypeManager
+  ) {
+    parent::__construct($plugin_id, $plugin_definition, $field_definition, $settings, $third_party_settings);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $plugin_id,
+      $plugin_definition,
+      $configuration['field_definition'],
+      $configuration['settings'],
+      $configuration['third_party_settings'],
+      $container->get('entity_type.manager'),
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function formElement(FieldItemListInterface $items, $delta, array $element, array &$form, FormStateInterface $form_state): array {
+    $element['external_id'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('External ID'),
+      '#default_value' => $items[$delta]->external_id ?? NULL,
+      '#required' => FALSE,
+    ];
+
+    $element['external_owner_target_type'] = [
+      '#type' => 'select',
+      '#title' => $this->t('External Owner Target Type'),
+      '#options' => $this->getAllowedExternalOwnerTargetTypes(),
+      '#empty_value' => '',
+      '#default_value' => $items[$delta]->external_owner_target_type ?? NULL,
+      '#required' => FALSE,
+    ];
+
+    // @todo Ideally use entity_autocomplete, or something like provided by
+    //   dynamic_entity_reference. ATM this values will be mostly provided
+    //   programmatically, this is why UI/UX is not polished yet. Also
+    //   beside consumers entities, there are no other entity types to select
+    //   from, but we need to build it in a way that we can support more than
+    //   one entity type.
+    $element['external_owner_id'] = [
+      '#type' => 'number',
+      '#title' => $this->t('External Owner'),
+      '#default_value' => $items[$delta]->external_owner_id ?? NULL,
+      '#min' => 1,
+      '#required' => FALSE,
+    ];
+
+    return $element;
+  }
+
+  /**
+   * Returns list of allowed External Owner Entity Types.
+   *
+   * @return array
+   *   Returns an array of allowed target types, where key is target type
+   *   machine name and value is label.
+   */
+  protected function getAllowedExternalOwnerTargetTypes(): array {
+    $allowed_target_types = [];
+
+    $field_storage_definition = $this->fieldDefinition->getFieldStorageDefinition();
+    $storage_settings = $field_storage_definition->getSettings();
+    $target_types = $storage_settings['target_types'] ?? [];
+    foreach ($target_types as $target_type) {
+      $target_type_info = $this->entityTypeManager->getDefinition($target_type);
+      if (!empty($target_type_info)) {
+        $allowed_target_types[$target_type] = $target_type_info->getLabel();
+      }
+    }
+
+    return $allowed_target_types;
+  }
+
+}

--- a/modules/social_features/social_core/src/Plugin/Validation/Constraint/ExternalIdentifierEmptySubfieldsConstraint.php
+++ b/modules/social_features/social_core/src/Plugin/Validation/Constraint/ExternalIdentifierEmptySubfieldsConstraint.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Drupal\social_core\Plugin\Validation\Constraint;
+
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * Provides a custom constraint for external identifier field.
+ *
+ * Prevents field values from being saved if not all required subfield values
+ * are set. This can be either that all subfield values are empty, or that all
+ * subfield values are provided but partially filled subfield values are not
+ * allowed.
+ *
+ * @Constraint(
+ *   id = "ExternalIdentifierEmptySubfieldsConstraint",
+ *   label = @Translation("Makes sure that all required subfields values are set", context = "Validation"),
+ *   type = {"field"}
+ * )
+ */
+class ExternalIdentifierEmptySubfieldsConstraint extends Constraint {
+
+  /**
+   * The error message when all required subfield values are not set.
+   *
+   * @var string
+   */
+  public $requiredSubfieldsAreNotSet = 'Not all required subfields have been set. Please insert values for: %empty_required_subfield_list.';
+
+}

--- a/modules/social_features/social_core/src/Plugin/Validation/Constraint/ExternalIdentifierEmptySubfieldsConstraintValidator.php
+++ b/modules/social_features/social_core/src/Plugin/Validation/Constraint/ExternalIdentifierEmptySubfieldsConstraintValidator.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Drupal\social_core\Plugin\Validation\Constraint;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+
+/**
+ * Validates the ExternalIdentifierEmptySubfieldsConstraint constraint.
+ */
+class ExternalIdentifierEmptySubfieldsConstraintValidator extends ConstraintValidator {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function validate(mixed $item, Constraint $constraint) {
+    if (!$constraint instanceof ExternalIdentifierEmptySubfieldsConstraint) {
+      return;
+    }
+
+    $values = $item->getValue();
+    $empty_subfields = [];
+
+    foreach ($values as $key => $value) {
+      if ($value === '' or $value === NULL) {
+        $empty_subfields[] = $key;
+      }
+    }
+
+    // It is allowed that all fields are empty.
+    if (count($empty_subfields) === count($values)) {
+      return;
+    }
+
+    if (count($empty_subfields) > 0) {
+      // Add label beside subfield machine name.
+      $nice_subfield_labels = [];
+      foreach ($empty_subfields as $empty_subfield) {
+        $nice_subfield_labels[] = $item->getProperties()[$empty_subfield]->getDataDefinition()->getLabel() . ' (' . $empty_subfield . ')';
+      }
+      $this->context->addViolation($constraint->requiredSubfieldsAreNotSet, [
+        '%empty_required_subfield_list' => implode(', ', $nice_subfield_labels),
+      ]);
+    }
+
+  }
+
+}

--- a/modules/social_features/social_core/src/Plugin/Validation/Constraint/ExternalIdentifierExternalOwnerIdConstraint.php
+++ b/modules/social_features/social_core/src/Plugin/Validation/Constraint/ExternalIdentifierExternalOwnerIdConstraint.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Drupal\social_core\Plugin\Validation\Constraint;
+
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * Provides a custom constraint for external identifier field.
+ *
+ * Prevents field values from being saved if the external owner entity does not
+ * exist.
+ *
+ * @Constraint(
+ *   id = "ExternalIdentifierExternalOwnerIdConstraint",
+ *   label = @Translation("Makes sure that External Owner Entity exist", context = "Validation"),
+ *   type = {"field"}
+ * )
+ */
+class ExternalIdentifierExternalOwnerIdConstraint extends Constraint {
+  /**
+   * The error message when entity does not exist.
+   *
+   * @var string
+   */
+  public $nonexistentIdMessage = 'The entity of type "%entity_type" and ID "%entity_id" does not exist.';
+
+}

--- a/modules/social_features/social_core/src/Plugin/Validation/Constraint/ExternalIdentifierExternalOwnerIdConstraintValidator.php
+++ b/modules/social_features/social_core/src/Plugin/Validation/Constraint/ExternalIdentifierExternalOwnerIdConstraintValidator.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Drupal\social_core\Plugin\Validation\Constraint;
+
+use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+
+/**
+ * Validates the ExternalIdentifierExternalOwnerIdConstraint constraint.
+ */
+class ExternalIdentifierExternalOwnerIdConstraintValidator extends ConstraintValidator implements ContainerInjectionInterface {
+
+  /**
+   * Constructs a new ExternalIdentifierExternalOwnerIdConstraintValidator.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
+   *   The entity type manager service.
+   */
+  public function __construct(
+    protected EntityTypeManagerInterface $entityTypeManager
+  ) {
+
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container): static {
+    return new static(
+      $container->get('entity_type.manager')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function validate(mixed $item, Constraint $constraint) {
+    if (!$constraint instanceof ExternalIdentifierExternalOwnerIdConstraint) {
+      return;
+    }
+
+    $external_owner_target_type = $item->external_owner_target_type;
+    $external_owner_id = $item->external_owner_id;
+
+    // Nonexistent entity type validation is handled by
+    // ExternalIdentifierExternalOwnerTargetTypeConstraint.
+    if (!$this->entityTypeManager->hasDefinition($external_owner_target_type)) {
+      return;
+    }
+
+    // Empty entity id validation is handled by
+    // ExternalIdentifierEmptySubfieldsConstraint.
+    if (empty($external_owner_id)) {
+      return;
+    }
+
+    // Undefined target_types validation is handled by
+    // ExternalIdentifierExternalOwnerTargetTypeConstraint.
+    $target_types = $item->getFieldDefinition()->getFieldStorageDefinition()->getSettings()['target_types'] ?? [];
+    if (empty($target_types)) {
+      return;
+    }
+
+    $entity = $this->entityTypeManager->getStorage($external_owner_target_type)->load($external_owner_id);
+    if (empty($entity)) {
+      $this->context->addViolation($constraint->nonexistentIdMessage, [
+        '%entity_type' => $external_owner_target_type,
+        '%entity_id' => $external_owner_id,
+      ]);
+
+    }
+
+  }
+
+}

--- a/modules/social_features/social_core/src/Plugin/Validation/Constraint/ExternalIdentifierExternalOwnerTargetTypeConstraint.php
+++ b/modules/social_features/social_core/src/Plugin/Validation/Constraint/ExternalIdentifierExternalOwnerTargetTypeConstraint.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Drupal\social_core\Plugin\Validation\Constraint;
+
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * Provides a custom constraint for external identifier field.
+ *
+ * Prevents field values from being stored if the referenced target type is not
+ * on the list of allowed ones. The list of allowed ones is defined by the field
+ * storage configuration and may contain more than one allowed target type.
+ *
+ * @Constraint(
+ *   id = "ExternalIdentifierExternalOwnerTargetTypeConstraint",
+ *   label = @Translation("Makes sure that target type exist and is allowed", context = "Validation"),
+ *   type = {"field"}
+ * )
+ */
+class ExternalIdentifierExternalOwnerTargetTypeConstraint extends Constraint {
+
+  /**
+   * The error message when target type is not valid.
+   *
+   * @var string
+   */
+  public $invalidTargetTypeMessage = 'Target type "%invalid_target_type" is not valid. Valid target types are: "%allowed_target_types".';
+
+  /**
+   * The error message when target type does not exist.
+   *
+   * @var string
+   */
+  public $nonexistentTargetTypeMessage = 'The entity type "%entity_type" does not exist.';
+
+  /**
+   * The error message, when there are no target type is supported.
+   *
+   * @var string
+   */
+  public $noAvailableTargetTypes = 'Currently, there are no available target types (allowed entity types). Please contact the system administrator to enable at least one target type.';
+
+}

--- a/modules/social_features/social_core/src/Plugin/Validation/Constraint/ExternalIdentifierExternalOwnerTargetTypeConstraintValidator.php
+++ b/modules/social_features/social_core/src/Plugin/Validation/Constraint/ExternalIdentifierExternalOwnerTargetTypeConstraintValidator.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Drupal\social_core\Plugin\Validation\Constraint;
+
+use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+
+/**
+ * Validates the ExternalIdentifierExternalOwnerTargetTypeConstraint constraint.
+ */
+class ExternalIdentifierExternalOwnerTargetTypeConstraintValidator extends ConstraintValidator implements ContainerInjectionInterface {
+
+  /**
+   * Constructs a new constraint validator.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
+   *   The entity type manager service.
+   */
+  public function __construct(
+    protected EntityTypeManagerInterface $entityTypeManager
+  ) {
+
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container): static {
+    return new static(
+      $container->get('entity_type.manager'),
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function validate(mixed $item, Constraint $constraint) {
+    if (!$constraint instanceof ExternalIdentifierExternalOwnerTargetTypeConstraint) {
+      return;
+    }
+    $external_owner_target_type = $item->external_owner_target_type;
+
+    // Empty constraint is handled by
+    // ExternalIdentifierEmptySubfieldsConstraint.
+    if (empty($external_owner_target_type)) {
+      return;
+    }
+    // Check if entity type is on list of allowed external owner target types.
+    $field_storage_definition = $item->getFieldDefinition()->getFieldStorageDefinition();
+    $storage_settings = $field_storage_definition->getSettings();
+    $target_types = $storage_settings['target_types'] ?? [];
+
+    if (empty($target_types)) {
+      $this->context->addViolation($constraint->noAvailableTargetTypes);
+
+      // It does not make sense to continue validation, if the base requirement
+      // is not fulfilled.
+      return;
+    }
+
+    if (!in_array($external_owner_target_type, $target_types)) {
+      $this->context->addViolation($constraint->invalidTargetTypeMessage, [
+        '%invalid_target_type' => $external_owner_target_type,
+        '%allowed_target_types' => implode(', ', array_keys($target_types)),
+      ]);
+    }
+
+    // Check if the entity type exists (this is triggered only if entity type is
+    // listed on allowed external owner target types list, while entity type
+    // does not exist as such.
+    if (!$this->entityTypeManager->hasDefinition($external_owner_target_type)) {
+      $this->context->addViolation($constraint->nonexistentTargetTypeMessage, ['%entity_type' => $external_owner_target_type]);
+    }
+  }
+
+}

--- a/modules/social_features/social_core/tests/modules/social_core_test_entity_provider/social_core_test_entity_provider.info.yml
+++ b/modules/social_features/social_core/tests/modules/social_core_test_entity_provider/social_core_test_entity_provider.info.yml
@@ -1,0 +1,8 @@
+name: "Social Core Entity Provider"
+type: module
+description: "A provider of an entity type."
+package: Testing
+core_version_requirement: ^10 || ^11
+hidden: TRUE
+dependencies:
+  - drupal:entity_test

--- a/modules/social_features/social_core/tests/modules/social_core_test_entity_provider/src/Entity/ExternalOwnerEntityTestProvider.php
+++ b/modules/social_features/social_core/tests/modules/social_core_test_entity_provider/src/Entity/ExternalOwnerEntityTestProvider.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Drupal\social_core_test_entity_provider\Entity;
+
+use Drupal\entity_test\Entity\EntityTest;
+
+/**
+ * Defines the External Owner Test entity.
+ *
+ * @ContentEntityType(
+ *   id = "test_external_owner_entity",
+ *   label = @Translation("Test External Owner Entity"),
+ *   entity_keys = {
+ *     "uuid" = "uuid",
+ *     "id" = "id",
+ *     "label" = "name",
+ *   }
+ * )
+ */
+class ExternalOwnerEntityTestProvider extends EntityTest {
+
+}

--- a/modules/social_features/social_core/tests/src/Kernel/ExternalIdFieldTypeTest.php
+++ b/modules/social_features/social_core/tests/src/Kernel/ExternalIdFieldTypeTest.php
@@ -1,0 +1,399 @@
+<?php
+
+namespace Drupal\Tests\social_core\Kernel;
+
+use Drupal\Core\Field\FieldStorageDefinitionInterface;
+use Drupal\field\Entity\FieldConfig;
+use Drupal\field\Entity\FieldStorageConfig;
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\node\Entity\Node;
+use Drupal\node\Entity\NodeType;
+use Drupal\social_core_test_entity_provider\Entity\ExternalOwnerEntityTestProvider;
+
+/**
+ * Tests the social_external_identifier field type.
+ *
+ * @group social_external_identifier
+ */
+class ExternalIdFieldTypeTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'node',
+    'field',
+    'user',
+    'system',
+    'text',
+    'entity_test',
+    'social_core_test_entity_provider',
+    'social_core',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $this->installEntitySchema('node');
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('test_external_owner_entity');
+    $this->installConfig(['field', 'node', 'user']);
+
+    // Create a node type.
+    $node_type = NodeType::create([
+      'type' => 'test',
+      'name' => 'Test',
+    ]);
+    $node_type->save();
+
+    // Create the field storage.
+    $field_storage_field_social_external_identifier = FieldStorageConfig::create([
+      'field_name' => 'field_social_external_identifier',
+      'entity_type' => 'node',
+      'type' => 'social_external_identifier',
+      'settings' => [
+        'target_types' => [
+          'test_external_owner_entity' => 'test_external_owner_entity',
+        ],
+      ],
+      'cardinality' => FieldStorageDefinitionInterface::CARDINALITY_UNLIMITED,
+    ]);
+    $field_storage_field_social_external_identifier->save();
+    // Create the field.
+    $field_field_social_external_identifier = FieldConfig::create([
+      'field_storage' => $field_storage_field_social_external_identifier,
+      'bundle' => 'test',
+      'label' => 'External Identifier example',
+    ]);
+    $field_field_social_external_identifier->save();
+
+    // Create the field storage for field without target types defined.
+    $field_storage_field_sei_no_target_types = FieldStorageConfig::create([
+      // `sei` stands for social_external_identifier.
+      'field_name' => 'field_sei_no_target_types',
+      'entity_type' => 'node',
+      'type' => 'social_external_identifier',
+      'settings' => [
+        'target_types' => [],
+      ],
+      'cardinality' => FieldStorageDefinitionInterface::CARDINALITY_UNLIMITED,
+    ]);
+    $field_storage_field_sei_no_target_types->save();
+    // Create the field.
+    $field_field_storage_field_sei_no_target_types = FieldConfig::create([
+      'field_storage' => $field_storage_field_sei_no_target_types,
+      'bundle' => 'test',
+      'label' => 'External Identifier example',
+    ]);
+    $field_field_storage_field_sei_no_target_types->save();
+  }
+
+  // TOC
+  //
+  // Configuration:
+  // Case 0: Test external identifier field settings.
+  //
+  // Field:
+  // Case 1: Create a node with the external identifier field values.
+  // Case 2: Create a node without the external identifier field values.
+  // Case 3: Create a node with the external identifier field with NULL values.
+  // Case 4: Create a node with the external identifier field with empty values.
+  //
+  // Constraints:
+  // Case 5: Without the external_id subfield value provided.
+  // Case 6: Without the external_owner_target_type subfield value provided.
+  // Case 7: Without the external_owner_id subfield value provided.
+  // Case 8: Not allowed target type.
+  // Case 9: Invalid target type.
+  // Case 10: Target types are not defined.
+
+  /**
+   * Case 0: Test external identifier field settings.
+   *
+   * Tests that the social_external_identifier settings are correctly applied.
+   */
+  public function testFieldSettings(): void {
+    // Load the field storage configuration and verify settings.
+    /** @var \Drupal\field\FieldStorageConfigInterface $field_storage */
+    $field_storage = FieldStorageConfig::loadByName('node', 'field_social_external_identifier');
+    $this->assertEquals(['test_external_owner_entity' => 'test_external_owner_entity'], $field_storage->getSettings()['target_types']);
+  }
+
+  /**
+   * Case 1: Create a node with the external identifier field.
+   *
+   * Tests that the external identifier field values can be added to a node and
+   * that values are stored correctly.
+   */
+  public function testExternalIdentifierFieldType(): void {
+    $test_owner_entity = ExternalOwnerEntityTestProvider::create([
+      'name' => 'External Owner Entity Example',
+    ]);
+    $test_owner_entity->save();
+
+    $node = Node::create([
+      'type' => 'test',
+      'title' => 'Test node',
+      'field_social_external_identifier' => [
+        'external_id' => '123-456-789-abc-def',
+        'external_owner_target_type' => 'test_external_owner_entity',
+        'external_owner_id' => '1',
+      ],
+    ]);
+    $node->save();
+
+    // Reload the node and check the field values.
+    /** @var \Drupal\node\Entity\Node $node */
+    $node = Node::load($node->id());
+    /** @var \Drupal\social_core\Plugin\Field\FieldType\ExternalIdentifierItem $field */
+    $field = $node->get('field_social_external_identifier')->first();
+
+    $this->assertEquals('123-456-789-abc-def', $field->get('external_id')->getValue());
+    $this->assertEquals('test_external_owner_entity', $field->get('external_owner_target_type')->getValue());
+    $this->assertEquals('1', $field->get('external_owner_id')->getValue());
+
+    // Check that the entity can be loaded via magic method.
+    $entity = $field->getExternalOwnerEntity();
+    $this->assertInstanceOf('Drupal\Core\Entity\EntityInterface', $entity);
+    $this->assertInstanceOf('Drupal\social_core_test_entity_provider\Entity\ExternalOwnerEntityTestProvider', $entity);
+    $this->assertEquals('External Owner Entity Example', $entity->getName());
+  }
+
+  /**
+   * Case 2: Create a node without the external identifier field.
+   *
+   * Tests that the external identifier field values can be omitted when
+   * creating a node, and that not defining these values does not cause
+   * any errors.
+   */
+  public function testNodeWithoutExternalIdentifierFieldType(): void {
+    $node_without_external_identifier = Node::create([
+      'type' => 'test',
+      'title' => 'Test node',
+    ]);
+    $violations = $node_without_external_identifier->validate();
+    $this->assertCount(0, $violations);
+  }
+
+  /**
+   * Case 3: Create a node with the external identifier field with NULL values.
+   *
+   * Test that the external identifier field values with subfield values set to
+   * NULL do not cause errors.
+   */
+  public function testNodeWithNullValuesOnExternalIdentifierFieldType(): void {
+    $node_with_null_external_identifier = Node::create([
+      'type' => 'test',
+      'title' => 'Test node',
+      'field_social_external_identifier' => [
+        'external_id' => NULL,
+        'external_owner_target_type' => NULL,
+        'external_owner_id' => NULL,
+      ],
+    ]);
+    $violations_null = $node_with_null_external_identifier->validate();
+    $this->assertCount(0, $violations_null);
+  }
+
+  /**
+   * Case 4: Create a node with the external identifier field with empty values.
+   *
+   * Verify that the external identifier field values with subfield values set
+   * to empty do not cause errors.
+   */
+  public function testNodeWithEmptyValuesOnExternalIdentifierFieldType(): void {
+    // Case 4: Create a node with the external identifier field with subfield
+    // values set as empty string.
+    $node_with_empty_external_identifier = Node::create([
+      'type' => 'test',
+      'title' => 'Test node',
+      'field_social_external_identifier' => [
+        'external_id' => '',
+        'external_owner_target_type' => '',
+        'external_owner_id' => '',
+      ],
+    ]);
+    $violations_empty = $node_with_empty_external_identifier->validate();
+    $this->assertCount(0, $violations_empty);
+  }
+
+  /**
+   * Case 5: Without the external_id subfield value provided.
+   *
+   * Tests that constraints ExternalIdentifierEmptySubfieldsConstraint and
+   * NotNullConstraint are triggered when external_id subfield value is not
+   * provided.
+   */
+  public function testConstraintForExternalIdentifierFieldTypeWithoutExternalId(): void {
+    $test_owner_entity = ExternalOwnerEntityTestProvider::create([
+      'name' => 'External Owner Entity Example',
+    ]);
+    $test_owner_entity->save();
+
+    // Create a node with external identifier field, but without the external_id
+    // subfield.
+    $node = Node::create([
+      'type' => 'test',
+      'title' => 'Test node',
+      'field_social_external_identifier' => [
+        'external_owner_target_type' => 'test_external_owner_entity',
+        'external_owner_id' => '1',
+      ],
+    ]);
+    $violations = $node->validate();
+    $this->assertCount(2, $violations);
+    $this->assertInstanceOf('Drupal\social_core\Plugin\Validation\Constraint\ExternalIdentifierEmptySubfieldsConstraint', $violations->get(0)->getConstraint());
+    /** @var \Drupal\Core\StringTranslation\TranslatableMarkup; $message_1 */
+    $message_1 = $violations->get(0)->getMessage();
+    $this->assertSame('Not all required subfields have been set. Please insert values for: <em class="placeholder">External ID (external_id)</em>.', $message_1->render());
+    $this->assertInstanceOf('Drupal\Core\Validation\Plugin\Validation\Constraint\NotNullConstraint', $violations->get(1)->getConstraint());
+    /** @var \Drupal\Core\StringTranslation\TranslatableMarkup; $message_2 */
+    $message_2 = $violations->get(1)->getMessage();
+    $this->assertSame('This value should not be null.', $message_2->render());
+  }
+
+  /**
+   * Case 6: Without the external_owner_target_type subfield value provided.
+   *
+   * Tests that constraint ExternalIdentifierEmptySubfieldsConstraint is
+   * triggered when external_id subfield value is not provided.
+   */
+  public function testConstraintForExternalIdentifierFieldTypeWithoutExternalOwnerTargetType(): void {
+    // Create a node with external identifier field, but without the
+    // external_owner_target_type subfield.
+    $node = Node::create([
+      'type' => 'test',
+      'title' => 'Test node',
+      'field_social_external_identifier' => [
+        'external_id' => '123-456-789-abc-def',
+        'external_owner_id' => '1',
+      ],
+    ]);
+    $violations = $node->validate();
+    $this->assertCount(1, $violations);
+    $this->assertInstanceOf('Drupal\social_core\Plugin\Validation\Constraint\ExternalIdentifierEmptySubfieldsConstraint', $violations->get(0)->getConstraint());
+    /** @var \Drupal\Core\StringTranslation\TranslatableMarkup; $message */
+    $message = $violations->get(0)->getMessage();
+    $this->assertSame('Not all required subfields have been set. Please insert values for: <em class="placeholder">Target Entity Type (external_owner_target_type)</em>.', $message->render());
+  }
+
+  /**
+   * Case 7: Without the external_owner_id subfield value provided.
+   *
+   * Tests that constraints ExternalIdentifierEmptySubfieldsConstraint and
+   * NotNullConstraint are triggered when external_owner_id subfield value is
+   * not provided.
+   */
+  public function testConstraintForExternalIdentifierFieldTypeWithoutExternalOwnerId():void {
+    // Create a node with external identifier field, but without the
+    // external_owner_id subfield.
+    $node = Node::create([
+      'type' => 'test',
+      'title' => 'Test node',
+      'field_social_external_identifier' => [
+        'external_id' => '123-456-789-abc-def',
+        'external_owner_target_type' => 'test_external_owner_entity',
+      ],
+    ]);
+    $violations = $node->validate();
+    $this->assertCount(2, $violations);
+    $this->assertInstanceOf('Drupal\social_core\Plugin\Validation\Constraint\ExternalIdentifierEmptySubfieldsConstraint', $violations->get(0)->getConstraint());
+    /** @var \Drupal\Core\StringTranslation\TranslatableMarkup; $message_1 */
+    $message_1 = $violations->get(0)->getMessage();
+    $this->assertSame('Not all required subfields have been set. Please insert values for: <em class="placeholder">External Owner (external_owner_id)</em>.', $message_1->render());
+    $this->assertInstanceOf('Drupal\Core\Validation\Plugin\Validation\Constraint\NotNullConstraint', $violations->get(1)->getConstraint());
+    /** @var \Drupal\Core\StringTranslation\TranslatableMarkup; $message_2 */
+    $message_2 = $violations->get(1)->getMessage();
+    $this->assertSame('This value should not be null.', $message_2->render());
+  }
+
+  /**
+   * Case 8: Not allowed target type.
+   *
+   * Tests that constraints ExternalIdentifierExternalOwnerTargetTypeConstraint
+   * and ExternalIdentifierExternalOwnerIdConstraint are triggered when not
+   * allowed target type is provided on external_owner_target_type subfield.
+   */
+  public function testConstraintForExternalIdentifierFieldTypeWithNotAllowedTargetType():void {
+    $node = Node::create([
+      'type' => 'test',
+      'title' => 'Test node',
+      'field_social_external_identifier' => [
+        'external_id' => '123-456-789-abc-def',
+        // Target type exist, but is not allowed.
+        'external_owner_target_type' => 'node',
+        'external_owner_id' => '1',
+      ],
+    ]);
+    $violations = $node->validate();
+    $this->assertCount(2, $violations);
+    $this->assertInstanceOf('Drupal\social_core\Plugin\Validation\Constraint\ExternalIdentifierExternalOwnerTargetTypeConstraint', $violations->get(0)->getConstraint());
+    /** @var \Drupal\Core\StringTranslation\TranslatableMarkup; $message_1 */
+    $message_1 = $violations->get(0)->getMessage();
+    $this->assertSame('Target type "<em class="placeholder">node</em>" is not valid. Valid target types are: "<em class="placeholder">test_external_owner_entity</em>".', $message_1->render());
+    $this->assertInstanceOf('Drupal\social_core\Plugin\Validation\Constraint\ExternalIdentifierExternalOwnerIdConstraint', $violations->get(1)->getConstraint());
+    /** @var \Drupal\Core\StringTranslation\TranslatableMarkup; $message_2 */
+    $message_2 = $violations->get(1)->getMessage();
+    $this->assertSame('The entity of type "<em class="placeholder">node</em>" and ID "<em class="placeholder">1</em>" does not exist.', $message_2->render());
+  }
+
+  /**
+   * Case 9: Invalid target type.
+   *
+   * Tests that constraint ExternalIdentifierExternalOwnerTargetTypeConstraint
+   * is triggered when invalid target type is provided on
+   * external_owner_target_type subfield.
+   */
+  public function testConstraintForExternalIdentifierFieldTypeWithInvalidTargetType():void {
+    $node = Node::create([
+      'type' => 'test',
+      'title' => 'Test node',
+      'field_social_external_identifier' => [
+        'external_id' => '123-456-789-abc-def',
+        // Target type does not exist.
+        'external_owner_target_type' => 'wrong_target_type',
+        'external_owner_id' => '1',
+      ],
+    ]);
+    $violations = $node->validate();
+    $this->assertCount(2, $violations);
+    $this->assertInstanceOf('Drupal\social_core\Plugin\Validation\Constraint\ExternalIdentifierExternalOwnerTargetTypeConstraint', $violations->get(0)->getConstraint());
+    /** @var \Drupal\Core\StringTranslation\TranslatableMarkup; $message_1 */
+    $message_1 = $violations->get(0)->getMessage();
+    $this->assertSame('Target type "<em class="placeholder">wrong_target_type</em>" is not valid. Valid target types are: "<em class="placeholder">test_external_owner_entity</em>".', $message_1->render());
+    $this->assertInstanceOf('Drupal\social_core\Plugin\Validation\Constraint\ExternalIdentifierExternalOwnerTargetTypeConstraint', $violations->get(1)->getConstraint());
+    /** @var \Drupal\Core\StringTranslation\TranslatableMarkup; $message_2 */
+    $message_2 = $violations->get(1)->getMessage();
+    $this->assertSame('The entity type "<em class="placeholder">wrong_target_type</em>" does not exist.', $message_2->render());
+  }
+
+  /**
+   * Case 10: Target types are not defined.
+   *
+   * Tests that constraint ExternalIdentifierExternalOwnerTargetTypeConstraint
+   * is triggered when target types are not defined in field storage
+   * configuration.
+   */
+  public function testConstraintForExternalIdentifierFieldTypeWhenTargetTypesAreNotDefined():void {
+    $node = Node::create([
+      'type' => 'test',
+      'title' => 'Test node',
+      'field_sei_no_target_types' => [
+        'external_id' => '123-456-789-abc-def',
+        // Target types are not defined in field storage configuration.
+        'external_owner_target_type' => 'test_external_owner_entity',
+        'external_owner_id' => '1',
+      ],
+    ]);
+    $violations = $node->validate();
+    $this->assertCount(1, $violations);
+    $this->assertInstanceOf('Drupal\social_core\Plugin\Validation\Constraint\ExternalIdentifierExternalOwnerTargetTypeConstraint', $violations->get(0)->getConstraint());
+    /** @var \Drupal\Core\StringTranslation\TranslatableMarkup; $message_1 */
+    $message_1 = $violations->get(0)->getMessage();
+    $this->assertSame('Currently, there are no available target types (allowed entity types). Please contact the system administrator to enable at least one target type.', $message_1->render());
+  }
+
+}


### PR DESCRIPTION
## Problem
As a developer I want a re-usable externalId implementation so that I can easily apply this to different entity types.

SCIM provides [the concept of externalId](https://datatracker.ietf.org/doc/html/rfc7643#section-3.1) which can be used to identify a resource with an identifier that is known to the SCIM client. This prevents the SCIM client from having to store a mapping between its internal data and our ID, instead putting that burden on us as a service provider.

Although not covered by SCIM itself, it provides various [recommendations for multi-tenancy](https://datatracker.ietf.org/doc/html/rfc7644#section-6) where multiple external systems may want to manage their own user data. Given our intention of targeting Enterprise users it’s likely that they’ll want to connect multiple systems to Open Social (e.g. managing users within their organization). We’ll want to combine this with SCIM’s [privacy recommendations](https://datatracker.ietf.org/doc/html/rfc7643#section-9.3) and determine how we want to handle the externalId.

We’ll want to decide whether we want to support multiple external systems managing the same user. This may be desired for migrations or when we need to pull data from multiple systems that might overlap and want to de-duplicate users. We use this ourselves in our Private Packagist where a developer can login with either Bitbucket or GitHub and user groups are managed through both (until we fully move to GitHub).

Regardless of our support for shared management of resources we’ll want to make sure that our externalId is tied to the system that created the user. This ensures that if multiple systems can only manage their own users they don’t run into conflicts (e.g. because they both have an externalId of user:5 which represent their own 5th users).

**Acceptance Criteria**
- An externalId field type which has sub-data of
  - external_id (string)
  - ~external_owner (entity_reference → blank by default)~
  - external_owner_target (string)
  - external_owner_id (int)
- Multi-valued (cardinality unlimited)
- Optional ~(default NULL)~ (default is empty, no record in database)
- The field type exists in the distribution
- When SCIM is enabled external_owner reference config is changed to allow consumer as target (this can be configured via field storage configuration)
- The field type is added to the user entity in ~the distribution~ enterprise version of Open Social.
- It’s easy to re-use this field on other entity types (e.g. group or organization)

## Solution
- Create new field type with 3 subfields:
  - External ID (external_id, string)
  - External Owner Target type (external_owner_target_type, string)
  - External Owner ID (external_owner_id, integer)
- In the field storage settings, it can be determined which entity types can be referenced.
- Field provides method `getExternalOwnerEntity()`, which returns an entity object based on External Owner Target type and External Owner ID

Decision records why we did not used dynamic entity reference / core entity reference field are in PROD-29703

## Issue tracker
- [3457487](https://www.drupal.org/project/social/issues/3457487)
- PROD-29703
- IOSAP-457

## How to use field
- Add external field type to any entity as any other regular field
- In field storage settings define which entities can be referenced as external owners
- in case that field values are managed programatically, do not forget to use `validate()` method on field/entity before saving, because most of the business logic needed for correct behaviour is validated with constraints and constraints are not triggered without field/entity validation.

## Theme issue tracker
N/A

## How to test
- [ ] As a developer I should be able to apply/use this field on any entity type.
- [ ] As a developer I should be able to apply single or multiple external ides per entity type.
- [ ] As a developer I should be able to select which target entity types (external owners) are supported per each field.
- [ ] As a developer I should be able to use this field via UI or as hidden field.
- [ ] As a user or developer I should be able to save this fields with all subfields values empty
- [ ] As a user or developer I should not be able to save this field if any subfield value is missing (except if all are empty)

## Screenshots
![Screenshot 2024-06-27 at 08 18 41](https://github.com/goalgorilla/open_social/assets/13753184/b7660e90-1147-441c-8f3e-9df7217fe376)
![Screenshot 2024-06-27 at 08 18 52](https://github.com/goalgorilla/open_social/assets/13753184/224f906e-f556-44a3-b747-812c076238ff)
![Screenshot 2024-06-27 at 08 19 29](https://github.com/goalgorilla/open_social/assets/13753184/66eb705f-bd3e-4c12-9ee6-78b37d9b5549)
![Screenshot 2024-06-27 at 08 19 50](https://github.com/goalgorilla/open_social/assets/13753184/6ef175ef-e702-4608-9349-74bb5b888a12)


## Release notes
Provides re-usable externalId implementation, that can be easily applied to different entity types.

## Change Record
N/A

## Translations
N/A
