### PR TITLE
PROD-30979: Implement "user delete" event for the EDA

### DIFF
--- a/modules/social_features/social_user/asyncapi.yml
+++ b/modules/social_features/social_user/asyncapi.yml
@@ -589,6 +589,86 @@ channels:
                                   type: string
                                   format: uri
                                   description: Canonical URL of the actor user.
+  userDelete:
+    address: com.getopensocial.cms.user.delete
+    messages:
+      userDelete:
+        payload:
+          allOf:
+            - $ref: '#/components/schemas/cloudEventsSchema'
+            - type: object
+              properties:
+                data:
+                  type: object
+                  properties:
+                    id:
+                      type: string
+                      description: The UUID of the user.
+                    created:
+                      type: string
+                      format: date-time
+                      description: The creation time of the user.
+                    updated:
+                      type: string
+                      format: date-time
+                      description: The last updated time of the user.
+                    status:
+                      type: string
+                      description: The status of the user.
+                      enum:
+                        - active
+                        - blocked
+                    displayName:
+                      type: string
+                      description: The display name of the user.
+                    roles:
+                      type: array
+                      items:
+                        type: string
+                      description: Roles assigned to the user.
+                    timezone:
+                      type: string
+                      description: The timezone of the user.
+                    language:
+                      type: string
+                      description: The preferred language of the user.
+                    href:
+                      type: object
+                      properties:
+                        canonical:
+                          type: string
+                          format: uri
+                          description: Canonical URL of the user.
+                    actor:
+                      type: object
+                      properties:
+                        application:
+                          type: object
+                          nullable: true
+                          properties:
+                            id:
+                              type: string
+                              description: The UUID of the application.
+                            name:
+                              type: string
+                              description: The name of the application.
+                        user:
+                          type: object
+                          nullable: true
+                          properties:
+                            id:
+                              type: string
+                              description: The UUID of the actor user.
+                            displayName:
+                              type: string
+                              description: The display name of the actor user.
+                            href:
+                              type: object
+                              properties:
+                                canonical:
+                                  type: string
+                                  format: uri
+                                  description: Canonical URL of the actor user.
 
 operations:
   onUserCreate:
@@ -611,3 +691,7 @@ operations:
     action: 'receive'
     channel:
       $ref: '#/channels/userBlock'
+  onUserDelete:
+    action: 'receive'
+    channel:
+      $ref: '#/channels/userDelete'

--- a/modules/social_features/social_user/social_user.module
+++ b/modules/social_features/social_user/social_user.module
@@ -723,23 +723,26 @@ function social_user_user_insert(UserInterface $user): void {
  */
 function social_user_profile_insert(ProfileInterface $profile): void {
   $user = $profile->get('uid')->entity;
-  $current_request = \Drupal::requestStack()->getCurrentRequest();
-  $user_settings = \Drupal::config('user.settings');
-  $trigger = FALSE;
 
-  // If user is created from the route `user.register`.
-  if ($current_request && $current_request->get('_route') == 'user.register') {
-    // Admin approval is required.
-    if ($user_settings->get('register') != 'visitors_admin_approval') {
+  if ($user instanceof UserInterface) {
+    $current_request = \Drupal::requestStack()->getCurrentRequest();
+    $user_settings = \Drupal::config('user.settings');
+    $trigger = FALSE;
+
+    // If user is created from the route `user.register`.
+    if ($current_request && $current_request->get('_route') == 'user.register') {
+      // Admin approval is required.
+      if ($user_settings->get('register') != 'visitors_admin_approval') {
+        $trigger = TRUE;
+      }
+    }
+    else {
       $trigger = TRUE;
     }
-  }
-  else {
-    $trigger = TRUE;
-  }
 
-  if ($trigger && $user instanceof UserInterface) {
-    \Drupal::service('social_user.eda_handler')->userCreate($user);
+    if ($trigger && !str_starts_with($user->getAccountName(), '__DELETED_USER')) {
+      \Drupal::service('social_user.eda_handler')->userCreate($user);
+    }
   }
 }
 

--- a/modules/social_features/social_user/social_user.module
+++ b/modules/social_features/social_user/social_user.module
@@ -774,6 +774,17 @@ function social_user_user_update(EntityInterface $entity): void {
 }
 
 /**
+ * Implements hook_entity_predelete().
+ *
+ * When a user is about to be deleted, trigger the corresponding EDA event.
+ */
+function social_user_entity_predelete(EntityInterface $entity): void {
+  if ($entity instanceof UserInterface) {
+    \Drupal::service('social_user.eda_handler')->userDelete($entity);
+  }
+}
+
+/**
  * Implements hook_ENTITY_TYPE_update().
  *
  * When a profile is updated we should trigger the corresponding EDA event.

--- a/modules/social_features/social_user/src/EdaHandler.php
+++ b/modules/social_features/social_user/src/EdaHandler.php
@@ -129,6 +129,15 @@ final class EdaHandler {
   }
 
   /**
+   * User delete handler.
+   */
+  public function userDelete(UserInterface $user): void {
+    $event_type = 'com.getopensocial.cms.user.delete';
+    $topic_name = 'com.getopensocial.cms.user.delete';
+    $this->dispatch($topic_name, $event_type, $user);
+  }
+
+  /**
    * Transforms a NodeInterface into a CloudEvent.
    */
   public function fromEntity(UserInterface $user, string $event_type): CloudEvent {

--- a/modules/social_features/social_user/src/EdaHandler.php
+++ b/modules/social_features/social_user/src/EdaHandler.php
@@ -170,6 +170,7 @@ final class EdaHandler {
       case 'com.getopensocial.cms.user.logout':
       case 'com.getopensocial.cms.user.block':
       case 'com.getopensocial.cms.user.unblock':
+      case 'com.getopensocial.cms.user.delete':
         $user_data = new UserEventDataLite(
           id: $user->get('uuid')->value,
           created: DateTime::fromTimestamp($user->getCreatedTime())->toString(),

--- a/modules/social_features/social_user/tests/src/Unit/EdaHandlerTest.php
+++ b/modules/social_features/social_user/tests/src/Unit/EdaHandlerTest.php
@@ -410,6 +410,33 @@ class EdaHandlerTest extends UnitTestCase {
   }
 
   /**
+   * Test the userDelete() method.
+   *
+   * @covers ::userDelete
+   */
+  public function testUserDelete(): void {
+    // Create the handler instance.
+    $handler = $this->getMockedHandler();
+
+    // Create the event object.
+    $event = $handler->fromEntity($this->user, 'com.getopensocial.cms.user.delete');
+
+    // Expect the dispatch method in the dispatcher to be called.
+    $this->dispatcher->expects($this->once())
+      ->method('dispatch')
+      ->with(
+        $this->equalTo('com.getopensocial.cms.user.delete'),
+        $this->equalTo($event)
+      );
+
+    // Call the userDelete method.
+    $handler->userDelete($this->user);
+
+    // Assert that the correct event is dispatched.
+    $this->assertEquals('com.getopensocial.cms.user.delete', $event->getType());
+  }
+
+  /**
    * Returns a mocked handler with dependencies injected.
    *
    * @return \Drupal\social_user\EdaHandler


### PR DESCRIPTION
## Description
This pull request introduces the new EDA event "user delete" which is dispatches to the Kafka topic `com.getopensocial.cms.user.delete`.

Here's an example of the generated payload:

```
{
	"specversion": "1.0",
	"id": "7ad93ebc-d8b1-4e98-9d69-1c9299e87c8e",
	"source": "/batch",
	"type": "com.getopensocial.cms.user.delete",
	"datacontenttype": "application/json",
	"time": "2024-11-01T14:10:26Z",
	"data": {
		"user": {
			"id": "a8c4e812-ef52-11e5-9ce9-5e5517507c66",
			"created": "2024-11-01T14:10:26",
			"updated": "2024-11-01T14:10:26",
			"status": "active",
			"displayName": "benflorez",
			"roles": [
				"authenticated",
				"sitemanager",
				"verified"
			],
			"timezone": "Europe/Amsterdam",
			"language": "en",
			"href": {
				"canonical": "http://cablecar.localhost/user/14/home"
			}
		},
		"actor": {
			"application": null,
			"user": {
				"id": "abbb2877-33ee-48bc-8036-fd67385d02ba",
				"displayName": "admin",
				"href": {
					"canonical": "http://cablecar.localhost/user/1/home"
				}
			}
		}
	}
}
```

## Release notes (to customers)
N/A

## Issue tracker
https://getopensocial.atlassian.net/browse/PROD-30979

## Theme issue tracker
N/A

## How to test
- [x] Checkout branch `issue/PROD-30979-eda-user-delete`
- [x] Enable modules `social_eda` and `social_eda_dispatcher`
- [x] Delete any user

The message should be dispatched to Kafka. If you are running locally using the Docker containers, you should be able to see the message on the Kafka UI at http://localhost:8080/.

## Change Record
<!-- *[Required if applicable] If this Pull Request changes the way that developers should do things or introduces a new API for developers then a change record to document this is needed. Please provide a draft for a change record or a link to an unpublished change record below. Existing change records can be consulted as example. Please provide a draft for a change record or a link to an unpublished change record below. [Existing change records](https://www.drupal.org/list-changes/social) can be consulted as example.* -->

## Translations
<!--
*[Optional]Translatable strings are always extracted from the latest development branch. To ensure translations remain available for platforms running older versions of Open Social the original string should be added to `translations.php` when it's changed or removed.*
- [ ] Changed or removed source strings are added to the `translations.php` file.
-->
