### PR TITLE
Issue #3492845: Ajax error on enrolling to an event

### DIFF
--- a/modules/social_features/social_event/src/Form/EnrollActionForm.php
+++ b/modules/social_features/social_event/src/Form/EnrollActionForm.php
@@ -505,8 +505,8 @@ class EnrollActionForm extends FormBase {
       ));
     }
 
-    $new_form = $this->buildForm($form, $form_state);
-    $new_form = $this->formBuilder->doBuildForm($this->getFormId(), $new_form, $form_state);
+    // Rebuild the form.
+    $new_form = $this->formBuilder->rebuildForm($this->getFormId(), $form_state, $form);
     $response->addCommand(new ReplaceCommand('#enroll-wrapper', $new_form['enroll_wrapper']));
     return $response;
   }


### PR DESCRIPTION
## Problem 
Enrolling to the events with "Invite-only" enrollment method cause the ajax error:

<img src="https://www.drupal.org/files/issues/2024-12-10/Screenshot%202024-12-09%20at%2016.13.44.png" width="400" alt="alt" />

<img src="https://www.drupal.org/files/issues/2024-12-10/Screenshot%202024-12-09%20at%2016.12.12.png" width="400" alt="alt" />

```php
An AJAX HTTP error occurred.
HTTP Result Code: 200
Debugging information follows.
Path: /node/1475/all-enrollments?ajax_form=1
StatusText: parsererror
ResponseText: TypeError: implode(): Argument #1 ($array) must be of type array, string given in implode() (line 981 of /var/www/html/html/core/lib/Drupal/Core/Form/FormBuilder.php).
```

## Solution
Replace `doBuildForm` with `rebuildForm` method.

## Release notes 
Fix ajax error when enrolling to the events with the "Invite-only" enrollment method.

## Issue tracker
- https://www.drupal.org/project/social/issues/3492845
- https://getopensocial.atlassian.net/browse/PROD-31500

## How to test
- [ ] Login as admin
- [ ] Enable `social_event_invite` module
- [ ] Create a public event with "Invite-only" enroll method
- [ ] Login as SM
- [ ] Visit the event
- [ ] Enroll in the event by clicking the "ENROLL" button
  - [ ] **EB**: SM should not get the ajax error
- [ ] Invite VU to the event (on _/node/{nid}/all-enrollments_)
- [ ] Login as VU
- [ ] Cancel the enrollment
  - [ ] **EB**: VU should not get the ajax error
