### PR TITLE
PROD-31219: Update broken NL translation

### DIFF
--- a/translations/nl.po
+++ b/translations/nl.po
@@ -234,7 +234,7 @@ msgstr "/group/{{ gid }}/content/{{ id }}/reject-membership"
 
 #: modules/social_features/social_event/config/install/views.view.event_enrollments.yml:0
 msgid "/node/{{ raw_arguments.nid }}/enrollments"
-msgstr "/node/{ raw_arguments.nid }}/aanmeldingen"
+msgstr "/node/{{ raw_arguments.nid }}/enrollments"
 
 #: modules/custom/download_count/src/Plugin/Field/FieldFormatter/FieldDownloadCount.php:174
 msgid "0 downloads"


### PR DESCRIPTION
## Problem (for internal)
<!-- *[Required] Describe the problem you're trying to solve, this should motivate why the changes you're proposing are needed.* -->
When using NL language on an event, the public link to see all members is broken due to wrong translation. 

## Solution (for internal)
<!-- *[Required] Describe the solution you've created, elaborate on any technical choices you've made. Why is this the right solution and is a different solution not the right one? What is the reasoning behind the chosen solution?* -->
Update the translation of the link.

<!-- [Optional] If this Pull Request makes visual changes then please include some screenshots that show what has changed here. A before and after screenshot helps the reviewer determine what changes were made. -->

## Release notes (to customers)
<!-- [Required if new feature, and if applicable] A summary of the changes that were made that can be included in release notes to customers.
Please provide enough context and detail, so the editorial review is done efficiently. -->
Fixing a bug that breaks the NL translation of the public link to see all registered people of an event.

## Issue tracker
<!-- *[Required] Paste a link to the drupal.org issue queue item. If any other issue trackers were used, include links to those too.* -->
https://getopensocial.atlassian.net/browse/PROD-31219

## Theme issue tracker
<!-- *[Required if applicable] Paste a link to the drupal.org theme issue queue item, either from [socialbase](https://www.drupal.org/project/socialbase) or [socialblue](https://www.drupal.org/project/socialblue). If any other issue trackers were used, include links to those too.* -->

## How to test
<!--
*[Required] For example*
- [ ] Using version X.Y.Z of Open Social with the example module enabled
- [ ] As a sitemanager
- [ ] Try to enable the option B on screen c/d/e
- [ ] When saving I expect the result to be F but instead see G.
- [ ] The expected result F is attained when repeating the steps with this fix applied.
-->
- Turn on `social_langue`
- go to `/admin/config/regional/language` add Dutch
- select Dutch as default
- go to an event with some registered people
- the link `Alle aanmeldingen` should be working.

## Change Record
<!-- *[Required if applicable] If this Pull Request changes the way that developers should do things or introduces a new API for developers then a change record to document this is needed. Please provide a draft for a change record or a link to an unpublished change record below. Existing change records can be consulted as example. Please provide a draft for a change record or a link to an unpublished change record below. [Existing change records](https://www.drupal.org/list-changes/social) can be consulted as example.* -->

## Translations
<!--
*[Optional]Translatable strings are always extracted from the latest development branch. To ensure translations remain available for platforms running older versions of Open Social the original string should be added to `translations.php` when it's changed or removed.*
- [ ] Changed or removed source strings are added to the `translations.php` file.
-->
