### PR TITLE
PROD-31252: Error on EdaEventEnrollmentHandler while deleting users

### DIFF
--- a/modules/social_features/social_event/tests/src/Unit/EdaEventEnrollmentHandlerTest.php
+++ b/modules/social_features/social_event/tests/src/Unit/EdaEventEnrollmentHandlerTest.php
@@ -362,6 +362,8 @@ class EdaEventEnrollmentHandlerTest extends UnitTestCase {
       'com.getopensocial.cms.event_enrollment.create'
     );
 
+    assert($event instanceof CloudEventInterface);
+
     // Assertions to verify the event has expected attributes.
     $this->assertEquals('1.0', $event->getSpecVersion());
     $this->assertEquals('com.getopensocial.cms.event_enrollment.create', $event->getType());


### PR DESCRIPTION
## Problem (for internal)
When deleting users, we are getting this error from EdaEventEnrollmentHandler
<img width="1280" alt="a467a19b-ed46-40c8-ac9b-bbae46dffb98" src="https://github.com/user-attachments/assets/2f3feda1-2b1e-457f-be99-5ca50bb23095">

## Solution (for internal)
When deleting users there is a code that cleans up event and event enrollment as well for the user, the issue is that event gets deleted before the enrollments, which is causing this error.


## Release notes (to customers)
Fixed an issue when deleting a user would cause a WSOD error.

## Issue tracker
https://getopensocial.atlassian.net/browse/PROD-31252

## Theme issue tracker
<!-- *[Required if applicable] Paste a link to the drupal.org theme issue queue item, either from [socialbase](https://www.drupal.org/project/socialbase) or [socialblue](https://www.drupal.org/project/socialblue). If any other issue trackers were used, include links to those too.* -->

## How to test
- [ ] Set up social_eda and social_eda_dispatcher modules (enabled them)
- [ ] Create a new event
- [ ] Create a new user and as this user enroll to the event created before
- [ ] As admin delete the user via the UI (and all its content)
- [ ] The user should be deleted without any errors and no EDA events for enrollments should be triggered.


## Change Record
<!-- *[Required if applicable] If this Pull Request changes the way that developers should do things or introduces a new API for developers then a change record to document this is needed. Please provide a draft for a change record or a link to an unpublished change record below. Existing change records can be consulted as example. Please provide a draft for a change record or a link to an unpublished change record below. [Existing change records](https://www.drupal.org/list-changes/social) can be consulted as example.* -->

## Translations
<!--
*[Optional]Translatable strings are always extracted from the latest development branch. To ensure translations remain available for platforms running older versions of Open Social the original string should be added to `translations.php` when it's changed or removed.*
- [ ] Changed or removed source strings are added to the `translations.php` file.
-->
