### PR TITLE
Issue #3475042: Create VBO Options with Config Modify module

### DIFF
--- a/modules/social_features/social_content_report/config/modify/social_content_export.add_vbo_actions_from_content_report.yml
+++ b/modules/social_features/social_content_report/config/modify/social_content_export.add_vbo_actions_from_content_report.yml
@@ -1,0 +1,20 @@
+dependencies:
+  module:
+    - social_content_export
+items:
+  views.view.content:
+    expected_config: { }
+    update_actions:
+      add:
+        display:
+          default:
+            display_options:
+              fields:
+                views_bulk_operations_bulk_form:
+                  id: views_bulk_operations_bulk_form
+                  table: views
+                  field: views_bulk_operations_bulk_form
+                  selected_actions:
+                    - action_id: flag_action:report_node_flag
+                      preconfiguration:
+                        add_confirmation: FALSE

--- a/modules/social_features/social_follow_content/config/modify/social_content_export.add_vbo_actions_from_follow_content.yml
+++ b/modules/social_features/social_follow_content/config/modify/social_content_export.add_vbo_actions_from_follow_content.yml
@@ -1,0 +1,23 @@
+dependencies:
+  module:
+    - social_content_export
+items:
+  views.view.content:
+    expected_config: { }
+    update_actions:
+      add:
+        display:
+          default:
+            display_options:
+              fields:
+                views_bulk_operations_bulk_form:
+                  id: views_bulk_operations_bulk_form
+                  table: views
+                  field: views_bulk_operations_bulk_form
+                  selected_actions:
+                    - action_id: flag_action:follow_content_flag
+                      preconfiguration:
+                        add_confirmation: FALSE
+                    - action_id: flag_action:follow_content_unflag
+                      preconfiguration:
+                        add_confirmation: FALSE


### PR DESCRIPTION
## Problem
The fields related with Social Follow Content and Social Content Report modules was being created by third module, so it was removed from there and should be added here using Config Modify module.

## Solution
Create config-modify file to create fields relate to Social Follow Content and Social Content Report module at VBO.

## Issue tracker
[PROD-30645](https://getopensocial.atlassian.net/browse/PROD-30645)
[#3475042](https://www.drupal.org/project/social/issues/3475042)

## Theme issue tracker
N/A

## How to test
- [ ] Test should be done at CableCar
- [ ] Apply a patch from this pull-request there
- [ ] Enable Social Content Export 
- [ ] Test the Content Export and Follow/Unfollow Content VBO
- [ ] Enable Social Content Report
- [ ] Test report a content as inappropriate using VBO

## Screenshots
N/A

## Release notes
Add VBO actions to be available when the  Social Content Export is enabled.

## Change Record
N/A

## Translations
N/A



[PROD-30645]: https://getopensocial.atlassian.net/browse/PROD-30645?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ