### PR TITLE
Issue #3458767: Remove the redundant "Content access" filter from views

### DIFF
--- a/modules/social_features/social_album/config/install/views.view.albums.yml
+++ b/modules/social_features/social_album/config/install/views.view.albums.yml
@@ -212,7 +212,6 @@ display:
         - 'languages:language_interface'
         - url
         - url.query_args
-        - 'user.node_grants:view'
       tags: {  }
   embed_album_cover:
     display_plugin: embed
@@ -459,7 +458,6 @@ display:
         - 'languages:language_content'
         - 'languages:language_interface'
         - url
-        - 'user.node_grants:view'
       tags:
         - 'config:field.storage.post.field_post_image'
   embed_album_overview:
@@ -786,7 +784,6 @@ display:
         - 'languages:language_interface'
         - url
         - url.query_args
-        - 'user.node_grants:view'
       tags:
         - 'config:field.storage.post.field_post_image'
   entity_reference:
@@ -845,7 +842,6 @@ display:
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
-        - 'user.node_grants:view'
       tags: {  }
   page_albums_overview:
     display_plugin: page
@@ -889,7 +885,6 @@ display:
         - 'languages:language_interface'
         - url
         - url.query_args
-        - 'user.node_grants:view'
       tags: {  }
   page_group_albums_overview:
     display_plugin: page
@@ -992,5 +987,4 @@ display:
         - url
         - url.query_args
         - user.group_permissions
-        - 'user.node_grants:view'
       tags: {  }

--- a/modules/social_features/social_event/config/install/views.view.events.yml
+++ b/modules/social_features/social_event/config/install/views.view.events.yml
@@ -292,7 +292,6 @@ display:
         - 'languages:language_interface'
         - url
         - url.query_args
-        - 'user.node_grants:view'
         - user.permissions
       tags: {  }
   block_events_on_profile:
@@ -494,44 +493,6 @@ display:
           entity_type: node
           plugin_id: event_enrolled_or_created
           entity_field: uid
-        nid:
-          id: nid
-          table: node_access
-          field: nid
-          relationship: none
-          group_type: group
-          admin_label: ''
-          operator: '='
-          value: ''
-          group: 1
-          exposed: false
-          expose:
-            operator_id: ''
-            label: ''
-            description: ''
-            use_operator: false
-            operator: ''
-            identifier: ''
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-            operator_limit_selection: false
-            operator_list: {  }
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
-          plugin_id: node_access
       use_ajax: false
       filter_groups:
         operator: AND
@@ -545,7 +506,6 @@ display:
         - 'languages:language_content'
         - 'languages:language_interface'
         - url
-        - 'user.node_grants:view'
         - user.permissions
       tags: {  }
   events_overview:
@@ -747,44 +707,6 @@ display:
             group_items: {  }
           entity_type: node
           plugin_id: event_enrolled_or_created
-        nid:
-          id: nid
-          table: node_access
-          field: nid
-          relationship: none
-          group_type: group
-          admin_label: ''
-          operator: '='
-          value: ''
-          group: 1
-          exposed: false
-          expose:
-            operator_id: ''
-            label: ''
-            description: ''
-            use_operator: false
-            operator: ''
-            identifier: ''
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-            operator_limit_selection: false
-            operator_list: {  }
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
-          plugin_id: node_access
       defaults:
         filters: false
         filter_groups: false
@@ -815,6 +737,5 @@ display:
         - 'languages:language_interface'
         - url
         - url.query_args
-        - 'user.node_grants:view'
         - user.permissions
       tags: {  }

--- a/modules/social_features/social_event/config/install/views.view.upcoming_events.yml
+++ b/modules/social_features/social_event/config/install/views.view.upcoming_events.yml
@@ -195,44 +195,6 @@ display:
             default_group_multiple: {  }
             group_items: {  }
           plugin_id: datetime
-        nid:
-          id: nid
-          table: node_access
-          field: nid
-          relationship: none
-          group_type: group
-          admin_label: ''
-          operator: '='
-          value: ''
-          group: 1
-          exposed: false
-          expose:
-            operator_id: ''
-            label: ''
-            description: ''
-            use_operator: false
-            operator: ''
-            identifier: ''
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-            operator_limit_selection: false
-            operator_list: {  }
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
-          plugin_id: node_access
       sorts:
         field_event_date_value:
           id: field_event_date_value
@@ -271,7 +233,6 @@ display:
         - 'languages:language_content'
         - 'languages:language_interface'
         - url.query_args
-        - 'user.node_grants:view'
         - user.permissions
       tags: {  }
   block_community_events:
@@ -306,7 +267,6 @@ display:
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
-        - 'user.node_grants:view'
         - user.permissions
       tags: {  }
   block_my_upcoming_events:
@@ -491,44 +451,6 @@ display:
             default_group_multiple: {  }
             group_items: {  }
           plugin_id: datetime
-        nid:
-          id: nid
-          table: node_access
-          field: nid
-          relationship: none
-          group_type: group
-          admin_label: ''
-          operator: '='
-          value: ''
-          group: 1
-          exposed: false
-          expose:
-            operator_id: ''
-            label: ''
-            description: ''
-            use_operator: false
-            operator: ''
-            identifier: ''
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-            operator_limit_selection: false
-            operator_list: {  }
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
-          plugin_id: node_access
       filter_groups:
         operator: AND
         groups:
@@ -569,7 +491,6 @@ display:
         - 'languages:language_interface'
         - url
         - user
-        - 'user.node_grants:view'
         - user.permissions
       tags: {  }
   page_community_events:
@@ -645,44 +566,6 @@ display:
                 operator: in
                 value: null
           plugin_id: social_event_date_filter
-        nid:
-          id: nid
-          table: node_access
-          field: nid
-          relationship: none
-          group_type: group
-          admin_label: ''
-          operator: '='
-          value: ''
-          group: 1
-          exposed: false
-          expose:
-            operator_id: ''
-            label: ''
-            description: ''
-            use_operator: false
-            operator: ''
-            identifier: ''
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-            operator_limit_selection: false
-            operator_list: {  }
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
-          plugin_id: node_access
         field_enroll_method_value:
           id: field_enroll_method_value
           table: node__field_enroll_method
@@ -760,7 +643,6 @@ display:
         - 'languages:language_interface'
         - url
         - url.query_args
-        - 'user.node_grants:view'
         - user.permissions
       tags: {  }
   upcoming_events_group:
@@ -906,44 +788,6 @@ display:
             default_group_multiple: {  }
             group_items: {  }
           plugin_id: datetime
-        nid:
-          id: nid
-          table: node_access
-          field: nid
-          relationship: none
-          group_type: group
-          admin_label: ''
-          operator: '='
-          value: ''
-          group: 1
-          exposed: false
-          expose:
-            operator_id: ''
-            label: ''
-            description: ''
-            use_operator: false
-            operator: ''
-            identifier: ''
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-            operator_limit_selection: false
-            operator_list: {  }
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
-          plugin_id: node_access
       filter_groups:
         operator: AND
         groups:
@@ -981,6 +825,5 @@ display:
         - 'languages:language_interface'
         - route
         - url
-        - 'user.node_grants:view'
         - user.permissions
       tags: {  }

--- a/modules/social_features/social_event/config/update/social_event_update_130005.yml
+++ b/modules/social_features/social_event/config/update/social_event_update_130005.yml
@@ -1,0 +1,34 @@
+views.view.events:
+  expected_config: {  }
+  update_actions:
+    delete:
+      display:
+        block_events_on_profile:
+          display_options:
+            filters:
+              nid: {  }
+        events_overview:
+          display_options:
+            filters:
+              nid: {  }
+views.view.upcoming_events:
+  expected_config: {  }
+  update_actions:
+    delete:
+      display:
+        default:
+          display_options:
+            filters:
+              nid: {  }
+        block_my_upcoming_events:
+          display_options:
+            filters:
+              nid: {  }
+        page_community_events:
+          display_options:
+            filters:
+              nid: {  }
+        upcoming_events_group:
+          display_options:
+            filters:
+              nid: {  }

--- a/modules/social_features/social_event/social_event.install
+++ b/modules/social_features/social_event/social_event.install
@@ -296,3 +296,13 @@ function social_event_update_130004(): void {
       ->save();
   }
 }
+
+/**
+ * Remove redundant "node_access" views filter.
+ */
+function social_event_update_130005(): string {
+  /** @var \Drupal\update_helper\Updater $updater */
+  $updater = \Drupal::service('update_helper.updater');
+  $updater->executeUpdate('social_event', __FUNCTION__);
+  return $updater->logger()->output();
+}

--- a/modules/social_features/social_event/tests/src/Kernel/GraphQL/QueryEventTest.php
+++ b/modules/social_features/social_event/tests/src/Kernel/GraphQL/QueryEventTest.php
@@ -213,7 +213,7 @@ class QueryEventTest extends SocialGraphQLTestBase {
         ->addCacheableDependency($event->getOwner())
         ->addCacheableDependency($event_manager)
         ->addCacheTags(['config:filter.format.plain_text', 'config:filter.settings', 'comment:1'])
-        ->addCacheContexts(['languages:language_interface', 'user.node_grants:view', 'url.site'])
+        ->addCacheContexts(['languages:language_interface', 'url.site'])
     );
   }
 

--- a/modules/social_features/social_featured_content/config/install/views.view.featured_content_reference.yml
+++ b/modules/social_features/social_featured_content/config/install/views.view.featured_content_reference.yml
@@ -153,42 +153,6 @@ display:
           expose:
             operator: ''
           group: 1
-        nid:
-          id: nid
-          table: node_access
-          field: nid
-          relationship: none
-          group_type: group
-          admin_label: ''
-          operator: '='
-          value: ''
-          group: 1
-          exposed: false
-          expose:
-            operator_id: ''
-            label: ''
-            description: ''
-            use_operator: false
-            operator: ''
-            identifier: ''
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
-          plugin_id: node_access
       sorts:
         title:
           id: title
@@ -216,7 +180,6 @@ display:
         - 'languages:language_content'
         - 'languages:language_interface'
         - url.query_args
-        - 'user.node_grants:view'
         - user.permissions
       tags: {  }
   entity_reference_1:
@@ -236,6 +199,5 @@ display:
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
-        - 'user.node_grants:view'
         - user.permissions
       tags: {  }

--- a/modules/social_features/social_featured_content/config/update/social_featured_content_update_13001.yml
+++ b/modules/social_features/social_featured_content/config/update/social_featured_content_update_13001.yml
@@ -1,0 +1,9 @@
+views.view.featured_content_reference:
+  expected_config: {  }
+  update_actions:
+    delete:
+      display:
+        default:
+          display_options:
+            filters:
+              nid: {  }

--- a/modules/social_features/social_featured_content/social_featured_content.install
+++ b/modules/social_features/social_featured_content/social_featured_content.install
@@ -49,3 +49,13 @@ function social_featured_content_update_13000(): ?string {
   // Output logged messages to related channel of update execution.
   return $updateHelper->logger()->output();
 }
+
+/**
+ * Remove redundant "node_access" views filter.
+ */
+function social_featured_content_update_13001(): string {
+  /** @var \Drupal\update_helper\Updater $updater */
+  $updater = \Drupal::service('update_helper.updater');
+  $updater->executeUpdate('social_featured_content', __FUNCTION__);
+  return $updater->logger()->output();
+}

--- a/modules/social_features/social_group/config/optional/views.view.group_events.yml
+++ b/modules/social_features/social_group/config/optional/views.view.group_events.yml
@@ -189,44 +189,6 @@ display:
                 operator: in
                 value: null
           plugin_id: social_event_date_filter
-        nid:
-          id: nid
-          table: node_access
-          field: nid
-          relationship: gc__node
-          group_type: group
-          admin_label: ''
-          operator: '='
-          value: ''
-          group: 1
-          exposed: false
-          expose:
-            operator_id: ''
-            label: ''
-            description: ''
-            use_operator: false
-            operator: ''
-            identifier: ''
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-            operator_limit_selection: false
-            operator_list: {  }
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
-          plugin_id: node_access
       sorts:
         event_date:
           id: event_date
@@ -319,7 +281,6 @@ display:
         - url
         - url.query_args
         - user.group_permissions
-        - 'user.node_grants:view'
       tags: {  }
   page_group_events:
     display_plugin: page
@@ -340,5 +301,4 @@ display:
         - url
         - url.query_args
         - user.group_permissions
-        - 'user.node_grants:view'
       tags: {  }

--- a/modules/social_features/social_group/config/optional/views.view.group_topics.yml
+++ b/modules/social_features/social_group/config/optional/views.view.group_topics.yml
@@ -232,44 +232,6 @@ display:
           entity_type: node
           entity_field: status
           plugin_id: boolean
-        nid:
-          id: nid
-          table: node_access
-          field: nid
-          relationship: gc__node
-          group_type: group
-          admin_label: ''
-          operator: '='
-          value: ''
-          group: 1
-          exposed: false
-          expose:
-            operator_id: ''
-            label: ''
-            description: ''
-            use_operator: false
-            operator: ''
-            identifier: ''
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-            operator_limit_selection: false
-            operator_list: {  }
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
-          plugin_id: node_access
         default_langcode:
           admin_label: ''
           entity_field: default_langcode
@@ -412,7 +374,6 @@ display:
         - 'url.query_args:sort_order'
         - user
         - user.group_permissions
-        - 'user.node_grants:view'
       tags: {  }
   page_group_topics:
     display_plugin: page
@@ -436,5 +397,4 @@ display:
         - 'url.query_args:sort_order'
         - user
         - user.group_permissions
-        - 'user.node_grants:view'
       tags: {  }

--- a/modules/social_features/social_group/config/update/social_group_update_13014.yml
+++ b/modules/social_features/social_group/config/update/social_group_update_13014.yml
@@ -1,0 +1,18 @@
+views.view.group_events:
+  expected_config: {  }
+  update_actions:
+    delete:
+      display:
+        default:
+          display_options:
+            filters:
+              nid: {  }
+views.view.group_topics:
+  expected_config: {  }
+  update_actions:
+    delete:
+      display:
+        default:
+          display_options:
+            filters:
+              nid: {  }

--- a/modules/social_features/social_group/modules/social_group_flexible_group/modules/social_flexible_group_book/config/install/views.view.group_books.yml
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/modules/social_flexible_group_book/config/install/views.view.group_books.yml
@@ -193,44 +193,6 @@ display:
           entity_type: node
           entity_field: status
           plugin_id: boolean
-        nid:
-          id: nid
-          table: node_access
-          field: nid
-          relationship: gc__node
-          group_type: group
-          admin_label: ''
-          operator: '='
-          value: ''
-          group: 1
-          exposed: false
-          expose:
-            operator_id: ''
-            label: ''
-            description: ''
-            use_operator: false
-            operator: ''
-            operator_limit_selection: false
-            operator_list: {  }
-            identifier: ''
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
-          plugin_id: node_access
         default_langcode:
           id: default_langcode
           table: node_field_data
@@ -410,7 +372,6 @@ display:
         - 'url.query_args:sort_by'
         - 'url.query_args:sort_order'
         - user.group_permissions
-        - 'user.node_grants:view'
       tags: {  }
   page_group_books:
     display_plugin: page
@@ -439,5 +400,4 @@ display:
         - 'url.query_args:sort_by'
         - 'url.query_args:sort_order'
         - user.group_permissions
-        - 'user.node_grants:view'
       tags: {  }

--- a/modules/social_features/social_group/modules/social_group_flexible_group/modules/social_flexible_group_book/config/update/social_flexible_group_book_update_13003.yml
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/modules/social_flexible_group_book/config/update/social_flexible_group_book_update_13003.yml
@@ -1,0 +1,9 @@
+views.view.group_books:
+  expected_config: {  }
+  update_actions:
+    delete:
+      display:
+        default:
+          display_options:
+            filters:
+              nid: {  }

--- a/modules/social_features/social_group/modules/social_group_flexible_group/modules/social_flexible_group_book/social_flexible_group_book.install
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/modules/social_flexible_group_book/social_flexible_group_book.install
@@ -128,3 +128,13 @@ function social_flexible_group_book_update_13002(): void {
   $config->set('text', $texts)
     ->save();
 }
+
+/**
+ * Remove redundant "node_access" views filter.
+ */
+function social_flexible_group_book_update_13003(): string {
+  /** @var \Drupal\update_helper\Updater $updater */
+  $updater = \Drupal::service('update_helper.updater');
+  $updater->executeUpdate('social_flexible_group_book', __FUNCTION__);
+  return $updater->logger()->output();
+}

--- a/modules/social_features/social_group/social_group.install
+++ b/modules/social_features/social_group/social_group.install
@@ -1015,3 +1015,13 @@ function social_group_update_13013(): void {
       ->save();
   }
 }
+
+/**
+ * Remove redundant "node_access" views filter.
+ */
+function social_group_update_13014(): string {
+  /** @var \Drupal\update_helper\Updater $updater */
+  $updater = \Drupal::service('update_helper.updater');
+  $updater->executeUpdate('social_group', __FUNCTION__);
+  return $updater->logger()->output();
+}

--- a/modules/social_features/social_topic/config/install/views.view.latest_topics.yml
+++ b/modules/social_features/social_topic/config/install/views.view.latest_topics.yml
@@ -136,44 +136,6 @@ display:
           expose:
             operator_limit_selection: false
             operator_list: {  }
-        nid:
-          id: nid
-          table: node_access
-          field: nid
-          relationship: none
-          group_type: group
-          admin_label: ''
-          operator: '='
-          value: ''
-          group: 1
-          exposed: false
-          expose:
-            operator_id: ''
-            label: ''
-            description: ''
-            use_operator: false
-            operator: ''
-            identifier: ''
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-            operator_limit_selection: false
-            operator_list: {  }
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
-          plugin_id: node_access
         default_langcode:
           admin_label: ''
           entity_field: default_langcode
@@ -253,7 +215,6 @@ display:
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
-        - 'user.node_grants:view'
         - user.permissions
       tags: {  }
   block_latest_topics:
@@ -280,7 +241,6 @@ display:
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
-        - 'user.node_grants:view'
         - user.permissions
       tags: {  }
   group_topics_block:
@@ -380,7 +340,6 @@ display:
         - 'languages:language_interface'
         - route
         - url
-        - 'user.node_grants:view'
         - user.permissions
       tags: {  }
   page_latest_topics:
@@ -501,44 +460,6 @@ display:
           hierarchy: false
           error_message: true
           plugin_id: taxonomy_index_tid
-        nid:
-          id: nid
-          table: node_access
-          field: nid
-          relationship: none
-          group_type: group
-          admin_label: ''
-          operator: '='
-          value: ''
-          group: 1
-          exposed: false
-          expose:
-            operator_id: ''
-            label: ''
-            description: ''
-            use_operator: false
-            operator: ''
-            identifier: ''
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-            operator_limit_selection: false
-            operator_list: {  }
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
-          plugin_id: node_access
         default_langcode:
           admin_label: ''
           entity_field: default_langcode
@@ -612,6 +533,5 @@ display:
         - 'url.query_args:sort_by'
         - 'url.query_args:sort_order'
         - user
-        - 'user.node_grants:view'
         - user.permissions
       tags: {  }

--- a/modules/social_features/social_topic/config/install/views.view.topics.yml
+++ b/modules/social_features/social_topic/config/install/views.view.topics.yml
@@ -227,44 +227,6 @@ display:
           plugin_id: boolean
           entity_type: node
           entity_field: status
-        nid:
-          id: nid
-          table: node_access
-          field: nid
-          relationship: none
-          group_type: group
-          admin_label: ''
-          operator: '='
-          value: ''
-          group: 1
-          exposed: false
-          expose:
-            operator_id: ''
-            label: ''
-            description: ''
-            use_operator: false
-            operator: ''
-            identifier: ''
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-            operator_limit_selection: false
-            operator_list: {  }
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
-          plugin_id: node_access
         default_langcode:
           admin_label: ''
           entity_field: default_langcode
@@ -394,7 +356,6 @@ display:
         - 'url.query_args:sort_by'
         - 'url.query_args:sort_order'
         - user
-        - 'user.node_grants:view'
         - user.permissions
       tags: {  }
   block_user_topics:
@@ -523,44 +484,6 @@ display:
           entity_type: node
           entity_field: status
           plugin_id: boolean
-        nid:
-          id: nid
-          table: node_access
-          field: nid
-          relationship: none
-          group_type: group
-          admin_label: ''
-          operator: '='
-          value: ''
-          group: 1
-          exposed: false
-          expose:
-            operator_id: ''
-            label: ''
-            description: ''
-            use_operator: false
-            operator: ''
-            identifier: ''
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-            operator_limit_selection: false
-            operator_list: {  }
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
-          plugin_id: node_access
         default_langcode:
           admin_label: ''
           entity_field: default_langcode
@@ -631,7 +554,6 @@ display:
         - 'languages:language_content'
         - 'languages:language_interface'
         - url
-        - 'user.node_grants:view'
         - user.permissions
       tags: {  }
   page_profile:
@@ -668,6 +590,5 @@ display:
         - 'url.query_args:sort_by'
         - 'url.query_args:sort_order'
         - user
-        - 'user.node_grants:view'
         - user.permissions
       tags: {  }

--- a/modules/social_features/social_topic/config/update/social_topic_update_130004.yml
+++ b/modules/social_features/social_topic/config/update/social_topic_update_130004.yml
@@ -1,0 +1,26 @@
+views.view.latest_topics:
+  expected_config: {  }
+  update_actions:
+    delete:
+      display:
+        default:
+          display_options:
+            filters:
+              nid: {  }
+        page_latest_topics:
+          display_options:
+            filters:
+              nid: {  }
+views.view.topics:
+  expected_config: {  }
+  update_actions:
+    delete:
+      display:
+        default:
+          display_options:
+            filters:
+              nid: {  }
+        block_user_topics:
+          display_options:
+            filters:
+              nid: {  }

--- a/modules/social_features/social_topic/social_topic.install
+++ b/modules/social_features/social_topic/social_topic.install
@@ -281,3 +281,13 @@ function social_topic_update_130003(): void {
     ->set('content', $content)
     ->save();
 }
+
+/**
+ * Remove redundant "node_access" views filter.
+ */
+function social_topic_update_130004(): string {
+  /** @var \Drupal\update_helper\Updater $updater */
+  $updater = \Drupal::service('update_helper.updater');
+  $updater->executeUpdate('social_topic', __FUNCTION__);
+  return $updater->logger()->output();
+}

--- a/modules/social_features/social_topic/tests/src/Kernel/GraphQL/QueryTopicTest.php
+++ b/modules/social_features/social_topic/tests/src/Kernel/GraphQL/QueryTopicTest.php
@@ -196,7 +196,7 @@ class QueryTopicTest extends SocialGraphQLTestBase {
         ->addCacheableDependency($topic)
         ->addCacheableDependency($topic->getOwner())
         ->addCacheTags(['taxonomy_term:1', 'config:filter.format.plain_text', 'config:filter.settings', 'comment:1'])
-        ->addCacheContexts(['languages:language_interface', 'user.node_grants:view', 'url.site'])
+        ->addCacheContexts(['languages:language_interface', 'url.site'])
     );
   }
 


### PR DESCRIPTION
> [!CAUTION]
> PR should be merged in #3961

> [!NOTE]  
> This PR doesn't require behat tests passing. Tests should be checked in #3961 

Remove the redundant "Content access" filter from views. 
More details about the reasons why we need this PR can be found at https://github.com/goalgorilla/open_social/pull/4098
