### PR TITLE
PROD-30212: Lock the Social Blue at 2.6.2 version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -168,7 +168,7 @@
         "drupal/search_api_solr": "4.3.4",
         "drupal/select2": "1.15.0",
         "drupal/shariff": "2.0.0",
-        "drupal/socialblue": "~2.6.1",
+        "drupal/socialblue": "2.6.2",
         "drupal/symfony_mailer": "^1.2",
         "drupal/token": "1.15.0",
         "drupal/ultimate_cron": "2.0.0-alpha7",


### PR DESCRIPTION
## Problem
The new version of Social Blue is using old version from Social Base and it is broken the system.

## Solution
Lock Social Blue at 2.6.2 version

## Issue tracker
[PROD-30212](https://getopensocial.atlassian.net/browse/PROD-30212)

## Theme issue tracker
N/A

## How to test
N/A

## Screenshots
N/A

## Release notes
Rollback the Social Blue to old version to fix an error.

## Change Record
N/A

## Translations
N/A


[PROD-30212]: https://getopensocial.atlassian.net/browse/PROD-30212?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ