### PR TITLE
Issue #3464971: Event types are displayed in the default language

### DIFF
--- a/modules/social_features/social_event/modules/social_event_type/social_event_type.module
+++ b/modules/social_features/social_event/modules/social_event_type/social_event_type.module
@@ -8,6 +8,7 @@
 use Drupal\Core\Ajax\AjaxResponse;
 use Drupal\Core\Ajax\ReplaceCommand;
 use Drupal\Core\Entity\ContentEntityInterface;
+use Drupal\Core\Entity\FieldableEntityInterface;
 use Drupal\Core\Field\FieldDefinitionInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Link;
@@ -75,6 +76,8 @@ function social_event_type_preprocess_node(array &$variables): void {
     $variables['event_type'] = NULL;
     $event_type = empty($event_types) ? NULL : reset($event_types);
     if ($event_type instanceof TermInterface) {
+      /** @var \Drupal\Core\Entity\EntityInterface $event_type */
+      $event_type = \Drupal::service('entity.repository')->getTranslationFromContext($event_type);
       $variables['metadata'] = t('in @event', [
         '@event' => $event_type->toLink()
           ->toString(),
@@ -93,6 +96,7 @@ function social_event_type_preprocess_node(array &$variables): void {
         ->toString();
       $variables['event_type'] = $event_type_link;
       if (
+        $event_type instanceof FieldableEntityInterface &&
         $event_type->hasField('field_event_type_icon') &&
         !$event_type->get('field_event_type_icon')->isEmpty()
       ) {


### PR DESCRIPTION
## Problem
<!-- *[Required] Describe the problem you're trying to solve, this should motivate why the changes you're proposing are needed.* -->
As a user I should see the correct translations of event type terms everywhere on the site.

For examples, we have various event type terms configured on our platform. These terms also have the correct translations configured (for French, Italian) in the backend. Yet, in some parts of the site (e.g. stream, /community-events, etc.), these translations do not appear. French users see the original German strings.

## Solution
<!-- *[Required] Describe the solution you've created, elaborate on any technical choices you've made. Why is this the right solution and is a different solution not the right one? What is the reasoning behind the chosen solution?* -->

In `social_event_type_preprocess_node()` use:
```
 $event_type = \Drupal::service('entity.repository')->getTranslationFromContext($event_type);
```


## Issue tracker
<!-- *[Required] Paste a link to the drupal.org issue queue item. If any other issue trackers were used, include links to those too.* -->
- https://www.drupal.org/project/social/issues/3464971
- https://getopensocial.atlassian.net/browse/PROD-29850

## Theme issue tracker
<!-- *[Required if applicable] Paste a link to the drupal.org theme issue queue item, either from [socialbase](https://www.drupal.org/project/socialbase) or [socialblue](https://www.drupal.org/project/socialblue). If any other issue trackers were used, include links to those too.* -->
N/A

## How to test
- [ ] Using the latest version of Open Social with the social_event_type module enabled
- [ ] As a sitemanager 
- [ ] Create a test event with selected event type 
- [ ] Add translation of the selected event type (term)
- [ ] Switch your profile language to different then default one
- [ ] And when you open preview event page, the event type displays still untranslated
- [ ] The expected result is attained when repeating the steps with this fix applied.

## Screenshots
<!-- *[Required if new feature, and if applicable] If this Pull Request makes visual changes then please include some screenshots that show what has changed here. A before and after screenshot helps the reviewer determine what changes were made.* -->
Before:
<img width="1255" alt="Screenshot 2024-07-31 at 15 46 57" src="https://github.com/user-attachments/assets/804216b4-93f4-4c03-bad5-c924c393c941">

After:
<img width="1252" alt="Screenshot 2024-07-31 at 15 47 10" src="https://github.com/user-attachments/assets/6a498841-ce10-4589-ada9-84d8ac8edca2">


## Release notes
<!-- *[Required if new feature, and if applicable] A short summary of the changes that were made that can be included in release notes.* -->
Fixes an issue with untranslated "Event types" field for Events

## Change Record
<!-- *[Required if applicable] If this Pull Request changes the way that developers should do things or introduces a new API for developers then a change record to document this is needed. Please provide a draft for a change record or a link to an unpublished change record below. Existing change records can be consulted as example. Please provide a draft for a change record or a link to an unpublished change record below. [Existing change records](https://www.drupal.org/list-changes/social) can be consulted as example.* -->
N/A

## Translations
<!--
*[Optional]Translatable strings are always extracted from the latest development branch. To ensure translations remain available for platforms running older versions of Open Social the original string should be added to `translations.php` when it's changed or removed.*
- [ ] Changed or removed source strings are added to the `translations.php` file.
-->
N/A
