### PR TITLE
PROD-30877: Implement "event removed" event for the EDA

### DIFF
--- a/modules/social_features/social_event/social_event.module
+++ b/modules/social_features/social_event/social_event.module
@@ -1130,6 +1130,16 @@ function social_event_node_update(EntityInterface $entity): void {
 }
 
 /**
+ * Implements hook_ENTITY_TYPE_delete().
+ */
+function social_event_node_delete(EntityInterface $entity): void {
+  if ($entity instanceof NodeInterface && $entity->getType() === 'event') {
+    // Trigger the EDA event.
+    \Drupal::service('social_event.eda_handler')->eventDelete($entity);
+  }
+}
+
+/**
  * Implements template_preprocess_views_view().
  */
 function social_event_preprocess_views_view(&$variables) {

--- a/modules/social_features/social_event/tests/src/Unit/EdaHandlerTest.php
+++ b/modules/social_features/social_event/tests/src/Unit/EdaHandlerTest.php
@@ -313,6 +313,30 @@ class EdaHandlerTest extends UnitTestCase {
   }
 
   /**
+   * Test the eventDelete() method.
+   *
+   * @covers ::eventDelete
+   */
+  public function testEventDelete(): void {
+    // Create the handler instance.
+    $handler = $this->getMockedHandler();
+
+    // Create the event object.
+    $event = $handler->fromEntity($this->node, 'com.getopensocial.cms.event.delete', 'delete');
+
+    // Expect the dispatch method in the dispatcher to be called.
+    $this->dispatcher->expects($this->once())
+      ->method('dispatch')
+      ->with(
+        $this->equalTo('com.getopensocial.cms.event.delete'),
+        $this->equalTo($event)
+      );
+
+    // Call the eventDelete method.
+    $handler->eventDelete($this->node);
+  }
+
+  /**
    * Test the $this->eventUnpublish() method.
    *
    * @covers ::eventUnpublish


### PR DESCRIPTION
## Description
This pull request introduces the new EDA event "event removed" which is dispatched to the Kafka topic `com.getopensocial.cms.event.delete`. The event is triggered on `hook_ENTITY_TYPE_delete()`.

An example of the payload:

```
{
	"specversion": "1.0",
	"id": "893a6d20-e982-40b6-9253-d585b025c931",
	"source": "/node/25/delete",
	"type": "com.getopensocial.cms.event.delete",
	"datacontenttype": "application/json",
	"time": "2024-09-30T14:08:38Z",
	"data": {
		"event": {
			"id": "b2b88fb5-5bd9-4508-b63b-8d95eed628c1",
			"created": "2024-09-30T14:08:38",
			"updated": "2024-10-03T13:26:46",
			"status": "removed",
			"label": "Event test 2",
			"visibility": {
				"type": "community",
				"groups": [],
				"roles": []
			},
			"group": null,
			"author": {
				"id": "b0dc9a92-7e00-425d-a307-e6fb8418a69b",
				"displayName": "admin",
				"href": {
					"canonical": "http://cablecar.localhost/user/1/home"
				}
			},
			"allDay": true,
			"start": "2024-09-30T00:00:00",
			"end": "2024-10-01T00:00:00",
			"timezone": "UTC",
			"address": {
				"label": "",
				"countryCode": "",
				"administrativeArea": "",
				"locality": "",
				"dependentLocality": "",
				"postalCode": "",
				"sortingCode": "",
				"addressLine1": "",
				"addressLine2": ""
			},
			"enrollment": {
				"enabled": true,
				"method": "request"
			},
			"href": {
				"canonical": "http://cablecar.localhost/node/25"
			},
			"type": null
		},
		"actor": {
			"application": null,
			"user": {
				"id": "b0dc9a92-7e00-425d-a307-e6fb8418a69b",
				"displayName": "admin",
				"href": {
					"canonical": "http://cablecar.localhost/user/1/home"
				}
			}
		}
	}
}
```

## Issue tracker
https://getopensocial.atlassian.net/browse/PROD-30877

## Theme issue tracker
N/A

## How to test
- [ ] Checkout branch `issue/PROD-30877-eda-event-removed` of 'open_social'
- [ ] Enable the modules `social_eda` and `social_eda_dispatcher`
- [ ] Delete any node of type event

## Screenshots
N/A

## Release notes
N/A 

## Change Record
N/A 

## Translations
<!--
*[Optional]Translatable strings are always extracted from the latest development branch. To ensure translations remain available for platforms running older versions of Open Social the original string should be added to `translations.php` when it's changed or removed.*
- [ ] Changed or removed source strings are added to the `translations.php` file.
-->
