### PR TITLE
Issue #3456218: Revoke Administer taxonomy permission for SM

### DIFF
--- a/modules/social_features/social_content_report/social_content_report.install
+++ b/modules/social_features/social_content_report/social_content_report.install
@@ -78,6 +78,9 @@ function social_content_report_install() {
       'view inappropriate reports',
       'close inappropriate reports',
       'administer social_content_report settings',
+      'create terms in report_reasons',
+      'delete terms in report_reasons',
+      'edit terms in report_reasons',
     ]
   );
 }
@@ -87,4 +90,16 @@ function social_content_report_install() {
  */
 function social_content_report_update_last_removed() : int {
   return 11401;
+}
+
+/**
+ * Grant permissions to manage report_reasons terms for sitemanager.
+ */
+function social_content_report_update_130001(): void {
+  $permissions = [
+    'create terms in report_reasons',
+    'delete terms in report_reasons',
+    'edit terms in report_reasons',
+  ];
+  user_role_grant_permissions('sitemanager', $permissions);
 }

--- a/modules/social_features/social_core/social_core.install
+++ b/modules/social_features/social_core/social_core.install
@@ -86,7 +86,6 @@ function social_core_install() {
       'access toolbar',
       'administer nodes',
       'administer menu',
-      'administer taxonomy',
       'access site reports',
       'access administration pages',
       'view all revisions',
@@ -530,4 +529,11 @@ function social_core_update_130007(): void {
 
   // Change file_managed table only files from field_file field.
   \Drupal::database()->query("UPDATE {file_managed} SET {file_managed}.uri = REPLACE({file_managed}.uri, 'secret://', 'private://') WHERE fid IN (SELECT {node__field_files}.field_files_target_id FROM {node__field_files})");
+}
+
+/**
+ * Revoke administer taxonomy permission for sitemanager.
+ */
+function social_core_update_130008(): void {
+  user_role_revoke_permissions('sitemanager', ['administer taxonomy']);
 }

--- a/modules/social_features/social_profile/modules/social_profile_fields/social_profile_fields.install
+++ b/modules/social_features/social_profile/modules/social_profile_fields/social_profile_fields.install
@@ -20,6 +20,14 @@ function social_profile_fields_install() {
   _social_profile_fields_update_search_index();
   _social_profile_fields_update_search_index('social_all');
   _social_profile_fields_nationalities();
+
+  $permissions = [
+    'create terms in nationality',
+    'delete terms in nationality',
+    'edit terms in nationality',
+  ];
+  user_role_grant_permissions('sitemanager', $permissions);
+
 }
 
 /**
@@ -140,4 +148,16 @@ function social_profile_fields_update_121001(): void {
       $role->save();
     }
   }
+}
+
+/**
+ * Grant permissions to manage nationality terms for sitemanager.
+ */
+function social_profile_fields_update_130001(): void {
+  $permissions = [
+    'create terms in nationality',
+    'delete terms in nationality',
+    'edit terms in nationality',
+  ];
+  user_role_grant_permissions('sitemanager', $permissions);
 }


### PR DESCRIPTION
## Problem
Currently we allow Site Managers to create, edit and translate taxonomy vocabularies in the taxonomy overview page at `/admin/structure/taxonomy`

These actions are not supported by our frontend so the changes applied to the vocabularies have no effect in the platform.

This generates confusion and it is hard to explain to Community Managers why this is happening.
We have decided to remove these unused options and present a more functional experience to our customers.

## Solution

- Revoke permission `administer taxonomy` from the site manager.
- Grant permissions to manage terms in all vocabularies.

## Issue tracker

- https://getopensocial.atlassian.net/browse/PROD-27327
- https://getopensocial.atlassian.net/browse/PROD-29643
- https://www.drupal.org/project/social/issues/3444592

## Theme issue tracker
N/A

## How to test

- [ ] As a Site Manager go to /admin/structure/taxonomy
- [ ] Site Managers are no longer able to edit or add taxonomy vocabularies
- [ ] Site Manager can still perform all the other actions (Add terms, Edit term, Delete term)


## Screenshots
N/A

## Release notes
Remove unsupported functionality for taxonomy vocabularies.

Currently we allow Site Managers to create, edit and translate taxonomy vocabularies in the taxonomy overview page at `/admin/structure/taxonomy`

These actions are not supported by our frontend so the changes applied to the vocabularies have no effect in the platform.

This generates confusion and it is hard to explain to Community Managers why this is happening.
We have decided to remove these unused options and present a more functional experience to our customers.

## Change Record
A related change record for Drupal Core:
- https://www.drupal.org/node/2902390

## Translations
N/A
