### PR TITLE
Issue #3482245: User group invite view has old group v1 references breaking the handler

### DIFF
--- a/modules/social_features/social_group/modules/social_group_invite/config/optional/views.view.social_group_user_invitations.yml
+++ b/modules/social_features/social_group/modules/social_group_invite/config/optional/views.view.social_group_user_invitations.yml
@@ -216,7 +216,7 @@ display:
           plugin_id: field
         group_membership_count:
           id: group_membership_count
-          table: group_content
+          table: group_relationship
           field: group_membership_count
           relationship: none
           group_type: group

--- a/modules/social_features/social_group/modules/social_group_invite/config/update/social_group_invite_update_13004.yml
+++ b/modules/social_features/social_group/modules/social_group_invite/config/update/social_group_invite_update_13004.yml
@@ -1,0 +1,11 @@
+views.view.social_group_user_invitations:
+  expected_config: {  }
+  update_actions:
+    change:
+      display:
+        default:
+          display_options:
+            fields:
+              group_membership_count:
+                relationship: none
+                table: group_relationship

--- a/modules/social_features/social_group/modules/social_group_invite/social_group_invite.install
+++ b/modules/social_features/social_group/modules/social_group_invite/social_group_invite.install
@@ -148,3 +148,17 @@ function social_group_invite_update_13003() : string {
   // Output logged messages to related channel of update execution.
   return $updater->logger()->output();
 }
+
+/**
+ * Update group_invite views config to use a correct table - membership count.
+ */
+function social_group_invite_update_13004(): string {
+  /** @var \Drupal\update_helper\Updater $updater */
+  $updater = \Drupal::service('update_helper.updater');
+
+  // Execute configuration update definitions with logging of success.
+  $updater->executeUpdate('social_group_invite', 'social_group_invite_update_13004');
+
+  // Output logged messages to related channel of update execution.
+  return $updater->logger()->output();
+}

--- a/modules/social_features/social_group/social_group.views.inc
+++ b/modules/social_features/social_group/social_group.views.inc
@@ -35,7 +35,7 @@ function social_group_views_data_alter(array &$data) {
   ];
 
   // Field with the count of group members.
-  $data['group_content']['group_membership_count'] = [
+  $data['group_relationship']['group_membership_count'] = [
     'title' => t('Membership count'),
     'field' => [
       'title' => t('Membership count'),


### PR DESCRIPTION
## Problem (for internal)
During the group v2 update we forgot to update all the table references in the user group invite view. This causes the view to show a broken handler. 

For some reason it didn't break functionally.

## Solution (for internal)
Update the tables for the membership count in the user group invite view to be compatible with group v2

<!-- [Optional] If this Pull Request makes visual changes then please include some screenshots that show what has changed here. A before and after screenshot helps the reviewer determine what changes were made. -->

## Release notes (to customers)
None - For customers nothing actually changes as the functionality itself was not broken.

## Issue tracker
https://www.drupal.org/project/social/issues/3482245

## Theme issue tracker
<!-- *[Required if applicable] Paste a link to the drupal.org theme issue queue item, either from [socialbase](https://www.drupal.org/project/socialbase) or [socialblue](https://www.drupal.org/project/socialblue). If any other issue trackers were used, include links to those too.* -->

## How to test
- [ ] Do a clean install of open social.
- [ ] Enable views_ui and go to /admin/structure/views/view/social_group_user_invitations/edit/page_1
- [ ] See that the membership_count field is broken
- [ ] Check out to this branch and run a drush updb and check again to see it's fixed.

Functional:
- [ ] After verifying the last step that the view is correct. Create a group
- [ ] Go to membership page and invite a second user that has been created already
- [ ] Now login as this second user and go to /user/[user-id]/group-invites
- [ ] You should see the group invite with the correct count of members in the group.
- [ ] Also try to add more members to the group and see this count should be correct.


## Change Record
<!-- *[Required if applicable] If this Pull Request changes the way that developers should do things or introduces a new API for developers then a change record to document this is needed. Please provide a draft for a change record or a link to an unpublished change record below. Existing change records can be consulted as example. Please provide a draft for a change record or a link to an unpublished change record below. [Existing change records](https://www.drupal.org/list-changes/social) can be consulted as example.* -->

## Translations
<!--
*[Optional]Translatable strings are always extracted from the latest development branch. To ensure translations remain available for platforms running older versions of Open Social the original string should be added to `translations.php` when it's changed or removed.*
- [ ] Changed or removed source strings are added to the `translations.php` file.
-->
