### PR TITLE
Issue #3490130: I want to see that a Book page is part of a Group

### DIFF
--- a/config/optional/node.type.book.yml
+++ b/config/optional/node.type.book.yml
@@ -19,4 +19,4 @@ description: '<em>Books</em> have a built-in hierarchical navigation. Use for ha
 help: ''
 new_revision: false
 preview_mode: 1
-display_submitted: false
+display_submitted: true

--- a/modules/social_features/social_book/social_book.install
+++ b/modules/social_features/social_book/social_book.install
@@ -113,3 +113,16 @@ function social_book_update_130000(): ?string {
   // Output logged messages to a related channel of update execution.
   return $updateHelper->logger()->output();
 }
+
+/**
+ * Enable author info on book pages.
+ */
+function social_book_update_130001(): void {
+  $config = \Drupal::configFactory()->getEditable('node.type.book');
+  if (!empty($config->getRawData())) {
+    \Drupal::configFactory()
+      ->getEditable('node.type.book')
+      ->set('display_submitted', TRUE)
+      ->save(TRUE);
+  }
+}


### PR DESCRIPTION
## Problem (for internal)
When a topic or event are added to a Group, this information is visible in teasers and node page.
For book pages this information is missing.

## Solution (for internal)
Add general metadata info to book pages as well.

## Release notes (to customers)
Updated the book display so it shows the author and group information on teaser and full view modes.

**Before:**
![image](https://github.com/user-attachments/assets/287655e3-6b77-41c9-ab33-ac8db784b23b)
![image](https://github.com/user-attachments/assets/bbdd5339-4a9d-409d-869f-d2c50d49ba71)

**After:**
![image](https://github.com/user-attachments/assets/bab05ee7-3475-43b9-a1d1-be05c3f3af8a)
![image](https://github.com/user-attachments/assets/a8a75458-ccfb-47ec-a794-d99541f00813)

## Issue tracker

- https://www.drupal.org/project/social/issues/3490130
- https://getopensocial.atlassian.net/browse/PROD-19343

## Theme issue tracker
<!-- *[Required if applicable] Paste a link to the drupal.org theme issue queue item, either from [socialbase](https://www.drupal.org/project/socialbase) or [socialblue](https://www.drupal.org/project/socialblue). If any other issue trackers were used, include links to those too.* -->

Note: For teasers to work, you need this change:
- https://www.drupal.org/project/socialbase/issues/3490131#comment-15875719**

## How to test
1. Create a new topic and set it as part of the group
2. You should see the author information and the information that its part of a group below the title
3. Enable social_book and social_flexible_group_book modules
4. Create a new book and place it in a group
5. The info below the title about the author and a group is missing.

