### PR TITLE
Issue #3469681: Allow to change batch size for activities deletion during user cancellation

### DIFF
--- a/modules/custom/activity_creator/src/Service/ActivityCreatorBatchActivityDeletion.php
+++ b/modules/custom/activity_creator/src/Service/ActivityCreatorBatchActivityDeletion.php
@@ -3,6 +3,7 @@
 namespace Drupal\activity_creator\Service;
 
 use Drupal\Core\Batch\BatchBuilder;
+use Drupal\Core\Site\Settings;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 
 /**
@@ -47,9 +48,9 @@ class ActivityCreatorBatchActivityDeletion {
     $activity_storage = \Drupal::entityTypeManager()->getStorage('activity');
 
     // Elements per operation.
-    $limit = 50;
+    $limit = Settings::get('entity_update_batch_size', 25);
 
-    // Set default progress values.
+    // Ensure the platform can determine how many items we process.
     if (empty($context['sandbox']['progress'])) {
       $context['sandbox']['progress'] = 0;
       $context['sandbox']['max'] = count($items);


### PR DESCRIPTION
## Problem
Attempt to delete a user who has a lot of related activities causes the error:
<img width="1624" alt="Screenshot 2024-08-22 at 13 19 17" src="https://github.com/user-attachments/assets/06a6fc90-667e-4991-aac4-2b14c89a2fd9">

## Solution
- Allow to change batch size for activities deletion during user cancellation in `settings.php`.
- Decrease default batch size for activities deleted during user cancellation.

## Issue tracker
- https://www.drupal.org/project/social/issues/3469681
- https://getopensocial.atlassian.net/browse/PROD-29647

## How to test
_Notice: The issue is reproducible for instances with limited memory resources._

## Release notes
Allow to change batch size for activities deletion during user cancellation to prevent errors with memory size.
