### PR TITLE
Issue #3470967: Account Settings - Copy improvements

### DIFF
--- a/modules/social_features/social_user/social_user.module
+++ b/modules/social_features/social_user/social_user.module
@@ -543,11 +543,12 @@ function social_user_form_user_admin_settings_alter(&$form, FormStateInterface $
 
   $form['registration_cancellation']['verified_immediately'] = [
     '#type' => 'checkbox',
-    '#title' => new TranslatableMarkup('Registered users are verified immediately'),
+    '#title' => new TranslatableMarkup('New users automatically get the Verified User role assigned'),
     '#description' => new TranslatableMarkup('New registered users get the "verified user & authenticated" role when they are registered. With this setting disabled, new registered users get the "authenticated" role when they are registered.'),
     '#default_value' => $config->get('verified_immediately'),
     '#weight' => -10,
   ];
+  $form['registration_cancellation']['user_email_verification']['#description'] = new TranslatableMarkup('New users will be required to confirm their email address via an account activation email prior to logging in. With this setting disabled, users will be logged in immediately upon registering, and may select their own passwords during registration.');
 
   $form['#submit'][] = 'social_user_form_user_admin_settings_submit';
 }
@@ -702,9 +703,9 @@ function social_user_module_implements_alter(&$implementations, $hook) {
  * @throws \Drupal\Core\Entity\EntityStorageException
  */
 function social_user_user_insert(UserInterface $user): void {
-  // If site setting "Registered users are verified immediately" is enabled:
-  // new registered users get the "verified user & authenticated" role when they
-  // are registered.
+  // If site setting "New users automatically get the Verified User role
+  // assigned" is enabled: new registered users get the
+  // "verified user & authenticated" role when they are registered.
   $config = \Drupal::config('social_user.settings');
   $verified_immediately = $config->get('verified_immediately');
   if ($verified_immediately) {

--- a/tests/behat/features/capabilities/account/verified-user.feature
+++ b/tests/behat/features/capabilities/account/verified-user.feature
@@ -1,62 +1,64 @@
-@api @account @registration @stability @perfect @security @verified-user @no-update
+@api @no-update
 Feature: User is Verified
   Benefit: In order to distinguish between actual verified users who earned it to engage with the community and new users who might need to process payment or details in order to become trusted.
   Role: As a Verified
   Goal/desire: New registered users get the "verified user & authenticated" role when they are registered.
 
   @verified-immediately-enabled
-  Scenario: "Registered users are verified immediately" is enabled.
+  Scenario: "New users automatically get the Verified User role assigned" is enabled.
     # User registration.
     Given I am on the homepage
+
     When I click "Sign up"
-      And I fill in the following:
-        | Email address | verified_dude@example.com |
-        | Username      | verified_dude             |
-      And I press "Create new account"
+    And I fill in the following:
+      | Email address | verified_dude@example.com |
+      | Username      | verified_dude             |
+    And I press "Create new account"
+
     Then I should see the success message "A welcome message with further instructions has been sent to your email address."
 
-    # Be sure that "Registered users are verified immediately" is enabled by
+    # Be sure that "New users automatically get the Verified User role assigned" is enabled by
     # default.
-    Given I am logged in as an "sitemanager"
-    When I am on "admin/config/people/accounts"
-    Then I should see checked the box "Registered users are verified immediately"
+    And I am logged in as an "sitemanager"
+    And I am on "admin/config/people/accounts"
+    And I should see checked the box "New users automatically get the Verified User role assigned"
 
     # Check that the registered user has a Verified role.
-    Given I am logged in as an "administrator"
-    When I am on "admin/people"
-      And I fill in the following:
-        | Name or email contains | verified_dude@example.com |
-      And I press "Filter"
-    Then I should see "verified_dude"
-      And I click "Edit account"
-      And I should see checked the box "Verified user"
+    And I am logged in as an "administrator"
+    And I am on "admin/people"
+    And I fill in the following:
+      | Name or email contains | verified_dude@example.com |
+    And I press "Filter"
+    And I should see "verified_dude"
+    And I click "Edit account"
+    And I should see checked the box "Verified user"
 
   @verified-immediately-disable
-  Scenario: "Registered users are verified immediately" is disable.
-    # Be sure that "Registered users are verified immediately" is disable.
+  Scenario: "New users automatically get the Verified User role assigned" is enabled.
+    # Be sure that "New users automatically get the Verified User role assigned" is disable.
     Given I am logged in as an "sitemanager"
-    When I am on "admin/config/people/accounts"
-    Then I should see checked the box "Registered users are verified immediately"
-      And I uncheck the box "Registered users are verified immediately"
-      And I press "Save configuration"
-      And I logout
+    And I am on "admin/config/people/accounts"
+    And I should see checked the box "New users automatically get the Verified User role assigned"
+    And I uncheck the box "New users automatically get the Verified User role assigned"
+    And I press "Save configuration"
+    And I logout
 
     # User registration.
-    Given I am on the homepage
-    When I click "Sign up"
-      And I fill in the following:
-        | Email address | not_verified_dude@example.com  |
-        | Username      | not_verified_dude              |
-      And I press "Create new account"
-    Then I should see the success message "A welcome message with further instructions has been sent to your email address."
+    And I am on the homepage
+    And I click "Sign up"
+    And I fill in the following:
+      | Email address | not_verified_dude@example.com  |
+      | Username      | not_verified_dude              |
+    And I press "Create new account"
+    And I should see the success message "A welcome message with further instructions has been sent to your email address."
 
     # Check that the registered user has no a Verified role.
-    Given I am logged in as an "administrator"
-    When I am on "admin/people"
-      And I fill in the following:
-        | Name or email contains | not_verified_dude@example.com |
-      And I press "Filter"
-    Then I should see "not_verified_dude"
-      And I click "Edit account"
-      And I should see unchecked the box "Verified user"
-      And I enable that the registered users to be verified immediately
+    And I am logged in as an "administrator"
+    And I am on "admin/people"
+    And I fill in the following:
+      | Name or email contains | not_verified_dude@example.com |
+    And I press "Filter"
+    And I should see "not_verified_dude"
+    And I click "Edit account"
+    And I should see unchecked the box "Verified user"
+    And I enable that the registered users to be verified immediately

--- a/translations.php
+++ b/translations.php
@@ -185,3 +185,7 @@ new TranslatableMarkup('Are you sure you want to send your email to to the follo
 // String added because original one was changed due to #3445024 issue.
 new TranslatableMarkup('Find people by name or email address');
 new TranslatableMarkup('You can enter or paste multiple entries separated by comma or semicolon');
+
+// String added because original one was changed due to #3470967 issue.
+new TranslatableMarkup('Registered users are verified immediately');
+new TranslatableMarkup('New users will be required to validate their email address prior to logging into the site, and will be assigned a system-generated password. With this setting disabled, users will be logged in immediately upon registering, and may select their own passwords during registration.');


### PR DESCRIPTION
## Problem
We need to change the copy of the user account settings to make sure the end user understands what the settings do and how they affect behavior on the site.

## Solution
Change the copy to:

- Registered users are verified immediately → New users automatically get the Verified User role assigned
- New users will be required to validate their email address prior to logging into the site, and will be assigned a system-generated password. With this setting disabled, users will be logged in immediately upon registering, and may select their own passwords during registration. -> New users will be required to confirm their email address via an account activation email prior to logging in. With this setting disabled, users will be logged in immediately upon registering, and may select their own passwords during registration. 

## Issue tracker

- https://getopensocial.atlassian.net/browse/PROD-29694
- https://www.drupal.org/project/social/issues/3470967

## Theme issue tracker
N/A

## How to test
- [ ] Go to `/admin/config/people/accounts`
- [ ] Check the copy

## Screenshots
![image](https://github.com/user-attachments/assets/42c309b8-14c8-4c6c-b12f-8ee63a9e6593)


## Release notes
We change the copy to make sure the end user understands what the settings do and how they affect behavior on the site.

## Change Record
N/A

## Translations
Changes added to the https://github.com/goalgorilla/open_social/blob/main/translations.php
