### PR TITLE
PROD-31120: Implement dynamic option list group tab management

### DIFF
--- a/modules/social_features/social_group/modules/social_group_default_route/social_group_default_route.module
+++ b/modules/social_features/social_group/modules/social_group_default_route/social_group_default_route.module
@@ -28,42 +28,88 @@ function social_group_default_route_form_alter(&$form, FormStateInterface $form_
 
     // Get the form entity.
     $group = $form_state->getFormObject()->getEntity();
-    // Fetch the rotes for member and non-member.
-    $member_routes = $redirect_service->getMemberRoutes($group);
-    $non_member_routes = $redirect_service->getNonMemberRoutes($group);
-
+    // The wrapper for 'Tab management settings'.
+    $wrapper_id = 'edit-tab-settings';
     // Add a (hidden) card for the tabs.
     $form['tab_settings'] = [
       '#type' => 'details',
       '#title' => t('Tab Management'),
       '#group' => 'group_settings',
       '#weight' => '3',
+      '#attributes' => [
+        'class' => [$wrapper_id],
+        'id' => $wrapper_id,
+      ],
     ];
 
-    // Define options for member.
-    $member_options = _social_group_default_route_groups_get_options($member_routes);
-    // Define options for non-member.
-    $non_member_options = _social_group_default_route_groups_get_options($non_member_routes);
-    // Define a default route for members.
-    $default_route = $group ? $redirect_service->getDefaultMemberRoute($group) : '';
-    // Define a default route for non-members.
-    $default_route_an = $group ? $redirect_service->getDefaultNonMemberRoute($group) : '';
     // The default route field.
     $form['tab_settings']['default_route'] = [
       '#type' => 'select',
       '#title' => t('Group members landing tab'),
-      '#default_value' => $default_route,
-      '#options' => $member_options,
     ];
 
     // The default route field.
     $form['tab_settings']['default_route_an'] = [
       '#type' => 'select',
       '#title' => t('Non members landing tab'),
-      '#default_value' => $default_route_an,
-      '#options' => $non_member_options,
     ];
+
+    /** @var \Drupal\social_group_default_route\GroupLandingTabManagerInterface $group_tab_manager */
+    $group_tab_manager = \Drupal::service('plugin.manager.group_landing_tabs');
+    $conditions = $group_tab_manager->getGroupManagementTabConditions($group);
+    // Add Ajax callback to all field form group landing tab conditions.
+    $enabled_conditions = [];
+    foreach ($conditions as $field => $value) {
+      if (isset($form[$field])) {
+        $form_value = $form_state->getValue($field);
+        if ($form_value) {
+          $enabled_conditions[$field] = $form_value['value'];
+        }
+
+        $form[$field]['widget']['value']['#ajax'] = [
+          'callback' => '_social_group_default_route_update_tab_settings',
+          'event' => 'change',
+          'wrapper' => $wrapper_id,
+          'progress' => [
+            'type' => 'throbber',
+          ],
+        ];
+      }
+    }
+    // Fetch the rotes for member and non-member.
+    $member_routes = $redirect_service->getMemberRoutes($group, $enabled_conditions);
+    $non_member_routes = $redirect_service->getNonMemberRoutes($group, $enabled_conditions);
+    // Filter non-available routes.
+    $available_member_routes = _social_group_default_route_groups_get_options($member_routes);
+    $available_non_member_routes = _social_group_default_route_groups_get_options($non_member_routes);
+    // Define a default route for members.
+    $default_route = $group ? $redirect_service->getDefaultMemberRoute($group, $available_member_routes) : '';
+    // Define a default route for non-members.
+    $default_route_an = $group ? $redirect_service->getDefaultNonMemberRoute($group, $available_non_member_routes) : '';
+    // Set default value and options.
+    $form['tab_settings']['default_route']['#options'] = $available_member_routes;
+    $form['tab_settings']['default_route_an']['#options'] = $available_non_member_routes;
+
+    $form['tab_settings']['default_route']['#default_value'] = $default_route;
+    $form['tab_settings']['default_route_an']['#default_value'] = $default_route_an;
+
+    $form['#attached']['library'][] = 'core/drupal.ajax';
   }
+}
+
+/**
+ * The Ajax callback.
+ *
+ * @param array $form
+ *   The form object.
+ * @param \Drupal\Core\Form\FormStateInterface $form_state
+ *   The form state.
+ *
+ * @return array
+ *   The form array.
+ */
+function _social_group_default_route_update_tab_settings(array $form, FormStateInterface $form_state): array {
+  return $form['tab_settings'];
 }
 
 /**

--- a/modules/social_features/social_group/modules/social_group_default_route/src/GroupLandingTabManagerInterface.php
+++ b/modules/social_features/social_group/modules/social_group_default_route/src/GroupLandingTabManagerInterface.php
@@ -37,10 +37,23 @@ interface GroupLandingTabManagerInterface {
    *    - GroupLandingTabManagerInterface:MEMBER;
    *    - GroupLandingTabManagerInterface:NON_MEMBER;
    *    - GroupLandingTabManagerInterface:ALL.
+   * @param array $field_values
+   *   The array of group field valued.
    *
    * @return array
    *   The array of tabs.
    */
-  public function getAvailableLendingTabs(GroupInterface $group, string $type): array;
+  public function getAvailableLendingTabs(GroupInterface $group, string $type, array $field_values = []): array;
+
+  /**
+   * Get group tab management conditions.
+   *
+   * @param \Drupal\group\Entity\GroupInterface $group
+   *   The group object.
+   *
+   * @return array
+   *   The array of conditions.
+   */
+  public function getGroupManagementTabConditions(GroupInterface $group): array;
 
 }

--- a/modules/social_features/social_group/modules/social_group_default_route/src/SocialGroupDefaultRouteRedirectService.php
+++ b/modules/social_features/social_group/modules/social_group_default_route/src/SocialGroupDefaultRouteRedirectService.php
@@ -125,14 +125,22 @@ class SocialGroupDefaultRouteRedirectService {
    *
    * @param \Drupal\group\Entity\GroupInterface $group
    *   The group object.
+   * @param array $available_routes
+   *   The available route.
    *
    * @return string
    *   The default route.
    */
-  public function getDefaultNonMemberRoute(GroupInterface $group): string {
-    return $group->get('default_route_an')->isEmpty() ?
-      self::GROUP_ABOUT_ROUTE :
-      $group->get('default_route_an')->getString();
+  public function getDefaultNonMemberRoute(GroupInterface $group, array $available_routes = []): string {
+    if ($group->get('default_route_an')->isEmpty()) {
+      return self::GROUP_ABOUT_ROUTE;
+    }
+    elseif (!empty($available_routes) && !isset($available_routes[$group->get('default_route_an')->getString()])) {
+      return self::GROUP_ABOUT_ROUTE;
+    }
+    else {
+      return $group->get('default_route_an')->getString();
+    }
   }
 
   /**
@@ -140,34 +148,52 @@ class SocialGroupDefaultRouteRedirectService {
    *
    * @param \Drupal\group\Entity\GroupInterface $group
    *   The group object.
+   * @param array $available_routes
+   *   The available route.
    *
    * @return string
    *   The default route.
    */
-  public function getDefaultMemberRoute(GroupInterface $group): string {
-    return $group->get('default_route')->isEmpty() ?
-      self::GROUP_STREAM_ROUTE :
-      $group->get('default_route')->getString();
+  public function getDefaultMemberRoute(GroupInterface $group, array $available_routes = []): string {
+    if ($group->get('default_route')->isEmpty()) {
+      return self::GROUP_STREAM_ROUTE;
+    }
+    elseif (!empty($available_routes) && !isset($available_routes[$group->get('default_route')->getString()])) {
+      return self::GROUP_STREAM_ROUTE;
+    }
+    else {
+      return $group->get('default_route')->getString();
+    }
   }
 
   /**
    * Get allowed routes for non-member.
    *
+   * @param \Drupal\group\Entity\GroupInterface $group
+   *   The group object.
+   * @param array $field_values
+   *   The field values.
+   *
    * @return array
    *   The array of routes.
    */
-  public function getNonMemberRoutes(GroupInterface $group): array {
-    return $this->landingTabManager->getAvailableLendingTabs($group, GroupLandingTabManagerInterface::NON_MEMBER);
+  public function getNonMemberRoutes(GroupInterface $group, array $field_values = []): array {
+    return $this->landingTabManager->getAvailableLendingTabs($group, GroupLandingTabManagerInterface::NON_MEMBER, $field_values);
   }
 
   /**
    * Get allowed routes for group member.
    *
+   * @param \Drupal\group\Entity\GroupInterface $group
+   *   The group object.
+   * @param array $field_values
+   *   The field values.
+   *
    * @return array
    *   The array of routes.
    */
-  public function getMemberRoutes(GroupInterface $group): array {
-    return $this->landingTabManager->getAvailableLendingTabs($group, GroupLandingTabManagerInterface::MEMBER);
+  public function getMemberRoutes(GroupInterface $group, array $field_values = []): array {
+    return $this->landingTabManager->getAvailableLendingTabs($group, GroupLandingTabManagerInterface::MEMBER, $field_values);
   }
 
 }


### PR DESCRIPTION
## Problem (for internal)
The option list should be changed dynamically if the corresponding checkbox is enabled - "Discussion", "Tasks", etc.

## Solution (for internal)
Add an AJAX callback to refresh the option list when the field set as a condition in the 'Landing Tab' plugin is triggered.

## Release notes (to customers)
Implemented dynamic option list of group tab management.

## Issue tracker
https://getopensocial.atlassian.net/browse/PROD-31120
https://www.drupal.org/project/social/issues/3481367

## How to test
Need to test with modules from Cablecar with changes from https://github.com/goalgorilla/cablecar/pull/2238
- [x] Enable social_discussion_group, social_task_fg, social_media_directory modules
- [x] As a sitemanager go to the group creation page
- [x] Try enable/disable checkboxes "Enable files", "Enbale discussions", "Enable tasks" - the options "Discussions", "Tasks" and "Files" should appear/dissapear in option list

