### PR TITLE
Issue #3472313: Fix Vimeo link pattern

### DIFF
--- a/modules/social_features/social_embed/src/Service/SocialEmbedHelper.php
+++ b/modules/social_features/social_embed/src/Service/SocialEmbedHelper.php
@@ -123,7 +123,7 @@ class SocialEmbedHelper {
       '(open.spotify.com\/track\/(.*))',
       '(twitter.com\/(.*)\/status\/(.*))',
       '(x.com\/(.*)\/status\/(.*))',
-      '(vimeo.com\/\d{7,9})',
+      '(vimeo.com\/[a-zA-Z0-9]+(?:\/[a-zA-Z0-9]+)?\/?)',
       '(youtube.com\/watch[?]v=(.*))',
       '(youtu.be\/(.*))',
       '(ted.com\/talks\/(.*))',


### PR DESCRIPTION
## Problem
The filter _"Convert SUPPORTED URLs to URL embeds"_ provided by **Social Embed** module converts links of video from Vimeo in the incorrect way - so the user can't add the correct video. This module used an incorrect regex pattern for such links - `vimeo.com\/\d{7,9}`

## Solution
Change link pattern for Vimeo from `vimeo.com\/\d{7,9}` to `vimeo.com\/[a-zA-Z0-9]+(?:\/[a-zA-Z0-9]+)?\/?`

## Issue tracker
https://www.drupal.org/project/social/issues/3472313
https://getopensocial.atlassian.net/browse/PROD-30623

## How to test
- [ ] Enable `social_features` and `social_embed` module
- [ ] As a site manager go to `admin/config/content/formats/manage/plain_text` and enable _"Convert SUPPORTED URLs to URL embeds"_
- [ ] Go to the "Home" page and create any post with link https://vimeo.com/1005868752/55fca000bd
- [ ] You should see the next embedded video in the post: 
![image](https://github.com/user-attachments/assets/949ea41b-687c-4285-b9f7-69b3e12de490)


## Screenshots
before:
![image](https://github.com/user-attachments/assets/9f231019-1ff5-499a-8254-4abc8613f35c)

After:
![image](https://github.com/user-attachments/assets/949ea41b-687c-4285-b9f7-69b3e12de490)

## Change Record
Url pattern of Vimeo videos was updated  from `vimeo.com\/\d{7,9}` to `vimeo.com\/[a-zA-Z0-9]+(?:\/[a-zA-Z0-9]+)?\/?`
