### PR TITLE
PROD-30974: Implement "user logs in" event for the EDA

### DIFF
--- a/modules/social_features/social_user/asyncapi.yml
+++ b/modules/social_features/social_user/asyncapi.yml
@@ -269,6 +269,141 @@ channels:
                                   type: string
                                   format: uri
                                   description: Canonical URL of the actor user.
+  userLogin:
+    address: com.getopensocial.cms.user.login
+    messages:
+      userLogin:
+        payload:
+          allOf:
+            - $ref: '#/components/schemas/cloudEventsSchema'
+            - type: object
+              properties:
+                data:
+                  type: object
+                  properties:
+                    id:
+                      type: string
+                      description: The UUID of the user.
+                    created:
+                      type: string
+                      format: date-time
+                      description: The creation time of the user.
+                    updated:
+                      type: string
+                      format: date-time
+                      description: The last updated time of the user.
+                    status:
+                      type: string
+                      description: The status of the user.
+                      enum:
+                        - active
+                        - blocked
+                    displayName:
+                      type: string
+                      description: The display name of the user.
+                    firstName:
+                      type: string
+                      nullable: true
+                      description: The first name of the user.
+                    lastName:
+                      type: string
+                      nullable: true
+                      description: The last name of the user.
+                    email:
+                      type: string
+                      format: email
+                      description: The email address of the user.
+                    roles:
+                      type: array
+                      items:
+                        type: string
+                      description: Roles assigned to the user.
+                    timezone:
+                      type: string
+                      description: The timezone of the user.
+                    language:
+                      type: string
+                      description: The preferred language of the user.
+                    address:
+                      type: object
+                      nullable: true
+                      properties:
+                        label:
+                          type: string
+                          description: The label of the user address.
+                        countryCode:
+                          type: string
+                          description: The country code of the user address.
+                        administrativeArea:
+                          type: string
+                          description: The administrative area of the user address.
+                        locality:
+                          type: string
+                          description: The locality of the user address.
+                        dependentLocality:
+                          type: string
+                          description: The dependent locality of the user address.
+                        postalCode:
+                          type: string
+                          description: The postal code of the user address.
+                        sortingCode:
+                          type: string
+                          description: The sorting code of the user address.
+                        addressLine1:
+                          type: string
+                          description: The first address line of the user address.
+                        addressLine2:
+                          type: string
+                          description: The second address line of the user address.
+                    phone:
+                      type: string
+                      nullable: true
+                      description: The phone number of the user.
+                    function:
+                      type: string
+                      nullable: true
+                      description: The job function of the user.
+                    organization:
+                      type: string
+                      nullable: true
+                      description: The organization of the user.
+                    href:
+                      type: object
+                      properties:
+                        canonical:
+                          type: string
+                          format: uri
+                          description: Canonical URL of the user.
+                    actor:
+                      type: object
+                      properties:
+                        application:
+                          type: object
+                          nullable: true
+                          properties:
+                            id:
+                              type: string
+                              description: The UUID of the application.
+                            name:
+                              type: string
+                              description: The name of the application.
+                        user:
+                          type: object
+                          nullable: true
+                          properties:
+                            id:
+                              type: string
+                              description: The UUID of the actor user.
+                            displayName:
+                              type: string
+                              description: The display name of the actor user.
+                            href:
+                              type: object
+                              properties:
+                                canonical:
+                                  type: string
+                                  format: uri
+                                  description: Canonical URL of the actor user.
 
 operations:
   onUserCreate:
@@ -279,3 +414,7 @@ operations:
     action: 'receive'
     channel:
       $ref: '#/channels/profileUpdate'
+  onUserLogin:
+    action: 'receive'
+    channel:
+      $ref: '#/channels/userLogin'

--- a/modules/social_features/social_user/social_user.module
+++ b/modules/social_features/social_user/social_user.module
@@ -793,6 +793,15 @@ function social_user_profile_update(EntityInterface $entity): void {
 }
 
 /**
+ * Implements hook_user_login().
+ *
+ * When a user logs in we should trigger the corresponding EDA event.
+ */
+function social_user_user_login(UserInterface $user): void {
+  \Drupal::service('social_user.eda_handler')->userLogin($user);
+}
+
+/**
  * Implements hook_views_data_alter().
  */
 function social_user_views_data_alter(array &$data): void {

--- a/modules/social_features/social_user/src/Event/UserEventDataLite.php
+++ b/modules/social_features/social_user/src/Event/UserEventDataLite.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Drupal\social_user\Event;
+
+use Drupal\social_eda\Types\Href;
+
+/**
+ * Contains data about an Open Social user.
+ */
+class UserEventDataLite {
+
+  /**
+   * {@inheritDoc}
+   */
+  public function __construct(
+    public readonly string $id,
+    public readonly string $created,
+    public readonly string $updated,
+    public readonly string $status,
+    public readonly string $displayName,
+    public readonly array $roles,
+    public readonly string $timezone,
+    public readonly string $language,
+    public readonly Href $href,
+  ) {}
+
+}

--- a/modules/social_features/social_user/tests/src/Unit/EdaHandlerTest.php
+++ b/modules/social_features/social_user/tests/src/Unit/EdaHandlerTest.php
@@ -302,6 +302,33 @@ class EdaHandlerTest extends UnitTestCase {
   }
 
   /**
+   * Test the userLogin() method.
+   *
+   * @covers ::userLogin
+   */
+  public function testUserLogin(): void {
+    // Create the handler instance.
+    $handler = $this->getMockedHandler();
+
+    // Create the event object.
+    $event = $handler->fromEntity($this->user, 'com.getopensocial.cms.user.login');
+
+    // Expect the dispatch method in the dispatcher to be called.
+    $this->dispatcher->expects($this->once())
+      ->method('dispatch')
+      ->with(
+        $this->equalTo('com.getopensocial.cms.user.login'),
+        $this->equalTo($event)
+      );
+
+    // Call the userLogin method.
+    $handler->userLogin($this->user);
+
+    // Assert that the correct event is dispatched.
+    $this->assertEquals('com.getopensocial.cms.user.login', $event->getType());
+  }
+
+  /**
    * Returns a mocked handler with dependencies injected.
    *
    * @return \Drupal\social_user\EdaHandler


### PR DESCRIPTION
> [!CAUTION]
> This PR depends on #4143

## Description
This pull request introduces the new EDA event "user logs in" which is dispatches to the Kafka topic `com.getopensocial.cms.user.login`.

Here's an example of the generated payload:

```
{
	"specversion": "1.0",
	"id": "3f20068e-c6e2-4bc5-89c7-a2e91164656a",
	"source": "/user/login",
	"type": "com.getopensocial.cms.user.login",
	"datacontenttype": "application/json",
	"time": "2024-10-24T12:15:59Z",
	"data": {
		"user": {
			"id": "3cd53a66-b86a-41b4-8225-66eed5bb5fe3",
			"created": "2024-10-24T12:15:59",
			"updated": "2024-10-24T12:15:59",
			"status": "active",
			"displayName": "admin",
			"firstName": "",
			"lastName": "",
			"email": "devel@getopensocial.com",
			"roles": [
				"authenticated",
				"administrator"
			],
			"timezone": "UTC",
			"language": "en",
			"address": {
				"label": "",
				"countryCode": "",
				"administrativeArea": "",
				"locality": "",
				"dependentLocality": "",
				"postalCode": "",
				"sortingCode": "",
				"addressLine1": "",
				"addressLine2": ""
			},
			"phone": "",
			"function": "",
			"organization": "",
			"href": {
				"canonical": "http://cablecar.localhost/user/1/home"
			}
		},
		"actor": {
			"application": null,
			"user": {
				"id": "3cd53a66-b86a-41b4-8225-66eed5bb5fe3",
				"displayName": "admin",
				"href": {
					"canonical": "http://cablecar.localhost/user/1/home"
				}
			}
		}
	}
}
```

## Release notes (to customers)
N/A

## Issue tracker
https://getopensocial.atlassian.net/browse/PROD-30974

## Theme issue tracker
N/A

## How to test
- [ ] Checkout branch `issue/PROD-30974-eda-user-login`
- [ ] Enable modules `social_eda` and `social_eda_dispatcher`
- [ ] Log in as any user

The message should be dispatched to Kafka. If you are running locally using the Docker containers, you should be able to see the message on the Kafka UI at http://localhost:8080/.

## Change Record
<!-- *[Required if applicable] If this Pull Request changes the way that developers should do things or introduces a new API for developers then a change record to document this is needed. Please provide a draft for a change record or a link to an unpublished change record below. Existing change records can be consulted as example. Please provide a draft for a change record or a link to an unpublished change record below. [Existing change records](https://www.drupal.org/list-changes/social) can be consulted as example.* -->

## Translations
<!--
*[Optional]Translatable strings are always extracted from the latest development branch. To ensure translations remain available for platforms running older versions of Open Social the original string should be added to `translations.php` when it's changed or removed.*
- [ ] Changed or removed source strings are added to the `translations.php` file.
-->
