### PR TITLE
Issue #3464465: "Page not found" on the content pages that don't have current language translation

### DIFF
--- a/modules/custom/social_language/social_language.services.yml
+++ b/modules/custom/social_language/social_language.services.yml
@@ -1,6 +1,6 @@
 services:
   social_language.override:
-    class: \Drupal\social_language\SocialLanguageConfigOverride
+    class: Drupal\social_language\SocialLanguageConfigOverride
     tags:
       - {name: config.factory.override, priority: 5}
   social_language.access:
@@ -18,3 +18,11 @@ services:
     calls:
       - [setContext, ['@?router.request_context']]
     deprecated: The "%service_id%" service is deprecated. You should use the 'url_generator' service instead. See https://www.drupal.org/project/social/issues/3098046
+  social_language.path_processor:
+    class: Drupal\social_language\PathProcessor\SocialLanguagePathProcessor
+    arguments: ['@path_alias.manager', '@language_manager']
+    tags:
+      # Priority should be higher than \Drupal\path_alias\PathProcessor\AliasPathProcessor::processInbound().
+      - { name: path_processor_inbound, priority: 101 }
+      # Priority should be higher than \Drupal\path_alias\PathProcessor\AliasPathProcessor::processOutbound().
+      - { name: path_processor_outbound, priority: 301 }

--- a/modules/custom/social_language/src/PathProcessor/SocialLanguagePathProcessor.php
+++ b/modules/custom/social_language/src/PathProcessor/SocialLanguagePathProcessor.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Drupal\social_language\PathProcessor;
+
+use Drupal\Core\Language\LanguageInterface;
+use Drupal\Core\Language\LanguageManagerInterface;
+use Drupal\Core\Render\BubbleableMetadata;
+use Drupal\path_alias\AliasManagerInterface;
+use Drupal\path_alias\PathProcessor\AliasPathProcessor;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Overrides "AliasPathProcessor" path processor to prevent "404" exceptions.
+ */
+class SocialLanguagePathProcessor extends AliasPathProcessor {
+
+  /**
+   * Language manager.
+   */
+  protected LanguageManagerInterface $languageManager;
+
+  /**
+   * Constructs a SocialLanguagePathProcessor object.
+   *
+   * @param \Drupal\path_alias\AliasManagerInterface $alias_manager
+   *   An alias manager for looking up the system path.
+   * @param \Drupal\Core\Language\LanguageManagerInterface $language_manager
+   *   The language manager.
+   */
+  public function __construct(AliasManagerInterface $alias_manager, LanguageManagerInterface $language_manager) {
+    parent::__construct($alias_manager);
+
+    $this->languageManager = $language_manager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function processInbound($path, Request $request): string {
+    $possible_alias = $path;
+    $path = parent::processInbound($possible_alias, $request);
+
+    if ($path !== $possible_alias) {
+      return $path;
+    }
+
+    if (!$this->languageManager->isMultilingual()) {
+      return $path;
+    }
+
+    $langcode = $this->languageManager->getCurrentLanguage(LanguageInterface::TYPE_URL)->getId();
+    $default_langcode = $this->languageManager->getDefaultLanguage()->getId();
+    if ($langcode === $default_langcode) {
+      return $path;
+    }
+
+    // Case: when we have a topic in "English" version but a user has "Dutch"
+    // and try to visit the topic the result will be "Page not found".
+    // There we're trying to find path for alias in default language and
+    // prevent 404 exception.
+    return $this->aliasManager->getPathByAlias($path, $default_langcode);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function processOutbound($path, &$options = [], Request $request = NULL, BubbleableMetadata $bubbleable_metadata = NULL) {
+    $alias = parent::processOutbound($path, $options, $request, $bubbleable_metadata);
+    if ($path !== $alias) {
+      return $alias;
+    }
+
+    if (!$this->languageManager->isMultilingual()) {
+      return $alias;
+    }
+
+    $langcode = isset($options['language']) ? $options['language']->getId() : NULL;
+    $default_langcode = $this->languageManager->getDefaultLanguage()->getId();
+    if ($langcode === $default_langcode) {
+      return $alias;
+    }
+
+    if (empty($options['alias'])) {
+      $alias = $this->aliasManager->getAliasByPath($path, $default_langcode);
+      // Ensure the resulting path has at most one leading slash, to prevent it
+      // becoming an external URL without a protocol like //example.com. This
+      // is done in \Drupal\Core\Routing\UrlGenerator::generateFromRoute()
+      // also, to protect against this problem in arbitrary path processors,
+      // but it is duplicated here to protect any other URL generation code
+      // that might call this method separately.
+      if (str_starts_with($alias, '//')) {
+        $alias = '/' . ltrim($alias, '/');
+      }
+    }
+
+    return $alias;
+  }
+
+}


### PR DESCRIPTION
## Problem
For multilingual sites, users can't see content (topic, event, group, etc) in languages other than the current user language. For example, if a user with "Dutch" language tries to visit a topic that has only "English" version user gets "Page not found" exception. The expected behavior is that the user should be able to visit "English" version of the topic (because, for example, a user can see topic teasers in "/all-topic" page).

## Solution
- Redirect users to the content `default language` version if it exists;
- Override `\Drupal\social_language\PathProcessor\AliasPathProcessor`;

## Issue tracker
- https://www.drupal.org/project/social/issues/3464465
- https://getopensocial.atlassian.net/browse/PROD-29925

## How to test
- [ ] Set up multilingual OS site (for example, "English" and "Dutch")
- [ ] Login as LU
- [ ] Create a topic in "English"
- [ ] Switch to "Dutch" language on "/user/edit" page
- [ ] Visit a topic page
  - [ ] **EB**: LU should be able to see "English" topic version

## Release notes
Prevent "Page not found" on the content pages that don't have current language translation.
