### PR TITLE
Issue #3487312: Site managers can't see content of groups they are not part of

### DIFF
--- a/modules/social_features/social_group/src/Entity/Access/SocialGroupAccessControlHandler.php
+++ b/modules/social_features/social_group/src/Entity/Access/SocialGroupAccessControlHandler.php
@@ -53,7 +53,6 @@ class SocialGroupAccessControlHandler extends GroupAccessControlHandler implemen
    */
   protected function checkCreateAccess(AccountInterface $account, array $context, $entity_bundle = NULL) {
     if (
-      !$account->hasPermission('bypass group access') &&
       !$account->hasPermission('bypass create group access') &&
       !$this->configFactory->get('social_group.settings')->get('allow_group_create')
     ) {


### PR DESCRIPTION
## Problem (for internal)
The site-managers is not able to see the content in groups that they are not part of. So as for now, the group membership kind of outweighs the site manager status, which should not be the case.

## Solution (for internal)
We are using 'bypass group access' permission from group module and it was removed after version 2, check [#3259076](https://www.drupal.org/project/group/issues/3259076)

So I changed the validation to check group-permission from logged user.

## Release notes (to customers)
Fixed access from site-manager at group contents without be part of them.

## Issue tracker
[PROD-31123](https://getopensocial.atlassian.net/browse/PROD-31123)
[#3487312](https://www.drupal.org/project/social/issues/3487312)

## Theme issue tracker
N/A

## How to test
- [ ] Create a group
- [ ] Create some posts private to group and others for community
- [ ] Log-in with site-managers not-member of group created before
- [ ] Go to group and check the posts, the site-managers should be able to see all content from group

## Change Record
N/A

## Translations
N/A



[PROD-31123]: https://getopensocial.atlassian.net/browse/PROD-31123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ