### PR TITLE
Issue #3426460: Error to save Account Settings 

### DIFF
--- a/modules/social_features/social_user/social_user.install
+++ b/modules/social_features/social_user/social_user.install
@@ -219,3 +219,28 @@ function social_user_update_13003() : string {
   // Output logged messages to related channel of update execution.
   return $updater->logger()->output();
 }
+
+/**
+ * Copy show-main-in-messages to new structure and delete old structure.
+ */
+function social_user_update_13004(): void {
+  $system_config = \Drupal::configFactory()
+    ->get('system.site');
+
+  // Return early when this configuration is empty.
+  if (is_null($system_config->get('show_mail_in_messages'))) {
+    return;
+  }
+
+  // Copy configuration to new structure.
+  \Drupal::configFactory()
+    ->getEditable('social_user.settings')
+    ->set('show_mail_in_messages', (boolean) $system_config->get('show_mail_in_messages'))
+    ->save();
+
+  // Delete old structure.
+  \Drupal::configFactory()
+    ->getEditable('system.site')
+    ->clear('show_mail_in_messages')
+    ->save();
+}


### PR DESCRIPTION
## Problem
On #3869 we moved a variable to a new structure, but one condition made some installation continue using other structure.

## Solution
Recreate the hook-update with a new condition

## Issue tracker
[PROD-29296](https://getopensocial.atlassian.net/browse/PROD-29296)
[#3426460](https://www.drupal.org/project/social/issues/3426460)

## Theme issue tracker
N/A

## How to test
This error should be forced or get a database with error.
- [ ] Execute command to force the error: `drush cset system.site show_mail_in_messages 0`
- [ ] Go to People -> Account Settings: /admin/config/people/accounts
- [ ] Try to save this page

## Screenshots
N/A

## Release notes
The error to save Account Settings will be fixed.

## Change Record
N/A

## Translations
N/A


[PROD-29296]: https://getopensocial.atlassian.net/browse/PROD-29296?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ