### PR TITLE
#3456839: Flexible group book update hook 13002 incorrect due to typo and crashing.

### DIFF
--- a/modules/social_features/social_group/modules/social_group_flexible_group/modules/social_flexible_group_book/social_flexible_group_book.install
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/modules/social_flexible_group_book/social_flexible_group_book.install
@@ -118,7 +118,7 @@ function social_flexible_group_book_update_13001() : string {
  */
 function social_flexible_group_book_update_13002(): void {
   $config = \Drupal::configFactory()
-    ->getEditable('create_book_group');
+    ->getEditable('message.template.create_book_group');
 
   $texts = array_map(function ($text) {
     $text['value'] = str_replace('message:author', 'message:revision_author', $text['value']);


### PR DESCRIPTION
## Problem
The PR https://github.com/goalgorilla/open_social/pull/3948/files contains a typo in the flexible_group_book update hook where it tries to retrieve the config create_book_group. This does not exist and needs to be message.template.create_book_group. This is now crashing the update hook.

## Solution
Correct the typo

## Issue tracker
https://www.drupal.org/project/social/issues/3456839

## Theme issue tracker
<!-- [Required if applicable] Paste a link to the drupal.org theme issue queue item, either from [socialbase](https://www.drupal.org/project/socialbase) or [socialblue](https://www.drupal.org/project/socialblue). If any other issue trackers were used, include links to those too. -->

## How to test
- [ ] Enable social_flexible_group_book on an installation without https://github.com/goalgorilla/open_social/pull/3948/files so you have the old message template in the database
- [ ] Update your installation with the new codebase
- [ ] Run the update hook and see that the author token has changed.

## Screenshots
<!-- [Required if new feature, and if applicable] If this Pull Request makes visual changes then please include some screenshots that show what has changed here. A before and after screenshot helps the reviewer determine what changes were made. -->

## Release notes
A typo has been fixed in retrieving a config for the social_flexible_group_book crashing the update hook.

## Change Record
<!-- [Required if applicable] If this Pull Request changes the way that developers should do things or introduces a new API for developers then a change record to document this is needed. Please provide a draft for a change record or a link to an unpublished change record below. Existing change records can be consulted as example. Please provide a draft for a change record or a link to an unpublished change record below. [Existing change records](https://www.drupal.org/list-changes/social) can be consulted as example. -->

## Translations
<!--
[Optional]Translatable strings are always extracted from the latest development branch. To ensure translations remain available for platforms running older versions of Open Social the original string should be added to `translations.php` when it's changed or removed.*
- [ ] Changed or removed source strings are added to the `translations.php` file.
-->
