### PR TITLE
PROD-31232: Implement "group create" event for the EDA

### DIFF
--- a/modules/social_features/social_group/modules/social_group_flexible_group/asyncapi.yml
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/asyncapi.yml
@@ -1,0 +1,147 @@
+channels:
+  groupCreate:
+    address: com.getopensocial.cms.group.create
+    messages:
+      groupCreate:
+        payload:
+          allOf:
+            - $ref: '#/components/schemas/cloudEventsSchema'
+            - type: object
+              properties:
+                data:
+                  type: object
+                  properties:
+                id:
+                  type: string
+                  description: Unique group ID (UUIDv4)
+                created:
+                  type: string
+                  format: date-time
+                  description: Creation time of the group
+                updated:
+                  type: string
+                  format: date-time
+                  description: Last update time of the group
+                status:
+                  type: string
+                  description: Status of the group (e.g., published or unpublished)
+                  enum:
+                   - published
+                   - unpublished
+                label:
+                  type: string
+                  description: Label of the group
+                visibility:
+                  type: object
+                  properties:
+                    type:
+                      type: string
+                      description: The visibility type.
+                    roles:
+                      type: array
+                      description: The list of roles ids.
+                contentVisibility:
+                  type: object
+                  properties:
+                    method:
+                      type: string
+                      description: Visibility of content
+                      enum:
+                       - public
+                       - community
+                       - group
+                membership:
+                  type: object
+                  properties:
+                    method:
+                      type: string
+                      description: Method of membership
+                      enum:
+                       - open
+                       - invite
+                       - request
+                type:
+                  type: string
+                  nullable: true
+                  description: Type of the group (optional)
+                address:
+                  type: object
+                  properties:
+                    label:
+                      type: string
+                      nullable: true
+                      description: Label for the address (optional)
+                    countryCode:
+                      type: string
+                      nullable: true
+                      description: Country code (optional)
+                    administrativeArea:
+                      type: string
+                      nullable: true
+                      description: Administrative area (optional)
+                    locality:
+                      type: string
+                      nullable: true
+                      description: Locality (optional)
+                    dependentLocality:
+                      type: string
+                      nullable: true
+                      description: Dependent locality (optional)
+                    postalCode:
+                      type: string
+                      nullable: true
+                      description: Postal code (optional)
+                    sortingCode:
+                      type: string
+                      nullable: true
+                      description: Sorting code (optional)
+                    addressLine1:
+                      type: string
+                      nullable: true
+                      description: Address line 1 (optional)
+                    addressLine2:
+                      type: string
+                      nullable: true
+                      description: Address line 2 (optional)
+                href:
+                  type: object
+                  properties:
+                    canonical:
+                      type: string
+                      format: uri
+                      description: Canonical URL for the group
+            actor:
+              type: object
+              properties:
+                application:
+                  type: object
+                  nullable: true
+                  properties:
+                    id:
+                      type: string
+                      description: Application ID (UUIDv4)
+                    name:
+                      type: string
+                      description: Name of the application
+                user:
+                  type: object
+                  nullable: true
+                  properties:
+                    id:
+                      type: string
+                      description: Actor user ID (UUIDv4)
+                    displayName:
+                      type: string
+                      description: Display name of the actor user
+                    href:
+                      type: object
+                      properties:
+                        canonical:
+                          type: string
+                          format: uri
+                          description: Canonical URL for the actor profile
+operations:
+  onGroupCreate:
+    action: 'receive'
+    channel:
+      $ref: '#/channels/groupCreate'

--- a/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.module
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.module
@@ -337,6 +337,15 @@ function social_group_flexible_group_group_access(EntityInterface $entity, $oper
 }
 
 /**
+ * Implements hook_ENTITY_TYPE_insert().
+ */
+function social_group_flexible_group_group_insert(GroupInterface $group): void {
+  if ($group->bundle() == "flexible_group") {
+    \Drupal::service('social_group_flexible_group.eda_handler')->groupCreate($group);
+  }
+}
+
+/**
  * Implements template_preprocess_form_element().
  */
 function social_group_flexible_group_preprocess_form_element(&$variables) {

--- a/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.services.yml
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.services.yml
@@ -30,3 +30,9 @@ services:
     tags:
       - { name: config.factory.override, priority: 5 }
       - { name: social_language_defaults }
+
+  social_group_flexible_group.eda_handler:
+    autowire: true
+    class: Drupal\social_group_flexible_group\EdaHandler
+    tags:
+      - { name: social.eda.handler }

--- a/modules/social_features/social_group/modules/social_group_flexible_group/src/EdaHandler.php
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/src/EdaHandler.php
@@ -1,0 +1,216 @@
+<?php
+
+namespace Drupal\social_group_flexible_group;
+
+use CloudEvents\V1\CloudEvent;
+use Drupal\Component\Uuid\UuidInterface;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Extension\ModuleHandlerInterface;
+use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\Core\Session\AccountProxyInterface;
+use Drupal\group\Entity\GroupInterface;
+use Drupal\social_eda\DispatcherInterface;
+use Drupal\social_eda\Types\Address;
+use Drupal\social_eda\Types\Application;
+use Drupal\social_eda\Types\DateTime;
+use Drupal\social_eda\Types\Href;
+use Drupal\social_eda\Types\User;
+use Drupal\social_group_flexible_group\Event\GroupEntityData;
+use Drupal\social_group_flexible_group\Types\GroupMembershipMethod;
+use Drupal\social_group_flexible_group\Types\GroupVisibility;
+use Drupal\user\UserInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/**
+ * Handles hook invocations for EDA related operations of the event entity.
+ */
+final class EdaHandler {
+
+  /**
+   * The current logged-in user.
+   *
+   * @var \Drupal\user\UserInterface|null
+   */
+  protected ?UserInterface $currentUser = NULL;
+
+  /**
+   * The source.
+   *
+   * @var string
+   */
+  protected string $source;
+
+  /**
+   * The current route name.
+   *
+   * @var string
+   */
+  protected string $routeName;
+
+  /**
+   * The community namespace.
+   *
+   * @var string
+   */
+  protected string $namespace;
+
+  /**
+   * The topic name.
+   *
+   * @var string
+   */
+  protected string $topicName;
+
+  /**
+   * {@inheritDoc}
+   */
+  public function __construct(
+    private readonly ?DispatcherInterface $dispatcher,
+    private readonly UuidInterface $uuid,
+    private readonly RequestStack $requestStack,
+    private readonly ModuleHandlerInterface $moduleHandler,
+    private readonly EntityTypeManagerInterface $entityTypeManager,
+    private readonly AccountProxyInterface $account,
+    private readonly RouteMatchInterface $routeMatch,
+    private readonly ConfigFactoryInterface $configFactory,
+  ) {
+    // Load the full user entity if the account is authenticated.
+    $account_id = $this->account->id();
+    if ($account_id && $account_id !== 0) {
+      $user = $this->entityTypeManager->getStorage('user')->load($account_id);
+      if ($user instanceof UserInterface) {
+        $this->currentUser = $user;
+      }
+    }
+
+    // Set source.
+    $request = $this->requestStack->getCurrentRequest();
+    $this->source = $request ? $request->getPathInfo() : '';
+
+    // Set route name.
+    $this->routeName = $this->routeMatch->getRouteName() ?: '';
+
+    // Set the community namespace.
+    $this->namespace = $this->configFactory->get('social_eda.settings')->get('namespace') ?? 'com.getopensocial';
+
+    // Set the community namespace.
+    $this->topicName = "{$this->namespace}.cms.group.v1";
+  }
+
+  /**
+   * Create event handler.
+   */
+  public function groupCreate(GroupInterface $group): void {
+    $this->dispatch(
+      topic_name: $this->topicName,
+      event_type: "{$this->namespace}.cms.group.create",
+      group: $group
+    );
+  }
+
+  /**
+   * Transforms a GroupInterface into a CloudEvent.
+   *
+   * @throws \Drupal\Core\Entity\EntityMalformedException
+   * @throws \Drupal\Core\TypedData\Exception\MissingDataException
+   */
+  public function fromEntity(GroupInterface $group, string $event_type, string $op = ''): CloudEvent {
+    // Determine actors.
+    [$actor_application, $actor_user] = $this->determineActors();
+
+    // Determine status.
+    if ($op == 'delete') {
+      $status = 'removed';
+    }
+    else {
+      $status = $group->get('status')->value ? 'published' : 'unpublished';
+    }
+
+    return new CloudEvent(
+      id: $this->uuid->generate(),
+      source: $this->source,
+      type: $event_type,
+      data: [
+        'group' => new GroupEntityData(
+          id: $group->get('uuid')->value,
+          created: DateTime::fromTimestamp($group->getCreatedTime())->toString(),
+          updated: DateTime::fromTimestamp($group->getChangedTime())->toString(),
+          status: $status,
+          label: (string) $group->label(),
+          visibility: GroupVisibility::fromEntity($group),
+          contentVisibility: $group->get('field_group_allowed_visibility')->value,
+          membership: GroupMembershipMethod::fromEntity($group),
+          type: $group->getGroupType()->get('uuid'),
+          author: User::fromEntity($group->get('uid')->entity),
+          address: Address::fromFieldItem(
+            item: $group->get('field_group_address')->first(),
+            label: $group->get('field_group_location')->value
+          ),
+          href: Href::fromEntity($group),
+        ),
+        'actor' => [
+          'application' => $actor_application ? Application::fromId($actor_application) : NULL,
+          'user' => $actor_user ? User::fromEntity($actor_user) : NULL,
+        ],
+      ],
+      dataContentType: 'application/json',
+      dataSchema: NULL,
+      subject: NULL,
+      time: DateTime::fromTimestamp($group->getCreatedTime())->toImmutableDateTime(),
+    );
+  }
+
+  /**
+   * Determines the actor (application and user) for the CloudEvent.
+   *
+   * @return array
+   *   An array with two elements: the application and the user.
+   */
+  private function determineActors(): array {
+    $application = NULL;
+    $user = NULL;
+
+    if ($this->currentUser instanceof UserInterface) {
+      $user = $this->currentUser;
+    }
+
+    if ($this->routeName == 'entity.ultimate_cron_job.run') {
+      $application = 'cron';
+    }
+
+    return [
+      $application,
+      $user,
+    ];
+  }
+
+  /**
+   * Dispatches the event.
+   *
+   * @param string $topic_name
+   *   The topic name.
+   * @param string $event_type
+   *   The event type.
+   * @param \Drupal\group\Entity\GroupInterface $group
+   *   The group object.
+   * @param string $op
+   *   The operation.
+   *
+   * @throws \Drupal\Core\Entity\EntityMalformedException
+   * @throws \Drupal\Core\TypedData\Exception\MissingDataException
+   */
+  private function dispatch(string $topic_name, string $event_type, GroupInterface $group, string $op = ''): void {
+    // Skip if required modules are not enabled.
+    if (!$this->moduleHandler->moduleExists('social_eda') || !$this->dispatcher) {
+      return;
+    }
+
+    // Build the event.
+    $event = $this->fromEntity($group, $event_type, $op);
+
+    // Dispatch to message broker.
+    $this->dispatcher->dispatch($topic_name, $event);
+  }
+
+}

--- a/modules/social_features/social_group/modules/social_group_flexible_group/src/Event/GroupEntityData.php
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/src/Event/GroupEntityData.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Drupal\social_group_flexible_group\Event;
+
+use Drupal\social_eda\Types\Address;
+use Drupal\social_eda\Types\Href;
+use Drupal\social_eda\Types\User;
+use Drupal\social_group_flexible_group\Types\GroupMembershipMethod;
+use Drupal\social_group_flexible_group\Types\GroupVisibility;
+
+/**
+ * Contains data about the creation of an Open Social group.
+ */
+class GroupEntityData {
+
+  /**
+   * {@inheritDoc}
+   */
+  public function __construct(
+    public readonly string $id,
+    public readonly string $created,
+    public readonly string $updated,
+    public readonly string $status,
+    public readonly string $label,
+    public readonly GroupVisibility|null $visibility,
+    public readonly string $contentVisibility,
+    public readonly GroupMembershipMethod|null $membership,
+    public readonly ?string $type,
+    public readonly User $author,
+    public readonly Address $address,
+    public readonly Href $href,
+  ) {}
+
+}

--- a/modules/social_features/social_group/modules/social_group_flexible_group/src/Types/GroupMembershipMethod.php
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/src/Types/GroupMembershipMethod.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\social_group_flexible_group\Types;
+
+use Drupal\group\Entity\GroupInterface;
+
+/**
+ * Type class for Group membership data.
+ */
+class GroupMembershipMethod {
+
+  /**
+   * Constructs the GroupMembershipMethod type.
+   *
+   * @param string $method
+   *   The method.
+   */
+  public function __construct(
+    public readonly string $method,
+  ) {}
+
+  /**
+   * Get formatted GroupMembership output.
+   *
+   * @param \Drupal\group\Entity\GroupInterface $entity
+   *   The Group object.
+   *
+   * @return self
+   *   The GroupMembership data object.
+   *
+   * @throws \Drupal\Core\Entity\EntityMalformedException
+   */
+  public static function fromEntity(GroupInterface $entity): self {
+    return new self(
+      method: (string) $entity->get('field_group_allowed_join_method')->value,
+    );
+  }
+
+}

--- a/modules/social_features/social_group/modules/social_group_flexible_group/src/Types/GroupVisibility.php
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/src/Types/GroupVisibility.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\social_group_flexible_group\Types;
+
+use Drupal\Core\Entity\ContentEntityInterface;
+use Drupal\social_role_visibility\Service\VisibilityElementManager;
+
+/**
+ * Type class for GroupVisibility data.
+ */
+class GroupVisibility {
+
+  /**
+   * Constructs the ContentVisibility type.
+   */
+  public function __construct(
+    public readonly string $type,
+    public readonly array $roles = [],
+  ) {}
+
+  /**
+   * Get formatted GroupVisibility output.
+   *
+   * @param \Drupal\Core\Entity\ContentEntityInterface $entity
+   *   The entity object.
+   *
+   * @return self|null
+   *   The GroupVisibility object or null.
+   */
+  public static function fromEntity(ContentEntityInterface $entity): ?self {
+    if (!$entity->hasField('field_flexible_group_visibility')) {
+      return NULL;
+    }
+
+    $visibility_type = $entity->get('field_flexible_group_visibility')->value;
+
+    switch ($visibility_type) {
+      case "visibility_by_role":
+        $roles = [];
+        if ($entity->hasField('role_visibility')) {
+          $visibility_roles = $entity->get('role_visibility')->getValue();
+
+          foreach ($visibility_roles as $item) {
+            $id = $item['value'];
+
+            // CM+ is a special role that applies to multiple ids.
+            if ($id == "cm_plus" && class_exists('\Drupal\social_role_visibility\Service\VisibilityElementManager')) {
+              foreach (VisibilityElementManager::CM_PLUS_ROLES as $role_id) {
+                $roles[] = $role_id;
+              }
+              continue;
+            }
+
+            $roles[] = $id;
+          }
+        }
+
+        return new self(
+          type: 'roles',
+          roles: $roles,
+        );
+
+      default:
+        return new self(
+          type: (string) $visibility_type,
+        );
+
+    }
+  }
+
+}

--- a/modules/social_features/social_group/modules/social_group_flexible_group/tests/src/Unit/EdaHandlerTest.php
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/tests/src/Unit/EdaHandlerTest.php
@@ -1,0 +1,334 @@
+<?php
+
+namespace Drupal\Tests\social_group_flexible_group\Unit;
+
+use CloudEvents\V1\CloudEventInterface;
+use Consolidation\Config\ConfigInterface;
+use Drupal\address\Plugin\Field\FieldType\AddressFieldItemList;
+use Drupal\address\Plugin\Field\FieldType\AddressItem;
+use Drupal\Component\Uuid\UuidInterface;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\DependencyInjection\ContainerBuilder;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Entity\EntityStorageInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Extension\ModuleHandlerInterface;
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Language\LanguageInterface;
+use Drupal\Core\Language\LanguageManagerInterface;
+use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\Core\Session\AccountProxyInterface;
+use Drupal\Core\Url;
+use Drupal\group\Entity\GroupInterface;
+use Drupal\group\Entity\GroupType;
+use Drupal\group\Entity\GroupTypeInterface;
+use Drupal\social_eda\DispatcherInterface;
+use Drupal\social_eda\Types\DateTime;
+use Drupal\social_group_flexible_group\EdaHandler;
+use Drupal\Tests\UnitTestCase;
+use Drupal\user\UserInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/**
+ * @coversDefaultClass \Drupal\social_group_flexible_group\EdaHandler
+ */
+class EdaHandlerTest extends UnitTestCase {
+
+  /**
+   * Handles module-related operations.
+   */
+  protected ModuleHandlerInterface $moduleHandler;
+
+  /**
+   * Mocked dispatcher service for sending CloudEvents.
+   */
+  protected MockObject $dispatcher;
+
+  /**
+   * Handles UUID generation.
+   */
+  protected UuidInterface $uuid;
+
+  /**
+   * Handles HTTP request stack operations.
+   */
+  protected RequestStack $requestStack;
+
+  /**
+   * Represents the canonical URL of an entity.
+   */
+  protected Url $url;
+
+  /**
+   * Represents a generic entity in Drupal.
+   */
+  protected EntityInterface $entityInterface;
+
+  /**
+   * Represents a user entity.
+   */
+  protected UserInterface $userInterface;
+
+  /**
+   * Represents an address field item.
+   */
+  protected AddressItem $addressItem;
+
+  /**
+   * Represents a list of address field items.
+   */
+  protected AddressFieldItemList $addressItemList;
+
+  /**
+   * Represents an group type.
+   */
+  protected GroupTypeInterface $groupType;
+
+  /**
+   * Represents a list of field items, such as a reference to groups.
+   */
+  protected FieldItemListInterface $fieldItemList;
+
+  /**
+   * Represents a group entity.
+   */
+  protected GroupInterface $group;
+
+  /**
+   * Represents an HTTP request.
+   */
+  protected Request $request;
+
+  /**
+   * Manages entity types and their storage handlers.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected EntityTypeManagerInterface $entityTypeManager;
+
+  /**
+   * Represents the route match.
+   */
+  protected RouteMatchInterface $routeMatch;
+
+  /**
+   * Represents the account proxy.
+   */
+  protected AccountProxyInterface $account;
+
+  /**
+   * Represents the CloudEvent.
+   */
+  protected CloudEventInterface $cloudEvent;
+
+  /**
+   * Represents the ConfigFactoryInterface.
+   */
+  protected ConfigFactoryInterface $configFactory;
+
+  /**
+   * {@inheritDoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    // Mock the language_manager service.
+    $languageManagerMock = $this->prophesize(LanguageManagerInterface::class);
+    $languageMock = $this->prophesize(LanguageInterface::class);
+    $languageMock->getId()->willReturn('en');
+    $languageManagerMock->getCurrentLanguage()
+      ->willReturn($languageMock->reveal());
+
+    // Mock the configuration for `social_eda.settings.namespaces`.
+    $configMock = $this->prophesize(ConfigInterface::class);
+    $configMock->get('namespace')->willReturn('com.getopensocial');
+
+    $configFactoryMock = $this->prophesize(ConfigFactoryInterface::class);
+    $configFactoryMock->get('social_eda.settings')->willReturn($configMock->reveal());
+    $this->configFactory = $configFactoryMock->reveal();
+
+    // Mock Drupal's container.
+    $container = new ContainerBuilder();
+    $container->set('language_manager', $languageManagerMock->reveal());
+    \Drupal::setContainer($container);
+
+    // Prophesize the module handler and ensure `social_eda` is enabled.
+    $moduleHandlerProphecy = $this->prophesize(ModuleHandlerInterface::class);
+    $moduleHandlerProphecy->moduleExists('social_eda')->willReturn(TRUE);
+    $this->moduleHandler = $moduleHandlerProphecy->reveal();
+
+    // Prophesize the Dispatcher service.
+    $this->dispatcher = $this->getMockBuilder(DispatcherInterface::class)
+      ->disableOriginalConstructor()
+      ->getMock();
+
+    // Prophesize the EntityTypeManagerInterface and the corresponding storage.
+    $entityStorageMock = $this->prophesize(EntityStorageInterface::class);
+    $entityTypeManagerMock = $this->prophesize(EntityTypeManagerInterface::class);
+    $entityTypeManagerMock->getStorage('user')
+      ->willReturn($entityStorageMock->reveal());
+    $this->entityTypeManager = $entityTypeManagerMock->reveal();
+
+    // Prophesize the AccountProxyInterface.
+    $accountMock = $this->prophesize(AccountProxyInterface::class);
+    $accountMock->id()->willReturn(1);
+    $this->account = $accountMock->reveal();
+
+    // Prophesize the RouteMatchInterface.
+    $routeMatchMock = $this->prophesize(RouteMatchInterface::class);
+    $routeMatchMock->getRouteName()->willReturn('entity.node.edit_form');
+    $this->routeMatch = $routeMatchMock->reveal();
+
+    // Prophesize the UUID.
+    $uuidMock = $this->prophesize(UuidInterface::class);
+    $uuidMock->generate()->willReturn('a5715874-5859-4d8a-93ba-9f8433ea44af');
+    $this->uuid = $uuidMock->reveal();
+
+    // Prophesize the Request.
+    $requestMock = $this->prophesize(Request::class);
+    $requestMock->getUri()->willReturn('http://example.com/node/add/event');
+    $requestMock->getPathInfo()->willReturn('/node/add/event');
+    $this->request = $requestMock->reveal();
+
+    $requestStackMock = $this->prophesize(RequestStack::class);
+    $requestStackMock->getCurrentRequest()->willReturn($this->request);
+    $this->requestStack = $requestStackMock->reveal();
+
+    // Prophesize the URL object.
+    $urlMock = $this->prophesize(Url::class);
+    $urlMock->toString()->willReturn('http://example.com');
+    $this->url = $urlMock->reveal();
+
+    // Prophesize the EntityInterface.
+    $entityMock = $this->prophesize(EntityInterface::class);
+    $entityMock->toUrl('canonical', ['absolute' => TRUE])
+      ->willReturn($this->url);
+    $entityMock->uuid()->willReturn('a5715874-5859-4d8a-93ba-9f8433ea44af');
+    $entityMock->label()->willReturn('Test Entity');
+    $this->entityInterface = $entityMock->reveal();
+
+    // Prophesize the UserInterface.
+    $userMock = $this->prophesize(UserInterface::class);
+    $userMock->uuid()->willReturn('a5715874-5859-4d8a-93ba-9f8433ea44af');
+    $userMock->getDisplayName()->willReturn('User name');
+    $userMock->toUrl('canonical', ['absolute' => TRUE])->willReturn($this->url);
+    $this->userInterface = $userMock->reveal();
+
+    // Mock Group Type.
+    $groupTypeMock = $this->prophesize(GroupType::class);
+    $groupTypeMock->get('uuid')
+      ->willReturn('a5715874-5859-4d8a-93ba-9f8433ea44ao');
+    $this->groupType = $groupTypeMock->reveal();
+
+    // Mock Address field.
+    $addressItemMock = $this->prophesize(AddressItem::class);
+    $this->addressItem = $addressItemMock->reveal();
+
+    $addressItemListMock = $this->prophesize(AddressFieldItemList::class);
+    $addressItemListMock->first()->willReturn($this->addressItem);
+    $this->addressItemList = $addressItemListMock->reveal();
+
+    // Prophesize the FieldItemListInterface.
+    $fieldItemListMock = $this->prophesize(FieldItemListInterface::class);
+    $fieldItemListMock->isEmpty()->willReturn(FALSE);
+    $fieldItemListMock->getEntity()->willReturn($this->entityInterface);
+    $this->fieldItemList = $fieldItemListMock->reveal();
+
+    // Prophesize the Group.
+    $groupMock = $this->prophesize(GroupInterface::class);
+    $groupMock->label()->willReturn('Group Title');
+    $groupMock->getCreatedTime()->willReturn(1692614400);
+    $groupMock->getGroupType()->willReturn($this->groupType);
+    $groupMock->hasField('field_group_allowed_visibility')->willReturn(TRUE);
+    $groupMock->hasField('field_flexible_group_visibility')->willReturn(TRUE);
+    $groupMock->getChangedTime()->willReturn(1692618000);
+    $groupMock->get('uuid')
+      ->willReturn((object) ['value' => 'a5715874-5859-4d8a-93ba-9f8433ea44af']);
+    $groupMock->get('status')->willReturn((object) ['value' => 1]);
+    $groupMock->get('field_group_allowed_visibility')
+      ->willReturn((object) ['value' => 'public']);
+    $groupMock->get('field_flexible_group_visibility')
+      ->willReturn((object) ['value' => 'public']);
+    $groupMock->get('field_group_allowed_join_method')->willReturn((object) ['value' => 'request']);
+    $groupMock->get('field_group_address')->willReturn($this->addressItemList);
+    $groupMock->get('field_group_location')->willReturn($this->addressItemList);
+    $groupMock->get('uid')
+      ->willReturn((object) ['entity' => $this->userInterface]);
+    $groupMock->toUrl('canonical', ['absolute' => TRUE])->willReturn($this->url);
+    $this->group = $groupMock->reveal();
+
+    // Prophesize the CloudEvent class.
+    $cloudEventMock = $this->prophesize(CloudEventInterface::class);
+    $this->cloudEvent = $cloudEventMock->reveal();
+  }
+
+  /**
+   * Test method fromEntity().
+   *
+   * @covers ::fromEntity
+   */
+  public function testFromEntity(): void {
+    // Create the handler instance.
+    $handler = $this->getMockedHandler();
+
+    // Create the event object.
+    $event = $handler->fromEntity($this->group, 'com.getopensocial.cms.group.create');
+
+    // Check that the event has expected attributes.
+    $this->assertEquals('1.0', $event->getSpecVersion());
+    $this->assertEquals('com.getopensocial.cms.group.create', $event->getType());
+    $this->assertEquals('/node/add/event', $event->getSource());
+    $this->assertEquals('a5715874-5859-4d8a-93ba-9f8433ea44af', $event->getId());
+    $this->assertEquals(DateTime::fromTimestamp($this->group->getCreatedTime())->toImmutableDateTime(), $event->getTime());
+  }
+
+  /**
+   * Test the groupCreate() method.
+   *
+   * @covers ::groupCreate
+   */
+  public function testGroupCreate(): void {
+    // Create the handler instance.
+    $handler = $this->getMockedHandler();
+
+    // Create the group object.
+    $group = $handler->fromEntity($this->group, 'com.getopensocial.cms.group.create');
+
+    // Expect the dispatch method in the dispatcher to be called.
+    $this->dispatcher->expects($this->once())
+      ->method('dispatch')
+      ->with(
+        $this->equalTo('com.getopensocial.cms.group.v1'),
+        $this->equalTo($group)
+      );
+
+    // Call the groupCreate method.
+    $handler->groupCreate($this->group);
+
+    // Assert that the correct group is dispatched.
+    $this->assertEquals('com.getopensocial.cms.group.create', $group->getType());
+  }
+
+  /**
+   * Returns a mocked handler with dependencies injected.
+   *
+   * @return \Drupal\social_group_flexible_group\EdaHandler
+   *   The mocked handler instance.
+   */
+  protected function getMockedHandler(): EdaHandler {
+    return new EdaHandler(
+      // @phpstan-ignore-next-line
+      $this->dispatcher,
+      $this->uuid,
+      $this->requestStack,
+      $this->moduleHandler,
+      $this->entityTypeManager,
+      $this->account,
+      $this->routeMatch,
+      $this->configFactory
+    );
+  }
+
+}

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -13034,3 +13034,8 @@ parameters:
 			message: "#^Parameter \\$item of static method Drupal\\\\social_eda\\\\Types\\\\Address::fromFieldItem\\(\\) expects Drupal\\\\address\\\\Plugin\\\\Field\\\\FieldType\\\\AddressItem\\|null, Drupal\\\\Core\\\\Field\\\\FieldItemInterface\\|null given\\.$#"
 			count: 1
 			path: modules/social_features/social_event/src/EdaEventEnrollmentHandler.php
+
+		-
+			message: "#^Parameter \\$item of static method Drupal\\\\social_eda\\\\Types\\\\Address::fromFieldItem\\(\\) expects Drupal\\\\address\\\\Plugin\\\\Field\\\\FieldType\\\\AddressItem\\|null, Drupal\\\\Core\\\\Field\\\\FieldItemInterface\\|null given\\.$#"
+			count: 1
+			path: modules/social_features/social_group/modules/social_group_flexible_group/src/EdaHandler.php


### PR DESCRIPTION
## Problem (for internal)
Currently we don't have an EDA event that fires when a group is created.

## Solution (for internal)
Add the new event

Payload:

```
{
	"specversion": "1.0",
	"id": "70e9f519-a3d0-421f-bf42-659a08c4191f",
	"source": "/group/add/flexible_group",
	"type": "com.getopensocial.cms.group.create",
	"datacontenttype": "application/json",
	"time": "2024-11-21T15:11:46Z",
	"data": {
		"group": {
			"id": "1bd53650-0316-4713-a8da-bdffd14c539f",
			"created": "2024-11-21T15:11:46",
			"updated": "2024-11-21T15:11:46",
			"status": "published",
			"label": "Test",
			"visibility": {
				"type": "community",
				"roles": []
			},
			"contentVisibility": {
				"type": "community"
			},
			"membership": {
				"method": "request"
			},
			"type": "27aaa381-4322-4096-9cfa-63d4df67d538",
			"author": {
				"id": "53bb767a-cdc0-4872-81eb-9a4db10374bf",
				"displayName": "admin",
				"href": {
					"canonical": "https://opensocial.ddev.site/user/1/home"
				}
			},
			"address": {
				"label": "",
				"countryCode": "",
				"administrativeArea": "",
				"locality": "",
				"dependentLocality": "",
				"postalCode": "",
				"sortingCode": "",
				"addressLine1": "",
				"addressLine2": ""
			},
			"href": {
				"canonical": "https://opensocial.ddev.site/group/23/stream"
			}
		},
		"actor": {
			"application": null,
			"user": {
				"id": "53bb767a-cdc0-4872-81eb-9a4db10374bf",
				"displayName": "admin",
				"href": {
					"canonical": "https://opensocial.ddev.site/user/1/home"
				}
			}
		}
	}
}
```


## Release notes (to customers)
<!-- [Required if new feature, and if applicable] A summary of the changes that were made that can be included in release notes to customers.
Please provide enough context and detail, so the editorial review is done efficiently. -->

## Issue tracker
https://getopensocial.atlassian.net/browse/PROD-31232

## Theme issue tracker
<!-- *[Required if applicable] Paste a link to the drupal.org theme issue queue item, either from [socialbase](https://www.drupal.org/project/socialbase) or [socialblue](https://www.drupal.org/project/socialblue). If any other issue trackers were used, include links to those too.* -->

## How to test
1. Enable social_eda
2. Enable and set up the social_eda_dispatcher
3. Create a new group.
4. An event should be dispatched with the payload similar to above


## Change Record
<!-- *[Required if applicable] If this Pull Request changes the way that developers should do things or introduces a new API for developers then a change record to document this is needed. Please provide a draft for a change record or a link to an unpublished change record below. Existing change records can be consulted as example. Please provide a draft for a change record or a link to an unpublished change record below. [Existing change records](https://www.drupal.org/list-changes/social) can be consulted as example.* -->

## Translations
<!--
*[Optional]Translatable strings are always extracted from the latest development branch. To ensure translations remain available for platforms running older versions of Open Social the original string should be added to `translations.php` when it's changed or removed.*
- [ ] Changed or removed source strings are added to the `translations.php` file.
-->
