### PR TITLE
Issue #3492536: Disable group redirection for unsupported routes

### DIFF
--- a/modules/social_features/social_group/modules/social_group_default_route/social_group_default_route.api.php
+++ b/modules/social_features/social_group/modules/social_group_default_route/social_group_default_route.api.php
@@ -28,7 +28,8 @@ function hook_social_group_default_route_types_alter(array $types) {
  * @return array
  *   An associative array of group bundles that shows if group tab management
  *    should be applied and the default routes for applicable group bundle,
- *    keyed by group bundle.
+ *    keyed by group bundle. The route should be available as a "Landing Tab"
+ *    for the provided group type, otherwise the route will be ignored.
  */
 function hook_social_group_default_route_group_types(): array {
   return [
@@ -43,7 +44,9 @@ function hook_social_group_default_route_group_types(): array {
  * Alter group bundles for which entities redirection will be applicable.
  *
  * @param array $types
- *   An associative array of group bundles.
+ *   An associative array of group bundles and default routes. The route should
+ *    be available as a "Landing Tab" for the provided group type, otherwise
+ *    the route will be ignored.
  */
 function hook_social_group_default_route_group_types_alter(array &$types): void {
   if (isset($types['flexible_group']) && !$types['flexible_group']) {


### PR DESCRIPTION
## Problem (for internal)
When the group type provides hook_social_group_default_route_group_types and the default route for non-members is inaccessible for AN user, and a route alias has been generated for it, an infinite redirect occurs.

## Solution (for internal)
Disable redirection for inaccessible default routes, and ignore hardcoded default routes provided by `hook_social_group_default_route_group_types` if this route isn't a "Landing Tab" option.

## Release notes (to customers)
Internal: Fix group redirection for unsupported routes

## Issue tracker

- https://www.drupal.org/project/social/issues/3492536
- https://getopensocial.atlassian.net/browse/PROD-31504

## How to test
Need to test with a DB dump containing old data (groups with created aliases), without the 'social_group_default_group' module enabled.
- [ ] Enable module 'social_group_default_group'
- [ ] In the file `social_group_flexible_group.module` in hook - `social_group_flexible_group_social_group_default_route_group_types` - change any route on the route that isn't accessible for non-member (ex. `social_group_default.group_home`) and clear cache
- [ ] As a non-member go to any of created Flexible groups - you should get access denied and redirected or be redirected to the login page if it was AN