### PR TITLE
Issue #3481367: Enhance group tab management

### DIFF
--- a/modules/social_features/social_album/social_album.group_landing_tabs.yml
+++ b/modules/social_features/social_album/social_album.group_landing_tabs.yml
@@ -1,0 +1,5 @@
+social_album.group:
+  title: Albums
+  route_name: view.albums.page_group_albums_overview
+  membership: all
+  weight: 15

--- a/modules/social_features/social_group/modules/social_group_default_route/social_group_default_route.api.php
+++ b/modules/social_features/social_group/modules/social_group_default_route/social_group_default_route.api.php
@@ -6,15 +6,35 @@
  */
 
 /**
- * @addtogroup hooks
- * @{
+ * Provide group bundles for which entities redirection will be applicable.
+ *
+ * @return array
+ *   An associative array of group bundles that shows if group tab management
+ *    should be applied and the default routes for applicable group bundle,
+ *    keyed by group bundle.
+ */
+function hook_social_group_default_route_types(): array {
+  return [
+    'flexible_group' => [
+      'member' => 'social_group.stream',
+      'non-member' => 'view.group_information.page_group_about',
+    ],
+  ];
+}
+
+/**
+ * Alter group bundles for which entities redirection will be applicable.
  *
  * @param array $types
- *   An array of all available group types.
+ *   An associative array of group bundles returned by hook_group_types().
  */
-function hook_social_group_default_route_types_alter(array $types) {
-  // Enable functionality for secret groups.
-  $types[] = 'my_custom_group';
+function hook_social_group_default_route_types_alter(array &$types): void {
+  if (isset($types['flexible_group']) && !$types['flexible_group']) {
+    $types['flexible_group'] = [
+      'member' => 'social_group.stream',
+      'non-member' => 'view.group_information.page_group_about',
+    ];
+  }
 }
 
 /**

--- a/modules/social_features/social_group/modules/social_group_default_route/social_group_default_route.module
+++ b/modules/social_features/social_group/modules/social_group_default_route/social_group_default_route.module
@@ -9,12 +9,12 @@ use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Field\BaseFieldDefinition;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\group\Entity\GroupType;
+use Symfony\Component\Routing\Exception\RouteNotFoundException;
 
 /**
  * Implements hook_form_alter().
  */
 function social_group_default_route_form_alter(&$form, FormStateInterface $form_state, $form_id) {
-
   $forms = [];
   foreach (_social_group_default_route_group_types() as $type) {
     $forms[] = 'group_' . $type . '_edit_form';
@@ -23,52 +23,98 @@ function social_group_default_route_form_alter(&$form, FormStateInterface $form_
 
   // Check if this group type is supported.
   if (in_array($form_id, $forms, TRUE)) {
-
-    // Fetch the tabs.
-    $group_tabs = _social_group_default_route_group_tabs();
+    /** @var \Drupal\social_group_default_route\SocialGroupDefaultRouteRedirectService $redirect_service */
+    $redirect_service = \Drupal::service('social_group_default_route.redirect_service');
 
     // Get the form entity.
     $group = $form_state->getFormObject()->getEntity();
-
+    // If redirection isn't applicable for current group bundle.
+    $group_routes = $redirect_service->getGroupDefaultRoutes($group);
+    if (empty($group_routes)) {
+      return;
+    }
+    // The wrapper for 'Tab management settings'.
+    $wrapper_id = 'edit-tab-settings';
     // Add a (hidden) card for the tabs.
     $form['tab_settings'] = [
       '#type' => 'details',
       '#title' => t('Tab Management'),
       '#group' => 'group_settings',
       '#weight' => '3',
+      '#attributes' => [
+        'class' => [$wrapper_id],
+        'id' => $wrapper_id,
+      ],
     ];
-
-    // Define options for default route.
-    $options = [
-      '' => t('- Default -'),
-    ];
-
-    // Load the other tabs.
-    foreach ($group_tabs as $group_tab) {
-      $route = $group_tab->getRouteName();
-      /** @var \Drupal\Core\Menu\LocalTaskDefault $group_tab */
-      $options[$route] = $group_tab->getTitle();
-    }
-
-    $default_route = $group ? $group->getFieldValue('default_route', 'value') : '';
-    $default_route_an = $group ? $group->getFieldValue('default_route_an', 'value') : '';
 
     // The default route field.
     $form['tab_settings']['default_route'] = [
       '#type' => 'select',
       '#title' => t('Group members landing tab'),
-      '#default_value' => $default_route,
-      '#options' => $options,
     ];
 
     // The default route field.
     $form['tab_settings']['default_route_an'] = [
       '#type' => 'select',
       '#title' => t('Non members landing tab'),
-      '#default_value' => $default_route_an,
-      '#options' => $options,
     ];
+
+    /** @var \Drupal\social_group_default_route\GroupLandingTabManagerInterface $group_tab_manager */
+    $group_tab_manager = \Drupal::service('plugin.manager.group_landing_tabs');
+    $conditions = $group_tab_manager->getGroupManagementTabConditions($group);
+    // Add Ajax callback to all field form group landing tab conditions.
+    $enabled_conditions = [];
+    foreach ($conditions as $field => $value) {
+      if (isset($form[$field])) {
+        $form_value = $form_state->getValue($field);
+        if ($form_value) {
+          $enabled_conditions[$field] = $form_value['value'];
+        }
+
+        $form[$field]['widget']['value']['#ajax'] = [
+          'callback' => '_social_group_default_route_update_tab_settings',
+          'event' => 'change',
+          'wrapper' => $wrapper_id,
+          'progress' => [
+            'type' => 'throbber',
+          ],
+        ];
+      }
+    }
+    // Fetch the rotes for member and non-member.
+    $member_routes = $redirect_service->getMemberRoutes($group, $enabled_conditions);
+    $non_member_routes = $redirect_service->getNonMemberRoutes($group, $enabled_conditions);
+    // Filter non-available routes.
+    $available_member_routes = _social_group_default_route_groups_get_options($member_routes);
+    $available_non_member_routes = _social_group_default_route_groups_get_options($non_member_routes);
+    // Define a default route for members.
+    $default_route = $group ? $redirect_service->getDefaultMemberRoute($group, $available_member_routes) : '';
+    // Define a default route for non-members.
+    $default_route_an = $group ? $redirect_service->getDefaultNonMemberRoute($group, $available_non_member_routes) : '';
+    // Set default value and options.
+    $form['tab_settings']['default_route']['#options'] = $available_member_routes;
+    $form['tab_settings']['default_route_an']['#options'] = $available_non_member_routes;
+
+    $form['tab_settings']['default_route']['#default_value'] = $default_route;
+    $form['tab_settings']['default_route_an']['#default_value'] = $default_route_an;
+
+    $form['#attached']['library'][] = 'core/drupal.ajax';
   }
+}
+
+/**
+ * The Ajax callback.
+ *
+ * @param array $form
+ *   The form object.
+ * @param \Drupal\Core\Form\FormStateInterface $form_state
+ *   The form state.
+ *
+ * @return array
+ *   The form array.
+ */
+function _social_group_default_route_update_tab_settings(array $form, FormStateInterface $form_state): array {
+  return $form['tab_settings'];
 }
 
 /**
@@ -130,30 +176,30 @@ function _social_group_default_route_group_types() {
 }
 
 /**
- * Fetch all available group tabs.
+ * Get tab options.
+ *
+ * @param array $routes
+ *   The routes.
  *
  * @return array
- *   The group tabs.
+ *   The options.
  */
-function _social_group_default_route_group_tabs() {
-  $tabs = &drupal_static(__FUNCTION__);
-
-  if (!isset($tabs)) {
-    /** @var \Drupal\Core\Menu\LocalTaskManager $taskManager */
-    $taskManager = Drupal::service('plugin.manager.menu.local_task');
-    $tabs = [];
-
-    $group_tabs = $taskManager->getLocalTasksForRoute('entity.group.canonical');
-    $group_tabs = $group_tabs[0];
-
-    // Loop over the available tabs on a group.
-    foreach ($group_tabs as $route => $localtask) {
-      // Add to the array.
-      $tabs[$route] = $localtask;
+function _social_group_default_route_groups_get_options(array $routes): array {
+  /** @var \Drupal\Core\Routing\RouteProviderInterface $route_provider */
+  $route_provider = \Drupal::service('router.route_provider');
+  // Define options for member.
+  $options = [];
+  // Load the members tabs.
+  foreach ($routes as $route => $title) {
+    try {
+      $route_object = $route_provider->getRouteByName($route);
+      $options[$route] = $title;
     }
-    // Allow other modules to change the group types.
-    Drupal::moduleHandler()->alter('social_group_default_route_tabs', $tabs);
+    catch (RouteNotFoundException $e) {
+      // Skip if route isn't exist.
+      continue;
+    }
   }
 
-  return $tabs;
+  return $options;
 }

--- a/modules/social_features/social_group/modules/social_group_default_route/social_group_default_route.services.yml
+++ b/modules/social_features/social_group/modules/social_group_default_route/social_group_default_route.services.yml
@@ -10,4 +10,7 @@ services:
       - { name: event_subscriber, priority: 3 }
   social_group_default_route.redirect_service:
     class: Drupal\social_group_default_route\SocialGroupDefaultRouteRedirectService
-    arguments: [ '@current_route_match', '@current_user' ]
+    arguments: [ '@current_route_match', '@current_user', '@module_handler', '@plugin.manager.group_landing_tabs' ]
+  plugin.manager.group_landing_tabs:
+    class: Drupal\social_group_default_route\GroupLandingTabManager
+    arguments: ['@cache.discovery', '@module_handler']

--- a/modules/social_features/social_group/modules/social_group_default_route/src/Controller/SocialGroupDefaultRouteController.php
+++ b/modules/social_features/social_group/modules/social_group_default_route/src/Controller/SocialGroupDefaultRouteController.php
@@ -20,8 +20,13 @@ class SocialGroupDefaultRouteController extends ControllerBase {
    *
    * @param \Drupal\Core\Session\AccountInterface $current_user
    *   The current user.
+   * @param \Drupal\social_group_default_route\SocialGroupDefaultRouteRedirectService $redirectService
+   *   The redirect service.
    */
-  public function __construct(AccountInterface $current_user) {
+  public function __construct(
+    AccountInterface $current_user,
+    protected SocialGroupDefaultRouteRedirectService $redirectService,
+  ) {
     $this->currentUser = $current_user;
   }
 
@@ -31,6 +36,7 @@ class SocialGroupDefaultRouteController extends ControllerBase {
   public static function create(ContainerInterface $container): self {
     return new static(
       $container->get('current_user'),
+      $container->get('social_group_default_route.redirect_service'),
     );
   }
 
@@ -44,10 +50,10 @@ class SocialGroupDefaultRouteController extends ControllerBase {
    *   The redirect response.
    */
   public function groupDefaultRoute(SocialGroupInterface $group): RedirectResponse {
-    // The members and non-members should be redirected to the different pages.
+    // The members and non-members should be redirected to their default routes.
     $default_route = $group->hasMember($this->currentUser) ?
-      SocialGroupDefaultRouteRedirectService::DEFAULT_ROUTE :
-      SocialGroupDefaultRouteRedirectService::DEFAULT_CLOSED_ROUTE;
+      $this->redirectService->getDefaultMemberRoute($group) :
+      $this->redirectService->getDefaultNonMemberRoute($group);
 
     $url = Url::fromRoute($default_route, ['group' => $group->id()]);
 

--- a/modules/social_features/social_group/modules/social_group_default_route/src/GroupLandingTabManager.php
+++ b/modules/social_features/social_group/modules/social_group_default_route/src/GroupLandingTabManager.php
@@ -1,0 +1,202 @@
+<?php
+
+namespace Drupal\social_group_default_route;
+
+use Drupal\Component\Discovery\YamlDiscovery as YamlDiscoveryComponent;
+use Drupal\Component\Plugin\Discovery\DiscoveryInterface;
+use Drupal\Core\Cache\CacheBackendInterface;
+use Drupal\Core\Extension\ModuleHandlerInterface;
+use Drupal\Core\Plugin\DefaultPluginManager;
+use Drupal\Core\Plugin\Discovery\ContainerDerivativeDiscoveryDecorator;
+use Drupal\Core\Plugin\Discovery\YamlDiscovery;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\group\Entity\GroupInterface;
+
+/**
+ * Provides the default group landing tabs using YML as primary definition.
+ */
+class GroupLandingTabManager extends DefaultPluginManager implements GroupLandingTabManagerInterface {
+
+  use StringTranslationTrait;
+
+  /**
+   * The object that discovers plugins managed by this manager.
+   *
+   * @var \Drupal\Component\Plugin\Discovery\DiscoveryInterface
+   */
+  protected $discovery;
+
+  /**
+   * The YAML discovery class to find all .group_landing_tabs.yml files.
+   *
+   * @var \Drupal\Component\Discovery\YamlDiscovery
+   */
+  protected $yamlDiscovery;
+
+  /**
+   * Provides default values for a group landing tab definition.
+   *
+   * @var array
+   */
+  protected $defaults = [
+    // (required) The name of the route to link to.
+    'route_name' => '',
+    // (required) The group landing tab title.
+    'title' => '',
+    // The weight of the tab.
+    'weight' => NULL,
+    // The group membership: member, non-member or all.
+    'membership' => 'all',
+    // The group types for witch tab will be available.
+    'group_types' => [],
+    // Conditions by group fields.
+    'conditions' => [],
+  ];
+
+  /**
+   * GroupLandingTabManager constructor.
+   *
+   * @param \Drupal\Core\Cache\CacheBackendInterface $cache_backend
+   *   The cache backend service.
+   * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
+   *   The module handler service.
+   */
+  public function __construct(CacheBackendInterface $cache_backend, ModuleHandlerInterface $module_handler) {
+    $this->moduleHandler = $module_handler;
+    $this->alterInfo('group_landing_tabs');
+    $this->setCacheBackend($cache_backend, 'group_landing_tabs_plugins');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getDiscovery(): DiscoveryInterface|ContainerDerivativeDiscoveryDecorator {
+    // @phpstan-ignore-next-line
+    if (!isset($this->discovery)) {
+      $yaml_discovery = new YamlDiscovery('group_landing_tabs', $this->moduleHandler->getModuleDirectories());
+      $yaml_discovery->addTranslatableProperty('title', 'title_context');
+      $this->discovery = new ContainerDerivativeDiscoveryDecorator($yaml_discovery);
+    }
+    return $this->discovery;
+  }
+
+  /**
+   * Gets the YAML discovery.
+   *
+   * @return \Drupal\Component\Discovery\YamlDiscovery
+   *   The YAML discovery.
+   */
+  protected function getYamlDiscovery(): YamlDiscoveryComponent {
+    // @phpstan-ignore-next-line
+    if (!isset($this->yamlDiscovery)) {
+      $this->yamlDiscovery = new YamlDiscoveryComponent('group_landing_tabs', $this->moduleHandler->getModuleDirectories());
+    }
+    return $this->yamlDiscovery;
+  }
+
+  /**
+   * Get all available group lending tabs.
+   *
+   * @param \Drupal\group\Entity\GroupInterface $group
+   *   The group object.
+   * @param array $field_values
+   *   The array of ajax data.
+   *
+   * @return array
+   *   The array of all group landing tabs.
+   */
+  protected function getAllGroupManagementTabs(GroupInterface $group, array $field_values = []): array {
+    $all_tabs = [];
+    foreach ($this->getYamlDiscovery()->findAll() as $tabs) {
+      foreach ($tabs as $name => $data) {
+        $tab_data = [
+          'title' => isset($data['title']) ? $this->t('@title', ['@title' => $data['title']]) : NULL,
+          'route_name' => $data['route_name'] ?? NULL,
+          'weight' => $data['weight'] ?? NULL,
+          'membership' => $data['membership'] ?? NULL,
+          'group_types' => $data['group_types'] ?? NULL,
+          'conditions' => $data['conditions'] ?? NULL,
+        ];
+        // Skip if current tab isn't available for current group.
+        if (is_array($tab_data['group_types']) && !in_array($group->bundle(), $tab_data['group_types'])) {
+          continue;
+        }
+        // Skip by conditions.
+        $skip_by_conditions = FALSE;
+        if (is_array($tab_data['conditions'])) {
+          $skip_by_conditions = TRUE;
+          foreach ($tab_data['conditions'] as $group_field => $value) {
+            if (isset($field_values[$group_field]) && $field_values[$group_field] == $value) {
+              $skip_by_conditions = FALSE;
+            }
+            elseif ($group->hasField($group_field) && $group->get($group_field)->getString() === $value && isset($field_values[$group_field]) && $field_values[$group_field] == $group->get($group_field)->getString()) {
+              $skip_by_conditions = FALSE;
+            }
+            elseif ($group->hasField($group_field) && $group->get($group_field)->getString() === $value && !isset($field_values[$group_field])) {
+              $skip_by_conditions = FALSE;
+            }
+          }
+
+        }
+
+        if ($skip_by_conditions) {
+          continue;
+        }
+
+        if ($tab_data['title'] && $tab_data['route_name']) {
+          $membership = $tab_data['membership'];
+
+          switch ($membership) {
+            case self::NON_MEMBER:
+            case self::MEMBER:
+              $all_tabs[$membership][$name] = $tab_data;
+              break;
+
+            case self::ALL:
+              $all_tabs[self::NON_MEMBER][$name] = $tab_data;
+              $all_tabs[self::MEMBER][$name] = $tab_data;
+              break;
+          }
+        }
+      }
+    }
+
+    return $all_tabs;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getAvailableLendingTabs(GroupInterface $group, string $type, array $field_values = []): array {
+    $all_tabs = $this->getAllGroupManagementTabs($group, $field_values);
+    $members_tabs = $all_tabs[$type];
+    // Sort by weight.
+    uasort($members_tabs, function ($a, $b) {
+      return $a['weight'] <=> $b['weight'];
+    });
+    $result = [];
+
+    foreach ($members_tabs as $tab) {
+      $result[$tab['route_name']] = $tab['title'];
+    }
+
+    return $result;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getGroupManagementTabConditions(GroupInterface $group): array {
+    $conditions = [];
+    foreach ($this->getYamlDiscovery()->findAll() as $tabs) {
+      foreach ($tabs as $name => $data) {
+        if (isset($data['conditions'])) {
+          $conditions = array_merge($conditions, $data['conditions']);
+        }
+      }
+    }
+
+    return $conditions;
+  }
+
+}

--- a/modules/social_features/social_group/modules/social_group_default_route/src/GroupLandingTabManagerInterface.php
+++ b/modules/social_features/social_group/modules/social_group_default_route/src/GroupLandingTabManagerInterface.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Drupal\social_group_default_route;
+
+use Drupal\group\Entity\GroupInterface;
+
+/**
+ * Manages discovery and instantiation of group landing tab plugins.
+ *
+ * Group landing tabs are links that used as default pages of Group entity
+ * depends on Group membership.
+ */
+interface GroupLandingTabManagerInterface {
+
+  /**
+   * The membership - member.
+   */
+  const MEMBER = 'member';
+
+  /**
+   * The membership - non-member.
+   */
+  const NON_MEMBER = 'non-member';
+
+  /**
+   * The membership - all.
+   */
+  const ALL = 'all';
+
+  /**
+   * Get available landing tabs.
+   *
+   * @param \Drupal\group\Entity\GroupInterface $group
+   *   The group object.
+   * @param string $type
+   *   The tab type by group membership:
+   *    - GroupLandingTabManagerInterface:MEMBER;
+   *    - GroupLandingTabManagerInterface:NON_MEMBER;
+   *    - GroupLandingTabManagerInterface:ALL.
+   * @param array $field_values
+   *   The array of group field valued.
+   *
+   * @return array
+   *   The array of tabs.
+   */
+  public function getAvailableLendingTabs(GroupInterface $group, string $type, array $field_values = []): array;
+
+  /**
+   * Get group tab management conditions.
+   *
+   * @param \Drupal\group\Entity\GroupInterface $group
+   *   The group object.
+   *
+   * @return array
+   *   The array of conditions.
+   */
+  public function getGroupManagementTabConditions(GroupInterface $group): array;
+
+}

--- a/modules/social_features/social_group/modules/social_group_default_route/src/SocialGroupDefaultRouteRedirectService.php
+++ b/modules/social_features/social_group/modules/social_group_default_route/src/SocialGroupDefaultRouteRedirectService.php
@@ -2,10 +2,13 @@
 
 namespace Drupal\social_group_default_route;
 
+use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\Session\AccountProxyInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Core\Url;
 use Drupal\group\Entity\Group;
+use Drupal\group\Entity\GroupInterface;
 use Drupal\social_group\SocialGroupInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpKernel\Event\ExceptionEvent;
@@ -16,10 +19,17 @@ use Symfony\Component\HttpKernel\Event\RequestEvent;
  */
 class SocialGroupDefaultRouteRedirectService {
 
+  use StringTranslationTrait;
+
   /**
-   * The route name of the default page of any group type except closed groups.
+   * Default route for group non-members.
    */
-  const DEFAULT_ROUTE = 'social_group.stream';
+  const GROUP_ABOUT_ROUTE = 'view.group_information.page_group_about';
+
+  /**
+   * Default route for group members.
+   */
+  const GROUP_STREAM_ROUTE = 'social_group.stream';
 
   /**
    * The route name of the group default page is provided by the current module.
@@ -32,21 +42,22 @@ class SocialGroupDefaultRouteRedirectService {
   const DEFAULT_GROUP_ROUTE = 'entity.group.canonical';
 
   /**
-   * The route name of the default page of closed groups.
-   */
-  const DEFAULT_CLOSED_ROUTE = 'view.group_information.page_group_about';
-
-  /**
    * SocialGroupDefaultRedirectService constructor.
    *
    * @param \Drupal\Core\Routing\RouteMatchInterface $routeMatch
    *   The current route.
    * @param \Drupal\Core\Session\AccountProxyInterface $currentUser
    *   The current user.
+   * @param \Drupal\Core\Extension\ModuleHandlerInterface $moduleHandler
+   *   The module handler.
+   * @param \Drupal\social_group_default_route\GroupLandingTabManager $landingTabManager
+   *   The landing tab manager.
    */
   public function __construct(
     protected RouteMatchInterface $routeMatch,
     protected AccountProxyInterface $currentUser,
+    protected ModuleHandlerInterface $moduleHandler,
+    protected GroupLandingTabManager $landingTabManager,
   ) {
   }
 
@@ -61,31 +72,27 @@ class SocialGroupDefaultRouteRedirectService {
   public function doRedirect(ExceptionEvent|RequestEvent $event, SocialGroupInterface $group): void {
     $route_name = $this->routeMatch->getRouteName();
     // Check if current user is a member.
-    if (!$group->hasMember($this->currentUser)) {
-      /** @var string|null $route */
-      $route = $group->default_route_an->value;
-
-      if ($route === NULL) {
-        $route = self::DEFAULT_CLOSED_ROUTE;
-      }
-    }
-    else {
-      /** @var string|null $route */
-      $route = $group->default_route->value;
-
-      // Still no route here? Then we use the normal default.
-      if ($route === NULL) {
-        $route = self::DEFAULT_ROUTE;
-      }
-    }
+    $route = $group->hasMember($this->currentUser) ?
+      $this->getDefaultMemberRoute($group) :
+      $this->getDefaultNonMemberRoute($group);
 
     // Determine the URL we want to redirect to.
     $url = Url::fromRoute($route, ['group' => $group->id()]);
 
     // If it's not set, set to canonical, or the current user has no access.
-    if ($route === $route_name || $url->access($this->currentUser) === FALSE) {
+    if ($route === $route_name) {
       // This basically means that the normal flow remains intact.
       return;
+    }
+
+    // If  current user has no access.
+    if ($url->access($this->currentUser) === FALSE) {
+      $route = $group->hasMember($this->currentUser) ?
+        self::GROUP_STREAM_ROUTE :
+        self::GROUP_ABOUT_ROUTE;
+
+      $url = Url::fromRoute($route, ['group' => $group->id()]);
+      $event->setResponse(new RedirectResponse($url->toString()));
     }
 
     // Redirect.
@@ -111,6 +118,99 @@ class SocialGroupDefaultRouteRedirectService {
     }
 
     return $group;
+  }
+
+  /**
+   * Get default route for non-members.
+   *
+   * @param \Drupal\group\Entity\GroupInterface $group
+   *   The group object.
+   * @param array $available_routes
+   *   The available route.
+   *
+   * @return string
+   *   The default route.
+   */
+  public function getDefaultNonMemberRoute(GroupInterface $group, array $available_routes = []): string {
+    $group_routes = $this->getGroupDefaultRoutes($group);
+
+    if ($group->get('default_route_an')->isEmpty() ||
+      (!empty($available_routes) && !isset($available_routes[$group->get('default_route_an')->getString()]))
+    ) {
+      return $group_routes['non-member'] ?? self::GROUP_ABOUT_ROUTE;
+    }
+    else {
+      return $group->get('default_route_an')->getString();
+    }
+  }
+
+  /**
+   * Get default route for members.
+   *
+   * @param \Drupal\group\Entity\GroupInterface $group
+   *   The group object.
+   * @param array $available_routes
+   *   The available route.
+   *
+   * @return string
+   *   The default route.
+   */
+  public function getDefaultMemberRoute(GroupInterface $group, array $available_routes = []): string {
+    $group_routes = $this->getGroupDefaultRoutes($group);
+
+    if ($group->get('default_route')->isEmpty() ||
+      (!empty($available_routes) && !isset($available_routes[$group->get('default_route')->getString()]))
+    ) {
+      return $group_routes['member'] ?? self::GROUP_STREAM_ROUTE;
+    }
+    else {
+      return $group->get('default_route')->getString();
+    }
+  }
+
+  /**
+   * Get allowed routes for non-member.
+   *
+   * @param \Drupal\group\Entity\GroupInterface $group
+   *   The group object.
+   * @param array $field_values
+   *   The field values.
+   *
+   * @return array
+   *   The array of routes.
+   */
+  public function getNonMemberRoutes(GroupInterface $group, array $field_values = []): array {
+    return $this->landingTabManager->getAvailableLendingTabs($group, GroupLandingTabManagerInterface::NON_MEMBER, $field_values);
+  }
+
+  /**
+   * Get allowed routes for group member.
+   *
+   * @param \Drupal\group\Entity\GroupInterface $group
+   *   The group object.
+   * @param array $field_values
+   *   The field values.
+   *
+   * @return array
+   *   The array of routes.
+   */
+  public function getMemberRoutes(GroupInterface $group, array $field_values = []): array {
+    return $this->landingTabManager->getAvailableLendingTabs($group, GroupLandingTabManagerInterface::MEMBER, $field_values);
+  }
+
+  /**
+   * Get group default routes.
+   *
+   * @param \Drupal\group\Entity\GroupInterface $group
+   *   The group object.
+   *
+   * @return array
+   *   The array of routes.
+   */
+  public function getGroupDefaultRoutes(GroupInterface $group): array {
+    $group_bundles = $this->moduleHandler->invokeAll('social_group_default_route_types');
+    $this->moduleHandler->alter('social_group_default_route_types', $group_bundles);
+    return $group_bundles[$group->bundle()] ?? [];
   }
 
 }

--- a/modules/social_features/social_group/modules/social_group_flexible_group/modules/social_flexible_group_book/social_flexible_group_book.group_landing_tabs.yml
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/modules/social_flexible_group_book/social_flexible_group_book.group_landing_tabs.yml
@@ -1,0 +1,9 @@
+social_flexible_group_book.books:
+  title: Books
+  route_name: view.group_books.page_group_books
+  membership: all
+  weight: 16
+  group_types:
+    - flexible_group
+  conditions:
+    enable_books: '1'

--- a/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.module
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.module
@@ -880,3 +880,15 @@ function social_group_flexible_group_social_user_account_header_create_links($co
     ] + $link->toRenderable(),
   ];
 }
+
+/**
+ * Implements hook_social_group_default_route_types().
+ */
+function social_group_flexible_group_social_group_default_route_types(): array {
+  return [
+    'flexible_group' => [
+      'member' => 'social_group.stream',
+      'non-member' => 'view.group_information.page_group_about',
+    ],
+  ];
+}

--- a/modules/social_features/social_group/social_group.group_landing_tabs.yml
+++ b/modules/social_features/social_group/social_group.group_landing_tabs.yml
@@ -1,0 +1,29 @@
+social_group.about:
+  title: About
+  route_name: view.group_information.page_group_about
+  membership: all
+  weight: 0
+
+social_group.stream:
+  title: Stream
+  route_name: social_group.stream
+  membership: member
+  weight: 10
+
+social_group.events:
+  route_name: view.group_events.page_group_events
+  membership: all
+  title: Events
+  weight: 20
+
+social_group.members:
+  title: Members
+  route_name: view.group_members.page_group_members
+  membership: member
+  weight: 30
+
+social_group.topics:
+  title: Topics
+  route_name: view.group_topics.page_group_topics
+  membership: all
+  weight: 40


### PR DESCRIPTION
## Problem (for internal)
Currently, the Group Tab Manager module allows managers to select a wide range of options. In this story, we want to clean up these options to align with what we allow.

Acceptance Criteria:

- As a group creator, I can select only the allowed tabs for non-members in the tab manager options:
  1. About
  2. Albums
  3. Books
  4. Discussions (provided by module from Cablecar)
  5. Events
  6. Files  (provided by module from Cablecar)
  7. Tasks (provided by module from Cablecar)
  8. Topics
- As a group creator, I can select only the allowed tabs for members in the tab manager options:
  1. About
  2. Stream
  3. Albums
  4. Books
  5. Discussions (provided by module from Cablecar)
  6. Events
  7. Files (provided by module from Cablecar)
  8. Members
  9. Tasks (provided by module from Cablecar)
  10. Topics

- An option is visible only if it is also enabled in the group personalization checkboxes.
- Options are ordered as listed above.
- The default option is About for non-members and Stream for members.

## Solution (for internal)
1. Create `SocialGroupDefaultRouteRedirectService` to combine all redirection methods in one place, so it becomes reusable
2. Set "About" and "Stream" routes as default for non-members and members accordingly
3. Add new YmlDiscovery plugin manager - `GroupLandingTabManager` - now new options of landings tabs could be added with `module_name.group_landing_tabs.yml` file with the next structure:
```
module_name.tab_name:
  title: Example
  route_name: example_route
  membership: member/non-member/all
  weight: 16
  // Isn't required, if it isn't set tabs will appear for all group types.
  group_types:
    - example_group_type
  // Isn't required, if it isn't set tabs will appear without conditions.
  conditions:
    group_field_name: value
```
4. Add `social_group.group_landing_tabs.yml` to provide default landing tabs.
5. Add `social_flexible_group_book.group_landing_tabs.yml` to provide "Books" landing tab.
6. Add `social_album.group_landing_tabs.yml` to provide "Album" landing tab.


## Screenshots
![image](https://github.com/user-attachments/assets/e71f9601-40de-470d-b67e-0c4a3174937a)


## Release notes (to customers)
1. The "About" and "Stream" pages were set as default for non-members and members accordingly
2. The list of available options was changed according to AC

## Issue tracker
https://www.drupal.org/project/social/issues/3481367
https://getopensocial.atlassian.net/browse/PROD-30966

## How to test
- [ ] Enable module `social_group_default_route`
- [ ] Create two verified users - "Member" and "Non-member"
- [ ] Create a public group "Flexible group" - check the settings - there should be the 'Tab Management setting" with default options: 
   - [ ] For member: About, Stream, Events, Members, Topics
   - [ ] For non-members: About, Events, Topics
- [ ] Enable module `social_flexible_group_book`
- [ ] The new option "Books" should appear In the 'Tab Management setting" options.
- [ ] Add user "Member" as a member to the "Flexible group" group.
- [ ] As AU or "Non-member" got to page `group/1` - you should be redirected to the "About" page.
- [ ] As "Member" got to page `group/1` - you should be redirected to the "Stream" page.
- [ ] Go to the edit page of "Test" group `group/1/edit`
- [ ] As AU or "Non-member" got to page `group/1` - you should be redirected to the "Event" page.
- [ ] As "Member" got to page `group/1` - you should be redirected to the "Topics" page.
- [ ] Try to change the landing tab for member and no-member - they should be redirected to the according pages.
