### PR TITLE
Issue #3477793: As a user I can not access the stream and members tab in any Flexible group I am not a member of

### DIFF
--- a/modules/social_features/social_group/modules/social_group_default_route/src/EventSubscriber/RedirectSubscriber.php
+++ b/modules/social_features/social_group/modules/social_group_default_route/src/EventSubscriber/RedirectSubscriber.php
@@ -5,10 +5,13 @@ namespace Drupal\social_group_default_route\EventSubscriber;
 use Drupal\Core\Routing\CurrentRouteMatch;
 use Drupal\Core\Session\AccountProxy;
 use Drupal\Core\Url;
+use Drupal\group\Entity\Group;
 use Drupal\social_group\SocialGroupInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpKernel\Event\ExceptionEvent;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\KernelEvents;
 
 /**
@@ -70,6 +73,7 @@ class RedirectSubscriber implements EventSubscriberInterface {
    */
   public static function getSubscribedEvents() {
     $events[KernelEvents::REQUEST][] = ['groupLandingPage'];
+    $events[KernelEvents::EXCEPTION][] = ['onKernelException', 100];
     return $events;
   }
 
@@ -80,7 +84,6 @@ class RedirectSubscriber implements EventSubscriberInterface {
    *   The event.
    */
   public function groupLandingPage(RequestEvent $event) {
-
     // First check if the current route is the group canonical.
     $route_name = $this->currentRoute->getRouteName();
 
@@ -100,13 +103,56 @@ class RedirectSubscriber implements EventSubscriberInterface {
       return;
     }
 
+    $this->doRedirect($event, $group);
+  }
+
+  /**
+   * Redirect on exceptions.
+   *
+   * @param \Symfony\Component\HttpKernel\Event\ExceptionEvent $event
+   *   The exception event.
+   */
+  public function onKernelException(ExceptionEvent $event): void {
+    $exception = $event->getThrowable();
+    if ($exception instanceof AccessDeniedHttpException) {
+      // Check if there is a group object on the current route.
+      $group = $this->currentRoute->getParameter('group');
+      // On some routes group param could be string.
+      if (is_string($group)) {
+        $group = Group::load($group);
+      }
+
+      if (!$group instanceof SocialGroupInterface) {
+        return;
+      }
+      // Do not redirect form access denied if user doesn't have access to
+      // view the group (secret group, etc.).
+      if (!$group->access('view', $this->currentUser)) {
+        return;
+      }
+
+      $this->doRedirect($event, $group);
+    }
+
+  }
+
+  /**
+   * Do redirect.
+   *
+   * @param \Symfony\Component\HttpKernel\Event\ExceptionEvent|\Symfony\Component\HttpKernel\Event\RequestEvent $event
+   *   The event object.
+   * @param \Drupal\social_group\SocialGroupInterface $group
+   *   The group object.
+   */
+  protected function doRedirect(ExceptionEvent|RequestEvent $event, SocialGroupInterface $group): void {
+    $route_name = $this->currentRoute->getRouteName();
     // Check if current user is a member.
     if (!$group->hasMember($this->currentUser)) {
       /** @var string|null $route */
       $route = $group->default_route_an->value;
 
       if ($route === NULL) {
-        $route = self::DEFAULT_ROUTE;
+        $route = self::DEFAULT_CLOSED_ROUTE;
       }
     }
     else {

--- a/modules/social_features/social_group/modules/social_group_flexible_group/config/install/group.role.flexible_group-anonymous.yml
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/config/install/group.role.flexible_group-anonymous.yml
@@ -13,8 +13,6 @@ global_role: anonymous
 group_type: flexible_group
 permissions:
   - 'view group'
-  - 'view group stream page'
-  - 'view group_membership relationship'
   - 'view group_node:event relationship'
   - 'view group_node:event entity'
   - 'view group_node:topic relationship'

--- a/modules/social_features/social_group/modules/social_group_flexible_group/config/install/group.role.flexible_group-verified.yml
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/config/install/group.role.flexible_group-verified.yml
@@ -3,12 +3,11 @@ status: true
 dependencies:
   config:
     - group.type.flexible_group
-id: flexible_group-outsider
-label: Outsider
-weight: -101
+id: flexible_group-verified
+label: Verified
 admin: false
 scope: outsider
-global_role: authenticated
+global_role: verified
 group_type: flexible_group
 permissions:
   - 'access comments'

--- a/modules/social_features/social_group/modules/social_group_flexible_group/config/update/social_group_flexible_group_update_130006.yml
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/config/update/social_group_flexible_group_update_130006.yml
@@ -1,0 +1,3 @@
+__global_actions:
+  import_configs:
+    - group.role.flexible_group-verified

--- a/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.info.yml
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.info.yml
@@ -18,6 +18,7 @@ dependencies:
   - social:social_event
   - social:social_topic
   - social:social_email_broadcast
+  - social:social_group_default_route
   - drupal:text
   - drupal:user
   - config_modify:config_modify

--- a/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.install
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.install
@@ -250,3 +250,57 @@ function social_group_flexible_group_update_130005() : void {
     \Drupal::service('module_installer')->install(['social_email_broadcast']);
   }
 }
+
+/**
+ * Add 'Verified' group role, enable redirection for Flexible group type.
+ */
+function social_group_flexible_group_update_130006(): string {
+  /** @var \Drupal\update_helper\Updater $updater */
+  $updater = \Drupal::service('update_helper.updater');
+
+  if (\Drupal::moduleHandler()->moduleExists('social_group_flexible_group') &&
+    empty(\Drupal::config('group.role.flexible_group-verified')->getRawData())
+  ) {
+    // Execute configuration update definitions with logging of success.
+    $updater->executeUpdate('social_group_flexible_group', __FUNCTION__);
+  }
+  // Output logged messages to related channel of update execution.
+  return $updater->logger()->output();
+
+}
+
+/**
+ * Revoke group permissions for Outsider and Anonymous roles.
+ */
+function social_group_flexible_group_update_130007(): void {
+  $roles_permissions = [
+    'flexible_group-outsider' => [
+      'view group_membership relationship',
+      'view group stream page',
+    ],
+    'flexible_group-anonymous' => [
+      'view group_membership relationship',
+      'view group stream page',
+    ],
+  ];
+
+  foreach ($roles_permissions as $role_id => $permissions) {
+    /** @var \Drupal\group\Entity\GroupRoleInterface $role */
+    $role = \Drupal::entityTypeManager()->getStorage('group_role')->load($role_id);
+
+    foreach ($permissions as $permission) {
+      $role->revokePermission($permission);
+    }
+
+    $role->save();
+  }
+}
+
+/**
+ * Install the "Social group default route" module.
+ */
+function social_group_flexible_group_update_130008() : void {
+  if (!\Drupal::moduleHandler()->moduleExists('social_group_default_route')) {
+    \Drupal::service('module_installer')->install(['social_group_default_route']);
+  }
+}

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -7274,11 +7274,6 @@ parameters:
 			path: modules/social_features/social_group/modules/social_group_default_route/social_group_default_route.module
 
 		-
-			message: "#^Constant Drupal\\\\social_group_default_route\\\\EventSubscriber\\\\RedirectSubscriber\\:\\:DEFAULT_CLOSED_ROUTE is unused\\.$#"
-			count: 1
-			path: modules/social_features/social_group/modules/social_group_default_route/src/EventSubscriber/RedirectSubscriber.php
-
-		-
 			message: "#^Method Drupal\\\\social_group_default_route\\\\EventSubscriber\\\\RedirectSubscriber\\:\\:groupLandingPage\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: modules/social_features/social_group/modules/social_group_default_route/src/EventSubscriber/RedirectSubscriber.php

--- a/tests/behat/features/capabilities/groups/flexible/groups-flexible-page-access.feature
+++ b/tests/behat/features/capabilities/groups/flexible/groups-flexible-page-access.feature
@@ -1,0 +1,48 @@
+@api @javascript
+Feature: Validate accessibility of flexible group pages for different users
+
+  Background:
+    Given I enable the module "social_group_flexible_group"
+    And I am logged in as an "sitemanager"
+    And users:
+      | name        | mail                    | status | roles       |
+      | Behat Owner | behat_owner@example.com | 1      | sitemanager |
+      | Non Member  | non_member@example.com  | 1      |             |
+      | Member      | member@example.com      | 1      |             |
+
+    And groups no validation:
+      | label           | type           | author      | field_flexible_group_visibility |
+      | Test Challenge  | flexible_group | Behat Owner | public                          |
+    And group members with values:
+      | group          | user   | group_roles           |
+      | Test Challenge | Member | flexible_group-member |
+
+  Scenario: Anonymous user should be redirected to the About page from "Members" and "Stream" pages.
+    Given I am an anonymous user
+
+    When I go to "/group/1/stream"
+
+    Then the URL should match "^\/group\/[^\/]+\/about$"
+
+    And I go to "/group/1/members"
+    And the URL should match "^\/group\/[^\/]+\/about$"
+
+  Scenario: Verified user should be redirected to the About page from "Members" and "Stream" pages if he is non-member.
+    Given I am logged in as "Non Member"
+
+    When I go to "/group/1/stream"
+
+    Then the URL should match "^\/group\/[^\/]+\/about$"
+
+    And I go to "/group/1/members"
+    And the URL should match "^\/group\/[^\/]+\/about$"
+
+  Scenario: Group member shouldn't be redirected to the About page from "Members" and "Stream" pages.
+    Given I am logged in as "Member"
+
+    When I go to "/group/1/stream"
+
+    Then the URL should match "^\/group\/[^\/]+\/stream"
+
+    And I go to "/group/1/members"
+    And the URL should match "^\/group\/[^\/]+\/members$"

--- a/tests/behat/features/capabilities/groups/flexible/groups-flexible-sidebar-blocks.feature
+++ b/tests/behat/features/capabilities/groups/flexible/groups-flexible-sidebar-blocks.feature
@@ -18,4 +18,3 @@ Feature: Flexible groups sidebar blocks are correctly displayed
 
     Then I should see "Upcoming events" in the "Sidebar second"
     And I should see "Newest topics" in the "Sidebar second"
-    And I should see "Newest Members" in the "Sidebar second"

--- a/tests/behat/features/capabilities/groups/flexible/groups-flexible-view-outsider-authenticated.feature
+++ b/tests/behat/features/capabilities/groups/flexible/groups-flexible-view-outsider-authenticated.feature
@@ -1,4 +1,4 @@
-@api @javascript @flexible-groups
+@api @javascript
 Feature: Flexible groups view access for authenticated but unverified users
   Background:
     Given I enable the module "social_group_flexible_group"
@@ -33,7 +33,7 @@ Feature: Flexible groups view access for authenticated but unverified users
 
     When I am viewing the group "Test group"
 
-    Then I should not see "Test group"
+    Then I should see "You are not authorized to access this page"
 
   Scenario: As unverified user I can view a public group I'm not a member of on the groups search
     Given groups with non-anonymous owner:

--- a/tests/behat/features/capabilities/groups/flexible/groups-flexible-view-outsider-verified.feature
+++ b/tests/behat/features/capabilities/groups/flexible/groups-flexible-view-outsider-verified.feature
@@ -1,4 +1,4 @@
-@api @javascript @flexible-groups
+@api @javascript
 Feature: Flexible groups view access for verified users
   Background:
     Given I enable the module "social_group_flexible_group"
@@ -35,7 +35,7 @@ Feature: Flexible groups view access for verified users
 
     When I am viewing the group "Test group"
 
-    Then I should not see "Test group"
+    Then I should see "You are not authorized to access this page"
 
   Scenario: As verified user I can view a public group I'm not a member of on the groups search
     Given groups with non-anonymous owner:


### PR DESCRIPTION
## Problem
Users currently experience inconsistent access to group information, allowing non-members to view the stream and members page. This issue necessitates the creation of a new role, "Verified User (outsider)" to ensure proper permissions.

## Solution

1. Create a `Verified User (outsider)` group role for the Flexible group
2. Revoke `view group stream page` and `view group_membership relationship` permissions for AU, AN and VU user

Sub-PR:
- https://github.com/goalgorilla/open_social/pull/4120

## Issue tracker

- https://www.drupal.org/project/social/issues/3477793
- https://getopensocial.atlassian.net/browse/PROD-28608

## How to test
- [ ] Install module "social_group" and "social_group_flexible_group" and "social_group_default_route"
- [ ] Create public "Flexible" group "Test public group", in settings chose default landing page for non-members - "About", for members "Stream", otherwise the default link of group for non-members will be "Stream" and non-members will get Access denied
- [ ] Create AU -  "AU test"
- [ ] Create VU -  "VU test"
- [ ] Create VU -  "VU member"
- [ ] Add "VU member" as member to "Test public group"
- [ ] As a user "AU test" - go to page `group/1/stream` - you should get "Access Denied"
- [ ] As a user "AU test" - go to page `group/1/members` - you should get "Access Denied"
- [ ]  For AN user the same behavior
- [ ] As "VU member" - go to page `group/1/stream` - it should be accessible
- [ ] As "VU member" - go to page `group/1/members` - it should be accessible
- [ ] Create a secret "Flexible" group "Test secret group" with "Group members only" visibility
- [ ] As a user "AU test" or AN  - go to page `group/1/stream` - you should get "Access Denied"
- [ ] As a user "AU test" - go to page `group/1/members` - you should get "Access Denied"

## Release notes
With this story we want to make sure a user can not access the stream and members page of any  group with any visibility if they are not members of the group.
