### PR TITLE
PROD-30875: Implement "event published" event for the EDA

### DIFF
--- a/modules/custom/social_eda/src/Types/Application.php
+++ b/modules/custom/social_eda/src/Types/Application.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Drupal\social_eda\Types;
+
+/**
+ * Type class for Application data.
+ */
+class Application {
+
+  /**
+   * Constructs the Application type.
+   *
+   * @param string $id
+   *   The UUID.
+   * @param string $name
+   *   The application name.
+   */
+  public function __construct(
+    public readonly string $id,
+    public readonly string $name,
+  ) {}
+
+  /**
+   * Get Application from an ID.
+   *
+   * @param string $id
+   *   The application ID.
+   *
+   * @return self
+   *   The Application data object.
+   *
+   * @throws \InvalidArgumentException
+   *   Thrown if the application ID is not recognized.
+   */
+  public static function fromId(string $id): self {
+    // Define the known applications with their UUIDs.
+    $applications = [
+      'cron' => [
+        'uuid' => '123e4567-e89b-12d3-a456-426614174000',
+        'name' => 'Cron',
+      ],
+      'graphql' => [
+        'uuid' => '123e4567-e89b-12d3-a456-426614174001',
+        'name' => 'GraphQL',
+      ],
+    ];
+
+    // Check if the given ID exists in the known applications.
+    if (!array_key_exists($id, $applications)) {
+      throw new \InvalidArgumentException(sprintf('Unknown application ID: %s', $id));
+    }
+
+    // Return the corresponding application data.
+    return new self(
+      id: $applications[$id]['uuid'],
+      name: $applications[$id]['name'],
+    );
+  }
+
+}

--- a/modules/social_features/social_core/social_core.api.php
+++ b/modules/social_features/social_core/social_core.api.php
@@ -180,3 +180,39 @@ function hook_social_core_default_main_menu_links_alter(array &$links) {
 /**
  * @} End of "defaultmainmenulinks hooks".
  */
+
+/**
+ * Act on an entity being published.
+ *
+ * This hook is fired when an entity's status is changed to "published."
+ * It works for any entity type that has a `status` field, such as nodes or
+ * taxonomy terms. The hook is dynamically invoked based on the entity type.
+ * For example:
+ * - hook_social_core_node_published() for nodes
+ * - hook_social_core_taxonomy_term_published() for taxonomy terms.
+ *
+ * @param \Drupal\Core\Entity\EntityInterface $entity
+ *   The entity being published.
+ *
+ * @ingroup hooks
+ */
+function hook_social_core_ENTITY_TYPE_published(\Drupal\Core\Entity\EntityInterface $entity) {
+}
+
+/**
+ * Act on an entity being unpublished.
+ *
+ * This hook is fired when an entity's status is changed to "unpublished."
+ * It works for any entity type that has a `status` field, such as nodes or
+ * taxonomy terms. The hook is dynamically invoked based on the entity type.
+ * For example:
+ * - hook_social_core_node_unpublished() for nodes
+ * - hook_social_core_taxonomy_term_unpublished() for taxonomy terms.
+ *
+ * @param \Drupal\Core\Entity\EntityInterface $entity
+ *   The entity being unpublished.
+ *
+ * @ingroup hooks
+ */
+function hook_social_core_ENTITY_TYPE_unpublished(\Drupal\Core\Entity\EntityInterface $entity) {
+}

--- a/modules/social_features/social_core/social_core.module
+++ b/modules/social_features/social_core/social_core.module
@@ -1497,3 +1497,29 @@ function _social_core_install_blocks(array $items, callable $function = NULL): v
     }
   }
 }
+
+/**
+ * Implements hook_entity_update().
+ */
+function social_core_entity_update(EntityInterface $entity): void {
+  // Get the original status from the current entity.
+  $original_status = NULL;
+  if (isset($entity->original) && isset($entity->original->status)) {
+    $original_status = (bool) $entity->original->status->value;
+  }
+
+  // Get the new status from the current entity.
+  $new_status = isset($entity->status) ? (bool) $entity->status->value : NULL;
+
+  // If the status changed (published/unpublished), trigger the custom hooks.
+  if ($original_status != $new_status) {
+    // Entity has been published.
+    if ($new_status == 1) {
+      \Drupal::moduleHandler()->invokeAll('social_core_' . $entity->getEntityTypeId() . '_published', [$entity]);
+    }
+    // Entity has been unpublished.
+    elseif ($new_status == 0) {
+      \Drupal::moduleHandler()->invokeAll('social_core_' . $entity->getEntityTypeId() . '_unpublished', [$entity]);
+    }
+  }
+}

--- a/modules/social_features/social_event/asyncapi.yml
+++ b/modules/social_features/social_event/asyncapi.yml
@@ -135,9 +135,148 @@ channels:
                       type: string
                       nullable: true
                       description: The type of the event.
+  eventPublish:
+    address: com.getopensocial.cms.event.publish
+    messages:
+      eventCreate:
+        payload:
+          allOf:
+            - $ref: '#/components/schemas/cloudEventsSchema'
+            - type: object
+              properties:
+                data:
+                  type: object
+                  properties:
+                    id:
+                      type: string
+                      description: The UUID of the event.
+                    created:
+                      type: string
+                      format: date-time
+                      description: The creation time of the event.
+                    updated:
+                      type: string
+                      format: date-time
+                      description: The last updated time of the event.
+                    status:
+                      type: string
+                      description: The status of the event.
+                      enum:
+                        - published
+                    label:
+                      type: string
+                      description: The label of the event.
+                    visibility:
+                      type: string
+                      description: The visibility of the event content.
+                    group:
+                      type: object
+                      nullable: true
+                      properties:
+                        id:
+                          type: string
+                          description: The UUID of the group.
+                        label:
+                          type: string
+                          description: The label of the group.
+                        href:
+                          type: object
+                          properties:
+                            canonical:
+                              type: string
+                              format: uri
+                              description: Canonical URL of the group.
+                    author:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                          description: The UUID of the author.
+                        displayName:
+                          type: string
+                          description: The display name of the author.
+                        href:
+                          type: object
+                          properties:
+                            canonical:
+                              type: string
+                              format: uri
+                              description: Canonical URL of the author.
+                    allDay:
+                      type: boolean
+                      description: Indicates if the event lasts all day.
+                    start:
+                      type: string
+                      format: date-time
+                      description: The start time of the event.
+                    end:
+                      type: string
+                      format: date-time
+                      description: The end time of the event.
+                    timezone:
+                      type: string
+                      description: The timezone of the event.
+                    address:
+                      type: object
+                      properties:
+                        label:
+                          type: string
+                          description: The label of the event location.
+                        countryCode:
+                          type: string
+                          description: The country code of the event location.
+                        administrativeArea:
+                          type: string
+                          description: The administrative area of the event location.
+                        locality:
+                          type: string
+                          description: The locality of the event location.
+                        dependentLocality:
+                          type: string
+                          description: The dependent locality of the event location.
+                        postalCode:
+                          type: string
+                          description: The postal code of the event location.
+                        sortingCode:
+                          type: string
+                          description: The sorting code of the event location.
+                        addressLine1:
+                          type: string
+                          description: The first address line of the event location.
+                        addressLine2:
+                          type: string
+                          description: The second address line of the event location.
+                    enrollment:
+                      type: object
+                      properties:
+                        enabled:
+                          type: boolean
+                          description: Indicates if enrollment is enabled.
+                        method:
+                          type: string
+                          description: The method of enrollment.
+                          enum:
+                            - open
+                            - invite
+                            - request
+                    href:
+                      type: object
+                      properties:
+                        canonical:
+                          type: string
+                          format: uri
+                          description: Canonical URL of the event.
+                    type:
+                      type: string
+                      nullable: true
+                      description: The type of the event.
 
 operations:
   onEventCreate:
     action: 'receive'
     channel:
       $ref: '#/channels/eventCreate'
+  onEventPublish:
+    action: 'receive'
+    channel:
+      $ref: '#/channels/eventPublish'

--- a/modules/social_features/social_event/social_event.module
+++ b/modules/social_features/social_event/social_event.module
@@ -511,6 +511,15 @@ function social_event_node_insert(NodeInterface $node): void {
 }
 
 /**
+ * Implements hook_social_core_ENTITY_TYPE_published().
+ */
+function social_event_social_core_node_published(EntityInterface $entity): void {
+  if ($entity instanceof NodeInterface && $entity->bundle() == 'event') {
+    \Drupal::service('social_event.eda_handler')->eventPublish($entity);
+  }
+}
+
+/**
  * Implements hook_ENTITY_TYPE_insert().
  */
 function social_event_flagging_insert(EntityInterface $entity) {

--- a/modules/social_features/social_event/src/EdaHandler.php
+++ b/modules/social_features/social_event/src/EdaHandler.php
@@ -4,15 +4,20 @@ namespace Drupal\social_event;
 
 use CloudEvents\V1\CloudEvent;
 use Drupal\Component\Uuid\UuidInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
+use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\Core\Session\AccountProxyInterface;
 use Drupal\node\NodeInterface;
 use Drupal\social_eda\Types\Address;
+use Drupal\social_eda\Types\Application;
 use Drupal\social_eda\Types\DateTime;
 use Drupal\social_eda\Types\Entity;
 use Drupal\social_eda\Types\Href;
 use Drupal\social_eda\Types\User;
 use Drupal\social_eda_dispatcher\Dispatcher as SocialEdaDispatcher;
-use Drupal\social_event\Event\EventCreateEventData;
+use Drupal\social_event\Event\EventEntityData;
+use Drupal\user\UserInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
@@ -21,14 +26,25 @@ use Symfony\Component\HttpFoundation\RequestStack;
 final class EdaHandler {
 
   /**
-   * The Kafka topic name.
+   * The current logged-in user.
+   *
+   * @var \Drupal\user\UserInterface|null
    */
-  const TOPIC_NAME = 'com.getopensocial.cms.event.create';
+  protected ?UserInterface $currentUser = NULL;
 
   /**
-   * The Event type.
+   * The source.
+   *
+   * @var string
    */
-  const EVENT_TYPE = 'com.getopensocial.cms.event.create';
+  protected string $source;
+
+  /**
+   * The current route name.
+   *
+   * @var string
+   */
+  protected string $routeName;
 
   /**
    * {@inheritDoc}
@@ -38,46 +54,68 @@ final class EdaHandler {
     private readonly UuidInterface $uuid,
     private readonly RequestStack $requestStack,
     private readonly ModuleHandlerInterface $moduleHandler,
-  ) {}
+    private readonly EntityTypeManagerInterface $entityTypeManager,
+    private readonly AccountProxyInterface $account,
+    private readonly RouteMatchInterface $routeMatch,
+  ) {
+    // Load the full user entity if the account is authenticated.
+    $account_id = $this->account->id();
+    if ($account_id && $account_id !== 0) {
+      $user = $this->entityTypeManager->getStorage('user')->load($account_id);
+      if ($user instanceof UserInterface) {
+        $this->currentUser = $user;
+      }
+    }
+
+    // Set source.
+    $request = $this->requestStack->getCurrentRequest();
+    $this->source = $request ? $request->getPathInfo() : '';
+
+    // Set route name.
+    $this->routeName = $this->routeMatch->getRouteName() ?: '';
+  }
 
   /**
    * Create event handler.
    */
   public function eventCreate(NodeInterface $node): void {
-    // Skip if required modules are not enabled.
-    if (!$this->moduleHandler->moduleExists('social_eda') || !$this->dispatcher) {
-      return;
-    }
+    $event_type = 'com.getopensocial.cms.event.create';
+    $topic_name = 'com.getopensocial.cms.event.create';
+    $this->dispatch($topic_name, $event_type, $node);
+  }
 
-    // Transform the node into a CloudEvent.
-    $event = $this->fromEntity($node);
-
-    // Dispatch the event to the message broker.
-    $this->dispatcher->dispatch(self::TOPIC_NAME, $event);
+  /**
+   * Publish event handler.
+   */
+  public function eventPublish(NodeInterface $node): void {
+    $event_type = 'com.getopensocial.cms.event.publish';
+    $topic_name = 'com.getopensocial.cms.event.publish';
+    $this->dispatch($topic_name, $event_type, $node);
   }
 
   /**
    * Transforms a NodeInterface into a CloudEvent.
    *
    * @throws \Drupal\Core\Entity\EntityMalformedException
+   * @throws \Drupal\Core\TypedData\Exception\MissingDataException
    */
-  public function fromEntity(NodeInterface $node): CloudEvent {
-    // Get current request.
-    $request = $this->requestStack->getCurrentRequest();
+  public function fromEntity(NodeInterface $node, string $event_type): CloudEvent {
+    // Determine actors.
+    [$actor_application, $actor_user] = $this->determineActors();
 
     // List enrollment methods.
     $enrollment_methods = ['open', 'request', 'invite'];
 
     return new CloudEvent(
       id: $this->uuid->generate(),
-      source: $request ? $request->getUri() : '/node/add/event',
-      type: self::EVENT_TYPE,
+      source: $this->source,
+      type: $event_type,
       data: [
-        'event' => new EventCreateEventData(
+        'event' => new EventEntityData(
           id: $node->get('uuid')->value,
           created: DateTime::fromTimestamp($node->getCreatedTime())->toString(),
           updated: DateTime::fromTimestamp($node->getChangedTime())->toString(),
-          status: $node->get('status')->value,
+          status: $node->get('status')->value ? 'published' : 'unpublished',
           label: (string) $node->label(),
           visibility: $node->get('field_content_visibility')->value,
           group: !$node->get('groups')->isEmpty() ? Entity::fromEntity($node->get('groups')->getEntity()) : NULL,
@@ -98,8 +136,8 @@ final class EdaHandler {
           type: $node->hasField('field_event_type') && !$node->get('field_event_type')->isEmpty() ? $node->get('field_event_type')->getEntity()->label() : NULL,
         ),
         'actor' => [
-          'application' => NULL,
-          'user' => User::fromEntity($node->get('uid')->entity),
+          'application' => $actor_application ? Application::fromId($actor_application) : NULL,
+          'user' => $actor_user ? User::fromEntity($actor_user) : NULL,
         ],
       ],
       dataContentType: 'application/json',
@@ -107,6 +145,59 @@ final class EdaHandler {
       subject: NULL,
       time: DateTime::fromTimestamp($node->getCreatedTime())->toImmutableDateTime(),
     );
+  }
+
+  /**
+   * Determines the actor (application and user) for the CloudEvent.
+   *
+   * @return array
+   *   An array with two elements: the application and the user.
+   */
+  private function determineActors(): array {
+    $application = NULL;
+    $user = NULL;
+
+    switch ($this->routeName) {
+      case 'entity.node.edit_form':
+      case 'system.admin_content':
+        $user = $this->currentUser;
+        break;
+
+      case 'entity.ultimate_cron_job.run':
+        $application = 'cron';
+        break;
+    }
+
+    return [
+      $application,
+      $user,
+    ];
+  }
+
+  /**
+   * Dispatches the event.
+   *
+   * @param string $topic_name
+   *   The topic name.
+   * @param string $event_type
+   *   The event type.
+   * @param \Drupal\node\NodeInterface $node
+   *   The node object.
+   *
+   * @throws \Drupal\Core\Entity\EntityMalformedException
+   * @throws \Drupal\Core\TypedData\Exception\MissingDataException
+   */
+  private function dispatch(string $topic_name, string $event_type, NodeInterface $node): void {
+    // Skip if required modules are not enabled.
+    if (!$this->moduleHandler->moduleExists('social_eda') || !$this->dispatcher) {
+      return;
+    }
+
+    // Build the event.
+    $event = $this->fromEntity($node, $event_type);
+
+    // Dispatch to message broker.
+    $this->dispatcher->dispatch($topic_name, $event);
   }
 
 }

--- a/modules/social_features/social_event/src/Event/EventEntityData.php
+++ b/modules/social_features/social_event/src/Event/EventEntityData.php
@@ -10,7 +10,7 @@ use Drupal\social_eda\Types\User;
 /**
  * Contains data about the creation of an Open Social event.
  */
-class EventCreateEventData {
+class EventEntityData {
 
   /**
    * {@inheritDoc}
@@ -19,7 +19,7 @@ class EventCreateEventData {
     public readonly string $id,
     public readonly string $created,
     public readonly string $updated,
-    public readonly bool $status,
+    public readonly string $status,
     public readonly string $label,
     public readonly string $visibility,
     public readonly Entity|null $group,


### PR DESCRIPTION
## Description

This pull request introduces the new EDA event "event publish" which is dispatched to the Kafka topic `com.getopensocial.cms.event.publish`. The event is triggered on `hook_social_core_event_published`, a new custom hook also provided by this PR;

Here's an example of the generated payload:

```
{
	"specversion": "1.0",
	"id": "62d4fc19-88b1-4e33-a82c-47657696388b",
	"source": "/admin/config/system/cron/jobs/scheduler_cron/run",
	"type": "com.getopensocial.cms.event.publish",
	"datacontenttype": "application/json",
	"time": "2024-10-03T13:36:41Z",
	"data": {
		"event": {
			"id": "c42d8ff9-a2a4-4e79-8312-d3ecb8bb1af5",
			"created": "2024-10-03T13:36:41",
			"updated": "2024-10-03T15:36:17",
			"status": "published",
			"label": "xzczxc",
			"visibility": "community",
			"group": null,
			"author": {
				"id": "b0dc9a92-7e00-425d-a307-e6fb8418a69b",
				"displayName": "admin",
				"href": {
					"canonical": "http://cablecar.localhost/user/1/home"
				}
			},
			"allDay": true,
			"start": "2024-10-03T00:00:00",
			"end": "2024-10-18T00:00:00",
			"timezone": "UTC",
			"address": {
				"label": "",
				"countryCode": "",
				"administrativeArea": "",
				"locality": "",
				"dependentLocality": "",
				"postalCode": "",
				"sortingCode": "",
				"addressLine1": "",
				"addressLine2": ""
			},
			"enrollment": {
				"enabled": true,
				"method": "request"
			},
			"href": {
				"canonical": "http://cablecar.localhost/event/xzczxc"
			},
			"type": null
		},
		"actor": {
			"application": {
				"id": "123e4567-e89b-12d3-a456-426614174000",
				"name": "Cron Application"
			},
			"user": null
		}
	}
}
```

## Issue tracker
https://getopensocial.atlassian.net/browse/PROD-30875

## Theme issue tracker
N/A

## How to test
- [ ] Checkout branch `issue/PROD-30875-eda-event-published` of 'open_social'
- [ ] Enable the modules `social_eda` and `social_eda_dispatcher`
- [ ] Publish an Event by:
  - [ ] Manually changing the status in the node form
  - [ ] Using the bulk operations in `/admin/content` page
  - [ ] Scheduling the publication using `social_scheduler`

The message should be dispatched to Kafka. If you are running locally using the Docker containers, you should be able to see the message on the Kafka UI at http://localhost:8080.

## Screenshots
<!-- *[Required if new feature, and if applicable] If this Pull Request makes visual changes then please include some screenshots that show what has changed here. A before and after screenshot helps the reviewer determine what changes were made.* -->

## Release notes
N/A

## Change Record

Two new custom hooks were introduced:
- `hook_social_core_ENTITY_TYPE_published()`: fired when an entity of the given type is published
- `hook_social_core_ENTITY_TYPE_unpublished()`: fired when an entity of the given type is unpublished

The new hooks will be used in many EDA events we create. 

## Translations
<!--
*[Optional]Translatable strings are always extracted from the latest development branch. To ensure translations remain available for platforms running older versions of Open Social the original string should be added to `translations.php` when it's changed or removed.*
- [ ] Changed or removed source strings are added to the `translations.php` file.
-->
