### PR TITLE
PROD-31226: Fix group statistics count method

### DIFF
--- a/modules/social_features/social_group/src/GroupStatistics.php
+++ b/modules/social_features/social_group/src/GroupStatistics.php
@@ -73,9 +73,9 @@ class GroupStatistics {
     $query = $this->database->select('group_relationship_field_data', 'gcfd');
     $query->addField('gcfd', 'gid');
     $query->condition('gcfd.gid', $group->id());
-    $query->condition('gcfd.type', $group->getGroupType()->id() . '-' . $type, 'LIKE');
+    $query->condition('gcfd.plugin_id', $type);
 
-    return $query->countQuery()->execute()->fetchField();
+    return (int) $query->countQuery()->execute()->fetchField();
   }
 
 }


### PR DESCRIPTION
## Problem (for internal)
In the database we have table "group_relationship_field_data" which is the data table for group content entities. In this table, we can see the columns type, group_type and plugin_id.

The pattern for the group membership type is usually <group_type>-<plugin>. The type (column) is limited to 32 characters, and for example closed_challenge-group_membership (33 characters) is just too long.

Group includes a way to generate names that fit the limits imposed by Drupal core, and it does this consistently in its own code. However, this means that where a <bundle>-<plugin> concatenation would exceed the limit, it instead converts it to 'group_content_type_' . md5($preferred_id) and truncates it. This is done in GroupRelationshipTypeStorage::getRelationshipTypeId. The problem is that our code is naively looking at the concatenation and doesn't handle the "too long" case, which is handled by the group module.

## Solution (for internal)
To solve the problem, we replaced the type condition in the count database query with the plugin_id condition, because we do not need the relationship type, which is unique per plugin_id and group_type. Since group_type is always the same per group entity (and we count per entity), filtering by plugin_id instead of type gives the expected result.

<!-- [Optional] If this Pull Request makes visual changes then please include some screenshots that show what has changed here. A before and after screenshot helps the reviewer determine what changes were made. -->

## Release notes (to customers)
<!-- [Required if new feature, and if applicable] A summary of the changes that were made that can be included in release notes to customers.
Please provide enough context and detail, so the editorial review is done efficiently. -->

## Issue tracker
<!--[PROD-31226](https://getopensocial.atlassian.net/browse/PROD-31226) -->

## Theme issue tracker
N/A

## How to test
<!--
*[Required] For example*
- [ ] Using version X.Y.Z of Open Social with the example module enabled
- [ ] As a sitemanager
- [ ] Try to enable the option B on screen c/d/e
- [ ] When saving I expect the result to be F but instead see G.
- [ ] The expected result F is attained when repeating the steps with this fix applied.
-->


## Change Record
<!-- *[Required if applicable] If this Pull Request changes the way that developers should do things or introduces a new API for developers then a change record to document this is needed. Please provide a draft for a change record or a link to an unpublished change record below. Existing change records can be consulted as example. Please provide a draft for a change record or a link to an unpublished change record below. [Existing change records](https://www.drupal.org/list-changes/social) can be consulted as example.* -->

## Translations
N/A


[PROD-31226]: https://getopensocial.atlassian.net/browse/PROD-31226?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ