### PR TITLE
Issue #3471613: Display "Group managers" block regardless of the join method

### DIFF
--- a/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.module
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.module
@@ -752,7 +752,6 @@ function social_group_flexible_group_block_access(Block $block, $operation, Acco
     'views_block:groups-block_user_groups',
     'views_block:upcoming_events-upcoming_events_group',
     'views_block:latest_topics-group_topics_block',
-    'views_block:group_managers-block_list_managers',
   ];
   // We don't care for other blocks.
   if (!in_array($block_id, $managed_blocks, FALSE)) {
@@ -762,14 +761,6 @@ function social_group_flexible_group_block_access(Block $block, $operation, Acco
   $group = _social_group_get_current_group();
   // We don't care about other group types in here.
   if ($group && $group->getGroupType()->id() === 'flexible_group') {
-    // Only when users cant join directly, add the managers block
-    // so they know who to contact.
-    if ($operation === 'view' &&
-      social_group_flexible_group_can_join_directly($group) &&
-      $block->getPluginId() === 'views_block:group_managers-block_list_managers') {
-      return AccessResult::forbidden();
-    }
-
     // All users with permissions can see the rest.
     if ($account->hasPermission('manage all groups')) {
       return AccessResult::neutral();

--- a/tests/behat/features/capabilities/groups/flexible/groups-flexible-group-manager-block.feature
+++ b/tests/behat/features/capabilities/groups/flexible/groups-flexible-group-manager-block.feature
@@ -1,0 +1,57 @@
+@api
+Feature: Group Managers block is accessible to users with the VU+ role
+  Background:
+    Given I enable the module "social_group_flexible_group"
+    And I disable that the registered users to be verified immediately
+
+  Scenario: Only verified user or with higher role should see "Group Managers" block on the "About" group page
+    Given users:
+      | name          | status | roles       |
+      | Manager       | 1      | sitemanager |
+      | Verified      | 1      | verified    |
+
+    And groups:
+      | label         | field_group_description | field_flexible_group_visibility |field_group_allowed_join_method | author  | type            | created  |
+      | Public Group  | My Description          | public                          | direct                         | Manager | flexible_group  | 01/01/01 |
+      | Request Group | My Description          | public                          | request                        | Manager | flexible_group  | 01/01/01 |
+      | Invite Group  | My Description          | public                          | added                          | Manager | flexible_group  | 01/01/01 |
+
+    When I am an anonymous user
+    And I am viewing the about page of group "Public group"
+    And I should not see "Group managers"
+
+    And I am viewing the about page of group "Request group"
+    And I should not see "Group managers"
+
+    And I am viewing the about page of group "Invite group"
+    And I should not see "Group managers"
+
+    And I am logged in as an "authenticated user"
+    And I am viewing the about page of group "Public group"
+    And I should not see "Group managers"
+
+    And I am viewing the about page of group "Request group"
+    And I should not see "Group managers"
+
+    And I am viewing the about page of group "Invite group"
+    And I should not see "Group managers"
+
+    And I am logged in as Verified
+    And I am viewing the about page of group "Public group"
+    And I should see "Group managers"
+
+    And I am viewing the about page of group "Request group"
+    And I should see "Group managers"
+
+    And I am viewing the about page of group "Invite group"
+    And I should see "Group managers"
+
+    And I am logged in as Manager
+    And I am viewing the about page of group "Public group"
+    And I should see "Group managers"
+
+    And I am viewing the about page of group "Request group"
+    And I should see "Group managers"
+
+    And I am viewing the about page of group "Invite group"
+    And I should see "Group managers"


### PR DESCRIPTION
## Improvement
<!-- *[Required] Describe the problem you're trying to solve, this should motivate why the changes you're proposing are needed.* -->
Verified user (member and non member of the group) can always see the Managers block on the about page regardless of the join method

## Solution
<!-- *[Required] Describe the solution you've created, elaborate on any technical choices you've made. Why is this the right solution and is a different solution not the right one? What is the reasoning behind the chosen solution?* -->
Remove restriction for the block_list_managers in hook_block_access to display it regardless of the join method. So, users with access to the "About group" page will have an access to that block as well

## Issue tracker
<!-- *[Required] Paste a link to the drupal.org issue queue item. If any other issue trackers were used, include links to those too.* -->
- https://www.drupal.org/project/social/issues/3471613
- https://getopensocial.atlassian.net/browse/PROD-30140

## Theme issue tracker
<!-- *[Required if applicable] Paste a link to the drupal.org theme issue queue item, either from [socialbase](https://www.drupal.org/project/socialbase) or [socialblue](https://www.drupal.org/project/socialblue). If any other issue trackers were used, include links to those too.* -->
N/A

## How to test
- [ ] Using the latest version of Open Social 
- [ ] As a sitemanager
- [ ] Try to create Flexible groups with different join methods: Open to Join/Request/Invite
- [ ] When i'm viewing all those groups as VU I expect to see the "Group Manager" block 
- [ ] But instead see it only for groups where join method is not “Open to Join”.
- [ ] The expected result is attained when repeating the steps with this fix applied.


## Screenshots
<!-- *[Required if new feature, and if applicable] If this Pull Request makes visual changes then please include some screenshots that show what has changed here. A before and after screenshot helps the reviewer determine what changes were made.* -->
<img width="1790" alt="Screenshot 2024-09-02 at 18 16 31" src="https://github.com/user-attachments/assets/b9d957c2-f3bc-4abe-9d13-7452b8497ae6">

## Release notes
<!-- *[Required if new feature, and if applicable] A short summary of the changes that were made that can be included in release notes.* -->
- Display "Group managers" block for VU on the about page regardless of the join method

## Change Record
<!-- *[Required if applicable] If this Pull Request changes the way that developers should do things or introduces a new API for developers then a change record to document this is needed. Please provide a draft for a change record or a link to an unpublished change record below. Existing change records can be consulted as example. Please provide a draft for a change record or a link to an unpublished change record below. [Existing change records](https://www.drupal.org/list-changes/social) can be consulted as example.* -->
N/A
## Translations
<!--
*[Optional]Translatable strings are always extracted from the latest development branch. To ensure translations remain available for platforms running older versions of Open Social the original string should be added to `translations.php` when it's changed or removed.*
- [ ] Changed or removed source strings are added to the `translations.php` file.
-->
N/A
