### PR TITLE
PROD-31103: Bump Address (drupal/address) to 2.0.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -116,7 +116,7 @@
         "php": "^8.1",
         "composer/installers": "~1.0 || ~2.0",
         "cweagans/composer-patches": "^1.6.0",
-        "drupal/address": "^1.12.0 || ^2.0.1",
+        "drupal/address": "^2.0.2",
         "drupal/admin_toolbar": "3.5.0",
         "drupal/advancedqueue": "1.2.0",
         "drupal/ajax_comments": "1.0.0-beta5",


### PR DESCRIPTION
## Problem (for internal)
The Address module has a new version to be compatible with D11.

## Solution (for internal)
Update Address module to 2.0.2 version to be compatible with D11.

## Release notes (to customers)
Address release note: https://www.drupal.org/project/address/releases/2.0.2

## Issue tracker
[PROD-31103](https://getopensocial.atlassian.net/browse/PROD-31103)

## Theme issue tracker
N/A

## How to test
- [ ] Enable Social Profile Fields module
- [ ] Check if Address fields is enabled to be used at Profile
- [ ] Log with user and edit they address on Profile page.


## Change Record
N/A

## Translations
N/A


[PROD-31103]: https://getopensocial.atlassian.net/browse/PROD-31103?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ