### PR TITLE
Internal: Remove outdated patch after new socialbase theme release

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -106,9 +106,6 @@
                 "Issue #3173822: Exposed operators are not included in fieldsets": "https://git.drupalcode.org/project/views_ef_fieldset/-/merge_requests/1/diffs.patch",
                 "Issue #3404443: Views Exposed Form Fieldset doesn't respect simple fieldset element": "https://git.drupalcode.org/project/views_ef_fieldset/-/merge_requests/12/diffs.patch",
                 "Issue #3404562: Reset button has fixed position with enabled BEF": "https://git.drupalcode.org/project/views_ef_fieldset/-/merge_requests/13/diffs.patch"
-            },
-            "drupal/socialbase": {
-                "Issue #3473257: Improve the reset password link according to the accessibility changes": "https://www.drupal.org/files/issues/2024-09-10/3473257-reset_password_improvements-1.patch"
             }
         }
     },


### PR DESCRIPTION
## Problem
New socialbase has been released where #3473257 has been merged.

## Solution
Remove the patch from the distro.

## Issue tracker
https://drupal.org/node/3473257

## Theme issue tracker
<!-- *[Required if applicable] Paste a link to the drupal.org theme issue queue item, either from [socialbase](https://www.drupal.org/project/socialbase) or [socialblue](https://www.drupal.org/project/socialblue). If any other issue trackers were used, include links to those too.* -->

## How to test
- [ ] run composer.json and see everything still applies

## Screenshots
<!-- *[Required if new feature, and if applicable] If this Pull Request makes visual changes then please include some screenshots that show what has changed here. A before and after screenshot helps the reviewer determine what changes were made.* -->

## Release notes
Removed outdated patch after socialbase theme got updated.

## Change Record
<!-- *[Required if applicable] If this Pull Request changes the way that developers should do things or introduces a new API for developers then a change record to document this is needed. Please provide a draft for a change record or a link to an unpublished change record below. Existing change records can be consulted as example. Please provide a draft for a change record or a link to an unpublished change record below. [Existing change records](https://www.drupal.org/list-changes/social) can be consulted as example.* -->

## Translations
<!--
*[Optional]Translatable strings are always extracted from the latest development branch. To ensure translations remain available for platforms running older versions of Open Social the original string should be added to `translations.php` when it's changed or removed.*
- [ ] Changed or removed source strings are added to the `translations.php` file.
-->
