### PR TITLE
Issue #3464465: Prevent "Page not found" for non-translated content pages

### DIFF
--- a/modules/custom/social_language/social_language.services.yml
+++ b/modules/custom/social_language/social_language.services.yml
@@ -20,7 +20,7 @@ services:
     deprecated: The "%service_id%" service is deprecated. You should use the 'url_generator' service instead. See https://www.drupal.org/project/social/issues/3098046
   social_language.path_processor:
     class: Drupal\social_language\PathProcessor\SocialLanguagePathProcessor
-    arguments: ['@path_alias.manager', '@language_manager']
+    arguments: ['@path_alias.manager', '@language_manager', '@entity_type.manager']
     tags:
       # Priority should be higher than \Drupal\path_alias\PathProcessor\AliasPathProcessor::processInbound().
       - { name: path_processor_inbound, priority: 101 }


### PR DESCRIPTION
## Problem
Follow up #3995 

## Solution
Redirect users to the canonical URL if alias can't be detected.

## Issue tracker
- https://www.drupal.org/project/social/issues/3464465
- https://getopensocial.atlassian.net/browse/PROD-28352

## How to test
- [ ] Login as admin
- [ ] Enable "Social Language", "Social Content Translation" modules
- [ ] Set up multilingual OS site (for example, "English" and "Dutch")
- [ ] On _/admin/config/regional/language/detection_ enable language detection by User
- [ ] Login as LU
- [ ] Create a topic in "Dutch"
- [ ] Switch to "English" language on "/user/edit" page
- [ ] Visit a topic page
  - [ ] **EB**: LU should be able to see topic 

## Release notes
Fix redirect to the content if the alias can't be detected on multilingual sites.