### PR TITLE
PROD-30481: Add patch to metatag to fix non-execution of the batch for single entity deletion

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -109,6 +109,9 @@
             },
             "drupal/socialblue": {
                 "Issue #3475568: Add hyperlink to Expertise and Interests profile tags": "https://www.drupal.org/files/issues/2024-09-19/3475568-4-add-hyperlink-to-expertise-interest-profile-tags.patch"
+            },
+            "drupal/metatag": {
+                "Issue #3476944: Batch can't be processed after entity deletion since version 2.0": "https://www.drupal.org/files/issues/2024-09-26/metatag-fix-batc-execution-3476944-1.patch"
             }
         }
     },

--- a/tests/behat/features/capabilities/comment/comment-delete.feature
+++ b/tests/behat/features/capabilities/comment/comment-delete.feature
@@ -1,19 +1,74 @@
-@api @comment @stability @DS-478 @stability-3 @comment-delete
+@api
 Feature: Delete Comment
   Benefit: In order to manage my content
   Role: As a Verified
   Goal/desire: I want to delete my comments on the platform
 
-  Scenario: Successfully delete comment
+  Scenario: Successfully delete comment on a topic
     Given I am logged in as an "verified"
     And I am viewing a "topic" with the title "Comment delete topic"
+
     When I fill in the following:
          | Add a comment | This is my comment |
     And I press "Comment"
-    Then I should see "This is my comment" in the "Main content"
-    When I click the element with css selector ".comment .comment__actions .dropdown-toggle"
+    And I should see "This is my comment" in the "Main content"
+    And I click the element with css selector ".comment .comment__actions .dropdown-toggle"
     And I should see the link "Delete"
-    When I click "Delete"
+    And I click "Delete"
     And I should see "Any replies to this comment will be lost."
     And I click "Delete"
-    And I should not see "This is my comment"
+
+    Then I should not see "This is my comment"
+
+  Scenario: Successfully delete comment on a homepage
+    Given I am logged in as an "verified"
+    And I am viewing a "topic" with the title "Comment delete topic"
+
+    When I fill in the following:
+         | Add a comment | This is my comment |
+    And I press "Comment"
+    And I should see "This is my comment" in the "Main content"
+    And I click the element with css selector ".comment .comment__actions .dropdown-toggle"
+    And I should see the link "Delete"
+    And I click "Delete"
+    And I should see "Any replies to this comment will be lost."
+    And I click "Delete"
+
+    Then I should not see "This is my comment"
+
+  Scenario: Successfully delete comment on a group
+    Given users:
+      | name           | mail                     | status | roles    |
+      | Group User One | group_user_1@example.com | 1      | verified |
+    And groups with non-anonymous owner:
+      | label      | field_group_description | type           | langcode | field_flexible_group_visibility | field_group_allowed_join_method |
+      | Test group | Public visibility       | flexible_group | en       | public                          | direct                          |
+    And group members:
+      | group      | user            |
+      | Test group | Group User One  |
+    And I am logged in as "Group User One"
+
+    When I am viewing the group "Test group"
+    And I click "Stream"
+    And I fill in "Say something to the group" with "This is a post in a group."
+    And I press "Post"
+    And I should see "This is a post in a group."
+    And I should see "Group User One" in the ".media-heading" element
+    And I fill in "Write a comment..." with "This is a comment in post in a group."
+    And I press "Comment"
+    And I should see "Your comment has been posted."
+    And I should see "This is a comment in post in a group."
+    And I am on the homepage
+    And I should see "This is a comment in post in a group."
+
+    # Delete post
+    Then I am viewing the group "Test group"
+    And I click the element with css selector ".comment .comment__actions .dropdown-toggle"
+    And I click the element with css selector ".comment-delete"
+    And I should see "Any replies to this comment will be lost. This action cannot be undone."
+    And I press "Delete"
+    And I wait for AJAX to finish
+    And I should see "The comment and all its replies have been deleted."
+    And I should not see "This is a comment in post in a group."
+    And I am on the homepage
+    And I should not see "This is a comment in post in a group."

--- a/tests/behat/features/capabilities/event/event-delete.feature
+++ b/tests/behat/features/capabilities/event/event-delete.feature
@@ -22,7 +22,7 @@ Feature: Delete Event
       | Test group | Event manager    |
     And event content:
       | title                   | body                   | field_event_date | field_event_date_end | groups     | field_content_visibility    | author            |
-      | Public event in group   | Body description text. | +2 days          | +3 days              | 6          | public                      | Event manager     |
+      | Public event in group   | Body description text. | +2 days          | +3 days              | 1          | public                      | Event manager     |
     And event enrollees:
       | event                 | user             |
       | Public event in group | Event enrollee 1 |

--- a/tests/behat/features/capabilities/event/event-delete.feature
+++ b/tests/behat/features/capabilities/event/event-delete.feature
@@ -1,0 +1,54 @@
+@api
+Feature: Delete Event
+  Benefit: In order to delete content created
+  Role: As a Verified
+  Goal/desire: I want to delete Events
+
+  @verified @perfect @critical
+  Scenario: Successfully create event within a group
+    Given I enable the module "automated_cron"
+    And users:
+      | name             | status | roles        |
+      | Event enrollee 1 |      1 | verified     |
+      | Event enrollee 2 |      1 | verified     |
+      | Event manager    |      1 | verified     |
+    And groups with non-anonymous owner:
+      | label      | field_group_description | type           | langcode | field_flexible_group_visibility | field_group_allowed_join_method |
+      | Test group | Public visibility       | flexible_group | en       | public                          | direct                          |
+    And group members:
+      | group      | user             |
+      | Test group | Event enrollee 1 |
+      | Test group | Event enrollee 2 |
+      | Test group | Event manager    |
+    And event content:
+      | title                   | body                   | field_event_date | field_event_date_end | groups     | field_content_visibility    | author            |
+      | Public event in group   | Body description text. | +2 days          | +3 days              | 6          | public                      | Event manager     |
+    And event enrollees:
+      | event                 | user             |
+      | Public event in group | Event enrollee 1 |
+      | Public event in group | Event enrollee 2 |
+      | Public event in group | Event manager    |
+    And I run cron
+    And I wait for the queue to be empty
+    And I am logged in as "Event manager"
+    And I should see "Event manager created an event in Test group"
+    And I should see "Public event in group"
+    And I am viewing the group "Test group"
+    And I click "Stream"
+    And I should see "Event manager created an event in Test group"
+    And I should see "Public event in group"
+
+    #delete event
+    When I click "Public event in group"
+    And I click "Edit content"
+    And I click "Delete"
+    And I should see "Are you sure you want to delete the content item Public event in group?"
+    And I should see "This action cannot be undone."
+    And I press "Delete"
+    And I wait for AJAX to finish
+
+    Then I should see "The Event Public event in group has been deleted."
+    And I should not see "Event manager created an event in Test group"
+    And I am viewing the group "Test group"
+    And I click "Stream"
+    And I should not see "Event manager created an event in Test group"

--- a/tests/behat/features/capabilities/post/post-delete.feature
+++ b/tests/behat/features/capabilities/post/post-delete.feature
@@ -1,0 +1,39 @@
+@api
+Feature: Delete Post
+  Benefit: In order to be able to delete content created
+  Role: As a Verified
+  Goal/desire: I want to delete Posts
+
+  Scenario: Successfully delete post
+    Given users:
+      | name            | status | pass            | roles    |
+      | PostCreateUser1 |      1 | PostCreateUser1 | verified |
+      | PostCreateUser2 |      1 | PostCreateUser2 | verified |
+    And I am logged in as "PostCreateUser1"
+    And I am on the homepage
+
+    When I fill in "Say something to the Community" with "This is a post made on the homepage."
+    And I select post visibility "Public"
+    And I press "Post"
+    And I should see the success message "Your post has been posted."
+    And I should see "This is a post made on the homepage."
+    And I should see "PostCreateUser1" in the "Main content front"
+    And I am on "/user"
+    And I should see "This is a post made on the homepage."
+
+    # Delete post
+    Then I click the element with css selector ".btn.btn-icon-toggle.dropdown-toggle.waves-effect.waves-circle"
+    And I click "Delete"
+    And I should see "Are you sure you want to delete the post"
+    And I should see "This action cannot be undone."
+    And I press "Delete"
+    And I wait for AJAX to finish
+    And I should see "has been deleted."
+    And I should not see "This is a post made on the homepage."
+    And I am on the homepage
+    And I should not see "This is a post made on the homepage."
+    And I am logged in as "PostCreateUser2"
+    And I am on the homepage
+    And I should not see "This is a post made on the homepage."
+
+

--- a/tests/behat/features/capabilities/post/post-group.feature
+++ b/tests/behat/features/capabilities/post/post-group.feature
@@ -1,14 +1,13 @@
 @api
-Feature: Create Post on Group
+Feature: Create and Delete a Post on Group
   Benefit: In order to share knowledge with people in group
   Role: As a Verified
-  Goal/desire: I want to create Posts
+  Goal/desire: I want to create Posts in a group
 
-  Scenario: Successfully create, edit and delete post in group
+  Scenario: Successfully create and edit post in group
     Given users:
       | name           | mail                     | status | roles    |
       | Group User One | group_user_1@example.com | 1      | verified |
-      | Group User Two | group_user_2@example.com | 1      | verified |
     And I am logged in as "Group User One"
     And I am on "group/add/flexible_group"
 
@@ -43,3 +42,39 @@ Feature: Create Post on Group
     # Scenario: See post on profile stream
     And I am on "/user"
     And I should see "This is a community post in a group."
+
+  Scenario: Successfully delete post in group
+    Given users:
+      | name           | mail                     | status | roles    |
+      | Group User One | group_user_1@example.com | 1      | verified |
+    And groups with non-anonymous owner:
+      | label      | field_group_description | type           | langcode | field_flexible_group_visibility | field_group_allowed_join_method |
+      | Test group | Public visibility       | flexible_group | en       | public                          | direct                          |
+    And group members:
+      | group      | user            |
+      | Test group | Group User One  |
+    And I am logged in as "Group User One"
+
+    When I am viewing the group "Test group"
+    And I click "Stream"
+    And I fill in "Say something to the group" with "This is a post in a group."
+    And I press "Post"
+    And I should see "This is a post in a group."
+    And I should see "Group User One" in the ".media-heading" element
+    And I am on the homepage
+    And I should see "This is a post in a group."
+    And I should see "Group User One" in the ".media-heading" element
+
+    # Delete post
+    Then I am viewing the group "Test group"
+    And I click the element with css selector ".btn.btn-icon-toggle.dropdown-toggle.waves-effect.waves-circle"
+    And I click "Delete"
+    And I should see "Are you sure you want to delete the post"
+    And I should see "This action cannot be undone."
+    And I press "Delete"
+    And I wait for AJAX to finish
+    And I should see "has been deleted."
+    And I should not see "This is a post in a group."
+    And I am on the homepage
+    And I should not see "This is a post in a group."
+


### PR DESCRIPTION
## Problem
<!-- *[Required] Describe the problem you're trying to solve, this should motivate why the changes you're proposing are needed.* -->
Metatag branch 2.x introduced `$renderer->executeInRenderContext()` which breaks the standard propagation and avoid the batch to run when we try to delete a single post.

## Solution
<!-- *[Required] Describe the solution you've created, elaborate on any technical choices you've made. Why is this the right solution and is a different solution not the right one? What is the reasoning behind the chosen solution?* -->
Patching metatag to process a standard rendering/propagation if a batch is set.
https://www.drupal.org/project/metatag/issues/3476944

## Issue tracker
<!-- *[Required] Paste a link to the drupal.org issue queue item. If any other issue trackers were used, include links to those too.* -->
https://getopensocial.atlassian.net/browse/PROD-30481

## Theme issue tracker
<!-- *[Required if applicable] Paste a link to the drupal.org theme issue queue item, either from [socialbase](https://www.drupal.org/project/socialbase) or [socialblue](https://www.drupal.org/project/socialblue). If any other issue trackers were used, include links to those too.* -->

## How to test
<!--
*[Required] For example*
- [ ] Using version X.Y.Z of Open Social with the example module enabled
- [ ] As a sitemanager
- [ ] Try to enable the option B on screen c/d/e
- [ ] When saving I expect the result to be F but instead see G.
- [ ] The expected result F is attained when repeating the steps with this fix applied.
-->
- Create a post from a group
- Delete that post - you will see the batch page
- Go to home page -> the post is deleted.

## Screenshots
<!-- *[Required if new feature, and if applicable] If this Pull Request makes visual changes then please include some screenshots that show what has changed here. A before and after screenshot helps the reviewer determine what changes were made.* -->

## Release notes
<!-- *[Required if new feature, and if applicable] A short summary of the changes that were made that can be included in release notes.* -->
Fix a bug introduced by metatag 2.x thats prevent batch to run on hook_entity_delete

## Change Record
<!-- *[Required if applicable] If this Pull Request changes the way that developers should do things or introduces a new API for developers then a change record to document this is needed. Please provide a draft for a change record or a link to an unpublished change record below. Existing change records can be consulted as example. Please provide a draft for a change record or a link to an unpublished change record below. [Existing change records](https://www.drupal.org/list-changes/social) can be consulted as example.* -->

## Translations
<!--
*[Optional]Translatable strings are always extracted from the latest development branch. To ensure translations remain available for platforms running older versions of Open Social the original string should be added to `translations.php` when it's changed or removed.*
- [ ] Changed or removed source strings are added to the `translations.php` file.
-->
