### PR TITLE
PROD-30967: Hux implementation

### DIFF
--- a/modules/social_features/social_activity/modules/social_activity_filter/src/Plugin/views/display/FilterBlock.php
+++ b/modules/social_features/social_activity/modules/social_activity_filter/src/Plugin/views/display/FilterBlock.php
@@ -214,7 +214,7 @@ class FilterBlock extends ModeBlock {
   /**
    * Handles switching the available terms based on the selected vocabulary.
    */
-  public static function updateTagsOptions($form, FormStateInterface $form_state) {
+  public static function updateTagsOptions(array $form, FormStateInterface $form_state) {
 
     // Check if there is triggered parent of element.
     if ($triggered = $form_state->getTriggeringElement()) {

--- a/modules/social_features/social_group/social_group.services.yml
+++ b/modules/social_features/social_group/social_group.services.yml
@@ -49,3 +49,9 @@ services:
     arguments: []
     tags:
       - { name: cache.context }
+
+  social_group.current_group:
+    class: Drupal\social_group\CurrentGroupService
+    arguments:
+      - '@entity_type.manager'
+      - '@group.group_route_context'

--- a/modules/social_features/social_group/social_group.services.yml
+++ b/modules/social_features/social_group/social_group.services.yml
@@ -51,6 +51,5 @@ services:
       - { name: cache.context }
 
   Drupal\social_group\CurrentGroupService:
-    class: Drupal\social_group\CurrentGroupService
+    social_group.current_group_service: '@Drupal\social_group\CurrentGroupService'
     autowire: true
-    social_group.current_group: '@Drupal\social_group\CurrentGroupService'

--- a/modules/social_features/social_group/social_group.services.yml
+++ b/modules/social_features/social_group/social_group.services.yml
@@ -50,8 +50,7 @@ services:
     tags:
       - { name: cache.context }
 
-  social_group.current_group:
+  Drupal\social_group\CurrentGroupService:
     class: Drupal\social_group\CurrentGroupService
-    arguments:
-      - '@entity_type.manager'
-      - '@group.group_route_context'
+    autowire: true
+    social_group.current_group: '@Drupal\social_group\CurrentGroupService'

--- a/modules/social_features/social_group/src/CurrentGroupService.php
+++ b/modules/social_features/social_group/src/CurrentGroupService.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Drupal\social_group;
+
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Plugin\Context\ContextProviderInterface;
+use Drupal\group\Entity\GroupInterface;
+
+/**
+ * Centralized ways to get the current group.
+ *
+ * @package Drupal\social_group.
+ */
+class CurrentGroupService {
+
+  /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  private EntityTypeManagerInterface $entityTypeManager;
+
+  /**
+   * The group route context.
+   *
+   * @var \Drupal\Core\Plugin\Context\ContextProviderInterface
+   */
+  private ContextProviderInterface $groupRouteContext;
+
+  /**
+   * Constructor.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager.
+   * @param \Drupal\Core\Plugin\Context\ContextProviderInterface $group_route_context
+   *   The group route context.
+   */
+  public function __construct(
+        EntityTypeManagerInterface $entity_type_manager,
+        ContextProviderInterface $group_route_context,
+    ) {
+    $this->entityTypeManager = $entity_type_manager;
+    $this->groupRouteContext = $group_route_context;
+  }
+
+  /**
+   * Get group from runtime contexts.
+   *
+   * @return \Drupal\group\Entity\GroupInterface|null
+   *   The current group or NULL.
+   *
+   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
+   * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
+   */
+  public function fromRunTimeContexts(): ?GroupInterface {
+    $runtime_context = $this->groupRouteContext->getRuntimeContexts([]);
+    if (isset($runtime_context['group']) === FALSE) {
+      return NULL;
+    }
+
+    $group = $runtime_context['group']->getContextData()->getValue();
+    if ($group instanceof GroupInterface) {
+      return $group;
+    }
+
+    if (is_int($group) === TRUE) {
+      /** @var \Drupal\group\Entity\GroupInterface $loadedGroup */
+      $loadedGroup = $this->entityTypeManager
+        ->getStorage('group')->load($group);
+      return $loadedGroup;
+    }
+
+    return NULL;
+  }
+
+}

--- a/modules/social_features/social_group/src/Tests/Unit/CurrentGroupServiceTest.php
+++ b/modules/social_features/social_group/src/Tests/Unit/CurrentGroupServiceTest.php
@@ -1,0 +1,161 @@
+<?php
+
+namespace Drupal\Tests\social_group\Unit;
+
+use Drupal\Core\Entity\EntityStorageInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Plugin\Context\ContextInterface;
+use Drupal\Core\Plugin\Context\ContextProviderInterface;
+use Drupal\Core\TypedData\TypedDataInterface;
+use Drupal\group\Entity\GroupInterface;
+use Drupal\social_group\CurrentGroupService;
+use Drupal\Tests\UnitTestCase;
+use PHPUnit\Framework\MockObject\MockObject;
+
+/**
+ * Unit test for CurrentGroupService.
+ *
+ * @group social_group
+ */
+class CurrentGroupServiceTest extends UnitTestCase {
+
+  /**
+   * The mocked EntityTypeManagerInterface.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface|\PHPUnit\Framework\MockObject\MockObject
+   */
+  private EntityTypeManagerInterface|MockObject $entityTypeManager;
+
+  /**
+   * The mocked ContextProviderInterface.
+   *
+   * @var \Drupal\Core\Plugin\Context\ContextProviderInterface|\PHPUnit\Framework\MockObject\MockObject
+   */
+  private ContextProviderInterface|MockObject $groupRouteContext;
+
+  /**
+   * The service under test.
+   *
+   * @var \Drupal\social_group\CurrentGroupService
+   */
+  private CurrentGroupService $currentGroupService;
+
+  /**
+   * Set up the test case.
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $this->entityTypeManager = $this->createMock(EntityTypeManagerInterface::class);
+    $this->groupRouteContext = $this->createMock(ContextProviderInterface::class);
+
+    $this->currentGroupService = new CurrentGroupService(
+      $this->entityTypeManager,
+      $this->groupRouteContext
+    );
+  }
+
+  /**
+   * Helper function to create a mock context.
+   *
+   * @param mixed $value
+   *   The value returned by typeDataInterface.
+   *
+   * @return \Drupal\Core\Plugin\Context\ContextInterface
+   *   The updated mock context.
+   */
+  private function createContextWithValue(mixed $value): ContextInterface {
+    $typeDataInterface = $this->createMock(TypedDataInterface::class);
+    $typeDataInterface->expects($this->once())
+      ->method('getValue')
+      ->willReturn($value);
+
+    $context = $this->createMock(ContextInterface::class);
+    $context->expects($this->once())
+      ->method('getContextData')
+      ->willReturn($typeDataInterface);
+
+    return $context;
+  }
+
+  /**
+   * Test that fromRunTimeContexts() returns NULL when no group context is set.
+   */
+  public function testFromRunTimeContextsNoGroupContext(): void {
+    $this->groupRouteContext
+      ->expects($this->once())
+      ->method('getRuntimeContexts')
+      ->willReturn([]);
+
+    $group = $this->currentGroupService->fromRunTimeContexts();
+
+    $this->assertNull($group, 'No group context should return NULL.');
+  }
+
+  /**
+   * Test that fromRunTimeContexts() returns a GroupInterface when available.
+   */
+  public function testFromRunTimeContextsWithGroup(): void {
+    $group = $this->createMock(GroupInterface::class);
+    $context = $this->createContextWithValue($group);
+
+    $this->groupRouteContext
+      ->expects($this->once())
+      ->method('getRuntimeContexts')
+      ->willReturn(['group' => $context]);
+
+    $result = $this->currentGroupService->fromRunTimeContexts();
+
+    $this->assertSame($group, $result, 'Group should be returned when found in context.');
+  }
+
+  /**
+   * Test that fromRunTimeContexts() loads a group by ID.
+   */
+  public function testFromRunTimeContextsWithGroupId(): void {
+    $groupId = 1;
+    $group = $this->createMock(GroupInterface::class);
+
+    $context = $this->createContextWithValue($groupId);
+
+    $this->groupRouteContext
+      ->expects($this->once())
+      ->method('getRuntimeContexts')
+      ->willReturn(['group' => $context]);
+
+    $storage = $this->createMock(EntityStorageInterface::class);
+    $this->entityTypeManager
+      ->expects($this->once())
+      ->method('getStorage')
+      ->with('group')
+      ->willReturn($storage);
+
+    $storage
+      ->expects($this->once())
+      ->method('load')
+      ->with($groupId)
+      ->willReturn($group);
+
+    $result = $this->currentGroupService->fromRunTimeContexts();
+
+    $this->assertSame($group, $result, 'Group should be loaded by ID and returned.');
+  }
+
+  /**
+   * Test that fromRunTimeContexts() returns NULL when no valid group found.
+   */
+  public function testFromRunTimeContextsInvalidGroup(): void {
+    $invalidValue = 'invalid';
+    $context = $this->createContextWithValue($invalidValue);
+
+    $this->groupRouteContext
+      ->expects($this->once())
+      ->method('getRuntimeContexts')
+      ->willReturn(['group' => $context]);
+
+    $result = $this->currentGroupService->fromRunTimeContexts();
+
+    $this->assertNull($result, 'Invalid group value should return NULL.');
+  }
+
+}

--- a/modules/social_features/social_post/modules/social_post_photo/src/Plugin/Block/PostPhotoBlock.php
+++ b/modules/social_features/social_post/modules/social_post_photo/src/Plugin/Block/PostPhotoBlock.php
@@ -25,8 +25,8 @@ class PostPhotoBlock extends PostBlock {
    */
   public function __construct(
     array $configuration,
-          $plugin_id,
-          $plugin_definition,
+    $plugin_id,
+    $plugin_definition,
     EntityTypeManagerInterface $entity_type_manager,
     AccountProxyInterface $current_user,
     FormBuilderInterface $form_builder,

--- a/modules/social_features/social_post/modules/social_post_photo/src/Plugin/Block/PostPhotoBlock.php
+++ b/modules/social_features/social_post/modules/social_post_photo/src/Plugin/Block/PostPhotoBlock.php
@@ -5,7 +5,9 @@ namespace Drupal\social_post_photo\Plugin\Block;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Form\FormBuilderInterface;
+use Drupal\Core\Routing\CurrentRouteMatch;
 use Drupal\Core\Session\AccountProxyInterface;
+use Drupal\social_group\CurrentGroupService;
 use Drupal\social_post\Plugin\Block\PostBlock;
 
 /**
@@ -23,12 +25,14 @@ class PostPhotoBlock extends PostBlock {
    */
   public function __construct(
     array $configuration,
-    $plugin_id,
-    $plugin_definition,
+          $plugin_id,
+          $plugin_definition,
     EntityTypeManagerInterface $entity_type_manager,
     AccountProxyInterface $current_user,
     FormBuilderInterface $form_builder,
-    ModuleHandlerInterface $module_handler
+    ModuleHandlerInterface $module_handler,
+    CurrentRouteMatch $route_match,
+    CurrentGroupService $current_group_service,
   ) {
     parent::__construct(
       $configuration,
@@ -37,7 +41,9 @@ class PostPhotoBlock extends PostBlock {
       $entity_type_manager,
       $current_user,
       $form_builder,
-      $module_handler
+      $module_handler,
+      $route_match,
+      $current_group_service,
     );
 
     // Override the bundle type.

--- a/modules/social_features/social_post/modules/social_post_photo/src/Plugin/Block/PostPhotoGroupBlock.php
+++ b/modules/social_features/social_post/modules/social_post_photo/src/Plugin/Block/PostPhotoGroupBlock.php
@@ -5,7 +5,9 @@ namespace Drupal\social_post_photo\Plugin\Block;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Form\FormBuilderInterface;
+use Drupal\Core\Routing\CurrentRouteMatch;
 use Drupal\Core\Session\AccountProxyInterface;
+use Drupal\social_group\CurrentGroupService;
 use Drupal\social_post\Plugin\Block\PostGroupBlock;
 
 /**
@@ -28,7 +30,9 @@ class PostPhotoGroupBlock extends PostGroupBlock {
     EntityTypeManagerInterface $entity_type_manager,
     AccountProxyInterface $current_user,
     FormBuilderInterface $form_builder,
-    ModuleHandlerInterface $module_handler
+    ModuleHandlerInterface $module_handler,
+    CurrentRouteMatch $route_match,
+    CurrentGroupService $current_group_service,
   ) {
     parent::__construct(
       $configuration,
@@ -37,7 +41,9 @@ class PostPhotoGroupBlock extends PostGroupBlock {
       $entity_type_manager,
       $current_user,
       $form_builder,
-      $module_handler
+      $module_handler,
+      $route_match,
+      $current_group_service,
     );
 
     // Override the bundle type.

--- a/modules/social_features/social_post/modules/social_post_photo/src/Plugin/Block/PostPhotoProfileBlock.php
+++ b/modules/social_features/social_post/modules/social_post_photo/src/Plugin/Block/PostPhotoProfileBlock.php
@@ -5,7 +5,9 @@ namespace Drupal\social_post_photo\Plugin\Block;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Form\FormBuilderInterface;
+use Drupal\Core\Routing\CurrentRouteMatch;
 use Drupal\Core\Session\AccountProxyInterface;
+use Drupal\social_group\CurrentGroupService;
 use Drupal\social_post\Plugin\Block\PostProfileBlock;
 
 /**
@@ -23,13 +25,14 @@ class PostPhotoProfileBlock extends PostProfileBlock {
    */
   public function __construct(
     array $configuration,
-    $plugin_id,
-    $plugin_definition,
+          $plugin_id,
+          $plugin_definition,
     EntityTypeManagerInterface $entity_type_manager,
     AccountProxyInterface $current_user,
     FormBuilderInterface $form_builder,
     ModuleHandlerInterface $module_handler,
-    $account
+    CurrentRouteMatch $route_match,
+    CurrentGroupService $current_group_service,
   ) {
     parent::__construct(
       $configuration,
@@ -39,7 +42,8 @@ class PostPhotoProfileBlock extends PostProfileBlock {
       $current_user,
       $form_builder,
       $module_handler,
-      $account
+      $route_match,
+      $current_group_service,
     );
 
     // Override the bundle type.

--- a/modules/social_features/social_post/modules/social_post_photo/src/Plugin/Block/PostPhotoProfileBlock.php
+++ b/modules/social_features/social_post/modules/social_post_photo/src/Plugin/Block/PostPhotoProfileBlock.php
@@ -25,8 +25,8 @@ class PostPhotoProfileBlock extends PostProfileBlock {
    */
   public function __construct(
     array $configuration,
-          $plugin_id,
-          $plugin_definition,
+    $plugin_id,
+    $plugin_definition,
     EntityTypeManagerInterface $entity_type_manager,
     AccountProxyInterface $current_user,
     FormBuilderInterface $form_builder,

--- a/modules/social_features/social_post/social_post.info.yml
+++ b/modules/social_features/social_post/social_post.info.yml
@@ -5,13 +5,14 @@ core_version_requirement: ^9 || ^10
 dependencies:
   - drupal:block
   - drupal:comment
-  - social:dropdown
   - drupal:field
-  - group:group
   - drupal:options
-  - social:social_comment
   - drupal:text
   - drupal:user
   - drupal:views
+  - group:group
   - social:activity_creator
+  - social:dropdown
+  - social:social_comment
+  - social:social_group
 package: Social

--- a/modules/social_features/social_post/social_post.module
+++ b/modules/social_features/social_post/social_post.module
@@ -17,45 +17,6 @@ use Drupal\user\UserInterface;
 
 /**
  * Implements hook_form_FORM_ID_alter().
- */
-function social_post_form_post_form_alter(&$form, FormStateInterface $form_state, $form_id) {
-
-  if (
-    $form_state->getFormObject()->getEntity()->isNew() &&
-    ($content = \Drupal::service('social_post.helper')->buildCurrentUserImage())
-  ) {
-    $form['current_user_image'] = $content;
-  }
-
-  // Reset title display.
-  $form['field_post']['widget'][0]['#title_display'] = "";
-
-  // Set submit button caption to Post instead of Save.
-  $form['actions']['submit']['#value'] = t('Post', [], ['context' => 'Post button']);
-
-  if (!empty($form['field_post']) && !empty($form['field_post']['widget'][0])) {
-    // For posting on the stream on the group stream.
-    if (!empty(_social_group_get_current_group())) {
-      $form['field_post']['widget'][0]['#placeholder'] = t('Say something to the group');
-      $form['field_post']['widget'][0]['#title'] = t('Say something to the group');
-    }
-    // For the post on a users profile.
-    elseif (!empty(\Drupal::routeMatch()->getParameter('user')) && \Drupal::routeMatch()->getParameter('user')->id() != \Drupal::currentUser()->id()) {
-      $user_profile = \Drupal::routeMatch()->getParameter('user');
-      $name = $user_profile->getDisplayName();
-      $form['field_post']['widget'][0]['#placeholder'] = t('Leave a message to @name', ['@name' => $name]);
-      $form['field_post']['widget'][0]['#title'] = t('Leave a message to @name', ['@name' => $name]);
-    }
-    else {
-      $title = t('Say something to the Community');
-      $form['field_post']['widget'][0]['#title'] = $title;
-      $form['field_post']['widget'][0]['#placeholder'] = $title;
-    }
-  }
-}
-
-/**
- * Implements hook_form_FORM_ID_alter().
  *
  * Alter the comment_post_comment_form form.
  */

--- a/modules/social_features/social_post/social_post.services.yml
+++ b/modules/social_features/social_post/social_post.services.yml
@@ -20,3 +20,8 @@ services:
     - '@current_user'
     tags:
       - { name: hooks }
+
+    Drupal\social_post\Hooks\SocialPostFormHooks:
+      class: Drupal\social_post\Hooks\SocialPostFormHooks
+      autowire: true
+      social_post.form.hooks: '@Drupal\social_post\Hooks\SocialPostFormHooks'

--- a/modules/social_features/social_post/social_post.services.yml
+++ b/modules/social_features/social_post/social_post.services.yml
@@ -12,13 +12,11 @@ services:
     class: Drupal\social_post\Service\SocialPostHelper
     arguments: ['@entity_type.manager', '@current_user']
 
-
   #hooks replacement
   social_post.form.hooks:
     class: Drupal\social_post\Hooks\SocialPostFormHooks
     arguments:
     - '@social_post.helper'
-    - '@current_route_match'
     - '@current_user'
     tags:
       - { name: hooks }

--- a/modules/social_features/social_post/social_post.services.yml
+++ b/modules/social_features/social_post/social_post.services.yml
@@ -11,3 +11,14 @@ services:
   social_post.helper:
     class: Drupal\social_post\Service\SocialPostHelper
     arguments: ['@entity_type.manager', '@current_user']
+
+
+  #hooks replacement
+  social_post.form.hooks:
+    class: Drupal\social_post\Hooks\SocialPostFormHooks
+    arguments:
+    - '@social_post.helper'
+    - '@current_route_match'
+    - '@current_user'
+    tags:
+      - { name: hooks }

--- a/modules/social_features/social_post/src/Hooks/SocialPostFormHooks.php
+++ b/modules/social_features/social_post/src/Hooks/SocialPostFormHooks.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace Drupal\social_post\Hooks;
+
+use Drupal\Core\Entity\ContentEntityForm;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Session\AccountProxyInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\hux\Attribute\Alter;
+use Drupal\social_post\Service\SocialPostHelperInterface;
+
+/**
+ * Replace hook: social_post_form_post_form_alter.
+ *
+ * @package Drupal\social_post\Hooks
+ */
+final class SocialPostFormHooks {
+
+  /**
+   * The social post helper service.
+   *
+   * @var \Drupal\social_post\Service\SocialPostHelperInterface
+   */
+  private SocialPostHelperInterface $socialPostHelper;
+
+  /**
+   * The account proxy.
+   *
+   * @var \Drupal\Core\Session\AccountProxyInterface
+   */
+  private AccountProxyInterface $currentUser;
+
+  /**
+   * Constructor.
+   *
+   * @param \Drupal\social_post\Service\SocialPostHelperInterface $social_post_helper
+   *   The social post helper.
+   * @param \Drupal\Core\Session\AccountProxyInterface $current_user
+   *   The account proxy.
+   */
+  public function __construct(
+    SocialPostHelperInterface $social_post_helper,
+    AccountProxyInterface $current_user,
+  ) {
+    $this->socialPostHelper = $social_post_helper;
+    $this->currentUser = $current_user;
+  }
+
+  /**
+   * From alter hook: replacement of social_post_form_post_form_alter.
+   *
+   * The method definition contains all standard parameters defined by the
+   * definition of the hook.
+   *
+   * @param array $form
+   *   The drupal form.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The form state.
+   */
+  #[Alter('form_post_form')]
+  public function formPostFormAlter(array &$form, FormStateInterface $form_state): void {
+    $content = $this->socialPostHelper->buildCurrentUserImage();
+
+    if ($form_state->getFormObject() instanceof ContentEntityForm === FALSE) {
+      return;
+    }
+
+    if ($form_state->getFormObject()->getEntity()->isNew()
+      && $content !== NULL) {
+      $form['current_user_image'] = $content;
+    }
+
+    // Reset title display.
+    $form['field_post']['widget'][0]['#title_display'] = '';
+
+    // Set submit button caption to Post instead of Save.
+    $form['actions']['submit']['#value'] = t('Post', [], ['context' => 'Post button']);
+
+    if (empty($form['field_post']) || empty($form['field_post']['widget'][0])) {
+      return;
+    }
+
+    // Default value.
+    $form = $this->setFormTitleAndPlaceholder($form, t('Say something to the Community'));
+
+    if ($form_state->get('currentGroup') !== NULL) {
+      $form = $this->setFormTitleAndPlaceholder($form, t('Say something to the group'));
+    }
+
+    // $user_profile = $this->routeMatch->getParameter('user');
+    $user_profile = $form_state->get('recipientUser');
+    if ($user_profile !== NULL
+      && $user_profile->id() != $this->currentUser->id()) {
+      $this->setFormTitleAndPlaceholder($form, t('Leave a message to @name', [
+        '@name' => $user_profile->getDisplayName(),
+      ]));
+    }
+  }
+
+  /**
+   * Set form title and placeholder value.
+   *
+   * @param array $form
+   *   The drupal form.
+   * @param \Drupal\Core\StringTranslation\TranslatableMarkup $displayedValue
+   *   The translatable markup value to display.
+   *
+   * @return array
+   *   The updated form title and placeholder.
+   */
+  private function setFormTitleAndPlaceholder(array $form, TranslatableMarkup $displayedValue): array {
+    $form['field_post']['widget'][0]['#title'] = $displayedValue;
+    $form['field_post']['widget'][0]['#placeholder'] = $displayedValue;
+    return $form;
+  }
+
+}

--- a/modules/social_features/social_post/src/Hooks/SocialPostFormHooks.php
+++ b/modules/social_features/social_post/src/Hooks/SocialPostFormHooks.php
@@ -60,12 +60,13 @@ final class SocialPostFormHooks {
   #[Alter('form_post_form')]
   public function formPostFormAlter(array &$form, FormStateInterface $form_state): void {
     $content = $this->socialPostHelper->buildCurrentUserImage();
+    $form_object = $form_state->getFormObject();
 
-    if ($form_state->getFormObject() instanceof ContentEntityForm === FALSE) {
+    if ($form_object instanceof ContentEntityForm === FALSE) {
       return;
     }
 
-    if ($form_state->getFormObject()->getEntity()->isNew()
+    if ($form_object->getEntity()->isNew()
       && $content !== NULL) {
       $form['current_user_image'] = $content;
     }
@@ -90,8 +91,8 @@ final class SocialPostFormHooks {
     // $user_profile = $this->routeMatch->getParameter('user');
     $user_profile = $form_state->get('recipientUser');
     if ($user_profile !== NULL
-      && $user_profile->id() != $this->currentUser->id()) {
-      $this->setFormTitleAndPlaceholder($form, t('Leave a message to @name', [
+      && $user_profile->id() !== $this->currentUser->id()) {
+      $form = $this->setFormTitleAndPlaceholder($form, t('Leave a message to @name', [
         '@name' => $user_profile->getDisplayName(),
       ]));
     }

--- a/modules/social_features/social_post/src/Plugin/Block/PostBlock.php
+++ b/modules/social_features/social_post/src/Plugin/Block/PostBlock.php
@@ -154,7 +154,7 @@ class PostBlock extends BlockBase implements ContainerFactoryPluginInterface {
       $container->get('form_builder'),
       $container->get('module_handler'),
       $container->get('current_route_match'),
-      $container->get('social_group.current_group'),
+      $container->get(CurrentGroupService::class),
     );
   }
 

--- a/modules/social_features/social_post/src/Plugin/Block/PostGroupBlock.php
+++ b/modules/social_features/social_post/src/Plugin/Block/PostGroupBlock.php
@@ -5,10 +5,12 @@ namespace Drupal\social_post\Plugin\Block;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Form\FormBuilderInterface;
+use Drupal\Core\Routing\CurrentRouteMatch;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Session\AccountProxyInterface;
 use Drupal\group\Entity\GroupInterface;
+use Drupal\social_group\CurrentGroupService;
 
 /**
  * Provides a 'PostGroupBlock' block.
@@ -30,7 +32,9 @@ class PostGroupBlock extends PostBlock {
     EntityTypeManagerInterface $entity_type_manager,
     AccountProxyInterface $current_user,
     FormBuilderInterface $form_builder,
-    ModuleHandlerInterface $module_handler
+    ModuleHandlerInterface $module_handler,
+    CurrentRouteMatch $route_match,
+    CurrentGroupService $current_group_service,
   ) {
     parent::__construct(
       $configuration,
@@ -39,7 +43,9 @@ class PostGroupBlock extends PostBlock {
       $entity_type_manager,
       $current_user,
       $form_builder,
-      $module_handler
+      $module_handler,
+      $route_match,
+      $current_group_service,
     );
 
     $this->entityType = 'post';

--- a/modules/social_features/social_post/src/Plugin/Block/PostProfileBlock.php
+++ b/modules/social_features/social_post/src/Plugin/Block/PostProfileBlock.php
@@ -5,8 +5,9 @@ namespace Drupal\social_post\Plugin\Block;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Form\FormBuilderInterface;
+use Drupal\Core\Routing\CurrentRouteMatch;
 use Drupal\Core\Session\AccountProxyInterface;
-use Symfony\Component\DependencyInjection\ContainerInterface;
+use Drupal\social_group\CurrentGroupService;
 
 /**
  * Provides a 'PostProfileBlock' block.
@@ -19,27 +20,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 class PostProfileBlock extends PostBlock {
 
   /**
-   * PostProfileBlock constructor.
-   *
-   * @param array $configuration
-   *   The plugin configuration, i.e. an array with configuration values keyed
-   *   by configuration option name. The special key 'context' may be used to
-   *   initialize the defined contexts by setting it to an array of context
-   *   values keyed by context names.
-   * @param string $plugin_id
-   *   The plugin_id for the plugin instance.
-   * @param mixed $plugin_definition
-   *   The plugin implementation definition.
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
-   *   The entity type manager.
-   * @param \Drupal\Core\Session\AccountProxyInterface $current_user
-   *   The current user.
-   * @param \Drupal\Core\Form\FormBuilderInterface $form_builder
-   *   The form builder.
-   * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
-   *   The module handler.
-   * @param mixed $account
-   *   The user object or user ID.
+   * {@inheritdoc}
    */
   public function __construct(
     array $configuration,
@@ -49,7 +30,8 @@ class PostProfileBlock extends PostBlock {
     AccountProxyInterface $current_user,
     FormBuilderInterface $form_builder,
     ModuleHandlerInterface $module_handler,
-    $account
+    CurrentRouteMatch $route_match,
+    CurrentGroupService $current_group_service,
   ) {
     parent::__construct(
       $configuration,
@@ -58,7 +40,9 @@ class PostProfileBlock extends PostBlock {
       $entity_type_manager,
       $current_user,
       $form_builder,
-      $module_handler
+      $module_handler,
+      $route_match,
+      $current_group_service,
     );
 
     $this->entityType = 'post';
@@ -67,26 +51,11 @@ class PostProfileBlock extends PostBlock {
 
     // Check if current user is the same as the profile.
     // In this case use the default form display.
+    $account = $this->routeMatch->getParameter('user');
     $uid = $this->currentUser->id();
     if (isset($account) && ($account === $uid || (is_object($account) && $uid === $account->id()))) {
       $this->formDisplay = 'default';
     }
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
-    return new static(
-      $configuration,
-      $plugin_id,
-      $plugin_definition,
-      $container->get('entity_type.manager'),
-      $container->get('current_user'),
-      $container->get('form_builder'),
-      $container->get('module_handler'),
-      $container->get('current_route_match')->getParameter('user')
-    );
   }
 
 }

--- a/modules/social_features/social_post/src/Test/Unit/SocialPostFormHooksTest.php
+++ b/modules/social_features/social_post/src/Test/Unit/SocialPostFormHooksTest.php
@@ -1,0 +1,240 @@
+<?php
+
+namespace Drupal\Tests\social_post\Unit;
+
+use Drupal\Core\DependencyInjection\ContainerBuilder;
+use Drupal\Core\Entity\ContentEntityForm;
+use Drupal\Core\Entity\ContentEntityInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Session\AccountProxyInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\Core\StringTranslation\TranslationInterface;
+use Drupal\social_post\Hooks\SocialPostFormHooks;
+use Drupal\social_post\Service\SocialPostHelperInterface;
+use Drupal\Tests\UnitTestCase;
+use Drupal\user\Entity\User;
+use PHPUnit\Framework\MockObject\MockObject;
+
+/**
+ * Unit test for SocialPostFormHooks class.
+ *
+ * @group social_post
+ */
+class SocialPostFormHooksTest extends UnitTestCase {
+
+  /**
+   * The mocked SocialPostHelperInterface.
+   *
+   * @var \Drupal\social_post\Service\SocialPostHelperInterface|\PHPUnit\Framework\MockObject\MockObject
+   */
+  protected SocialPostHelperInterface|MockObject $socialPostHelper;
+
+  /**
+   * The mocked AccountProxyInterface.
+   *
+   * @var \Drupal\Core\Session\AccountProxyInterface|\PHPUnit\Framework\MockObject\MockObject
+   */
+  protected AccountProxyInterface| MockObject $currentUser;
+
+  /**
+   * The mocked form state interface.
+   *
+   * @var \Drupal\Core\Form\FormStateInterface|\PHPUnit\Framework\MockObject\MockObject
+   */
+  protected FormStateInterface|MockObject $formState;
+
+  /**
+   * The class under test.
+   *
+   * @var \Drupal\social_post\Hooks\SocialPostFormHooks
+   */
+  protected SocialPostFormHooks $socialPostFormHooks;
+
+
+  /**
+   * The drupal form.
+   *
+   * @var array
+   */
+  protected array $form = [];
+
+  /**
+   * Setup the test case.
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $this->socialPostHelper = $this->createMock(SocialPostHelperInterface::class);
+    $this->currentUser = $this->createMock(AccountProxyInterface::class);
+    $this->formState = $this->createMock(FormStateInterface::class);
+
+    $this->socialPostFormHooks = new SocialPostFormHooks(
+      $this->socialPostHelper,
+      $this->currentUser
+    );
+
+    // Create a mock TranslationInterface.
+    $translation = $this->createMock(TranslationInterface::class);
+    $translation->method('translate')
+      ->willReturnCallback(function ($string, array $args = [], array $options = []) {
+        // phpcs:ignore
+        return new TranslatableMarkup($string, $args, $options);
+      });
+
+    // Set up the container with the string_translation service.
+    $container = new ContainerBuilder();
+    $container->set('string_translation', $translation);
+    \Drupal::setContainer($container);
+
+    $this->form = [
+      'field_post' => ['widget' => [0 => []]],
+      'actions' => ['submit' => ['#value' => '']],
+    ];
+  }
+
+  /**
+   * Test formPostFormAlter with a new post and valid current user image.
+   */
+  public function testFormPostFormAlterWithNewPostAndImage(): void {
+    $this->mockContentEntityForm();
+    $currentUserImage = $this->mockUserImage();
+
+    $this->socialPostFormHooks->formPostFormAlter($this->form, $this->formState);
+
+    // Check if the user image is added to the form.
+    $this->assertEquals($currentUserImage, $this->form['current_user_image']);
+
+    // Check if submit button caption is set to "Post".
+    $this->assertEquals(
+      new TranslatableMarkup('Post', [], ['context' => 'Post button']),
+      $this->form['actions']['submit']['#value']
+    );
+
+    // Check if the title is set correctly.
+    $this->assertEquals(
+      new TranslatableMarkup('Say something to the Community'),
+      $this->form['field_post']['widget'][0]['#title']
+    );
+  }
+
+  /**
+   * Test formPostFormAlter when there's a current group set.
+   */
+  public function testFormPostFormAlterWithCurrentGroup(): void {
+    $this->mockContentEntityForm();
+    $currentUserImage = $this->mockUserImage();
+
+    $this->formState->expects($this->exactly(2))
+      ->method('get')
+      ->willReturnMap([
+        ['currentGroup', 2],
+        ['recipientUser', NULL],
+      ]);
+
+    $this->socialPostFormHooks->formPostFormAlter($this->form, $this->formState);
+
+    // Assert that the current user image is set.
+    $this->assertEquals($currentUserImage, $this->form['current_user_image']);
+
+    // Assert that the submit button value is set to "Post".
+    $this->assertEquals(
+      new TranslatableMarkup('Post', [], ['context' => 'Post button']),
+      $this->form['actions']['submit']['#value']
+    );
+
+    // Assert the title placeholder value.
+    $this->assertEquals(
+      new TranslatableMarkup('Say something to the group'),
+      $this->form['field_post']['widget'][0]['#title']
+    );
+    $this->assertEquals(
+      new TranslatableMarkup('Say something to the group'),
+      $this->form['field_post']['widget'][0]['#placeholder']
+    );
+  }
+
+  /**
+   * Test formPostFormAlter when it's a private message.
+   */
+  public function testFormPostFormAlterWithRecipientUser(): void {
+    $this->mockContentEntityForm();
+    $currentUserImage = $this->mockUserImage();
+
+    $recipientUser = $this->createMock(User::class);
+
+    $this->formState->expects($this->exactly(2))
+      ->method('get')
+      ->willReturnMap([
+        ['currentGroup', NULL],
+        ['recipientUser', $recipientUser],
+      ]);
+
+    $recipientUser->expects($this->once())
+      ->method('getDisplayName')
+      ->willReturn('John Doe');
+    $recipientUser->expects($this->once())
+      ->method('id')
+      ->willReturn(2);
+
+    $this->currentUser->expects($this->once())
+      ->method('id')
+      ->willReturn(1);
+
+    // Call the form alter hook.
+    $this->socialPostFormHooks->formPostFormAlter($this->form, $this->formState);
+
+    // Assert that the current user image is set.
+    $this->assertEquals($currentUserImage, $this->form['current_user_image']);
+
+    // Assert that the submit button value is set to "Post".
+    $this->assertEquals(
+      new TranslatableMarkup('Post', [], ['context' => 'Post button']),
+      $this->form['actions']['submit']['#value']
+    );
+
+    // Assert title and placeholder value.
+    $this->assertEquals(
+      new TranslatableMarkup('Leave a message to @name', ['@name' => 'John Doe']),
+      $this->form['field_post']['widget'][0]['#title']
+    );
+    $this->assertEquals(
+      new TranslatableMarkup('Leave a message to @name', ['@name' => 'John Doe']),
+      $this->form['field_post']['widget'][0]['#placeholder']
+    );
+  }
+
+  /**
+   * Mock user image.
+   *
+   * @return array
+   *   The mocked user image.
+   */
+  private function mockUserImage(): array {
+    // Mock the SocialPostHelper to return user image.
+    $currentUserImage = ['#markup' => 'User Image'];
+    $this->socialPostHelper->expects($this->once())
+      ->method('buildCurrentUserImage')
+      ->willReturn($currentUserImage);
+    return $currentUserImage;
+  }
+
+  /**
+   * Mock content entity form.
+   */
+  public function mockContentEntityForm(): void {
+    $contentEntityForm = $this->createMock(ContentEntityForm::class);
+    $entity = $this->createMock(ContentEntityInterface::class);
+    $entity->expects($this->once())
+      ->method('isNew')
+      ->willReturn(TRUE);
+
+    $contentEntityForm->expects($this->once())
+      ->method('getEntity')
+      ->willReturn($entity);
+
+    $this->formState->expects($this->once())
+      ->method('getFormObject')
+      ->willReturn($contentEntityForm);
+  }
+
+}

--- a/modules/social_features/social_post/src/Test/Unit/SocialPostFormHooksTest.php
+++ b/modules/social_features/social_post/src/Test/Unit/SocialPostFormHooksTest.php
@@ -50,7 +50,6 @@ class SocialPostFormHooksTest extends UnitTestCase {
    */
   protected SocialPostFormHooks $socialPostFormHooks;
 
-
   /**
    * The drupal form.
    *
@@ -59,7 +58,7 @@ class SocialPostFormHooksTest extends UnitTestCase {
   protected array $form = [];
 
   /**
-   * Setup the test case.
+   * Set up the test case.
    */
   protected function setUp(): void {
     parent::setUp();
@@ -73,7 +72,6 @@ class SocialPostFormHooksTest extends UnitTestCase {
       $this->currentUser
     );
 
-    // Create a mock TranslationInterface.
     $translation = $this->createMock(TranslationInterface::class);
     $translation->method('translate')
       ->willReturnCallback(function ($string, array $args = [], array $options = []) {
@@ -81,7 +79,6 @@ class SocialPostFormHooksTest extends UnitTestCase {
         return new TranslatableMarkup($string, $args, $options);
       });
 
-    // Set up the container with the string_translation service.
     $container = new ContainerBuilder();
     $container->set('string_translation', $translation);
     \Drupal::setContainer($container);
@@ -101,16 +98,11 @@ class SocialPostFormHooksTest extends UnitTestCase {
 
     $this->socialPostFormHooks->formPostFormAlter($this->form, $this->formState);
 
-    // Check if the user image is added to the form.
     $this->assertEquals($currentUserImage, $this->form['current_user_image']);
-
-    // Check if submit button caption is set to "Post".
     $this->assertEquals(
       new TranslatableMarkup('Post', [], ['context' => 'Post button']),
       $this->form['actions']['submit']['#value']
     );
-
-    // Check if the title is set correctly.
     $this->assertEquals(
       new TranslatableMarkup('Say something to the Community'),
       $this->form['field_post']['widget'][0]['#title']
@@ -133,16 +125,11 @@ class SocialPostFormHooksTest extends UnitTestCase {
 
     $this->socialPostFormHooks->formPostFormAlter($this->form, $this->formState);
 
-    // Assert that the current user image is set.
     $this->assertEquals($currentUserImage, $this->form['current_user_image']);
-
-    // Assert that the submit button value is set to "Post".
     $this->assertEquals(
       new TranslatableMarkup('Post', [], ['context' => 'Post button']),
       $this->form['actions']['submit']['#value']
     );
-
-    // Assert the title placeholder value.
     $this->assertEquals(
       new TranslatableMarkup('Say something to the group'),
       $this->form['field_post']['widget'][0]['#title']
@@ -180,19 +167,13 @@ class SocialPostFormHooksTest extends UnitTestCase {
       ->method('id')
       ->willReturn(1);
 
-    // Call the form alter hook.
     $this->socialPostFormHooks->formPostFormAlter($this->form, $this->formState);
 
-    // Assert that the current user image is set.
     $this->assertEquals($currentUserImage, $this->form['current_user_image']);
-
-    // Assert that the submit button value is set to "Post".
     $this->assertEquals(
       new TranslatableMarkup('Post', [], ['context' => 'Post button']),
       $this->form['actions']['submit']['#value']
     );
-
-    // Assert title and placeholder value.
     $this->assertEquals(
       new TranslatableMarkup('Leave a message to @name', ['@name' => 'John Doe']),
       $this->form['field_post']['widget'][0]['#title']
@@ -210,9 +191,8 @@ class SocialPostFormHooksTest extends UnitTestCase {
    *   The mocked user image.
    */
   private function mockUserImage(): array {
-    // Mock the SocialPostHelper to return user image.
     $currentUserImage = ['#markup' => 'User Image'];
-    $this->socialPostHelper->expects($this->once())
+    $this->socialPostHelper
       ->method('buildCurrentUserImage')
       ->willReturn($currentUserImage);
     return $currentUserImage;
@@ -221,7 +201,7 @@ class SocialPostFormHooksTest extends UnitTestCase {
   /**
    * Mock content entity form.
    */
-  public function mockContentEntityForm(): void {
+  private function mockContentEntityForm(): void {
     $contentEntityForm = $this->createMock(ContentEntityForm::class);
     $entity = $this->createMock(ContentEntityInterface::class);
     $entity->expects($this->once())

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -9715,11 +9715,6 @@ parameters:
 			path: modules/social_features/social_post/social_post.install
 
 		-
-			message: "#^Call to an undefined method Drupal\\\\Core\\\\Form\\\\FormInterface\\:\\:getEntity\\(\\)\\.$#"
-			count: 1
-			path: modules/social_features/social_post/social_post.module
-
-		-
 			message: "#^Function _social_post_comment_post_comment_form_submit\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: modules/social_features/social_post/social_post.module
@@ -9746,21 +9741,6 @@ parameters:
 
 		-
 			message: "#^Function social_post_form_comment_post_comment_form_alter\\(\\) has parameter \\$form_id with no type specified\\.$#"
-			count: 1
-			path: modules/social_features/social_post/social_post.module
-
-		-
-			message: "#^Function social_post_form_post_form_alter\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: modules/social_features/social_post/social_post.module
-
-		-
-			message: "#^Function social_post_form_post_form_alter\\(\\) has parameter \\$form with no type specified\\.$#"
-			count: 1
-			path: modules/social_features/social_post/social_post.module
-
-		-
-			message: "#^Function social_post_form_post_form_alter\\(\\) has parameter \\$form_id with no type specified\\.$#"
 			count: 1
 			path: modules/social_features/social_post/social_post.module
 
@@ -9826,11 +9806,6 @@ parameters:
 
 		-
 			message: "#^Function social_post_views_data_alter\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: modules/social_features/social_post/social_post.module
-
-		-
-			message: "#^Not allowed to call private function _social_group_get_current_group from module social_post\\.$#"
 			count: 1
 			path: modules/social_features/social_post/social_post.module
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2809,11 +2809,6 @@ parameters:
 			path: modules/social_features/social_activity/modules/social_activity_filter/src/Plugin/views/display/FilterBlock.php
 
 		-
-			message: "#^Method Drupal\\\\social_activity_filter\\\\Plugin\\\\views\\\\display\\\\FilterBlock\\:\\:updateTagsOptions\\(\\) has parameter \\$form with no type specified\\.$#"
-			count: 1
-			path: modules/social_features/social_activity/modules/social_activity_filter/src/Plugin/views/display/FilterBlock.php
-
-		-
 			message: "#^Offset '\\#parents' does not exist on array\\|null\\.$#"
 			count: 2
 			path: modules/social_features/social_activity/modules/social_activity_filter/src/Plugin/views/display/FilterBlock.php

--- a/social.info.yml
+++ b/social.info.yml
@@ -18,9 +18,9 @@ dependencies:
   - color:color
   - improved_theme_settings:improved_theme_settings
   # Open Social
+  - social:social_group
   - social:social_activity
   - social:social_core
-  - social:social_group
   - social:social_swiftmail
   - social:social_user
 


### PR DESCRIPTION
## Problem
<!-- *[Required] Describe the problem you're trying to solve, this should motivate why the changes you're proposing are needed.* -->
As outlined in our decision record, we have identified the need to integrate Hux instead of relying on traditional hooks for managing interactions and events within our software. The use of hooks, while functional, has led to limitations in scalability, maintainability, and flexibility. 

## Solution
<!-- *[Required] Describe the solution you've created, elaborate on any technical choices you've made. Why is this the right solution and is a different solution not the right one? What is the reasoning behind the chosen solution?* -->
We will migrate from the current hook-based implementation to Hux. The Hux library offers a more modern and modular approach for handling events, making the system easier to maintain and extend in the long term.
Blog post on how to: https://www.previousnext.com.au/blog/hux-alternative-to-hooks
Drupal seems to go the same way: https://www.drupal.org/node/3442349

## Issue tracker
<!-- *[Required] Paste a link to the drupal.org issue queue item. If any other issue trackers were used, include links to those too.* -->
https://getopensocial.atlassian.net/browse/PROD-30967

## Theme issue tracker
<!-- *[Required if applicable] Paste a link to the drupal.org theme issue queue item, either from [socialbase](https://www.drupal.org/project/socialbase) or [socialblue](https://www.drupal.org/project/socialblue). If any other issue trackers were used, include links to those too.* -->

## How to test
<!--
*[Required] For example*
- [ ] Using version X.Y.Z of Open Social with the example module enabled
- [ ] As a sitemanager
- [ ] Try to enable the option B on screen c/d/e
- [ ] When saving I expect the result to be F but instead see G.
- [ ] The expected result F is attained when repeating the steps with this fix applied.
-->

## Screenshots
<!-- *[Required if new feature, and if applicable] If this Pull Request makes visual changes then please include some screenshots that show what has changed here. A before and after screenshot helps the reviewer determine what changes were made.* -->

## Release notes
<!-- *[Required if new feature, and if applicable] A short summary of the changes that were made that can be included in release notes.* -->

## Change Record
<!-- *[Required if applicable] If this Pull Request changes the way that developers should do things or introduces a new API for developers then a change record to document this is needed. Please provide a draft for a change record or a link to an unpublished change record below. Existing change records can be consulted as example. Please provide a draft for a change record or a link to an unpublished change record below. [Existing change records](https://www.drupal.org/list-changes/social) can be consulted as example.* -->
Creation of a `current group service` to fetch the current group service from the context.

## Translations
<!--
*[Optional]Translatable strings are always extracted from the latest development branch. To ensure translations remain available for platforms running older versions of Open Social the original string should be added to `translations.php` when it's changed or removed.*
- [ ] Changed or removed source strings are added to the `translations.php` file.
-->
