### PR TITLE
Updates: socialbase and socialblue themes to the 2.6.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -118,9 +118,6 @@
             },
             "drupal/votingapi": {
                 "Issue #3341513: Voting Storages does not check access on entity query\n": "https://www.drupal.org/files/issues/2023-07-06/3341513_votingapi_use-access-checks-14.diff"
-            },
-            "drupal/socialbase": {
-                "Replace non-existing classes according to group module upgrade to 2.x": "https://git.drupalcode.org/project/socialbase/-/merge_requests/199.patch"
             }
         }
     },
@@ -177,7 +174,7 @@
         "drupal/search_api_solr": "4.3.3",
         "drupal/select2": "1.15.0",
         "drupal/shariff": "2.0.0",
-        "drupal/socialblue": "~2.5.6",
+        "drupal/socialblue": "~2.6.1",
         "drupal/symfony_mailer": "^1.2",
         "drupal/token": "1.14.0",
         "drupal/ultimate_cron": "2.0.0-alpha7",


### PR DESCRIPTION
## Problem
The Social Blue theme has a new Major version and some patch are outdated.

## Solution

- Update socialbase to 2.6.0
- Update socialblue to 2.6.0


## Issue tracker

- https://www.drupal.org/project/socialbase/releases/2.6.0
- https://www.drupal.org/project/socialblue/releases/2.6.0
- [PROD-29969](https://getopensocial.atlassian.net/browse/PROD-29969)

## Theme issue tracker
N/A

## How to test

## Screenshots

## Release notes
**SocialBase:**
- [#3417761: Replace non-existing classes according to group module upgrade to 2.x](https://www.drupal.org/project/socialbase/issues/3417761)
- [#3407006: Remove legacy group types](https://www.drupal.org/project/socialbase/issues/3407006)
- [#3455930: [UI] Remove extra `z-index` form the region content/content top](https://www.drupal.org/project/socialbase/issues/3455930)
- [#3456257: [UI] Improve position auth buttons](https://www.drupal.org/project/socialbase/issues/3456257)
- [#3444049: [UI] Issue with button alignment on the membership page](https://www.drupal.org/project/socialbase/issues/3444049)
- [#3439342: [UI]Add height to the comment avatar](https://www.drupal.org/project/socialbase/issues/3439342)
- [#3425768: [UI] Re-design Custom Content Block List](https://www.drupal.org/project/socialbase/issues/3425768)

**SocialBlue:**

- [#3407010: Remove legacy group types](https://www.drupal.org/project/socialblue/issues/3407010)
- [#3440435: [UI] Add dropdown behavior to the edit button on the event page(hero section)](https://www.drupal.org/project/socialblue/issues/3440435)
- [#3425773: [UI] Remove extra styles](https://www.drupal.org/project/socialblue/issues/3425773)

## Change Record

## Translations


[PROD-29969]: https://getopensocial.atlassian.net/browse/PROD-29969?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ