### PR TITLE
PROD-31167: Implement updated Kafka topics and set a default namespace

### DIFF
--- a/modules/custom/social_eda/config/install/social_eda.settings.yml
+++ b/modules/custom/social_eda/config/install/social_eda.settings.yml
@@ -1,0 +1,1 @@
+namespace: 'com.getopensocial'

--- a/modules/custom/social_eda/config/schema/social_eda.schema.yml
+++ b/modules/custom/social_eda/config/schema/social_eda.schema.yml
@@ -1,7 +1,7 @@
-# Schema for the configuration files of the Social EDA (Experimental) module.
+# Schema for the configuration files of the Social EDA module.
 social_eda.settings:
   type: config_object
-  label: 'Social EDA (Experimental) settings'
+  label: 'Social EDA settings'
   mapping:
     example:
       type: string

--- a/modules/custom/social_eda/config/schema/social_eda.schema.yml
+++ b/modules/custom/social_eda/config/schema/social_eda.schema.yml
@@ -1,0 +1,8 @@
+# Schema for the configuration files of the Social EDA (Experimental) module.
+social_eda.settings:
+  type: config_object
+  label: 'Social EDA (Experimental) settings'
+  mapping:
+    example:
+      type: string
+      label: 'Example'

--- a/modules/custom/social_eda/social_eda.info.yml
+++ b/modules/custom/social_eda/social_eda.info.yml
@@ -1,4 +1,4 @@
-name: 'Social EDA (Experimental)'
+name: 'Social EDA'
 type: module
 description: 'Social EDA core module'
 package: Social

--- a/modules/custom/social_eda/social_eda.links.menu.yml
+++ b/modules/custom/social_eda/social_eda.links.menu.yml
@@ -1,0 +1,5 @@
+social_eda.settings:
+  title: EDA Settings
+  description: EDA settings
+  route_name: social_eda.settings
+  parent: social_core.admin.config.social

--- a/modules/custom/social_eda/social_eda.permissions.yml
+++ b/modules/custom/social_eda/social_eda.permissions.yml
@@ -1,0 +1,2 @@
+administer social_eda configuration:
+  title: 'Administer social_eda configuration'

--- a/modules/custom/social_eda/social_eda.routing.yml
+++ b/modules/custom/social_eda/social_eda.routing.yml
@@ -1,0 +1,9 @@
+social_eda.settings:
+  path: '/admin/config/opensocial/eda'
+  defaults:
+    _title: 'EDA Settings'
+    _form: 'Drupal\social_eda\Form\SettingsForm'
+  requirements:
+    _permission: 'administer social_eda configuration'
+  options:
+    _admin_route: TRUE

--- a/modules/custom/social_eda/src/Form/SettingsForm.php
+++ b/modules/custom/social_eda/src/Form/SettingsForm.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\social_eda\Form;
+
+use Drupal\Core\Form\ConfigFormBase;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Configure Social EDA (Experimental) settings for this site.
+ */
+final class SettingsForm extends ConfigFormBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId(): string {
+    return 'social_eda_settings';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getEditableConfigNames(): array {
+    return ['social_eda.settings'];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state): array {
+    $form['namespace'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Namespace'),
+      '#default_value' => $this->config('social_eda.settings')->get('namespace'),
+      '#required' => TRUE,
+    ];
+    return parent::buildForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state): void {
+    $this->config('social_eda.settings')
+      ->set('namespace', $form_state->getValue('namespace'))
+      ->save();
+    parent::submitForm($form, $form_state);
+  }
+
+}

--- a/modules/custom/social_eda/src/Form/SettingsForm.php
+++ b/modules/custom/social_eda/src/Form/SettingsForm.php
@@ -8,7 +8,7 @@ use Drupal\Core\Form\ConfigFormBase;
 use Drupal\Core\Form\FormStateInterface;
 
 /**
- * Configure Social EDA (Experimental) settings for this site.
+ * Configure Social EDA settings for this site.
  */
 final class SettingsForm extends ConfigFormBase {
 

--- a/modules/social_features/social_event/tests/src/Unit/EdaHandlerTest.php
+++ b/modules/social_features/social_event/tests/src/Unit/EdaHandlerTest.php
@@ -3,9 +3,11 @@
 namespace Drupal\Tests\social_event\Unit;
 
 use CloudEvents\V1\CloudEventInterface;
+use Consolidation\Config\ConfigInterface;
 use Drupal\address\Plugin\Field\FieldType\AddressFieldItemList;
 use Drupal\address\Plugin\Field\FieldType\AddressItem;
 use Drupal\Component\Uuid\UuidInterface;
+use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\DependencyInjection\ContainerBuilder;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityStorageInterface;
@@ -126,6 +128,11 @@ class EdaHandlerTest extends UnitTestCase {
   protected CloudEventInterface $cloudEvent;
 
   /**
+   * Represents the ConfigFactoryInterface.
+   */
+  protected ConfigFactoryInterface $configFactory;
+
+  /**
    * {@inheritDoc}
    */
   protected function setUp(): void {
@@ -137,6 +144,17 @@ class EdaHandlerTest extends UnitTestCase {
     $languageMock->getId()->willReturn('en');
     $languageManagerMock->getCurrentLanguage()
       ->willReturn($languageMock->reveal());
+
+    // Mock the configuration for `social_eda.settings.namespaces`.
+    $configMock = $this->prophesize(ConfigInterface::class);
+    $configMock->get('namespace')->willReturn('com.getopensocial');
+
+    $configFactoryMock = $this->prophesize(ConfigFactoryInterface::class);
+    $configFactoryMock->get('social_eda.settings')->willReturn($configMock->reveal());
+    $this->configFactory = $configFactoryMock->reveal();
+
+    $container = new ContainerBuilder();
+    $container->set('config.factory', $configFactoryMock->reveal());
 
     // Mock Drupal's container.
     $container = new ContainerBuilder();
@@ -301,7 +319,7 @@ class EdaHandlerTest extends UnitTestCase {
     $this->dispatcher->expects($this->once())
       ->method('dispatch')
       ->with(
-        $this->equalTo('com.getopensocial.cms.event.create'),
+        $this->equalTo('com.getopensocial.cms.event.v1'),
         $this->equalTo($event)
       );
 
@@ -328,7 +346,7 @@ class EdaHandlerTest extends UnitTestCase {
     $this->dispatcher->expects($this->once())
       ->method('dispatch')
       ->with(
-        $this->equalTo('com.getopensocial.cms.event.delete'),
+        $this->equalTo('com.getopensocial.cms.event.v1'),
         $this->equalTo($event)
       );
 
@@ -352,7 +370,7 @@ class EdaHandlerTest extends UnitTestCase {
     $this->dispatcher->expects($this->once())
       ->method('dispatch')
       ->with(
-        $this->equalTo('com.getopensocial.cms.event.unpublish'),
+        $this->equalTo('com.getopensocial.cms.event.v1'),
         $this->equalTo($event)
       );
 
@@ -379,7 +397,7 @@ class EdaHandlerTest extends UnitTestCase {
     $this->dispatcher->expects($this->once())
       ->method('dispatch')
       ->with(
-        $this->equalTo('com.getopensocial.cms.event.publish'),
+        $this->equalTo('com.getopensocial.cms.event.v1'),
         $this->equalTo($event)
       );
 
@@ -406,7 +424,7 @@ class EdaHandlerTest extends UnitTestCase {
     $this->dispatcher->expects($this->once())
       ->method('dispatch')
       ->with(
-        $this->equalTo('com.getopensocial.cms.event.update'),
+        $this->equalTo('com.getopensocial.cms.event.v1'),
         $this->equalTo($event)
       );
 
@@ -432,7 +450,8 @@ class EdaHandlerTest extends UnitTestCase {
       $this->moduleHandler,
       $this->entityTypeManager,
       $this->account,
-      $this->routeMatch
+      $this->routeMatch,
+      $this->configFactory,
     );
   }
 

--- a/modules/social_features/social_user/asyncapi.yml
+++ b/modules/social_features/social_user/asyncapi.yml
@@ -135,7 +135,7 @@ channels:
                                   format: uri
                                   description: Canonical URL of the actor user.
   profileUpdate:
-    address: com.getopensocial.cms.profile.update
+    address: com.getopensocial.cms.user.profile.update
     messages:
       profileUpdate:
         payload:

--- a/modules/social_features/social_user/src/EdaHandler.php
+++ b/modules/social_features/social_user/src/EdaHandler.php
@@ -176,9 +176,11 @@ final class EdaHandler {
    * User delete handler.
    */
   public function userDelete(UserInterface $user): void {
-    $event_type = 'com.getopensocial.cms.user.delete';
-    $topic_name = 'com.getopensocial.cms.user.delete';
-    $this->dispatch($topic_name, $event_type, $user);
+    $this->dispatch(
+      topic_name: $this->topicName,
+      event_type: "{$this->namespace}.cms.user.delete",
+      user: $user,
+    );
   }
 
   /**

--- a/modules/social_features/social_user/src/EdaHandler.php
+++ b/modules/social_features/social_user/src/EdaHandler.php
@@ -114,7 +114,7 @@ final class EdaHandler {
   public function profileUpdate(UserInterface $user): void {
     $this->dispatch(
       topic_name: $this->topicName,
-      event_type: "{$this->namespace}.cms.profile.update",
+      event_type: "{$this->namespace}.cms.user.profile.update",
       user: $user,
     );
   }

--- a/modules/social_features/social_user/src/EdaHandler.php
+++ b/modules/social_features/social_user/src/EdaHandler.php
@@ -4,6 +4,7 @@ namespace Drupal\social_user;
 
 use CloudEvents\V1\CloudEvent;
 use Drupal\Component\Uuid\UuidInterface;
+use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
@@ -47,6 +48,20 @@ final class EdaHandler {
   protected string $routeName;
 
   /**
+   * The community namespace.
+   *
+   * @var string
+   */
+  protected string $namespace;
+
+  /**
+   * The topic name.
+   *
+   * @var string
+   */
+  protected string $topicName;
+
+  /**
    * {@inheritDoc}
    */
   public function __construct(
@@ -57,6 +72,7 @@ final class EdaHandler {
     private readonly EntityTypeManagerInterface $entityTypeManager,
     private readonly AccountProxyInterface $account,
     private readonly RouteMatchInterface $routeMatch,
+    private readonly ConfigFactoryInterface $configFactory,
   ) {
     // Load the full user entity if the account is authenticated.
     $account_id = $this->account->id();
@@ -73,60 +89,78 @@ final class EdaHandler {
 
     // Set route name.
     $this->routeName = $this->routeMatch->getRouteName() ?: '';
+
+    // Set the community namespace.
+    $this->namespace = $this->configFactory->get('social_eda.settings')->get('namespace') ?? 'com.getopensocial';
+
+    // Set the community namespace.
+    $this->topicName = "{$this->namespace}.cms.user.v1";
   }
 
   /**
    * Create user handler.
    */
   public function userCreate(UserInterface $user): void {
-    $event_type = 'com.getopensocial.cms.user.create';
-    $topic_name = 'com.getopensocial.cms.user.create';
-    $this->dispatch($topic_name, $event_type, $user);
+    $this->dispatch(
+      topic_name: $this->topicName,
+      event_type: "{$this->namespace}.cms.user.create",
+      user: $user,
+    );
   }
 
   /**
    * Profile update handler.
    */
   public function profileUpdate(UserInterface $user): void {
-    $event_type = 'com.getopensocial.cms.profile.update';
-    $topic_name = 'com.getopensocial.cms.profile.update';
-    $this->dispatch($topic_name, $event_type, $user);
+    $this->dispatch(
+      topic_name: $this->topicName,
+      event_type: "{$this->namespace}.cms.profile.update",
+      user: $user,
+    );
   }
 
   /**
    * User login handler.
    */
   public function userLogin(UserInterface $user): void {
-    $event_type = 'com.getopensocial.cms.user.login';
-    $topic_name = 'com.getopensocial.cms.user.login';
-    $this->dispatch($topic_name, $event_type, $user);
+    $this->dispatch(
+      topic_name: $this->topicName,
+      event_type: "{$this->namespace}.cms.user.login",
+      user: $user,
+    );
   }
 
   /**
    * User logout handler.
    */
   public function userLogout(UserInterface $user): void {
-    $event_type = 'com.getopensocial.cms.user.logout';
-    $topic_name = 'com.getopensocial.cms.user.logout';
-    $this->dispatch($topic_name, $event_type, $user);
+    $this->dispatch(
+      topic_name: $this->topicName,
+      event_type: "{$this->namespace}.cms.user.logout",
+      user: $user,
+    );
   }
 
   /**
    * User block handler.
    */
   public function userBlock(UserInterface $user): void {
-    $event_type = 'com.getopensocial.cms.user.block';
-    $topic_name = 'com.getopensocial.cms.user.block';
-    $this->dispatch($topic_name, $event_type, $user);
+    $this->dispatch(
+      topic_name: $this->topicName,
+      event_type: "{$this->namespace}.cms.user.block",
+      user: $user,
+    );
   }
 
   /**
    * User unblock handler.
    */
   public function userUnblock(UserInterface $user): void {
-    $event_type = 'com.getopensocial.cms.user.unblock';
-    $topic_name = 'com.getopensocial.cms.user.unblock';
-    $this->dispatch($topic_name, $event_type, $user);
+    $this->dispatch(
+      topic_name: $this->topicName,
+      event_type: "{$this->namespace}.cms.user.unblock",
+      user: $user,
+    );
   }
 
   /**

--- a/modules/social_features/social_user/tests/src/Unit/EdaHandlerTest.php
+++ b/modules/social_features/social_user/tests/src/Unit/EdaHandlerTest.php
@@ -467,7 +467,7 @@ class EdaHandlerTest extends UnitTestCase {
     $this->dispatcher->expects($this->once())
       ->method('dispatch')
       ->with(
-        $this->equalTo('com.getopensocial.cms.user.settings.email'),
+        $this->equalTo('com.getopensocial.cms.user.v1'),
         $this->equalTo($event)
       );
 

--- a/modules/social_features/social_user/tests/src/Unit/EdaHandlerTest.php
+++ b/modules/social_features/social_user/tests/src/Unit/EdaHandlerTest.php
@@ -299,7 +299,7 @@ class EdaHandlerTest extends UnitTestCase {
     $handler = $this->getMockedHandler();
 
     // Create the event object.
-    $event = $handler->fromEntity($this->user, 'com.getopensocial.cms.profile.update');
+    $event = $handler->fromEntity($this->user, 'com.getopensocial.cms.user.profile.update');
 
     // Expect the dispatch method in the dispatcher to be called.
     $this->dispatcher->expects($this->once())
@@ -313,7 +313,7 @@ class EdaHandlerTest extends UnitTestCase {
     $handler->profileUpdate($this->user);
 
     // Assert that the correct event is dispatched.
-    $this->assertEquals('com.getopensocial.cms.profile.update', $event->getType());
+    $this->assertEquals('com.getopensocial.cms.user.profile.update', $event->getType());
   }
 
   /**

--- a/modules/social_features/social_user/tests/src/Unit/EdaHandlerTest.php
+++ b/modules/social_features/social_user/tests/src/Unit/EdaHandlerTest.php
@@ -440,7 +440,7 @@ class EdaHandlerTest extends UnitTestCase {
     $this->dispatcher->expects($this->once())
       ->method('dispatch')
       ->with(
-        $this->equalTo('com.getopensocial.cms.user.delete'),
+        $this->equalTo('com.getopensocial.cms.user.v1'),
         $this->equalTo($event)
       );
 

--- a/modules/social_features/social_user/tests/src/Unit/EdaHandlerTest.php
+++ b/modules/social_features/social_user/tests/src/Unit/EdaHandlerTest.php
@@ -2,9 +2,11 @@
 
 namespace Drupal\Tests\social_user\Unit;
 
+use Consolidation\Config\ConfigInterface;
 use Drupal\address\Plugin\Field\FieldType\AddressFieldItemList;
 use Drupal\address\Plugin\Field\FieldType\AddressItem;
 use Drupal\Component\Uuid\UuidInterface;
+use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\DependencyInjection\ContainerBuilder;
 use Drupal\Core\Entity\EntityStorageInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
@@ -119,6 +121,11 @@ class EdaHandlerTest extends UnitTestCase {
   protected $profile;
 
   /**
+   * Represents the ConfigFactoryInterface.
+   */
+  protected ConfigFactoryInterface $configFactory;
+
+  /**
    * Set up the test environment.
    */
   protected function setUp(): void {
@@ -129,6 +136,14 @@ class EdaHandlerTest extends UnitTestCase {
     $languageMock = $this->prophesize(LanguageInterface::class);
     $languageMock->getId()->willReturn('en');
     $languageManagerMock->getCurrentLanguage()->willReturn($languageMock->reveal());
+
+    // Mock the configuration for `social_eda.settings.namespaces`.
+    $configMock = $this->prophesize(ConfigInterface::class);
+    $configMock->get('namespace')->willReturn('com.getopensocial');
+
+    $configFactoryMock = $this->prophesize(ConfigFactoryInterface::class);
+    $configFactoryMock->get('social_eda.settings')->willReturn($configMock->reveal());
+    $this->configFactory = $configFactoryMock->reveal();
 
     // Set up Drupal's container.
     $container = new ContainerBuilder();
@@ -263,7 +278,7 @@ class EdaHandlerTest extends UnitTestCase {
     $this->dispatcher->expects($this->once())
       ->method('dispatch')
       ->with(
-        $this->equalTo('com.getopensocial.cms.user.create'),
+        $this->equalTo('com.getopensocial.cms.user.v1'),
         $this->equalTo($event)
       );
 
@@ -290,7 +305,7 @@ class EdaHandlerTest extends UnitTestCase {
     $this->dispatcher->expects($this->once())
       ->method('dispatch')
       ->with(
-        $this->equalTo('com.getopensocial.cms.profile.update'),
+        $this->equalTo('com.getopensocial.cms.user.v1'),
         $this->equalTo($event)
       );
 
@@ -317,7 +332,7 @@ class EdaHandlerTest extends UnitTestCase {
     $this->dispatcher->expects($this->once())
       ->method('dispatch')
       ->with(
-        $this->equalTo('com.getopensocial.cms.user.login'),
+        $this->equalTo('com.getopensocial.cms.user.v1'),
         $this->equalTo($event)
       );
 
@@ -344,7 +359,7 @@ class EdaHandlerTest extends UnitTestCase {
     $this->dispatcher->expects($this->once())
       ->method('dispatch')
       ->with(
-        $this->equalTo('com.getopensocial.cms.user.logout'),
+        $this->equalTo('com.getopensocial.cms.user.v1'),
         $this->equalTo($event)
       );
 
@@ -371,7 +386,7 @@ class EdaHandlerTest extends UnitTestCase {
     $this->dispatcher->expects($this->once())
       ->method('dispatch')
       ->with(
-        $this->equalTo('com.getopensocial.cms.user.block'),
+        $this->equalTo('com.getopensocial.cms.user.v1'),
         $this->equalTo($event)
       );
 
@@ -398,7 +413,7 @@ class EdaHandlerTest extends UnitTestCase {
     $this->dispatcher->expects($this->once())
       ->method('dispatch')
       ->with(
-        $this->equalTo('com.getopensocial.cms.user.unblock'),
+        $this->equalTo('com.getopensocial.cms.user.v1'),
         $this->equalTo($event)
       );
 
@@ -478,7 +493,8 @@ class EdaHandlerTest extends UnitTestCase {
       $this->moduleHandler,
       $this->entityTypeManager,
       $this->account,
-      $this->routeMatch
+      $this->routeMatch,
+      $this->configFactory,
     );
   }
 


### PR DESCRIPTION
## Problem (for internal)
Although we had separate variables for event types and topics, both were using the same value. After internal meeting, we decided to update the Kafka topic names.

## Solution (for internal)
- Add a config form to set the community namespace. There's also a new permission to access this form;
- Update Kafka topic names;
- Update unit tests

> [!WARNING]  
> Although the topic name ends with `.v1`, this code still does not support more than 1 versions of the payload, as we may not need this anytime soon. When this requirement arrives we can implement it.

## Release notes (to customers)
N/A

## Issue tracker
- https://getopensocial.atlassian.net/browse/PROD-31167

## Theme issue tracker
N/A

## How to test
- [ ] Clone the branch `issue/PROD-31167-update-kafka-topics`
- [ ] Install the modules `social_eda` and `social_eda_dispatcher`
- [ ] Perform a task that would trigger an EDA event (e.g. create an event)
- [ ] Confirm that the event was sent to the proper topic (which ends with `.v1`)

The payload can be viewed on http://localhost:8080.

## Change Record
N/A

## Translations
N/A
