### PR TITLE
Issue #3472527: Remove legacy CKEditor 4 code from Social Mentions

### DIFF
--- a/modules/social_features/social_mentions/js/social_mentions.js
+++ b/modules/social_features/social_mentions/js/social_mentions.js
@@ -6,16 +6,6 @@
 
   "use strict";
 
-  // Get CKEditor object.
-  var getCkeditor = function (){
-    return window.CKEDITOR || {
-      on: function(event, callback) {
-        callback();
-      },
-      instances: {}
-    };
-  }
-
   // Render Mention Item.
   var renderMentionItem = function (ul, item) {
     var $li = $("<li />"),
@@ -45,21 +35,17 @@
           return renderMentionItem(ul, item);
         },
         open: function(event, ui) {
-          var CKEDITOR = getCkeditor();
-          if (!CKEDITOR.instances[this.id]) {
-
-            if (window.matchMedia("(min-width: 600px)").matches) {
-              var commentTextarea = $(this).offset().top + $(this).height();
-              var userList = $(this).siblings(".ui-autocomplete");
-              var userListHeight = $(userList).innerHeight();
-              var mainHeight = $('.main-container').innerHeight();
-              var documentHeight = $(document).scrollTop() + $(window).height();
-              var distanceFromBottom = (documentHeight - commentTextarea);
-              if ((distanceFromBottom < userListHeight) || (mainHeight < (commentTextarea + userListHeight))) {
-                // class rule set bottom and top position
-                // so list displays above the textarea
-                $(userList).addClass("upward");
-              }
+          if (window.matchMedia("(min-width: 600px)").matches) {
+            var commentTextarea = $(this).offset().top + $(this).height();
+            var userList = $(this).siblings(".ui-autocomplete");
+            var userListHeight = $(userList).innerHeight();
+            var mainHeight = $('.main-container').innerHeight();
+            var documentHeight = $(document).scrollTop() + $(window).height();
+            var distanceFromBottom = (documentHeight - commentTextarea);
+            if ((distanceFromBottom < userListHeight) || (mainHeight < (commentTextarea + userListHeight))) {
+              // class rule set bottom and top position
+              // so list displays above the textarea
+              $(userList).addClass("upward");
             }
           }
         }
@@ -86,61 +72,18 @@
     $textarea.on('autosize:resized', function () { $(element).trigger('resize.mentionsInput'); });
   };
 
-  // Adds mention input config for the textarea.
-  var initCKEditorMentions = function(element, context, settings) {
-    $(element).mentionsOldInput({
-      source: settings.path.baseUrl + "mentions-autocomplete",
-      autocomplete: {
-        renderItem: function(ul, item) {
-          return renderMentionItem(ul, item);
-        },
-        open: function(event, ui) {
-          var CKEDITOR = getCkeditor();
-          if (!CKEDITOR.instances[this.id]) {
-            var menu = $(this).data("ui-mentionsAutocomplete").menu;
-            menu.focus(null, $("li", menu.element).eq(0));
-
-            if (window.matchMedia("(min-width: 600px)").matches) {
-              var commentTextarea = $(this).offset().top + $(this).height();
-              var userList = $(this).siblings(".ui-autocomplete");
-              var userListHeight = $(userList).innerHeight();
-              var mainHeight = $('.main-container').innerHeight();
-              var documentHeight = $(document).scrollTop() + $(window).height();
-              var distanceFromBottom = (documentHeight - commentTextarea);
-              if ((distanceFromBottom < userListHeight) || (mainHeight < (commentTextarea + userListHeight))) {
-                // class rule set bottom and top position
-                // so list displays above the textarea
-                $(userList).addClass("upward");
-              }
-            }
-          }
-        }
-      },
-      markup: function(item) {
-        return markupMentionItem(item, settings);
-      },
-      template: function(item) {
-        return item.value;
-      }
-    });
-  };
-
   // Initiate mentions.
   Drupal.behaviors.socialMentions = {
     attach: function(context, settings) {
       var formIds = ".comment-form, #social-post-entity-form";
-      var CKEDITOR = getCkeditor();
-      CKEDITOR.on("instanceReady", function () {
-        const $socialMentionsOnce = $(once('socialMentions', formIds));
-        $socialMentionsOnce.each(function (i, element) {
-          $.each($(".form-textarea", element), function (i, textarea) {
-            if (typeof CKEDITOR.instances[$(textarea).attr('id')] === 'undefined') {
+      var $socialMentionsOnce = $(once('socialMentions', formIds));
+      $socialMentionsOnce.each(function (i, element) {
+        $.each($(".form-textarea", element), function (i, textarea) {
+          window.setTimeout(function () {
+            if (!$(textarea).attr('data-ckeditor5-id')) {
               initMentions(textarea, context, settings);
             }
-            else {
-              initCKEditorMentions(textarea, context, settings);
-            }
-          });
+          }, 0);
         });
       });
     }
@@ -149,98 +92,66 @@
   // Adds a custom behaviour for clicking on the reply button.
   Drupal.behaviors.socialMentionsReply = {
     attach: function (context, settings) {
-      var CKEDITOR = getCkeditor();
-      CKEDITOR.on("instanceReady", function () {
-        const $socialMentionsReplyOnce =  $(once('socialMentionsReply', '.comment-form', context));
-        $socialMentionsReplyOnce.each(function (i, e) {
-          var form = e,
-            $textarea = $(".form-textarea", form),
-            mentionsInput = $textarea.data("mentionsInput"),
-            editor = CKEDITOR.instances[$textarea.attr("id")];
+      const $socialMentionsReplyOnce =  $(once('socialMentionsReply', '.comment-form', context));
+      $socialMentionsReplyOnce.each(function (i, e) {
+        var form = e,
+          $textarea = $(".form-textarea", form),
+          mentionsInput = $textarea.data("mentionsInput");
 
-          if (typeof $("[data-drupal-selector=\"comment-form\"]").offset() !== "undefined") {
-            $(".comments .comment__reply-btn a").on("click", function () {
-              $("html, body").animate({
-                scrollTop: $("[data-drupal-selector=\"comment-form\"]").offset().top
-              }, 1000);
-            });
-          }
+        if (typeof $("[data-drupal-selector=\"comment-form\"]").offset() !== "undefined") {
+          $(".comments .comment__reply-btn a").on("click", function () {
+            $("html, body").animate({
+              scrollTop: $("[data-drupal-selector=\"comment-form\"]").offset().top
+            }, 1000);
+          });
+        }
 
+        // Make sure we remove any open reply comment forms,
+        // we want to add "replying" to main comment form.
+        // we ensure this class is only added to reply forms in
+        // socialbase/includes/form.inc.
+        $(".js-comment .comment__reply-btn a").on("click", function () {
+          const $socialMentionsReplyFormCloseOnce = $(once('socialMentionsReplyFormClose', '.ajax-comments-form-reply'));
+          $socialMentionsReplyFormCloseOnce.each(function (i, e) {
+            $(this).parent('.comments').remove();
+            $(this).remove();
+          });
+        });
+
+        $(".mention-reply").on("click", function (e) {
+          e.preventDefault();
           // Make sure we remove any open reply comment forms,
           // we want to add "replying" to main comment form.
           // we ensure this class is only added to reply forms in
           // socialbase/includes/form.inc.
-          $(".js-comment .comment__reply-btn a").on("click", function () {
-            const $socialMentionsReplyFormCloseOnce = $(once('socialMentionsReplyFormClose', '.ajax-comments-form-reply'));
-            $socialMentionsReplyFormCloseOnce.each(function (i, e) {
-              $(this).parent('.comments').remove();
-              $(this).remove();
+          const $socialMentionsReplyOnReplyFormCloseOnce = $(once('socialMentionsReplyOnReplyFormClose', '.ajax-comments-form-reply'));
+          $socialMentionsReplyOnReplyFormCloseOnce.each(function (i, e) {
+            $(this).remove();
+          });
+
+          var author = $(this).data("author");
+
+          if (author) {
+            $textarea.val(author.value + ' ');
+
+            mentionsInput.mentions.length = 0;
+            mentionsInput._updateMentions();
+            mentionsInput._addMention({
+              name: author.value,
+              pos: 0,
+              uid: author.uid,
+              profile_id: author.profile_id
             });
-          });
+            mentionsInput._updateValue();
 
-          $(".mention-reply").on("click", function (e) {
-            e.preventDefault();
-            // Make sure we remove any open reply comment forms,
-            // we want to add "replying" to main comment form.
-            // we ensure this class is only added to reply forms in
-            // socialbase/includes/form.inc.
-            const $socialMentionsReplyOnReplyFormCloseOnce = $(once('socialMentionsReplyOnReplyFormClose', '.ajax-comments-form-reply'));
-            $socialMentionsReplyOnReplyFormCloseOnce.each(function (i, e) {
-              $(this).remove();
-            });
+            $textarea.focus();
 
-            var author = $(this).data("author");
+            if (this.hash.length) {
+              var pid = this.hash.substr(1);
 
-            if (author) {
-              if (!editor) {
-                $textarea.val(author.value + ' ');
-
-                mentionsInput.mentions.length = 0;
-                mentionsInput._updateMentions();
-                mentionsInput._addMention({
-                  name: author.value,
-                  pos: 0,
-                  uid: author.uid,
-                  profile_id: author.profile_id
-                });
-                mentionsInput._updateValue();
-
-                $textarea.focus();
-              }
-              else {
-                if(editor.getData().length) {
-                  $("[data-drupal-selector=\"comment-form\"]")
-                    .find('iframe')
-                    .contents()
-                    .find('body')
-                    .empty();
-                  editor.updateElement();
-                }
-                mentionsInput.handler.refreshMentions();
-
-                mentionsInput.handler.editor.focus();
-                mentionsInput.handler.handleInput();
-                mentionsInput.handler.onSelect({}, {
-                  item: author
-                });
-                mentionsInput.handler.editor.focus();
-              }
-
-              if (this.hash.length) {
-                var pid = this.hash.substr(1);
-
-                $(".parent-comment", form).val(pid);
-              }
+              $(".parent-comment", form).val(pid);
             }
-          });
-
-          $textarea.on("input", function () {
-            if (editor) {
-              if (!mentionsInput.mentions.length) {
-                $(".parent-comment", form).val("");
-              }
-            }
-          });
+          }
         });
       });
     }

--- a/modules/social_features/social_mentions/social_mentions.libraries.yml
+++ b/modules/social_features/social_mentions/social_mentions.libraries.yml
@@ -14,7 +14,7 @@ jquery.mentions:
       css/jquery.mentions.css: {}
   js:
     js/jquery.mentions.js: {}
-    js/jquery.mentions.ckeditor.js: {}
+    js/jquery.mentions.behavior.js: {}
   dependencies:
     - core/jquery
     - jquery_ui_autocomplete/autocomplete


### PR DESCRIPTION
## Problem
The CKeditor5 does not support the custom CKeditor.mention behavior (JavaScript code in the social_mentions module).

## Solution
Remove legacy JavaScript code from social_mentions module.

## Issue tracker

- https://www.drupal.org/project/social/issues/3472527
- https://getopensocial.atlassian.net/browse/PROD-30116

## Theme issue tracker
<!-- *[Required if applicable] Paste a link to the drupal.org theme issue queue item, either from [socialbase](https://www.drupal.org/project/socialbase) or [socialblue](https://www.drupal.org/project/socialblue). If any other issue trackers were used, include links to those too.* -->

## How to test

- [ ]  Compare the social_mentions.js file before and after the changes
- [ ]  Check if the users can use the mentions on the post and comment forms

## Screenshots
<!-- *[Required if new feature, and if applicable] If this Pull Request makes visual changes then please include some screenshots that show what has changed here. A before and after screenshot helps the reviewer determine what changes were made.* -->

## Release notes
Remove legacy ckeditor.mention behavior JavaScript code from the social_mentions module.

## Change Record
<!-- *[Required if applicable] If this Pull Request changes the way that developers should do things or introduces a new API for developers then a change record to document this is needed. Please provide a draft for a change record or a link to an unpublished change record below. Existing change records can be consulted as example. Please provide a draft for a change record or a link to an unpublished change record below. [Existing change records](https://www.drupal.org/list-changes/social) can be consulted as example.* -->

## Translations

