### PR TITLE
Issue #3456839: Different authors between content and activity

### DIFF
--- a/modules/social_features/social_activity/config/install/message.template.create_content_in_joined_group.yml
+++ b/modules/social_features/social_activity/config/install/message.template.create_content_in_joined_group.yml
@@ -24,13 +24,13 @@ label: 'Create a post, topic or event in a joined group'
 description: 'A person created a post, event or topic in a group I joined'
 text:
   -
-    value: "<p><a href=\"[message:author:url:absolute]\">[message:author:display-name]</a> created [social_group:created_entity_link_html] in the <a href=\"[message:gurl]\">[message:gtitle]</a> group [message:count_groups_per_node]</p>\r\n"
+    value: "<p><a href=\"[message:revision_author:url:absolute]\">[message:revision_author:display-name]</a> created [social_group:created_entity_link_html] in the <a href=\"[message:gurl]\">[message:gtitle]</a> group [message:count_groups_per_node]</p>\r\n"
     format: full_html
   -
-    value: "<p><a href=\"[message:author:url:absolute]\">[message:author:display-name]</a> created [social_group:created_entity_link_html] in the <a href=\"[message:gurl]\">[message:gtitle]</a> group [message:count_groups_per_node]</p>\r\n"
+    value: "<p><a href=\"[message:revision_author:url:absolute]\">[message:revision_author:display-name]</a> created [social_group:created_entity_link_html] in the <a href=\"[message:gurl]\">[message:gtitle]</a> group [message:count_groups_per_node]</p>\r\n"
     format: full_html
   -
-    value: "<p><a href=\"[message:author:url:absolute]\">[message:author:display-name]</a> published [social_group:content_type] in the <a href=\"[message:gurl]\">[message:gtitle]</a> group [message:count_groups_per_node] you are member of:</p>\r\n\r\n<p>[message:preview]</p>\r\n\r\n<p>[message:cta_button]</p>\r\n"
+    value: "<p><a href=\"[message:revision_author:url:absolute]\">[message:revision_author:display-name]</a> published [social_group:content_type] in the <a href=\"[message:gurl]\">[message:gtitle]</a> group [message:count_groups_per_node] you are member of:</p>\r\n\r\n<p>[message:preview]</p>\r\n\r\n<p>[message:cta_button]</p>\r\n"
     format: full_html
 settings:
   'token options':

--- a/modules/social_features/social_activity/config/install/message.template.create_event_community.yml
+++ b/modules/social_features/social_activity/config/install/message.template.create_event_community.yml
@@ -23,7 +23,7 @@ description: 'A user created an event in the community'
 text:
   -
     format: full_html
-    value: '<p><a href="[message:author:url:absolute]">[message:author:display-name]</a> created an event</p>'
+    value: '<p><a href="[message:revision_author:url:absolute]">[message:revision_author:display-name]</a> created an event</p>'
 settings:
   'token options':
     clear: false

--- a/modules/social_features/social_activity/config/install/message.template.create_event_gc.yml
+++ b/modules/social_features/social_activity/config/install/message.template.create_event_gc.yml
@@ -20,7 +20,7 @@ label: 'Create event as group content'
 description: 'A user add (create) a event to a group (or groups)'
 text:
   -
-    value: '<p><a href="[message:author:url:absolute]">[message:author:display-name]</a> created an event in <a href="[message:gurl]">[message:gtitle]</a></p>'
+    value: '<p><a href="[message:revision_author:url:absolute]">[message:revision_author:display-name]</a> created an event in <a href="[message:gurl]">[message:gtitle]</a></p>'
     format: basic_html
 settings:
   'token options':

--- a/modules/social_features/social_activity/config/install/message.template.create_event_group.yml
+++ b/modules/social_features/social_activity/config/install/message.template.create_event_group.yml
@@ -24,7 +24,7 @@ description: 'A user created an event in a group'
 text:
   -
     format: full_html
-    value: '<p><a href="[message:author:url:absolute]">[message:author:display-name]</a> created an event in <a href="[message:gurl]">[message:gtitle]</a> [message:count_groups_per_node]</p>'
+    value: '<p><a href="[message:revision_author:url:absolute]">[message:revision_author:display-name]</a> created an event in <a href="[message:gurl]">[message:gtitle]</a> [message:count_groups_per_node]</p>'
 settings:
   'token options':
     clear: false

--- a/modules/social_features/social_activity/config/install/message.template.create_topic_community.yml
+++ b/modules/social_features/social_activity/config/install/message.template.create_topic_community.yml
@@ -23,7 +23,7 @@ description: 'A user created a topic in the community'
 text:
   -
     format: full_html
-    value: '<p><a href="[message:author:url:absolute]">[message:author:display-name]</a> created a topic</p>'
+    value: '<p><a href="[message:revision_author:url:absolute]">[message:revision_author:display-name]</a> created a topic</p>'
 settings:
   'token options':
     clear: false

--- a/modules/social_features/social_activity/config/install/message.template.create_topic_gc.yml
+++ b/modules/social_features/social_activity/config/install/message.template.create_topic_gc.yml
@@ -20,7 +20,7 @@ label: 'Create topic as group content'
 description: 'A user add (create) a topic to a group (or groups)'
 text:
   -
-    value: '<p><a href="[message:author:url:absolute]">[message:author:display-name]</a> created a topic in <a href="[message:gurl]">[message:gtitle]</a></p>'
+    value: '<p><a href="[message:revision_author:url:absolute]">[message:revision_author:display-name]</a> created a topic in <a href="[message:gurl]">[message:gtitle]</a></p>'
     format: basic_html
 settings:
   'token options':

--- a/modules/social_features/social_activity/config/install/message.template.create_topic_group.yml
+++ b/modules/social_features/social_activity/config/install/message.template.create_topic_group.yml
@@ -24,7 +24,7 @@ description: 'A user created a topic in a group'
 text:
   -
     format: full_html
-    value: '<p><a href="[message:author:url:absolute]">[message:author:display-name]</a> created a topic in <a href="[message:gurl]">[message:gtitle]</a> [message:count_groups_per_node]</p>'
+    value: '<p><a href="[message:revision_author:url:absolute]">[message:revision_author:display-name]</a> created a topic in <a href="[message:gurl]">[message:gtitle]</a> [message:count_groups_per_node]</p>'
 settings:
   'token options':
     clear: false

--- a/modules/social_features/social_activity/social_activity.install
+++ b/modules/social_features/social_activity/social_activity.install
@@ -71,3 +71,32 @@ function social_activity_update_13000(): ?string {
   // Output logged messages to related channel of update execution.
   return $updateHelper->logger()->output();
 }
+
+/**
+ * Change token-replacement from create message template.
+ */
+function social_activity_update_13001(): void {
+  $message_templates = [
+    'message.template.create_topic_community',
+    'message.template.create_topic_gc',
+    'message.template.create_topic_group',
+    'message.template.create_event_group',
+    'message.template.create_event_gc',
+    'message.template.create_event_community',
+    'message.template.create_content_in_joined_group',
+  ];
+
+  $config_factory = \Drupal::configFactory();
+  foreach ($message_templates as $message_template) {
+    $config = $config_factory->getEditable($message_template);
+
+    $texts = array_map(function ($text) {
+      $text['value'] = str_replace('message:author', 'message:revision_author', $text['value']);
+
+      return $text;
+    }, $config->get('text'));
+
+    $config->set('text', $texts)
+      ->save();
+  }
+}

--- a/modules/social_features/social_activity/social_activity.tokens.inc
+++ b/modules/social_features/social_activity/social_activity.tokens.inc
@@ -174,7 +174,7 @@ function social_activity_tokens($type, $tokens, array $data, array $options, Bub
             ->load($related_object_value['target_id']);
           if (
             empty($related_object_content)
-            || !$related_object_content instanceof NodeInterface
+            || !method_exists($related_object_content, 'getOwner')
           ) {
             return $replacements;
           }

--- a/modules/social_features/social_activity/social_activity.tokens.inc
+++ b/modules/social_features/social_activity/social_activity.tokens.inc
@@ -172,7 +172,10 @@ function social_activity_tokens($type, $tokens, array $data, array $options, Bub
           $related_object_content = \Drupal::entityTypeManager()
             ->getStorage($related_object_value['target_type'])
             ->load($related_object_value['target_id']);
-          if (empty($related_object_content)) {
+          if (
+            empty($related_object_content)
+            || !$related_object_content instanceof NodeInterface
+          ) {
             return $replacements;
           }
 

--- a/modules/social_features/social_activity/social_activity.tokens.inc
+++ b/modules/social_features/social_activity/social_activity.tokens.inc
@@ -37,6 +37,11 @@ function social_activity_token_info() {
     'description' => t('Number of groups where node is added.'),
   ];
 
+  $tokens['revision_author'] = [
+    'name' => t("Author"),
+    'type' => 'user',
+  ];
+
   return [
     'tokens' => [
       'message' => $tokens,
@@ -154,6 +159,24 @@ function social_activity_tokens($type, $tokens, array $data, array $options, Bub
               }
               break;
           }
+        }
+
+        // Loading user data to user token as "object".
+        $token_service = \Drupal::token();
+        if ($author_tokens = $token_service->findWithPrefix($tokens, 'revision_author')) {
+          if ($message->field_message_related_object->isEmpty()) {
+            return $replacements;
+          }
+
+          $related_object_value = current($message->field_message_related_object->getValue());
+          $related_object_content = \Drupal::entityTypeManager()
+            ->getStorage($related_object_value['target_type'])
+            ->load($related_object_value['target_id']);
+          if (empty($related_object_content)) {
+            return $replacements;
+          }
+
+          $replacements += $token_service->generate('user', $author_tokens, ['user' => $related_object_content->getOwner()], $options, $bubbleable_metadata);
         }
       }
     }

--- a/modules/social_features/social_group/modules/social_group_flexible_group/modules/social_flexible_group_book/config/optional/message.template.create_book_group.yml
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/modules/social_flexible_group_book/config/optional/message.template.create_book_group.yml
@@ -24,13 +24,13 @@ label: 'Create book in group'
 description: 'A user created a book in a group'
 text:
   -
-    value: '<p><a href="[message:author:url:absolute]">[message:author:display-name]</a> created a book in <a href="[message:gurl]">[message:gtitle]</a> [message:count_groups_per_node]</p>'
+    value: '<p><a href="[message:revision_author:url:absolute]">[message:revision_author:display-name]</a> created a book in <a href="[message:gurl]">[message:gtitle]</a> [message:count_groups_per_node]</p>'
     format: full_html
   -
-    value: '<p><a href="[message:author:url:absolute]">[message:author:display-name]</a> created a book in <a href="[message:gurl]">[message:gtitle]</a> [message:count_groups_per_node]</p>'
+    value: '<p><a href="[message:revision_author:url:absolute]">[message:revision_author:display-name]</a> created a book in <a href="[message:gurl]">[message:gtitle]</a> [message:count_groups_per_node]</p>'
     format: full_html
   -
-    value: '<p><a href="[message:author:url:absolute]">[message:author:display-name]</a> created a book in <a href="[message:gurl]">[message:gtitle]</a> [message:count_groups_per_node]</p>'
+    value: '<p><a href="[message:revision_author:url:absolute]">[message:revision_author:display-name]</a> created a book in <a href="[message:gurl]">[message:gtitle]</a> [message:count_groups_per_node]</p>'
     format: full_html
 settings:
   'token options':

--- a/modules/social_features/social_group/modules/social_group_flexible_group/modules/social_flexible_group_book/social_flexible_group_book.install
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/modules/social_flexible_group_book/social_flexible_group_book.install
@@ -112,3 +112,19 @@ function social_flexible_group_book_update_13001() : string {
   // Output logged messages to related channel of update execution.
   return $updater->logger()->output();
 }
+
+/**
+ * Change token-replacement from create message template.
+ */
+function social_flexible_group_book_update_13002(): void {
+  $config = \Drupal::configFactory()
+    ->getEditable('create_book_group');
+
+  $texts = array_map(function ($text) {
+    $text['value'] = str_replace('message:author', 'message:revision_author', $text['value']);
+    return $text;
+  }, $config->get('text'));
+
+  $config->set('text', $texts)
+    ->save();
+}


### PR DESCRIPTION
## Problem
When a content has author change, the activity related with it continue showing first author and never be updated.

## Solution
I created a new Token on Social Acitivty module to get current revision user. 

## Issue tracker
[PROD-25155](https://getopensocial.atlassian.net/browse/PROD-25155)
[#3456839](https://www.drupal.org/project/social/issues/3456839)

## Theme issue tracker
N/A

## How to test
- [ ] Enable Create Book Group
- [ ] Create a Topic and Event  in a group and normal 
- [ ] Execute cron and check their activities
- [ ] Change the author from content created before 
- [ ] Check if activities is updated as well

## Screenshots
N/A

## Release notes
The error related to activities showing wrong author after the author from a content was updated, is fixed..

## Change Record
N/A

## Translations
N/A


[PROD-25155]: https://getopensocial.atlassian.net/browse/PROD-25155?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ