### PR TITLE
Issue #3492865: Install fullscreen plugin on CKEditor 5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -121,6 +121,7 @@
         "drupal/better_exposed_filters": "6.0.6",
         "drupal/block_field": "1.0.0-rc5",
         "drupal/ckeditor": "1.0.2",
+        "drupal/ckeditor5_plugin_pack": "^1.2",
         "drupal/config_modify": "^1",
         "drupal/config_update": "2.0.0-alpha4",
         "drupal/core": "~10.3.9",

--- a/modules/social_features/social_editor/config/install/editor.editor.basic_html.yml
+++ b/modules/social_features/social_editor/config/install/editor.editor.basic_html.yml
@@ -29,6 +29,8 @@ settings:
       - insertTable
       - '|'
       - code
+      - '|'
+      - fullScreen
   plugins:
     ckeditor5_heading:
       enabled_headings:

--- a/modules/social_features/social_editor/config/install/editor.editor.full_html.yml
+++ b/modules/social_features/social_editor/config/install/editor.editor.full_html.yml
@@ -35,6 +35,8 @@ settings:
       - style
       - '|'
       - sourceEditing
+      - '|'
+      - fullScreen
   plugins:
     ckeditor5_heading:
       enabled_headings:

--- a/modules/social_features/social_editor/config/install/editor.editor.mail_html.yml
+++ b/modules/social_features/social_editor/config/install/editor.editor.mail_html.yml
@@ -19,6 +19,7 @@ settings:
       - '|'
       - alignment
       - '|'
+      - fullScreen
   plugins:
     ckeditor5_alignment:
       enabled_alignments:

--- a/modules/social_features/social_editor/config/update/social_editor_update_13002.yml
+++ b/modules/social_features/social_editor/config/update/social_editor_update_13002.yml
@@ -1,0 +1,29 @@
+editor.editor.basic_html:
+  expected_config: { }
+  update_actions:
+    add:
+      settings:
+        toolbar:
+          items:
+            - '|'
+            - fullScreen
+
+editor.editor.full_html:
+  expected_config: { }
+  update_actions:
+    add:
+      settings:
+        toolbar:
+          items:
+            - '|'
+            - fullScreen
+
+editor.editor.mail_html:
+  expected_config: { }
+  update_actions:
+    add:
+      settings:
+        toolbar:
+          items:
+            - fullScreen
+

--- a/modules/social_features/social_editor/social_editor.info.yml
+++ b/modules/social_features/social_editor/social_editor.info.yml
@@ -9,4 +9,5 @@ dependencies:
   - drupal:filter
   - editor_advanced_link:editor_advanced_link
   - drupal:responsive_table_filter
+  - ckeditor5_plugin_pack:ckeditor5_premium_features_fullscreen
 package: Social

--- a/modules/social_features/social_editor/social_editor.install
+++ b/modules/social_features/social_editor/social_editor.install
@@ -29,3 +29,21 @@ function social_editor_update_13001(): string {
   // Output logged messages to related channel of update execution.
   return $updater->logger()->output();
 }
+
+/**
+ * Install and enable fullscreen button to CKEditor 5.
+ */
+function social_editor_update_13002(): string {
+  if (!\Drupal::service('module_handler')->moduleExists('ckeditor5_premium_features_fullscreen')) {
+    \Drupal::service('module_installer')->install(['ckeditor5_premium_features_fullscreen']);
+  }
+
+  /** @var \Drupal\update_helper\Updater $updater */
+  $updater = \Drupal::service('update_helper.updater');
+
+  // Execute configuration update definitions with logging of success.
+  $updater->executeUpdate('social_editor', __FUNCTION__);
+
+  // Output logged messages to related channel of update execution.
+  return $updater->logger()->output();
+}


### PR DESCRIPTION
## Problem (for internal)
After update CKEditor from 4 to 5 version we lost the fullscreen functionality, so it should be available again for all CKEditor fields.

## Solution (for internal)
Install [CKEditor 5 Plugin Pack](https://www.drupal.org/project/ckeditor5_plugin_pack) module and enable it for all editor.

## Release notes (to customers)
Add fullscreen mode to all text-editors.

## Issue tracker
[PROD-30681](https://getopensocial.atlassian.net/browse/PROD-30681)
[#3492865](https://www.drupal.org/project/social/issues/3492865)

## Theme issue tracker
N/A

## How to test
- Open some editors with CKEditor and check fullscreen button

## Change Record
N/A

## Translations
N/A


[PROD-30681]: https://getopensocial.atlassian.net/browse/PROD-30681?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ