### PR TITLE
PROD-31207: Implement an EDA event for when a user changes its locale information

### DIFF
--- a/modules/social_features/social_user/asyncapi.yml
+++ b/modules/social_features/social_user/asyncapi.yml
@@ -750,6 +750,87 @@ channels:
                                   type: string
                                   format: uri
                                   description: Canonical URL of the actor user.
+  userLocaleUpdate:
+    address: com.getopensocial.cms.user.settings.locale
+    messages:
+      userLocaleUpdate:
+        payload:
+          allOf:
+            - $ref: '#/components/schemas/cloudEventsSchema'
+            - type: object
+              properties:
+                data:
+                  type: object
+                  properties:
+                    user:
+                      type: object
+                      properties:
+                        created:
+                          type: string
+                          format: date-time
+                          description: Creation time of the user
+                        updated:
+                          type: string
+                          format: date-time
+                          description: Last update time of the user
+                        status:
+                          type: string
+                          description: Status of the user
+                        displayName:
+                          type: string
+                          description: Display name of the user
+                        email:
+                          type: string
+                          format: email
+                          description: Email of the user
+                        roles:
+                          type: array
+                          items:
+                            type: string
+                          description: List of user roles
+                        timezone:
+                          type: string
+                          description: Timezone of the user
+                        language:
+                          type: string
+                          description: Language preference of the user
+                        href:
+                          type: object
+                          properties:
+                            canonical:
+                              type: string
+                              format: uri
+                              description: Canonical URL for the user profile
+                    actor:
+                      type: object
+                      properties:
+                        application:
+                          type: object
+                          nullable: true
+                          properties:
+                            id:
+                              type: string
+                              description: The UUID of the application.
+                            name:
+                              type: string
+                              description: The name of the application.
+                        user:
+                          type: object
+                          nullable: true
+                          properties:
+                            id:
+                              type: string
+                              description: The UUID of the actor user.
+                            displayName:
+                              type: string
+                              description: The display name of the actor user.
+                            href:
+                              type: object
+                              properties:
+                                canonical:
+                                  type: string
+                                  format: uri
+                                  description: Canonical URL of the actor user.
 
 operations:
   onUserCreate:
@@ -780,3 +861,7 @@ operations:
     action: 'receive'
     channel:
       $ref: '#/channels/userEmailUpdate'
+  onUserLocaleUpdate:
+    action: 'receive'
+    channel:
+      $ref: '#/channels/userLocaleUpdate'

--- a/modules/social_features/social_user/social_user.module
+++ b/modules/social_features/social_user/social_user.module
@@ -778,6 +778,21 @@ function social_user_user_update(EntityInterface $entity): void {
     if ($original->getEmail() != $entity->getEmail()) {
       \Drupal::service('social_user.eda_handler')->userEmailUpdate($entity);
     }
+
+    // Timezone change.
+    if ($original->getTimeZone() != $entity->getTimeZone()) {
+      \Drupal::service('social_user.eda_handler')->userLocaleInformationUpdate(
+        $entity
+      );
+    }
+
+    // Langcode change.
+    if ($original->getPreferredLangcode() != $entity->getPreferredLangcode()) {
+      \Drupal::service('social_user.eda_handler')->userLocaleInformationUpdate(
+        $entity
+      );
+    }
+
   }
 
 }

--- a/modules/social_features/social_user/src/EdaHandler.php
+++ b/modules/social_features/social_user/src/EdaHandler.php
@@ -186,6 +186,15 @@ final class EdaHandler {
   }
 
   /**
+   * User locale information update handler.
+   */
+  public function userLocaleInformationUpdate(UserInterface $user): void {
+    $event_type = 'com.getopensocial.cms.user.settings.locale';
+    $topic_name = 'com.getopensocial.cms.user.settings.locale';
+    $this->dispatch($topic_name, $event_type, $user);
+  }
+
+  /**
    * Transforms a NodeInterface into a CloudEvent.
    */
   public function fromEntity(UserInterface $user, string $event_type): CloudEvent {
@@ -227,7 +236,7 @@ final class EdaHandler {
         href: Href::fromEntity($user),
       );
     }
-    elseif (preg_match('/\.cms\.user\.settings\.email$/', $event_type)) {
+    elseif (preg_match('/\.cms\.user\.settings\.(email|locale)$/', $event_type)) {
       $user_data = new UserEventEmailData(
         created: DateTime::fromTimestamp($user->getCreatedTime())->toString(),
         updated: DateTime::fromTimestamp($user->getChangedTime())->toString(),

--- a/modules/social_features/social_user/tests/src/Unit/EdaHandlerTest.php
+++ b/modules/social_features/social_user/tests/src/Unit/EdaHandlerTest.php
@@ -479,6 +479,33 @@ class EdaHandlerTest extends UnitTestCase {
   }
 
   /**
+   * Test the userLocaleInformationUpdate() method.
+   *
+   * @covers ::userLocaleInformationUpdate
+   */
+  public function testUserLocaleInformationUpdate(): void {
+    // Create the handler instance.
+    $handler = $this->getMockedHandler();
+
+    // Create the event object.
+    $event = $handler->fromEntity($this->user, 'com.getopensocial.cms.user.settings.locale');
+
+    // Expect the dispatch method in the dispatcher to be called.
+    $this->dispatcher->expects($this->once())
+      ->method('dispatch')
+      ->with(
+        $this->equalTo('com.getopensocial.cms.user.settings.locale'),
+        $this->equalTo($event)
+      );
+
+    // Call the userLocaleInformationUpdate method.
+    $handler->userLocaleInformationUpdate($this->user);
+
+    // Assert that the correct event is dispatched.
+    $this->assertEquals('com.getopensocial.cms.user.settings.locale', $event->getType());
+  }
+
+  /**
    * Returns a mocked handler with dependencies injected.
    *
    * @return \Drupal\social_user\EdaHandler


### PR DESCRIPTION
## Problem (for internal)
Currently we don't have an EDA event that fires when the user updates their locale setting.

## Solution (for internal)
Implement the EDA event.

Example payload:

```
{
	"specversion": "1.0",
	"id": "7ee7fa08-9020-41f9-a568-8299a92cd99b",
	"source": "/user/2/edit",
	"type": "com.getopensocial.cms.user.settings.email",
	"datacontenttype": "application/json",
	"time": "2024-07-04T05:52:01Z",
	"data": {
		"user": {
			"id": "44fc2486-da2f-11e5-b5d2-0a1d41d68578",
			"created": "2024-07-04T05:52:01",
			"updated": "2024-11-07T07:27:04",
			"status": "active",
                        "email": "test@test.com"
			"displayName": "Susan Williams",
			"roles": [
				"authenticated",
				"verified"
			],
			"timezone": "UTC",
			"language": "en",
			"href": {
				"canonical": "https://opensocial.ddev.site/user/2/home"
			}
		},
		"actor": {
			"application": null,
			"user": {
				"id": "53bb767a-cdc0-4872-81eb-9a4db10374bf",
				"displayName": "admin",
				"href": {
					"canonical": "https://opensocial.ddev.site/user/1/home"
				}
			}
		}
	}
}
```


## Release notes (to customers)
<!-- [Required if new feature, and if applicable] A summary of the changes that were made that can be included in release notes to customers.
Please provide enough context and detail, so the editorial review is done efficiently. -->

## Issue tracker
https://getopensocial.atlassian.net/browse/PROD-31207

## Theme issue tracker
<!-- *[Required if applicable] Paste a link to the drupal.org theme issue queue item, either from [socialbase](https://www.drupal.org/project/socialbase) or [socialblue](https://www.drupal.org/project/socialblue). If any other issue trackers were used, include links to those too.* -->

## How to test
- [ ] Enable social_eda
- [ ] Enable and set up the social_eda_dispatcher
- [ ] As a user try to update your locale settings (eg. timezone)
- [ ] An event should be dispatched with the payload similar to above


## Change Record
<!-- *[Required if applicable] If this Pull Request changes the way that developers should do things or introduces a new API for developers then a change record to document this is needed. Please provide a draft for a change record or a link to an unpublished change record below. Existing change records can be consulted as example. Please provide a draft for a change record or a link to an unpublished change record below. [Existing change records](https://www.drupal.org/list-changes/social) can be consulted as example.* -->

## Translations
<!--
*[Optional]Translatable strings are always extracted from the latest development branch. To ensure translations remain available for platforms running older versions of Open Social the original string should be added to `translations.php` when it's changed or removed.*
- [ ] Changed or removed source strings are added to the `translations.php` file.
-->