### PR TITLE
Issue #3345231: Fix missing accept/reject invitiation for invited users for request to join groups

### DIFF
--- a/modules/social_features/social_group/modules/social_group_invite/social_group_invite.module
+++ b/modules/social_features/social_group/modules/social_group_invite/social_group_invite.module
@@ -897,3 +897,29 @@ function social_group_invite_query_group_content_access_alter(AlterableInterface
 
   $group_relationship_query_conditions->condition($see_own_invites_condition);
 }
+
+/**
+ * Implements hook_social_group_join_method_usage_alter().
+ */
+function social_group_invite_social_group_join_method_usage_alter(array &$items): void {
+  // Ads "added" method for flexible_group, because users with certain
+  // permissions (SM/GM) can always invite users (member management feature),
+  // despite what join method is selected per flexible group.
+  foreach ($items as &$item) {
+
+    if (isset($item['bundle']) && in_array('flexible_group', (array) $item['bundle'])) {
+      if (isset($item['method'])) {
+        if (is_string($item['method'])) {
+          $item['method'] = [$item['method']];
+        }
+      }
+      else {
+        $item['method'] = [];
+      }
+
+      if (!array_search('added', $item['method'])) {
+        $item['method'][] = 'added';
+      }
+    }
+  }
+}

--- a/modules/social_features/social_group/modules/social_group_invite/src/Plugin/Join/SocialGroupInviteJoin.php
+++ b/modules/social_features/social_group/modules/social_group_invite/src/Plugin/Join/SocialGroupInviteJoin.php
@@ -106,6 +106,15 @@ class SocialGroupInviteJoin extends SocialGroupDirectJoin {
       $variables['#cache']['tags'][] = 'group_content_list:plugin:group_invitation:entity:' . $this->currentUser->id();
     }
     elseif (
+      $entity->hasField('field_group_allowed_join_method') &&
+      $entity->field_group_allowed_join_method->value === 'direct'
+    ) {
+      $items = parent::actions($entity, $variables);
+      $variables['#cache']['contexts'][] = 'user';
+      $variables['#cache']['tags'][] = 'group_content_list:entity:' . $this->currentUser->id();
+      $variables['#cache']['tags'][] = 'group_content_list:plugin:group_invitation:entity:' . $this->currentUser->id();
+    }
+    elseif (
       count($items = parent::actions($entity, $variables)) === 1 &&
       in_array($entity->bundle(), $this->types())
     ) {

--- a/modules/social_features/social_group/modules/social_group_request/social_group_request.module
+++ b/modules/social_features/social_group/modules/social_group_request/social_group_request.module
@@ -69,7 +69,14 @@ function social_group_request_entity_base_field_info(EntityTypeInterface $entity
  * Implements hook_social_group_join_method_usage().
  */
 function social_group_request_social_group_join_method_usage(): array {
-  return [];
+  return [
+    [
+      'entity_type' => 'group',
+      'bundle' => 'flexible_group',
+      'field' => 'field_group_allowed_join_method',
+      'method' => 'request',
+    ],
+  ];
 }
 
 /**

--- a/modules/social_features/social_group/modules/social_group_request/src/Plugin/Join/SocialGroupRequestJoin.php
+++ b/modules/social_features/social_group/modules/social_group_request/src/Plugin/Join/SocialGroupRequestJoin.php
@@ -6,6 +6,7 @@ use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Link;
 use Drupal\Core\Url;
 use Drupal\ginvite\GroupInvitationLoaderInterface;
+use Drupal\ginvite\Plugin\GroupContentEnabler\GroupInvitation as GroupInvitationEnabler;
 use Drupal\grequest\Plugin\Group\Relation\GroupMembershipRequest;
 use Drupal\social_group\EntityMemberInterface;
 use Drupal\social_group\JoinBase;
@@ -80,8 +81,9 @@ class SocialGroupRequestJoin extends JoinBase {
     // If user has a pending invite we should skip the request button.
     if ($this->loader !== NULL) {
       $group_invites = $this->loader->loadByProperties([
-        'gid' => $group->id(),
-        'uid' => $this->currentUser->id(),
+        'entity_id' => $this->currentUser->id(),
+        'gid' => $entity->id(),
+        'invitation_status' => GroupInvitationEnabler::INVITATION_PENDING,
       ]);
 
       if ($group_invites !== []) {

--- a/modules/social_features/social_group/social_group.module
+++ b/modules/social_features/social_group/social_group.module
@@ -975,6 +975,32 @@ function social_group_form_alter(&$form, FormStateInterface $form_state, $form_i
         $found = TRUE;
         break;
       }
+
+      // These conditions are here to check exactly the same as the code above
+      // except that `!isset($data['method']) &&` is replaced by
+      // `$data['field'] === 'field_group_allowed_join_method'` instead.
+      // The reason why we did this is that initial architecture of
+      // `@Join` plugins predicted that plugins where "method" is defined,
+      // should not be altered in this process, but there are groups which have
+      // "method" defined for fallback reasons and this is why we need to
+      // process them the same way as there would be no "method" defined.
+      // Currently, we are limiting this exception only for the groups with
+      // field field_group_allowed_join_method. In the future we can change this
+      // logic in a way that it would not be based on field name but rather on
+      // plugin setting.
+      if (
+        isset($data['field'], $form[$data['field']]) &&
+        $data['field'] === 'field_group_allowed_join_method' &&
+        $data['entity_type'] === $entity_type_id &&
+        (
+          !isset($data['bundle']) &&
+          $bundle === NULL ||
+          in_array($bundle, (array) $data['bundle'])
+        )
+      ) {
+        $found = TRUE;
+        break;
+      }
     }
 
     if ($found && isset($data)) {


### PR DESCRIPTION
## Problem

This PR resolves the problem highlighted in this PR https://github.com/goalgorilla/open_social/pull/3326 which got rolled back in this PR https://github.com/goalgorilla/open_social/pull/3353 as the modifications were leading to issues where users couldn't request to join a group designated as "invitation only".

## Solution
This PR include all the changes that were added in this PR https://github.com/goalgorilla/open_social/pull/3326 plus we have included flexible_group to allow `request` join method using `social_group_request_social_group_join_method_usage` hook.

## Issue tracker
https://www.drupal.org/project/social/issues/3345231

## How to test
- [ ] As a site manager create a new group where "Join methods" is "Request to join"
- [ ] As a group/site manager invite logged in user to join the group via group/{group_id}/membership > Add member > Invite users.
- [ ] As logged in user you will get notification in notification center that you are invited to group.
- [ ] As logged in user click on notification and you will be redirected to group/{group_id}/stream where "Request to join" button will be shown which is a bug.
- [ ] The expected result with button to accept/reject button is attained when repeating the steps with this fix applied.