### PR TITLE
Issue #3477759: Add a redirect to stream page of logged user from /my-profile path

### DIFF
--- a/modules/social_features/social_user/social_user.routing.yml
+++ b/modules/social_features/social_user/social_user.routing.yml
@@ -54,3 +54,10 @@ social_user.my_settings:
     _controller: '\Drupal\user\Controller\UserController::userEditPage'
   requirements:
     _user_is_logged_in: 'TRUE'
+
+social_user.my_profile:
+  path: '/my-profile'
+  defaults:
+    _controller: '\Drupal\social_user\Controller\SocialUserController::myProfileRedirect'
+  requirements:
+    _user_is_logged_in: 'TRUE'

--- a/modules/social_features/social_user/src/Controller/SocialUserController.php
+++ b/modules/social_features/social_user/src/Controller/SocialUserController.php
@@ -9,6 +9,7 @@ use Drupal\Core\Routing\RouteMatch;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\user\UserInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 
 /**
  * Class SocialUserController.
@@ -46,10 +47,10 @@ class SocialUserController extends ControllerBase {
   /**
    * OtherUserPage.
    *
-   * @return RedirectResponse
+   * @return \Symfony\Component\HttpFoundation\RedirectResponse
    *   Return Redirect to the user account.
    */
-  public function otherUserPage(UserInterface $user) {
+  public function otherUserPage(UserInterface $user): RedirectResponse {
     return $this->redirect('entity.user.canonical', ['user' => $user->id()]);
   }
 
@@ -114,6 +115,18 @@ class SocialUserController extends ControllerBase {
       return AccessResult::forbidden();
     }
     return AccessResult::allowed();
+  }
+
+  /**
+   * Redirects users from /my-profile to stream page of current user.
+   *
+   * @return \Symfony\Component\HttpFoundation\RedirectResponse
+   *   Returns a redirect to the stream page of current user.
+   */
+  public function myProfileRedirect(): RedirectResponse {
+    return $this->redirect('social_user.stream', [
+      'user' => $this->currentUser()->id(),
+    ]);
   }
 
 }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -12882,16 +12882,6 @@ parameters:
 			path: modules/social_features/social_user/src/ContextProvider/UserRouteContext.php
 
 		-
-			message: "#^Method Drupal\\\\social_user\\\\Controller\\\\SocialUserController\\:\\:otherUserPage\\(\\) has invalid return type Drupal\\\\social_user\\\\Controller\\\\RedirectResponse\\.$#"
-			count: 1
-			path: modules/social_features/social_user/src/Controller/SocialUserController.php
-
-		-
-			message: "#^Method Drupal\\\\social_user\\\\Controller\\\\SocialUserController\\:\\:otherUserPage\\(\\) should return Drupal\\\\social_user\\\\Controller\\\\RedirectResponse but returns Symfony\\\\Component\\\\HttpFoundation\\\\RedirectResponse\\.$#"
-			count: 1
-			path: modules/social_features/social_user/src/Controller/SocialUserController.php
-
-		-
 			message: "#^Method Drupal\\\\social_user\\\\Controller\\\\SocialUserController\\:\\:setUserStreamTitle\\(\\) should return string but return statement is missing\\.$#"
 			count: 1
 			path: modules/social_features/social_user/src/Controller/SocialUserController.php

--- a/tests/behat/features/capabilities/account/my-profile-page.feature
+++ b/tests/behat/features/capabilities/account/my-profile-page.feature
@@ -1,0 +1,12 @@
+@api
+Feature: Redirect user to their stream page from /my-profile path
+  Benefit: To make it easier for users to access their stream page
+  Role: As a Authenticated
+  Goal/desire: I want to be redirected to "/user/*/stream" when I go to "/my-profile"
+
+  Scenario: A user is redirected to their stream page
+    Given I am logged in as a user with the "authenticated" role
+
+    When I go to "/my-profile"
+
+    Then the URL should match "^\/user\/[^\/]+\/stream"


### PR DESCRIPTION
## Problem
Add a redirect from /my-profile path to /user/{user-id}/stream (stream page) of current user. It will smoth the user-experience.

## Solution
Created a route for logged user and add a redirect to stream page of logged user.

## Issue tracker
[PROD-30752](https://getopensocial.atlassian.net/browse/PROD-30752)
[#3477759](https://www.drupal.org/project/social/issues/3477759)

## Theme issue tracker
N/A

## How to test
**Non logged user**
- [ ] Try to access /my-profile url and check if was redirected to login page

**Logged user**
- [ ] Make login with authenticated user
- [ ] Try to access /my-profile url and check if was redirected to stream page

## Screenshots
N/A

## Release notes
Created /my-profile path and redirect the logged user to stream page when they try to access the new route.

## Change Record
N/A

## Translations
N/A


[PROD-30752]: https://getopensocial.atlassian.net/browse/PROD-30752?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ