### PR TITLE
Issue #3473583: Anonymous event enrollees see their names in emails

### DIFF
--- a/modules/social_features/social_swiftmail/social_swiftmail.module
+++ b/modules/social_features/social_swiftmail/social_swiftmail.module
@@ -123,6 +123,13 @@ function social_swiftmail_preprocess_email(array &$variables): void {
   /** @var \Drupal\symfony_mailer\EmailInterface $email */
   $email = $variables['email'];
   $context = $email->getParam('context');
+  if (empty($context)) {
+    // Symfony Mailer moves all parameters to a new property, so we
+    // should get the context from it if possible.
+    /* @see \Drupal\symfony_mailer\Plugin\EmailBuilder\LegacyEmailBuilder::createParams() */
+    $context = $email->getParam('legacy_message');
+    $context = $context['params']['context'] ?? NULL;
+  }
 
   // In our Symfony Mailer we have the EmailAdjuster reroute plugin.
   // If this is being applied to the emails we need a different way of getting


### PR DESCRIPTION
## Problem
When the event manager sends bulk emails to anonymous enrollees these receivers don't see their own names on emails.

## Solution
Symfony Mailer moves all parameters to a new property, so we should get the context from it if possible.
See `\Drupal\symfony_mailer\Plugin\EmailBuilder\LegacyEmailBuilder::createParams()`

## Issue tracker
- https://www.drupal.org/project/social/issues/3473583
- https://getopensocial.atlassian.net/browse/PROD-30024

## How to test
- [ ] Login as admin
- [ ] Create an event that allows anonymous to enroll in the event
- [ ] As AN enrollee to the event (with providing own name)
- [ ] Login as admin
- [ ] From "/node/{nid}/all-enrollments" send bulk email to anonymous enrollee
- [ ] Run cron

## Screenshots
_Before:_
<img width="576" alt="Screenshot 2024-09-11 at 15 03 44" src="https://github.com/user-attachments/assets/5d94eeaf-95a9-4a34-a7b4-07b66c4f183f">

_After:_
<img width="588" alt="Screenshot 2024-09-11 at 15 03 24" src="https://github.com/user-attachments/assets/c45df662-e5f0-48a2-a2ea-6b32b7ae7b6e">

## Release notes
_Anonymous event enrollees see their names in emails._
