### PR TITLE
PROD-31314: Implement "user is pending" event for the EDA

### DIFF
--- a/modules/social_features/social_user/social_user.module
+++ b/modules/social_features/social_user/social_user.module
@@ -727,21 +727,30 @@ function social_user_profile_insert(ProfileInterface $profile): void {
   if ($user instanceof UserInterface) {
     $current_request = \Drupal::requestStack()->getCurrentRequest();
     $user_settings = \Drupal::config('user.settings');
-    $trigger = FALSE;
 
     // If user is created from the route `user.register`.
     if ($current_request && $current_request->get('_route') == 'user.register') {
       // Admin approval is required.
       if ($user_settings->get('register') != 'visitors_admin_approval') {
-        $trigger = TRUE;
+        $eda_handler = 'userCreate';
+      }
+      else {
+        $eda_handler = 'userPending';
       }
     }
     else {
-      $trigger = TRUE;
+      $eda_handler = 'userCreate';
     }
 
-    if ($trigger && !str_starts_with($user->getAccountName(), '__DELETED_USER')) {
-      \Drupal::service('social_user.eda_handler')->userCreate($user);
+    // Call the EDA method dynamically if the account name doesn't start
+    // with '__DELETED_USER'.
+    if (!str_starts_with($user->getAccountName(), '__DELETED_USER')) {
+      $eda_service = \Drupal::service('social_user.eda_handler');
+
+      // Check if the method exists before calling it.
+      if (method_exists($eda_service, $eda_handler)) {
+        $eda_service->{$eda_handler}($user);
+      }
     }
   }
 }


### PR DESCRIPTION
## Description
This pull request introduces the new EDA event "user pending" which is dispatches to the Kafka topic com.getopensocial.cms.user.pending.

Here's an example of the generated payload:
```
{
	"specversion": "1.0",
	"id": "b539b771-3a50-41b0-b96d-4c54d6ae1f39",
	"source": "/user/register",
	"type": "com.getopensocial.cms.user.pending",
	"datacontenttype": "application/json",
	"time": "2024-11-18T13:53:27Z",
	"data": {
		"user": {
			"id": "1c03fa99-1ee4-47fa-981d-9290a8fc2155",
			"created": "2024-11-18T13:53:27",
			"updated": "2024-11-18T13:53:27",
			"status": "pending",
			"displayName": "dsds",
			"firstName": "",
			"lastName": "",
			"email": "dsdsds@sd.com",
			"roles": [
				"authenticated",
				"verified"
			],
			"timezone": "UTC",
			"language": "en",
			"address": {
				"label": "",
				"countryCode": "",
				"administrativeArea": "",
				"locality": "",
				"dependentLocality": "",
				"postalCode": "",
				"sortingCode": "",
				"addressLine1": "",
				"addressLine2": ""
			},
			"phone": "",
			"function": "",
			"organization": "",
			"href": {
				"canonical": "http://cablecar.localhost/user/24/home"
			}
		},
		"actor": {
			"application": null,
			"user": null
		}
	}
}
```

## Release notes (to customers)
N/A

## Issue tracker
https://getopensocial.atlassian.net/browse/PROD-31314

## Theme issue tracker
N/A

## How to test
- [ ] Checkout branch `issue/PROD-31314-eda-user-pending`
- [ ] Enable modules `social_eda` and `social_eda_dispatcher`
- [ ] Make sure the account settings is configured to `visitors_admin_approval`
- [ ] Register an account as anonymous


## Change Record
<!-- *[Required if applicable] If this Pull Request changes the way that developers should do things or introduces a new API for developers then a change record to document this is needed. Please provide a draft for a change record or a link to an unpublished change record below. Existing change records can be consulted as example. Please provide a draft for a change record or a link to an unpublished change record below. [Existing change records](https://www.drupal.org/list-changes/social) can be consulted as example.* -->

## Translations
<!--
*[Optional]Translatable strings are always extracted from the latest development branch. To ensure translations remain available for platforms running older versions of Open Social the original string should be added to `translations.php` when it's changed or removed.*
- [ ] Changed or removed source strings are added to the `translations.php` file.
-->
