### PR TITLE
#3465292: The Unique Nickname field is enabled without Nickname field

### DIFF
--- a/modules/social_features/social_profile/modules/social_profile_fields/src/Form/SocialProfileFieldsSettingsForm.php
+++ b/modules/social_features/social_profile/modules/social_profile_fields/src/Form/SocialProfileFieldsSettingsForm.php
@@ -219,15 +219,28 @@ class SocialProfileFieldsSettingsForm extends ConfigFormBase implements Containe
             '#default_value' => is_null($config->get('profile_address_field_administrative_area')) ? TRUE : $config->get('profile_address_field_administrative_area'),
           ];
         }
+
+        if ($type === 'profile' && $id === 'profile_profile_field_profile_nick_name') {
+          $form[$type]['profile_profile_nickname_wrapper']['nickname_settings'] = [
+            '#type' => 'details',
+            '#title' => $this->t('Nickname field settings'),
+            '#open' => TRUE,
+            '#states' => [
+              'visible' => [
+                ':input[name="' . $id . '"]' => ['checked' => TRUE],
+              ],
+            ],
+          ];
+
+          $form[$type]['profile_profile_nickname_wrapper']['nickname_settings']['nickname_unique_validation'] = [
+            '#type' => 'checkbox',
+            '#title' => $this->t('Unique nicknames'),
+            '#description' => $this->t('If you check this, validation is applied that verifies the users nickname is unique whenever they save their profile.'),
+            '#default_value' => $config->get('nickname_unique_validation'),
+          ];
+        }
       }
     }
-
-    $form['nickname_unique_validation'] = [
-      '#type' => 'checkbox',
-      '#title' => $this->t('Unique nicknames'),
-      '#description' => $this->t('If you check this, validation is applied that verifies the users nickname is unique whenever they save their profile.'),
-      '#default_value' => $config->get('nickname_unique_validation'),
-    ];
 
     $form['actions']['social_profile_fields_confirm_flush'] = [
       '#type' => 'submit',
@@ -262,7 +275,8 @@ class SocialProfileFieldsSettingsForm extends ConfigFormBase implements Containe
     $config->set('profile_address_field_postalcode', $main_address_value ? $form_state->getValue('profile_address_field_postalcode') : FALSE);
     $config->set('profile_address_field_administrative_area', $main_address_value ? $form_state->getValue('profile_address_field_administrative_area') : FALSE);
 
-    $config->set('nickname_unique_validation', $form_state->getValue('nickname_unique_validation'));
+    $nickname_unique_validation = $form_state->getValue('profile_profile_field_profile_nick_name') ? $form_state->getValue('nickname_unique_validation') : FALSE;
+    $config->set('nickname_unique_validation', $nickname_unique_validation);
     $config->save();
 
     parent::submitForm($form, $form_state);


### PR DESCRIPTION
## Problem
In the module social_profile_field we have the option to add nicknames.

There is an issue that when you enable “unique nicknames” at the bottom, but don’t enable nicknames above it will crash during registration as it expects input.

The ideal situation would be that unique nicknames cannot be select if you don’t have nickname enabled.

## Solution
Added the Unique Nickname field into a fieldset similar to Address fields and it should be visible only when the Nickname field is enabled.

## Issue tracker
[PROD-30230](https://getopensocial.atlassian.net/browse/PROD-30230)
[#3465292](https://www.drupal.org/project/social/issues/3465292)

## Theme issue tracker
N/A

## How to test
- [ ] Enable Social Profile Fields module
- [ ] Go to  "/admin/config/opensocial/profile-fields"
- [ ] Test 1: Test to enable only Unique Nickname field
- [ ] Test 2: After enable Nickname and Unique Nickname, check the registration page

## Screenshots
N/A

## Release notes
Changed the Nickname and Unique Nickname behavior to keep the integrity and avoid to enable Unique Nickname field without Nickname field.

## Change Record
N/A

## Translations
N/A



[PROD-30230]: https://getopensocial.atlassian.net/browse/PROD-30230?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ