### PR TITLE
Issue #3466386: Country field keeps popping back on edit content

### DIFF
--- a/modules/social_features/social_core/social_core.module
+++ b/modules/social_features/social_core/social_core.module
@@ -821,10 +821,6 @@ function social_core_field_widget_single_element_form_alter(&$element, FormState
 
     $element['#element_validate'] = ['social_core_path_validate'];
   }
-  if ($field_definition->getType() === 'address') {
-    $default_country = \Drupal::config('system.date')->get('country.default');
-    $element['address']['#default_value']['country_code'] = $element['address']['#default_value']['country_code'] ?? $default_country;
-  }
 }
 
 /**

--- a/modules/social_features/social_event/social_event.install
+++ b/modules/social_features/social_event/social_event.install
@@ -5,6 +5,7 @@
  * Install, update and uninstall functions for the social_event module.
  */
 
+use Drupal\field\Entity\FieldConfig;
 use Drupal\menu_link_content\Entity\MenuLinkContent;
 use Drupal\user\RoleInterface;
 
@@ -249,4 +250,49 @@ function social_event_update_130003() : string {
 
   // Output logged messages to related channel of update execution.
   return $updater->logger()->output();
+}
+
+/**
+ * Update default location from system configuration to event.
+ */
+function social_event_update_130004(): void {
+  $default_country = \Drupal::config('system.date')->get('country.default');
+  $event_address_field = FieldConfig::loadByName('node', 'event', 'field_event_address');
+  if (empty($event_address_field)) {
+    return;
+  }
+
+  // Init and fill default values variable.
+  $default_values = [];
+  if (!empty($default_country)) {
+    $default_values = $event_address_field->getDefaultValueLiteral();
+    // When the default values isn't initiated, so init it.
+    if (empty($default_values)) {
+      $default_values[] = [
+        'langcode' => NULL,
+        'administrative_area' => "",
+        'locality' => "",
+        'dependent_locality' => NULL,
+        'postal_code' => "",
+        'sorting_code' => NULL,
+        'address_line1' => "",
+        'address_line2' => NULL,
+        'address_line3' => NULL,
+        'organization' => NULL,
+        'given_name' => NULL,
+        'additional_name' => NULL,
+        'family_name' => NULL,
+      ];
+
+    }
+
+    // Add country code from site default country.
+    $default_values[0]['country_code'] = $default_country;
+  }
+
+  // Save field with new default value.
+  if (method_exists($event_address_field, 'setDefaultValue')) {
+    $event_address_field->setDefaultValue($default_values)
+      ->save();
+  }
 }

--- a/modules/social_features/social_event/social_event.module
+++ b/modules/social_features/social_event/social_event.module
@@ -23,6 +23,7 @@ use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\Core\Url;
 use Drupal\datetime\Plugin\Field\FieldType\DateTimeItemInterface;
+use Drupal\field\Entity\FieldConfig;
 use Drupal\group\Entity\GroupRelationship;
 use Drupal\group\GroupMembershipLoaderInterface;
 use Drupal\menu_link_content\MenuLinkContentInterface;
@@ -1510,4 +1511,64 @@ function _social_event_menu_local_tasks_routes(): array {
   \Drupal::moduleHandler()->invokeAll('social_event_menu_local_tasks_routes_alter', [&$routes]);
 
   return $routes;
+}
+
+/**
+ * Add a submit function to update default country for event location field.
+ *
+ * Implements hook_form_FORM_ID_alter().
+ */
+function social_event_form_system_regional_settings_alter(array &$form): void {
+  $form['#submit'][] = '_social_event_system_regional_settings_submit';
+}
+
+/**
+ * Submit function to save default country to event location field.
+ *
+ * @param array $form
+ *   Nested array of form elements that comprise the form.
+ * @param \Drupal\Core\Form\FormStateInterface $form_state
+ *   The current state of the form.
+ *
+ * @throws \Drupal\Core\Entity\EntityStorageException
+ */
+function _social_event_system_regional_settings_submit(array &$form, FormStateInterface $form_state): void {
+  // Load field configuration and return early if it isn't exist.
+  $event_address_field = FieldConfig::loadByName('node', 'event', 'field_event_address');
+  if (empty($event_address_field)) {
+    return;
+  }
+
+  // Init and fill default values variable.
+  $default_values = [];
+  if (!empty($form_state->getValue('site_default_country'))) {
+    $default_values = $event_address_field->getDefaultValueLiteral();
+    // When the default values isn't initiated, so init it.
+    if (empty($default_values)) {
+      $default_values[] = [
+        'langcode' => NULL,
+        'administrative_area' => "",
+        'locality' => "",
+        'dependent_locality' => NULL,
+        'postal_code' => "",
+        'sorting_code' => NULL,
+        'address_line1' => "",
+        'address_line2' => NULL,
+        'address_line3' => NULL,
+        'organization' => NULL,
+        'given_name' => NULL,
+        'additional_name' => NULL,
+        'family_name' => NULL,
+      ];
+    }
+
+    // Add country code from site default country.
+    $default_values[0]['country_code'] = $form_state->getValue('site_default_country');
+  }
+
+  // Save field with new default value.
+  if (method_exists($event_address_field, 'setDefaultValue')) {
+    $event_address_field->setDefaultValue($default_values)
+      ->save();
+  }
 }

--- a/modules/social_features/social_group/social_group.install
+++ b/modules/social_features/social_group/social_group.install
@@ -7,6 +7,7 @@
 
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Entity\Sql\SqlContentEntityStorage;
+use Drupal\field\Entity\FieldConfig;
 use Drupal\field\FieldStorageConfigInterface;
 use Drupal\group\Entity\GroupType;
 use Drupal\menu_link_content\Entity\MenuLinkContent;
@@ -968,5 +969,49 @@ function _social_group_update_permissions(mixed $group_type, string $permission)
     }
 
     $group_role->save();
+  }
+}
+
+/**
+ * Update default location from system configuration to group.
+ */
+function social_group_update_13013(): void {
+  $default_country = \Drupal::config('system.date')->get('country.default');
+  $group_address_field = FieldConfig::loadByName('group', 'flexible_group', 'field_group_address');
+  if (empty($group_address_field)) {
+    return;
+  }
+
+  // Init and fill default values variable.
+  $default_values = [];
+  if (!empty($default_country)) {
+    $default_values = $group_address_field->getDefaultValueLiteral();
+    // When the default values isn't initiated, so init it.
+    if (empty($default_values)) {
+      $default_values[] = [
+        'langcode' => NULL,
+        'administrative_area' => "",
+        'locality' => "",
+        'dependent_locality' => NULL,
+        'postal_code' => "",
+        'sorting_code' => NULL,
+        'address_line1' => "",
+        'address_line2' => NULL,
+        'address_line3' => NULL,
+        'organization' => NULL,
+        'given_name' => NULL,
+        'additional_name' => NULL,
+        'family_name' => NULL,
+      ];
+    }
+
+    // Add country code from site default country.
+    $default_values[0]['country_code'] = $default_country;
+  }
+
+  // Save field with new default value.
+  if (method_exists($group_address_field, 'setDefaultValue')) {
+    $group_address_field->setDefaultValue($default_values)
+      ->save();
   }
 }

--- a/modules/social_features/social_group/social_group.module
+++ b/modules/social_features/social_group/social_group.module
@@ -27,6 +27,7 @@ use Drupal\Core\Render\Element;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\Core\Url;
+use Drupal\field\Entity\FieldConfig;
 use Drupal\group\Entity\GroupRelationship;
 use Drupal\group\Entity\GroupRelationshipInterface;
 use Drupal\group\Entity\GroupRelationshipType;
@@ -2860,4 +2861,64 @@ function social_group_views_pre_view(ViewExecutable $view, string $display_id, a
  */
 function social_group_group_types(): array {
   return array_fill_keys(['node', 'user'], TRUE);
+}
+
+/**
+ * Add a submit function to update default country for group location field.
+ *
+ * Implements hook_form_FORM_ID_alter().
+ */
+function social_group_form_system_regional_settings_alter(array &$form): void {
+  $form['#submit'][] = '_social_group_system_regional_settings_submit';
+}
+
+/**
+ * Submit function to save default country to group location field.
+ *
+ * @param array $form
+ *   Nested array of form elements that comprise the form.
+ * @param \Drupal\Core\Form\FormStateInterface $form_state
+ *   The current state of the form.
+ *
+ * @throws \Drupal\Core\Entity\EntityStorageException
+ */
+function _social_group_system_regional_settings_submit(array &$form, FormStateInterface $form_state): void {
+  // Load field configuration and return early if it isn't exist.
+  $group_address_field = FieldConfig::loadByName('group', 'flexible_group', 'field_group_address');
+  if (empty($group_address_field)) {
+    return;
+  }
+
+  // Init and fill default values variable.
+  $default_values = [];
+  if (!empty($form_state->getValue('site_default_country'))) {
+    $default_values = $group_address_field->getDefaultValueLiteral();
+    // When the default values isn't initiated, so init it.
+    if (empty($default_values)) {
+      $default_values[] = [
+        'langcode' => NULL,
+        'administrative_area' => "",
+        'locality' => "",
+        'dependent_locality' => NULL,
+        'postal_code' => "",
+        'sorting_code' => NULL,
+        'address_line1' => "",
+        'address_line2' => NULL,
+        'address_line3' => NULL,
+        'organization' => NULL,
+        'given_name' => NULL,
+        'additional_name' => NULL,
+        'family_name' => NULL,
+      ];
+    }
+
+    // Add country code from site default country.
+    $default_values[0]['country_code'] = $form_state->getValue('site_default_country');
+  }
+
+  // Save field with new default value.
+  if (method_exists($group_address_field, 'setDefaultValue')) {
+    $group_address_field->setDefaultValue($default_values)
+      ->save();
+  }
 }


### PR DESCRIPTION
## Problem
When creating a new group or event, I change the country field to none. When I go to edit the content, the country field keeps popping back with the default value.

## Solution
Remove the code filling the default value and start to use the behavior from Address about default value.

So I added two submit function to copy the country default value when it is saved or updated and I added an hook-update to copy the value to old installation.

## Issue tracker
[PROD-27371](https://getopensocial.atlassian.net/browse/PROD-27371)
[#3466386](https://www.drupal.org/project/social/issues/3466386)

## Theme issue tracker
N/A

## How to test
- [ ] Enable the Field UI (We will use this module only to check the default value)
- [ ] Go to Regional Settings "/admin/config/regional/settings"
- [ ] Fill and change the Default Country and save
- [ ] All time you change the Default Country, go to Manage Field from Event and Flexible Group, check the default values from Address field (Event: /admin/structure/types/manage/event/fields/node.event.field_event_address | Group: /admin/group/types/manage/flexible_group/fields/group.flexible_group.field_group_address)
- [ ] Create an Event or a Group and check the default value is the same from filled before
- [ ] Edit the content created before and clean Country field
- [ ] Comeback to edit content again and check if Country field continue empty

## Screenshots
N/A

## Release notes
Fixed the bug about fill default value from Country field on Event and Group all time.

## Change Record
N/A

## Translations
N/A


[PROD-27371]: https://getopensocial.atlassian.net/browse/PROD-27371?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ