### PR TITLE
Issue #3464499: Hide Revisions tab for groups

### DIFF
--- a/modules/social_features/social_core/social_core.module
+++ b/modules/social_features/social_core/social_core.module
@@ -527,12 +527,38 @@ function social_core_menu_local_tasks_alter(&$data, $route_name) {
   }
 
   // Remove Revisions tab if revisions for the node not exist.
-  $node = \Drupal::routeMatch()->getParameter('node');
-  if ($node instanceof NodeInterface) {
-    $revisions = \Drupal::entityTypeManager()->getStorage('node')->revisionIds($node);
+  $entity = \Drupal::routeMatch()->getParameter('node') ?: \Drupal::routeMatch()->getParameter('group');
+  if ($entity instanceof EntityInterface) {
+    // Get the configuration factory service.
+    $config_factory = \Drupal::service('config.factory');
 
-    if ($revisions && count($revisions) === 1) {
-      unset($data['tabs'][0]['entity.node.version_history']);
+    // Load the configuration for the entity type.
+    $config = $config_factory->get($entity->getEntityTypeId() . '.type.' . $entity->bundle());
+
+    // If new revision is disabled.
+    if (!$config->get('new_revision')) {
+      if ($entity instanceof NodeInterface) {
+        // Handle node entities.
+        $storage = \Drupal::entityTypeManager()->getStorage('node');
+        $revisions = $storage->revisionIds($entity);
+
+        if ($revisions && count($revisions) === 1) {
+          unset($data['tabs'][0]['entity.node.version_history']);
+        }
+      }
+      elseif ($entity instanceof GroupInterface) {
+        // Query for all revisions of the group entity.
+        $query = \Drupal::entityQuery('group')
+          ->condition('id', $entity->id())
+          ->accessCheck(FALSE);
+
+        // Execute the query to get revision IDs.
+        $revision_ids = $query->execute();
+
+        if ($revision_ids && count($revision_ids) === 1) {
+          unset($data['tabs'][0]['entity.version_history:group.version_history']);
+        }
+      }
     }
   }
 


### PR DESCRIPTION
## Problem
In the PR https://github.com/goalgorilla/open_social/pull/3517 we decided to hide Revision tabs for Groups.

After update to Group 2 the group roles marked as **Admin role** are automatically granted all permissions in the group. By default, the roles set as admin in Open Social are: Administrator, Content manager and Site manager.

<img width="492" alt="image" src="https://github.com/user-attachments/assets/8d5a14ab-81cd-4f39-a9c0-27037bd91146">

That means those roles will automatically have the permission "**_Revisioning: View all revisions_**", which is the one checked in order to enable the Revisions tab. So even though the `new_revision` config is set to `FALSE` for all group types, users in those roles will always see the tab.

## Solution
Force hiding the Revisions tab the same way we do for nodes in `hook_menu_local_tasks_alter()`. The tab should be hidden if the config `new_revision` is disabled and there is only 1 revision.

## Issue tracker

- https://www.drupal.org/project/social/issues/3464499
- https://getopensocial.atlassian.net/browse/PROD-30091

## Theme issue tracker
<!-- *[Required if applicable] Paste a link to the drupal.org theme issue queue item, either from [socialbase](https://www.drupal.org/project/socialbase) or [socialblue](https://www.drupal.org/project/socialblue). If any other issue trackers were used, include links to those too.* -->

## How to test
- [ ] Make sure the config `new_revision` is set to `FALSE` for the given Group type
- [ ] Create a new Group
- [ ] Confirm the Revisions tab does not show

## Screenshots
<img width="1194" alt="image" src="https://github.com/user-attachments/assets/6668b267-1ad9-405f-bb80-6708a65d9ed9">


## Release notes
Hide Revisions tab for groups for Site Managers and higher roles if revisions are disabled.

