### PR TITLE
Issue #348563: Lock Views ef Fieldset module on 1.7.0 version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -103,8 +103,8 @@
                 "Issue #3347030: Add #submit attribute to ConfigureAction form": "https://www.drupal.org/files/issues/2023-09-15/issue-3347030-4-add-submit-attribute.patch"
             },
             "drupal/views_ef_fieldset": {
-                "Issue #3173822: Exposed operators are not included in fieldsets": "https://git.drupalcode.org/project/views_ef_fieldset/-/merge_requests/1/diffs.patch",
-                "Issue #3404443: Views Exposed Form Fieldset doesn't respect simple fieldset element": "https://git.drupalcode.org/project/views_ef_fieldset/-/merge_requests/12/diffs.patch",
+                "Issue #3173822: Exposed operators are not included in fieldsets": "https://www.drupal.org/files/issues/2024-11-05/3485631-2-patch-for-views-ef-fieldset-from-3173822.patch",
+                "Issue #3404443: Views Exposed Form Fieldset doesn't respect simple fieldset element": "https://www.drupal.org/files/issues/2024-11-05/3485631-2-patch-for-views-ef-fieldset-from-3404443.patch",
                 "Issue #3404562: Reset button has fixed position with enabled BEF": "https://git.drupalcode.org/project/views_ef_fieldset/-/merge_requests/13/diffs.patch"
             },
             "drupal/metatag": {
@@ -176,7 +176,7 @@
         "drupal/url_embed": "2.0.0-alpha3",
         "drupal/variationcache": "^1.4",
         "drupal/views_bulk_operations": "4.2.7",
-        "drupal/views_ef_fieldset": "^1.7",
+        "drupal/views_ef_fieldset": "1.7.0",
         "drupal/views_infinite_scroll": "2.0.3",
         "drupal/votingapi": "3.0.0-beta5",
         "eluceo/ical": "^2.7",


### PR DESCRIPTION
## Problem (for internal)
The Views ef Fieldset module was update automaticly to major version because it isn't locked in our composer file, this new version isn't be tested by us and it's incompatible if current patches.

## Solution (for internal)
Look the Views ef Fieldset module on old version and keep the patches as old version as well.

## Release notes (to customers)
Internal: Locked the Views ef Fieldset module on old version

## Issue tracker
<!-- *[Required] Paste a link to the drupal.org issue queue item. If any other issue trackers were used, include links to those too.* -->

## Theme issue tracker
N/A

## How to test
N/A

## Change Record
N/A

## Translations
N/A
