### PR TITLE
Issue #3457850: Add additional fields for content export

### DIFF
--- a/modules/social_features/social_event/modules/social_event_an_enroll/src/Plugin/ContentExportPlugin/ContentEventEnrolleesAn.php
+++ b/modules/social_features/social_event/modules/social_event_an_enroll/src/Plugin/ContentExportPlugin/ContentEventEnrolleesAn.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Drupal\social_event_an_enroll\Plugin\ContentExportPlugin;
+
+use Drupal\Core\Database\Connection;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Extension\ModuleHandlerInterface;
+use Drupal\node\NodeInterface;
+use Drupal\social_content_export\Plugin\ContentExportPluginBase;
+use Drupal\social_event_an_enroll\EventAnEnrollService;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Provides a 'ContentEventEnrolleesAn' content export row.
+ *
+ * @ContentExportPlugin(
+ *   id = "content_event_enrollees_an",
+ *   label = @Translation("Enrollees Anonymous"),
+ *   weight = -110,
+ * )
+ */
+class ContentEventEnrolleesAn extends ContentExportPluginBase {
+
+  /**
+   * The event enroll service.
+   *
+   * @var \Drupal\social_event_an_enroll\EventAnEnrollService
+   */
+  protected $eventAnEnrollService;
+
+  /**
+   * The module handler.
+   *
+   * @var \Drupal\Core\Extension\ModuleHandlerInterface
+   */
+  protected $moduleHandler;
+
+  /**
+   * Constructs of the ContentEventEnrolleesAn class.
+   *
+   * @param array $configuration
+   *   A configuration array containing information about the plugin instance.
+   * @param string $plugin_id
+   *   The plugin_id for the plugin instance.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager.
+   * @param \Drupal\Core\Database\Connection $database
+   *   The database connection.
+   * @param \Drupal\social_event_an_enroll\EventAnEnrollService $event_an_enroll_service
+   *   The event enroll service.
+   * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
+   *   The module handler.
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager, Connection $database, EventAnEnrollService $event_an_enroll_service, ModuleHandlerInterface $module_handler) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition, $entity_type_manager, $database);
+    $this->eventAnEnrollService = $event_an_enroll_service;
+    $this->moduleHandler = $module_handler;
+  }
+
+  /**
+   * The create method.
+   *
+   * @param \Symfony\Component\DependencyInjection\ContainerInterface $container
+   *   The service container.
+   * @param array $configuration
+   *   A configuration array containing information about the plugin instance.
+   * @param string $plugin_id
+   *   The plugin id for the plugin instance.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   *
+   * @return static
+   *   Returns an instance of this plugin.
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition): self {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('entity_type.manager'),
+      $container->get('database'),
+      $container->get('social_event_an_enroll.service'),
+      $container->get('module_handler')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getValue(NodeInterface $entity): string {
+    if ($entity->getType() == 'event') {
+      if ($this->moduleHandler->moduleExists('social_event_an_enroll')) {
+        return (string) $this->eventAnEnrollService->enrollmentCount((int) $entity->id());
+      }
+    }
+
+    return '';
+  }
+
+}

--- a/modules/social_features/social_event/modules/social_event_type/src/Plugin/ContentExportPlugin/ContentEventType.php
+++ b/modules/social_features/social_event/modules/social_event_type/src/Plugin/ContentExportPlugin/ContentEventType.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Drupal\social_event_type\Plugin\ContentExportPlugin;
+
+use Drupal\node\NodeInterface;
+use Drupal\social_content_export\Plugin\ContentExportPluginBase;
+use Drupal\taxonomy\TermInterface;
+
+/**
+ * Provides a 'ContentEventType' content export row.
+ *
+ * @ContentExportPlugin(
+ *   id = "content_event_type",
+ *   label = @Translation("Event Type"),
+ *   weight = -130,
+ * )
+ */
+class ContentEventType extends ContentExportPluginBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getValue(NodeInterface $entity): string {
+    if ($entity->getType() == 'event' && $entity->hasField('field_event_type')) {
+      $taxonomy = $entity->get('field_event_type')->entity;
+      if ($taxonomy instanceof TermInterface) {
+        return $taxonomy->getName();
+      }
+      else {
+        return '';
+      }
+    }
+
+    return '';
+  }
+
+}

--- a/modules/social_features/social_event/src/Plugin/ContentExportPlugin/ContentEventEnrollees.php
+++ b/modules/social_features/social_event/src/Plugin/ContentExportPlugin/ContentEventEnrollees.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Drupal\social_event\Plugin\ContentExportPlugin;
+
+use Drupal\node\NodeInterface;
+use Drupal\social_content_export\Plugin\ContentExportPluginBase;
+
+/**
+ * Provides a 'ContentEventType' content export row.
+ *
+ * @ContentExportPlugin(
+ *   id = "content_event_enrollees",
+ *   label = @Translation("Enrollees"),
+ *   weight = -120,
+ * )
+ */
+class ContentEventEnrollees extends ContentExportPluginBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getValue(NodeInterface $entity): string {
+    if ($entity->getType() == 'event') {
+      $storage = $this->entityTypeManager->getStorage('event_enrollment');
+      $enrollments_count = $storage->getQuery()
+        ->condition('field_event', $entity->id())
+        ->condition('field_enrollment_status', 1)
+        ->accessCheck()
+        ->count()
+        ->execute();
+
+      return (string) $enrollments_count;
+    }
+
+    return '';
+  }
+
+}

--- a/modules/social_features/social_tagging/src/Plugin/ContentExportPlugin/ContentTags.php
+++ b/modules/social_features/social_tagging/src/Plugin/ContentExportPlugin/ContentTags.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace Drupal\social_tagging\Plugin\ContentExportPlugin;
+
+use Drupal\Core\Database\Connection;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Extension\ModuleHandlerInterface;
+use Drupal\node\NodeInterface;
+use Drupal\social_content_export\Plugin\ContentExportPluginBase;
+use Drupal\taxonomy\Entity\Term;
+use Drupal\taxonomy\TermInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Provides a 'ContentTags' content export row.
+ *
+ * @ContentExportPlugin(
+ *   id = "content_tags",
+ *   label = @Translation("Tags"),
+ *   weight = -100,
+ * )
+ */
+class ContentTags extends ContentExportPluginBase {
+
+  /**
+   * The module handler.
+   *
+   * @var \Drupal\Core\Extension\ModuleHandlerInterface
+   */
+  protected $moduleHandler;
+
+  /**
+   * Constructs of the ContentTags class.
+   *
+   * @param array $configuration
+   *   A configuration array containing information about the plugin instance.
+   * @param string $plugin_id
+   *   The plugin_id for the plugin instance.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager.
+   * @param \Drupal\Core\Database\Connection $database
+   *   The database connection.
+   * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
+   *   The module handler.
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager, Connection $database, ModuleHandlerInterface $module_handler) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition, $entity_type_manager, $database);
+
+    $this->moduleHandler = $module_handler;
+  }
+
+  /**
+   * The create method.
+   *
+   * @param \Symfony\Component\DependencyInjection\ContainerInterface $container
+   *   Container interface.
+   * @param array $configuration
+   *   An array of configuration.
+   * @param string $plugin_id
+   *   The plugin id.
+   * @param mixed $plugin_definition
+   *   The plugin definition.
+   *
+   * @return \Drupal\social_content_export\Plugin\ContentExportPlugin\ContentTags
+   *   Returns the ContentTags plugin.
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition): self {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('entity_type.manager'),
+      $container->get('database'),
+      $container->get('module_handler')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getValue(NodeInterface $entity): string {
+    if ($this->moduleHandler->moduleExists('social_tagging')) {
+      $tags = $entity->get('social_tagging')->getValue();
+      if (!$tags) {
+        return '';
+      }
+
+      $ids = array_map(function ($item) {
+        return $item['target_id'];
+      }, $tags);
+
+      $terms = Term::loadMultiple($ids);
+
+      $terms_names = [];
+
+      foreach ($terms as $term) {
+        if ($term instanceof TermInterface) {
+          $terms_names[] = $term->getName();
+        }
+      }
+
+      return implode(', ', $terms_names);
+    }
+
+    return '';
+  }
+
+}

--- a/modules/social_features/social_topic/src/Plugin/ContentExportPlugin/ContentTopicType.php
+++ b/modules/social_features/social_topic/src/Plugin/ContentExportPlugin/ContentTopicType.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Drupal\social_topic\Plugin\ContentExportPlugin;
+
+use Drupal\node\NodeInterface;
+use Drupal\social_content_export\Plugin\ContentExportPluginBase;
+use Drupal\taxonomy\TermInterface;
+
+/**
+ * Provides a 'ContentTopicType' content export row.
+ *
+ * @ContentExportPlugin(
+ *   id = "content_topic_type",
+ *   label = @Translation("Topic Type"),
+ *   weight = -140,
+ * )
+ */
+class ContentTopicType extends ContentExportPluginBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getValue(NodeInterface $entity): string {
+    if ($entity->getType() == 'topic') {
+      $taxonomy = $entity->get('field_topic_type')->entity;
+      if ($taxonomy instanceof TermInterface) {
+        return $taxonomy->getName();
+      }
+      else {
+        return '';
+      }
+    }
+
+    return '';
+  }
+
+}

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,4 +1,11 @@
 parameters:
+	excludePaths:
+		- modules/social_features/social_event/modules/social_event_an_enroll/src/Plugin/ContentExportPlugin/ContentEventEnrolleesAn.php
+		- modules/social_features/social_event/modules/social_event_type/src/Plugin/ContentExportPlugin/ContentEventType.php
+		- modules/social_features/social_event/src/Plugin/ContentExportPlugin/ContentEventEnrollees.php
+		- modules/social_features/social_tagging/src/Plugin/ContentExportPlugin/ContentTags.php
+		- modules/social_features/social_topic/src/Plugin/ContentExportPlugin/ContentTopicType.php
+
 	ignoreErrors:
 		-
 			message: "#^Method Drupal\\\\activity_basics\\\\Plugin\\\\ActivityAction\\\\CreateActivityAction\\:\\:create\\(\\) has no return type specified\\.$#"


### PR DESCRIPTION
Reverts goalgorilla/open_social#4021 which reverted goalgorilla/open_social#3956 

Below you can find the original PR description from goalgorilla/open_social#3956

## Problem
It would be interesting for Site Managers to have further fields to enable greater filtering & analysis in the Content Export extension.

## Solution
Add extra `ContentExportPlugins` for:

- Topic Type (empty if the content is not a Topic)
- Event Type (empty if the content is not an Event)
- Event Enrollees (number of enrollees with an account)
- Event Enrollees Anonymous (number of anonymous enrollees)
- Content Tags (all tags are listed, no parent-child reference necessary)

## Issue tracker

- https://getopensocial.atlassian.net/browse/PROD-28483
- https://www.drupal.org/project/social/issues/3457850

## Theme issue tracker
N/A

## How to test
- [ ] Enable social_node_statistic and social_content_export, social_topic, social_event, social_event_type, social_event_an_enroll, social_tagging  modules
- [ ] Go to content page /admin/content
- [ ] Choose content for export
- [ ] Select action "Export the selected content to CSV"
- [ ] Click. the "Apply to selected item" button
- [ ] Download CSV file and check if all column exists and has the correct value

## Screenshots
N/A

## Release notes
Add new fields for content export extension.

