### PR TITLE
Hotfix: fix group redirection

### DIFF
--- a/modules/social_features/social_group/modules/social_group_default_route/social_group_default_route.services.yml
+++ b/modules/social_features/social_group/modules/social_group_default_route/social_group_default_route.services.yml
@@ -1,10 +1,13 @@
 services:
   social_group_default_route.redirect_subscriber:
     class: Drupal\social_group_default_route\EventSubscriber\RedirectSubscriber
-    arguments: ['@current_route_match', '@current_user']
+    arguments: ['@current_route_match', '@current_user', '@social_group_default_route.redirect_service']
     tags:
       - { name: event_subscriber }
   social_group_default_route.route_subscriber:
     class: Drupal\social_group_default_route\RouteSubscriber\RouteSubscriber
     tags:
       - { name: event_subscriber, priority: 3 }
+  social_group_default_route.redirect_service:
+    class: Drupal\social_group_default_route\RedirectService
+    arguments: [ '@current_route_match', '@current_user' ]

--- a/modules/social_features/social_group/modules/social_group_default_route/src/EventSubscriber/RedirectSubscriber.php
+++ b/modules/social_features/social_group/modules/social_group_default_route/src/EventSubscriber/RedirectSubscriber.php
@@ -4,14 +4,10 @@ namespace Drupal\social_group_default_route\EventSubscriber;
 
 use Drupal\Core\Routing\CurrentRouteMatch;
 use Drupal\Core\Session\AccountProxy;
-use Drupal\Core\Url;
-use Drupal\group\Entity\Group;
 use Drupal\social_group\SocialGroupInterface;
+use Drupal\social_group_default_route\RedirectService;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Symfony\Component\HttpFoundation\RedirectResponse;
-use Symfony\Component\HttpKernel\Event\ExceptionEvent;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
-use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\KernelEvents;
 
 /**
@@ -20,26 +16,6 @@ use Symfony\Component\HttpKernel\KernelEvents;
  * @package Drupal\social_group_default_route\EventSubscriber
  */
 class RedirectSubscriber implements EventSubscriberInterface {
-
-  /**
-   * The route name of the default page of any group type except closed groups.
-   */
-  private const DEFAULT_ROUTE = 'social_group.stream';
-
-  /**
-   * The route name of the group default page is provided by the current module.
-   */
-  private const ALTERNATIVE_ROUTE = 'social_group_default.group_home';
-
-  /**
-   * The route name of the default page of any group.
-   */
-  private const DEFAULT_GROUP_ROUTE = 'entity.group.canonical';
-
-  /**
-   * The route name of the default page of closed groups.
-   */
-  private const DEFAULT_CLOSED_ROUTE = 'view.group_information.page_group_about';
 
   /**
    * The current route.
@@ -56,16 +32,26 @@ class RedirectSubscriber implements EventSubscriberInterface {
   protected $currentUser;
 
   /**
+   * The redirect service.
+   *
+   * @var \Drupal\social_group_default_route\RedirectService
+   */
+  protected RedirectService $redirectService;
+
+  /**
    * RedirectSubscriber constructor.
    *
    * @param \Drupal\Core\Routing\CurrentRouteMatch $route_match
    *   The current route.
    * @param \Drupal\Core\Session\AccountProxy $current_user
    *   The current user.
+   * @param \Drupal\social_group_default_route\RedirectService $redirect_service
+   *   The redirect service.
    */
-  public function __construct(CurrentRouteMatch $route_match, AccountProxy $current_user) {
+  public function __construct(CurrentRouteMatch $route_match, AccountProxy $current_user, RedirectService $redirect_service) {
     $this->currentRoute = $route_match;
     $this->currentUser = $current_user;
+    $this->redirectService = $redirect_service;
   }
 
   /**
@@ -73,7 +59,6 @@ class RedirectSubscriber implements EventSubscriberInterface {
    */
   public static function getSubscribedEvents() {
     $events[KernelEvents::REQUEST][] = ['groupLandingPage'];
-    $events[KernelEvents::EXCEPTION][] = ['onKernelException', 100];
     return $events;
   }
 
@@ -89,8 +74,8 @@ class RedirectSubscriber implements EventSubscriberInterface {
 
     // Not group canonical, then we leave.
     if (
-      $route_name !== self::DEFAULT_GROUP_ROUTE &&
-      $route_name !== self::ALTERNATIVE_ROUTE
+      $route_name !== $this->redirectService::DEFAULT_GROUP_ROUTE &&
+      $route_name !== $this->redirectService::ALTERNATIVE_ROUTE
     ) {
       return;
     }
@@ -103,79 +88,7 @@ class RedirectSubscriber implements EventSubscriberInterface {
       return;
     }
 
-    $this->doRedirect($event, $group);
-  }
-
-  /**
-   * Redirect on exceptions.
-   *
-   * @param \Symfony\Component\HttpKernel\Event\ExceptionEvent $event
-   *   The exception event.
-   */
-  public function onKernelException(ExceptionEvent $event): void {
-    $exception = $event->getThrowable();
-    if ($exception instanceof AccessDeniedHttpException) {
-      // Check if there is a group object on the current route.
-      $group = $this->currentRoute->getParameter('group');
-      // On some routes group param could be string.
-      if (is_string($group)) {
-        $group = Group::load($group);
-      }
-
-      if (!$group instanceof SocialGroupInterface) {
-        return;
-      }
-      // Do not redirect form access denied if user doesn't have access to
-      // view the group (secret group, etc.).
-      if (!$group->access('view', $this->currentUser)) {
-        return;
-      }
-
-      $this->doRedirect($event, $group);
-    }
-
-  }
-
-  /**
-   * Do redirect.
-   *
-   * @param \Symfony\Component\HttpKernel\Event\ExceptionEvent|\Symfony\Component\HttpKernel\Event\RequestEvent $event
-   *   The event object.
-   * @param \Drupal\social_group\SocialGroupInterface $group
-   *   The group object.
-   */
-  protected function doRedirect(ExceptionEvent|RequestEvent $event, SocialGroupInterface $group): void {
-    $route_name = $this->currentRoute->getRouteName();
-    // Check if current user is a member.
-    if (!$group->hasMember($this->currentUser)) {
-      /** @var string|null $route */
-      $route = $group->default_route_an->value;
-
-      if ($route === NULL) {
-        $route = self::DEFAULT_CLOSED_ROUTE;
-      }
-    }
-    else {
-      /** @var string|null $route */
-      $route = $group->default_route->value;
-
-      // Still no route here? Then we use the normal default.
-      if ($route === NULL) {
-        $route = self::DEFAULT_ROUTE;
-      }
-    }
-
-    // Determine the URL we want to redirect to.
-    $url = Url::fromRoute($route, ['group' => $group->id()]);
-
-    // If it's not set, set to canonical, or the current user has no access.
-    if ($route === $route_name || $url->access($this->currentUser) === FALSE) {
-      // This basically means that the normal flow remains intact.
-      return;
-    }
-
-    // Redirect.
-    $event->setResponse(new RedirectResponse($url->toString()));
+    $this->redirectService->doRedirect($event, $group);
   }
 
 }

--- a/modules/social_features/social_group/modules/social_group_default_route/src/RedirectService.php
+++ b/modules/social_features/social_group/modules/social_group_default_route/src/RedirectService.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Drupal\social_group_default_route;
+
+use Drupal\Core\Routing\CurrentRouteMatch;
+use Drupal\Core\Session\AccountProxy;
+use Drupal\Core\Url;
+use Drupal\social_group\SocialGroupInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpKernel\Event\ExceptionEvent;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+
+/**
+ * Class RedirectService.
+ */
+class RedirectService {
+
+  /**
+   * The route name of the default page of any group type except closed groups.
+   */
+  public const DEFAULT_ROUTE = 'social_group.stream';
+
+  /**
+   * The route name of the group default page is provided by the current module.
+   */
+  public const ALTERNATIVE_ROUTE = 'social_group_default.group_home';
+
+  /**
+   * The route name of the default page of any group.
+   */
+  public const DEFAULT_GROUP_ROUTE = 'entity.group.canonical';
+
+  /**
+   * The route name of the default page of closed groups.
+   */
+  public const DEFAULT_CLOSED_ROUTE = 'view.group_information.page_group_about';
+
+  /**
+   * RedirectSubscriber constructor.
+   *
+   * @param \Drupal\Core\Routing\CurrentRouteMatch $routeMatch
+   *   The current route.
+   * @param \Drupal\Core\Session\AccountProxy $currentUser
+   *   The current user.
+   */
+  public function __construct(
+    protected CurrentRouteMatch $routeMatch,
+    protected AccountProxy $currentUser
+  ) {
+  }
+
+  /**
+   * Do redirect.
+   *
+   * @param \Symfony\Component\HttpKernel\Event\ExceptionEvent|\Symfony\Component\HttpKernel\Event\RequestEvent $event
+   *   The event object.
+   * @param \Drupal\social_group\SocialGroupInterface $group
+   *   The group object.
+   */
+  public function doRedirect(ExceptionEvent|RequestEvent $event, SocialGroupInterface $group): void {
+    $route_name = $this->routeMatch->getRouteName();
+    // Check if current user is a member.
+    if (!$group->hasMember($this->currentUser)) {
+      /** @var string|null $route */
+      $route = $group->default_route_an->value;
+
+      if ($route === NULL) {
+        $route = self::DEFAULT_CLOSED_ROUTE;
+      }
+    }
+    else {
+      /** @var string|null $route */
+      $route = $group->default_route->value;
+
+      // Still no route here? Then we use the normal default.
+      if ($route === NULL) {
+        $route = self::DEFAULT_ROUTE;
+      }
+    }
+
+    // Determine the URL we want to redirect to.
+    $url = Url::fromRoute($route, ['group' => $group->id()]);
+
+    // If it's not set, set to canonical, or the current user has no access.
+    if ($route === $route_name || $url->access($this->currentUser) === FALSE) {
+      // This basically means that the normal flow remains intact.
+      return;
+    }
+
+    // Redirect.
+    $event->setResponse(new RedirectResponse($url->toString()));
+  }
+
+}

--- a/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.services.yml
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.services.yml
@@ -21,7 +21,7 @@ services:
 
   social_group_flexible_group.redirect_subscriber:
     class: Drupal\social_group_flexible_group\EventSubscriber\RedirectSubscriber
-    arguments: ['@current_user', '@current_route_match']
+    arguments: ['@current_user', '@current_route_match', '@social_group_default_route.redirect_service']
     tags:
       - { name: event_subscriber }
 

--- a/modules/social_features/social_group/modules/social_group_flexible_group/src/EventSubscriber/RedirectSubscriber.php
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/src/EventSubscriber/RedirectSubscriber.php
@@ -4,11 +4,13 @@ namespace Drupal\social_group_flexible_group\EventSubscriber;
 
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\Session\AccountProxyInterface;
-use Drupal\Core\Url;
-use Drupal\group\Entity\GroupInterface;
+use Drupal\group\Entity\Group;
+use Drupal\social_group\SocialGroupInterface;
+use Drupal\social_group_default_route\RedirectService;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpKernel\Event\ExceptionEvent;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\KernelEvents;
 
 /**
@@ -33,19 +35,30 @@ class RedirectSubscriber implements EventSubscriberInterface {
   protected $routeMatch;
 
   /**
+   * The redirect service.
+   *
+   * @var \Drupal\social_group_default_route\RedirectService
+   */
+  protected RedirectService $redirectService;
+
+  /**
    * RedirectSubscriber constructor.
    *
    * @param \Drupal\Core\Session\AccountProxyInterface $current_user
    *   The current active user.
    * @param \Drupal\Core\Routing\RouteMatchInterface $route_match
    *   The currently active route match object.
+   * @param \Drupal\social_group_default_route\RedirectService $redirect_service
+   *   The redirect service.
    */
   public function __construct(
     AccountProxyInterface $current_user,
-    RouteMatchInterface $route_match
+    RouteMatchInterface $route_match,
+    RedirectService $redirect_service
   ) {
     $this->currentUser = $current_user;
     $this->routeMatch = $route_match;
+    $this->redirectService = $redirect_service;
   }
 
   /**
@@ -56,6 +69,7 @@ class RedirectSubscriber implements EventSubscriberInterface {
    */
   public static function getSubscribedEvents() {
     $events[KernelEvents::REQUEST][] = ['checkForRedirection'];
+    $events[KernelEvents::EXCEPTION][] = ['onKernelException', 100];
     return $events;
   }
 
@@ -101,31 +115,56 @@ class RedirectSubscriber implements EventSubscriberInterface {
       $route_name === 'entity.group.join' &&
       !social_group_flexible_group_can_join_directly($group)
     ) {
-      $this->doRedirect($event, $group);
+      $this->redirectService->doRedirect($event, $group);
     }
     elseif (
       in_array($route_name, $routes) &&
       !social_group_flexible_group_community_enabled($group) &&
       !social_group_flexible_group_public_enabled($group)
     ) {
-      $this->doRedirect($event, $group);
+      $this->redirectService->doRedirect($event, $group);
     }
   }
 
   /**
-   * Makes redirect to the "About" group tab.
+   * Redirect on exceptions.
    *
-   * @param \Symfony\Component\HttpKernel\Event\RequestEvent $event
-   *   The event.
-   * @param \Drupal\group\Entity\GroupInterface $group
-   *   The group.
+   * @param \Symfony\Component\HttpKernel\Event\ExceptionEvent $event
+   *   The exception event.
    */
-  protected function doRedirect(RequestEvent $event, GroupInterface $group) {
-    $url = Url::fromRoute('view.group_information.page_group_about', [
-      'group' => $group->id(),
-    ]);
+  public function onKernelException(ExceptionEvent $event): void {
+    $route_name = $this->routeMatch->getRouteName();
+    // Do not redirect from group content pages.
+    if ($route_name && preg_match('/^entity\.group_content\..*/', $route_name)) {
+      return;
+    }
+    $exception = $event->getThrowable();
 
-    $event->setResponse(new RedirectResponse($url->toString()));
+    if ($exception instanceof AccessDeniedHttpException) {
+      // Check if there is a group object on the current route.
+      $group = $this->routeMatch->getParameter('group');
+      // On some routes group param could be string.
+      if (is_string($group)) {
+        $group = Group::load($group);
+      }
+
+      if (!$group instanceof SocialGroupInterface) {
+        return;
+      }
+
+      // If a group type is flexible group.
+      if ($group->bundle() !== 'flexible_group') {
+        return;
+      }
+      // Do not redirect form access denied if user doesn't have access to
+      // view the group (secret group, etc.).
+      if (!$group->access('view', $this->currentUser)) {
+        return;
+      }
+
+      $this->redirectService->doRedirect($event, $group);
+    }
+
   }
 
 }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -7419,11 +7419,6 @@ parameters:
 			path: modules/social_features/social_group/modules/social_group_flexible_group/src/EventSubscriber/RedirectSubscriber.php
 
 		-
-			message: "#^Method Drupal\\\\social_group_flexible_group\\\\EventSubscriber\\\\RedirectSubscriber\\:\\:doRedirect\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: modules/social_features/social_group/modules/social_group_flexible_group/src/EventSubscriber/RedirectSubscriber.php
-
-		-
 			message: "#^Not allowed to call private function _social_group_get_current_group from module social_group_flexible_group\\.$#"
 			count: 1
 			path: modules/social_features/social_group/modules/social_group_flexible_group/src/EventSubscriber/RedirectSubscriber.php


### PR DESCRIPTION
## Problem (for internal)
After implementing Group redirection on Access Denied exception some issues occurred - on group content creation, the user was redirected to the "About" page, but it shouldn't. Also for some groups, this redirection shouldn't be applied.

## Solution (for internal)
Exclude group content routes from redirections, add hook `hook_social_group_default_route_excluded_groups_alter` to provide API to exclude group bundle from redirection behavior.

## Release notes (to customers)
Fixed group redirections.

## Issue tracker
https://www.drupal.org/project/social/issues/3477793
https://getopensocial.atlassian.net/browse/PROD-28608

## How to test
- [ ] Install module "social_group" and "social_group_flexible_group" and "social_group_default_route"
- [ ] Create public "Flexible" group "Test public group", in settings chose default landing page for non-members - "About", for members "Stream", otherwise the default link of group for non-members will be "Stream" and non-members will get Access denied
- [ ] Create AU -  "AU test"
- [ ] Create VU -  "VU test"
- [ ] Create VU -  "VU member"
- [ ] Add "VU member" as member to "Test public group"
- [ ] As a user "AU test" - go to page `group/1/stream` - you should be redirected to the "About" page
- [ ] As a user "AU test" - go to page `group/1/members` - you should be redirected to the "About" page
- [ ]  For AN user the same behavior
- [ ] As "VU member" - go to page `group/1/stream` - it should be accessible
- [ ] As "VU member" - go to page `group/1/members` - it should be accessible
- [ ] Create a secret "Flexible" group "Test secret group" with "Group members only" visibility
- [ ] As a user "AU test" or AN  - go to page `group/1/stream` - you should get "Access Denied"
- [ ] As a user "AU test" - go to page `group/1/members` - you should get "Access Denied"
