### PR TITLE
PROD-30973: Implement "user cancels enrollment to event" event for the EDA #4142

### DIFF
--- a/modules/social_features/social_event/social_event.module
+++ b/modules/social_features/social_event/social_event.module
@@ -303,6 +303,32 @@ function social_event_entity_insert(EntityInterface $entity): void {
 }
 
 /**
+ * Implements hook_entity_delete().
+ */
+function social_event_entity_delete(EntityInterface $entity): void {
+  if ($entity instanceof EventEnrollment) {
+    // Invite or user requests statuses.
+    $invite_or_request_statuses = [
+      EventEnrollmentInterface::REQUEST_OR_INVITE_DECLINED,
+      EventEnrollmentInterface::INVITE_INVALID_OR_EXPIRED,
+      EventEnrollmentInterface::INVITE_PENDING_REPLY,
+    ];
+
+    if (!$entity->get('field_request_or_invite_status')->isEmpty() &&
+      in_array(
+        (int) $entity->get('field_request_or_invite_status')->getString(),
+        $invite_or_request_statuses
+      )
+    ) {
+      return;
+    }
+
+    \Drupal::service('social_event.eda_event_enrollment_handler')
+      ->eventEnrollmentCancel($entity);
+  }
+}
+
+/**
  * Implements hook_block_view_alter().
  *
  * Add a title to the exposed filter block on the events overview.

--- a/modules/social_features/social_event/tests/src/Unit/EdaEventEnrollmentHandlerTest.php
+++ b/modules/social_features/social_event/tests/src/Unit/EdaEventEnrollmentHandlerTest.php
@@ -306,6 +306,27 @@ class EdaEventEnrollmentHandlerTest extends UnitTestCase {
   }
 
   /**
+   * Tests the eventEnrollmentCreate method.
+   *
+   * @covers ::eventEnrollmentCreate
+   */
+  public function testEventEnrollmentCancel(): void {
+    // Create the handler instance.
+    $handler = $this->getMockedHandler();
+
+    // Expect dispatch to be called with specific parameters.
+    $this->dispatcher->expects($this->once())
+      ->method('dispatch')
+      ->with(
+        $this->equalTo('com.getopensocial.event_enrollment.cancel'),
+        $this->isInstanceOf(CloudEvent::class)
+      );
+
+    // Call the eventEnrollmentCancel method.
+    $handler->eventEnrollmentCancel($this->eventEnrollment);
+  }
+
+  /**
    * Tests the fromEntity method.
    *
    * @covers ::fromEntity


### PR DESCRIPTION
## Problem (for internal)
Currently we don't have user cancels enrollment to the event.

## Solution (for internal)
Add this event.

Example payload:
```
{
	"specversion": "1.0",
	"id": "a63b41f9-eaa1-4c7c-8bd5-b1062ca7a253",
	"source": "/node/33",
	"type": "com.getopensocial.event_enrollment.cancel",
	"datacontenttype": "application/json",
	"time": "2024-11-04T08:58:44Z",
	"data": {
		"eventEnrollment": {
			"id": "3f07b8d0-15b9-439f-90eb-232aa664d080",
			"created": "2024-11-04T09:58:44",
			"updated": "2024-11-04T09:58:44",
			"status": "approved",
			"event": {
				"id": "75cc1fef-677b-455a-8d0e-266c6e575dcf",
				"created": "2024-11-04T09:44:55",
				"updated": "2024-11-04T09:45:08",
				"status": "published",
				"label": "Test Cancel",
				"visibility": {
					"type": "community",
					"groups": [],
					"roles": []
				},
				"group": null,
				"author": {
					"id": "53bb767a-cdc0-4872-81eb-9a4db10374bf",
					"displayName": "admin",
					"href": {
						"canonical": "https://opensocial.ddev.site/user/1/home"
					}
				},
				"allDay": true,
				"start": "2024-11-04T00:00:00",
				"end": "2024-11-13T00:00:00",
				"timezone": "Europe/Amsterdam",
				"address": {
					"label": "",
					"countryCode": "",
					"administrativeArea": "",
					"locality": "",
					"dependentLocality": "",
					"postalCode": "",
					"sortingCode": "",
					"addressLine1": "",
					"addressLine2": ""
				},
				"enrollment": {
					"enabled": true,
					"method": "invite"
				},
				"href": {
					"canonical": "https://opensocial.ddev.site/node/33"
				},
				"type": null
			},
			"user": {
				"id": "x9c4ebe6-ef52-11e5-9ce9-5e5517507c66",
				"displayName": "Tony Stark",
				"email": "",
				"href": {
					"canonical": "https://opensocial.ddev.site/user/16/home"
				}
			}
		},
		"actor": {
			"application": null,
			"user": {
				"id": "x9c4ebe6-ef52-11e5-9ce9-5e5517507c66",
				"displayName": "Tony Stark",
				"email": "",
				"href": {
					"canonical": "https://opensocial.ddev.site/user/16/home"
				}
			}
		}
	}
}
```

**The PR is based on this branch https://github.com/goalgorilla/open_social/pull/4136, so it needs to get merged first.**

## Release notes (to customers)
<!-- [Required if new feature, and if applicable] A summary of the changes that were made that can be included in release notes to customers.
Please provide enough context and detail, so the editorial review is done efficiently. -->

## Issue tracker
https://getopensocial.atlassian.net/browse/PROD-30973

## Theme issue tracker
<!-- *[Required if applicable] Paste a link to the drupal.org theme issue queue item, either from [socialbase](https://www.drupal.org/project/socialbase) or [socialblue](https://www.drupal.org/project/socialblue). If any other issue trackers were used, include links to those too.* -->

## How to test
1.Set up Open Social with broker (kafka) and kafka-ui for viewing messages
2.Enable the social_eda_dispatcher module
3.Create a new event
4. As a user join the event
5. Check the Kafka UI for a new topic and message for new enrollment.
6. As the same user cancels the enrollment via the cancel enrollment form
7. Check the Kafka UI for a new cancel event and test that it matches the spec


## Change Record
<!-- *[Required if applicable] If this Pull Request changes the way that developers should do things or introduces a new API for developers then a change record to document this is needed. Please provide a draft for a change record or a link to an unpublished change record below. Existing change records can be consulted as example. Please provide a draft for a change record or a link to an unpublished change record below. [Existing change records](https://www.drupal.org/list-changes/social) can be consulted as example.* -->

## Translations
<!--
*[Optional]Translatable strings are always extracted from the latest development branch. To ensure translations remain available for platforms running older versions of Open Social the original string should be added to `translations.php` when it's changed or removed.*
- [ ] Changed or removed source strings are added to the `translations.php` file.
-->