### PR TITLE
Internal: Fix PHPStan errors

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2809,11 +2809,6 @@ parameters:
 			path: modules/social_features/social_activity/modules/social_activity_filter/src/Plugin/views/display/FilterBlock.php
 
 		-
-			message: "#^Method Drupal\\\\social_activity_filter\\\\Plugin\\\\views\\\\display\\\\FilterBlock\\:\\:submitOptionsForm\\(\\) has parameter \\$form with no type specified\\.$#"
-			count: 1
-			path: modules/social_features/social_activity/modules/social_activity_filter/src/Plugin/views/display/FilterBlock.php
-
-		-
 			message: "#^Method Drupal\\\\social_activity_filter\\\\Plugin\\\\views\\\\display\\\\FilterBlock\\:\\:updateTagsOptions\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: modules/social_features/social_activity/modules/social_activity_filter/src/Plugin/views/display/FilterBlock.php
@@ -6634,11 +6629,6 @@ parameters:
 			path: modules/social_features/social_event/src/Plugin/views/filter/EventEnrolledOrCreated.php
 
 		-
-			message: "#^Method Drupal\\\\social_event\\\\Plugin\\\\views\\\\filter\\\\EventEnrolledOrCreated\\:\\:operatorForm\\(\\) has parameter \\$form with no type specified\\.$#"
-			count: 1
-			path: modules/social_features/social_event/src/Plugin/views/filter/EventEnrolledOrCreated.php
-
-		-
 			message: "#^Method Drupal\\\\social_event\\\\Plugin\\\\views\\\\filter\\\\EventEnrolledOrCreated\\:\\:query\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: modules/social_features/social_event/src/Plugin/views/filter/EventEnrolledOrCreated.php
@@ -7072,16 +7062,6 @@ parameters:
 			message: "#^Parameter \\#2 \\$nid of method Drupal\\\\social_follow_taxonomy\\\\Plugin\\\\ActivityContext\\\\FollowTaxonomyActivityContext\\:\\:haveAccessToNode\\(\\) expects int\\|string, int\\|string\\|null given\\.$#"
 			count: 1
 			path: modules/social_features/social_follow_taxonomy/src/Plugin/ActivityContext/FollowTaxonomyActivityContext.php
-
-		-
-			message: "#^Method Drupal\\\\social_follow_taxonomy\\\\Plugin\\\\views\\\\filter\\\\FollowTaxonomyViewsFilter\\:\\:buildExtraOptionsForm\\(\\) has parameter \\$form with no type specified\\.$#"
-			count: 1
-			path: modules/social_features/social_follow_taxonomy/src/Plugin/views/filter/FollowTaxonomyViewsFilter.php
-
-		-
-			message: "#^Method Drupal\\\\social_follow_taxonomy\\\\Plugin\\\\views\\\\filter\\\\FollowTaxonomyViewsFilter\\:\\:valueForm\\(\\) has parameter \\$form with no type specified\\.$#"
-			count: 1
-			path: modules/social_features/social_follow_taxonomy/src/Plugin/views/filter/FollowTaxonomyViewsFilter.php
 
 		-
 			message: "#^Function social_footer_install\\(\\) has no return type specified\\.$#"
@@ -8928,11 +8908,6 @@ parameters:
 			path: modules/social_features/social_group/src/Plugin/views/field/SocialGroupViewsBulkOperationsBulkForm.php
 
 		-
-			message: "#^Method Drupal\\\\social_group\\\\Plugin\\\\views\\\\filter\\\\FilterByGroup\\:\\:valueForm\\(\\) has parameter \\$form with no type specified\\.$#"
-			count: 1
-			path: modules/social_features/social_group/src/Plugin/views/filter/FilterByGroup.php
-
-		-
 			message: "#^Method Drupal\\\\social_group\\\\Routing\\\\RouteSubscriber\\:\\:alterRoutes\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: modules/social_features/social_group/src/Routing/RouteSubscriber.php
@@ -10216,11 +10191,6 @@ parameters:
 			path: modules/social_features/social_post/src/Plugin/views/filter/PostAccountStream.php
 
 		-
-			message: "#^Method Drupal\\\\social_post\\\\Plugin\\\\views\\\\filter\\\\PostAccountStream\\:\\:operatorForm\\(\\) has parameter \\$form with no type specified\\.$#"
-			count: 1
-			path: modules/social_features/social_post/src/Plugin/views/filter/PostAccountStream.php
-
-		-
 			message: "#^Method Drupal\\\\social_post\\\\Plugin\\\\views\\\\filter\\\\PostAccountStream\\:\\:query\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: modules/social_features/social_post/src/Plugin/views/filter/PostAccountStream.php
@@ -10256,11 +10226,6 @@ parameters:
 			path: modules/social_features/social_post/src/Plugin/views/filter/PostGroupStream.php
 
 		-
-			message: "#^Method Drupal\\\\social_post\\\\Plugin\\\\views\\\\filter\\\\PostGroupStream\\:\\:operatorForm\\(\\) has parameter \\$form with no type specified\\.$#"
-			count: 1
-			path: modules/social_features/social_post/src/Plugin/views/filter/PostGroupStream.php
-
-		-
 			message: "#^Method Drupal\\\\social_post\\\\Plugin\\\\views\\\\filter\\\\PostGroupStream\\:\\:query\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: modules/social_features/social_post/src/Plugin/views/filter/PostGroupStream.php
@@ -10292,11 +10257,6 @@ parameters:
 
 		-
 			message: "#^Method Drupal\\\\social_post\\\\Plugin\\\\views\\\\filter\\\\PostVisibilityAccess\\:\\:operatorForm\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: modules/social_features/social_post/src/Plugin/views/filter/PostVisibilityAccess.php
-
-		-
-			message: "#^Method Drupal\\\\social_post\\\\Plugin\\\\views\\\\filter\\\\PostVisibilityAccess\\:\\:operatorForm\\(\\) has parameter \\$form with no type specified\\.$#"
 			count: 1
 			path: modules/social_features/social_post/src/Plugin/views/filter/PostVisibilityAccess.php
 
@@ -11767,24 +11727,9 @@ parameters:
 			path: modules/social_features/social_profile/src/Plugin/views/filter/SocialSearchApiSplitProfileTerms.php
 
 		-
-			message: "#^Method Drupal\\\\social_profile\\\\Plugin\\\\views\\\\filter\\\\SocialSearchApiSplitProfileTerms\\:\\:validateExposed\\(\\) has parameter \\$form with no type specified\\.$#"
-			count: 1
-			path: modules/social_features/social_profile/src/Plugin/views/filter/SocialSearchApiSplitProfileTerms.php
-
-		-
 			message: "#^Method Drupal\\\\social_profile\\\\Plugin\\\\views\\\\filter\\\\SocialSearchApiSplitProfileTerms\\:\\:valueForm\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: modules/social_features/social_profile/src/Plugin/views/filter/SocialSearchApiSplitProfileTerms.php
-
-		-
-			message: "#^Method Drupal\\\\social_profile\\\\Plugin\\\\views\\\\filter\\\\SocialSplitProfileTerms\\:\\:validateExposed\\(\\) has parameter \\$form with no type specified\\.$#"
-			count: 1
-			path: modules/social_features/social_profile/src/Plugin/views/filter/SocialSplitProfileTerms.php
-
-		-
-			message: "#^Method Drupal\\\\social_profile\\\\Plugin\\\\views\\\\filter\\\\SocialSplitProfileTerms\\:\\:valueForm\\(\\) has parameter \\$form with no type specified\\.$#"
-			count: 1
-			path: modules/social_features/social_profile/src/Plugin/views/filter/SocialSplitProfileTerms.php
 
 		-
 			message: "#^Expression in empty\\(\\) is not falsy\\.$#"


### PR DESCRIPTION
## Description

This PR fixes the PHPStan errors recently merged into `main`: https://github.com/goalgorilla/open_social/actions/runs/11743894946/job/32717905178?pr=4163

<!-- [Optional] If this Pull Request makes visual changes then please include some screenshots that show what has changed here. A before and after screenshot helps the reviewer determine what changes were made. -->

## Release notes (to customers)
<!-- [Required if new feature, and if applicable] A summary of the changes that were made that can be included in release notes to customers.
Please provide enough context and detail, so the editorial review is done efficiently. -->

## Issue tracker
<!-- *[Required] Paste a link to the drupal.org issue queue item. If any other issue trackers were used, include links to those too.* -->

## Theme issue tracker
<!-- *[Required if applicable] Paste a link to the drupal.org theme issue queue item, either from [socialbase](https://www.drupal.org/project/socialbase) or [socialblue](https://www.drupal.org/project/socialblue). If any other issue trackers were used, include links to those too.* -->

## How to test
<!--
*[Required] For example*
- [ ] Using version X.Y.Z of Open Social with the example module enabled
- [ ] As a sitemanager
- [ ] Try to enable the option B on screen c/d/e
- [ ] When saving I expect the result to be F but instead see G.
- [ ] The expected result F is attained when repeating the steps with this fix applied.
-->


## Change Record
<!-- *[Required if applicable] If this Pull Request changes the way that developers should do things or introduces a new API for developers then a change record to document this is needed. Please provide a draft for a change record or a link to an unpublished change record below. Existing change records can be consulted as example. Please provide a draft for a change record or a link to an unpublished change record below. [Existing change records](https://www.drupal.org/list-changes/social) can be consulted as example.* -->

## Translations
<!--
*[Optional]Translatable strings are always extracted from the latest development branch. To ensure translations remain available for platforms running older versions of Open Social the original string should be added to `translations.php` when it's changed or removed.*
- [ ] Changed or removed source strings are added to the `translations.php` file.
-->
