### PR TITLE
PROD-30684: Reorganize the Social EDA modules to make all components compatible with Distro

### DIFF
--- a/cspell.words.txt
+++ b/cspell.words.txt
@@ -6,6 +6,7 @@ addtocal
 addtogroup
 behat
 cloudevents
+jangregor
 # Datestamp attribute for the add to iCal (ICS) feature.
 dtstamp
 langcode

--- a/cspell.words.txt
+++ b/cspell.words.txt
@@ -5,6 +5,7 @@ addtoanybuttons
 addtocal
 addtogroup
 behat
+cloudevents
 # Datestamp attribute for the add to iCal (ICS) feature.
 dtstamp
 langcode

--- a/modules/custom/social_eda/social_eda.info.yml
+++ b/modules/custom/social_eda/social_eda.info.yml
@@ -1,0 +1,6 @@
+name: 'Social EDA (Experimental)'
+type: module
+description: 'Social EDA core module'
+package: Social
+core_version_requirement: ^10 || ^11
+hidden: true

--- a/modules/custom/social_eda/src/Types/Address.php
+++ b/modules/custom/social_eda/src/Types/Address.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\social_eda\Types;
+
+use Drupal\address\Plugin\Field\FieldType\AddressItem;
+
+/**
+ * Type class for Address data.
+ */
+class Address {
+
+  /**
+   * Constructs the Address type.
+   *
+   * @param string|null $label
+   *   The address label.
+   * @param string|null $countryCode
+   *   The country code.
+   * @param string|null $administrativeArea
+   *   The administrative area.
+   * @param string|null $locality
+   *   The locality.
+   * @param string|null $dependentLocality
+   *   The dependent locality.
+   * @param string|null $postalCode
+   *   The postal code.
+   * @param string|null $sortingCode
+   *   The sorting code.
+   * @param string|null $addressLine1
+   *   The address line 1.
+   * @param string|null $addressLine2
+   *   The address line 2.
+   */
+  public function __construct(
+    public readonly ?string $label,
+    public readonly ?string $countryCode,
+    public readonly ?string $administrativeArea,
+    public readonly ?string $locality,
+    public readonly ?string $dependentLocality,
+    public readonly ?string $postalCode,
+    public readonly ?string $sortingCode,
+    public readonly ?string $addressLine1,
+    public readonly ?string $addressLine2,
+  ) {}
+
+  /**
+   * Get formatted Address output.
+   *
+   * @param ?\Drupal\address\Plugin\Field\FieldType\AddressItem $item
+   *   An address field item value.
+   * @param ?string $label
+   *   The location label.
+   *
+   * @return self
+   *   The address data object.
+   */
+  public static function fromFieldItem(?AddressItem $item = NULL, ?string $label = NULL): self {
+    $address = $item instanceof AddressItem ? $item->getValue() : NULL;
+
+    return new self(
+      label: $label ?? '',
+      countryCode: $address['country_code'] ?? '',
+      administrativeArea: $address['administrative_area'] ?? '',
+      locality: $address['locality'] ?? '',
+      dependentLocality: $address['dependent_locality'] ?? '',
+      postalCode: $address['postal_code'] ?? '',
+      sortingCode: $address['sorting_code'] ?? '',
+      addressLine1: $address['address_line1'] ?? '',
+      addressLine2: $address['address_line2'] ?? '',
+    );
+  }
+
+}

--- a/modules/custom/social_eda/src/Types/DateTime.php
+++ b/modules/custom/social_eda/src/Types/DateTime.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\social_eda\Types;
+
+use Drupal\Core\Datetime\DrupalDateTime;
+use Drupal\datetime\Plugin\Field\FieldType\DateTimeItemInterface;
+
+/**
+ * Type class for DateTime data.
+ */
+class DateTime {
+
+  /**
+   * Constructs the DateTime type.
+   *
+   * @param string $datetime
+   *   The datetime.
+   */
+  public function __construct(
+    public readonly string $datetime,
+  ) {}
+
+  /**
+   * Get formatted DateTime output.
+   *
+   * @param int $timestamp
+   *   The timestamp.
+   *
+   * @return self
+   *   The DateTime data object.
+   */
+  public static function fromTimestamp(int $timestamp): self {
+    $datetime = DrupalDateTime::createFromTimestamp($timestamp)->format(
+      DateTimeItemInterface::DATETIME_STORAGE_FORMAT
+    );
+
+    return new self($datetime);
+  }
+
+  /**
+   * Get the datetime string.
+   *
+   * @return string
+   *   The datetime string.
+   */
+  public function toString(): string {
+    return $this->datetime;
+  }
+
+  /**
+   * Get the ImmutableDateTime output.
+   *
+   * @return \DateTimeImmutable
+   *   The DateTimeImmutable.
+   *
+   * @throws \Exception
+   */
+  public function toImmutableDateTime(): \DateTimeImmutable {
+    return new \DateTimeImmutable($this->datetime);
+  }
+
+}

--- a/modules/custom/social_eda/src/Types/Entity.php
+++ b/modules/custom/social_eda/src/Types/Entity.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\social_eda\Types;
+
+use Drupal\Core\Entity\EntityInterface;
+
+/**
+ * Type class for Entity data.
+ */
+class Entity {
+
+  /**
+   * Constructs the Entity type.
+   *
+   * @param string $id
+   *   The UUID.
+   * @param string $label
+   *   The label.
+   * @param \Drupal\social_eda\Types\Href $href
+   *   The entity href.
+   */
+  public function __construct(
+    public readonly string $id,
+    public readonly string $label,
+    public readonly Href $href,
+  ) {}
+
+  /**
+   * Get formatted Entity output.
+   *
+   * @param \Drupal\Core\Entity\EntityInterface $entity
+   *   The entity.
+   *
+   * @return self
+   *   The Entity data object.
+   *
+   * @throws \Drupal\Core\Entity\EntityMalformedException
+   */
+  public static function fromEntity(EntityInterface $entity): self {
+    return new self(
+      id: (string) $entity->uuid(),
+      label: (string) $entity->label(),
+      href: Href::fromEntity($entity),
+    );
+  }
+
+}

--- a/modules/custom/social_eda/src/Types/Href.php
+++ b/modules/custom/social_eda/src/Types/Href.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\social_eda\Types;
+
+use Drupal\Core\Entity\EntityInterface;
+
+/**
+ * Type class for Href data.
+ */
+class Href {
+
+  /**
+   * Constructs the Href type.
+   *
+   * @param string $canonical
+   *   The canonical url of the entity.
+   */
+  public function __construct(
+    public readonly string $canonical,
+  ) {}
+
+  /**
+   * Get formatted Href output.
+   *
+   * @param \Drupal\Core\Entity\EntityInterface $entity
+   *   The entity object.
+   *
+   * @return self
+   *   The Href data object.
+   *
+   * @throws \Drupal\Core\Entity\EntityMalformedException
+   */
+  public static function fromEntity(EntityInterface $entity): self {
+    return new self(
+      canonical: $entity->toUrl('canonical', ['absolute' => TRUE])->toString(),
+    );
+  }
+
+}

--- a/modules/custom/social_eda/src/Types/User.php
+++ b/modules/custom/social_eda/src/Types/User.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\social_eda\Types;
+
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\user\UserInterface;
+
+/**
+ * Type class for Entity data.
+ */
+class User {
+
+  /**
+   * Constructs the User type.
+   *
+   * @param string $id
+   *   The UUID.
+   * @param string $displayName
+   *   The display name.
+   * @param \Drupal\social_eda\Types\Href $href
+   *   The entity href.
+   */
+  public function __construct(
+    public readonly string $id,
+    public readonly string $displayName,
+    public readonly Href $href,
+  ) {}
+
+  /**
+   * Get formatted User output.
+   *
+   * @param \Drupal\Core\Entity\EntityInterface|\Drupal\user\UserInterface $entity
+   *   The User object.
+   *
+   * @return self
+   *   The User data object.
+   *
+   * @throws \Drupal\Core\Entity\EntityMalformedException
+   */
+  public static function fromEntity(EntityInterface|UserInterface $entity): self {
+    return new self(
+      id: (string) $entity->uuid(),
+      displayName: (string) ($entity instanceof UserInterface ? $entity->getDisplayName() : $entity->label()),
+      href: Href::fromEntity($entity),
+    );
+  }
+
+}

--- a/modules/social_features/social_event/tests/src/Unit/EdaHandlerTest.php
+++ b/modules/social_features/social_event/tests/src/Unit/EdaHandlerTest.php
@@ -1,0 +1,237 @@
+<?php
+
+namespace Drupal\Tests\social_event\Unit;
+
+use CloudEvents\V1\CloudEvent;
+use Drupal\Core\Language\LanguageInterface;
+use Drupal\Core\Language\LanguageManagerInterface;
+use Drupal\Core\DependencyInjection\ContainerBuilder;
+use Drupal\address\Plugin\Field\FieldType\AddressFieldItemList;
+use Drupal\address\Plugin\Field\FieldType\AddressItem;
+use Drupal\Component\Uuid\UuidInterface;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Extension\ModuleHandlerInterface;
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Url;
+use Drupal\node\NodeInterface;
+use Drupal\social_eda_dispatcher\Dispatcher as SocialEdaDispatcher;
+use Drupal\social_event\EdaHandler;
+use Drupal\taxonomy\TermInterface;
+use Drupal\Tests\UnitTestCase;
+use Drupal\user\UserInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/**
+ * @coversDefaultClass \Drupal\social_event\EdaHandler
+ */
+class EdaHandlerTest extends UnitTestCase {
+
+  /**
+   * Handles module-related operations.
+   */
+  protected ModuleHandlerInterface $moduleHandler;
+
+  /**
+   * Mocked dispatcher service for sending CloudEvents.
+   */
+  protected SocialEdaDispatcher $dispatcher;
+
+  /**
+   * Handles UUID generation.
+   */
+  protected UuidInterface $uuid;
+
+  /**
+   * Handles HTTP request stack operations.
+   */
+  protected RequestStack $requestStack;
+
+  /**
+   * Represents the canonical URL of an entity.
+   */
+  protected Url $url;
+
+  /**
+   * Represents a generic entity in Drupal.
+   */
+  protected EntityInterface $entityInterface;
+
+  /**
+   * Represents a user entity.
+   */
+  protected UserInterface $userInterface;
+
+  /**
+   * Represents an address field item.
+   */
+  protected AddressItem $addressItem;
+
+  /**
+   * Represents a list of address field items.
+   */
+  protected AddressFieldItemList $addressItemList;
+
+  /**
+   * Represents a taxonomy term.
+   */
+  protected TermInterface $eventTypeTerm;
+
+  /**
+   * Represents the event type field, typically a taxonomy term.
+   */
+  protected FieldItemListInterface $eventTypeField;
+
+  /**
+   * Represents a list of field items, such as a reference to groups.
+   */
+  protected FieldItemListInterface $fieldItemList;
+
+  /**
+   * Represents a node entity.
+   */
+  protected NodeInterface $node;
+
+  /**
+   * Represents an HTTP request.
+   */
+  protected Request $request;
+
+  /**
+   * {@inheritDoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    // Mock the language_manager service.
+    $languageManagerMock = $this->prophesize(LanguageManagerInterface::class);
+    $languageMock = $this->prophesize(LanguageInterface::class);
+    $languageMock->getId()->willReturn('en');
+    $languageManagerMock->getCurrentLanguage()
+      ->willReturn($languageMock->reveal());
+
+    // Mock Drupal's container.
+    $container = new ContainerBuilder();
+    $container->set('language_manager', $languageManagerMock->reveal());
+    \Drupal::setContainer($container);
+
+    // Mock dependencies.
+    $this->moduleHandler = $this->prophesize(ModuleHandlerInterface::class)
+      ->reveal();
+
+    // Mock the SocialEdaDispatcher service.
+    $this->dispatcher = $this->getMockBuilder(SocialEdaDispatcher::class)
+      ->disableOriginalConstructor()
+      ->getMock();
+
+    $this->uuid = $this->prophesize(UuidInterface::class)->reveal();
+    $this->requestStack = $this->prophesize(RequestStack::class)->reveal();
+
+    // Resolve UUID.
+    $uuidMock = $this->prophesize(UuidInterface::class);
+    $uuidMock->generate()->willReturn('a5715874-5859-4d8a-93ba-9f8433ea44af');
+    $this->uuid = $uuidMock->reveal();
+
+    // Resolve Request.
+    $requestMock = $this->prophesize(Request::class);
+    $requestMock->getUri()->willReturn('http://example.com/node/add/event');
+    $this->request = $requestMock->reveal();
+
+    $requestStackMock = $this->prophesize(RequestStack::class);
+    $requestStackMock->getCurrentRequest()->willReturn($this->request);
+    $this->requestStack = $requestStackMock->reveal();
+
+    // Mock the URL object.
+    $urlMock = $this->prophesize(Url::class);
+    $urlMock->toString()->willReturn('http://example.com');
+    $this->url = $urlMock->reveal();
+
+    // Mock the EntityInterface.
+    $entityMock = $this->prophesize(EntityInterface::class);
+    $entityMock->toUrl('canonical', ['absolute' => TRUE])
+      ->willReturn($this->url);
+    $entityMock->uuid()->willReturn('a5715874-5859-4d8a-93ba-9f8433ea44af');
+    $entityMock->label()->willReturn('Test Entity');
+    $this->entityInterface = $entityMock->reveal();
+
+    // Mock the UserInterface.
+    $userMock = $this->prophesize(UserInterface::class);
+    $userMock->uuid()->willReturn('a5715874-5859-4d8a-93ba-9f8433ea44af');
+    $userMock->getDisplayName()->willReturn('User name');
+    $userMock->toUrl('canonical', ['absolute' => TRUE])->willReturn($this->url);
+    $this->userInterface = $userMock->reveal();
+
+    // Mock Address field.
+    $addressItemMock = $this->prophesize(AddressItem::class);
+    $this->addressItem = $addressItemMock->reveal();
+
+    $addressItemListMock = $this->prophesize(AddressFieldItemList::class);
+    $addressItemListMock->first()->willReturn($this->addressItem);
+    $this->addressItemList = $addressItemListMock->reveal();
+
+    // Mock the field_event_type.
+    $eventTypeTermMock = $this->prophesize(TermInterface::class);
+    $eventTypeTermMock->label()->willReturn('Term Label');
+    $this->eventTypeTerm = $eventTypeTermMock->reveal();
+
+    $eventTypeFieldMock = $this->prophesize(FieldItemListInterface::class);
+    $eventTypeFieldMock->isEmpty()->willReturn(FALSE);
+    $eventTypeFieldMock->getEntity()->willReturn($this->eventTypeTerm);
+    $this->eventTypeField = $eventTypeFieldMock->reveal();
+
+    // Mock the FieldItemListInterface.
+    $fieldItemListMock = $this->prophesize(FieldItemListInterface::class);
+    $fieldItemListMock->isEmpty()->willReturn(FALSE);
+    $fieldItemListMock->getEntity()->willReturn($this->entityInterface);
+    $this->fieldItemList = $fieldItemListMock->reveal();
+
+    // Mock the Node.
+    $nodeMock = $this->prophesize(NodeInterface::class);
+    $nodeMock->label()->willReturn('Event Title');
+    $nodeMock->getCreatedTime()->willReturn(1692614400);
+    $nodeMock->getChangedTime()->willReturn(1692618000);
+    $nodeMock->get('groups')->willReturn($this->fieldItemList);
+    $nodeMock->get('uuid')
+      ->willReturn((object) ['value' => 'a5715874-5859-4d8a-93ba-9f8433ea44af']);
+    $nodeMock->get('status')->willReturn((object) ['value' => 1]);
+    $nodeMock->get('field_content_visibility')
+      ->willReturn((object) ['value' => 'public']);
+    $nodeMock->get('field_event_all_day')->willReturn((object) ['value' => 1]);
+    $nodeMock->get('field_event_date')
+      ->willReturn((object) ['value' => '2024-08-21T10:00:00']);
+    $nodeMock->get('field_event_date_end')
+      ->willReturn((object) ['value' => '2024-08-21T10:00:00']);
+    $nodeMock->get('field_event_address')->willReturn($this->addressItemList);
+    $nodeMock->get('field_event_location')
+      ->willReturn((object) ['value' => 'Location Label']);
+    $nodeMock->get('field_event_enroll')->willReturn((object) ['value' => 1]);
+    $nodeMock->get('field_enroll_method')->willReturn((object) ['value' => 0]);
+    $nodeMock->get('field_event_type')->willReturn((object) ['value' => 0]);
+    $nodeMock->get('uid')
+      ->willReturn((object) ['entity' => $this->userInterface]);
+    $nodeMock->toUrl('canonical', ['absolute' => TRUE])->willReturn($this->url);
+    $nodeMock->hasField('field_event_type')->willReturn(TRUE);
+    $nodeMock->get('field_event_type')->willReturn($this->eventTypeField);
+    $this->node = $nodeMock->reveal();
+  }
+
+  /**
+   * Test method fromEntity().
+   */
+  public function testFromEntity(): void {
+    // Create the handler instance.
+    $handler = new EdaHandler(
+      $this->dispatcher,
+      $this->uuid,
+      $this->requestStack,
+      $this->moduleHandler,
+    );
+
+    // Create the event object.
+    $event = $handler->fromEntity($this->node);
+
+    // Assert the result is an instance of CloudEvent.
+    $this->assertInstanceOf(CloudEvent::class, $event);
+  }
+
+}

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1528,51 +1528,6 @@ parameters:
 			path: modules/custom/entity_access_by_field/src/Plugin/search_api/processor/EntityAccessByField.php
 
 		-
-			message: "#^Call to an undefined method Prophecy\\\\Prophecy\\\\ObjectProphecy\\<Drupal\\\\Core\\\\Session\\\\AccountInterface\\>\\:\\:hasPermission\\(\\)\\.$#"
-			count: 3
-			path: modules/custom/entity_access_by_field/tests/src/Unit/EntityAccessTest.php
-
-		-
-			message: "#^Call to an undefined method Prophecy\\\\Prophecy\\\\ObjectProphecy\\<Drupal\\\\Core\\\\Session\\\\AccountInterface\\>\\:\\:id\\(\\)\\.$#"
-			count: 3
-			path: modules/custom/entity_access_by_field/tests/src/Unit/EntityAccessTest.php
-
-		-
-			message: "#^Call to an undefined method Prophecy\\\\Prophecy\\\\ObjectProphecy\\<Drupal\\\\Core\\\\Session\\\\AccountInterface\\>\\:\\:isAuthenticated\\(\\)\\.$#"
-			count: 3
-			path: modules/custom/entity_access_by_field/tests/src/Unit/EntityAccessTest.php
-
-		-
-			message: "#^Call to an undefined method Prophecy\\\\Prophecy\\\\ObjectProphecy\\<Drupal\\\\node\\\\NodeInterface\\>\\:\\:bundle\\(\\)\\.$#"
-			count: 3
-			path: modules/custom/entity_access_by_field/tests/src/Unit/EntityAccessTest.php
-
-		-
-			message: "#^Call to an undefined method Prophecy\\\\Prophecy\\\\ObjectProphecy\\<Drupal\\\\node\\\\NodeInterface\\>\\:\\:get\\(\\)\\.$#"
-			count: 3
-			path: modules/custom/entity_access_by_field/tests/src/Unit/EntityAccessTest.php
-
-		-
-			message: "#^Call to an undefined method Prophecy\\\\Prophecy\\\\ObjectProphecy\\<Drupal\\\\node\\\\NodeInterface\\>\\:\\:getCacheContexts\\(\\)\\.$#"
-			count: 2
-			path: modules/custom/entity_access_by_field/tests/src/Unit/EntityAccessTest.php
-
-		-
-			message: "#^Call to an undefined method Prophecy\\\\Prophecy\\\\ObjectProphecy\\<Drupal\\\\node\\\\NodeInterface\\>\\:\\:getEntityTypeId\\(\\)\\.$#"
-			count: 3
-			path: modules/custom/entity_access_by_field/tests/src/Unit/EntityAccessTest.php
-
-		-
-			message: "#^Call to an undefined method Prophecy\\\\Prophecy\\\\ObjectProphecy\\<Drupal\\\\node\\\\NodeInterface\\>\\:\\:getFieldDefinitions\\(\\)\\.$#"
-			count: 4
-			path: modules/custom/entity_access_by_field/tests/src/Unit/EntityAccessTest.php
-
-		-
-			message: "#^Call to an undefined method Prophecy\\\\Prophecy\\\\ObjectProphecy\\<Drupal\\\\node\\\\NodeInterface\\>\\:\\:getOwnerId\\(\\)\\.$#"
-			count: 3
-			path: modules/custom/entity_access_by_field/tests/src/Unit/EntityAccessTest.php
-
-		-
 			message: "#^Function grequest_group_content_insert\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: modules/custom/grequest/grequest.module
@@ -13330,3 +13285,13 @@ parameters:
 			message: "#^Parameter \\$item of static method Drupal\\\\social_eda\\\\Types\\\\Address::fromFieldItem\\(\\) expects Drupal\\\\address\\\\Plugin\\\\Field\\\\FieldType\\\\AddressItem\\|null, Drupal\\\\Core\\\\Field\\\\FieldItemInterface\\|null given\\.$#"
 			count: 1
 			path: modules/social_features/social_event/src/EdaHandler.php
+
+		-
+			message: "#^Property Drupal\\\\Tests\\\\social_event\\\\Unit\\\\EdaHandlerTest::\\$dispatcher has unknown class Drupal\\\\social_eda_dispatcher\\\\Dispatcher as its type\\.$#"
+			count: 1
+			path: modules/social_features/social_event/tests/src/Unit/EdaHandlerTest.php
+
+		-
+			message: "#^Class Drupal\\\\social_eda_dispatcher\\\\Dispatcher not found\\.$#"
+			count: 1
+			path: modules/social_features/social_event/tests/src/Unit/EdaHandlerTest.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -13307,6 +13307,11 @@ parameters:
 			path: modules/social_features/social_user_export/src/Plugin/Action/ExportUser.php
 
 		-
+			message: "#^Class Drupal\\\\social_eda_dispatcher\\\\Dispatcher not found\\.$#"
+			count: 1
+			path: modules/social_features/social_core/src/SocialCoreServiceProvider.php
+
+		-
 			message: "#^Parameter \\$dispatcher of method Drupal\\\\social_event\\\\EdaHandler::__construct\\(\\) has invalid type Drupal\\\\social_eda_dispatcher\\\\Dispatcher\\.$#"
 			count: 1
 			path: modules/social_features/social_event/src/EdaHandler.php
@@ -13322,76 +13327,6 @@ parameters:
 			path: modules/social_features/social_event/src/EdaHandler.php
 
 		-
-			message: "#^Instantiated class CloudEvents\\\\V1\\\\CloudEvent not found\\.$#"
+			message: "#^Parameter \\$item of static method Drupal\\\\social_eda\\\\Types\\\\Address::fromFieldItem\\(\\) expects Drupal\\\\address\\\\Plugin\\\\Field\\\\FieldType\\\\AddressItem\\|null, Drupal\\\\Core\\\\Field\\\\FieldItemInterface\\|null given\\.$#"
 			count: 1
 			path: modules/social_features/social_event/src/EdaHandler.php
-
-		-
-			message: "#^Call to static method fromTimestamp\\(\\) on an unknown class Drupal\\\\social_eda\\\\Types\\\\DateTime\\.$#"
-			count: 3
-			path: modules/social_features/social_event/src/EdaHandler.php
-
-		-
-			message: "#^Call to static method fromEntity\\(\\) on an unknown class Drupal\\\\social_eda\\\\Types\\\\Entity\\.$#"
-			count: 1
-			path: modules/social_features/social_event/src/EdaHandler.php
-
-		-
-			message: "#^Call to static method fromEntity\\(\\) on an unknown class Drupal\\\\social_eda\\\\Types\\\\User\\.$#"
-			count: 2
-			path: modules/social_features/social_event/src/EdaHandler.php
-
-		-
-			message: "#^Call to static method fromFieldItem\\(\\) on an unknown class Drupal\\\\social_eda\\\\Types\\\\Address\\.$#"
-			count: 1
-			path: modules/social_features/social_event/src/EdaHandler.php
-
-		-
-			message: "#^Call to static method fromEntity\\(\\) on an unknown class Drupal\\\\social_eda\\\\Types\\\\Href\\.$#"
-			count: 1
-			path: modules/social_features/social_event/src/EdaHandler.php
-
-		-
-			message: "#^Parameter \\$group of method Drupal\\\\social_event\\\\Event\\\\EventCreateEventData::__construct\\(\\) has invalid type Drupal\\\\social_eda\\\\Types\\\\Entity\\.$#"
-			count: 1
-			path: modules/social_features/social_event/src/Event/EventCreateEventData.php
-
-		-
-			message: "#^Property Drupal\\\\social_event\\\\Event\\\\EventCreateEventData::\\$group has unknown class Drupal\\\\social_eda\\\\Types\\\\Entity as its type\\.$#"
-			count: 1
-			path: modules/social_features/social_event/src/Event/EventCreateEventData.php
-
-		-
-			message: "#^Parameter \\$author of method Drupal\\\\social_event\\\\Event\\\\EventCreateEventData::__construct\\(\\) has invalid type Drupal\\\\social_eda\\\\Types\\\\User\\.$#"
-			count: 1
-			path: modules/social_features/social_event/src/Event/EventCreateEventData.php
-
-		-
-			message: "#^Property Drupal\\\\social_event\\\\Event\\\\EventCreateEventData::\\$author has unknown class Drupal\\\\social_eda\\\\Types\\\\User as its type\\.$#"
-			count: 1
-			path: modules/social_features/social_event/src/Event/EventCreateEventData.php
-
-		-
-			message: "#^Parameter \\$address of method Drupal\\\\social_event\\\\Event\\\\EventCreateEventData::__construct\\(\\) has invalid type Drupal\\\\social_eda\\\\Types\\\\Address\\.$#"
-			count: 1
-			path: modules/social_features/social_event/src/Event/EventCreateEventData.php
-
-		-
-			message: "#^Property Drupal\\\\social_event\\\\Event\\\\EventCreateEventData::\\$address has unknown class Drupal\\\\social_eda\\\\Types\\\\Address as its type\\.$#"
-			count: 1
-			path: modules/social_features/social_event/src/Event/EventCreateEventData.php
-
-		-
-			message: "#^Parameter \\$href of method Drupal\\\\social_event\\\\Event\\\\EventCreateEventData::__construct\\(\\) has invalid type Drupal\\\\social_eda\\\\Types\\\\Href\\.$#"
-			count: 1
-			path: modules/social_features/social_event/src/Event/EventCreateEventData.php
-
-		-
-			message: "#^Property Drupal\\\\social_event\\\\Event\\\\EventCreateEventData::\\$href has unknown class Drupal\\\\social_eda\\\\Types\\\\Href as its type\\.$#"
-			count: 1
-			path: modules/social_features/social_event/src/Event/EventCreateEventData.php
-
-		-
-			message: "#^Class Drupal\\\\social_eda_dispatcher\\\\Dispatcher not found\\.$#"
-			count: 1
-			path: modules/social_features/social_core/src/SocialCoreServiceProvider.php

--- a/tests/composer.json
+++ b/tests/composer.json
@@ -23,7 +23,8 @@
     "require": {},
     "require-dev": {
         "cloudevents/sdk-php": "^1.1",
-        "goalgorilla/open_social_dev": "~1.4.0  || ~2.1.0"
+        "goalgorilla/open_social_dev": "~1.4.0  || ~2.1.0",
+        "jangregor/phpstan-prophecy": "^1.0"
     },
     "repositories": [
         {

--- a/tests/composer.json
+++ b/tests/composer.json
@@ -22,6 +22,7 @@
     },
     "require": {},
     "require-dev": {
+        "cloudevents/sdk-php": "^1.1",
         "goalgorilla/open_social_dev": "~1.4.0  || ~2.1.0"
     },
     "repositories": [


### PR DESCRIPTION
## Problem
While working on [PROD-30133](https://getopensocial.atlassian.net/browse/PROD-30133): Implement test coverage for "event create" story we came across the following issue: The event-related components are in `open_social`, but their dependencies (e.g. data types) are in `cablecar`. It made it impossible to successfully run the tests in the Distro, and would possibly bring new issues in the future.

## Solution
To address this issue, we decided to:
- Move `social_eda` module into `open_social`
- Keep `social_eda_dispatcher` in `cablecar` as a stand-alone module

## Issue tracker
https://getopensocial.atlassian.net/browse/PROD-30684

## Theme issue tracker
N/A

## How to test
N/A

## Screenshots
N/A

## Release notes
Internal.

## Change Record
N/A

## Translations
N/A

[PROD-30133]: https://getopensocial.atlassian.net/browse/PROD-30133?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ