### PR TITLE
Issue #3463318: Implement the ability to tag groups based on specific bundles.

### DIFF
--- a/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.module
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.module
@@ -433,11 +433,9 @@ function social_group_flexible_group_social_group_join_method_usage(): array {
  * Implements hook_social_tagging_type_alter().
  */
 function social_group_flexible_group_social_tagging_type_alter(array &$items): void {
-  $items['group']['sets'][] = [
-    'bundles' => ['flexible_group'],
-    'group' => 'additional_details',
-    'label' => t('Tags'),
-  ];
+  $items['group']['sets'][0]['bundles'][] = 'flexible_group';
+  $items['group']['sets'][0]['group'] = 'additional_details';
+  $items['group']['sets'][0]['label'] = t('Tags');
 }
 
 /**

--- a/modules/social_features/social_tagging/config/install/social_tagging.settings.yml
+++ b/modules/social_features/social_tagging/config/install/social_tagging.settings.yml
@@ -7,3 +7,4 @@ tag_node_type_event: true
 tag_node_type_landing_page: false
 tag_node_type_page: true
 tag_node_type_topic: true
+tag_group_type_flexible_group: true

--- a/modules/social_features/social_tagging/social_tagging.install
+++ b/modules/social_features/social_tagging/social_tagging.install
@@ -7,6 +7,8 @@
 
 use Drupal\Core\Entity\EntityStorageException;
 use Drupal\search_api\Item\Field;
+use Drupal\taxonomy\Entity\Term;
+use Drupal\taxonomy\TermInterface;
 
 /**
  * Install the module.
@@ -154,4 +156,76 @@ function social_tagging_update_last_removed() : int {
  */
 function social_tagging_update_130001(): void {
   user_role_grant_permissions('sitemanager', ['create terms in social_tagging']);
+}
+
+/**
+ * Update "Social Tagging" configs.
+ */
+function social_tagging_update_130002(): void {
+  $config_factory = \Drupal::configFactory();
+  $social_tagging_config = $config_factory->getEditable('social_tagging.settings');
+  $tag_type_group = $social_tagging_config->get('tag_type_group');
+  // Set 'tag_type_group' key value to new key 'tag_group_type_flexible_group'.
+  $social_tagging_config->set('tag_group_type_flexible_group', $tag_type_group);
+  // Delete old key.
+  $social_tagging_config->clear('tag_type_group');
+  $social_tagging_config->save(TRUE);
+}
+
+/**
+ * Update existed "Content tags" settings.
+ */
+function social_tagging_update_130003(array &$sandbox): void {
+  $query = \Drupal::entityQuery('taxonomy_term')
+    ->accessCheck(FALSE)
+    ->condition('vid', 'social_tagging')
+    ->condition('parent', 0);
+
+  if (!isset($sandbox['total'])) {
+    $tids = $query->execute();
+    $sandbox['total'] = count($tids);
+    $sandbox['current'] = 0;
+
+    if (empty($sandbox['total'])) {
+      $sandbox['#finished'] = 1;
+      return;
+    }
+  }
+
+  $terms_per_batch = 25;
+  $tids = $query
+    ->range($sandbox['current'], $terms_per_batch)
+    ->execute();
+
+  if (empty($tids)) {
+    $sandbox['#finished'] = 1;
+    return;
+  }
+
+  foreach ($tids as $tid) {
+    $term = Term::load($tid);
+    if ($term instanceof TermInterface && !$term->get('field_category_usage')->isEmpty()) {
+      $settings = unserialize($term->get('field_category_usage')->value);
+      // If term has a "Group" placement setting we need to change it on group
+      // bundle placement setting, by default it is "Flexible group" bundle.
+      if (is_array($settings) && in_array('group', $settings)) {
+        $settings = array_filter($settings, function ($value) {
+          return $value != 'group';
+        });
+
+        $settings[] = 'group_flexible_group';
+
+        $term->set('field_category_usage', serialize($settings));
+        $term->save();
+      }
+    }
+    $sandbox['current']++;
+  }
+
+  if ($sandbox['current'] >= $sandbox['total']) {
+    $sandbox['#finished'] = 1;
+  }
+  else {
+    $sandbox['#finished'] = ($sandbox['current'] / $sandbox['total']);
+  }
 }

--- a/modules/social_features/social_tagging/src/Plugin/Block/SocialGroupTagsBlock.php
+++ b/modules/social_features/social_tagging/src/Plugin/Block/SocialGroupTagsBlock.php
@@ -76,8 +76,11 @@ class SocialGroupTagsBlock extends BlockBase implements ContainerFactoryPluginIn
    * Logic to display the block in the sidebar.
    */
   protected function blockAccess(AccountInterface $account) {
+    // Get group from route.
+    $group = $this->routeMatch->getParameter('group');
+
     // If tagging is off, deny access always.
-    if (!$this->tagService->active() || !$this->tagService->groupActive()) {
+    if (!$this->tagService->active() || !$this->tagService->groupTypeActive($group)) {
       return AccessResult::forbidden();
     }
 
@@ -95,9 +98,6 @@ class SocialGroupTagsBlock extends BlockBase implements ContainerFactoryPluginIn
     if (in_array($this->routeMatch->getRouteName(), $ignore_routes)) {
       return AccessResult::forbidden();
     }
-
-    // Get group from route.
-    $group = $this->routeMatch->getParameter('group');
 
     if ($group instanceof Group) {
       if ($group->hasField('social_tagging')) {

--- a/modules/social_features/social_tagging/src/SocialTaggingOverrides.php
+++ b/modules/social_features/social_tagging/src/SocialTaggingOverrides.php
@@ -105,7 +105,7 @@ class SocialTaggingOverrides implements ConfigFactoryOverrideInterface {
     }
 
     // Remove tagging field from search index if not needed.
-    if (!$tag_service->groupActive()) {
+    if (!$tag_service->groupsActive()) {
       $field_settings = $config
         ->getEditable('search_api.index.social_groups')
         ->get('field_settings');
@@ -154,7 +154,7 @@ class SocialTaggingOverrides implements ConfigFactoryOverrideInterface {
     $config_views = [
       'views.view.search_content' => 'search_api_index_social_content',
     ];
-    if ($tag_service->groupActive()) {
+    if ($tag_service->groupsActive()) {
       $config_views['views.view.search_groups'] = 'search_api_index_social_groups';
     }
     if ($tag_service->profileActive()) {

--- a/modules/social_features/social_tagging/src/SocialTaggingServiceInterface.php
+++ b/modules/social_features/social_tagging/src/SocialTaggingServiceInterface.php
@@ -8,6 +8,7 @@ use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Language\LanguageManagerInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\group\Entity\Group;
 use Drupal\social_core\Service\MachineNameInterface;
 
 /**
@@ -88,9 +89,23 @@ interface SocialTaggingServiceInterface {
   ): bool;
 
   /**
-   * Returns whether the feature is turned on for groups or not.
+   * Returns whether the feature is turned on for certain group.
+   *
+   * @param \Drupal\group\Entity\Group|null $group
+   *   Group.
+   *
+   * @return bool
+   *   TRUE if the feature is turned, otherwise FALSE.
    */
-  public function groupActive(): bool;
+  public function groupTypeActive(Group $group = NULL): bool;
+
+  /**
+   * Returns whether the feature is turned on for groups.
+   *
+   * @return bool
+   *   TRUE if the feature is turned, otherwise FALSE.
+   */
+  public function groupsActive(): bool;
 
   /**
    * Returns whether the feature is turned on for profiles or not.


### PR DESCRIPTION
## Problem
Now we can allow or disallow tagging for all groups, but there may be cases where we need to disable tagging per group bundle, similar to nodes.

## Solution
Modify the the getKeyValueOptions() function - delete condition by group, to return keys for group bundles, similar to nodes.
Also, update `hook_social_tagging_type_alter` to allow adding multiple group types, similar to nodes.

## Issue tracker
https://www.drupal.org/project/social/issues/3463318
https://getopensocial.atlassian.net/browse/PROD-30189

## Theme issue tracker
N/A

## How to test
- [ ] Enable the `social_tagging` module
- [ ] Go to the tagging settings page `/admin/config/opensocial/tagging-settings`
- [ ] You should see `Group type: Flexible group` in the fieldset "Type configuration"
- [ ] Go to "Content tags" taxonomy term list
- [ ] Try to add new taxonomy
- [ ] You should see `Group type: Flexible group` in the fieldset "Placement"

## Screenshots
![image](https://github.com/user-attachments/assets/99113ed2-2962-473f-a6a9-70ce7112e717)
![image](https://github.com/user-attachments/assets/e5731ef1-ac74-4b42-9c4d-094415fbf418)

## Release notes
N/A

## Change Record
In this PR, the 'Group' option in the 'Social Tagging' settings was split into group bundles, similar to nodes. This change allows the ability to enable or disable tagging per group bundle, because if we want to create new group bundles in the future or if other modules will provide new group bundles - it will be a useful feature. If a user has this option enabled, it will be migrated to the new option, "Group type: Flexible group". To add additional group bundles to the 'Social Tagging' settings, you should implement the `hook_social_tagging_type_alter` function in the module that provides the bundle.

## Translations
N/A

