### PR TITLE
PROD-31497: Fix error while logging out the platform

### DIFF
--- a/modules/social_features/social_user/social_user.module
+++ b/modules/social_features/social_user/social_user.module
@@ -15,10 +15,11 @@ use Drupal\Core\Session\AnonymousUserSession;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\profile\Entity\ProfileInterface;
 use Drupal\social_group\SocialGroupHelperService;
-use Drupal\social_user\Entity\User;
+use Drupal\social_user\Entity\User as SocialUserEntityUser;
 use Drupal\social_user\Plugin\Action\SocialAddRoleUser;
 use Drupal\social_user\Plugin\Action\SocialBlockUser;
 use Drupal\social_user\Plugin\Action\SocialRemoveRoleUser;
+use Drupal\user\Entity\User;
 use Drupal\user\Plugin\Action\BlockUser;
 use Drupal\user\UserInterface;
 use Drupal\views\ViewExecutable;
@@ -29,7 +30,7 @@ use Drupal\social_user\SocialUserSearchContentBlockAlter;
  */
 function social_user_entity_type_alter(array &$entity_types) {
   if (isset($entity_types['user'])) {
-    $entity_types['user']->setClass(User::class);
+    $entity_types['user']->setClass(SocialUserEntityUser::class);
   }
 }
 


### PR DESCRIPTION
## Problem (for internal)
In social_user_user_logout(), we used User::load() to load the current user entity. It turns out the previously imported class was `Drupal\social_user\Entity\User` instead of `Drupal\user\Entity\User`.


## Solution (for internal)
Properly import both classes.

## Release notes (to customers)
N/A

## Issue tracker
https://getopensocial.atlassian.net/browse/PROD-31497

## Theme issue tracker
N/A

## How to test
- [ ] Checkout branch `bugfix/PROD-31497-error-logging-out`
- [ ] Login
- [ ] Logout

You should not see the exception.

## Change Record
N/A

## Translations
N/A