### PR TITLE
PROD-30822: Add bootstrap patch for Drupal 11 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -88,6 +88,9 @@
                 "Ensure field definition allowed values callbacks are used for field filter callbacks": "https://www.drupal.org/files/issues/2023-12-26/views_filter_options_callback--2949022-17.patch",
                 "Issue #3454939: Declaration of Drupal\\search_api_solr\\Plugin\\search_api\\backend\\SearchApiSolrBackend::__sleep() must be compatible": "https://www.drupal.org/files/issues/2024-06-17/3454939-search-api-solr-core-10.patch"
             },
+            "drupal/socialbase": {
+                "Issue #3484629: Add bootstrap patch for Drupal 11 compatibility": "https://www.drupal.org/files/issues/2024-10-30/3484629-3-add-bootstrap-patch-to-be-compatible-with-d11.patch"
+            },
             "drupal/url_embed": {
                 "Translate dialog title": "https://www.drupal.org/files/issues/2018-03-16/url_embed_translate_dialog_title-2953591-2.patch",
                 "Issue #2761187/#3386579 Improve how the module deals with non-embeddable URLs & WSODs (See: https://www.drupal.org/project/social/issues/3386579#comment-15225972) 2.x": "https://www.drupal.org/files/issues/2023-09-22/urlembed-non-embeddable-urls-2761187-opensocial-combined-21_2.x_1_ckeditor5.patch",


### PR DESCRIPTION
## Problem (for internal)
Looking forward to keep our theme compatible with D11, the socialbase has a new patch to make bootstrap compatible with D11.

## Solution (for internal)
Install patch from #3484629 to be compatible with D11.

## Release notes (to customers)
Make our theme compatible with D11.

## Issue tracker
[PROD-30822](https://getopensocial.atlassian.net/browse/PROD-30822)

## Theme issue tracker
[#3484629](https://www.drupal.org/project/socialbase/issues/3484629)

## How to test
- [ ] Regression test in Social theme

## Change Record
N/A

## Translations
N/A


[PROD-30822]: https://getopensocial.atlassian.net/browse/PROD-30822?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ