### PR TITLE
Issue #3298886: Fix group statistics count method

### DIFF
--- a/modules/social_features/social_group/social_group.services.yml
+++ b/modules/social_features/social_group/social_group.services.yml
@@ -40,7 +40,7 @@ services:
       - {name: config.factory.override, priority: 10}
   social_group.group_statistics:
     class: Drupal\social_group\GroupStatistics
-    arguments: ['@database']
+    arguments: ['@database', '@entity_type.manager']
   social_group.group_mute_notify:
     class: Drupal\social_group\GroupMuteNotify
     arguments: ['@flag', '@entity_type.manager']

--- a/modules/social_features/social_group/src/GroupStatistics.php
+++ b/modules/social_features/social_group/src/GroupStatistics.php
@@ -3,6 +3,7 @@
 namespace Drupal\social_group;
 
 use Drupal\Core\Database\Connection;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\group\Entity\GroupInterface;
 
 /**
@@ -20,13 +21,23 @@ class GroupStatistics {
   protected $database;
 
   /**
+   * The entity type manager interface.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
    * Constructor for SocialGroupMembersCount.
    *
    * @param \Drupal\Core\Database\Connection $connection
    *   The database connection.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager interface.
    */
-  public function __construct(Connection $connection) {
+  public function __construct(Connection $connection, EntityTypeManagerInterface $entity_type_manager) {
     $this->database = $connection;
+    $this->entityTypeManager = $entity_type_manager;
   }
 
   /**
@@ -54,7 +65,7 @@ class GroupStatistics {
    *   The number of nodes.
    */
   public function getGroupNodeCount(GroupInterface $group, $type) {
-    return $this->count($group, 'group_node-' . $type);
+    return $this->count($group, 'group_node:' . $type);
   }
 
   /**
@@ -70,12 +81,12 @@ class GroupStatistics {
    */
   protected function count(GroupInterface $group, $type) {
     // Additional caching not required since views does this for us.
-    $query = $this->database->select('group_relationship_field_data', 'gcfd');
-    $query->addField('gcfd', 'gid');
-    $query->condition('gcfd.gid', $group->id());
-    $query->condition('gcfd.type', $group->getGroupType()->id() . '-' . $type, 'LIKE');
-
-    return $query->countQuery()->execute()->fetchField();
+    return $this->entityTypeManager->getStorage('group_content')->getQuery()
+      ->accessCheck(FALSE)
+      ->condition('gid', $group->id())
+      ->condition('plugin_id', $type)
+      ->count()
+      ->execute();
   }
 
 }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -8783,11 +8783,6 @@ parameters:
 			path: modules/social_features/social_group/src/Form/SocialGroupSettings.php
 
 		-
-			message: "#^Cannot call method fetchField\\(\\) on Drupal\\\\Core\\\\Database\\\\StatementInterface\\|null\\.$#"
-			count: 1
-			path: modules/social_features/social_group/src/GroupStatistics.php
-
-		-
 			message: "#^Method Drupal\\\\social_group\\\\Plugin\\\\Action\\\\AddMembersToGroup\\:\\:execute\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: modules/social_features/social_group/src/Plugin/Action/AddMembersToGroup.php


### PR DESCRIPTION
## Problem (for internal)
In the database we have table "group_relationship_field_data" which is the data table for group content entities. In this table, we can see the columns type, group_type and plugin_id.

The pattern for the group membership type is usually `<group_type>-<plugin>`. The type (column) is limited to 32 characters, and for example closed_challenge-group_membership (33 characters) is just too long.

Group includes a way to generate names that fit the limits imposed by Drupal core, and it does this consistently in its own code. However, this means that where a `<bundle>-<plugin>` concatenation would exceed the limit, it instead converts it to 'group_content_type_' . md5($preferred_id) and truncates it. This is done in GroupRelationshipTypeStorage::getRelationshipTypeId. The problem is that our code is naively looking at the concatenation and doesn't handle the "too long" case, which is handled by the group module.

## Solution (for internal)
To solve the problem, we replaced the type condition in the count database query with the plugin_id condition, because we do not need the relationship type, which is unique per plugin_id and group_type. Since group_type is always the same per group entity (and we count per entity), filtering by plugin_id instead of type gives the expected result.

## Release notes (to customers)
Fix group statistic count (for group types with longer machine names).

## Issue tracker
<!--[PROD-31226](https://getopensocial.atlassian.net/browse/PROD-31226) -->
[3298886](https://www.drupal.org/project/social/issues/3298886)

## Theme issue tracker
N/A

## How to test

**Membership count scenario**
- [ ] Install Open Social
- [ ] Go to /admin/group/types/add add group with machine name longer than 16 characters (like "group_with_long_name")
- [ ] Add newly created group /group/add/group_with_long_name and become a member
- [ ] Go to /admin/group and you will see that membership count is 0
- [ ] Apply fix (and clear the cache)
- [ ] Go to /admin/group and you will see that membership count is 1

**Group content count scenario**
- [ ] Install Open Social
- [ ] Go to /group/add/flexible_group and create flexible group
- [ ] Go to /group/2/content/create/group_node%3Aevent end create X number of group events
- [ ] Go to /group/2/content/create/group_node%3Atopic and create Y number of group topics
- [ ] Go to /group/4/stream stream page and you should see correct number of events, topics and members
- [ ] Apply fix (and clear the cache)
- [ ] Number of events, topics and members should remain exactly the same after fix


 /admin/group/types/add
![Screenshot 2024-11-11 at 13 58 18](https://github.com/user-attachments/assets/42701d53-659a-40f3-a9ad-4048a0dbd922)

 /group/add/group_with_long_name
![Screenshot 2024-11-11 at 13 59 46](https://github.com/user-attachments/assets/a8d0a901-cf83-448c-93ed-28c440a47880)

Before fix
![Screenshot 2024-11-11 at 14 00 33](https://github.com/user-attachments/assets/01566e12-688c-453e-9284-f0771c56f1b7)

After fix
![Screenshot 2024-11-11 at 14 12 12](https://github.com/user-attachments/assets/219d672f-1fb5-4fa6-baa7-66c6e22189a9)

Flexible group before and after fix
![Screenshot 2024-11-11 at 17 09 23](https://github.com/user-attachments/assets/349eacde-9405-43ab-a05f-7bd4b2f50d02)

group_relationship_field_data table from database
![Screenshot 2024-11-11 at 17 40 18](https://github.com/user-attachments/assets/51a10848-9727-4719-b7f5-4822981bc211)

## Change Record
N/A

## Translations
N/A


[PROD-31226]: https://getopensocial.atlassian.net/browse/PROD-31226?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ