### PR TITLE
Issue #3460734: Define social_core as social_user dependency

### DIFF
--- a/modules/social_features/social_user/social_user.info.yml
+++ b/modules/social_features/social_user/social_user.info.yml
@@ -12,6 +12,7 @@ dependencies:
   - group:group
   - profile:profile
   - role_delegation:role_delegation
+  - social:social_core
   - social:social_editor
   - social:social_profile
   - views_bulk_operations:views_bulk_operations


### PR DESCRIPTION
## Problem
The dependency is there through social_profile, but social_user was also already relying on social_core in its code before. What is missing is to declare dependency explicitly. 

FUP of:[#3950](https://github.com/goalgorilla/open_social/pull/3950#issuecomment-2199398521)

## Solution
Declare dependency explicitly. 

## Issue tracker
[3460734](https://www.drupal.org/project/social/issues/3460734)
PROD-29703
IOSAP-457

## Theme issue tracker
N/A

## How to test
N/A

## Screenshots
N/A

## Release notes
Explicitly define social_core as a social_user dependency. Although the dependency was previously established through social_profile and social_user already relied on social_core in its code, this change formalizes the relationship.

## Change Record
N/A

## Translations
N/A
