### PR TITLE
Issue #3460260: Missing permissions for social_group_welcome_message

### DIFF
--- a/modules/social_features/social_group/modules/social_group_welcome_message/social_group_welcome_message.install
+++ b/modules/social_features/social_group/modules/social_group_welcome_message/social_group_welcome_message.install
@@ -11,3 +11,42 @@
 function social_group_welcome_message_update_last_removed() : int {
   return 10101;
 }
+
+/**
+ * Add private message permission if Social Chat is enabled.
+ */
+function social_group_welcome_message_update_13000(): void {
+  // If Social Chat module isn't enabled, we don't add permission.
+  if (\Drupal::service('module_handler')->moduleExists('social_chat')) {
+    return;
+  }
+
+  // Add Private Message permission.
+  user_role_grant_permissions(
+    'verified',
+    [
+      'use private messaging system',
+      'create private messages thread',
+      'reply to private messages thread',
+      'delete private messages thread',
+    ]
+  );
+  user_role_grant_permissions(
+    'contentmanager',
+    [
+      'use private messaging system',
+      'create private messages thread',
+      'reply to private messages thread',
+      'delete private messages thread',
+    ]
+  );
+  user_role_grant_permissions(
+    'sitemanager',
+    [
+      'use private messaging system',
+      'create private messages thread',
+      'reply to private messages thread',
+      'delete private messages thread',
+    ]
+  );
+}


### PR DESCRIPTION
## Problem
Some permission related to Social Group Welcome Message module was removed.
We think it's because this doesn't work together with our real time chat extension and someimtes manually these permissions are removed.

## Solution
Created a hook-update to add the permission again if Social Chat module isn't enabled.
This means:
- if Chat is enabled, nothing changes.
- if it isn't, we enable the entire range of private message permissions, this way we ensure social private message is also working, if we only limit the permissions to what welcome message needs that might cause regression.

## Issue tracker
[PROD-28479](https://getopensocial.atlassian.net/browse/PROD-28479)
[#3460260](https://www.drupal.org/project/social/issues/3460260)

## Theme issue tracker
N/A

## How to test
- [ ] Access /group/add/flexible_group as a SM
- [ ] Test welcome message

## Screenshots
N/A

## Release notes
Fix the bug to add welcome message to Group.

## Change Record
N/A

## Translations
N/A


[PROD-28479]: https://getopensocial.atlassian.net/browse/PROD-28479?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ