### PR TITLE
Issue #3458763: Add custom filter for table responsive behavior

### DIFF
--- a/modules/social_features/social_editor/config/install/filter.format.basic_html.yml
+++ b/modules/social_features/social_editor/config/install/filter.format.basic_html.yml
@@ -40,6 +40,14 @@ filters:
     status: true
     weight: 11
     settings: {  }
+  filter_responsive_table:
+    id: filter_responsive_table
+    provider: social_editor
+    status: true
+    weight: 0
+    settings:
+      wrapper_element: div
+      wrapper_classes: table-responsive
   filter_url:
     id: filter_url
     provider: filter

--- a/modules/social_features/social_editor/config/install/filter.format.full_html.yml
+++ b/modules/social_features/social_editor/config/install/filter.format.full_html.yml
@@ -25,6 +25,14 @@ filters:
     status: true
     weight: 10
     settings: {  }
+  filter_responsive_table:
+    id: filter_responsive_table
+    provider: social_editor
+    status: true
+    weight: 0
+    settings:
+      wrapper_element: div
+      wrapper_classes: table-responsive
   filter_url:
     id: filter_url
     provider: filter

--- a/modules/social_features/social_editor/src/Plugin/Filter/FilterResponsiveTable.php
+++ b/modules/social_features/social_editor/src/Plugin/Filter/FilterResponsiveTable.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Drupal\social_editor\Plugin\Filter;
+
+use Drupal\filter\FilterProcessResult;
+use Drupal\filter\Plugin\FilterBase;
+use Drupal\Component\Utility\Xss;
+use Drupal\Core\Template\Attribute;
+
+/**
+ * Provides a filter that wraps <table> tags with a <div> tag.
+ *
+ * @Filter(
+ *   id = "filter_responsive_table",
+ *   title = @Translation("Responsive Table filter"),
+ *   type = Drupal\filter\Plugin\FilterInterface::TYPE_TRANSFORM_REVERSIBLE,
+ *   settings = {
+ *     "wrapper_element" = "div",
+ *     "wrapper_classes" = "table-responsive"
+ *   }
+ * )
+ */
+class FilterResponsiveTable extends FilterBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function process($text, $langcode): FilterProcessResult {
+    $result = new FilterProcessResult($text);
+    $text = preg_replace_callback('@<table([^>]*)>(.+?)</table>@s', [
+      $this,
+      'processTableCallback',
+    ], $text);
+    $result->setProcessedText($text);
+    return $result;
+  }
+  /**
+   * {@inheritdoc}
+   */
+  public function tips($long = FALSE, $context = []) {
+    return $this->t('Wraps a %table tags with a %div tag.', [
+      '%table' => '<table>',
+      '%div' => '<' . $this->getWrapperElement() . '>',
+    ]);
+  }
+  /**
+   * Callback to replace content of the <table> elements.
+   */
+  private function processTableCallback(array $matches): string {
+    $attributes = $matches[1];
+    $text = $matches[2];
+    return '<' . $this->getWrapperElement() . $this->getWrapperAttributes() . '><table' . $attributes . '>' . $text . '</table></' . $this->getWrapperElement() . '>';
+  }
+
+  /**
+   * Get the wrapper HTML element.
+   */
+  private function getWrapperElement(): string {
+    return Xss::filter($this->settings['wrapper_element']);
+  }
+
+  /**
+   * Get the wrapper CSS class(es).
+   */
+  private function getWrapperAttributes(): Attribute {
+    return new Attribute([
+      'class' => [$this->settings['wrapper_classes']],
+    ]);
+  }
+}


### PR DESCRIPTION
## Problem
The table does not have a `table-responsive` wrapper for the correct behavior if we have a big table.

## Solution
Add a custom filter to the text format.

## Issue tracker
https://www.drupal.org/project/social/issues/3458763
https://getopensocial.atlassian.net/browse/PROD-29818

## Theme issue tracker
<!-- *[Required if applicable] Paste a link to the drupal.org theme issue queue item, either from [socialbase](https://www.drupal.org/project/socialbase) or [socialblue](https://www.drupal.org/project/socialblue). If any other issue trackers were used, include links to those too.* -->

## How to test
- [ ] Go to the Create Topic page.
- [ ] Go to the Ckeditor
- [ ] Add the table with a lot of rows and cells
- [ ] Add content to the cells.
- [ ] Save and check the page.

## Screenshots
before:
![Screenshot 2024-07-01 at 16 11 11](https://github.com/goalgorilla/open_social/assets/16086340/fe2ed1e3-aba8-4001-8532-cb0baf1c2d36)

after:
![Screenshot 2024-07-03 at 16 59 20](https://github.com/goalgorilla/open_social/assets/16086340/0280323a-ec16-4160-baac-2f6f2f4791f7)

## Release notes
Add a custom filter to the text format for table responsive.

## Change Record
<!-- *[Required if applicable] If this Pull Request changes the way that developers should do things or introduces a new API for developers then a change record to document this is needed. Please provide a draft for a change record or a link to an unpublished change record below. Existing change records can be consulted as example. Please provide a draft for a change record or a link to an unpublished change record below. [Existing change records](https://www.drupal.org/list-changes/social) can be consulted as example.* -->

## Translations
<!--
*[Optional]Translatable strings are always extracted from the latest development branch. To ensure translations remain available for platforms running older versions of Open Social the original string should be added to `translations.php` when it's changed or removed.*
- [ ] Changed or removed source strings are added to the `translations.php` file.
-->
