### PR TITLE
Issue #3474231: Translate the emoji picker search input

### DIFF
--- a/modules/social_features/social_emoji/assets/js/social_emoji_picker.js
+++ b/modules/social_features/social_emoji/assets/js/social_emoji_picker.js
@@ -98,6 +98,9 @@
    */
   Drupal.emojiPicker.prototype.createPickerElement = function(Picker) {
     this.pickerElement = new Picker();
+    // Override the i18n property to get the translated searchLabel from drupalSettings.
+    this.pickerElement.i18n.searchLabel = drupalSettings.social_emoji.searchLabel;
+    // Add custom attributes.
     this.pickerElement.setAttribute('aria-modal', 'true');
     // OS doesn't support light/dark themes. Let's stick to a light one atm.
     this.pickerElement.classList.add('light');

--- a/modules/social_features/social_emoji/social_emoji.module
+++ b/modules/social_features/social_emoji/social_emoji.module
@@ -19,6 +19,9 @@ function social_emoji_field_widget_single_element_text_textarea_form_alter(array
   if ($context['widget']->getThirdPartySetting('social_emoji', 'display_emoji_picker')) {
     $element['#attributes']['class'][] = 'social-emoji-capable';
     $element['#attached']['library'][] = 'social_emoji/emoji-picker-element';
+    $element['#attached']['drupalSettings']['social_emoji'] = [
+      'searchLabel' => t('Search'),
+    ];
   }
 }
 


### PR DESCRIPTION
## Problem
In a multilingual website, when the module social_emoji is enabled, the placeholder in the emoji picker is not translatable even though the string Search is already translated.

### Steps to reproduce

1. Add a new language
2. Translate the string "Search"
3. Install the module `social_emoji`
4. Go to the Stream page
5. Open the emoji picker form

You should see the placeholder "Search" is still not translated.

<img src="https://github.com/user-attachments/assets/e62ca602-844e-497b-b661-969e236391f5" width="400" />

## Solution

Override the property in the plugin instance to render the translated string in the input form by getting its value from`drupalSettings`.

## Issue tracker

- https://www.drupal.org/project/social/issues/3474231
- https://getopensocial.atlassian.net/browse/PROD-30714

## Theme issue tracker
N/A

## How to test
- [ ] Apply the patch
- [ ] Translate the string "Search"
- [ ] Go to the Stream page
- [ ] Open the emoji picker

The string should be translated.

## Screenshots
<img width="386" alt="image" src="https://github.com/user-attachments/assets/96405777-4166-488e-91b7-8e57b99ea522">


## Release notes
Add ability to translate the emoji picker search input.

## Change Record
N/A

## Translations
N/A