### PR TITLE
Issue #3485498: Fix PHP exception in activity visibility filter related to views join

### DIFF
--- a/modules/custom/activity_viewer/src/Plugin/views/filter/ActivityNotificationVisibilityAccess.php
+++ b/modules/custom/activity_viewer/src/Plugin/views/filter/ActivityNotificationVisibilityAccess.php
@@ -109,7 +109,21 @@ class ActivityNotificationVisibilityAccess extends FilterPluginBase {
     $query->addRelationship('post__field_visibility', $join, 'post__field_visibility');
 
     if ($account->isAnonymous()) {
-      $configuration['table'] = 'node_field_data';
+
+      $configuration = [
+        'left_table' => 'activity__field_activity_entity',
+        'left_field' => 'field_activity_entity_target_id',
+        'table' => 'node_field_data',
+        'field' => 'nid',
+        'operator' => '=',
+        'extra' => [
+          0 => [
+            'left_field' => 'field_activity_entity_target_type',
+            'value' => 'node',
+          ],
+        ],
+      ];
+
       /** @var \Drupal\views\Plugin\views\join\JoinPluginBase $join */
       $join = Views::pluginManager('join')->createInstance('standard', $configuration);
       $query->addRelationship('node_field_data', $join, 'node_field_data');


### PR DESCRIPTION
## Problem (for internal)
Now I see a PHP Exception in Activity stream notifications for anonymous users when I go by URL - /activities/streams/notifications

`Drupal\\Core\\Database\\DatabaseExceptionWrapper: Exception in Activity stream notifications[activity_stream_notifications]: SQLSTATE[42S22]: Column not found: 1054 Unknown column 'node_field_data.entity_id'`

## Solution (for internal)
The error says: `Column not found: 1054 Unknown column 'node_field_data.entity_id' in 'on clause'`
If I perform `DESCRIBE node_field_data` for my local install then I get next:

`MariaDB [main]> DESCRIBE node_field_data;`

```
+-------------------------------+------------------+------+-----+---------+-------+
| Field | Type | Null | Key | Default | Extra |
+-------------------------------+------------------+------+-----+---------+-------+
| nid | int(10) unsigned | NO | PRI | NULL | |
| vid | int(10) unsigned | NO | MUL | NULL | |
| type | varchar(32) | NO | MUL | NULL | |
| langcode | varchar(12) | NO | PRI | NULL | |
| status | tinyint(4) | NO | MUL | NULL | |
| uid | int(10) unsigned | NO | MUL | NULL | |
| title | varchar(255) | NO | MUL | NULL | |
| created | int(11) | NO | MUL | NULL | |
| changed | int(11) | NO | MUL | NULL | |
| promote | tinyint(4) | NO | MUL | NULL | |
| sticky | tinyint(4) | NO | | NULL | |
| default_langcode | tinyint(4) | NO | | NULL | |
| revision_translation_affected | tinyint(4) | YES | | NULL | |
| content_translation_source | varchar(12) | YES | | NULL | |
| content_translation_outdated | tinyint(4) | YES | | NULL | |
+-------------------------------+------------------+------+-----+---------+-------+
15 rows in set (0.001 sec)
```


You can see the entity_id column indeed doesn’t exist on this install either, but the table does look exactly like expected.
The field that the query is actually looking for is nid. So the question is why it’s trying to select `entity_id` and not `nid`. That’s usually caused by some code not respecting the entity key mapping but hardcoding `entity_id`. That’s controlled by the following part of the entity annotations

```
 *   entity_keys = {
 *     "id" = "nid",
 *     "revision" = "vid",
 *     "bundle" = "type",
 *     "label" = "title",
 *     "langcode" = "langcode",
 *     "uuid" = "uuid",
 *     "status" = "status",
 *     "published" = "status",
 *     "uid" = "uid",
 *     "owner" = "uid",
 *   },
```

The problem in `ActivityNotificationVisibilityAccess.php`

  ```
$configuration = [
      'left_table' => 'post',
      'left_field' => 'id',
      'table' => 'post__field_visibility',
      'field' => 'entity_id',
      'operator' => '=',
    ];
    /** @var \Drupal\views\Plugin\views\join\JoinPluginBase $join */
    $join = Views::pluginManager('join')->createInstance('standard', $configuration);
    $query->addRelationship('post__field_visibility', $join, 'post__field_visibility');

    if ($account->isAnonymous()) {
      $configuration['table'] = 'node_field_data';
      /** @var \Drupal\views\Plugin\views\join\JoinPluginBase $join */
      $join = Views::pluginManager('join')->createInstance('standard', $configuration);
      $query->addRelationship('node_field_data', $join, 'node_field_data');
    }
```

As you can see we try to join to `node_field_data` table, but field in `$configuration` is `entity_id` which not exist in `node_field_data` table. So, we need to add the new field to `$configuration` , so I should be:

```
if ($account->isAnonymous()) {
      $configuration['table'] = 'node_field_data';
      $configuration['field'] = 'nid';
      /** @var \Drupal\views\Plugin\views\join\JoinPluginBase $join */
      $join = Views::pluginManager('join')->createInstance('standard', $configuration);
      $query->addRelationship('node_field_data', $join, 'node_field_data');
    }
```

So, now we join to table by correct field, and error should be disseapear

## Release notes (to customers)
Fix PHP exception related to ActivityNotificationVisibilityAccess filter for anonymous users

## Issue tracker
https://www.drupal.org/project/social/issues/3485498

## Theme issue tracker
N/A

## How to test
- [ ] Create post and node, to have notifications related to this entities
- [ ] Go to `/activities/streams/notifications` from anonymous user
- [ ] You should not have fatal error

## Change Record
N/A

## Translations
N/A

