### PR TITLE
Issue #3468336: SM can receive emails about inappropriate content

### DIFF
--- a/modules/social_features/social_content_report/social_content_report.module
+++ b/modules/social_features/social_content_report/social_content_report.module
@@ -5,9 +5,13 @@
  * The Social Content Report module file.
  */
 
+use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Access\AccessResultInterface;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\Url;
 use Drupal\comment\CommentInterface;
+use Drupal\flag\FlaggingInterface;
 use Drupal\node\NodeInterface;
 use Drupal\social_post\Entity\PostInterface;
 
@@ -90,6 +94,22 @@ function social_content_report_mandatory_reason_validate(array $form, FormStateI
  */
 function _social_content_report_submit(array $form, FormStateInterface $form_state) {
   $form_state->setRedirectUrl(Url::fromUri($form_state->get('referer')));
+}
+
+/**
+ * Implements hook_ENTITY_TYPE_access().
+ */
+function social_content_report_flagging_access(FlaggingInterface $flagging, string $operation, AccountInterface $account): AccessResultInterface {
+  if ($operation !== 'view') {
+    return AccessResult::neutral();
+  }
+
+  if (!in_array($flagging->bundle(), ['report_comment', 'report_node', 'report_post'])) {
+    return AccessResult::neutral();
+  }
+
+  // Allow users with appropriate permission view flagging entity.
+  return AccessResult::allowedIfHasPermission($account, 'view inappropriate reports');
 }
 
 /**


### PR DESCRIPTION
## Problem
SM received a notification about inappropriate content but not an email.

## Solution
Allow users with `view inappropriate reports` permission to view flagging entities. This solves the related problem of sending emails with information about a user's report. Email can be sent only in cases if a receiver has view access to a related entity.

## Issue tracker
- https://getopensocial.atlassian.net/browse/PROD-29770
- https://www.drupal.org/project/social/issues/3468336

## How to test
- [ ]  Login as admin
- [ ]  Enable `social_content_repport` module
- [ ]  Report a comment (or any other content)
- [ ]  Run cron
  - [ ]  **EB**: SM should be able receive email about inappropriate content

## Release notes
_SM can now receive emails about inappropriate content._
