### PR TITLE
Issue #3427043: Hide activities about following content tags for non-followers

### DIFF
--- a/modules/social_features/social_follow_taxonomy/modules/social_follow_tag/social_follow_tag.module
+++ b/modules/social_features/social_follow_taxonomy/modules/social_follow_tag/social_follow_tag.module
@@ -589,7 +589,7 @@ function _social_follow_tag_update_term_list(array &$form): array {
 }
 
 /**
- * Implements hook_ENTITY_TYPE_view().
+ * Implements hook_ENTITY_TYPE_view() for "activity".
  */
 function social_follow_tag_activity_view(array &$build, ActivityInterface $activity, EntityViewDisplayInterface $display, string $view_mode): void {
   /** @var \Drupal\activity_creator\Entity\Activity $activity */
@@ -598,7 +598,7 @@ function social_follow_tag_activity_view(array &$build, ActivityInterface $activ
     return;
   }
 
-  if ($view->id() !== 'activity_stream' && $view->current_display !== 'block_stream_homepage') {
+  if ($view->storage->get('base_table') !== 'activity_field_data') {
     return;
   }
 
@@ -622,13 +622,13 @@ function social_follow_tag_activity_view(array &$build, ActivityInterface $activ
         ? array_column($entity->get('social_tagging')->getValue(), 'target_id')
         : [];
 
-      $is_node_follower = \Drupal::database()->select($flagging = 'flagging')
+      $is_node_follower = (bool) \Drupal::database()->select($flagging = 'flagging')
         ->fields($flagging)
         ->condition('entity_id', $tags ?: [0], 'IN')
         ->condition('entity_type', 'taxonomy_term')
         ->condition('flag_id', 'follow_term')
         ->condition('uid', \Drupal::currentUser()->id())
-        ->execute()?->fetchAll();
+        ->execute()?->fetchCol();
 
       if (!$is_node_follower) {
         // Hide the activity.


### PR DESCRIPTION
## Problem
Follow-up for #3979 

## Solution
Make sure we hide activities on all views with activities.

## Issue tracker
- https://www.drupal.org/project/social/issues/3427043
- https://getopensocial.atlassian.net/browse/PROD-30501

## How to test
- [ ] Login as admin
- [ ] On "_Block layout_" (_/admin/structure/block_) page place the "_Community activities block_" blocks in "_Page title_" region and save layout
<img width="638" alt="Screenshot 2024-09-05 at 14 56 50" src="https://github.com/user-attachments/assets/ac220ba2-56f7-4311-98b6-c6a17364f6cd">

- [ ] Enable `social_follow_tag` module
- [ ] Add at least one tag to "Content tags" vocabulary
- [ ] Create a topic
- [ ] Login as LU
- [ ] Follow the created content tag _/flag/confirm/flag/follow_term/{term_id}_
- [ ] Login as admin
- [ ] Edit a topic and add the created tag to "Tags" field
- [ ] Run cron
- [ ] Login as LU
  - [ ] **AB**: On "/stream" I should see a notification contains the text "Topic related to tag(s) you follow"
- [ ] Login as LU non-follower
  - [ ] **AB**: On "/stream" I should not see a notification contains the text "Topic related to tag(s) you follow"
- [ ] As anonymous
  - [ ] **AB**: On "/stream" I should not see a notification contains the text "Topic related to tag(s) you follow"

## Release notes
_Hide not relevant activities about changing content with followed tags for non-followers on all views pages with activities._

