### PR TITLE
PROD-31190: Fix patches from Views ef Fieldset module

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -103,8 +103,8 @@
                 "Issue #3347030: Add #submit attribute to ConfigureAction form": "https://www.drupal.org/files/issues/2023-09-15/issue-3347030-4-add-submit-attribute.patch"
             },
             "drupal/views_ef_fieldset": {
-                "Issue #3173822: Exposed operators are not included in fieldsets": "https://git.drupalcode.org/project/views_ef_fieldset/-/merge_requests/1/diffs.patch",
-                "Issue #3404443: Views Exposed Form Fieldset doesn't respect simple fieldset element": "https://git.drupalcode.org/project/views_ef_fieldset/-/merge_requests/12/diffs.patch",
+                "Issue #3173822: Exposed operators are not included in fieldsets": "https://www.drupal.org/files/issues/2024-11-04/3173822-20-view_ef_fieldset-operator-issue.patch",
+                "Issue #3404443: Views Exposed Form Fieldset doesn't respect simple fieldset element": "https://www.drupal.org/files/issues/2024-11-04/3404443-12-views_ef_fieldset-fieldset-does-not-respect-element.patch",
                 "Issue #3404562: Reset button has fixed position with enabled BEF": "https://git.drupalcode.org/project/views_ef_fieldset/-/merge_requests/13/diffs.patch"
             },
             "drupal/metatag": {


### PR DESCRIPTION
## Problem (for internal)
The Views ef Fieldset module has a new version and it broken some patches.

## Solution (for internal)
I reworked the patches from communitty to be compatible with new version.

## Release notes (to customers)
Internal: Reworked the patches to be compatible with new version of Views ef Fielset.

## Issue tracker
[PROD-31190](https://getopensocial.atlassian.net/browse/PROD-31190)
[#3173822](https://www.drupal.org/project/views_ef_fieldset/issues/3173822)
[#3404443](https://www.drupal.org/project/views_ef_fieldset/issues/3404443)

## Theme issue tracker
N/A

## How to test
N/A

## Change Record
N/A

## Translations
N/A


[PROD-31190]: https://getopensocial.atlassian.net/browse/PROD-31190?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ