### PR TITLE
Issue #3468174: Path alias can be set to an internal file path

### DIFF
--- a/modules/custom/social_path_manager/social_path_manager.module
+++ b/modules/custom/social_path_manager/social_path_manager.module
@@ -41,6 +41,78 @@ function social_path_manager_form_alter(&$form, FormStateInterface $form_state, 
   if (!empty($form['path']) && in_array($form_id, $user_forms, TRUE)) {
     unset($form['path']);
   }
+
+  // Add custom validation function.
+  $form['#validate'][] = "_social_path_manager_path_alias_validate";
+}
+
+/**
+ * Custom form validation handler for validating path alias.
+ *
+ * @param array $form
+ *   The form array.
+ * @param \Drupal\Core\Form\FormStateInterface $form_state
+ *   Form state.
+ */
+function _social_path_manager_path_alias_validate(array $form, FormStateInterface $form_state): void {
+  $path_alias = $form_state->getValue('path');
+  if (!$path_alias) {
+    return;
+  }
+
+  $path_alias = end($path_alias);
+  $alias_url = $path_alias['alias'] ?: NULL;
+  if (!$alias_url) {
+    return;
+  }
+
+  // Check if we are pointing to a file, which is not secure.
+  $file_path = DRUPAL_ROOT . $alias_url;
+  if (file_exists($file_path)) {
+    $form_state->setErrorByName(
+      'path',
+      t("A path alias cannot point to an existing file."),
+    );
+    return;
+  }
+
+  // Normalize the path to remove leading or trailing slashes.
+  $normalized_path = trim($alias_url, '/');
+
+  // List of reserved path prefixes.
+  $reserved_paths = [
+    'admin',
+    'user',
+    'node',
+    'taxonomy',
+    'system',
+    'comment',
+    'modules',
+    'themes',
+    'libraries',
+    'sites',
+    'core',
+    'profiles',
+    'index.php',
+    'robots.txt',
+    'favicon.ico',
+  ];
+
+  // Check if the path starts with any of the reserved prefixes.
+  foreach ($reserved_paths as $reserved) {
+    if (strpos($normalized_path, $reserved) === 0) {
+      $form_state->setErrorByName(
+        'path',
+        t(
+          "The path @url is reserved and cannot be used as an alias.",
+          [
+            '@url' => $alias_url,
+          ]
+        ),
+      );
+      return;
+    }
+  }
 }
 
 /**


### PR DESCRIPTION
## Problem
When creating a custom path alias, users currently can set the alias to an internal path, eg. `/modules/custom/my_custom_module/custom.js`.

When a users visit a node with this path alias, instead of showing the actual node data it will try to access the file instead.

## Solution
Add a custom validation function that disallow to set path alias that starts with a reserved Drupal path or a path that points to an actual file on the server itself.


## Issue tracker
https://www.drupal.org/project/social/issues/3468174

## Theme issue tracker
<!-- *[Required if applicable] Paste a link to the drupal.org theme issue queue item, either from [socialbase](https://www.drupal.org/project/socialbase) or [socialblue](https://www.drupal.org/project/socialblue). If any other issue trackers were used, include links to those too.* -->

## How to test
1. Create a new topic
2. Set the path alias to /modules/custom/my_custom_module/custom.js
3. Make sure that the actual path exist and that the file is actually there.
4. Try to visit this URL
5. You should be prompted to download this file.


## Screenshots
<!-- *[Required if new feature, and if applicable] If this Pull Request makes visual changes then please include some screenshots that show what has changed here. A before and after screenshot helps the reviewer determine what changes were made.* -->

## Release notes
<!-- *[Required if new feature, and if applicable] A short summary of the changes that were made that can be included in release notes.* -->

## Change Record
Added additional validations to path field to disallow to set path alias that points to internal file system paths.

## Translations
<!--
*[Optional]Translatable strings are always extracted from the latest development branch. To ensure translations remain available for platforms running older versions of Open Social the original string should be added to `translations.php` when it's changed or removed.*
- [ ] Changed or removed source strings are added to the `translations.php` file.
-->
