### PR TITLE
Issue #3460849: Define external identifier id uniqueness

### DIFF
--- a/modules/social_features/social_core/src/Plugin/Field/FieldType/ExternalIdentifierItem.php
+++ b/modules/social_features/social_core/src/Plugin/Field/FieldType/ExternalIdentifierItem.php
@@ -29,6 +29,7 @@ use Drupal\Core\TypedData\DataReferenceTargetDefinition;
  *     "ExternalIdentifierEmptySubfieldsConstraint" = {},
  *     "ExternalIdentifierExternalOwnerTargetTypeConstraint" = {},
  *     "ExternalIdentifierExternalOwnerIdConstraint" = {},
+ *     "ExternalIdentifierUniqueExternalIdConstraint" = {},
  *     "ComplexData" = {
  *       "external_id" = {
  *         "Length" = {"max" = 225}

--- a/modules/social_features/social_core/src/Plugin/Validation/Constraint/ExternalIdentifierUniqueExternalIdConstraint.php
+++ b/modules/social_features/social_core/src/Plugin/Validation/Constraint/ExternalIdentifierUniqueExternalIdConstraint.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Drupal\social_core\Plugin\Validation\Constraint;
+
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * Provides a custom constraint for external identifier field.
+ *
+ * Prevents field values from being stored if external id value is not unique
+ * per external owner.
+ *
+ * @Constraint(
+ *   id = "ExternalIdentifierUniqueExternalIdConstraint",
+ *   label = @Translation("Makes sure that external id is unique per external owner", context = "Validation"),
+ *   type = {"field"}
+ * )
+ */
+class ExternalIdentifierUniqueExternalIdConstraint extends Constraint {
+
+  /**
+   * The error message when external id is not unique per external owner.
+   *
+   * @var string
+   */
+  public $externalIdNotUniqueMessage = 'External identifier id should be unique. External identifier id "%external_id" is already used, with external owner "%external_owner_target_type" of id "%external_owner_id".';
+
+}

--- a/modules/social_features/social_core/src/Plugin/Validation/Constraint/ExternalIdentifierUniqueExternalIdConstraint.php
+++ b/modules/social_features/social_core/src/Plugin/Validation/Constraint/ExternalIdentifierUniqueExternalIdConstraint.php
@@ -23,6 +23,6 @@ class ExternalIdentifierUniqueExternalIdConstraint extends Constraint {
    *
    * @var string
    */
-  public $externalIdNotUniqueMessage = 'External identifier id should be unique. External identifier id "%external_id" is already used, with external owner "%external_owner_target_type" of id "%external_owner_id".';
+  public $externalIdNotUniqueMessage = 'The external identifier ID must be unique. The External ID "%external_id" is already in use.';
 
 }

--- a/modules/social_features/social_core/src/Plugin/Validation/Constraint/ExternalIdentifierUniqueExternalIdConstraintValidator.php
+++ b/modules/social_features/social_core/src/Plugin/Validation/Constraint/ExternalIdentifierUniqueExternalIdConstraintValidator.php
@@ -1,0 +1,186 @@
+<?php
+
+namespace Drupal\social_core\Plugin\Validation\Constraint;
+
+use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
+use Drupal\Core\Entity\EntityFieldManagerInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+
+/**
+ * Validates the ExternalIdentifierUniqueExternalIdConstraint constraint.
+ *
+ * Uniqueness rule:
+ *   External ID should be unique per entity and external owner, despite how
+ *   many fields of type "social_external_identifier" entity have.
+ *
+ * Uniqueness rules broken down in details:
+ *  1. External ID should be unique per entity type (for example: external ID
+ *     can be used only once per user entity).
+ *  2. External ID should be unique per all “social_external_identifier” fields
+ *     (Unlimited amount of fields of type social_external_identifier can be
+ *     added per one entity and even among all those fields External ID should
+ *     be unique).
+ *  3. external ID should be unique per external owner (External owner entity is
+ *     defined by "external_owner_target_type" and external_owner_id". External
+ *     ID can be used as many times per entity type, until each external ID is
+ *     connected to different external owner).
+ *
+ * Examples:
+ *
+ * Example 1: This situation is forbidden as External ID is not unique.
+ *
+ *   | Entity | Field                       | External ID | External owner |
+ *   | ------ | --------------------------- | ----------- | -------------- |
+ *   | User:1 | field_external_identifier_1 | 123         | consumer:1     |
+ *   | User:1 | field_external_identifier_1 | 123         | consumer:1     |
+ *
+ *  Example 2: This situation is forbidden as two users can not have same
+ *             External ID.
+ *
+ *    | Entity | Field               | External ID | External owner |
+ *    | ------ | ------------------- | ----------- | -------------- |
+ *    | User:1 | field_external_id_1 | 123         | consumer:1     |
+ *    | User:2 | field_external_id_1 | 123         | consumer:1     |
+ *
+ * Example 3: This situation is forbidden as same External ID is not allowed
+ *            even within two different fields within same entity type (User).
+ *
+ *   | Entity | Field               | External ID | External owner |
+ *   | ------ | ------------------- | ----------- | -------------- |
+ *   | User:1 | field_external_id_1 | 123         | consumer:1     |
+ *   | User:1 | field_external_id_2 | 123         | consumer:1     |
+ *
+ * Example 4: This situation is forbidden as same External ID is not allowed
+ *            even within two different entity bundles within same entity
+ *            type (Group).
+ *
+ *   | Entity  | Bundle   | Field               | External ID | External owner |
+ *   | ------- | -------- | ------------------- | ----------- | -------------- |
+ *   | Group:1 | course   | field_external_id_1 | 123         | consumer:1     |
+ *   | Group:2 | flexible | field_external_id_2 | 123         | consumer:1     |
+ *
+ * Example 5: This situation is allowed as External ID is unique per entity.
+ *
+ *   | Entity  | Field               | External ID | External owner |
+ *   | ------- | ------------------- | ----------- | -------------- |
+ *   | User:1  | field_external_id_1 | 123         | consumer:1     |
+ *   | Group:1 | field_external_id_1 | 123         | consumer:1     |
+ *
+ * Example 6: This situation is allowed as External ID is unique per external
+ *            owner.
+ *
+ *   | Entity | Field               | External ID | External owner |
+ *   | ------ | ------------------- | ----------- | -------------- |
+ *   | User:1 | field_external_id_1 | 123         | consumer:1     |
+ *   | User:1 | field_external_id_1 | 123         | consumer:2     |
+ *   | User:1 | field_external_id_1 | 123         | owner:1        |
+ */
+class ExternalIdentifierUniqueExternalIdConstraintValidator extends ConstraintValidator implements ContainerInjectionInterface {
+
+  const EXTERNAL_IDENTIFIER_FIELD_TYPE = 'social_external_identifier';
+
+  /**
+   * Constructs a new constraint validator.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
+   *   The entity type manager service.
+   * @param \Drupal\Core\Entity\EntityFieldManagerInterface $entityFieldManager
+   *   The entity field manager.
+   */
+  public function __construct(
+    protected EntityTypeManagerInterface $entityTypeManager,
+    protected EntityFieldManagerInterface $entityFieldManager
+  ) {
+
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container): static {
+    return new static(
+      $container->get('entity_type.manager'),
+      $container->get('entity_field.manager')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function validate(mixed $item, Constraint $constraint) {
+    if (!$constraint instanceof ExternalIdentifierUniqueExternalIdConstraint) {
+      return;
+    }
+
+    // Empty constraint is handled by
+    // ExternalIdentifierEmptySubfieldsConstraint.
+    if ($item->isEmpty()) {
+      return;
+    }
+
+    $entity = $item->getEntity();
+    $entity_type = $entity->getEntityTypeId();
+
+    // Check per each field of type "social_external_identifier" in given
+    // entity type, if external_id is unique per external owner.
+    foreach ($this->getFieldNamesByFieldType($entity_type) as $field) {
+      $query = $this->entityTypeManager->getStorage($entity_type)->getQuery();
+      $query->condition($field . '.external_id', $item->external_id);
+      $query->condition($field . '.external_owner_target_type', $item->external_owner_target_type);
+      $query->condition($field . '.external_owner_id', $item->external_owner_id);
+      // Exclude existing current entity.
+      if (!$entity->isNew()) {
+        $query->condition('id', $entity->id(), '<>');
+      }
+      $query->accessCheck(FALSE);
+      $result = $query->execute();
+
+      if (!empty($result)) {
+        $this->context->addViolation($constraint->externalIdNotUniqueMessage, [
+          '%external_id' => $item->external_id,
+          // @todo Do we even want to expose internal owner target type and id?
+          '%external_owner_target_type' => $item->external_owner_target_type,
+          '%external_owner_id' => $item->external_owner_id,
+        ]);
+      }
+    }
+
+  }
+
+  /**
+   * Get all field names of type 'social_external_identifier'.
+   *
+   * Get all field names of type 'social_external_identifier'
+   * for a given entity type.
+   *
+   * @param string $entity_type
+   *   The entity type ID.
+   *
+   * @return array
+   *   An array of field names.
+   */
+  private function getFieldNamesByFieldType(string $entity_type): array {
+    $fields = $this->entityFieldManager->getFieldStorageDefinitions($entity_type);
+    $social_external_identifier_fields = [];
+
+    foreach ($fields as $field_name => $field_definition) {
+      if ($field_definition->getType() === self::EXTERNAL_IDENTIFIER_FIELD_TYPE) {
+        $social_external_identifier_fields[] = $field_name;
+      }
+    }
+
+    $base_fields = $this->entityFieldManager->getBaseFieldDefinitions($entity_type);
+
+    foreach ($base_fields as $base_field_name => $field_definition) {
+      if ($field_definition->getType() === self::EXTERNAL_IDENTIFIER_FIELD_TYPE) {
+        $social_external_identifier_fields[] = $base_field_name;
+      }
+    }
+
+    return $social_external_identifier_fields;
+  }
+
+}

--- a/modules/social_features/social_core/tests/modules/social_core_test_entity_provider/src/Entity/ConsumerATestProvider.php
+++ b/modules/social_features/social_core/tests/modules/social_core_test_entity_provider/src/Entity/ConsumerATestProvider.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Drupal\social_core_test_entity_provider\Entity;
+
+use Drupal\entity_test\Entity\EntityTest;
+
+/**
+ * Defines the Consumer A Test entity.
+ *
+ * @ContentEntityType(
+ *   id = "test_consumer_a",
+ *   label = @Translation("Test consumer A"),
+ *   entity_keys = {
+ *     "uuid" = "uuid",
+ *     "id" = "id",
+ *     "label" = "name",
+ *   }
+ * )
+ */
+class ConsumerATestProvider extends EntityTest {
+
+}

--- a/modules/social_features/social_core/tests/modules/social_core_test_entity_provider/src/Entity/ConsumerBTestProvider.php
+++ b/modules/social_features/social_core/tests/modules/social_core_test_entity_provider/src/Entity/ConsumerBTestProvider.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Drupal\social_core_test_entity_provider\Entity;
+
+use Drupal\entity_test\Entity\EntityTest;
+
+/**
+ * Defines the Consumer B Test entity.
+ *
+ * @ContentEntityType(
+ *   id = "test_consumer_b",
+ *   label = @Translation("Test consumer B"),
+ *   entity_keys = {
+ *     "uuid" = "uuid",
+ *     "id" = "id",
+ *     "label" = "name",
+ *   }
+ * )
+ */
+class ConsumerBTestProvider extends EntityTest {
+
+}

--- a/modules/social_features/social_core/tests/src/Kernel/ExternalIdFieldTypeTest.php
+++ b/modules/social_features/social_core/tests/src/Kernel/ExternalIdFieldTypeTest.php
@@ -534,7 +534,7 @@ class ExternalIdFieldTypeTest extends KernelTestBase {
       // Scenario should trigger constraint error as External ID is not unique.
       [
         1,
-        'External identifier id should be unique. External identifier id "<em class="placeholder">123</em>" is already used, with external owner "<em class="placeholder">test_consumer_a</em>" of id "<em class="placeholder">1</em>".',
+        'The external identifier ID must be unique. The External ID "<em class="placeholder">123</em>" is already in use.',
         'node',
         [
           'type' => 'article',
@@ -558,7 +558,7 @@ class ExternalIdFieldTypeTest extends KernelTestBase {
       // even withing two different fields within same entity type.
       [
         1,
-        'External identifier id should be unique. External identifier id "<em class="placeholder">123</em>" is already used, with external owner "<em class="placeholder">test_consumer_a</em>" of id "<em class="placeholder">1</em>".',
+        'The external identifier ID must be unique. The External ID "<em class="placeholder">123</em>" is already in use.',
         'node',
         [
           'type' => 'article',
@@ -582,7 +582,7 @@ class ExternalIdFieldTypeTest extends KernelTestBase {
       // even within two different entity bundles within same entity type.
       [
         1,
-        'External identifier id should be unique. External identifier id "<em class="placeholder">123</em>" is already used, with external owner "<em class="placeholder">test_consumer_a</em>" of id "<em class="placeholder">1</em>".',
+        'The external identifier ID must be unique. The External ID "<em class="placeholder">123</em>" is already in use.',
         'node',
         [
           'type' => 'event',


### PR DESCRIPTION
## Problem
With [#3457487](https://www.drupal.org/project/social/issues/3457487) ([#3942](https://github.com/goalgorilla/open_social/pull/3942)), social_external_identifier field type has been provided. This field type holds a value of external identifier id (external_id). External ID should be unique per entity and external owner, despite how many fields of type "social_external_identifier" entity have. 

## Solution
Apply this rules by using constraint.

1. External ID should be unique per entity type (for example: external ID can be used only once per user entity).
2. External ID should be unique per all “social_external_identifier” fields (Unlimited amount of fields of type social_external_identifier can be added per one entity and even among all those fields External ID should be unique).
3. External ID should be unique per external owner (External owner entity is defined by "external_owner_target_type" and external_owner_id". External ID can be used as many times per entity type, until each external ID is connected to different external owner).

 **Note:**
The purpose of the external identifier field is to point to single entity  with a unique External ID per entity type. If the same External ID is used multiple times in the same field or across different fields for the same entity, it is not an issue from a relationship perspective. We will always find the correct (and only one) entity associated with the given external ID, even if multiple values point to it. Currently, there is no requirement to limit identical External IDs on the same entity. If such a requirement arises in the future, we will need to update the external ID field constraint and the related kernel test scenarios accordingly. The only known downside of the current development approach is that it allows redundant data in the system. However, this "issue" is not unique to this particular field, as there is no existing system to prevent such redundancy across other fields either.
 
**Roadmap Note:**
 In the future, we plan to limit unique External IDs to one per platform (currently, it is limited per entity type). However, this requires development considerations to ensure performance efficiency, as searching for duplicated values across all entity types and fields of type "social_external_identifier" can be resource-intensive. Ideally, we aim to restrict External IDs to be unique per entity, so each ID is stored only once in the database. Currently, it is possible to have redundant unique External IDs for the same entity.

## Issue tracker
[3460849](https://www.drupal.org/project/social/issues/3460849)
PROD-29703
IOSAP-457

## Theme issue tracker
N/A

## How to test
- [x] Install open social as usual
- [x] enable field_ui and consumers
- [x] As a administrator create one group with external identifier field (go to admin/group/types/manage/flexible_group/fields/add-field, select External Identifier, under "Allowed external owner target types" select "Consumer" and for "Allowed number of values" "Unlimited" value
- [x] Create group A (group/add/flexible_group) and fill in External Identifier field. Fill in ID 123, Consumer, 1 (like on "Example field value" screenshot)
- [x] Create group B (group/add/flexible_group) and fill in External Identifier field. Fill in exactly the same values as for Group A (ID 123, Consumer, 1)
- [x] You should see an error on field "External identifier id should be unique. External identifier id "123" is already used, with external owner "consumer" of id "1"."
- [x] Change External owner value and you should be able to save the entity (to make it work, please create additional consumer - admin/config/services/consumer)
- [x] Change External ID value and you should be able to save the entity

**Scenario with 2nd external identifier** 
- [x] As a administrator add one more external identifier field (go to admin/group/types/manage/flexible_group/fields/add-field, select External Identifier, under "Allowed external owner target types" select "Consumer" and for "Allowed number of values" "Unlimited" value
- [x] Create group new group C and fill in 2nd external identifier field. Fill in exactly the same values as for Group A (ID 123, Consumer, 1)
- [x] You should see an error on field "External identifier id should be unique. External identifier id "123" is already used, with external owner "consumer" of id "1"."
- [x] Change External owner value and you should be able to save the entity (to make it work, please create additional consumer - admin/config/services/consumer)
- [x] Change External ID value and you should be able to save the entity

**Scenario for developers**
- [ ] As a developer make sure that this constraint is correctly triggered when entities are created programatically.

## Screenshots
Example field value
![Screenshot 2024-07-11 at 19 05 56](https://github.com/goalgorilla/open_social/assets/13753184/ce30dd48-8ac7-472e-bc64-26c978cabf3b)

## Release notes
Makes sure that External ID is unique per entity and external owner, despite how many fields of type "social_external_identifier" entity have. 

## Change Record
N/A

## Translations
N/A
