### PR TITLE
Issue #3491068: combine patches for #2761187, #3386579, #3386590 to avoid composer failing to apply patches due to order

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -91,8 +91,7 @@
             },
             "drupal/url_embed": {
                 "Translate dialog title": "https://www.drupal.org/files/issues/2018-03-16/url_embed_translate_dialog_title-2953591-2.patch",
-                "Issue #2761187/#3386579 Improve how the module deals with non-embeddable URLs & WSODs (See: https://www.drupal.org/project/social/issues/3386579#comment-15225972) 2.x": "https://www.drupal.org/files/issues/2023-09-22/urlembed-non-embeddable-urls-2761187-opensocial-combined-21_2.x_1_ckeditor5.patch",
-                "Issue #3386590: preg_split in _filter_url breaks for long html tags": "https://www.drupal.org/files/issues/2023-09-11/3382821-url_embed-preg-split_2.x_1.patch"
+                "Issue #3491068: Combined patches for #2761187, #3386579, #3386590": "https://www.drupal.org/files/issues/2024-12-02/3491068-combined-patches_2761187_3386579_3386590.patch"
             },
             "drupal/views_infinite_scroll" : {
                 "Headers in table format repeat on load more instead of adding rows (v1.8)": "https://www.drupal.org/files/issues/2021-02-11/2899705-35.patch"

--- a/composer.json
+++ b/composer.json
@@ -86,9 +86,6 @@
                 "Ensure field definition allowed values callbacks are used for field filter callbacks": "https://www.drupal.org/files/issues/2023-12-26/views_filter_options_callback--2949022-17.patch",
                 "Issue #3454939: Declaration of Drupal\\search_api_solr\\Plugin\\search_api\\backend\\SearchApiSolrBackend::__sleep() must be compatible": "https://www.drupal.org/files/issues/2024-06-17/3454939-search-api-solr-core-10.patch"
             },
-            "drupal/socialbase": {
-                "Issue #3484629: Add bootstrap patch for Drupal 11 compatibility": "https://www.drupal.org/files/issues/2024-10-30/3484629-3-add-bootstrap-patch-to-be-compatible-with-d11.patch"
-            },
             "drupal/url_embed": {
                 "Translate dialog title": "https://www.drupal.org/files/issues/2018-03-16/url_embed_translate_dialog_title-2953591-2.patch",
                 "Issue #3491068: Combined patches for #2761187, #3386579, #3386590": "https://www.drupal.org/files/issues/2024-12-02/3491068-combined-patches_2761187_3386579_3386590.patch"
@@ -169,6 +166,7 @@
         "drupal/search_api_solr": "4.3.5",
         "drupal/select2": "1.15.0",
         "drupal/shariff": "2.0.0",
+        "drupal/socialbase": "2.6.8",
         "drupal/socialblue": "2.6.5",
         "drupal/symfony_mailer": "^1.2",
         "drupal/token": "1.15.0",


### PR DESCRIPTION
## Problem (for internal)
The automated quality checks are not running correctly anymore due to the patches for url_embed not applying anymore. As they seem to be applied in a wrong order.

## Solution (for internal)
Combine the patches so we don't have to worry about the order.

## Release notes (to customers)
None, internal

## Issue tracker
https://www.drupal.org/project/social/issues/3491068

## Theme issue tracker
<!-- *[Required if applicable] Paste a link to the drupal.org theme issue queue item, either from [socialbase](https://www.drupal.org/project/socialbase) or [socialblue](https://www.drupal.org/project/socialblue). If any other issue trackers were used, include links to those too.* -->

## How to test
- [ ] Using version X.Y.Z of Open Social with the example module enabled
- [ ] As a sitemanager
- [ ] Try to enable the option B on screen c/d/e
- [ ] When saving I expect the result to be F but instead see G.
- [ ] The expected result F is attained when repeating the steps with this fix applied.


## Change Record
<!-- *[Required if applicable] If this Pull Request changes the way that developers should do things or introduces a new API for developers then a change record to document this is needed. Please provide a draft for a change record or a link to an unpublished change record below. Existing change records can be consulted as example. Please provide a draft for a change record or a link to an unpublished change record below. [Existing change records](https://www.drupal.org/list-changes/social) can be consulted as example.* -->

## Translations
<!--
*[Optional]Translatable strings are always extracted from the latest development branch. To ensure translations remain available for platforms running older versions of Open Social the original string should be added to `translations.php` when it's changed or removed.*
- [ ] Changed or removed source strings are added to the `translations.php` file.
-->
