### PR TITLE
Issue #3487220: Fix user group list

### DIFF
--- a/modules/social_features/social_group/src/Plugin/views/argument/UserUid.php
+++ b/modules/social_features/social_group/src/Plugin/views/argument/UserUid.php
@@ -60,7 +60,7 @@ class UserUid extends ArgumentPluginBase {
       $subselect2 = $this->database->select('group_relationship_field_data', 'gc');
       $subselect2->addField('gc', 'gid');
       $subselect2->condition('gc.entity_id', $this->argument);
-      $subselect2->condition('gc.type', '%' . $this->database->escapeLike('membership') . '%', 'LIKE');
+      $subselect2->condition('gc.plugin_id', '%' . $this->database->escapeLike('membership') . '%', 'LIKE');
 
       if ($this->usesOptions && isset($this->options['group'])) {
         $this->query->addWhere($this->options['group'], $this->tableAlias . '.id', $subselect2, 'IN');


### PR DESCRIPTION
## Problem (for internal)
In the database we have table "group_relationship_field_data" which is the data table for group content entities. In this table, we can see the columns type, group_type and plugin_id.

The pattern for the group membership type is usually <group_type>-<plugin>. The type (column) is limited to 32 characters, and for example closed_challenge-group_membership (33 characters) is just too long.

Group includes a way to generate names that fit the limits imposed by Drupal core, and it does this consistently in its own code. However, this means that where a <bundle>-<plugin> concatenation would exceed the limit, it instead converts it to 'group_content_type_' . md5($preferred_id) and truncates it. This is done in GroupRelationshipTypeStorage::getRelationshipTypeId. The problem is that our code is naively looking at the concatenation and doesn't handle the "too long" case, which is handled by the group module.

## Solution (for internal)
To solve the problem, we replaced the "type" condition in the database query with the "plugin_id" condition, because we do not need the relationship "type", which is unique per plugin_id and group_type. Since group_type is always the same per group entity (and we filter per entity), filtering by "plugin_id" instead of "type" gives the expected result.

## Release notes (to customers)
Fix user groups page to include all groups (group types with longer machine names were excluded).


## Issue tracker
[3487220](https://www.drupal.org/project/social/issues/3487220)
<!--[PROD-31226](https://getopensocial.atlassian.net/browse/PROD-31226) -->

## Theme issue tracker
N/A

## How to test
- [ ] Install Open Social
- [ ] Go to /admin/group/types/add add group with machine name longer than 16 characters (like "Group with long name" -> "group_with_long_name")
- [ ] Add newly created group /group/add/group_with_long_name and become a member
- [ ] Go to /user/1/groups and you will not see your newly created group on the list
- [ ] Apply fix (and clear the cache)
- [ ] Go to /user/1/groups and you will see your newly created group on the list

Before:
![Screenshot 2024-11-13 at 13 20 47](https://github.com/user-attachments/assets/198a3220-2b87-4288-b91a-fad9f2b42c18)

After
![Screenshot 2024-11-13 at 13 22 06](https://github.com/user-attachments/assets/71a0c6da-8089-45b4-9979-a2d7aa8bc8f3)

## Change Record
N/A

## Translations
N/A


[PROD-31226]: https://getopensocial.atlassian.net/browse/PROD-31226?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ