### PR TITLE
Issue #3491855: Improve max-height style of the dialog popup on the admin pages

### DIFF
--- a/modules/social_features/social_core/assets/css/admin-dialog.css
+++ b/modules/social_features/social_core/assets/css/admin-dialog.css
@@ -1,0 +1,9 @@
+.ui-dialog:not(.ui-dialog-off-canvas) {
+  top: 50% !important;
+  transform: translateY(-50%) !important;
+}
+.ui-dialog:not(.ui-dialog-off-canvas) .ui-dialog-content {
+  max-height: 70vh !important;
+}
+
+/*# sourceMappingURL=admin-dialog.css.map */

--- a/modules/social_features/social_core/assets/css/admin-dialog.scss
+++ b/modules/social_features/social_core/assets/css/admin-dialog.scss
@@ -1,0 +1,8 @@
+.ui-dialog:not(.ui-dialog-off-canvas) {
+  top: 50% !important;
+  transform: translateY(-50%) !important;
+
+  .ui-dialog-content {
+    max-height: 70vh !important;
+  }
+}

--- a/modules/social_features/social_core/social_core.libraries.yml
+++ b/modules/social_features/social_core/social_core.libraries.yml
@@ -31,3 +31,8 @@ preview-popup:
   css:
     component:
       assets/css/preview-popup.css: {}
+
+admin-dialog:
+  css:
+    component:
+      assets/css/admin-dialog.css: {}

--- a/modules/social_features/social_core/social_core.module
+++ b/modules/social_features/social_core/social_core.module
@@ -41,6 +41,11 @@ function social_core_page_attachments(array &$attachments) {
 
   // The library with logo improvements on the top of the gin toolbar.
   $attachments['#attached']['library'][] = 'social_core/admin-toolbar';
+
+  // The library with dialog popup improvements attached only for admin pages.
+  if (\Drupal::service('router.admin_context')->isAdminRoute()) {
+    $attachments['#attached']['library'][] = 'social_core/admin-dialog';
+  }
 }
 
 /**


### PR DESCRIPTION
## Problem (for internal)
The dialog popup does not change the height if this popup contains details element.

## Solution (for internal)
Improve the `max-height` style of the dialog popup via jQuery only on the admin pages.

<!-- [Optional] If this Pull Request makes visual changes then please include some screenshots that show what has changed here. A before and after screenshot helps the reviewer determine what changes were made. -->

## Release notes (to customers)
Improve dialog popup height on the admin pages in cases when many form elements are displayed.

## Issue tracker
- https://www.drupal.org/project/social/issues/3491855

## Theme issue tracker
<!-- *[Required if applicable] Paste a link to the drupal.org theme issue queue item, either from [socialbase](https://www.drupal.org/project/socialbase) or [socialblue](https://www.drupal.org/project/socialblue). If any other issue trackers were used, include links to those too.* -->

## How to test
- [ ] Enable the `config_translation` module.
- [ ] Add the new language.
- [ ] Go to the `/admin/structure/message` page.
- [ ] Go to the translate page of the one of the message template.
- [ ] Click on the `Add ` button of the added language.

## Screenshots
before:
<img width="1166" alt="658d83a0-6cb7-4b85-b66c-f604406734b9" src="https://github.com/user-attachments/assets/7d20b689-0120-4d16-b871-7cad55d38244">

after:
![Screenshot 2024-12-05 at 10 51 40](https://github.com/user-attachments/assets/edfd21ea-cef8-4e85-b21e-f0d8d33ca40e)
