### PR TITLE
Issue #3468529: Update constraint to be able to use for users

### DIFF
--- a/modules/social_features/social_core/src/Plugin/Validation/Constraint/ExternalIdentifierUniqueExternalIdConstraintValidator.php
+++ b/modules/social_features/social_core/src/Plugin/Validation/Constraint/ExternalIdentifierUniqueExternalIdConstraintValidator.php
@@ -148,18 +148,18 @@ class ExternalIdentifierUniqueExternalIdConstraintValidator extends ConstraintVa
     }
 
     $entity = $item->getEntity();
-    $entity_type = $entity->getEntityTypeId();
+    $entity_type = $entity->getEntityType();
 
     // Check per each field of type "social_external_identifier" in given
     // entity type, if external_id is unique per external owner.
-    foreach ($this->getFieldNamesByFieldType($entity_type) as $field) {
-      $query = $this->entityTypeManager->getStorage($entity_type)->getQuery();
+    foreach ($this->getFieldNamesByFieldType($entity_type->id()) as $field) {
+      $query = $this->entityTypeManager->getStorage($entity_type->id())->getQuery();
       $query->condition($field . '.external_id', $item->external_id);
       $query->condition($field . '.external_owner_target_type', $item->external_owner_target_type);
       $query->condition($field . '.external_owner_id', $item->external_owner_id);
       // Exclude existing current entity.
       if (!$entity->isNew()) {
-        $query->condition('id', $entity->id(), '<>');
+        $query->condition($entity_type->getKey('id'), $entity->id(), '<>');
       }
       $query->accessCheck(FALSE);
       $result = $query->execute();


### PR DESCRIPTION
## Problem
When a field with the type social_external_identifier is updated for an existing user a database error appears.

## Solution
Use entity type object and get id from it, instead of a static string.

## Issue tracker
https://www.drupal.org/project/social/issues/3468529

## Theme issue tracker
<!-- *[Required if applicable] Paste a link to the drupal.org theme issue queue item, either from [socialbase](https://www.drupal.org/project/socialbase) or [socialblue](https://www.drupal.org/project/socialblue). If any other issue trackers were used, include links to those too.* -->

## How to test
- [ ] Tests should pass
- [ ] Create an entity/user that uses social_external_identifier
- [ ] There should be no errors for new and updated entity 

## Screenshots
<!-- *[Required if new feature, and if applicable] If this Pull Request makes visual changes then please include some screenshots that show what has changed here. A before and after screenshot helps the reviewer determine what changes were made.* -->

## Release notes
<!-- *[Required if new feature, and if applicable] A short summary of the changes that were made that can be included in release notes.* -->

## Change Record
<!-- *[Required if applicable] If this Pull Request changes the way that developers should do things or introduces a new API for developers then a change record to document this is needed. Please provide a draft for a change record or a link to an unpublished change record below. Existing change records can be consulted as example. Please provide a draft for a change record or a link to an unpublished change record below. [Existing change records](https://www.drupal.org/list-changes/social) can be consulted as example.* -->

## Translations
<!--
*[Optional]Translatable strings are always extracted from the latest development branch. To ensure translations remain available for platforms running older versions of Open Social the original string should be added to `translations.php` when it's changed or removed.*
- [ ] Changed or removed source strings are added to the `translations.php` file.
-->
