### PR TITLE
Issue #3474659: Fix filters for "All groups" view

### DIFF
--- a/modules/social_features/social_tagging/social_tagging.module
+++ b/modules/social_features/social_tagging/social_tagging.module
@@ -530,7 +530,7 @@ function social_tagging_form_views_exposed_form_alter(&$form, FormStateInterface
     'views-exposed-form-group-topics-page-group-topics' => ['node_topic'],
     'views-exposed-form-group-events-page-group-events' => ['node_event'],
     'views-exposed-form-group-books-page-group-books' => ['node_topic'],
-    'views-exposed-form-newest-groups-page-all-groups' => ['group'],
+    'views-exposed-form-newest-groups-page-all-groups' => _social_tagging_get_group_placement_ids(),
     'views-exposed-form-newest-users-page-newest-users' => ['profile'],
   ];
   $form_ids = array_keys($keys);
@@ -740,4 +740,24 @@ function _social_tagging_field(): FieldStorageDefinitionInterface {
     ])
     ->setDisplayConfigurable('form', TRUE)
     ->setDisplayConfigurable('view', TRUE);
+}
+
+/**
+ * Get array of available "Placement ID" for groups.
+ *
+ * @return array
+ *   The array of available "Placement ID" for groups.
+ */
+function _social_tagging_get_group_placement_ids(): array {
+  $group_bundles = \Drupal::service('entity_type.bundle.info')->getBundleInfo('group');
+
+  if (!$group_bundles) {
+    return [];
+  }
+
+  $group_bundles = array_keys($group_bundles);
+
+  return array_map(function ($group_bundle) {
+    return 'group_' . $group_bundle;
+  }, $group_bundles);
 }

--- a/modules/social_features/social_tagging/src/Form/SocialTaggingSettingsForm.php
+++ b/modules/social_features/social_tagging/src/Form/SocialTaggingSettingsForm.php
@@ -198,7 +198,7 @@ class SocialTaggingSettingsForm extends ConfigFormBase implements ContainerInjec
           $form['node_type_settings'][$key] = [
             '#type' => 'checkbox',
             '#title' => $title,
-            '#default_value' => $config->get($key) ?: !empty($bundles),
+            '#default_value' => $config->get($key),
           ];
         }
       }


### PR DESCRIPTION
## Problem
After implementing the feature [Allow disable/enable tagging per group bundle](https://www.drupal.org/node/3465212), a bug appeared: filters for 'Social Tags' disappeared from the 'All groups' view.

## Solution
In the file `social_tagging.module`, we have a hook `social_tagging_form_views_exposed_form_alter` that checks if filters are allowed for a view. The following code is present: `'views-exposed-form-newest-groups-page-all-groups' => ['group']`. However, the 'Placement ID' group no longer exists. It should be updated to a list of all available 'Placement IDs' for existing group bundles.

## Issue tracker

- https://www.drupal.org/project/social/issues/3474659
- https://getopensocial.atlassian.net/browse/PROD-30651

## How to test
- [ ] Enable module `social_tagging`
- [ ] Go to `admin/config/opensocial/tagging-settings` and enable checkbox **Group type: Flexible group** and **"Allow users to tag content in content."**
- [ ] Create a "Content Tag" **"Test"** and enable it for **"Flexible Group Type"**
- [ ] Create a child term for a "Content Tag" **"Test"** - **"Test 1"** and **"Test 2"**
- [ ] Create a flexible group **"Group 1"** with the tag **"Test 1"**
- [ ] Create a flexible group **"Group 2"** with the tag **"Test 2"**
- [ ] Go to **"All groups"** page - `/all-groups`
- [ ] There should be a filter **"Test"**

## Screenshots
before:
![image](https://github.com/user-attachments/assets/0e03be99-0d85-45ea-a2e3-e8ef1f75a29d)

After:
![image](https://github.com/user-attachments/assets/0fc6539d-114c-4c0c-a06d-c345451f3c61)

## Release notes
The filters on "All groups" page were fixed.
