### PR TITLE
Issue #3472514: Exclude unpublished "Events type" terms from selector of "Type" field of "Event" entity

### DIFF
--- a/modules/social_features/social_event/modules/social_event_type/config/install/field.field.node.event.field_event_type.yml
+++ b/modules/social_features/social_event/modules/social_event_type/config/install/field.field.node.event.field_event_type.yml
@@ -4,7 +4,6 @@ dependencies:
   config:
     - field.storage.node.field_event_type
     - node.type.event
-    - taxonomy.vocabulary.event_types
 id: node.event.field_event_type
 field_name: field_event_type
 entity_type: node
@@ -16,12 +15,10 @@ translatable: false
 default_value: {  }
 default_value_callback: ''
 settings:
-  handler: 'default:taxonomy_term'
+  handler: views
   handler_settings:
-    target_bundles:
-      event_types: event_types
-    sort:
-      field: _none
-    auto_create: false
-    auto_create_bundle: ''
+    view:
+      view_name: event_types
+      display_name: event_types_reference
+      arguments: {  }
 field_type: entity_reference

--- a/modules/social_features/social_event/modules/social_event_type/config/install/views.view.event_types.yml
+++ b/modules/social_features/social_event/modules/social_event_type/config/install/views.view.event_types.yml
@@ -1,0 +1,196 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.event_types
+  module:
+    - taxonomy
+    - user
+id: event_types
+label: 'Event types'
+module: views
+description: ''
+tag: ''
+base_table: taxonomy_term_field_data
+base_field: tid
+display:
+  default:
+    id: default
+    display_title: Default
+    display_plugin: default
+    position: 0
+    display_options:
+      fields:
+        name:
+          id: name
+          table: taxonomy_term_field_data
+          field: name
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: taxonomy_term
+          entity_field: name
+          plugin_id: term_name
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            make_link: false
+            absolute: false
+            word_boundary: false
+            ellipsis: false
+            strip_tags: false
+            trim: false
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          convert_spaces: false
+      pager:
+        type: mini
+        options:
+          offset: 0
+          items_per_page: 10
+          total_pages: null
+          id: 0
+          tags:
+            next: ››
+            previous: ‹‹
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: perm
+        options:
+          perm: 'access content'
+      cache:
+        type: tag
+        options: {  }
+      empty: {  }
+      sorts: {  }
+      arguments: {  }
+      filters:
+        status:
+          id: status
+          table: taxonomy_term_field_data
+          field: status
+          entity_type: taxonomy_term
+          entity_field: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
+          expose:
+            operator: ''
+        vid:
+          id: vid
+          table: taxonomy_term_field_data
+          field: vid
+          entity_type: taxonomy_term
+          entity_field: vid
+          plugin_id: bundle
+          value:
+            event_types: event_types
+      style:
+        type: default
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          uses_fields: false
+      row:
+        type: fields
+        options:
+          default_field_elements: true
+          inline: {  }
+          separator: ''
+          hide_empty: false
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
+      relationships: {  }
+      header: {  }
+      footer: {  }
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url.query_args
+        - user.permissions
+      tags: {  }
+  event_types_reference:
+    id: event_types_reference
+    display_title: 'Event types'
+    display_plugin: entity_reference
+    position: 1
+    display_options:
+      pager:
+        type: none
+        options:
+          offset: 0
+      style:
+        type: entity_reference
+        options:
+          search_fields:
+            name: name
+      row:
+        type: entity_reference
+        options:
+          default_field_elements: true
+          inline: {  }
+          separator: '-'
+          hide_empty: false
+      display_description: ''
+      display_extenders:
+        views_ef_fieldset: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - user.permissions
+      tags: {  }

--- a/modules/social_features/social_event/modules/social_event_type/config/update/social_event_type_update_130002.yml
+++ b/modules/social_features/social_event/modules/social_event_type/config/update/social_event_type_update_130002.yml
@@ -1,0 +1,15 @@
+__global_actions:
+  import_configs:
+    - views.view.event_types
+
+field.field.node.event.field_event_type:
+  expected_config: {}
+  update_actions:
+    change:
+      settings:
+        handler: views
+        handler_settings:
+          view:
+            view_name: event_types
+            display_name: event_types_reference
+            arguments: { }

--- a/modules/social_features/social_event/modules/social_event_type/social_event_type.install
+++ b/modules/social_features/social_event/modules/social_event_type/social_event_type.install
@@ -64,3 +64,17 @@ function social_event_type_update_last_removed() : int {
 function social_event_type_update_130001(): void {
   user_role_grant_permissions('sitemanager', ['create terms in event_types']);
 }
+
+/**
+ * Update "Type" field reference method.
+ */
+function social_event_type_update_130002() : string {
+  /** @var \Drupal\update_helper\Updater $updater */
+  $updater = \Drupal::service('update_helper.updater');
+
+  // Execute configuration update definitions with logging of success.
+  $updater->executeUpdate('social_event_type', __FUNCTION__);
+
+  // Output logged messages to related channel of update execution.
+  return $updater->logger()->output();
+}


### PR DESCRIPTION
## Problem
The "Type" field of "Event" contains unpublished terms, for users with 'Administer terms' permission. It creates some issues when the "Event" is created with the unpublished term of "Event type", users without 'Administer terms' permission couldn't see it, and it didn't make sense.

## Solution
Change a reference method of the "Type" field from "Default" to "View". Create an "Entity reference" view of "Event type" taxonomy terms with filter - "Published: true". Set this view as a reference method of the "Type" field.

## Issue tracker
https://www.drupal.org/project/social/issues/3472514
https://getopensocial.atlassian.net/browse/PROD-30486

## How to test
- [ ] Enable `social_event_type` module
- [ ] Create two terms of 'Event type" taxonomy: **"Published"** - with status _"published"_, and **"Unpublished"** with status _"unpublished"_
- [ ] Go to "Event" creation page `node/add/event`
- [ ] In the field "Type" you should see only  **"Published"* in the available options

## Screenshots
Before:
![wrong-event-types](https://github.com/user-attachments/assets/2281ade9-70c9-4396-886d-7c579afb2091)
After:
![event-types-fixed](https://github.com/user-attachments/assets/1be8db3a-63a9-43c1-b814-fff3ea561512)

## Release notes
Unpublished "Event type" terms were excluded from the "Type" field selector of "Event" entity.

## Change Record
Added new Entiry Reference Source view - "Event types". The reference method of the "Type" field was updated from "Default" to "View", and the view "Event types" was settled as referenced view. 
