### PR TITLE
Add treatment to Activities replacement-token to get entity from grou…

### DIFF
--- a/modules/social_features/social_activity/social_activity.tokens.inc
+++ b/modules/social_features/social_activity/social_activity.tokens.inc
@@ -10,6 +10,7 @@ use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\group\Entity\GroupRelationshipInterface;
 use Drupal\message\Entity\Message;
 use Drupal\node\NodeInterface;
+use Drupal\user\EntityOwnerInterface;
 
 /**
  * Implements hook_token_info().
@@ -168,18 +169,29 @@ function social_activity_tokens($type, $tokens, array $data, array $options, Bub
             return $replacements;
           }
 
+          // Get related content to change tokens.
           $related_object_value = current($message->field_message_related_object->getValue());
           $related_object_content = \Drupal::entityTypeManager()
             ->getStorage($related_object_value['target_type'])
             ->load($related_object_value['target_id']);
-          if (
-            empty($related_object_content)
-            || !method_exists($related_object_content, 'getOwner')
-          ) {
+          if (empty($related_object_content)) {
             return $replacements;
           }
 
-          $replacements += $token_service->generate('user', $author_tokens, ['user' => $related_object_content->getOwner()], $options, $bubbleable_metadata);
+          // Get the Entity when the entity type is group_content.
+          // The owner from group_content didn't update, so is outdated.
+          if (
+            $related_object_content->getEntityTypeId() === 'group_content'
+            && method_exists($related_object_content, 'getEntity')
+          ) {
+            $related_object_content = $related_object_content->getEntity();
+          }
+
+          if ($related_object_content instanceof EntityOwnerInterface) {
+            $replacements += $token_service->generate('user', $author_tokens, ['user' => $related_object_content->getOwner()], $options, $bubbleable_metadata);
+          }
+
+          return $replacements;
         }
       }
     }


### PR DESCRIPTION
## Problem
When a Topic from a group has a change from the Author, the Notification Center continue showing the old Author.

## Solution
When the Notification Center load the messages, their are loading Group Content, so I changed to load the Entity from Group Content, because the Group Content is have the update on they owner.

## Issue tracker
[PROD-30143](https://getopensocial.atlassian.net/browse/PROD-30143)
[#3462466](https://www.drupal.org/project/social/issues/3462466)

## Theme issue tracker
N/A

## How to test
- [ ] Login as SM
- [ ] Create a group and add some group members
- [ ] Create a topic or an event on the group
- [ ] Run cron
- [ ] Change the content created author
- [ ] Run the cron again
- [ ] Check the notification regarding the content creation on homepage or on the notification center
- [ ] Notification author is not updated

## Screenshots
N/A

## Release notes
Fix the bug from Notification Center, there is showing old owner when a Topic from group changed their owner.

## Change Record
N/A

## Translations
N/A


[PROD-30143]: https://getopensocial.atlassian.net/browse/PROD-30143?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ