### PR TITLE
PROD-29703: Add an external identifier field to the user entity

### DIFF
--- a/modules/social_features/social_user/config/install/field.field.user.user.field_external_identifier.yml
+++ b/modules/social_features/social_user/config/install/field.field.user.user.field_external_identifier.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.user.field_external_identifier
+  module:
+    - social_core
+    - user
+id: user.user.field_external_identifier
+field_name: field_external_identifier
+entity_type: user
+bundle: user
+label: 'External Identifier'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: social_external_identifier

--- a/modules/social_features/social_user/config/install/field.storage.user.field_external_identifier.yml
+++ b/modules/social_features/social_user/config/install/field.storage.user.field_external_identifier.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - social_core
+    - user
+id: user.field_external_identifier
+field_name: field_external_identifier
+entity_type: user
+type: social_external_identifier
+settings:
+  target_types: {  }
+module: social_core
+locked: true
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/social_features/social_user/config/update/social_user_update_13003.yml
+++ b/modules/social_features/social_user/config/update/social_user_update_13003.yml
@@ -1,0 +1,4 @@
+__global_actions:
+  import_configs:
+    - field.storage.user.field_external_identifier
+    - field.field.user.user.field_external_identifier

--- a/modules/social_features/social_user/social_user.install
+++ b/modules/social_features/social_user/social_user.install
@@ -205,3 +205,17 @@ function social_user_update_13002(): void {
     ->clear('show_mail_in_messages')
     ->save();
 }
+
+/**
+ * Add an external identifier field to the user entity.
+ */
+function social_user_update_13003() : string {
+  /** @var \Drupal\update_helper\Updater $updater */
+  $updater = \Drupal::service('update_helper.updater');
+
+  // Execute configuration update definitions with logging of success.
+  $updater->executeUpdate('social_user', __FUNCTION__);
+
+  // Output logged messages to related channel of update execution.
+  return $updater->logger()->output();
+}


### PR DESCRIPTION
## Problem
We need to implement `externalId` for user entity type. More info why this is needed here => https://github.com/goalgorilla/open_social/pull/3942

## Solution
Add an external identifier field to the user entity. This field is locked, as it should not be managed via the UI, but rather by modifying the configuration. The field is provided without any settings and is, therefore, unusable by default. At least one target type needs to be specified by modifying the field storage configuration to ensure the field can be properly used.

Since the field is locked, target types can be managed by other modules by using for example [config_modify](https://www.drupal.org/project/config_modify) to allow specific target types
Example:

File: scim/config/modify/scim.field_external_identifier_consumer_target_type.yml
````
dependencies:
  module:
    - consumers
items:
  field.storage.user.field_external_identifier:
    update_actions:
      add:
        settings:
          target_types:
            consumer: consumer
````

**Field usage example:**
SCIM provides the concept of externalId which
can be used to identify a resource with an identifier that is known to the SCIM client. This prevents the SCIM client from having to store a mapping between its internal data and our ID, instead putting that burden on us as a service provider.

Provides hook update for newly created field:
![Screenshot 2024-06-27 at 16 55 40](https://github.com/goalgorilla/open_social/assets/13753184/e964295e-43fe-438a-8817-e34f0bf7f667)

## Issue tracker
- [3457562](https://www.drupal.org/project/social/issues/3457562)
- PROD-29703
- IOSAP-457

## Theme issue tracker
N/A

## How to test
- [ ] install field_ui
- [ ] As a admin, go to /admin/config/people/accounts/fields
- [ ] Confirm that you can see field_external_indentifier field and that it is locked (see screenshot).
- [ ] Make sure that hook update is correctly triggered for existing installations and that same configuration is provided as for clean install.

## Screenshots
![Screenshot 2024-06-27 at 12 58 59](https://github.com/goalgorilla/open_social/assets/13753184/200162ce-26c2-46d4-8f60-bf2d2cd78f50)


## Release notes
Add an external identifier field to the user entity.

## Change Record
N/A

## Translations
N/A
