### PR TITLE
Issue #3490462: Revoke "Join group" and "request group membership" from Authenticated (outsider) group role

### DIFF
--- a/modules/social_features/social_group/modules/social_group_flexible_group/config/install/group.role.flexible_group-outsider.yml
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/config/install/group.role.flexible_group-outsider.yml
@@ -13,7 +13,6 @@ group_type: flexible_group
 permissions:
   - 'access comments'
   - 'access posts in group'
-  - 'join group'
   - 'update own group_node:event entity'
   - 'update own group_node:topic entity'
   - 'view group'

--- a/modules/social_features/social_group/modules/social_group_flexible_group/config/install/group.role.flexible_group-verified.yml
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/config/install/group.role.flexible_group-verified.yml
@@ -13,6 +13,7 @@ permissions:
   - 'access comments'
   - 'access posts in group'
   - 'join group'
+  - 'request group membership'
   - 'update own group_node:event entity'
   - 'update own group_node:topic entity'
   - 'view group'

--- a/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.install
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/social_group_flexible_group.install
@@ -7,6 +7,7 @@
 
 use Drupal\Core\Config\FileStorage;
 use Drupal\group\Entity\GroupInterface;
+use Drupal\group\Entity\GroupRoleInterface;
 use Drupal\group\GroupMembership;
 use Drupal\social_group\Entity\Group;
 use Drupal\user\Entity\User;
@@ -331,4 +332,38 @@ function social_group_flexible_group_update_130008(): void {
   $form_display->set('hidden', $hidden)
     ->set('content', $content)
     ->save();
+}
+
+/**
+ * Revoke permissions for Authenticated (outsider) group role.
+ */
+function social_group_flexible_group_update_130009(): void {
+  $group_authenticated_role = \Drupal::entityTypeManager()
+    ->getStorage('group_role')
+    ->load('flexible_group-outsider');
+
+  if ($group_authenticated_role instanceof GroupRoleInterface) {
+    $group_authenticated_role->revokePermissions([
+      'join group',
+      'request group membership',
+    ])->save();
+  }
+
+}
+
+/**
+ * Grant permissions for Verified (outsider) group role.
+ */
+function social_group_flexible_group_update_130010(): void {
+  $group_verified_role = \Drupal::entityTypeManager()
+    ->getStorage('group_role')
+    ->load('flexible_group-verified');
+
+  if ($group_verified_role instanceof GroupRoleInterface) {
+    $group_verified_role->grantPermissions([
+      'join group',
+      'request group membership',
+    ])->save();
+  }
+
 }

--- a/modules/social_features/social_group/modules/social_group_flexible_group/src/Subscriber/Route.php
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/src/Subscriber/Route.php
@@ -57,6 +57,7 @@ class Route extends RouteSubscriberBase {
         $route->addRequirements($requirements);
       }
     }
+
   }
 
 }

--- a/modules/social_features/social_group/modules/social_group_invite/src/Controller/SocialGroupInvitationController.php
+++ b/modules/social_features/social_group/modules/social_group_invite/src/Controller/SocialGroupInvitationController.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Drupal\social_group_invite\Controller;
+
+use Drupal\Core\Access\AccessResult;
+use Drupal\ginvite\Controller\InvitationOperations;
+use Drupal\group\Entity\GroupRelationshipInterface;
+
+/**
+ * Handles Accept/Decline operations and Access check for Social groups.
+ */
+class SocialGroupInvitationController extends InvitationOperations {
+
+  /**
+   * {@inheritDoc}
+   */
+  public function checkAccess(GroupRelationshipInterface $group_content): AccessResult {
+    $result = parent::checkAccess($group_content);
+    $group = $group_content->getGroup();
+
+    if (!$group->hasPermission('join group', $this->currentUser())) {
+      AccessResult::forbidden();
+    }
+
+    return $result;
+  }
+
+}

--- a/modules/social_features/social_group/modules/social_group_invite/src/Controller/SocialGroupInvitationOperations.php
+++ b/modules/social_features/social_group/modules/social_group_invite/src/Controller/SocialGroupInvitationOperations.php
@@ -61,9 +61,10 @@ class SocialGroupInvitationOperations extends InvitationOperations {
    */
   public function checkAccess(GroupRelationshipInterface $group_content) {
     $invited = $group_content->getEntityId();
+    $group = $group_content->getGroup();
 
     // Only allow user accept/decline own invitations.
-    if ($invited == $this->currentUser()->id()) {
+    if ($invited == $this->currentUser()->id() && $group->hasPermission('join group', $this->currentUser())) {
       return AccessResult::allowed();
     }
     return AccessResult::forbidden();

--- a/modules/social_features/social_group/modules/social_group_invite/src/Routing/RouteSubscriber.php
+++ b/modules/social_features/social_group/modules/social_group_invite/src/Routing/RouteSubscriber.php
@@ -3,6 +3,7 @@
 namespace Drupal\social_group_invite\Routing;
 
 use Drupal\Core\Routing\RouteSubscriberBase;
+use Drupal\social_group_invite\Controller\SocialGroupInvitationController;
 use Symfony\Component\Routing\RouteCollection;
 
 /**
@@ -25,6 +26,14 @@ class RouteSubscriber extends RouteSubscriberBase {
       unset($requirements['_group_permission']);
       $route->setDefaults($defaults);
       $route->setRequirements($requirements);
+    }
+
+    // Do not allow to accept invitation without "join group" permission.
+    if ($route = $collection->get('ginvite.invitation.accept')) {
+      $route->setRequirement(
+        '_custom_access',
+        SocialGroupInvitationController::class . '::checkAccess',
+      );
     }
   }
 

--- a/modules/social_features/social_group/modules/social_group_request/social_group_request.install
+++ b/modules/social_features/social_group/modules/social_group_request/social_group_request.install
@@ -40,11 +40,11 @@ function social_group_request_update_dependencies(): array {
  */
 function _social_group_request_set_permissions(): void {
   if (\Drupal::moduleHandler()->moduleExists('social_group_flexible_group')) {
-    /** @var \Drupal\group\Entity\GroupRoleInterface $outsider */
-    $outsider = \Drupal::entityTypeManager()
+    /** @var \Drupal\group\Entity\GroupRoleInterface $verified */
+    $verified = \Drupal::entityTypeManager()
       ->getStorage('group_role')
-      ->load('flexible_group-outsider');
-    $outsider->grantPermission('request group membership')->save();
+      ->load('flexible_group-verified');
+    $verified->grantPermission('request group membership')->save();
 
     /** @var \Drupal\group\Entity\GroupRoleInterface $group_manager */
     $group_manager = \Drupal::entityTypeManager()

--- a/modules/social_features/social_group/modules/social_group_request/src/SocialGroupRequestConfigOverride.php
+++ b/modules/social_features/social_group/modules/social_group_request/src/SocialGroupRequestConfigOverride.php
@@ -87,19 +87,6 @@ class SocialGroupRequestConfigOverride implements ConfigFactoryOverrideInterface
     $outsider_role_configs = [];
     foreach ($social_group_types as $social_group_type) {
       $default_form_display_configs[] = "core.entity_form_display.group.{$social_group_type}.default";
-      $outsider_role_configs[] = "group.role.{$social_group_type}-outsider";
-    }
-
-    foreach ($outsider_role_configs as $config_name) {
-      if (in_array($config_name, $names)) {
-        $config = $this->configFactory->getEditable($config_name);
-        $permissions = $config->get('permissions');
-        $permissions[] = 'request group membership';
-
-        $overrides[$config_name] = [
-          'permissions' => $permissions,
-        ];
-      }
     }
 
     foreach ($default_form_display_configs as $config_name) {


### PR DESCRIPTION
## Problem (for internal)
The change is based on permissions, so the ability to join a group should be removed from the AU Outsider role.
This improvement should be applied by default when a new platform is set up and should also apply to all existing platforms.

Expected Behavior:

- **As an AU, I cannot join an Open-to-Join group**: The "Join" button is not visible to AUs.
- **As an AU, I cannot request to join a Request-to-Join group**: The "Request to Join" button is not visible to AUs.
- **As an AU, I cannot see the Invite-Only button**: The "Invite Only" button is not visible to AUs.
- **As an AU, I cannot be invited to join a group**: AU users are not included in the list of invitees.
- **As an AU, I cannot be added directly as a member of a group**: AU users do not appear in the list when someone tries to add members to a group.
- **As an AU, I cannot quick join any group**: Using a quick join link will result in an "Access Denied" message.
- **As an AU, I cannot use a direct link to join a group**: A direct link will result in an "Access Denied" message.


## Solution (for internal)

1. Remove group permissions config override from [SocialGroupRequestConfigOverride.php](https://github.com/goalgorilla/open_social/compare/issue/3490462-update-group-join-premissions?expand=1#diff-95d62c5aeba77af9abb161d39402be90ee5cfe7664c7ef2a6676d8356369c11b)
2. Add `social_group_flexible_group_update_130009` to revoke 'join group' and 'request group membership' permissions from Authenticated group roles.
3. Remove 'join group' permission from the default permissions of the Authenticated group role of the Flexible group
4. Add the `_group_permission: join` group requirement to the `ginvite.invitation.accept` route to restrict access, ensuring that users without the "join group" permission cannot accept group invitations.

## Release notes (to customers)
Revoke the permissions from the Authenticated group role of the Flexible group to prevent access to the actions of joining, inviting, or requesting to join.

## Issue tracker
https://www.drupal.org/project/social/issues/3490462
https://getopensocial.atlassian.net/browse/PROD-28267

## How to test

- [ ] Enable module `social_group_quickjoin`
- [ ] Go to `/admin/config/opensocial/group-quickjoin` and enable "Quick join"
- [ ] Create Flexible group "Flexible group 1" with Join method: Open to join
- [ ] Create Flexible group "Flexible group 2" with Join method: Request to join
- [ ] Create Flexible group "Flexible group 3" with Join method: Invite only
- [ ] Go to admin/config/people/accounts and disable 'New users automatically get the Verified User role assigned' checkbox, save settings
- [ ] Create AU user "AU user"
- [ ] As AU go to page /group/1/about - you shouldn't see the "Join" button
- [ ] As AU go to page /group/2/about - you shouldn't see the "Request" button
- [ ] As AU go to page /group/3/about - you shouldn't see the "Invite-Only" button
- [ ] Try go to '/group/1/quickjoin' - you should get an Access Denied exception
- [ ] Try to go '/social-group-invite/3/accept' - you should get an Access Denied exception
- [ ] As the group admin try to add directly the member "AU user" - this user shouldn't appear in the suggestion list

## Screenshots
![image](https://github.com/user-attachments/assets/bff98b5c-d929-427f-82c0-0a78c74bd98d)
![image](https://github.com/user-attachments/assets/a7a101ad-5b90-44a2-8fb2-7864c960d770)
![image](https://github.com/user-attachments/assets/3c308fa5-9bde-41e1-b852-2a70c28cce19)
