### PR TITLE
PROD-29620: Replace all EDA Handlers with dummies if there is no Publisher

### DIFF
--- a/modules/social_features/social_core/src/EdaDummyHandler.php
+++ b/modules/social_features/social_core/src/EdaDummyHandler.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Drupal\social_core;
+
+/**
+ * A dummy handler that equals a no-op.
+ *
+ * This ensures people who do not use the EDA to publish events to an external
+ * event bus don't have any performance penalty from loading or formatting data.
+ */
+class EdaDummyHandler {
+
+  /**
+   * {@inheritDoc}
+   */
+  public function __call(string $name, array $arguments): void {}
+
+}

--- a/modules/social_features/social_event/social_event.services.yml
+++ b/modules/social_features/social_event/social_event.services.yml
@@ -22,3 +22,5 @@ services:
   social_event.eda_handler:
     autowire: true
     class: Drupal\social_event\EdaHandler
+    tags:
+      - { name: social.eda.handler }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -4764,11 +4764,6 @@ parameters:
 			path: modules/social_features/social_core/src/Routing/RouteSubscriber.php
 
 		-
-			message: "#^Method Drupal\\\\social_core\\\\SocialCoreServiceProvider\\:\\:alter\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: modules/social_features/social_core/src/SocialCoreServiceProvider.php
-
-		-
 			message: "#^Method Drupal\\\\social_download_count\\\\SocialDownloadCountConfigOverride\\:\\:createConfigObject\\(\\) should return Drupal\\\\Core\\\\Config\\\\StorableConfigBase but returns null\\.$#"
 			count: 1
 			path: modules/social_features/social_download_count/src/SocialDownloadCountConfigOverride.php
@@ -13400,3 +13395,8 @@ parameters:
 			message: "#^Property Drupal\\\\social_event\\\\Event\\\\EventCreateEventData::\\$href has unknown class Drupal\\\\social_eda\\\\Types\\\\Href as its type\\.$#"
 			count: 1
 			path: modules/social_features/social_event/src/Event/EventCreateEventData.php
+
+		-
+			message: "#^Class Drupal\\\\social_eda_dispatcher\\\\Dispatcher not found\\.$#"
+			count: 1
+			path: modules/social_features/social_core/src/SocialCoreServiceProvider.php


### PR DESCRIPTION
## Problem
We want the events for our Event Driven Architecture to live in the modules that own the objects that trigger the events. For example `social_event` is responsible for the creation and management of events in our CMS and thus should be responsible for triggering EDA events related to events. 

However, we want the actual code that publishes all our events to live in Cable Car since we expect this to be a SaaS only feature (as it requires dedicated infrastructure). Because the event generating code lives in the distribution and building an EDA event may have a slight performance cost, we don’t want to distribution users to incur this cost unnecessarily.

## Solution
Replace all EDA Handlers with dummies if there is no Publisher using the ServiceProvider.

## Issue tracker
https://getopensocial.atlassian.net/browse/PROD-29620

## Theme issue tracker
N/A

## How to test
- [x] Checkout branch `issue/PROD-29620-dummy-pattern`
- [x] Apply the patch [PROD-29620.txt](https://github.com/user-attachments/files/16470524/PROD-29620.txt) which will add status messages in the methods `EdaHandler::eventCreate` and `EdaDummyHandler::__call` to help us debug
- [x] While the module `social_eda_dispatcher` is still disabled, create a new Event; The status message **_Dummy Handler loaded_** should be displayed.
- [x] Now enable the module `social_eda_dispatcher` and create another Event; The status message **_Custom Handler loaded_** should be displayed.

## Screenshots
N/A

## Release notes
N/A

## Change Record
N/A

## Translations
N/A
