### PR TITLE
Issue #3464394: Improve behavior of the profile preview popup

### DIFF
--- a/modules/social_features/social_core/assets/css/preview-el.css
+++ b/modules/social_features/social_core/assets/css/preview-el.css
@@ -7,7 +7,35 @@
   height: 100%;
   cursor: pointer;
 }
-.preview-popup-link:before {
+.preview-popup-link,
+.preview-popup-link img {
+  border-radius: 50% !important;
+}
+.teaser--small__media .preview-popup-link {
+  width: 44px;
+  height: 44px;
+}
+
+.preview-popup-link--image {
+  position: relative;
+  display: block;
+}
+
+img.preview-popup-link--image,
+.preview-popup-link--text img {
+  border: 2px solid transparent;
+}
+img.preview-popup-link--image:before,
+.preview-popup-link--text img:before {
+  display: none;
+}
+img.preview-popup-link--image:hover,
+.preview-popup-link--text img:hover {
+  box-shadow: 0 0 0 1px var(--primary-color);
+}
+
+.preview-popup-link:before,
+.preview-popup-link--image:before {
   content: "";
   position: absolute;
   height: calc(100% + 6px);
@@ -17,104 +45,13 @@
   left: -3px;
   border-radius: 50%;
 }
-.preview-popup-link:hover:before {
+.preview-popup-link:hover:before,
+.preview-popup-link--image:hover:before {
   border-color: var(--primary-color);
 }
 
-.card--stream img.preview-popup-link,
-.img-grid img.preview-popup-link {
-  width: 44px;
-  height: 44px;
-}
-
-.teaser--small span.preview-popup-link,
-.teaser--small a.preview-popup-link,
-.card--stream .media-body span.preview-popup-link,
-.card--stream .media-body a.preview-popup-link,
-.comment .comment__content span.preview-popup-link,
-.comment .comment__content a.preview-popup-link,
-.teaser span.preview-popup-link,
-.teaser a.preview-popup-link,
-.hero__banner .metainfo__content span.preview-popup-link,
-.hero__banner .metainfo__content a.preview-popup-link,
-.message span.preview-popup-link,
-.message a.preview-popup-link,
-.view--group-managers .list-item__text span.preview-popup-link,
-.view--group-managers .list-item__text a.preview-popup-link,
-.view-group-pending-members span.preview-popup-link,
-.view-group-pending-members a.preview-popup-link,
-.views-field.views-field-name span.preview-popup-link,
-.views-field.views-field-name a.preview-popup-link,
-.list-item__text span.preview-popup-link,
-.list-item__text a.preview-popup-link,
-.social-post-album--popup .media-heading span.preview-popup-link,
-.social-post-album--popup .media-heading a.preview-popup-link,
-.field--name-requests span.preview-popup-link,
-.field--name-requests a.preview-popup-link {
-  display: inline;
-  width: auto;
-  height: auto;
-}
-.teaser--small span.preview-popup-link:before,
-.teaser--small a.preview-popup-link:before,
-.card--stream .media-body span.preview-popup-link:before,
-.card--stream .media-body a.preview-popup-link:before,
-.comment .comment__content span.preview-popup-link:before,
-.comment .comment__content a.preview-popup-link:before,
-.teaser span.preview-popup-link:before,
-.teaser a.preview-popup-link:before,
-.hero__banner .metainfo__content span.preview-popup-link:before,
-.hero__banner .metainfo__content a.preview-popup-link:before,
-.message span.preview-popup-link:before,
-.message a.preview-popup-link:before,
-.view--group-managers .list-item__text span.preview-popup-link:before,
-.view--group-managers .list-item__text a.preview-popup-link:before,
-.view-group-pending-members span.preview-popup-link:before,
-.view-group-pending-members a.preview-popup-link:before,
-.views-field.views-field-name span.preview-popup-link:before,
-.views-field.views-field-name a.preview-popup-link:before,
-.list-item__text span.preview-popup-link:before,
-.list-item__text a.preview-popup-link:before,
-.social-post-album--popup .media-heading span.preview-popup-link:before,
-.social-post-album--popup .media-heading a.preview-popup-link:before,
-.field--name-requests span.preview-popup-link:before,
-.field--name-requests a.preview-popup-link:before {
-  display: none;
-}
-.teaser--small span.preview-popup-link:hover,
-.teaser--small a.preview-popup-link:hover,
-.card--stream .media-body span.preview-popup-link:hover,
-.card--stream .media-body a.preview-popup-link:hover,
-.comment .comment__content span.preview-popup-link:hover,
-.comment .comment__content a.preview-popup-link:hover,
-.teaser span.preview-popup-link:hover,
-.teaser a.preview-popup-link:hover,
-.hero__banner .metainfo__content span.preview-popup-link:hover,
-.hero__banner .metainfo__content a.preview-popup-link:hover,
-.message span.preview-popup-link:hover,
-.message a.preview-popup-link:hover,
-.view--group-managers .list-item__text span.preview-popup-link:hover,
-.view--group-managers .list-item__text a.preview-popup-link:hover,
-.view-group-pending-members span.preview-popup-link:hover,
-.view-group-pending-members a.preview-popup-link:hover,
-.views-field.views-field-name span.preview-popup-link:hover,
-.views-field.views-field-name a.preview-popup-link:hover,
-.list-item__text span.preview-popup-link:hover,
-.list-item__text a.preview-popup-link:hover,
-.social-post-album--popup .media-heading span.preview-popup-link:hover,
-.social-post-album--popup .media-heading a.preview-popup-link:hover,
-.field--name-requests span.preview-popup-link:hover,
-.field--name-requests a.preview-popup-link:hover {
+.preview-popup-link--text:hover {
   text-decoration: underline;
-}
-
-.views-field.views-field-name a.preview-popup-link {
-  margin-left: 10px;
-}
-
-.img-grid a.preview-popup-link {
-  width: auto;
-  height: auto;
 }
 
 /*# sourceMappingURL=preview-el.css.map */

--- a/modules/social_features/social_core/assets/css/preview-el.scss
+++ b/modules/social_features/social_core/assets/css/preview-el.scss
@@ -1,3 +1,13 @@
+@mixin hoverEl {
+  position: absolute;
+  height: calc(100% + 6px);
+  width: calc(100% + 6px);
+  border: 1px solid transparent;
+  top: -3px;
+  left: -3px;
+  border-radius: 50%;
+}
+
 .preview-popup-link {
   position: relative;
   display: flex;
@@ -7,15 +17,40 @@
   height: 100%;
   cursor: pointer;
 
+  &,
+  img {
+    border-radius: 50% !important;
+  }
+
+  .teaser--small__media & {
+    width: 44px;
+    height: 44px;
+  }
+}
+
+.preview-popup-link--image {
+  position: relative;
+  display: block;
+}
+
+img.preview-popup-link--image,
+.preview-popup-link--text img {
+  border: 2px solid transparent;
+
+  &:before {
+    display: none;
+  }
+
+  &:hover {
+    box-shadow: 0 0 0 1px var(--primary-color);
+  }
+}
+
+.preview-popup-link,
+.preview-popup-link--image {
   &:before {
     content: '';
-    position: absolute;
-    height: calc(100% + 6px);
-    width: calc(100% + 6px);
-    border: 1px solid transparent;
-    top: -3px;
-    left: -3px;
-    border-radius: 50%;
+    @include hoverEl;
   }
 
   &:hover {
@@ -25,51 +60,8 @@
   }
 }
 
-.card--stream,
-.img-grid {
-  img.preview-popup-link {
-    width: 44px;
-    height: 44px;
-  }
-}
-
-.teaser--small,
-.card--stream .media-body,
-.comment .comment__content,
-.teaser,
-.hero__banner .metainfo__content,
-.message,
-.view--group-managers .list-item__text,
-.view-group-pending-members,
-.views-field.views-field-name,
-.list-item__text,
-.social-post-album--popup .media-heading,
-.field--name-requests {
-  span.preview-popup-link,
-  a.preview-popup-link {
-    display: inline;
-    width: auto;
-    height: auto;
-
-    &:before {
-      display: none;
-    }
-
-    &:hover {
-      text-decoration: underline;
-    }
-  }
-}
-
-.views-field.views-field-name {
-  a.preview-popup-link {
-    margin-left: 10px;
-  }
-}
-
-.img-grid {
-  a.preview-popup-link {
-    width: auto;
-    height: auto;
+.preview-popup-link--text {
+  &:hover {
+    text-decoration: underline;
   }
 }

--- a/modules/social_features/social_profile/modules/social_profile_preview/src/Service/SocialProfilePreviewHelper.php
+++ b/modules/social_features/social_profile/modules/social_profile_preview/src/Service/SocialProfilePreviewHelper.php
@@ -79,7 +79,12 @@ class SocialProfilePreviewHelper implements SocialProfilePreviewHelperInterface 
         $attributes = $attributes->toArray();
       }
 
-      $attributes['class'][] = 'preview-popup-link';
+      if (isset($attributes['loading']) && $attributes['loading']) {
+        $attributes['class'][] = 'preview-popup-link--image';
+      }
+      else {
+        $attributes['class'][] = 'preview-popup-link--text';
+      }
 
       $preview_url = Url::fromRoute('social_profile_preview.canonical', [
         'profile' => $profile->get('profile_id')->value,


### PR DESCRIPTION
## Problem
According to the new implementation of the preview popup, the profile preview hover element has a lot of different behavior, resulting in many bugs.

## Solution
Should add specific classes for the preview image and text elements. Improve the hover behavior of the profile preview elements.

## Issue tracker
- https://www.drupal.org/project/social/issues/3464394
- https://getopensocial.atlassian.net/browse/PROD-30055

## Theme issue tracker
<!-- *[Required if applicable] Paste a link to the drupal.org theme issue queue item, either from [socialbase](https://www.drupal.org/project/socialbase) or [socialblue](https://www.drupal.org/project/socialblue). If any other issue trackers were used, include links to those too.* -->

## How to test

- Enable the `social_profile_preview` module
- Hover on the user name or avatar

## Screenshots
**Before:**
<img width="700" alt="image" src="https://github.com/user-attachments/assets/e57f8d9e-54b0-4a3e-a263-d84762f2e529">

**After:**
![image](https://github.com/user-attachments/assets/d761e6ee-e2a4-462e-9f33-0d63b3b9e9d2)


## Release notes
The profile preview element has the correct behavior on the default and hover states.

