### PR TITLE
Issue #3473138: Add default permission for Content Tags based in Taxonomy Access Fix

### DIFF
--- a/modules/social_features/social_tagging/config/modify/social_tagging.default_permissions.yml
+++ b/modules/social_features/social_tagging/config/modify/social_tagging.default_permissions.yml
@@ -1,0 +1,57 @@
+dependencies:
+  module:
+    - taxonomy_access_fix
+items:
+  user.role.sitemanager:
+    expected_config:
+      permissions: { }
+    update_actions:
+      add:
+        permissions:
+          - 'view social_tagging'
+          - 'view terms in social_tagging'
+          - 'select terms in social_tagging'
+          - 'view term names in social_tagging'
+          - 'create terms in social_tagging'
+          - 'edit terms in social_tagging'
+          - 'delete terms in social_tagging'
+  user.role.contentmanager:
+    expected_config:
+      permissions: { }
+    update_actions:
+      add:
+        permissions:
+          - 'view social_tagging'
+          - 'view terms in social_tagging'
+          - 'select terms in social_tagging'
+          - 'view term names in social_tagging'
+          - 'create terms in social_tagging'
+          - 'edit terms in social_tagging'
+          - 'delete terms in social_tagging'
+  user.role.verified:
+    expected_config:
+      permissions: { }
+    update_actions:
+      add:
+        permissions:
+          - 'view social_tagging'
+          - 'view terms in social_tagging'
+          - 'select terms in social_tagging'
+          - 'view term names in social_tagging'
+  user.role.authenticated:
+    expected_config:
+      permissions: { }
+    update_actions:
+      add:
+        permissions:
+          - 'view social_tagging'
+          - 'view terms in social_tagging'
+          - 'select terms in social_tagging'
+          - 'view term names in social_tagging'
+  user.role.anonymous:
+    expected_config:
+      permissions: { }
+    update_actions:
+      add:
+        permissions:
+          - 'view social_tagging'


### PR DESCRIPTION
## Problem
It's not possible to create taxonomy items of Content tags when the Taxonomy Access Fix module is enabled.

## Solution
I created a configuration-modify to apply when the Taxonomy Access Fix module is enabled to add default permission.

## Issue tracker
[PROD-30610](https://getopensocial.atlassian.net/browse/PROD-30610)
[#3473138](https://www.drupal.org/project/social/issues/3473138)

## Theme issue tracker
N/A

## How to test
- [ ] Install and enable Taxonomy Access Fix module
- [ ] Enable Social Taggins module
- [ ] Try to create a term for Content Tags module

## Screenshots
N/A

## Release notes
Fix permission related to Social Tagging module and Taxonomy Access Fix module to create term for Content Tags

## Change Record
N/A

## Translations
N/A


[PROD-30610]: https://getopensocial.atlassian.net/browse/PROD-30610?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ