### PR TITLE
Issue #3490982: Usernames in activity streams shouldn't be translatable

### DIFF
--- a/modules/social_features/social_activity/config/install/message.template.create_content_in_joined_group.yml
+++ b/modules/social_features/social_activity/config/install/message.template.create_content_in_joined_group.yml
@@ -24,13 +24,13 @@ label: 'Create a post, topic or event in a joined group'
 description: 'A person created a post, event or topic in a group I joined'
 text:
   -
-    value: "<p><a href=\"[message:revision_author:url:absolute]\">[message:revision_author:display-name]</a> created [social_group:created_entity_link_html] in the <a href=\"[message:gurl]\">[message:gtitle]</a> group [message:count_groups_per_node]</p>\r\n"
+    value: '<p><a href="[message:revision_author:url:absolute]" translate="no">[message:revision_author:display-name]</a> created [social_group:created_entity_link_html] in the <a href=\"[message:gurl]\">[message:gtitle]</a> group [message:count_groups_per_node]</p>\r\n'
     format: full_html
   -
-    value: "<p><a href=\"[message:revision_author:url:absolute]\">[message:revision_author:display-name]</a> created [social_group:created_entity_link_html] in the <a href=\"[message:gurl]\">[message:gtitle]</a> group [message:count_groups_per_node]</p>\r\n"
+    value: '<p><a href="[message:revision_author:url:absolute]" translate="no">[message:revision_author:display-name]</a> created [social_group:created_entity_link_html] in the <a href=\"[message:gurl]\">[message:gtitle]</a> group [message:count_groups_per_node]</p>\r\n'
     format: full_html
   -
-    value: "<p><a href=\"[message:revision_author:url:absolute]\">[message:revision_author:display-name]</a> published [social_group:content_type] in the <a href=\"[message:gurl]\">[message:gtitle]</a> group [message:count_groups_per_node] you are member of:</p>\r\n\r\n<p>[message:preview]</p>\r\n\r\n<p>[message:cta_button]</p>\r\n"
+    value: '<p><a href="[message:revision_author:url:absolute]" translate="no">[message:revision_author:display-name]</a> published [social_group:content_type] in the <a href=\"[message:gurl]\">[message:gtitle]</a> group [message:count_groups_per_node] you are member of:</p>\r\n\r\n<p>[message:preview]</p>\r\n\r\n<p>[message:cta_button]</p>\r\n'
     format: full_html
 settings:
   'token options':

--- a/modules/social_features/social_activity/config/install/message.template.create_event_community.yml
+++ b/modules/social_features/social_activity/config/install/message.template.create_event_community.yml
@@ -23,7 +23,7 @@ description: 'A user created an event in the community'
 text:
   -
     format: full_html
-    value: '<p><a href="[message:revision_author:url:absolute]">[message:revision_author:display-name]</a> created an event</p>'
+    value: '<p><a href="[message:revision_author:url:absolute]" translate="no">[message:revision_author:display-name]</a> created an event</p>'
 settings:
   'token options':
     clear: false

--- a/modules/social_features/social_activity/config/install/message.template.create_event_gc.yml
+++ b/modules/social_features/social_activity/config/install/message.template.create_event_gc.yml
@@ -20,7 +20,7 @@ label: 'Create event as group content'
 description: 'A user add (create) a event to a group (or groups)'
 text:
   -
-    value: '<p><a href="[message:revision_author:url:absolute]">[message:revision_author:display-name]</a> created an event in <a href="[message:gurl]">[message:gtitle]</a></p>'
+    value: '<p><a href="[message:revision_author:url:absolute]" translate="no">[message:revision_author:display-name]</a> created an event in <a href="[message:gurl]">[message:gtitle]</a></p>'
     format: basic_html
 settings:
   'token options':

--- a/modules/social_features/social_activity/config/install/message.template.create_event_group.yml
+++ b/modules/social_features/social_activity/config/install/message.template.create_event_group.yml
@@ -24,7 +24,7 @@ description: 'A user created an event in a group'
 text:
   -
     format: full_html
-    value: '<p><a href="[message:revision_author:url:absolute]">[message:revision_author:display-name]</a> created an event in <a href="[message:gurl]">[message:gtitle]</a> [message:count_groups_per_node]</p>'
+    value: '<p><a href="[message:revision_author:url:absolute]" translate="no">[message:revision_author:display-name]</a> created an event in <a href="[message:gurl]">[message:gtitle]</a> [message:count_groups_per_node]</p>'
 settings:
   'token options':
     clear: false

--- a/modules/social_features/social_activity/config/install/message.template.create_topic_community.yml
+++ b/modules/social_features/social_activity/config/install/message.template.create_topic_community.yml
@@ -23,7 +23,7 @@ description: 'A user created a topic in the community'
 text:
   -
     format: full_html
-    value: '<p><a href="[message:revision_author:url:absolute]">[message:revision_author:display-name]</a> created a topic</p>'
+    value: '<p><a href="[message:revision_author:url:absolute]" translate="no">[message:revision_author:display-name]</a> created a topic</p>'
 settings:
   'token options':
     clear: false

--- a/modules/social_features/social_activity/config/install/message.template.create_topic_gc.yml
+++ b/modules/social_features/social_activity/config/install/message.template.create_topic_gc.yml
@@ -20,7 +20,7 @@ label: 'Create topic as group content'
 description: 'A user add (create) a topic to a group (or groups)'
 text:
   -
-    value: '<p><a href="[message:revision_author:url:absolute]">[message:revision_author:display-name]</a> created a topic in <a href="[message:gurl]">[message:gtitle]</a></p>'
+    value: '<p><a href="[message:revision_author:url:absolute]" translate="no">[message:revision_author:display-name]</a> created a topic in <a href="[message:gurl]">[message:gtitle]</a></p>'
     format: basic_html
 settings:
   'token options':

--- a/modules/social_features/social_activity/config/install/message.template.create_topic_group.yml
+++ b/modules/social_features/social_activity/config/install/message.template.create_topic_group.yml
@@ -24,7 +24,7 @@ description: 'A user created a topic in a group'
 text:
   -
     format: full_html
-    value: '<p><a href="[message:revision_author:url:absolute]">[message:revision_author:display-name]</a> created a topic in <a href="[message:gurl]">[message:gtitle]</a> [message:count_groups_per_node]</p>'
+    value: '<p><a href="[message:revision_author:url:absolute]" translate="no">[message:revision_author:display-name]</a> created a topic in <a href="[message:gurl]">[message:gtitle]</a> [message:count_groups_per_node]</p>'
 settings:
   'token options':
     clear: false

--- a/modules/social_features/social_activity/social_activity.install
+++ b/modules/social_features/social_activity/social_activity.install
@@ -100,3 +100,32 @@ function social_activity_update_13001(): void {
       ->save();
   }
 }
+
+/**
+ * Adds no translation property to user profile link HTML in message templates.
+ */
+function social_activity_update_13002(): void {
+  $message_templates = [
+    'message.template.create_topic_community',
+    'message.template.create_topic_gc',
+    'message.template.create_topic_group',
+    'message.template.create_event_group',
+    'message.template.create_event_gc',
+    'message.template.create_event_community',
+    'message.template.create_content_in_joined_group',
+  ];
+
+  $config_factory = \Drupal::configFactory();
+  foreach ($message_templates as $message_template) {
+    $config = $config_factory->getEditable($message_template);
+
+    $texts = array_map(function ($text) {
+      $text['value'] = str_replace('<a href="[message:revision_author:url:absolute]" translate="no">[message:revision_author:display-name]</a>', '<a href="[message:revision_author:url:absolute]" translate="no">[message:revision_author:display-name]</a>', $text['value']);
+
+      return $text;
+    }, $config->get('text'));
+
+    $config->set('text', $texts)
+      ->save();
+  }
+}

--- a/modules/social_features/social_group/modules/social_group_flexible_group/modules/social_flexible_group_book/config/optional/message.template.create_book_group.yml
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/modules/social_flexible_group_book/config/optional/message.template.create_book_group.yml
@@ -24,13 +24,13 @@ label: 'Create book in group'
 description: 'A user created a book in a group'
 text:
   -
-    value: '<p><a href="[message:revision_author:url:absolute]">[message:revision_author:display-name]</a> created a book in <a href="[message:gurl]">[message:gtitle]</a> [message:count_groups_per_node]</p>'
+    value: '<p><a href="[message:revision_author:url:absolute]" translate="no">[message:revision_author:display-name]</a> created a book in <a href="[message:gurl]">[message:gtitle]</a> [message:count_groups_per_node]</p>'
     format: full_html
   -
-    value: '<p><a href="[message:revision_author:url:absolute]">[message:revision_author:display-name]</a> created a book in <a href="[message:gurl]">[message:gtitle]</a> [message:count_groups_per_node]</p>'
+    value: '<p><a href="[message:revision_author:url:absolute]" translate="no">[message:revision_author:display-name]</a> created a book in <a href="[message:gurl]">[message:gtitle]</a> [message:count_groups_per_node]</p>'
     format: full_html
   -
-    value: '<p><a href="[message:revision_author:url:absolute]">[message:revision_author:display-name]</a> created a book in <a href="[message:gurl]">[message:gtitle]</a> [message:count_groups_per_node]</p>'
+    value: '<p><a href="[message:revision_author:url:absolute]" translate="no">[message:revision_author:display-name]</a> created a book in <a href="[message:gurl]">[message:gtitle]</a> [message:count_groups_per_node]</p>'
     format: full_html
 settings:
   'token options':

--- a/modules/social_features/social_group/modules/social_group_flexible_group/modules/social_flexible_group_book/social_flexible_group_book.install
+++ b/modules/social_features/social_group/modules/social_group_flexible_group/modules/social_flexible_group_book/social_flexible_group_book.install
@@ -128,3 +128,19 @@ function social_flexible_group_book_update_13002(): void {
   $config->set('text', $texts)
     ->save();
 }
+
+/**
+ * Adds no translation property to user profile link HTML in message templates.
+ */
+function social_flexible_group_book_update_13003(): void {
+  $config = \Drupal::configFactory()
+    ->getEditable('message.template.create_book_group');
+
+  $texts = array_map(function ($text) {
+    $text['value'] = str_replace('<a href="[message:revision_author:url:absolute]" translate="no">[message:revision_author:display-name]</a>', '<a href="[message:revision_author:url:absolute]" translate="no">[message:revision_author:display-name]</a>', $text['value']);
+    return $text;
+  }, $config->get('text'));
+
+  $config->set('text', $texts)
+    ->save();
+}


### PR DESCRIPTION
## Problem (for internal)
The usernames of the people in the streams were getting translated when using an external translation tool like Google Translation. They shouldn't be translatable

The output in the stream is coming from message templates text ( https://github.com/goalgorilla/open_social/blob/main/modules/custom/activity_creator/src/ActivityFactory.php#L146  ) which is getting added on activity page in https://github.com/goalgorilla/open_social/blob/main/modules/custom/activity_creator/activity.page.inc#L38 which then gets added in https://git.drupalcode.org/project/socialbase/-/blob/2.6.x/templates/activity/activity.html.twig?ref_type=heads#L48

## Solution (for internal)
We added “no translate” attribute with message output text.

## Release notes (to customers)
We smashed a bug where our usernames in the activity streams were getting translated when using third party services like Google Translate

## Issue tracker
https://www.drupal.org/project/social/issues/3490982

## Theme issue tracker
N.A

## How to test
- [ ] Install a multilingual Open Social website
- [ ] Create content in different language (other than English)
- [ ] Use module that provides third party translators to convert them in different languages
- [ ] This is tricky that which username or word it picks for translation, but observe the usernames in activity stream
- [ ] Checkout to this branch
- [ ] Run updates
- [ ] Try translating again
- [ ] You should observe that usernames will remain same.


## Change Record
N.A

## Translations
N.A
