### PR TITLE
Issue #3481407: Cannot save alternative frontpage changes

### DIFF
--- a/modules/custom/social_path_manager/social_path_manager.module
+++ b/modules/custom/social_path_manager/social_path_manager.module
@@ -5,6 +5,8 @@
  * The Social Path Manager module.
  */
 
+use Drupal\Core\Entity\ContentEntityInterface;
+use Drupal\Core\Entity\EntityFormInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Url;
@@ -43,7 +45,13 @@ function social_path_manager_form_alter(&$form, FormStateInterface $form_state, 
   }
 
   // Add custom validation function.
-  $form['#validate'][] = "_social_path_manager_path_alias_validate";
+  // This is only applicable on all content entities which has field
+  // 'path' in the form.
+  if ($form_state->getFormObject() instanceof EntityFormInterface
+    && $form_state->getFormObject()->getEntity() instanceof ContentEntityInterface
+  ) {
+    $form['#validate'][] = "_social_path_manager_path_alias_validate";
+  }
 }
 
 /**


### PR DESCRIPTION
## Problem (for internal)
In https://www.drupal.org/project/social/issues/3468174 we added a validation handler. This validation handler is also triggering on submission of form at /admin/config/alternative_frontpage which is causing an issue on `$path_alias = end($path_alias);`

## Solution (for internal)
So, we have added a check in form alter that the validation should only trigger on content entity's which are nodes and groups in our case.

## Release notes (to customers)
We resolved an issue which was faced by site mangers while updating alternative frontpage settings. As SM, you should be able to make changes to alternative frontpage settings.

## Issue tracker
https://www.drupal.org/project/social/issues/3481407

## Theme issue tracker
N.A

## How to test
- [ ] Using latest version of Open Social with the alternative frontpage module enabled
- [ ] As a sitemanager
- [ ] Try to add alternative frontpages
- [ ] or, try to edit an existing setting
- [ ] You should be able to save your settings


## Change Record
N.A

## Translations
N.A