### PR TITLE
Issue #3486730:  "View group" button is broken in "group_core_comments" module

### DIFF
--- a/modules/custom/group_core_comments/assets/js/group_core_comments.js
+++ b/modules/custom/group_core_comments/assets/js/group_core_comments.js
@@ -1,32 +1,34 @@
 (function ($, Drupal) {
   Drupal.behaviors.groupCoreComments = {
     attach: function (context) {
-      var forbiddenPost = $('.forbidden-post-comments-wrapper', context);
-      var popup = forbiddenPost.find('.popup-info', context);
-      var popupH = popup.outerHeight();
-      var link = forbiddenPost.find('.description .btn-action__group');
+      $(once('forbidden-post-comments', '.forbidden-post-comments-wrapper', context)).each(function () {
+        let forbiddenPost = $(this);
+        let popup = forbiddenPost.find('.popup-info', context);
+        let popupH = popup.outerHeight();
+        let link = forbiddenPost.find('.description .btn-action__group');
+        console.log(link);
+        popup.css('top', (-popupH - 5));
 
-      popup.css('top', (-popupH - 5));
+        $(window).on('resize', function () {
+          let popupHResize = popup.outerHeight();
+          popup.css('top', (-popupHResize - 5));
+        });
 
-      $(window).on('resize', function () {
-        var popupHResize = popup.outerHeight();
-        popup.css('top', (-popupHResize - 5));
-      });
+        link.on('click', function (event) {
+          event.preventDefault();
+          $(this).toggleClass('open');
+        });
 
-      link.on('click', function (event) {
-        event.preventDefault();
-        $(this).toggleClass('open');
-      });
-
-      $(document).click(function (event) {
-        if ($(event.target).closest('.forbidden-post-comments-wrapper .description .btn-action__group').length) {
-          return;
-        }
-        if ($(event.target).closest('.forbidden-post-comments-wrapper .popup-info').length) {
-         return;
-        }
-        link.removeClass('open');
-        event.stopPropagation();
+        $(document).click(function (event) {
+          if ($(event.target).closest('.forbidden-post-comments-wrapper .description .btn-action__group').length) {
+            return;
+          }
+          if ($(event.target).closest('.forbidden-post-comments-wrapper .popup-info').length) {
+            return;
+          }
+          link.removeClass('open');
+          event.stopPropagation();
+        });
       });
     }
   };


### PR DESCRIPTION
## Problem (for internal)
When enabling [Group Core Comments support](https://github.com/goalgorilla/open_social/tree/main/modules/custom/group_core_comments) module a verified user who isn't a group member will see the block with a suggestion to join a group which the current content belongs. 
Unfortunately, the **"View group"** button in the block doesn't work (nothing happens on click).

## Solution (for internal)
Add `once()` to `group_core_comments/group_core_comments` library to make the **"View group"** button work.

_Before:_
<img width="778" alt="Screenshot 2024-11-11 at 12 13 38" src="https://github.com/user-attachments/assets/faad8acb-e7ca-4cac-bca2-df3d9154f985">

_After:_
<img width="909" alt="Screenshot 2024-11-11 at 12 34 03" src="https://github.com/user-attachments/assets/861f61af-b4e5-4693-a1f2-2c80e8ebf82b">

## Release notes (to customers)
Fixed the "View group" button and popup in the comments section of content added to the group.

## Issue tracker
- https://www.drupal.org/project/social/issues/3486730
- https://getopensocial.atlassian.net/browse/PROD-31191

## How to test
- [ ] Login as admin
- [ ] Enable `social_flexible_group` and `group_core_comments` modules
- [ ] Create a flexible group with a `community` visibility
- [ ] Add a topic to the group; Make it commentable
- [ ] Login as LU
- [ ] Visit topic page

