### PR TITLE
PROD-30875: Add defensive check for boolean to get the status field for entities

### DIFF
--- a/modules/social_features/social_core/social_core.module
+++ b/modules/social_features/social_core/social_core.module
@@ -1504,12 +1504,15 @@ function _social_core_install_blocks(array $items, callable $function = NULL): v
 function social_core_entity_update(EntityInterface $entity): void {
   // Get the original status from the current entity.
   $original_status = NULL;
-  if (isset($entity->original) && isset($entity->original->status)) {
-    $original_status = (bool) $entity->original->status->value;
+  if (isset($entity->original, $entity->original->status)) {
+    $original_status = is_bool($entity->original->status) ? $entity->original->status : (bool) $entity->original->status->value;
   }
 
   // Get the new status from the current entity.
-  $new_status = isset($entity->status) ? (bool) $entity->status->value : NULL;
+  $new_status = NULL;
+  if (isset($entity->status)) {
+    $new_status = is_bool($entity->status) ? $entity->status : (bool) $entity->status->value;
+  }
 
   // If the status changed (published/unpublished), trigger the custom hooks.
   if ($original_status != $new_status) {


### PR DESCRIPTION
## Problem
In the social_core entity_update we are checking on the status field when entities changes. We assume that the status field needs to be converted to boolean but in custom entities the status field can also be defined as boolean. This will then cause the issue that the value method is always returning a false.

## Solution
Add a defensive check to first see if the status field is already a boolean.

## Issue tracker
https://getopensocial.atlassian.net/browse/PROD-30875

## Theme issue tracker
<!-- *[Required if applicable] Paste a link to the drupal.org theme issue queue item, either from [socialbase](https://www.drupal.org/project/socialbase) or [socialblue](https://www.drupal.org/project/socialblue). If any other issue trackers were used, include links to those too.* -->

## How to test
- [ ] Put a breakpoint in the social_core_entity_update
- [ ] Create a topic and update this again
- [ ] Notice it wil return the correct status
- [ ] Also try this with a custom entity where the status field is boolean.
       - Or you can also hardcode $entity->original->status to "True" or "False"
- [ ] Update the topic again and notice it will complain about getting ->value on a boolean and will return false.
- [ ] Check out to this branch and see everything works.

## Screenshots
<!-- *[Required if new feature, and if applicable] If this Pull Request makes visual changes then please include some screenshots that show what has changed here. A before and after screenshot helps the reviewer determine what changes were made.* -->

## Release notes
Internal: Fixed an issue in the EDA architecture where an entity update hook tried to convert the status field to boolean when it can already be boolean.

## Change Record
<!-- *[Required if applicable] If this Pull Request changes the way that developers should do things or introduces a new API for developers then a change record to document this is needed. Please provide a draft for a change record or a link to an unpublished change record below. Existing change records can be consulted as example. Please provide a draft for a change record or a link to an unpublished change record below. [Existing change records](https://www.drupal.org/list-changes/social) can be consulted as example.* -->

## Translations
<!--
*[Optional]Translatable strings are always extracted from the latest development branch. To ensure translations remain available for platforms running older versions of Open Social the original string should be added to `translations.php` when it's changed or removed.*
- [ ] Changed or removed source strings are added to the `translations.php` file.
-->
