### PR TITLE
Internal: Revert PR 4117 for better_exposed_filter dependency update

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -120,7 +120,7 @@
         "drupal/admin_toolbar": "3.5.0",
         "drupal/advancedqueue": "1.2.0",
         "drupal/ajax_comments": "1.0.0-beta5",
-        "drupal/better_exposed_filters": "7.0.2",
+        "drupal/better_exposed_filters": "6.0.6",
         "drupal/block_field": "1.0.0-rc5",
         "drupal/ckeditor": "1.0.2",
         "drupal/config_modify": "^1",


### PR DESCRIPTION
## Problem (for internal)
PR https://github.com/goalgorilla/open_social/pull/4117 was merged but didn't pass all the checks yet causing the main branch to fail now.
https://github.com/goalgorilla/open_social/actions/runs/11571789354/job/32210701334

## Solution (for internal)
Revert the change.

## Release notes (to customers)
X

## Issue tracker
X

## Theme issue tracker
<!-- *[Required if applicable] Paste a link to the drupal.org theme issue queue item, either from [socialbase](https://www.drupal.org/project/socialbase) or [socialblue](https://www.drupal.org/project/socialblue). If any other issue trackers were used, include links to those too.* -->

## How to test
X


## Change Record
<!-- *[Required if applicable] If this Pull Request changes the way that developers should do things or introduces a new API for developers then a change record to document this is needed. Please provide a draft for a change record or a link to an unpublished change record below. Existing change records can be consulted as example. Please provide a draft for a change record or a link to an unpublished change record below. [Existing change records](https://www.drupal.org/list-changes/social) can be consulted as example.* -->

## Translations
<!--
*[Optional]Translatable strings are always extracted from the latest development branch. To ensure translations remain available for platforms running older versions of Open Social the original string should be added to `translations.php` when it's changed or removed.*
- [ ] Changed or removed source strings are added to the `translations.php` file.
-->
