### PR TITLE
Issue #3477121: Improve preview popup link behavior if the href does …

### DIFF
--- a/modules/social_features/social_core/assets/js/preview-popup.js
+++ b/modules/social_features/social_core/assets/js/preview-popup.js
@@ -11,11 +11,22 @@
       var delayClose = 200;
       var delta = 0;
 
-      // Remove a preview popup if you use back button in the browser.ß
+      // Remove a preview popup if you use back button in the browser.
       $(window).bind("pageshow", function(event) {
         if (event.originalEvent.persisted) {
           $('.social-dialog--user-preview').remove();
           $(context).find('.social-dialog--user-preview').remove();
+        }
+      });
+
+      // Disable a preview popup link if this link does not have a path to the content.
+      var previewEl = '.preview-popup-link, .preview-popup-link, .preview-popup-link--text';
+      $(once('previewElBehavior', previewEl, context)).on('click', function (e) {
+        var $linkHref = $(this).attr('href');
+
+        if($linkHref === '#' || $linkHref === '') {
+          e.preventDefault();
+          return false;
         }
       });
 
@@ -54,6 +65,10 @@
                       })
                       .on('mouseleave scroll', function () {
                         timeouts[selector] = window.setTimeout(function () {
+                          // Trigger click on the close dialog button.
+                          currentDialog.find('.ui-dialog-titlebar-close').trigger('click');
+
+                          // Remove the current dialog is the trigger click on the close dialog button does not work.
                           currentDialog.remove();
 
                           if (refresh === 1) {
@@ -61,8 +76,7 @@
                             cleanupUserData(previewPopup);
                           }
                         }, delayClose);
-                      })
-                      .find('.ui-dialog-titlebar-close').remove();
+                      });
 
                     // Clean up stored user data and display actual info.
                     var cleanupUserData = function (items) {
@@ -76,9 +90,6 @@
                   open: function () {
                     $(this).find('a').blur();
                     $('.ui-widget-overlay').remove();
-                    setTimeout(function () {
-                      $('html').css('overflow', 'visible');
-                    }, 0);
                   }
                 }
               );
@@ -158,9 +169,17 @@
 
           timeouts[selector] = window.setTimeout(function () {
             if (dialogs[selector] !== undefined && dialogs[selector].open) {
-              $('html').css('overflow', 'visible');
-              $(context).find('.social-dialog--user-preview').remove();
-              $('.social-dialog--user-preview').remove();
+              var $contextDialog = $(context).find('.social-dialog--user-preview');
+              var $dialog = $('.social-dialog--user-preview');
+              var closeDialogButton = '.ui-dialog-titlebar-close';
+
+              // Trigger click on the close dialog button.
+              $contextDialog.find(closeDialogButton).trigger('click');
+              $dialog.find(closeDialogButton).trigger('click');
+
+              // Remove the current dialog is the trigger click on the close dialog button does not work.
+              $contextDialog.remove();
+              $dialog.remove();
             }
           }, delayClose);
         });


### PR DESCRIPTION
…not have path to the content

## Problem
The preview popup link has a strange behavior on the click event if the current link does not have a path to the content.

## Solution
Add a condition if the preview popup link has a `#` symbol or is empty.
Improve the close behavior of the preview popup.

## Issue tracker
https://iatasfdc.atlassian.net/browse/IOSAP-1101

## Theme issue tracker
<!-- *[Required if applicable] Paste a link to the drupal.org theme issue queue item, either from [socialbase](https://www.drupal.org/project/socialbase) or [socialblue](https://www.drupal.org/project/socialblue). If any other issue trackers were used, include links to those too.* -->

## How to test
Add a couple of organizations.
Those organizations should appear on the home stream page on the right sidebar in the `Newest organizations` block.
Go to the mobile view.
Click on the image of the organization teaser.

## Screenshots
<!-- *[Required if new feature, and if applicable] If this Pull Request makes visual changes then please include some screenshots that show what has changed here. A before and after screenshot helps the reviewer determine what changes were made.* -->

## Release notes
The page does not scroll to the top if the user clicks on the preview popup link.

## Change Record
<!-- *[Required if applicable] If this Pull Request changes the way that developers should do things or introduces a new API for developers then a change record to document this is needed. Please provide a draft for a change record or a link to an unpublished change record below. Existing change records can be consulted as example. Please provide a draft for a change record or a link to an unpublished change record below. [Existing change records](https://www.drupal.org/list-changes/social) can be consulted as example.* -->

## Translations
<!--
*[Optional]Translatable strings are always extracted from the latest development branch. To ensure translations remain available for platforms running older versions of Open Social the original string should be added to `translations.php` when it's changed or removed.*
- [ ] Changed or removed source strings are added to the `translations.php` file.
-->
