### PR TITLE
PROD-29995: Implement EDA event for when a user completes the process for account registration

### DIFF
--- a/modules/custom/social_eda/src/Types/Application.php
+++ b/modules/custom/social_eda/src/Types/Application.php
@@ -40,7 +40,7 @@ class Application {
         'name' => 'Cron',
       ],
       'graphql' => [
-        'uuid' => '123e4567-e89b-12d3-a456-426614174001',
+        'uuid' => 'fd4b26f6-ec5e-47c2-8bf1-d8db7fc9d094',
         'name' => 'GraphQL',
       ],
     ];

--- a/modules/social_features/social_event/src/EdaHandler.php
+++ b/modules/social_features/social_event/src/EdaHandler.php
@@ -51,7 +51,7 @@ final class EdaHandler {
    * {@inheritDoc}
    */
   public function __construct(
-    private readonly DispatcherInterface $dispatcher,
+    private readonly ?DispatcherInterface $dispatcher,
     private readonly UuidInterface $uuid,
     private readonly RequestStack $requestStack,
     private readonly ModuleHandlerInterface $moduleHandler,
@@ -193,17 +193,12 @@ final class EdaHandler {
     $application = NULL;
     $user = NULL;
 
-    switch ($this->routeName) {
-      case 'entity.node.edit_form':
-      case 'entity.node.delete_form':
-      case 'entity.node.delete_multiple_form':
-      case 'system.admin_content':
-        $user = $this->currentUser;
-        break;
+    if ($this->currentUser instanceof UserInterface) {
+      $user = $this->currentUser;
+    }
 
-      case 'entity.ultimate_cron_job.run':
-        $application = 'cron';
-        break;
+    if ($this->routeName == 'entity.ultimate_cron_job.run') {
+      $application = 'cron';
     }
 
     return [
@@ -229,7 +224,7 @@ final class EdaHandler {
    */
   private function dispatch(string $topic_name, string $event_type, NodeInterface $node, string $op = ''): void {
     // Skip if required modules are not enabled.
-    if (!$this->moduleHandler->moduleExists('social_eda')) {
+    if (!$this->moduleHandler->moduleExists('social_eda') || !$this->dispatcher) {
       return;
     }
 

--- a/modules/social_features/social_user/asyncapi.yml
+++ b/modules/social_features/social_user/asyncapi.yml
@@ -1,0 +1,142 @@
+channels:
+  userCreate:
+    address: com.getopensocial.cms.user.create
+    messages:
+      userCreate:
+        payload:
+          allOf:
+            - $ref: '#/components/schemas/cloudEventsSchema'
+            - type: object
+              properties:
+                data:
+                  type: object
+                  properties:
+                    id:
+                      type: string
+                      description: The UUID of the user.
+                    created:
+                      type: string
+                      format: date-time
+                      description: The creation time of the user.
+                    updated:
+                      type: string
+                      format: date-time
+                      description: The last updated time of the user.
+                    status:
+                      type: string
+                      description: The status of the user.
+                      enum:
+                        - active
+                        - blocked
+                    displayName:
+                      type: string
+                      description: The display name of the user.
+                    firstName:
+                      type: string
+                      nullable: true
+                      description: The first name of the user.
+                    lastName:
+                      type: string
+                      nullable: true
+                      description: The last name of the user.
+                    email:
+                      type: string
+                      format: email
+                      description: The email address of the user.
+                    roles:
+                      type: array
+                      items:
+                        type: string
+                      description: Roles assigned to the user.
+                    timezone:
+                      type: string
+                      description: The timezone of the user.
+                    language:
+                      type: string
+                      description: The preferred language of the user.
+                    address:
+                      type: object
+                      nullable: true
+                      properties:
+                        label:
+                          type: string
+                          description: The label of the user address.
+                        countryCode:
+                          type: string
+                          description: The country code of the user address.
+                        administrativeArea:
+                          type: string
+                          description: The administrative area of the user address.
+                        locality:
+                          type: string
+                          description: The locality of the user address.
+                        dependentLocality:
+                          type: string
+                          description: The dependent locality of the user address.
+                        postalCode:
+                          type: string
+                          description: The postal code of the user address.
+                        sortingCode:
+                          type: string
+                          description: The sorting code of the user address.
+                        addressLine1:
+                          type: string
+                          description: The first address line of the user address.
+                        addressLine2:
+                          type: string
+                          description: The second address line of the user address.
+                    phone:
+                      type: string
+                      nullable: true
+                      description: The phone number of the user.
+                    function:
+                      type: string
+                      nullable: true
+                      description: The job function of the user.
+                    organization:
+                      type: string
+                      nullable: true
+                      description: The organization of the user.
+                    href:
+                      type: object
+                      properties:
+                        canonical:
+                          type: string
+                          format: uri
+                          description: Canonical URL of the user.
+                    actor:
+                      type: object
+                      properties:
+                        application:
+                          type: object
+                          nullable: true
+                          properties:
+                            id:
+                              type: string
+                              description: The UUID of the application.
+                            name:
+                              type: string
+                              description: The name of the application.
+                        user:
+                          type: object
+                          nullable: true
+                          properties:
+                            id:
+                              type: string
+                              description: The UUID of the actor user.
+                            displayName:
+                              type: string
+                              description: The display name of the actor user.
+                            href:
+                              type: object
+                              properties:
+                                canonical:
+                                  type: string
+                                  format: uri
+                                  description: Canonical URL of the actor user.
+
+operations:
+  onUserCreate:
+    action: 'receive'
+    channel:
+      $ref: '#/channels/userCreate'

--- a/modules/social_features/social_user/social_user.module
+++ b/modules/social_features/social_user/social_user.module
@@ -6,6 +6,7 @@
  */
 
 use Drupal\Core\Block\BlockPluginInterface;
+use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Link;
@@ -711,6 +712,56 @@ function social_user_user_insert(UserInterface $user): void {
   if ($verified_immediately) {
     $user->addRole('verified');
     $user->save();
+  }
+}
+
+/**
+ * Implements hook_ENTITY_TYPE_insert().
+ *
+ * When a new Profile entity is created (if it does not require admin approval),
+ * we should trigger the EDA event.
+ */
+function social_user_profile_insert(ProfileInterface $profile): void {
+  $user = $profile->get('uid')->entity;
+  $current_request = \Drupal::requestStack()->getCurrentRequest();
+  $user_settings = \Drupal::config('user.settings');
+  $trigger = FALSE;
+
+  // If user is created from the route `user.register`.
+  if ($current_request && $current_request->get('_route') == 'user.register') {
+    // Admin approval is required.
+    if ($user_settings->get('register') != 'visitors_admin_approval') {
+      $trigger = TRUE;
+    }
+  }
+  else {
+    $trigger = TRUE;
+  }
+
+  if ($trigger && $user instanceof UserInterface) {
+    \Drupal::service('social_user.eda_handler')->userCreate($user);
+  }
+}
+
+/**
+ * Implements hook_ENTITY_TYPE_update().
+ *
+ * When the user account is created but depends on admin approval,
+ * we must use the hook_ENTITY_TYPE_update() to capture the status change
+ * so that we can trigger the EDA event.
+ */
+function social_user_user_update(EntityInterface $entity): void {
+  // Make sure the updated entity is a user entity.
+  if ($entity instanceof UserInterface) {
+    $original = $entity->original;
+
+    // Status changed to active.
+    if ($entity->isActive() && $original instanceof UserInterface && $original->isBlocked()) {
+      // The user never logged in & the created time is equals to changed time.
+      if ($entity->getLastLoginTime() == 0 && $original->getCreatedTime() == $original->getChangedTime()) {
+        \Drupal::service('social_user.eda_handler')->userCreate($entity);
+      }
+    }
   }
 }
 

--- a/modules/social_features/social_user/social_user.services.yml
+++ b/modules/social_features/social_user/social_user.services.yml
@@ -17,3 +17,8 @@ services:
     arguments: ['@current_route_match', '@current_user', '@config.factory']
     tags:
       - { name: event_subscriber }
+  social_user.eda_handler:
+    autowire: true
+    class: Drupal\social_user\EdaHandler
+    tags:
+      - { name: social.eda.handler }

--- a/modules/social_features/social_user/src/EdaHandler.php
+++ b/modules/social_features/social_user/src/EdaHandler.php
@@ -1,0 +1,193 @@
+<?php
+
+namespace Drupal\social_user;
+
+use CloudEvents\V1\CloudEvent;
+use Drupal\Component\Uuid\UuidInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Extension\ModuleHandlerInterface;
+use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\Core\Session\AccountProxyInterface;
+use Drupal\social_eda\DispatcherInterface;
+use Drupal\social_eda\Types\Address;
+use Drupal\social_eda\Types\Application;
+use Drupal\social_eda\Types\DateTime;
+use Drupal\social_eda\Types\Href;
+use Drupal\social_eda\Types\User;
+use Drupal\social_user\Event\UserEventData;
+use Drupal\user\UserInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/**
+ * Handles hook invocations for EDA related operations of the user entity.
+ */
+final class EdaHandler {
+
+  /**
+   * The current logged-in user.
+   *
+   * @var \Drupal\user\UserInterface|null
+   */
+  protected ?UserInterface $currentUser = NULL;
+
+  /**
+   * The source.
+   *
+   * @var string
+   */
+  protected string $source;
+
+  /**
+   * The current route name.
+   *
+   * @var string
+   */
+  protected string $routeName;
+
+  /**
+   * {@inheritDoc}
+   */
+  public function __construct(
+    private readonly ?DispatcherInterface $dispatcher,
+    private readonly UuidInterface $uuid,
+    private readonly RequestStack $requestStack,
+    private readonly ModuleHandlerInterface $moduleHandler,
+    private readonly EntityTypeManagerInterface $entityTypeManager,
+    private readonly AccountProxyInterface $account,
+    private readonly RouteMatchInterface $routeMatch,
+  ) {
+    // Load the full user entity if the account is authenticated.
+    $account_id = $this->account->id();
+    if ($account_id && $account_id !== 0) {
+      $user = $this->entityTypeManager->getStorage('user')->load($account_id);
+      if ($user instanceof UserInterface) {
+        $this->currentUser = $user;
+      }
+    }
+
+    // Set source.
+    $request = $this->requestStack->getCurrentRequest();
+    $this->source = $request ? $request->getPathInfo() : '';
+
+    // Set route name.
+    $this->routeName = $this->routeMatch->getRouteName() ?: '';
+  }
+
+  /**
+   * Create user handler.
+   */
+  public function userCreate(UserInterface $user): void {
+    $event_type = 'com.getopensocial.cms.user.create';
+    $topic_name = 'com.getopensocial.cms.user.create';
+    $this->dispatch($topic_name, $event_type, $user);
+  }
+
+  /**
+   * Transforms a NodeInterface into a CloudEvent.
+   */
+  public function fromEntity(UserInterface $user, string $event_type): CloudEvent {
+    // Determine actors.
+    [$actor_application, $actor_user] = $this->determineActors();
+
+    // Query for the user's profile based on the user ID and profile type.
+    $profileStorage = $this->entityTypeManager->getStorage('profile');
+
+    /** @var \Drupal\profile\Entity\ProfileInterface[] $profiles */
+    $profiles = $profileStorage->loadByProperties([
+      'uid' => $user->id(),
+      'type' => 'profile',
+    ]);
+
+    // If there is a profile, retrieve the first one.
+    $profile = !empty($profiles) ? reset($profiles) : NULL;
+
+    if ($profile) {
+      $first_name = $profile->get('field_profile_first_name')->value;
+      $last_name = $profile->get('field_profile_last_name')->value;
+      $address = $profile->get('field_profile_address')->value;
+      $phone_number = $profile->get('field_profile_phone_number')->value;
+      $function = $profile->get('field_profile_function')->value;
+      $organization = $profile->get('field_profile_organization')->value;
+    }
+
+    return new CloudEvent(
+      id: $this->uuid->generate(),
+      source: $this->source,
+      type: $event_type,
+      data: [
+        'user' => new UserEventData(
+          id: $user->get('uuid')->value,
+          created: DateTime::fromTimestamp($user->getCreatedTime())->toString(),
+          updated: DateTime::fromTimestamp($user->getChangedTime())->toString(),
+          status: $user->isActive() ? 'active' : 'blocked',
+          displayName: $user->getDisplayName(),
+          firstName: $first_name ?? '',
+          lastName: $last_name ?? '',
+          email: (string) $user->getEmail(),
+          roles: array_values($user->getRoles()),
+          timezone: $user->getTimeZone(),
+          language: $user->getPreferredLangcode(),
+          address: Address::fromFieldItem(
+            item: $address ?? NULL,
+          ),
+          phone: $phone_number ?? '',
+          function: $function ?? '',
+          organization: $organization ?? '',
+          href: Href::fromEntity($user),
+        ),
+        'actor' => [
+          'application' => $actor_application ? Application::fromId($actor_application) : NULL,
+          'user' => $actor_user ? User::fromEntity($actor_user) : NULL,
+        ],
+      ],
+      dataContentType: 'application/json',
+      dataSchema: NULL,
+      subject: NULL,
+      time: DateTime::fromTimestamp($user->getCreatedTime())->toImmutableDateTime(),
+    );
+  }
+
+  /**
+   * Determines the actor (application and user) for the CloudEvent.
+   *
+   * @return array
+   *   An array with two elements: the application and the user.
+   */
+  private function determineActors(): array {
+    $application = NULL;
+    $user = NULL;
+
+    if ($this->currentUser instanceof UserInterface) {
+      $user = $this->currentUser;
+    }
+
+    return [
+      $application,
+      $user,
+    ];
+  }
+
+  /**
+   * Dispatches the event.
+   *
+   * @param string $topic_name
+   *   The topic name.
+   * @param string $event_type
+   *   The event type.
+   * @param \Drupal\user\UserInterface $user
+   *   The user object.
+   */
+  private function dispatch(string $topic_name, string $event_type, UserInterface $user): void {
+    // Skip if required modules are not enabled.
+    if (!$this->moduleHandler->moduleExists('social_eda') || !$this->dispatcher) {
+      return;
+    }
+
+    // Build the event.
+    $event = $this->fromEntity($user, $event_type);
+
+    // Dispatch to message broker.
+    $this->dispatcher->dispatch($topic_name, $event);
+  }
+
+}

--- a/modules/social_features/social_user/src/Event/UserEventData.php
+++ b/modules/social_features/social_user/src/Event/UserEventData.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Drupal\social_user\Event;
+
+use Drupal\social_eda\Types\Address;
+use Drupal\social_eda\Types\Href;
+
+/**
+ * Contains data about an Open Social user.
+ */
+class UserEventData {
+
+  /**
+   * {@inheritDoc}
+   */
+  public function __construct(
+    public readonly string $id,
+    public readonly string $created,
+    public readonly string $updated,
+    public readonly string $status,
+    public readonly string $displayName,
+    public readonly ?string $firstName,
+    public readonly ?string $lastName,
+    public readonly string $email,
+    public readonly array $roles,
+    public readonly string $timezone,
+    public readonly string $language,
+    public readonly Address $address,
+    public readonly ?string $phone,
+    public readonly ?string $function,
+    public readonly ?string $organization,
+    public readonly Href $href,
+  ) {}
+
+}

--- a/modules/social_features/social_user/tests/src/Unit/EdaHandlerTest.php
+++ b/modules/social_features/social_user/tests/src/Unit/EdaHandlerTest.php
@@ -1,0 +1,296 @@
+<?php
+
+namespace Drupal\Tests\social_user\Unit;
+
+use Drupal\address\Plugin\Field\FieldType\AddressFieldItemList;
+use Drupal\address\Plugin\Field\FieldType\AddressItem;
+use Drupal\Component\Uuid\UuidInterface;
+use Drupal\Core\DependencyInjection\ContainerBuilder;
+use Drupal\Core\Entity\EntityStorageInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Extension\ModuleHandlerInterface;
+use Drupal\Core\Language\LanguageInterface;
+use Drupal\Core\Language\LanguageManagerInterface;
+use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\Core\Session\AccountProxyInterface;
+use Drupal\Core\Url;
+use Drupal\profile\Entity\ProfileInterface;
+use Drupal\profile\ProfileStorageInterface;
+use Drupal\social_eda\DispatcherInterface;
+use Drupal\social_user\EdaHandler;
+use Drupal\Tests\UnitTestCase;
+use Drupal\user\UserInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/**
+ * @coversDefaultClass \Drupal\social_user\EdaHandler
+ */
+class EdaHandlerTest extends UnitTestCase {
+
+  /**
+   * The module handler service.
+   *
+   * @var \Drupal\Core\Extension\ModuleHandlerInterface
+   */
+  protected $moduleHandler;
+
+  /**
+   * Mocked dispatcher service for sending CloudEvents.
+   */
+  protected MockObject $dispatcher;
+
+  /**
+   * The UUID generator service.
+   *
+   * @var \Drupal\Component\Uuid\UuidInterface
+   */
+  protected $uuid;
+
+  /**
+   * The HTTP request stack service.
+   *
+   * @var \Symfony\Component\HttpFoundation\RequestStack
+   */
+  protected $requestStack;
+
+  /**
+   * The entity type manager service.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * The account proxy service, representing the current user.
+   *
+   * @var \Drupal\Core\Session\AccountProxyInterface
+   */
+  protected $account;
+
+  /**
+   * The current route match service.
+   *
+   * @var \Drupal\Core\Routing\RouteMatchInterface
+   */
+  protected $routeMatch;
+
+  /**
+   * The address field item mock.
+   *
+   * @var \Drupal\address\Plugin\Field\FieldType\AddressItem
+   */
+  protected $addressItem;
+
+  /**
+   * The list of address field items mock.
+   *
+   * @var \Drupal\address\Plugin\Field\FieldType\AddressFieldItemList
+   */
+  protected $addressItemList;
+
+  /**
+   * The request.
+   *
+   * @var \Symfony\Component\HttpFoundation\Request
+   */
+  protected $request;
+
+  /**
+   * The URL.
+   *
+   * @var \Drupal\Core\Url
+   */
+  protected $url;
+
+  /**
+   * The user entity.
+   *
+   * @var \Drupal\user\UserInterface
+   */
+  protected $user;
+
+  /**
+   * The profile entity.
+   *
+   * @var \Drupal\profile\Entity\ProfileInterface
+   */
+  protected $profile;
+
+  /**
+   * Set up the test environment.
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    // Mock the language_manager service using Prophecy.
+    $languageManagerMock = $this->prophesize(LanguageManagerInterface::class);
+    $languageMock = $this->prophesize(LanguageInterface::class);
+    $languageMock->getId()->willReturn('en');
+    $languageManagerMock->getCurrentLanguage()->willReturn($languageMock->reveal());
+
+    // Set up Drupal's container.
+    $container = new ContainerBuilder();
+    $container->set('language_manager', $languageManagerMock->reveal());
+    \Drupal::setContainer($container);
+
+    // Prophesize the module handler and ensure `social_eda` is enabled.
+    $moduleHandlerProphecy = $this->prophesize(ModuleHandlerInterface::class);
+    $moduleHandlerProphecy->moduleExists('social_eda')->willReturn(TRUE);
+    $moduleHandlerProphecy->moduleExists('social_eda_dispatcher')->willReturn(TRUE);
+    $this->moduleHandler = $moduleHandlerProphecy->reveal();
+
+    // Prophesize the Dispatcher service.
+    $this->dispatcher = $this->getMockBuilder(DispatcherInterface::class)
+      ->disableOriginalConstructor()
+      ->getMock();
+
+    // Resolve UUID.
+    $uuidMock = $this->prophesize(UuidInterface::class);
+    $uuidMock->generate()->willReturn('a5715874-5859-4d8a-93ba-9f8433ea44af');
+    $this->uuid = $uuidMock->reveal();
+
+    // Mock the URL object.
+    $urlMock = $this->prophesize(Url::class);
+    $urlMock->toString()->willReturn('http://example.com');
+    $this->url = $urlMock->reveal();
+
+    // Mock the EntityTypeManagerInterface and ProfileStorageInterface.
+    $profileStorage = $this->prophesize(ProfileStorageInterface::class);
+
+    // Mock the User entity using Prophecy.
+    $user = $this->prophesize(UserInterface::class);
+    $user->get('uuid')->willReturn((object) ['value' => 'a5715874-5859-4d8a-93ba-9f8433ea44af']);
+    $user->uuid()->willReturn('a5715874-5859-4d8a-93ba-9f8433ea44af');
+    $user->id()->willReturn(1);
+    $user->getCreatedTime()->willReturn(1692614400);
+    $user->getChangedTime()->willReturn(1692618000);
+    $user->isActive()->willReturn(TRUE);
+    $user->getDisplayName()->willReturn('User Name');
+    $user->getEmail()->willReturn('user@example.com');
+    $user->getRoles()->willReturn(['authenticated']);
+    $user->getPreferredLangcode()->willReturn('en');
+    $user->getTimeZone()->willReturn('UTC');
+    $user->toUrl('canonical', ['absolute' => TRUE])->willReturn($this->url);
+    $userMock = $user->reveal();
+    $this->user = $userMock;
+
+    $userStorage = $this->prophesize(EntityStorageInterface::class);
+    $userStorage->load(1)->willReturn($userMock);
+
+    // Mock the Profile entity using Prophecy.
+    $profile = $this->prophesize(ProfileInterface::class);
+    $profile->get('field_profile_first_name')->willReturn((object) ['value' => 'First']);
+    $profile->get('field_profile_last_name')->willReturn((object) ['value' => 'Last']);
+    $profile->get('field_profile_phone_number')->willReturn((object) ['value' => '123456789']);
+    $profile->get('field_profile_function')->willReturn((object) ['value' => 'Developer']);
+    $profile->get('field_profile_organization')->willReturn((object) ['value' => 'Organization']);
+    $profile->get('field_profile_address')->willReturn($this->addressItemList);
+    $profileMock = $profile->reveal();
+    $this->profile = $profileMock;
+
+    // Mock the EntityTypeManagerInterface.
+    $entityTypeManagerMock = $this->prophesize(EntityTypeManagerInterface::class);
+    $entityTypeManagerMock->getStorage('profile')->willReturn($profileStorage->reveal());
+    $entityTypeManagerMock->getStorage('user')->willReturn($userStorage->reveal());
+    $this->entityTypeManager = $entityTypeManagerMock->reveal();
+
+    // Mock the AccountProxyInterface.
+    $accountMock = $this->prophesize(AccountProxyInterface::class);
+    $accountMock->id()->willReturn(1);
+    $this->account = $accountMock->reveal();
+
+    // Mock the RouteMatchInterface.
+    $routeMatchMock = $this->prophesize(RouteMatchInterface::class);
+    $routeMatchMock->getRouteName()->willReturn('entity.node.edit_form');
+    $this->routeMatch = $routeMatchMock->reveal();
+
+    // Mock the Request and RequestStack using Prophecy.
+    $requestMock = $this->prophesize(Request::class);
+    $requestMock->getUri()->willReturn('http://example.com/user/register');
+    $requestMock->getPathInfo()->willReturn('/user/register');
+    $this->request = $requestMock->reveal();
+
+    $requestStackMock = $this->prophesize(RequestStack::class);
+    $requestStackMock->getCurrentRequest()->willReturn($this->request);
+    $this->requestStack = $requestStackMock->reveal();
+
+    // Mock the Address field.
+    $addressItemMock = $this->prophesize(AddressItem::class);
+    $this->addressItem = $addressItemMock->reveal();
+
+    $addressItemListMock = $this->prophesize(AddressFieldItemList::class);
+    $addressItemListMock->first()->willReturn($this->addressItem);
+    $this->addressItemList = $addressItemListMock->reveal();
+
+    // Finally, reveal the entity type manager.
+    $this->entityTypeManager = $entityTypeManagerMock->reveal();
+  }
+
+  /**
+   * Test method fromEntity().
+   *
+   * @covers ::fromEntity
+   */
+  public function testFromEntity(): void {
+    // Create the handler instance.
+    $handler = $this->getMockedHandler();
+
+    // Test the fromEntity method.
+    $event = $handler->fromEntity($this->user, 'com.getopensocial.cms.user.create');
+
+    // Check that the event has expected attributes.
+    $this->assertEquals('1.0', $event->getSpecVersion());
+    $this->assertEquals('com.getopensocial.cms.user.create', $event->getType());
+    $this->assertEquals('/user/register', $event->getSource());
+    $this->assertEquals('a5715874-5859-4d8a-93ba-9f8433ea44af', $event->getId());
+  }
+
+  /**
+   * Test the userCreate() method.
+   *
+   * @covers ::userCreate
+   */
+  public function testUserCreate(): void {
+    // Create the handler instance.
+    $handler = $this->getMockedHandler();
+
+    // Create the event object.
+    $event = $handler->fromEntity($this->user, 'com.getopensocial.cms.user.create');
+
+    // Expect the dispatch method in the dispatcher to be called.
+    $this->dispatcher->expects($this->once())
+      ->method('dispatch')
+      ->with(
+        $this->equalTo('com.getopensocial.cms.user.create'),
+        $this->equalTo($event)
+      );
+
+    // Call the userCreate method.
+    $handler->userCreate($this->user);
+
+    // Assert that the correct event is dispatched.
+    $this->assertEquals('com.getopensocial.cms.user.create', $event->getType());
+  }
+
+  /**
+   * Returns a mocked handler with dependencies injected.
+   *
+   * @return \Drupal\social_user\EdaHandler
+   *   The mocked handler instance.
+   */
+  protected function getMockedHandler(): EdaHandler {
+    return new EdaHandler(
+      // @phpstan-ignore-next-line
+      $this->dispatcher,
+      $this->uuid,
+      $this->requestStack,
+      $this->moduleHandler,
+      $this->entityTypeManager,
+      $this->account,
+      $this->routeMatch
+    );
+  }
+
+}


### PR DESCRIPTION
## Description

This pull request introduces the new EDA event "user created" which is dispatched to the Kafka topic `com.getopensocial.cms.user.create`. 

The event is triggered on the following conditions:
- When the user profile is inserted we send the event unless SCIM provisioning is enabled or unless "approval is required by administrator" is configured and this was a self sign-up
- When SCIM provisioning is completed
- When the account is approved by the administrator

Here's an example of the generated payload:

```
{
	"specversion": "1.0",
	"id": "53117d0c-72d3-4946-b3af-046d734d1060",
	"source": "/admin/people/create",
	"type": "com.getopensocial.cms.user.create",
	"datacontenttype": "application/json",
	"time": "2024-10-09T18:50:53Z",
	"data": {
		"user": {
			"id": "60bb3249-0a59-4422-b899-87f05a3887c2",
			"created": "2024-10-09T18:50:53",
			"updated": "2024-10-09T18:50:53",
			"status": "active",
			"displayName": "test34",
			"firstName": "",
			"lastName": "",
			"email": "test34@gmail.com",
			"roles": [
				"authenticated",
				"verified"
			],
			"timezone": "UTC",
			"language": "en",
			"address": {
				"label": "",
				"countryCode": "",
				"administrativeArea": "",
				"locality": "",
				"dependentLocality": "",
				"postalCode": "",
				"sortingCode": "",
				"addressLine1": "",
				"addressLine2": ""
			},
			"phone": "",
			"function": "",
			"organization": "",
			"href": {
				"canonical": "http://cablecar.localhost/user/55/home"
			}
		},
		"actor": {
			"application": null,
			"user": {
				"id": "b0dc9a92-7e00-425d-a307-e6fb8418a69b",
				"displayName": "admin",
				"href": {
					"canonical": "http://cablecar.localhost/user/1/home"
				}
			}
		}
	}
}
```

## Issue tracker
https://getopensocial.atlassian.net/browse/PROD-29995

## Theme issue tracker
N/A

## How to test
- [x] Checkout branch `issue/PROD-29995-eda-event-user-create` of 'open_social'
- [x] Enable the modules `social_eda` and `social_eda_dispatcher`
- [x] Create user account as Admin
- [x] Register as anonymous (when admin approval is not required)
- [x] Register as anonymous, and approve as admin  (when admin approval is required)

The message should be dispatched to Kafka. If you are running locally using the Docker containers, you should be able to see the message on the Kafka UI at http://localhost:8080.

## Screenshots
<!-- *[Required if new feature, and if applicable] If this Pull Request makes visual changes then please include some screenshots that show what has changed here. A before and after screenshot helps the reviewer determine what changes were made.* -->

## Release notes
N/A

## Change Record
N/A

## Translations
<!--
*[Optional]Translatable strings are always extracted from the latest development branch. To ensure translations remain available for platforms running older versions of Open Social the original string should be added to `translations.php` when it's changed or removed.*
- [ ] Changed or removed source strings are added to the `translations.php` file.
-->
