### PR TITLE
Issue #3484629: Lock the socialbase version to avoid conflicts

### DIFF
--- a/.github/workflows/behat.yml
+++ b/.github/workflows/behat.yml
@@ -110,7 +110,7 @@ jobs:
           # Also include a hardcoded version for instaclick/php-webdriver, drupal/dynamic_entity_reference and drupal/core
           # as we didnt lock the version, and the patch isn't applying on the latest, so we require it
           # specifically to match the version that was installed at that moment in time.
-          composer require goalgorilla/open_social:~$PREVIOUS_MAJOR instaclick/php-webdriver:1.4.16 drupal/dynamic_entity_reference:3.1.0 drupal/core:10.2.3 "drupal/flexible_permissions:^1.1.0" "drupal/socialbase:2.5.19" "drupal/views_ef_fieldset:1.7.0"
+          composer require goalgorilla/open_social:~$PREVIOUS_MAJOR instaclick/php-webdriver:1.4.16 drupal/dynamic_entity_reference:3.1.0 drupal/core:10.2.3 "drupal/flexible_permissions:^1.1.0" "drupal/socialbase:2.5.19" "drupal/views_ef_fieldset:1.6.0"
 
           # Installation
           # This is purposefully duplicated because we may change how

--- a/.github/workflows/behat.yml
+++ b/.github/workflows/behat.yml
@@ -110,7 +110,7 @@ jobs:
           # Also include a hardcoded version for instaclick/php-webdriver, drupal/dynamic_entity_reference and drupal/core
           # as we didnt lock the version, and the patch isn't applying on the latest, so we require it
           # specifically to match the version that was installed at that moment in time.
-          composer require goalgorilla/open_social:~$PREVIOUS_MAJOR instaclick/php-webdriver:1.4.16 drupal/dynamic_entity_reference:3.1.0 drupal/core:10.2.3 "drupal/flexible_permissions:^1.1.0" "drupal/socialbase:2.5.19" "drupal/views_ef_fieldset:1.6.0"
+          composer require goalgorilla/open_social:~$PREVIOUS_MAJOR instaclick/php-webdriver:1.4.16
 
           # Installation
           # This is purposefully duplicated because we may change how

--- a/.github/workflows/behat.yml
+++ b/.github/workflows/behat.yml
@@ -110,7 +110,7 @@ jobs:
           # Also include a hardcoded version for instaclick/php-webdriver, drupal/dynamic_entity_reference and drupal/core
           # as we didnt lock the version, and the patch isn't applying on the latest, so we require it
           # specifically to match the version that was installed at that moment in time.
-          composer require goalgorilla/open_social:~$PREVIOUS_MAJOR instaclick/php-webdriver:1.4.16
+          composer require goalgorilla/open_social:~$PREVIOUS_MAJOR instaclick/php-webdriver:1.4.16 drupal/dynamic_entity_reference:3.1.0 drupal/core:10.2.3 "drupal/flexible_permissions:^1.1.0" "drupal/socialbase:2.5.19"
 
           # Installation
           # This is purposefully duplicated because we may change how

--- a/.github/workflows/behat.yml
+++ b/.github/workflows/behat.yml
@@ -110,7 +110,7 @@ jobs:
           # Also include a hardcoded version for instaclick/php-webdriver, drupal/dynamic_entity_reference and drupal/core
           # as we didnt lock the version, and the patch isn't applying on the latest, so we require it
           # specifically to match the version that was installed at that moment in time.
-          composer require goalgorilla/open_social:~$PREVIOUS_MAJOR instaclick/php-webdriver:1.4.16
+          composer require "goalgorilla/open_social:dev-issue/combine-patches-url-embed as 12.4.7" instaclick/php-webdriver:1.4.16
 
           # Installation
           # This is purposefully duplicated because we may change how

--- a/.github/workflows/behat.yml
+++ b/.github/workflows/behat.yml
@@ -110,7 +110,7 @@ jobs:
           # Also include a hardcoded version for instaclick/php-webdriver, drupal/dynamic_entity_reference and drupal/core
           # as we didnt lock the version, and the patch isn't applying on the latest, so we require it
           # specifically to match the version that was installed at that moment in time.
-          composer require goalgorilla/open_social:~$PREVIOUS_MAJOR instaclick/php-webdriver:1.4.16 drupal/dynamic_entity_reference:3.1.0 drupal/core:10.2.3 "drupal/flexible_permissions:^1.1.0" "drupal/socialbase:2.5.19"
+          composer require goalgorilla/open_social:~$PREVIOUS_MAJOR instaclick/php-webdriver:1.4.16 drupal/dynamic_entity_reference:3.1.0 drupal/core:10.2.3 "drupal/flexible_permissions:^1.1.0" "drupal/socialbase:2.5.19" "drupal/views_ef_fieldset:1.7.0"
 
           # Installation
           # This is purposefully duplicated because we may change how

--- a/composer.json
+++ b/composer.json
@@ -86,9 +86,6 @@
                 "Ensure field definition allowed values callbacks are used for field filter callbacks": "https://www.drupal.org/files/issues/2023-12-26/views_filter_options_callback--2949022-17.patch",
                 "Issue #3454939: Declaration of Drupal\\search_api_solr\\Plugin\\search_api\\backend\\SearchApiSolrBackend::__sleep() must be compatible": "https://www.drupal.org/files/issues/2024-06-17/3454939-search-api-solr-core-10.patch"
             },
-            "drupal/socialbase": {
-                "Issue #3484629: Add bootstrap patch for Drupal 11 compatibility": "https://www.drupal.org/files/issues/2024-10-30/3484629-3-add-bootstrap-patch-to-be-compatible-with-d11.patch"
-            },
             "drupal/url_embed": {
                 "Translate dialog title": "https://www.drupal.org/files/issues/2018-03-16/url_embed_translate_dialog_title-2953591-2.patch",
                 "Issue #2761187/#3386579 Improve how the module deals with non-embeddable URLs & WSODs (See: https://www.drupal.org/project/social/issues/3386579#comment-15225972) 2.x": "https://www.drupal.org/files/issues/2023-09-22/urlembed-non-embeddable-urls-2761187-opensocial-combined-21_2.x_1_ckeditor5.patch",
@@ -170,6 +167,7 @@
         "drupal/search_api_solr": "4.3.5",
         "drupal/select2": "1.15.0",
         "drupal/shariff": "2.0.0",
+        "drupal/socialbase": "2.6.8",
         "drupal/socialblue": "2.6.5",
         "drupal/symfony_mailer": "^1.2",
         "drupal/token": "1.15.0",


### PR DESCRIPTION
## Problem (for internal)
A new socialbase theme was released that included a patch that was also in the distro, but since the distro is not locked on socialbase it now fails on the main branch.

## Solution (for internal)
Lock the socialbase version.

## Release notes (to customers)
Internal

## Issue tracker
https://www.drupal.org/project/socialbase/issues/3484629

## Theme issue tracker
<!-- *[Required if applicable] Paste a link to the drupal.org theme issue queue item, either from [socialbase](https://www.drupal.org/project/socialbase) or [socialblue](https://www.drupal.org/project/socialblue). If any other issue trackers were used, include links to those too.* -->

## How to test
- [ ] composer does not fail



## Change Record
<!-- *[Required if applicable] If this Pull Request changes the way that developers should do things or introduces a new API for developers then a change record to document this is needed. Please provide a draft for a change record or a link to an unpublished change record below. Existing change records can be consulted as example. Please provide a draft for a change record or a link to an unpublished change record below. [Existing change records](https://www.drupal.org/list-changes/social) can be consulted as example.* -->

## Translations
<!--
*[Optional]Translatable strings are always extracted from the latest development branch. To ensure translations remain available for platforms running older versions of Open Social the original string should be added to `translations.php` when it's changed or removed.*
- [ ] Changed or removed source strings are added to the `translations.php` file.
-->
