### PR TITLE
PROD-30977: Implement "user is unblocked" event for the EDA

### DIFF
--- a/modules/social_features/social_user/asyncapi.yml
+++ b/modules/social_features/social_user/asyncapi.yml
@@ -509,6 +509,86 @@ channels:
                                   type: string
                                   format: uri
                                   description: Canonical URL of the actor user.
+  userUnblock:
+    address: com.getopensocial.cms.user.unblock
+    messages:
+      userUnblock:
+        payload:
+          allOf:
+            - $ref: '#/components/schemas/cloudEventsSchema'
+            - type: object
+              properties:
+                data:
+                  type: object
+                  properties:
+                    id:
+                      type: string
+                      description: The UUID of the user.
+                    created:
+                      type: string
+                      format: date-time
+                      description: The creation time of the user.
+                    updated:
+                      type: string
+                      format: date-time
+                      description: The last updated time of the user.
+                    status:
+                      type: string
+                      description: The status of the user.
+                      enum:
+                        - active
+                        - blocked
+                    displayName:
+                      type: string
+                      description: The display name of the user.
+                    roles:
+                      type: array
+                      items:
+                        type: string
+                      description: Roles assigned to the user.
+                    timezone:
+                      type: string
+                      description: The timezone of the user.
+                    language:
+                      type: string
+                      description: The preferred language of the user.
+                    href:
+                      type: object
+                      properties:
+                        canonical:
+                          type: string
+                          format: uri
+                          description: Canonical URL of the user.
+                    actor:
+                      type: object
+                      properties:
+                        application:
+                          type: object
+                          nullable: true
+                          properties:
+                            id:
+                              type: string
+                              description: The UUID of the application.
+                            name:
+                              type: string
+                              description: The name of the application.
+                        user:
+                          type: object
+                          nullable: true
+                          properties:
+                            id:
+                              type: string
+                              description: The UUID of the actor user.
+                            displayName:
+                              type: string
+                              description: The display name of the actor user.
+                            href:
+                              type: object
+                              properties:
+                                canonical:
+                                  type: string
+                                  format: uri
+                                  description: Canonical URL of the actor user.
 
 operations:
   onUserCreate:

--- a/modules/social_features/social_user/social_user.module
+++ b/modules/social_features/social_user/social_user.module
@@ -752,18 +752,22 @@ function social_user_profile_insert(ProfileInterface $profile): void {
  */
 function social_user_user_update(EntityInterface $entity): void {
   // Make sure the updated entity is a user entity.
-  if ($entity instanceof UserInterface) {
+  if ($entity instanceof UserInterface && $entity->original instanceof UserInterface) {
     $original = $entity->original;
 
     // Status changed to active.
-    if ($entity->isActive() && $original instanceof UserInterface && $original->isBlocked()) {
+    if ($entity->isActive() && $original->isBlocked()) {
       // The user never logged in & the created time is equals to changed time.
       if ($entity->getLastLoginTime() == 0 && $original->getCreatedTime() == $original->getChangedTime()) {
         \Drupal::service('social_user.eda_handler')->userCreate($entity);
       }
+      // This was previously an active user who is being unblocked.
+      else {
+        \Drupal::service('social_user.eda_handler')->userUnblock($entity);
+      }
     }
     // Status changed to blocked.
-    elseif ($entity->isBlocked() && $original instanceof UserInterface && $original->isActive()) {
+    elseif ($entity->isBlocked() && $original->isActive()) {
       \Drupal::service('social_user.eda_handler')->userBlock($entity);
     }
   }

--- a/modules/social_features/social_user/src/EdaHandler.php
+++ b/modules/social_features/social_user/src/EdaHandler.php
@@ -120,6 +120,15 @@ final class EdaHandler {
   }
 
   /**
+   * User unblock handler.
+   */
+  public function userUnblock(UserInterface $user): void {
+    $event_type = 'com.getopensocial.cms.user.unblock';
+    $topic_name = 'com.getopensocial.cms.user.unblock';
+    $this->dispatch($topic_name, $event_type, $user);
+  }
+
+  /**
    * Transforms a NodeInterface into a CloudEvent.
    */
   public function fromEntity(UserInterface $user, string $event_type): CloudEvent {
@@ -151,6 +160,7 @@ final class EdaHandler {
       case 'com.getopensocial.cms.user.login':
       case 'com.getopensocial.cms.user.logout':
       case 'com.getopensocial.cms.user.block':
+      case 'com.getopensocial.cms.user.unblock':
         $user_data = new UserEventDataLite(
           id: $user->get('uuid')->value,
           created: DateTime::fromTimestamp($user->getCreatedTime())->toString(),

--- a/modules/social_features/social_user/tests/src/Unit/EdaHandlerTest.php
+++ b/modules/social_features/social_user/tests/src/Unit/EdaHandlerTest.php
@@ -383,6 +383,33 @@ class EdaHandlerTest extends UnitTestCase {
   }
 
   /**
+   * Test the userUnblock() method.
+   *
+   * @covers ::userUnblock
+   */
+  public function testUserUnblock(): void {
+    // Create the handler instance.
+    $handler = $this->getMockedHandler();
+
+    // Create the event object.
+    $event = $handler->fromEntity($this->user, 'com.getopensocial.cms.user.unblock');
+
+    // Expect the dispatch method in the dispatcher to be called.
+    $this->dispatcher->expects($this->once())
+      ->method('dispatch')
+      ->with(
+        $this->equalTo('com.getopensocial.cms.user.unblock'),
+        $this->equalTo($event)
+      );
+
+    // Call the userUnblock method.
+    $handler->userUnblock($this->user);
+
+    // Assert that the correct event is dispatched.
+    $this->assertEquals('com.getopensocial.cms.user.unblock', $event->getType());
+  }
+
+  /**
    * Returns a mocked handler with dependencies injected.
    *
    * @return \Drupal\social_user\EdaHandler


### PR DESCRIPTION
> [!CAUTION]
> This PR depends on #4156

## Description
This pull request introduces the new EDA event "user is unblocked" which is dispatches to the Kafka topic `com.getopensocial.cms.user.unblock`.

Here's an example of the generated payload:

```
{
	"specversion": "1.0",
	"id": "b675caa4-b272-4d0d-9a54-b4092832e146",
	"source": "/user/11/edit",
	"type": "com.getopensocial.cms.user.unblock",
	"datacontenttype": "application/json",
	"time": "2024-11-01T14:10:26Z",
	"data": {
		"user": {
			"id": "44fc433a-da2f-11e5-b5d2-0a1d41d68578",
			"created": "2024-11-01T14:10:26",
			"updated": "2024-11-04T14:49:09",
			"status": "active",
			"displayName": "Alisonnn Hendrix",
			"firstName": "Alisonnn",
			"lastName": "Hendrix",
			"email": "drupal_social+alisonhendrix@goalgorilla.com",
			"roles": [
				"authenticated",
				"verified"
			],
			"timezone": "Europe/Berlin",
			"language": "en",
			"address": {
				"label": "",
				"countryCode": "",
				"administrativeArea": "",
				"locality": "",
				"dependentLocality": "",
				"postalCode": "",
				"sortingCode": "",
				"addressLine1": "",
				"addressLine2": ""
			},
			"phone": "",
			"function": "",
			"organization": "",
			"href": {
				"canonical": "http://cablecar.localhost/user/11/home"
			}
		},
		"actor": {
			"application": null,
			"user": {
				"id": "abbb2877-33ee-48bc-8036-fd67385d02ba",
				"displayName": "admin",
				"href": {
					"canonical": "http://cablecar.localhost/user/1/home"
				}
			}
		}
	}
}
```

## Release notes (to customers)
N/A

## Issue tracker
https://getopensocial.atlassian.net/browse/PROD-30977

## Theme issue tracker
N/A

## How to test
- [x] Checkout branch `issue/PROD-30977-eda-user-unblocked`
- [x] Enable modules `social_eda` and `social_eda_dispatcher`
- [x] Unblock any user

The message should be dispatched to Kafka. If you are running locally using the Docker containers, you should be able to see the message on the Kafka UI at http://localhost:8080/.

## Change Record
<!-- *[Required if applicable] If this Pull Request changes the way that developers should do things or introduces a new API for developers then a change record to document this is needed. Please provide a draft for a change record or a link to an unpublished change record below. Existing change records can be consulted as example. Please provide a draft for a change record or a link to an unpublished change record below. [Existing change records](https://www.drupal.org/list-changes/social) can be consulted as example.* -->

## Translations
<!--
*[Optional]Translatable strings are always extracted from the latest development branch. To ensure translations remain available for platforms running older versions of Open Social the original string should be added to `translations.php` when it's changed or removed.*
- [ ] Changed or removed source strings are added to the `translations.php` file.
-->
