### PR TITLE
Issue #3476409: Add hook to alter query and conditions of activities v…

### DIFF
--- a/modules/custom/activity_viewer/activity_viewer.api.php
+++ b/modules/custom/activity_viewer/activity_viewer.api.php
@@ -5,6 +5,7 @@
  * Hooks provided by the Activity Viewer module.
  */
 
+use Drupal\Core\Database\Query\ConditionInterface;
 use Drupal\Core\Database\Query\SelectInterface;
 use Drupal\Core\Session\AccountInterface;
 
@@ -36,6 +37,20 @@ function hook_activity_viewer_available_nodes_query_alter(SelectInterface $query
 function hook_activity_viewer_available_posts_query_alter(SelectInterface $query, AccountInterface $user) {
 
 }
+
+/**
+ * Alter the query in filter.
+ *
+ * Sometimes we need to change visibility for custom entities in activities.
+ *
+ * @param \Drupal\views\Plugin\views\query\Sql $filter_query
+ *   Query from the filter.
+ * @param \Drupal\Core\Database\Query\ConditionInterface $or_condition
+ *   Current user.
+ * @param \Drupal\Core\Session\AccountInterface $user
+ *   Current user.
+ */
+function hook_activity_viewer_personalized_homepage_query_alter(SelectInterface $filter_query, ConditionInterface $or_condition,  AccountInterface $user) {}
 
 /**
  * @} End of "addtogroup hooks".

--- a/modules/custom/activity_viewer/src/Plugin/views/filter/ActivityFilterPersonalisedHomepage.php
+++ b/modules/custom/activity_viewer/src/Plugin/views/filter/ActivityFilterPersonalisedHomepage.php
@@ -179,6 +179,9 @@ class ActivityFilterPersonalisedHomepage extends FilterPluginBase {
 
     $this->alter($or);
 
+    // Alter query for custom conditions.
+    $this->moduleHandler->alter('activity_viewer_personalized_homepage_query', $filter_query, $or, $account);
+
     // Lets add all the or conditions to the Views query.
     if (!empty($or->conditions()[0])) {
       $and_wrapper->condition($or);


### PR DESCRIPTION
## Problem
`ActivityFilterPersonalzedHomepage` plugin filters the activity on the stream on the home page. However, it filters by the three types `node`, `comment`, and `post`. If we want to display activities related to a custom entity, we get a bug - these activities are simply not displayed on the stream for verified users.

## Solution
Add a hook this plugin, to have the possibility to alter the query of this filter, and also specifically alter the condition in one of the OR group conditions

## Issue tracker
https://www.drupal.org/project/social/issues/3476409

## Theme issue tracker
N/A

## How to test
N/A


## Screenshots
N/A


## Release notes
<!-- *[Required if new feature, and if applicable] A short summary of the changes that were made that can be included in release notes.* -->

## Change Record
<!-- *[Required if applicable] If this Pull Request changes the way that developers should do things or introduces a new API for developers then a change record to document this is needed. Please provide a draft for a change record or a link to an unpublished change record below. Existing change records can be consulted as example. Please provide a draft for a change record or a link to an unpublished change record below. [Existing change records](https://www.drupal.org/list-changes/social) can be consulted as example.* -->

## Translations
N/A
