### PR TITLE
Issue #3468340: Hide Revisions tab from Manage members page in the group

### DIFF
--- a/modules/social_features/social_core/social_core.module
+++ b/modules/social_features/social_core/social_core.module
@@ -527,36 +527,44 @@ function social_core_menu_local_tasks_alter(&$data, $route_name) {
   }
 
   // Remove Revisions tab if revisions for the node not exist.
-  $entity = \Drupal::routeMatch()->getParameter('node') ?: \Drupal::routeMatch()->getParameter('group');
-  if ($entity instanceof EntityInterface) {
-    // Get the configuration factory service.
-    $config_factory = \Drupal::service('config.factory');
+  if ($entity = \Drupal::routeMatch()->getParameter('node') ?: \Drupal::routeMatch()->getParameter('group')) {
+    // Make sure $entity contains the entity object.
+    if (!$entity instanceof EntityInterface) {
+      $entity_type = \Drupal::routeMatch()->getParameter('node') ? 'node' : 'group';
+      $entity = \Drupal::entityTypeManager()->getStorage($entity_type)->load($entity);
+    }
 
-    // Load the configuration for the entity type.
-    $config = $config_factory->get($entity->getEntityTypeId() . '.type.' . $entity->bundle());
+    // Check again to ensure $entity is an instance of EntityInterface.
+    if ($entity instanceof EntityInterface) {
+      // Get the configuration factory service.
+      $config_factory = \Drupal::service('config.factory');
 
-    // If new revision is disabled.
-    if (!$config->get('new_revision')) {
-      if ($entity instanceof NodeInterface) {
-        // Handle node entities.
-        $storage = \Drupal::entityTypeManager()->getStorage('node');
-        $revisions = $storage->revisionIds($entity);
+      // Load the configuration for the entity type.
+      $config = $config_factory->get($entity->getEntityTypeId() . '.type.' . $entity->bundle());
 
-        if ($revisions && count($revisions) === 1) {
-          unset($data['tabs'][0]['entity.node.version_history']);
+      // If new revision is disabled.
+      if (!$config->get('new_revision')) {
+        if ($entity instanceof NodeInterface) {
+          // Handle node entities.
+          $storage = \Drupal::entityTypeManager()->getStorage('node');
+          $revisions = $storage->revisionIds($entity);
+
+          if ($revisions && count($revisions) === 1) {
+            unset($data['tabs'][0]['entity.node.version_history']);
+          }
         }
-      }
-      elseif ($entity instanceof GroupInterface) {
-        // Query for all revisions of the group entity.
-        $query = \Drupal::entityQuery('group')
-          ->condition('id', $entity->id())
-          ->accessCheck(FALSE);
+        elseif ($entity instanceof GroupInterface) {
+          // Query for all revisions of the group entity.
+          $query = \Drupal::entityQuery('group')
+            ->condition('id', $entity->id())
+            ->accessCheck(FALSE);
 
-        // Execute the query to get revision IDs.
-        $revision_ids = $query->execute();
+          // Execute the query to get revision IDs.
+          $revision_ids = $query->execute();
 
-        if ($revision_ids && count($revision_ids) === 1) {
-          unset($data['tabs'][0]['entity.version_history:group.version_history']);
+          if ($revision_ids && count($revision_ids) === 1) {
+            unset($data['tabs'][0]['entity.version_history:group.version_history']);
+          }
         }
       }
     }


### PR DESCRIPTION
## Problem
In the issue [#3464499: Hide the Revisions tab for groups](https://www.drupal.org/project/social/issues/3464499) we hid the Revisions tab for all group pages. But it's still being displayed when accessing the Manage members page. The problem is that this route does not return the complete $entity object. Instead it returns the entity id.

## Solution
Make sure the `$entity` object is complete for this route as well, so that the Revisions tab is hidden.

## Issue tracker

- https://www.drupal.org/project/social/issues/3468340
- https://getopensocial.atlassian.net/browse/PROD-30391

## Theme issue tracker
N/A

## How to test
- [ ] Checkout branch `issue/3468340-hide-revisions-tab-manage-members`
- [ ] Go to a group as admin
- [ ] Navigate to the tab **_Manage members_**
- [ ] The revisions tab should not be displayed.

## Screenshots
N/A

## Release notes
Hide Revisions tab from Manage members page in the group if revisions are disabled.

## Change Record
N/A

## Translations
N/A