### PR TITLE
Issue #3490929: Add a redirect for profile canonical links to user information page

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -12606,11 +12606,6 @@ parameters:
 			path: modules/social_features/social_user/src/Controller/SocialUserController.php
 
 		-
-			message: "#^Method Drupal\\\\social_user\\\\EventSubscriber\\\\RedirectSubscriber\\:\\:profileLandingPage\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: modules/social_features/social_user/src/EventSubscriber/RedirectSubscriber.php
-
-		-
 			message: "#^Method Drupal\\\\social_user\\\\Form\\\\SocialUserFloodForm\\:\\:submitForm\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: modules/social_features/social_user/src/Form/SocialUserFloodForm.php


### PR DESCRIPTION
## Problem (for internal)
In https://www.drupal.org/project/social/issues/3044337, we added a user experience in which we added a redirect from canonical user entity urls (/user/uid) to user stream page.

Even though we will hardly see the profile canonical urls being presented to end user on the platform, but we have certain edge cases where these URL may appear. For example, the profile entities are indexed with the profile canonical urls in social_user and social_all indexes. They may appear in searches if someone decides to add some custom search pages. Also, a user can simply visit /profile/profile-id which may appear broken as it is not intended user information page.

## Solution (for internal)
Since, we do not want to alter the canonical profile urls as it may break some default behaviors of profile entity, so we are adding a redirect to user stream page or to the page which set by site manager or admin as default user profile landing page at /admin/config/opensocial/user.

## Release notes (to customers)
Clicking on the user profile result in search autocomplete results will now land you on user information page.

## Issue tracker
https://www.drupal.org/project/social/issues/3490929

## Theme issue tracker
N.A

## How to test
- [ ] Using latest version of Open Social
- [ ] Go to /profile/profile-id. You can use user ID in this url.
- [ ] You will land on a page which may appear broken
- [ ] Checkout to this branch
- [ ] Clear Cache.
- [ ] Go to /profile/profile-id
- [ ] You should end up on default user profile page


## Change Record
N.A

## Translations
N.A