### PR TITLE
Issue #3475568: Add hyperlink to Expertise and Interests profile tags

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -106,6 +106,9 @@
                 "Issue #3173822: Exposed operators are not included in fieldsets": "https://git.drupalcode.org/project/views_ef_fieldset/-/merge_requests/1/diffs.patch",
                 "Issue #3404443: Views Exposed Form Fieldset doesn't respect simple fieldset element": "https://git.drupalcode.org/project/views_ef_fieldset/-/merge_requests/12/diffs.patch",
                 "Issue #3404562: Reset button has fixed position with enabled BEF": "https://git.drupalcode.org/project/views_ef_fieldset/-/merge_requests/13/diffs.patch"
+            },
+            "drupal/socialblue": {
+                "Issue #3475568: Add hyperlink to Expertise and Interests profile tags": "https://www.drupal.org/files/issues/2024-09-19/3475568-4-add-hyperlink-to-expertise-interest-profile-tags.patch"
             }
         }
     },


### PR DESCRIPTION
## Problem
The profile page already have hyperlink at Profile Tags and other tag fields, when the user click on it, the user will redirect to users search page applying Profile Tags as filter.
That same behaivor should be added for Expertise and Interests tags on Profile page.

## Solution
Add link to Expertise and Interest tag on profile page.

## Issue tracker
[PROD-30669](https://getopensocial.atlassian.net/browse/PROD-30669)
[#3475568](https://www.drupal.org/project/socialblue/issues/3475568)

## Theme issue tracker
N/A

## How to test
- [ ] Install Social Profile Extra and Social Profile Fields modules
- [ ] Add some Expertise and/or Interest data to different users
- [ ] Index Search user on Search API settings
- [ ] Clear cache
- [ ] Access the profile page from users editted before and try to click on Expertise and/or Interest tag

## Screenshots
N/A

## Release notes
Add hyperlink at Expertise and Interest tag on Profile page to users search page filter by tag clicked on profile page.

## Change Record
N/A

## Translations
N/A


[PROD-30669]: https://getopensocial.atlassian.net/browse/PROD-30669?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ