### PR TITLE
Issue #3458854: Fix url in getRelatedEntityUrl if entity doesn't have canonical link

### DIFF
--- a/modules/custom/activity_creator/src/Entity/Activity.php
+++ b/modules/custom/activity_creator/src/Entity/Activity.php
@@ -282,7 +282,7 @@ class Activity extends ContentEntityBase implements ActivityInterface {
       $entity_storage = \Drupal::entityTypeManager()
         ->getStorage($target_type);
       $entity = $entity_storage->load($target_id);
-      if ($entity !== NULL) {
+      if ($entity !== NULL && $entity->hasLinkTemplate('canonical')) {
         /** @var \Drupal\Core\Url $link */
         /** @var \Drupal\Core\Entity\EntityInterface $entity */
         $link = $entity->toUrl('canonical');


### PR DESCRIPTION
## Problem
Sometimes the entity related to the activity does not have a canonical URL, which causes a fatal error when viewing the activity.
This error occurs because there is no check to see if the entity has a canonical LinkTemplate

## Solution
Add condition with check if the entity has `canonical` `linkTemplate`

## Issue tracker
https://www.drupal.org/project/social/issues/3458854

## Theme issue tracker
N/A

## How to test
- [ ] Create the message template related to the entity that doesn't have canonical link template
- [ ] Trigger action to receive the notification
- [ ] Go to the notification center 
- [ ] You should not have the fatal error

## Screenshots
N/A

## Release notes
Fix the URL in the getRelatedEntityUrl method if the entity doesn't have canonical linTemplate

## Change Record
N/A

## Translations
N/A
