### PR TITLE
PROD-30972: Implement "user enrolls to event" event for the EDA

### DIFF
--- a/modules/social_features/social_event/asyncapi.yml
+++ b/modules/social_features/social_event/asyncapi.yml
@@ -568,7 +568,233 @@ channels:
                       type: string
                       nullable: true
                       description: The type of the event.
-
+  eventEnrollmentCreate:
+    address: com.getopensocial.event.enrollment.create
+    messages:
+      eventEnrollmentCreate:
+        payload:
+          allOf:
+            - $ref: '#/components/schemas/cloudEventsSchema'
+            - type: object
+              properties:
+                data:
+                  type: object
+                  properties:
+                    eventEnrollment:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                          description: The UUID of the enrollment.
+                        created:
+                          type: string
+                          format: date-time
+                          description: The creation time of the enrollment.
+                        updated:
+                          type: string
+                          format: date-time
+                          description: The last updated time of the enrollment.
+                        status:
+                          type: string
+                          description: The status of the enrollment.
+                          enum:
+                            - approved
+                            - pending
+                            - rejected
+                        event:
+                          type: object
+                          properties:
+                            id:
+                              type: string
+                              description: The UUID of the event.
+                            created:
+                              type: string
+                              format: date-time
+                              description: The creation time of the event.
+                            updated:
+                              type: string
+                              format: date-time
+                              description: The last updated time of the event.
+                            status:
+                              type: string
+                              description: The status of the event.
+                              enum:
+                                - published
+                                - unpublished
+                            label:
+                              type: string
+                              description: The label of the event.
+                            visibility:
+                              type: object
+                              properties:
+                                type:
+                                  type: string
+                                  description: The visibility type.
+                                  enum:
+                                    - public
+                                    - community
+                                    - groups
+                                    - roles
+                                groups:
+                                  type: array
+                                  description: List of group UUIDs (only applicable for "groups" visibility).
+                                roles:
+                                  type: array
+                                  description: List of role IDs (only applicable for "roles" visibility).
+                            type:
+                              type: string
+                              nullable: true
+                              description: The type of the event.
+                            group:
+                              type: object
+                              nullable: true
+                              properties:
+                                id:
+                                  type: string
+                                  description: The UUID of the group.
+                                label:
+                                  type: string
+                                  description: The label of the group.
+                                href:
+                                  type: object
+                                  properties:
+                                    canonical:
+                                      type: string
+                                      format: uri
+                                      description: Canonical URL of the group.
+                            author:
+                              type: object
+                              properties:
+                                id:
+                                  type: string
+                                  description: The UUID of the author.
+                                displayName:
+                                  type: string
+                                  description: The display name of the author.
+                                href:
+                                  type: object
+                                  properties:
+                                    canonical:
+                                      type: string
+                                      format: uri
+                                      description: Canonical URL of the author.
+                            allDay:
+                              type: boolean
+                              description: Indicates if the event lasts all day.
+                            start:
+                              type: string
+                              format: date-time
+                              description: The start time of the event.
+                            end:
+                              type: string
+                              format: date-time
+                              description: The end time of the event.
+                            timezone:
+                              type: string
+                              description: The timezone of the event.
+                            address:
+                              type: object
+                              properties:
+                                label:
+                                  type: string
+                                  description: The label of the event location.
+                                countryCode:
+                                  type: string
+                                  description: The country code of the event location.
+                                administrativeArea:
+                                  type: string
+                                  description: The administrative area of the event location.
+                                locality:
+                                  type: string
+                                  description: The locality of the event location.
+                                dependentLocality:
+                                  type: string
+                                  description: The dependent locality of the event location.
+                                postalCode:
+                                  type: string
+                                  description: The postal code of the event location.
+                                sortingCode:
+                                  type: string
+                                  description: The sorting code of the event location.
+                                addressLine1:
+                                  type: string
+                                  description: The first address line of the event location.
+                                addressLine2:
+                                  type: string
+                                  description: The second address line of the event location.
+                            enrollment:
+                              type: object
+                              properties:
+                                enabled:
+                                  type: boolean
+                                  description: Indicates if enrollment is enabled.
+                                method:
+                                  type: string
+                                  description: The method of enrollment.
+                                  enum:
+                                    - open
+                                    - invite
+                                    - request
+                            href:
+                              type: object
+                              properties:
+                                canonical:
+                                  type: string
+                                  format: uri
+                                  description: Canonical URL of the event.
+                        user:
+                          type: object
+                          properties:
+                            id:
+                              type: string
+                              nullable: true
+                              description: The UUID of the user (empty if anonymous).
+                            displayName:
+                              type: string
+                              description: The display name of the user.
+                            email:
+                              type: string
+                              format: email
+                              nullable: true
+                              description: The email of the user (present if anonymous).
+                            href:
+                              type: object
+                              properties:
+                                canonical:
+                                  type: string
+                                  format: uri
+                                  description: Canonical URL of the user.
+                    actor:
+                      type: object
+                      properties:
+                        application:
+                          type: object
+                          nullable: true
+                          properties:
+                            id:
+                              type: string
+                              description: The UUID of the application.
+                            name:
+                              type: string
+                              description: The name of the application.
+                        user:
+                          type: object
+                          nullable: true
+                          properties:
+                            id:
+                              type: string
+                              nullable: true
+                              description: The UUID of the user (empty if anonymous).
+                            displayName:
+                              type: string
+                              description: The display name of the user.
+                            href:
+                              type: object
+                              properties:
+                                canonical:
+                                  type: string
+                                  format: uri
+                                  description: Canonical URL of the user.
 operations:
   onEventCreate:
     action: 'receive'
@@ -586,3 +812,7 @@ operations:
     action: 'receive'
     channel:
       $ref: '#/channels/eventUpdate'
+  onEventEnrollmentCreate:
+    action: 'receive'
+    channel:
+      $ref: '#/channels/eventEnrollmentCreate'

--- a/modules/social_features/social_event/social_event.module
+++ b/modules/social_features/social_event/social_event.module
@@ -30,6 +30,7 @@ use Drupal\menu_link_content\MenuLinkContentInterface;
 use Drupal\node\Entity\Node;
 use Drupal\node\NodeInterface;
 use Drupal\social_event\Controller\SocialEventController;
+use Drupal\social_event\Entity\EventEnrollment;
 use Drupal\social_event\Entity\Node\Event;
 use Drupal\social_event\EventEnrollmentInterface;
 use Drupal\social_event\SocialEventDateAllDay;
@@ -267,6 +268,37 @@ function social_event_views_query_alter(ViewExecutable $view, QueryPluginBase $q
         'operator' => '=',
       ];
     }
+  }
+}
+
+/**
+ * Implements hook_entity_insert().
+ */
+function social_event_entity_insert(EntityInterface $entity): void {
+  if ($entity instanceof EventEnrollment) {
+
+    // Invite or user requests statuses.
+    $invite_or_request_statuses = [
+      EventEnrollmentInterface::REQUEST_PENDING,
+      EventEnrollmentInterface::REQUEST_APPROVED,
+      EventEnrollmentInterface::REQUEST_OR_INVITE_DECLINED,
+      EventEnrollmentInterface::INVITE_INVITED,
+      EventEnrollmentInterface::INVITE_PENDING_REPLY,
+      EventEnrollmentInterface::INVITE_ACCEPTED_AND_JOINED,
+      EventEnrollmentInterface::INVITE_INVALID_OR_EXPIRED,
+    ];
+
+    if (!$entity->get('field_request_or_invite_status')->isEmpty() &&
+      in_array(
+        (int) $entity->get('field_request_or_invite_status')->getString(),
+        $invite_or_request_statuses
+      )
+    ) {
+      return;
+    }
+
+    \Drupal::service('social_event.eda_event_enrollment_handler')
+      ->eventEnrollmentCreate($entity);
   }
 }
 

--- a/modules/social_features/social_event/social_event.services.yml
+++ b/modules/social_features/social_event/social_event.services.yml
@@ -24,3 +24,8 @@ services:
     class: Drupal\social_event\EdaHandler
     tags:
       - { name: social.eda.handler }
+  social_event.eda_event_enrollment_handler:
+    autowire: true
+    class: Drupal\social_event\EdaEventEnrollmentHandler
+    tags:
+      - { name: social.eda.handler }

--- a/modules/social_features/social_event/src/EdaEventEnrollmentHandler.php
+++ b/modules/social_features/social_event/src/EdaEventEnrollmentHandler.php
@@ -1,0 +1,245 @@
+<?php
+
+namespace Drupal\social_event;
+
+use CloudEvents\V1\CloudEvent;
+use Drupal\Component\Uuid\UuidInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Extension\ModuleHandlerInterface;
+use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\Core\Session\AccountProxyInterface;
+use Drupal\social_eda\Types\Address;
+use Drupal\social_eda\Types\Application;
+use Drupal\social_eda\Types\ContentVisibility;
+use Drupal\social_eda\Types\DateTime;
+use Drupal\social_eda\Types\Entity;
+use Drupal\social_eda\Types\Href;
+use Drupal\social_eda\Types\User;
+use Drupal\social_event\Event\EventEntityData;
+use Drupal\user\UserInterface;
+use Drupal\node\NodeInterface;
+use Drupal\social_eda\DispatcherInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/**
+ * Handles invocations for EDA related operations of event enrollment entity.
+ */
+final class EdaEventEnrollmentHandler {
+
+  /**
+   * The current logged-in user.
+   *
+   * @var \Drupal\user\UserInterface|null
+   */
+  protected ?UserInterface $currentUser = NULL;
+
+  /**
+   * The source.
+   *
+   * @var string
+   */
+  protected string $source;
+
+  /**
+   * The current route name.
+   *
+   * @var string
+   */
+  protected string $routeName;
+
+  /**
+   * {@inheritDoc}
+   */
+  public function __construct(
+    private readonly DispatcherInterface $dispatcher,
+    private readonly UuidInterface $uuid,
+    private readonly RequestStack $requestStack,
+    private readonly ModuleHandlerInterface $moduleHandler,
+    private readonly EntityTypeManagerInterface $entityTypeManager,
+    private readonly AccountProxyInterface $account,
+    private readonly RouteMatchInterface $routeMatch,
+  ) {
+    // Load the full user entity if the account is authenticated.
+    $account_id = $this->account->id();
+    if ($account_id && $account_id !== 0) {
+      $user = $this->entityTypeManager->getStorage('user')->load($account_id);
+      if ($user instanceof UserInterface) {
+        $this->currentUser = $user;
+      }
+    }
+
+    // Set source.
+    $request = $this->requestStack->getCurrentRequest();
+    $this->source = $request ? $request->getPathInfo() : '';
+
+    // Set route name.
+    $this->routeName = $this->routeMatch->getRouteName() ?: '';
+  }
+
+  /**
+   * Create event enrollment.
+   */
+  public function eventEnrollmentCreate(EventEnrollmentInterface $event_enrollment): void {
+    $event_type = 'com.getopensocial.event_enrollment.create';
+    $topic_name = 'com.getopensocial.event_enrollment.create';
+    $this->dispatch($topic_name, $event_type, $event_enrollment);
+  }
+
+  /**
+   * Transforms a EventEnrollment into a CloudEvent.
+   *
+   * @throws \Drupal\Core\Entity\EntityMalformedException
+   * @throws \Drupal\Core\TypedData\Exception\MissingDataException
+   */
+  public function fromEntity(EventEnrollmentInterface $event_enrollment, string $event_type): CloudEvent {
+    // Determine actors.
+    [$actor_application, $actor_user] = $this->determineActors();
+
+    // List enrollment methods.
+    $enrollment_methods = ['open', 'request', 'invite'];
+
+    // List enrollment statuses.
+    $enrollment_status = [
+      EventEnrollmentInterface::REQUEST_PENDING => 'pending',
+      EventEnrollmentInterface::REQUEST_APPROVED => 'approved',
+      EventEnrollmentInterface::INVITE_INVITED => 'invited',
+      EventEnrollmentInterface::INVITE_ACCEPTED_AND_JOINED => 'joined',
+    ];
+
+    $enrollment_status_value = (string) $event_enrollment
+      ->get('field_request_or_invite_status')
+      ->value;
+
+    if (!$enrollment_status_value) {
+      $enrollment_status_value = 1;
+    }
+
+    // Get event.
+    $event = $event_enrollment->getEvent();
+    assert($event instanceof NodeInterface);
+
+    // Get enrollee data.
+    $enrollee = $event_enrollment->getAccountEntity();
+    $enrollee_data = [];
+    if ($enrollee && $enrollee->id() != 0) {
+      $enrollee_data = [
+        'id' => (string) $enrollee->uuid(),
+        'displayName' => (string) $enrollee->getDisplayName(),
+        'email' => "",
+        'href' => Href::fromEntity($enrollee),
+      ];
+    }
+    else {
+      $first_name = $event_enrollment->get('field_first_name')->value;
+      $last_name = $event_enrollment->get('field_last_name')->value;
+      $email = $event_enrollment->get('field_email')->value;
+      $enrollee_data = [
+        'id' => NULL,
+        'displayName' => $first_name . " " . $last_name,
+        'email' => $email,
+        'href' => NULL,
+      ];
+    }
+
+    return new CloudEvent(
+      id: $this->uuid->generate(),
+      source: $this->source,
+      type: $event_type,
+      data: [
+        'eventEnrollment' => [
+          'id' => $event_enrollment->get('uuid')->value,
+          'created' => DateTime::fromTimestamp($event_enrollment->getCreatedTime())->toString(),
+          'updated' => DateTime::fromTimestamp($event_enrollment->getChangedTime())->toString(),
+          'status' => $enrollment_status[$enrollment_status_value],
+          'event' => new EventEntityData(
+            id: $event->get('uuid')->value,
+            created: DateTime::fromTimestamp($event->getCreatedTime())->toString(),
+            updated: DateTime::fromTimestamp($event->getChangedTime())->toString(),
+            status: $event->get('status')->value ? 'published' : 'unpublished',
+            label: (string) $event->label(),
+            visibility: ContentVisibility::fromEntity($event),
+            group: !$event->get('groups')->isEmpty() ? Entity::fromEntity($event->get('groups')->getEntity()) : NULL,
+            author: User::fromEntity($event->get('uid')->entity),
+            allDay: $event->get('field_event_all_day')->value,
+            start: $event->get('field_event_date')->value,
+            end: $event->get('field_event_date_end')->value,
+            timezone: date_default_timezone_get(),
+            address: Address::fromFieldItem(
+              item: $event->get('field_event_address')->first(),
+              label: $event->get('field_event_location')->value
+            ),
+            enrollment: [
+              'enabled' => (bool) $event->get('field_event_enroll')->value,
+              'method' => $enrollment_methods[$event->get('field_enroll_method')->value],
+            ],
+            href: Href::fromEntity($event),
+            type: $event->hasField('field_event_type') && !$event->get('field_event_type')->isEmpty() ? $event->get('field_event_type')->getEntity()->label() : NULL,
+          ),
+          'user' => $enrollee_data,
+        ],
+        'actor' => [
+          'application' => $actor_application ? Application::fromId($actor_application) : NULL,
+          'user' => $actor_user ? User::fromEntity($actor_user) : NULL,
+        ],
+      ],
+      dataContentType: 'application/json',
+      dataSchema: NULL,
+      subject: NULL,
+      time: DateTime::fromTimestamp($event_enrollment->getCreatedTime())->toImmutableDateTime(),
+    );
+  }
+
+  /**
+   * Determines the actor (application and user) for the CloudEvent.
+   *
+   * @return array
+   *   An array with two elements: the application and the user.
+   */
+  private function determineActors(): array {
+    $application = NULL;
+    $user = NULL;
+
+    switch ($this->routeName) {
+      case 'entity.node.edit_form':
+      case 'system.admin_content':
+        $user = $this->currentUser;
+        break;
+
+      case 'entity.ultimate_cron_job.run':
+        $application = 'cron';
+        break;
+    }
+
+    return [
+      $application,
+      $user,
+    ];
+  }
+
+  /**
+   * Dispatches the event.
+   *
+   * @param string $topic_name
+   *   The topic name.
+   * @param string $event_type
+   *   The event type.
+   * @param \Drupal\social_event\EventEnrollmentInterface $event_enrollment
+   *   The event enrollment.
+   *
+   * @throws \Drupal\Core\Entity\EntityMalformedException
+   * @throws \Drupal\Core\TypedData\Exception\MissingDataException
+   */
+  private function dispatch(string $topic_name, string $event_type, EventEnrollmentInterface $event_enrollment): void {
+    // Skip if required modules are not enabled.
+    if (!$this->moduleHandler->moduleExists('social_eda')) {
+      return;
+    }
+
+    // Build the event.
+    $event = $this->fromEntity($event_enrollment, $event_type);
+
+    // Dispatch to message broker.
+    $this->dispatcher->dispatch($topic_name, $event);
+  }
+
+}

--- a/modules/social_features/social_event/tests/src/Unit/EdaEventEnrollmentHandlerTest.php
+++ b/modules/social_features/social_event/tests/src/Unit/EdaEventEnrollmentHandlerTest.php
@@ -1,0 +1,350 @@
+<?php
+
+namespace Drupal\Tests\social_event\Unit;
+
+use CloudEvents\V1\CloudEvent;
+use CloudEvents\V1\CloudEventInterface;
+use Drupal\address\Plugin\Field\FieldType\AddressFieldItemList;
+use Drupal\address\Plugin\Field\FieldType\AddressItem;
+use Drupal\Component\Uuid\UuidInterface;
+use Drupal\Core\DependencyInjection\ContainerBuilder;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Entity\EntityStorageInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Extension\ModuleHandlerInterface;
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Language\LanguageInterface;
+use Drupal\Core\Language\LanguageManagerInterface;
+use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\Core\Session\AccountProxyInterface;
+use Drupal\Core\Url;
+use Drupal\node\NodeInterface;
+use Drupal\social_eda\DispatcherInterface;
+use Drupal\social_event\EdaEventEnrollmentHandler;
+use Drupal\taxonomy\TermInterface;
+use Drupal\Tests\UnitTestCase;
+use Drupal\user\UserInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Drupal\social_event\EventEnrollmentInterface;
+
+/**
+ * @coversDefaultClass \Drupal\social_event\EdaEventEnrollmentHandler
+ */
+class EdaEventEnrollmentHandlerTest extends UnitTestCase {
+
+  /**
+   * Handles module-related operations.
+   */
+  protected ModuleHandlerInterface $moduleHandler;
+
+  /**
+   * Mocked dispatcher service for sending CloudEvents.
+   */
+  protected MockObject $dispatcher;
+
+  /**
+   * Handles UUID generation.
+   */
+  protected UuidInterface $uuid;
+
+  /**
+   * Handles HTTP request stack operations.
+   */
+  protected RequestStack $requestStack;
+
+  /**
+   * Represents the canonical URL of an entity.
+   */
+  protected Url $url;
+
+  /**
+   * Represents a generic entity in Drupal.
+   */
+  protected EntityInterface $entityInterface;
+
+  /**
+   * Represents a user entity.
+   */
+  protected UserInterface $userInterface;
+
+  /**
+   * Represents an address field item.
+   */
+  protected AddressItem $addressItem;
+
+  /**
+   * Represents a list of address field items.
+   */
+  protected AddressFieldItemList $addressItemList;
+
+  /**
+   * Represents a taxonomy term.
+   */
+  protected TermInterface $eventTypeTerm;
+
+  /**
+   * Represents the event type field, typically a taxonomy term.
+   */
+  protected FieldItemListInterface $eventTypeField;
+
+  /**
+   * Represents a list of field items, such as a reference to groups.
+   */
+  protected FieldItemListInterface $fieldItemList;
+
+  /**
+   * Represents a event enrollment entity.
+   */
+  protected EventEnrollmentInterface $eventEnrollment;
+
+  /**
+   * Represents an HTTP request.
+   */
+  protected Request $request;
+
+  /**
+   * Manages entity types and their storage handlers.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected EntityTypeManagerInterface $entityTypeManager;
+
+  /**
+   * Represents the route match.
+   */
+  protected RouteMatchInterface $routeMatch;
+
+  /**
+   * Represents the account proxy.
+   */
+  protected AccountProxyInterface $account;
+
+  /**
+   * Represents the CloudEvent.
+   */
+  protected CloudEventInterface $cloudEvent;
+
+  /**
+   * {@inheritDoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    // Mock the language_manager service.
+    $languageManagerMock = $this->prophesize(LanguageManagerInterface::class);
+    $languageMock = $this->prophesize(LanguageInterface::class);
+    $languageMock->getId()->willReturn('en');
+    $languageManagerMock->getCurrentLanguage()
+      ->willReturn($languageMock->reveal());
+
+    // Mock Drupal's container.
+    $container = new ContainerBuilder();
+    $container->set('language_manager', $languageManagerMock->reveal());
+    \Drupal::setContainer($container);
+
+    // Prophesize the module handler and ensure `social_eda` is enabled.
+    $moduleHandlerProphecy = $this->prophesize(ModuleHandlerInterface::class);
+    $moduleHandlerProphecy->moduleExists('social_eda')->willReturn(TRUE);
+    $this->moduleHandler = $moduleHandlerProphecy->reveal();
+
+    // Prophesize the Dispatcher service.
+    $this->dispatcher = $this->getMockBuilder(DispatcherInterface::class)
+      ->disableOriginalConstructor()
+      ->getMock();
+
+    // Prophesize the EntityTypeManagerInterface and the corresponding storage.
+    $entityStorageMock = $this->prophesize(EntityStorageInterface::class);
+    $entityTypeManagerMock = $this->prophesize(EntityTypeManagerInterface::class);
+    $entityTypeManagerMock->getStorage('user')
+      ->willReturn($entityStorageMock->reveal());
+    $this->entityTypeManager = $entityTypeManagerMock->reveal();
+
+    // Prophesize the AccountProxyInterface.
+    $accountMock = $this->prophesize(AccountProxyInterface::class);
+    $accountMock->id()->willReturn(1);
+    $this->account = $accountMock->reveal();
+
+    // Prophesize the RouteMatchInterface.
+    $routeMatchMock = $this->prophesize(RouteMatchInterface::class);
+    $routeMatchMock->getRouteName()->willReturn('entity.node.edit_form');
+    $this->routeMatch = $routeMatchMock->reveal();
+
+    // Prophesize the UUID.
+    $uuidMock = $this->prophesize(UuidInterface::class);
+    $uuidMock->generate()->willReturn('a5715874-5859-4d8a-93ba-9f8433ea44af');
+    $this->uuid = $uuidMock->reveal();
+
+    // Prophesize the Request.
+    $requestMock = $this->prophesize(Request::class);
+    $requestMock->getUri()->willReturn('http://example.com/node/add/event');
+    $requestMock->getPathInfo()->willReturn('/node/add/event');
+    $this->request = $requestMock->reveal();
+
+    $requestStackMock = $this->prophesize(RequestStack::class);
+    $requestStackMock->getCurrentRequest()->willReturn($this->request);
+    $this->requestStack = $requestStackMock->reveal();
+
+    // Prophesize the URL object.
+    $urlMock = $this->prophesize(Url::class);
+    $urlMock->toString()->willReturn('http://example.com');
+    $this->url = $urlMock->reveal();
+
+    // Prophesize the EntityInterface.
+    $entityMock = $this->prophesize(EntityInterface::class);
+    $entityMock->toUrl('canonical', ['absolute' => TRUE])
+      ->willReturn($this->url);
+    $entityMock->uuid()->willReturn('a5715874-5859-4d8a-93ba-9f8433ea44af');
+    $entityMock->label()->willReturn('Test Entity');
+    $this->entityInterface = $entityMock->reveal();
+
+    // Prophesize the UserInterface.
+    $userMock = $this->prophesize(UserInterface::class);
+    $userMock->uuid()->willReturn('a5715874-5859-4d8a-93ba-9f8433ea44af');
+    $userMock->id()->willReturn(10);
+    $userMock->getDisplayName()->willReturn('User name');
+    $userMock->toUrl('canonical', ['absolute' => TRUE])->willReturn($this->url);
+    $this->userInterface = $userMock->reveal();
+
+    // Mock Address field.
+    $addressItemMock = $this->prophesize(AddressItem::class);
+    $this->addressItem = $addressItemMock->reveal();
+
+    $addressItemListMock = $this->prophesize(AddressFieldItemList::class);
+    $addressItemListMock->first()->willReturn($this->addressItem);
+    $this->addressItemList = $addressItemListMock->reveal();
+
+    // Prophesize the field_event_type.
+    $eventTypeTermMock = $this->prophesize(TermInterface::class);
+    $eventTypeTermMock->label()->willReturn('Term Label');
+    $this->eventTypeTerm = $eventTypeTermMock->reveal();
+
+    $eventTypeFieldMock = $this->prophesize(FieldItemListInterface::class);
+    $eventTypeFieldMock->isEmpty()->willReturn(FALSE);
+    $eventTypeFieldMock->getEntity()->willReturn($this->eventTypeTerm);
+    $this->eventTypeField = $eventTypeFieldMock->reveal();
+
+    // Prophesize the FieldItemListInterface.
+    $fieldItemListMock = $this->prophesize(FieldItemListInterface::class);
+    $fieldItemListMock->isEmpty()->willReturn(FALSE);
+    $fieldItemListMock->getEntity()->willReturn($this->entityInterface);
+    $this->fieldItemList = $fieldItemListMock->reveal();
+
+    // Prophesize the Event.
+    $nodeMock = $this->prophesize(NodeInterface::class);
+    $nodeMock->label()->willReturn('Event Title');
+    $nodeMock->getCreatedTime()->willReturn(1692614400);
+    $nodeMock->hasField('field_content_visibility')->willReturn(TRUE);
+    $nodeMock->hasField('groups')->willReturn(TRUE);
+    $nodeMock->getChangedTime()->willReturn(1692618000);
+    $nodeMock->get('groups')->willReturn($this->fieldItemList);
+    $nodeMock->get('uuid')
+      ->willReturn((object) ['value' => 'a5715874-5859-4d8a-93ba-9f8433ea44af']);
+    $nodeMock->get('status')->willReturn((object) ['value' => 1]);
+    $nodeMock->get('field_content_visibility')
+      ->willReturn((object) ['value' => 'public']);
+    $nodeMock->get('field_event_all_day')->willReturn((object) ['value' => 1]);
+    $nodeMock->get('field_event_date')
+      ->willReturn((object) ['value' => '2024-08-21T10:00:00']);
+    $nodeMock->get('field_event_date_end')
+      ->willReturn((object) ['value' => '2024-08-21T10:00:00']);
+    $nodeMock->get('field_event_address')->willReturn($this->addressItemList);
+    $nodeMock->get('field_event_location')
+      ->willReturn((object) ['value' => 'Location Label']);
+    $nodeMock->get('field_event_enroll')->willReturn((object) ['value' => 1]);
+    $nodeMock->get('field_enroll_method')->willReturn((object) ['value' => 0]);
+    $nodeMock->get('field_event_type')->willReturn((object) ['value' => 0]);
+    $nodeMock->get('uid')
+      ->willReturn((object) ['entity' => $this->userInterface]);
+    $nodeMock->toUrl('canonical', ['absolute' => TRUE])->willReturn($this->url);
+    $nodeMock->hasField('field_event_type')->willReturn(TRUE);
+    $nodeMock->get('field_event_type')->willReturn($this->eventTypeField);
+
+    // Prophesize the Event Enrollment.
+    $eventEnrollmentMock = $this->prophesize(EventEnrollmentInterface::class);
+    $eventEnrollmentMock->get('field_request_or_invite_status')
+      ->willReturn((object) ['value' => 1]);
+    $eventEnrollmentMock->get('field_first_name')
+      ->willReturn((object) ['value' => 'First name']);
+    $eventEnrollmentMock->get('field_last_name')
+      ->willReturn((object) ['value' => 'Last name']);
+    $eventEnrollmentMock->get('field_email')
+      ->willReturn((object) ['value' => 'test@test.com']);
+    $eventEnrollmentMock->get('uuid')
+      ->willReturn((object) ['value' => 'a5715874-5859-4d8a-93ba-9f8433ea44af']);
+    $eventEnrollmentMock->getCreatedTime()->willReturn(1692614400);
+    $eventEnrollmentMock->getChangedTime()->willReturn(1692614400);
+    $eventEnrollmentMock->getEvent()->willReturn($nodeMock);
+    $eventEnrollmentMock->getAccountEntity()->willReturn($userMock);
+    $this->eventEnrollment = $eventEnrollmentMock->reveal();
+
+    // Prophesize the CloudEvent class.
+    $cloudEventMock = $this->prophesize(CloudEventInterface::class);
+    $this->cloudEvent = $cloudEventMock->reveal();
+  }
+
+  /**
+   * Tests the eventEnrollmentCreate method.
+   *
+   * @covers ::eventEnrollmentCreate
+   */
+  public function testEventEnrollmentCreate(): void {
+    // Create the handler instance.
+    $handler = $this->getMockedHandler();
+
+    // Expect dispatch to be called with specific parameters.
+    $this->dispatcher->expects($this->once())
+      ->method('dispatch')
+      ->with(
+        $this->equalTo('com.getopensocial.event_enrollment.create'),
+        $this->isInstanceOf(CloudEvent::class)
+      );
+
+    // Call the eventEnrollmentCreate method.
+    $handler->eventEnrollmentCreate($this->eventEnrollment);
+  }
+
+  /**
+   * Tests the fromEntity method.
+   *
+   * @covers ::fromEntity
+   */
+  public function testFromEntity(): void {
+    // Create the handler instance.
+    $handler = $this->getMockedHandler();
+
+    // Create the event object.
+    $event = $handler->fromEntity(
+      $this->eventEnrollment,
+      'com.getopensocial.event_enrollment.create'
+    );
+
+    // Assertions to verify the event has expected attributes.
+    $this->assertInstanceOf(CloudEvent::class, $event);
+    $this->assertEquals('com.getopensocial.event_enrollment.create', $event->getType());
+    $this->assertEquals('/node/add/event', $event->getSource());
+    $this->assertEquals('a5715874-5859-4d8a-93ba-9f8433ea44af', $event->getId());
+    $this->assertEquals('application/json', $event->getDataContentType());
+  }
+
+  /**
+   * Returns a mocked handler with dependencies injected.
+   *
+   * @return \Drupal\social_event\EdaEventEnrollmentHandler
+   *   The mocked handler instance.
+   */
+  protected function getMockedHandler(): EdaEventEnrollmentHandler {
+    return new EdaEventEnrollmentHandler(
+      // @phpstan-ignore-next-line
+      $this->dispatcher,
+      $this->uuid,
+      $this->requestStack,
+      $this->moduleHandler,
+      $this->entityTypeManager,
+      $this->account,
+      $this->routeMatch
+    );
+  }
+
+}

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -13130,3 +13130,8 @@ parameters:
 			message: "#^Class Drupal\\\\social_eda_dispatcher\\\\Dispatcher not found\\.$#"
 			count: 1
 			path: modules/social_features/social_core/src/SocialCoreServiceProvider.php
+
+		-
+			message: "#^Parameter \\$item of static method Drupal\\\\social_eda\\\\Types\\\\Address::fromFieldItem\\(\\) expects Drupal\\\\address\\\\Plugin\\\\Field\\\\FieldType\\\\AddressItem\\|null, Drupal\\\\Core\\\\Field\\\\FieldItemInterface\\|null given\\.$#"
+			count: 1
+			path: modules/social_features/social_event/src/EdaEventEnrollmentHandler.php


### PR DESCRIPTION
## Problem (for internal)
Currently we don't have the eventEnrollmentCreate event.

## Solution (for internal)
Create an eventEnrollmentCreate event based on the specification.

Example of the payload:

```
{
	"specversion": "1.0",
	"id": "889ef7bf-db9e-4ae4-80bf-a4a8519a12cf",
	"source": "/node/32/all-enrollments/add-enrollees",
	"type": "com.getopensocial.event_enrollment.create",
	"datacontenttype": "application/json",
	"time": "2024-11-04T08:07:26Z",
	"data": {
		"eventEnrollment": {
			"id": "db320b4f-9ee1-413f-a748-3f4f288c8fe1",
			"created": "2024-11-04T08:07:26",
			"updated": "2024-11-04T08:07:26",
			"status": "approved",
			"event": {
				"id": "862d01ad-7c9f-4864-a1ca-c479adf52886",
				"created": "2024-11-04T07:46:40",
				"updated": "2024-11-04T07:46:55",
				"status": "published",
				"label": "Test",
				"visibility": {
					"type": "community",
					"groups": [],
					"roles": []
				},
				"group": null,
				"author": {
					"id": "53bb767a-cdc0-4872-81eb-9a4db10374bf",
					"displayName": "admin",
					"href": {
						"canonical": "https://opensocial.ddev.site/user/1/home"
					}
				},
				"allDay": true,
				"start": "2024-11-05T00:00:00",
				"end": "2024-11-06T00:00:00",
				"timezone": "UTC",
				"address": {
					"label": "",
					"countryCode": "",
					"administrativeArea": "",
					"locality": "",
					"dependentLocality": "",
					"postalCode": "",
					"sortingCode": "",
					"addressLine1": "",
					"addressLine2": ""
				},
				"enrollment": {
					"enabled": true,
					"method": "invite"
				},
				"href": {
					"canonical": "https://opensocial.ddev.site/node/32"
				},
				"type": null
			},
			"user": {
				"id": "a8c4ebe6-ef52-11e5-9ce9-5e5517507c66",
				"displayName": "Janna Miesner",
				"email": "",
				"href": {
					"canonical": "https://opensocial.ddev.site/user/15/home"
				}
			}
		},
		"actor": {
			"application": null,
			"user": null
		}
	}
}
```

<!-- [Optional] If this Pull Request makes visual changes then please include some screenshots that show what has changed here. A before and after screenshot helps the reviewer determine what changes were made. -->

## Release notes (to customers)
<!-- [Required if new feature, and if applicable] A summary of the changes that were made that can be included in release notes to customers.
Please provide enough context and detail, so the editorial review is done efficiently. -->

## Issue tracker
https://getopensocial.atlassian.net/browse/PROD-30972

## Theme issue tracker
<!-- *[Required if applicable] Paste a link to the drupal.org theme issue queue item, either from [socialbase](https://www.drupal.org/project/socialbase) or [socialblue](https://www.drupal.org/project/socialblue). If any other issue trackers were used, include links to those too.* -->

## How to test
1.Set up Open Social with broker (kafka) and kafka-ui for viewing messages
2.Enable the social_eda_dispatcher module
3.Create a new event
4. As a user join the event
5. Check the Kafka UI for a new topic and message for new enrollment.

## Change Record
<!-- *[Required if applicable] If this Pull Request changes the way that developers should do things or introduces a new API for developers then a change record to document this is needed. Please provide a draft for a change record or a link to an unpublished change record below. Existing change records can be consulted as example. Please provide a draft for a change record or a link to an unpublished change record below. [Existing change records](https://www.drupal.org/list-changes/social) can be consulted as example.* -->

## Translations
<!--
*[Optional]Translatable strings are always extracted from the latest development branch. To ensure translations remain available for platforms running older versions of Open Social the original string should be added to `translations.php` when it's changed or removed.*
- [ ] Changed or removed source strings are added to the `translations.php` file.
-->
