### PR TITLE
PROD-30063: Add test coverage for flexible group request to join

### DIFF
--- a/tests/behat/features/capabilities/groups/flexible/groups-flexible-view-outsider-anonymous.feature
+++ b/tests/behat/features/capabilities/groups/flexible/groups-flexible-view-outsider-anonymous.feature
@@ -1,29 +1,8 @@
-@api @javascript
+@api
 Feature: Flexible groups view access for anonymous users
   Background:
     Given I enable the module "social_group_flexible_group"
     And I disable that the registered users to be verified immediately
-
-  Scenario: As anonymous user view a public group
-    Given groups with non-anonymous owner:
-      | label      | field_group_description | type           | langcode | field_flexible_group_visibility | field_group_allowed_join_method |
-      | Test group | Public visibility       | flexible_group | en       | public                          | direct                          |
-    And I am an anonymous user
-
-    When I am viewing the "stream" page of group "Test group"
-
-    Then I should see "Test group"
-
-  Scenario: As anonymous redirect to the group when visiting the request membership
-    Given groups with non-anonymous owner:
-      | label      | field_group_description | type           | langcode | field_flexible_group_visibility | field_group_allowed_join_method |
-      | Test group | Public visibility       | flexible_group | en       | public                          | request                         |
-    And I am an anonymous user
-
-    When I am viewing the "anonymous-request-membership" page of group "Test group"
-
-    Then I should see "Test group"
-    And I should see "Request to join"
 
   Scenario: As anonymous user I can't view a community group
     Given groups with non-anonymous owner:

--- a/tests/behat/features/capabilities/groups/join/groups-join-direct.feature
+++ b/tests/behat/features/capabilities/groups/join/groups-join-direct.feature
@@ -1,0 +1,13 @@
+@api
+Feature: A group can be configured to allow joining directly
+
+  Scenario: As anonymous user view a public group
+    Given groups with non-anonymous owner:
+      | label      | field_group_description | type           | langcode | field_flexible_group_visibility | field_group_allowed_join_method |
+      | Test group | Public visibility       | flexible_group | en       | public                          | direct                          |
+    And I am an anonymous user
+
+    When I am viewing the "stream" page of group "Test group"
+
+    Then I should see "Test group"
+    And I should see the link Join

--- a/tests/behat/features/capabilities/groups/join/groups-join-request-manage.feature
+++ b/tests/behat/features/capabilities/groups/join/groups-join-request-manage.feature
@@ -1,0 +1,96 @@
+@api
+Feature: Requests to join for a group can be managed
+
+  Background:
+    Given I enable the module social_group_flexible_group
+    And I enable the module social_group_request
+    And groups with non-anonymous owner:
+      | label      | field_group_description | type           | langcode | field_flexible_group_visibility | field_group_allowed_join_method |
+      | Test group | Public visibility       | flexible_group | en       | public                          | request                         |
+    And users:
+      | name           | mail                | status | roles    |
+      | Pending Member | pending@example.com | 1      | verified |
+    And group membership requests:
+      | group      | user           |
+      | Test group | Pending Member |
+
+  Scenario: As a group manager I can approve a membership request
+    Given I am logged in as a user with the "verified" role
+    # Todo: Fix the role declaration.
+    And I am a member of "Test group" with the "flexible_group-group_manager" role
+
+    When I am viewing the "membership-requests" page of group "Test group"
+    And I press "Approve Membership"
+    And I press "Yes"
+
+    Then I should see the success message "Membership request approved"
+    And I should see "No membership requests available."
+    And I am viewing the "members" page of group "Test group"
+    And I should see "Pending Member"
+
+  Scenario: As a group manager I can reject a membership request
+    Given I am logged in as a user with the "verified" role
+    # Todo: Fix the role declaration.
+    And I am a member of "Test group" with the "flexible_group-group_manager" role
+
+    When I am viewing the "membership-requests" page of group "Test group"
+    And I press "Toggle Dropdown"
+    And I click "Reject Membership"
+    And I press "Yes"
+
+    Then I should see the success message "Membership request rejected"
+    And I should see "No membership requests available."
+    And I am viewing the "members" page of group "Test group"
+    And I should not see "Pending Member"
+
+  Scenario: As a sitemanager I can approve a membership request for groups I'm a member of
+    Given I am logged in as a user with the "sitemanager" role
+    And I am a member of "Test group"
+
+    When I am viewing the "membership-requests" page of group "Test group"
+    And I press "Approve Membership"
+    And I press "Yes"
+
+    Then I should see the success message "Membership request approved"
+    And I should see "No membership requests available."
+    And I am viewing the "members" page of group "Test group"
+    And I should see "Pending Member"
+
+  Scenario: As a sitemanager I can reject a membership request for groups I'm a member of
+    Given I am logged in as a user with the "sitemanager" role
+    And I am a member of "Test group"
+
+    When I am viewing the "membership-requests" page of group "Test group"
+    And I press "Toggle Dropdown"
+    And I click "Reject Membership"
+    And I press "Yes"
+
+    Then I should see the success message "Membership request rejected"
+    And I should see "No membership requests available."
+    And I am viewing the "members" page of group "Test group"
+    And I should not see "Pending Member"
+
+  Scenario: As a sitemanager I can approve a membership request for groups I'm not a member of
+    Given I am logged in as a user with the "sitemanager" role
+
+    When I am viewing the "membership-requests" page of group "Test group"
+    And I press "Approve Membership"
+    And I press "Yes"
+
+    Then I should see the success message "Membership request approved"
+    And I should see "No membership requests available."
+    And I am viewing the "members" page of group "Test group"
+    And I should see "Pending Member"
+
+  Scenario: As a sitemanager I can reject a membership request for groups I'm not a member of
+    Given I am logged in as a user with the "sitemanager" role
+
+    When I am viewing the "membership-requests" page of group "Test group"
+    And I press "Toggle Dropdown"
+    And I click "Reject Membership"
+    And I press "Yes"
+
+    Then I should see the success message "Membership request rejected"
+    And I should see "No membership requests available."
+    And I am viewing the "members" page of group "Test group"
+    And I should not see "Pending Member"

--- a/tests/behat/features/capabilities/groups/join/groups-join-request.feature
+++ b/tests/behat/features/capabilities/groups/join/groups-join-request.feature
@@ -1,0 +1,130 @@
+@api @javascript
+Feature: A group can be configured to require membership to be requested
+
+  Background:
+    Given I enable the module social_group_flexible_group
+    And I enable the module social_group_request
+    And groups with non-anonymous owner:
+      | label      | field_group_description | type           | langcode | field_flexible_group_visibility | field_group_allowed_join_method |
+      | Test group | Public visibility       | flexible_group | en       | public                          | request                         |
+
+  Scenario Outline: The feature is available for everyone that can create groups for public visibility
+    Given I am logged in as a user with the <role> role
+
+    When I view the group creation page
+    And I select the radio button "Public"
+
+    Then I should see "Request to join"
+
+  Examples:
+    | role           |
+    | authenticated  |
+    | verified       |
+    | contentmanager |
+    | sitemanager    |
+
+  Scenario Outline: The feature is available for everyone that can create groups for community visibility
+    Given I am logged in as a user with the <role> role
+
+    When I view the group creation page
+    And I select the radio button "Community"
+
+    Then I should see "Request to join"
+
+  Examples:
+    | role           |
+    | authenticated  |
+    | verified       |
+    | contentmanager |
+    | sitemanager    |
+
+#  @todo Scenario requires a step that checks whether a radio button is disabled.
+#  Scenario: The feature is not available regardless of role for groups with member visibility
+#    Given I am logged in as a user with the verified role
+#
+#    When I view the group creation page
+#    And I select the radio button "Group members only (secret)"
+#
+#    Then I should not be able to select the radio button "Request to join"
+
+  Scenario: As an anonymous user I am asked to login when I try to request access to a public group
+    Given I am an anonymous user
+
+    When I am viewing the about page of group "Test group"
+    And I click "Request to join"
+
+    Then I should see "Request to join"
+    And I should see "In order to send your request, please first sign up or log in."
+    And I should see the button "Sign up"
+    And I should see the button "Log in"
+
+  Scenario: As an anonymous user I can not visit the anonymous request callback URL directly
+    Given I am an anonymous user
+
+    When I am viewing the "anonymous-request-membership" page of group "Test group"
+
+    Then I should see "Test group"
+    And I should see the link "Request to join"
+
+  Scenario Outline: As a regular user, content manager or site manager I must request access to a group configured with request to join
+    Given I am logged in as a user with the <role> role
+
+    When I am viewing the group "Test group"
+    And I click "Request to join"
+    And I wait for AJAX to finish
+    And I press "Send request"
+
+    Then I should see "Your request has been sent successfully"
+
+  Examples:
+    | role           |
+    | authenticated  |
+    | verified       |
+    | contentmanager |
+    | sitemanager    |
+
+  Scenario: A user can not request membership while a previous request is pending
+    Given users:
+      | name           | mail                | status | roles    |
+      | Pending Member | pending@example.com | 1      | verified |
+    And group membership requests:
+      | group      | user           |
+      | Test group | Pending Member |
+    And I am logged in as "Pending Member"
+
+    When I am viewing the group "Test group"
+
+    Then I should not see "Request to join"
+    And I should see "Request sent"
+
+  Scenario: A user can request membership after a previous request has been rejected
+    Given users:
+      | name            | mail                 | status | roles    |
+      | Rejected Member | rejected@example.com | 1      | verified |
+    And group membership requests:
+      | group      | user            | status   |
+      | Test group | Rejected Member | rejected |
+    And I am logged in as "Rejected Member"
+
+    When I am viewing the group "Test group"
+    And I click "Request to join"
+    And I wait for AJAX to finish
+    And I press "Send request"
+
+    Then I should see "Your request has been sent successfully"
+
+  Scenario: A user can request membership after a previous request has been approved but they left the group
+    Given users:
+      | name            | mail                 | status | roles    |
+      | Approved Member | approved@example.com | 1      | verified |
+    And group membership requests:
+      | group      | user            | status   |
+      | Test group | Approved Member | approved |
+    And I am logged in as "Approved Member"
+
+    When I am viewing the group "Test group"
+    And I click "Request to join"
+    And I wait for AJAX to finish
+    And I press "Send request"
+
+    Then I should see "Your request has been sent successfully"


### PR DESCRIPTION

## Problem / Solution
This commits adds test to document the behaviour of the "Request to Join" feature for flexible groups after discussing the behaviour with our PO and Designer.

The join functionality is moved to a new folder under "groups" in the testing structure. The outsider view test was previously modified to have a bit of test code around request to join and direct joining. This was moved to their own test so that the feature for viewing is really only for viewing and the joining features are separate.

The join functionality is not placed under flexible because after the group migration we're only left with a single group type. The functionality for other group-module-based things are different features.

## Issue tracker
https://getopensocial.atlassian.net/browse/PROD-30063

## Theme issue tracker
<!-- *[Required if applicable] Paste a link to the drupal.org theme issue queue item, either from [socialbase](https://www.drupal.org/project/socialbase) or [socialblue](https://www.drupal.org/project/socialblue). If any other issue trackers were used, include links to those too.* -->

## How to test
- [x] The tests give sufficient test coverage for how our feature works
- [x] The tests pass

## Screenshots
<!-- *[Required if new feature, and if applicable] If this Pull Request makes visual changes then please include some screenshots that show what has changed here. A before and after screenshot helps the reviewer determine what changes were made.* -->

## Release notes
<!-- *[Required if new feature, and if applicable] A short summary of the changes that were made that can be included in release notes.* -->

## Change Record
<!-- *[Required if applicable] If this Pull Request changes the way that developers should do things or introduces a new API for developers then a change record to document this is needed. Please provide a draft for a change record or a link to an unpublished change record below. Existing change records can be consulted as example. Please provide a draft for a change record or a link to an unpublished change record below. [Existing change records](https://www.drupal.org/list-changes/social) can be consulted as example.* -->

## Translations
<!--
*[Optional]Translatable strings are always extracted from the latest development branch. To ensure translations remain available for platforms running older versions of Open Social the original string should be added to `translations.php` when it's changed or removed.*
- [ ] Changed or removed source strings are added to the `translations.php` file.
-->
