### PR TITLE
Issue #3466883: Fix copy in group settings to "Allow verified users to create new groups"

### DIFF
--- a/modules/social_features/social_group/config/schema/social_group.schema.yml
+++ b/modules/social_features/social_group/config/schema/social_group.schema.yml
@@ -4,10 +4,10 @@ social_group.settings:
   mapping:
     allow_group_create:
       type: boolean
-      label: 'Allow regular users to create new groups'
+      label: 'Allow verified users to create new groups'
     allow_group_selection_in_node:
       type: boolean
-      label: 'Allow regular users to change the group their content belong to'
+      label: 'Allow verified users to change the group their content belong to'
     address_visibility_settings:
       type: boolean
       label: 'Only show the group address to the group members'

--- a/modules/social_features/social_group/src/Form/SocialGroupSettings.php
+++ b/modules/social_features/social_group/src/Form/SocialGroupSettings.php
@@ -103,8 +103,8 @@ class SocialGroupSettings extends ConfigFormBase {
       '#type' => 'checkboxes',
       '#title' => $this->t('Group permissions'),
       '#options' => [
-        'allow_group_create' => $this->t('Allow regular users to create new groups'),
-        'allow_group_selection_in_node' => $this->t('Allow regular users to change the group their content belong to'),
+        'allow_group_create' => $this->t('Allow verified users to create new groups'),
+        'allow_group_selection_in_node' => $this->t('Allow verified users to change the group their content belong to'),
         'address_visibility_settings' => $this->t('Only show the group address to the group members'),
       ],
       '#weight' => 10,


### PR DESCRIPTION
## Problem
On `/admin/config/opensocial/social-group` a Site Manager can grant users the possibility to create groups.
This feature is supposed to be targeted for Verified users but in the current implementation Authenticated users are affected too.

## Solution
Change the copy in group settings, to be clear, that only verified users can create a group if settings are enabled.

## Issue tracker

- https://getopensocial.atlassian.net/browse/PROD-28703
- https://www.drupal.org/project/social/issues/3466883

## How to test
- [ ] Install the Social Group module
- [ ] Go to `/admin/config/opensocial/social-group`
- [ ] Enable permissions and check if VU can create a group

## Screenshots
N/A

## Release notes
Change the copy in group settings, to be clear, that only verified users can create a group if settings are enabled.
