### PR TITLE
Issue #3490604: Remove CSV export button in group and event manage members view when all CSV plugins options disabled by SM

### DIFF
--- a/modules/social_features/social_event/modules/social_event_an_enroll/src/Plugin/views/field/SocialEventAnEnrollViewsBulkOperationsBulkForm.php
+++ b/modules/social_features/social_event/modules/social_event_an_enroll/src/Plugin/views/field/SocialEventAnEnrollViewsBulkOperationsBulkForm.php
@@ -3,6 +3,7 @@
 namespace Drupal\social_event_an_enroll\Plugin\views\field;
 
 use Drupal\Core\Action\ActionManager;
+use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
@@ -53,6 +54,8 @@ class SocialEventAnEnrollViewsBulkOperationsBulkForm extends SocialEventManagers
    *   The entity type manager.
    * @param \Drupal\Core\Action\ActionManager $pluginActionManager
    *   The action manager.
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   The config factory.
    * @param \Drupal\social_event_an_enroll\EventAnEnrollManager $social_event_an_enroll_manager
    *   The event an enroll manager.
    */
@@ -68,10 +71,10 @@ class SocialEventAnEnrollViewsBulkOperationsBulkForm extends SocialEventManagers
     RequestStack $requestStack,
     EntityTypeManagerInterface $entity_type_manager,
     ActionManager $pluginActionManager,
-    EventAnEnrollManager $social_event_an_enroll_manager
+    ConfigFactoryInterface $config_factory,
+    EventAnEnrollManager $social_event_an_enroll_manager,
   ) {
-    parent::__construct($configuration, $plugin_id, $plugin_definition, $viewData, $actionManager, $actionProcessor, $tempStoreFactory, $currentUser, $requestStack, $entity_type_manager, $pluginActionManager);
-
+    parent::__construct($configuration, $plugin_id, $plugin_definition, $viewData, $actionManager, $actionProcessor, $tempStoreFactory, $currentUser, $requestStack, $entity_type_manager, $pluginActionManager, $config_factory);
     $this->socialEventAnEnrollManager = $social_event_an_enroll_manager;
   }
 

--- a/modules/social_features/social_user_export/social_user_export.install
+++ b/modules/social_features/social_user_export/social_user_export.install
@@ -30,3 +30,10 @@ function social_user_export_install(): void {
 function social_user_export_update_last_removed() : int {
   return 11002;
 }
+
+/**
+ * Assign a new administer social_user_export permission to SM.
+ */
+function social_user_export_update_11003(): void {
+  user_role_grant_permissions('sitemanager', ['administer social_user_export']);
+}

--- a/modules/social_features/social_user_export/social_user_export.permissions.yml
+++ b/modules/social_features/social_user_export/social_user_export.permissions.yml
@@ -1,0 +1,4 @@
+administer social_user_export:
+  title: 'Administer user export'
+  description: 'Allows users to export users even if disabled via config.'
+  restrict access: true

--- a/tests/behat/features/capabilities/administration/check-export-users-to-csv.feature
+++ b/tests/behat/features/capabilities/administration/check-export-users-to-csv.feature
@@ -240,3 +240,17 @@ Feature: Export users
       3,34fff0f1-8897-4ca8-a682-707c9dd87501,ExportUser2,ExportUser2,exportuser2@example.com,never,never,"02/17/2023 - 14:42",Active,"authenticated, verified",1,1,1,1,1,0,0,,0
       2,85e14211-147c-4f01-ae18-b97300671de6,ExportUser1,ExportUser1,exportuser1@example.com,never,never,"02/17/2023 - 14:42",Active,"authenticated, verified",1,1,1,1,1,0,0,,1
       """
+
+  Scenario: The export group members is not displayed if every export plugin is disabled
+    Given I am logged in as a user with the "sitemanager" role
+
+    When I am on "/admin/config/opensocial/export"
+    And I uncheck the box "edit-plugins-display-name"
+    And I uncheck the box "edit-plugins-user-first-name"
+    And I uncheck the box "edit-plugins-user-last-name"
+    And I press the "Save configuration" button
+    And I enable the module "social_group_members_export"
+    And I am on "group/1/membership"
+    And I should see the button "Actions"
+    And I click the xth "0" element with the css "#vbo-action-form-wrapper .dropdown .dropdown-toggle"
+    And I should not see the link "Export selected enrollees"


### PR DESCRIPTION
## Problem (for internal)
When all the CSV fields in admin/config/opensocial/export aren't checked, the CSV export action should not appear in the group or event manage members views .

## Solution (for internal)
The export CSV actions should not be displayed if we have disabled all the user fields in the config.


## Release notes (to customers)
Fixed an issue where CSV export members action was available in the group/event manage members field, even if all the CSV fields were disabled by the SM in the configuration options of CSV export module.

## Issue tracker

- https://www.drupal.org/project/social/issues/3490604
- https://getopensocial.atlassian.net/browse/PROD-28635

## Theme issue tracker
<!-- *[Required if applicable] Paste a link to the drupal.org theme issue queue item, either from [socialbase](https://www.drupal.org/project/socialbase) or [socialblue](https://www.drupal.org/project/socialblue). If any other issue trackers were used, include links to those too.* -->

## How to test
1. Enable social_user_export, social_group_members_export modules
2. Go to /admin/config/opensocial/export
3. Disable everything
4. Go to any group
5. In Manager Members tab you will see "Export" in actions

## Change Record
<!-- *[Required if applicable] If this Pull Request changes the way that developers should do things or introduces a new API for developers then a change record to document this is needed. Please provide a draft for a change record or a link to an unpublished change record below. Existing change records can be consulted as example. Please provide a draft for a change record or a link to an unpublished change record below. [Existing change records](https://www.drupal.org/list-changes/social) can be consulted as example.* -->

## Translations
<!--
*[Optional]Translatable strings are always extracted from the latest development branch. To ensure translations remain available for platforms running older versions of Open Social the original string should be added to `translations.php` when it's changed or removed.*
- [ ] Changed or removed source strings are added to the `translations.php` file.
-->
