### PR TITLE
Issue #3490695: Wrong users number on bulk email sending

### DIFF
--- a/modules/social_features/social_email_broadcast/social_email_broadcast.services.yml
+++ b/modules/social_features/social_email_broadcast/social_email_broadcast.services.yml
@@ -1,3 +1,9 @@
 services:
   Drupal\social_email_broadcast\SocialEmailBroadcast:
     arguments: ['@database']
+
+  Drupal\social_email_broadcast\ViewsBulkOperationsActionProcessorDecorator:
+    decorates: views_bulk_operations.processor
+    parent: views_bulk_operations.processor
+    decoration_on_invalid: ignore
+    public: false

--- a/modules/social_features/social_email_broadcast/src/ViewsBulkOperationsActionProcessorDecorator.php
+++ b/modules/social_features/social_email_broadcast/src/ViewsBulkOperationsActionProcessorDecorator.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Drupal\social_email_broadcast;
+
+use Drupal\views_bulk_operations\Service\ViewsBulkOperationsActionProcessor as Inner;
+
+/**
+ * Decorates VBO action processor service.
+ */
+class ViewsBulkOperationsActionProcessorDecorator extends Inner {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function populateQueue(array $data, array &$context = []): int {
+    $count = parent::populateQueue($data, $context);
+
+    // Check if action has validation callback that checks if user is subscribed
+    // for receiving emails. If not, then remove the item from processed queue.
+    if (!isset($this->bulkFormData['validate_email_subscriptions_callback'])) {
+      return $count;
+    }
+
+    if (!method_exists($this->action, $method = $this->bulkFormData['validate_email_subscriptions_callback'])) {
+      return $count;
+    }
+
+    foreach ($this->queue as $key => $entity) {
+      $is_valid = $this->action->{$method}($entity);
+      if (!$is_valid) {
+        unset($this->queue[$key]);
+
+        if (isset($context['results']['removed_selections']['count'])) {
+          $context['results']['removed_selections']['count']++;
+        }
+      }
+    }
+
+    return \count($this->queue);
+  }
+
+}

--- a/modules/social_features/social_event/modules/social_event_an_enroll/src/Plugin/Action/SocialEventAnEnrollSendEmail.php
+++ b/modules/social_features/social_event/modules/social_event_an_enroll/src/Plugin/Action/SocialEventAnEnrollSendEmail.php
@@ -3,12 +3,9 @@
 namespace Drupal\social_event_an_enroll\Plugin\Action;
 
 use Drupal\Core\Entity\EntityTypeManagerInterface;
-use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Language\LanguageManagerInterface;
 use Drupal\Core\Queue\QueueFactory;
-use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\Site\Settings;
-use Drupal\Core\TempStore\PrivateTempStoreFactory;
 use Drupal\Core\Utility\Token;
 use Drupal\social_email_broadcast\SocialEmailBroadcast;
 use Drupal\social_event\EventEnrollmentInterface;
@@ -57,9 +54,6 @@ class SocialEventAnEnrollSendEmail extends SocialEventManagersSendEmail {
     EmailValidator $email_validator,
     QueueFactory $queue_factory,
     $allow_text_format,
-    ModuleHandlerInterface $module_handler,
-    PrivateTempStoreFactory $temp_store_factory,
-    AccountInterface $current_user,
     SocialEmailBroadcast $email_broadcast_service,
     EventAnEnrollManager $event_an_enroll_manager
   ) {
@@ -74,9 +68,6 @@ class SocialEventAnEnrollSendEmail extends SocialEventManagersSendEmail {
       $email_validator,
       $queue_factory,
       $allow_text_format,
-      $module_handler,
-      $temp_store_factory,
-      $current_user,
       $email_broadcast_service
     );
 
@@ -95,9 +86,6 @@ class SocialEventAnEnrollSendEmail extends SocialEventManagersSendEmail {
       $container->get('email.validator'),
       $container->get('queue'),
       $container->get('current_user')->hasPermission('use text format mail_html'),
-      $container->get('module_handler'),
-      $container->get('tempstore.private'),
-      $container->get('current_user'),
       $container->get(SocialEmailBroadcast::class),
       $container->get('social_event_an_enroll.manager'),
     );

--- a/modules/social_features/social_event/modules/social_event_managers/social_event_managers.module
+++ b/modules/social_features/social_event/modules/social_event_managers/social_event_managers.module
@@ -511,7 +511,7 @@ function _social_event_managers_action_batch_finish($success, array $results, ar
     return;
   }
 
-  $results_count = $results['operations'][0]['count'];
+  $results_count = $results['operations'][0]['count'] ?? 0;
 
   $hook = 'social_event_managers_action_' . $results['action'] . '_finish';
 
@@ -536,6 +536,18 @@ function _social_event_managers_action_batch_finish($success, array $results, ar
       }
     }
   });
+
+  // Build the message when there are some items user selected but these items
+  // where removed during precessing.
+  if (!empty($results['removed_selections']['count'])) {
+    $removed_selections = $results['removed_selections'];
+    $message = \Drupal::translation()->formatPlural(
+      $removed_selections['count'],
+      $removed_selections['message']['singular'] ?? '',
+      $removed_selections['message']['plural'] ?? ''
+    );
+    \Drupal::messenger()->addWarning($message);
+  }
 }
 
 /**

--- a/modules/social_features/social_group/social_group.module
+++ b/modules/social_features/social_group/social_group.module
@@ -2348,7 +2348,11 @@ function _social_group_action_batch_finish($success, array $results, array $oper
   }
 
   // Count changed entities.
-  if (is_array($results['operations'][0]) && $results['operations'][0]['count']) {
+  if (
+    isset($results['operations'][0]) &&
+    is_array($results['operations'][0]) &&
+    $results['operations'][0]['count']
+  ) {
     $results_count = $results['operations'][0]['count'];
   }
   else {
@@ -2378,6 +2382,18 @@ function _social_group_action_batch_finish($success, array $results, array $oper
       }
     }
   });
+
+  // Build the message when there are some items user selected but these items
+  // where removed during precessing.
+  if (!empty($results['removed_selections']['count'])) {
+    $removed_selections = $results['removed_selections'];
+    $message = \Drupal::translation()->formatPlural(
+      $removed_selections['count'],
+      $removed_selections['message']['singular'] ?? '',
+      $removed_selections['message']['plural'] ?? ''
+    );
+    \Drupal::messenger()->addWarning($message);
+  }
 }
 
 /**

--- a/modules/social_features/social_group/src/Plugin/views/field/SocialGroupViewsBulkOperationsBulkForm.php
+++ b/modules/social_features/social_group/src/Plugin/views/field/SocialGroupViewsBulkOperationsBulkForm.php
@@ -115,6 +115,8 @@ class SocialGroupViewsBulkOperationsBulkForm extends ViewsBulkOperationsBulkForm
       }
       // Add the Group ID to the data.
       $tempstoreData['group_id'] = $group->id();
+      // Add the group bundle to the data.
+      $tempstoreData['group_type'] = $group->bundle();
       $this->setTempstoreData($tempstoreData, $this->view->id(), $this->view->current_display);
     }
 


### PR DESCRIPTION
## Problem
In https://github.com/goalgorilla/open_social/pull/3905 we added the ability to prevent sending emails on bulk operation for groups and events if a user is unsubscribed from these email receiving.

On the group "manage members" page, the group manager can send an email collectively to selected users.

The problem is that if the group has a large number of members (> 100), then choosing the "select all" option, only a part of users will receive the email (this part is always equal to the number of pager).

## Solution
If select all users and send bulk email:
<img width="1152" alt="Screenshot 2024-11-29 at 18 23 15" src="https://github.com/user-attachments/assets/caedc29f-72cc-4532-9b20-3fc36911e146">

_Before_:
<img width="763" alt="Screenshot 2024-11-29 at 18 27 58" src="https://github.com/user-attachments/assets/c7e24b95-1ca8-4d93-9809-28e3a69825b5">

_After_:
<img width="793" alt="Screenshot 2024-11-29 at 18 23 41" src="https://github.com/user-attachments/assets/a3b7fe58-b962-4600-82aa-070bc31f37d7">

_Before_:
<img width="1167" alt="Screenshot 2024-11-29 at 18 29 38" src="https://github.com/user-attachments/assets/b26bfd51-8d0d-4956-9298-37821b02e33b">

_After_:
<img width="1169" alt="Screenshot 2024-11-29 at 18 24 14" src="https://github.com/user-attachments/assets/223f27d6-11ba-4591-bf92-cfb8afe019f6">

## Release notes
Fix the wrong users number during bulk email sending

## Issue tracker
- https://www.drupal.org/project/social/issues/3490695
- https://getopensocial.atlassian.net/browse/PROD-31389

## How to test
- [x] Login as admin
- [x] Enable modules: `social_group_flexible_group`, `social_group_gvbo`, `social_email_broadcast`
- [ ] Create a flexible group
- [ ] Add more than 100 members to a group
- [ ] Try to send bulk email to all users on _/group/{gid}/membership_
**EB**: You should see correct numbers during email sending flow

