### PR TITLE
Issue #3477793: Fix social_group_flexible_group_update_130006 update

### DIFF
--- a/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.install
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.install
@@ -257,9 +257,17 @@ function social_group_flexible_group_update_130005() : void {
 function social_group_flexible_group_update_130006(): string {
   /** @var \Drupal\update_helper\Updater $updater */
   $updater = \Drupal::service('update_helper.updater');
-
+  // Load existing "Verified" group role.
+  $verified_roles = \Drupal::entityTypeManager()
+    ->getStorage('group_role')
+    ->loadByProperties([
+      'scope' => 'outsider',
+      'global_role' => 'verified',
+      'group_type' => 'flexible_group',
+    ]);
+  // Create "Verified" group role if it isn't exist.
   if (\Drupal::moduleHandler()->moduleExists('social_group_flexible_group') &&
-    empty(\Drupal::config('group.role.flexible_group-verified')->getRawData())
+    empty($verified_roles)
   ) {
     // Execute configuration update definitions with logging of success.
     $updater->executeUpdate('social_group_flexible_group', __FUNCTION__);


### PR DESCRIPTION
## Problem (for internal)
The social_group_flexible_group_update_130006 was failing because of an already existing "verified" role.

## Solution (for internal)
The config name of the group role could be hashed if the length of the name is longer than 32 symbols, so we can't check configs by name, so we should check if such a role exists by GroupRole entity properties.

## Release notes (to customers)
Internal.

## Issue tracker

- https://www.drupal.org/project/social/issues/3477793
- https://getopensocial.atlassian.net/browse/PROD-28608
