### PR TITLE
Issue #3490022 - Revert #4183 from `12.4.x` to fix `Column not found: 1054 Unknown column 'gc.plugin_id'`

### DIFF
--- a/modules/social_features/social_group/src/Plugin/views/argument/UserUid.php
+++ b/modules/social_features/social_group/src/Plugin/views/argument/UserUid.php
@@ -60,7 +60,7 @@ class UserUid extends ArgumentPluginBase {
       $subselect2 = $this->database->select('group_content_field_data', 'gc');
       $subselect2->addField('gc', 'gid');
       $subselect2->condition('gc.entity_id', $this->argument);
-      $subselect2->condition('gc.plugin_id', '%' . $this->database->escapeLike('membership') . '%', 'LIKE');
+      $subselect2->condition('gc.type', '%' . $this->database->escapeLike('membership') . '%', 'LIKE');
 
       if ($this->usesOptions && isset($this->options['group'])) {
         $this->query->addWhere($this->options['group'], $this->tableAlias . '.id', $subselect2, 'IN');


### PR DESCRIPTION
## Problem (for internal)
#4183 
Was cherry-picked to 12.4.x but contains fixes using Group version 2 changes, that isn't part of 12.4.x only 13.x so we can't cherry-pick this.

This caused:

```
Drupal\Core\Database\DatabaseExceptionWrapper: Exception in User Groups[groups]: SQLSTATE[42S22]: Column not found: 1054 Unknown column 'gc.plugin_id' in 'where clause': SELECT "groups_field_data"."created" AS "groups_field_data_created", "groups_field_data"."label" AS "groups_field_data_label", "groups_field_data"."id" AS "id", "flagging_groups_field_data"."id" AS "flagging_groups_field_data_id" FROM "groups_field_data" "groups_field_data" LEFT JOIN "flagging" 
```
For those on 12.4.x

## Solution (for internal)
Revert the commit just from 12.4.x, it is valid for 13.x
I've reverted it as an additional commit, to ensure we can explain our reasoning in the history of commits, instead of completely removing it.

## Release notes (to customers)
None, this is 12.4.x only.

## Issue tracker
https://www.drupal.org/project/social/issues/3490022

## How to test
Reinstall on 12.4.x with demo content and visit `/user/1/groups`