### PR TITLE
Issue #3472091: Add cache context by user for "GroupHeroBlock" block

### DIFF
--- a/modules/social_features/social_group/src/Plugin/Block/GroupHeroBlock.php
+++ b/modules/social_features/social_group/src/Plugin/Block/GroupHeroBlock.php
@@ -4,6 +4,7 @@ namespace Drupal\social_group\Plugin\Block;
 
 use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Block\BlockBase;
+use Drupal\Core\Cache\Cache;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\Session\AccountInterface;
@@ -93,6 +94,15 @@ class GroupHeroBlock extends BlockBase implements ContainerFactoryPluginInterfac
     }
 
     return parent::blockAccess($account);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function getCacheContexts(): array {
+    return Cache::mergeContexts(parent::getCacheContexts(), [
+      'user',
+    ]);
   }
 
 }


### PR DESCRIPTION
## Problem
The GroupHeroBlock lacks a user cache context. As a result, when a group admin adds a member to a group with "Group members only (secret)" visibility, the block does not appear for the new member until the cache is cleared.

## Solution
Add cache context by user for the "GroupHeroBlock" block.

## Issue tracker

- https://www.drupal.org/project/social/issues/3472091
- https://getopensocial.atlassian.net/browse/PROD-30483

## Theme issue tracker
N/A

## How to test
- [ ] Create a group with "Group members only (secret)" visibility
- [ ] Create a user "Verified" with verified role
- [ ] Go to the "About" page of the created group as a "Verified" user, and you should see "Access denied"
- [ ] As a Site manager or Group Admin add a member - "Verified" user
- [ ] Go to the "About" page of the created group as a "Verified" user
- [ ] You should see the GroupHeroBlock block

## Screenshots
Before:
![image](https://github.com/user-attachments/assets/609525aa-ec64-4d5d-9d50-1a049c15e632)

After:
![image](https://github.com/user-attachments/assets/1493ba74-4bba-4b1a-846d-54eceff9c2bb)


## Release notes
N/A

## Change Record
Add cache context by user for the "GroupHeroBlock" block.

## Translations
N/A
