### PR TITLE
Issue #3472528: Move the "Forgot password?" link to separate wrapper

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -106,6 +106,9 @@
                 "Issue #3173822: Exposed operators are not included in fieldsets": "https://git.drupalcode.org/project/views_ef_fieldset/-/merge_requests/1/diffs.patch",
                 "Issue #3404443: Views Exposed Form Fieldset doesn't respect simple fieldset element": "https://git.drupalcode.org/project/views_ef_fieldset/-/merge_requests/12/diffs.patch",
                 "Issue #3404562: Reset button has fixed position with enabled BEF": "https://git.drupalcode.org/project/views_ef_fieldset/-/merge_requests/13/diffs.patch"
+            },
+            "drupal/socialbase": {
+                "Issue #3473257: Improve the reset password link according to the accessibility changes": "https://www.drupal.org/files/issues/2024-09-10/3473257-reset_password_improvements-1.patch"
             }
         }
     },

--- a/modules/social_features/social_user/src/Form/SocialUserLoginForm.php
+++ b/modules/social_features/social_user/src/Form/SocialUserLoginForm.php
@@ -66,16 +66,23 @@ class SocialUserLoginForm extends UserLoginForm {
 
     $reset_pass_link = Link::createFromRoute($this->t('Forgot password?'), 'user.pass');
     $generated_reset_pass_link = $reset_pass_link->toString();
-    $pass_description = $generated_reset_pass_link->getGeneratedLink();
 
     $form['username_login']['pass'] = [
       '#type' => 'password',
       '#title' => $this->t('Password'),
       '#size' => 60,
-      '#description' => $pass_description,
       '#required' => TRUE,
       '#attributes' => [
         'autocomplete' => 'current-password',
+      ],
+    ];
+
+    $form['username_login']['reset_pass'] = [
+      '#type' => 'html_tag',
+      '#tag' => 'div',
+      '#value' => $generated_reset_pass_link,
+      '#attributes' => [
+        'class' => 'help-block',
       ],
     ];
 


### PR DESCRIPTION
## Problem
The password edit field name is not meaningful for screen reader users. It happens because the "Password" field wrapper also contains the "Forgot password?" link.

## Solution
Move the "Forgot password?" link to a separate wrapper.

## Issue tracker

- https://www.drupal.org/project/social/issues/3472528
- https://getopensocial.atlassian.net/browse/PROD-30325

## How to test
- [ ] Go to login form
- [ ] Check accessibility by any tool

## Screenshots
Before:
![Screenshot 2024-09-10 at 12 26 27](https://github.com/user-attachments/assets/6c8c53aa-9ea2-4d6f-a8e4-d0abbe9394de)

After:
![Screenshot 2024-09-10 at 12 25 21](https://github.com/user-attachments/assets/0e9ae334-0b71-4e61-93c3-f52a13708a4c)

## Release notes
Password edit field name is now meaningful for screen reader users.
