### PR TITLE
Issue #3484615: Remove block button from Private Message using hook-entity-view

### DIFF
--- a/modules/social_features/social_private_message/social_private_message.module
+++ b/modules/social_features/social_private_message/social_private_message.module
@@ -706,3 +706,17 @@ function social_private_message_private_message_notify_exclude(PrivateMessageInt
     }
   }
 }
+
+/**
+ * Implements hook_ENTITY_TYPE_view().
+ *
+ * @see hook_entity_view()
+ */
+function social_private_message_user_view(array &$build): void {
+  $route_name = \Drupal::routeMatch()->getRouteName();
+  if ($route_name !== 'social_user.stream' && empty($build['block_user'])) {
+    return;
+  }
+
+  unset($build['block_user']);
+}


### PR DESCRIPTION
## Problem (for internal)
When the user go to the following page as admin you will see a Block button at the top of the content. The button can be used to block user from sending you private messages.

## Solution (for internal)
The button is being added by an hook-entity-view from Private Message module, so create a new hook-entity-view to remove the Block button.

## Release notes (to customers)
The block button from user stream page will be removed.

## Issue tracker
[PROD-31118](https://getopensocial.atlassian.net/browse/PROD-31118)
[#3484615](https://www.drupal.org/project/social/issues/3484615)

## Theme issue tracker
N/A

## How to test
- [ ] Enable Social Private Message module
- [ ] Log-in with admin user
- [ ] Go to /user/{user-id}/stream and check block button

## Change Record
N/A

## Translations
N/A


[PROD-31118]: https://getopensocial.atlassian.net/browse/PROD-31118?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ