### PR TITLE
Issue #3460545: Deprecate Social Lets Connect Contact module

### DIFF
--- a/modules/custom/social_lets_connect/modules/social_lets_connect_contact/social_lets_connect_contact.info.yml
+++ b/modules/custom/social_lets_connect/modules/social_lets_connect_contact/social_lets_connect_contact.info.yml
@@ -3,6 +3,8 @@ type: module
 description: 'Contact the Open Social development team and help us improve the product.'
 core_version_requirement: ^9 || ^10
 package: 'Social Lets Connect'
+lifecycle: deprecated
+lifecycle_link: https://www.drupal.org/project/social/issues/3460545
 
 dependencies:
   - social_lets_connect


### PR DESCRIPTION
## Problem
The Social Lets Connect Contact module is not be maintain any more and will be removed on next version.

## Solution
Deprecated the Social Lets Connect Contact module.

## Issue tracker
[PROD-30041](https://getopensocial.atlassian.net/browse/PROD-30041)
[#3460545](https://www.drupal.org/project/social/issues/3460545)

## Theme issue tracker
N/A

## How to test
N/A

## Screenshots
N/A

## Release notes
Deprecated the Social Lets Connect Contact module to be removed on next version.

## Change Record
N/A

## Translations
N/A


[PROD-30041]: https://getopensocial.atlassian.net/browse/PROD-30041?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ