### PR TITLE
PROD-30226: Implement the visibility options as an object for the EDA

### DIFF
--- a/modules/custom/social_eda/src/Types/ContentVisibility.php
+++ b/modules/custom/social_eda/src/Types/ContentVisibility.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\social_eda\Types;
+
+use Drupal\Core\Entity\ContentEntityInterface;
+use Drupal\social_role_visibility\Service\VisibilityElementManager;
+
+/**
+ * Type class for ContentVisibility data.
+ */
+class ContentVisibility {
+
+  /**
+   * Constructs the ContentVisibility type.
+   */
+  public function __construct(
+    public readonly string $type,
+    public readonly array $groups = [],
+    public readonly array $roles = [],
+  ) {}
+
+  /**
+   * Get formatted ContentVisibility output.
+   *
+   * @param \Drupal\Core\Entity\ContentEntityInterface $entity
+   *   The entity object.
+   *
+   * @return self|null
+   *   The ContentVisibility object or null.
+   */
+  public static function fromEntity(ContentEntityInterface $entity): ?self {
+    if (!$entity->hasField('field_content_visibility')) {
+      return NULL;
+    }
+
+    $visibility_type = $entity->get('field_content_visibility')->value;
+
+    switch ($visibility_type) {
+      case "group":
+        $groups_ids = [];
+        if ($entity->hasField('groups')) {
+          /** @var \Drupal\group\Entity\GroupInterface $groups */
+          $groups = $entity->get('groups');
+          foreach ($groups->referencedEntities() as $group) {
+            $groups_ids[] = $group->uuid();
+          }
+        }
+
+        return new self(
+          type: 'groups',
+          groups: $groups_ids,
+        );
+
+      case "visibility_by_role":
+        $roles = [];
+        if ($entity->hasField('role_visibility')) {
+          $visibility_roles = $entity->get('role_visibility')->getValue();
+
+          foreach ($visibility_roles as $item) {
+            $id = $item['value'];
+
+            // CM+ is a special role that applies to multiple ids.
+            if ($id == "cm_plus" && class_exists('\Drupal\social_role_visibility\Service\VisibilityElementManager')) {
+              foreach (VisibilityElementManager::CM_PLUS_ROLES as $role_id) {
+                $roles[] = $role_id;
+              }
+              continue;
+            }
+
+            $roles[] = $id;
+          }
+        }
+
+        return new self(
+          type: 'roles',
+          roles: $roles,
+        );
+
+      default:
+        return new self(
+          type: (string) $visibility_type,
+        );
+
+    }
+  }
+
+}

--- a/modules/social_features/social_event/asyncapi.yml
+++ b/modules/social_features/social_event/asyncapi.yml
@@ -32,8 +32,17 @@ channels:
                       type: string
                       description: The label of the event.
                     visibility:
-                      type: string
-                      description: The visibility of the event content.
+                      type: object
+                      properties:
+                        type:
+                          type: string
+                          description: The visibility type.
+                        groups:
+                          type: array
+                          description: The list of groups.
+                        roles:
+                          type: array
+                          description: The list of roles ids.
                     group:
                       type: object
                       nullable: true
@@ -167,8 +176,17 @@ channels:
                       type: string
                       description: The label of the event.
                     visibility:
-                      type: string
-                      description: The visibility of the event content.
+                      type: object
+                      properties:
+                        type:
+                          type: string
+                          description: The visibility type.
+                        groups:
+                          type: array
+                          description: The list of groups.
+                        roles:
+                          type: array
+                          description: The list of roles ids.
                     group:
                       type: object
                       nullable: true
@@ -302,8 +320,17 @@ channels:
                       type: string
                       description: The label of the event.
                     visibility:
-                      type: string
-                      description: The visibility of the event content.
+                      type: object
+                      properties:
+                        type:
+                          type: string
+                          description: The visibility type.
+                        groups:
+                          type: array
+                          description: The list of groups.
+                        roles:
+                          type: array
+                          description: The list of roles ids.
                     group:
                       type: object
                       nullable: true

--- a/modules/social_features/social_event/src/EdaHandler.php
+++ b/modules/social_features/social_event/src/EdaHandler.php
@@ -10,6 +10,7 @@ use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\Session\AccountProxyInterface;
 use Drupal\node\NodeInterface;
 use Drupal\social_eda\Types\Address;
+use Drupal\social_eda\Types\ContentVisibility;
 use Drupal\social_eda\Types\Application;
 use Drupal\social_eda\Types\DateTime;
 use Drupal\social_eda\Types\Entity;
@@ -126,7 +127,7 @@ final class EdaHandler {
           updated: DateTime::fromTimestamp($node->getChangedTime())->toString(),
           status: $node->get('status')->value ? 'published' : 'unpublished',
           label: (string) $node->label(),
-          visibility: $node->get('field_content_visibility')->value,
+          visibility: ContentVisibility::fromEntity($node),
           group: !$node->get('groups')->isEmpty() ? Entity::fromEntity($node->get('groups')->getEntity()) : NULL,
           author: User::fromEntity($node->get('uid')->entity),
           allDay: $node->get('field_event_all_day')->value,

--- a/modules/social_features/social_event/src/Event/EventEntityData.php
+++ b/modules/social_features/social_event/src/Event/EventEntityData.php
@@ -3,6 +3,7 @@
 namespace Drupal\social_event\Event;
 
 use Drupal\social_eda\Types\Address;
+use Drupal\social_eda\Types\ContentVisibility;
 use Drupal\social_eda\Types\Entity;
 use Drupal\social_eda\Types\Href;
 use Drupal\social_eda\Types\User;
@@ -21,7 +22,7 @@ class EventEntityData {
     public readonly string $updated,
     public readonly string $status,
     public readonly string $label,
-    public readonly string $visibility,
+    public readonly ContentVisibility|null $visibility,
     public readonly Entity|null $group,
     public readonly User $author,
     public readonly bool $allDay,

--- a/modules/social_features/social_event/tests/src/Unit/EdaHandlerTest.php
+++ b/modules/social_features/social_event/tests/src/Unit/EdaHandlerTest.php
@@ -225,6 +225,8 @@ class EdaHandlerTest extends UnitTestCase {
     $nodeMock = $this->prophesize(NodeInterface::class);
     $nodeMock->label()->willReturn('Event Title');
     $nodeMock->getCreatedTime()->willReturn(1692614400);
+    $nodeMock->hasField('field_content_visibility')->willReturn(TRUE);
+    $nodeMock->hasField('groups')->willReturn(TRUE);
     $nodeMock->getChangedTime()->willReturn(1692618000);
     $nodeMock->get('groups')->willReturn($this->fieldItemList);
     $nodeMock->get('uuid')


### PR DESCRIPTION
## Problem
Currently the visibility in the eventCreate event is a string, this is not correct according to the specification, it should be an object.

## Solution
Implement a specific type for the visibility that will return the object that is according to the specifications.

## Issue tracker
https://getopensocial.atlassian.net/browse/PROD-30226

## Theme issue tracker
<!-- *[Required if applicable] Paste a link to the drupal.org theme issue queue item, either from [socialbase](https://www.drupal.org/project/socialbase) or [socialblue](https://www.drupal.org/project/socialblue). If any other issue trackers were used, include links to those too.* -->

## How to test
- [ ] Set up Open Social with broker (kafka) and kafka-ui for viewing messages
- [ ] Enable the social_eda_dispatcher module
- [ ] Create an event and set the visibility option to group and select a group
- [ ] When event is created, check the Kafka UI for a new message and check that the payload of visibility field is like this:
```
			"visibility": {
				"type": "groups",
				"groups": [
					"3bc51523-4f40-459c-887c-056432fe17cd"
				],
				"roles": []
			},

```



## Screenshots
<!-- *[Required if new feature, and if applicable] If this Pull Request makes visual changes then please include some screenshots that show what has changed here. A before and after screenshot helps the reviewer determine what changes were made.* -->

## Release notes
<!-- *[Required if new feature, and if applicable] A short summary of the changes that were made that can be included in release notes.* -->

## Change Record
<!-- *[Required if applicable] If this Pull Request changes the way that developers should do things or introduces a new API for developers then a change record to document this is needed. Please provide a draft for a change record or a link to an unpublished change record below. Existing change records can be consulted as example. Please provide a draft for a change record or a link to an unpublished change record below. [Existing change records](https://www.drupal.org/list-changes/social) can be consulted as example.* -->

## Translations
<!--
*[Optional]Translatable strings are always extracted from the latest development branch. To ensure translations remain available for platforms running older versions of Open Social the original string should be added to `translations.php` when it's changed or removed.*
- [ ] Changed or removed source strings are added to the `translations.php` file.
-->
