### PR TITLE
PROD-30134: Move AsyncAPI definition for "event create" event into the social_event module

### DIFF
--- a/modules/social_features/social_event/asyncapi.yml
+++ b/modules/social_features/social_event/asyncapi.yml
@@ -1,0 +1,143 @@
+channels:
+  eventCreate:
+    address: com.getopensocial.cms.event.create
+    messages:
+      eventCreate:
+        payload:
+          allOf:
+            - $ref: '#/components/schemas/cloudEventsSchema'
+            - type: object
+              properties:
+                data:
+                  type: object
+                  properties:
+                    id:
+                      type: string
+                      description: The UUID of the event.
+                    created:
+                      type: string
+                      format: date-time
+                      description: The creation time of the event.
+                    updated:
+                      type: string
+                      format: date-time
+                      description: The last updated time of the event.
+                    status:
+                      type: string
+                      description: The status of the event.
+                      enum:
+                        - published
+                        - unpublished
+                    label:
+                      type: string
+                      description: The label of the event.
+                    visibility:
+                      type: string
+                      description: The visibility of the event content.
+                    group:
+                      type: object
+                      nullable: true
+                      properties:
+                        id:
+                          type: string
+                          description: The UUID of the group.
+                        label:
+                          type: string
+                          description: The label of the group.
+                        href:
+                          type: object
+                          properties:
+                            canonical:
+                              type: string
+                              format: uri
+                              description: Canonical URL of the group.
+                    author:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                          description: The UUID of the author.
+                        displayName:
+                          type: string
+                          description: The display name of the author.
+                        href:
+                          type: object
+                          properties:
+                            canonical:
+                              type: string
+                              format: uri
+                              description: Canonical URL of the author.
+                    allDay:
+                      type: boolean
+                      description: Indicates if the event lasts all day.
+                    start:
+                      type: string
+                      format: date-time
+                      description: The start time of the event.
+                    end:
+                      type: string
+                      format: date-time
+                      description: The end time of the event.
+                    timezone:
+                      type: string
+                      description: The timezone of the event.
+                    address:
+                      type: object
+                      properties:
+                        label:
+                          type: string
+                          description: The label of the event location.
+                        countryCode:
+                          type: string
+                          description: The country code of the event location.
+                        administrativeArea:
+                          type: string
+                          description: The administrative area of the event location.
+                        locality:
+                          type: string
+                          description: The locality of the event location.
+                        dependentLocality:
+                          type: string
+                          description: The dependent locality of the event location.
+                        postalCode:
+                          type: string
+                          description: The postal code of the event location.
+                        sortingCode:
+                          type: string
+                          description: The sorting code of the event location.
+                        addressLine1:
+                          type: string
+                          description: The first address line of the event location.
+                        addressLine2:
+                          type: string
+                          description: The second address line of the event location.
+                    enrollment:
+                      type: object
+                      properties:
+                        enabled:
+                          type: boolean
+                          description: Indicates if enrollment is enabled.
+                        method:
+                          type: string
+                          description: The method of enrollment.
+                          enum:
+                            - open
+                            - invite
+                            - request
+                    href:
+                      type: object
+                      properties:
+                        canonical:
+                          type: string
+                          format: uri
+                          description: Canonical URL of the event.
+                    type:
+                      type: string
+                      nullable: true
+                      description: The type of the event.
+
+operations:
+  onEventCreate:
+    action: 'receive'
+    channel:
+      $ref: '#/channels/eventCreate'


### PR DESCRIPTION
## Description

We want the AsyncAPI definitions to be co-located with the modules that produces the events. 

The first event "event create" was pushed to Cable Car because it was pending an script to [automatically aggregate all definitions into a single file](https://github.com/goalgorilla/cablecar/pull/1813). This PR moves it to `social_event` module.

Here's the workflow run that generates the final documentation after aggregating all definitions:
https://github.com/goalgorilla/cablecar/actions/runs/10149822534

## Issue tracker
https://getopensocial.atlassian.net/browse/PROD-30134

## Theme issue tracker
N/A
<!-- *[Required if applicable] Paste a link to the drupal.org theme issue queue item, either from [socialbase](https://www.drupal.org/project/socialbase) or [socialblue](https://www.drupal.org/project/socialblue). If any other issue trackers were used, include links to those too.* -->

## How to test
N/A

<!--
*[Required] For example*
- [ ] Using version X.Y.Z of Open Social with the example module enabled
- [ ] As a sitemanager
- [ ] Try to enable the option B on screen c/d/e
- [ ] When saving I expect the result to be F but instead see G.
- [ ] The expected result F is attained when repeating the steps with this fix applied.
-->

## Screenshots
N/A
<!-- *[Required if new feature, and if applicable] If this Pull Request makes visual changes then please include some screenshots that show what has changed here. A before and after screenshot helps the reviewer determine what changes were made.* -->

## Release notes
N/A
<!-- *[Required if new feature, and if applicable] A short summary of the changes that were made that can be included in release notes.* -->

## Change Record
N/A
<!-- *[Required if applicable] If this Pull Request changes the way that developers should do things or introduces a new API for developers then a change record to document this is needed. Please provide a draft for a change record or a link to an unpublished change record below. Existing change records can be consulted as example. Please provide a draft for a change record or a link to an unpublished change record below. [Existing change records](https://www.drupal.org/list-changes/social) can be consulted as example.* -->

## Translations
N/A
<!--
*[Optional]Translatable strings are always extracted from the latest development branch. To ensure translations remain available for platforms running older versions of Open Social the original string should be added to `translations.php` when it's changed or removed.*
- [ ] Changed or removed source strings are added to the `translations.php` file.
-->
