### PR TITLE
Issue #3476285: Hide path field from Nationality taxonomy

### DIFF
--- a/modules/social_features/social_profile/modules/social_profile_fields/social_profile_fields.install
+++ b/modules/social_features/social_profile/modules/social_profile_fields/social_profile_fields.install
@@ -161,3 +161,32 @@ function social_profile_fields_update_130001(): void {
   ];
   user_role_grant_permissions('sitemanager', $permissions);
 }
+
+/**
+ * Hidden path from Nationality taxonomy.
+ */
+function social_profile_fields_update_130002(): void {
+  $storage = \Drupal::entityTypeManager()->getStorage('entity_form_display');
+  $form_display = $storage->load('taxonomy_term.nationality.default');
+
+  // If the entity-form-display isn't found, return early.
+  if (empty($form_display)) {
+    \Drupal::logger('social_profile_fields')->info('The entity-form-display from Nationality taxonomy is empty.');
+    return;
+  }
+
+  // Get fields and check if path is already be hidden.
+  $hidden = $form_display->get('hidden');
+  $content = $form_display->get('content');
+  if (in_array('path', array_keys($hidden))) {
+    \Drupal::logger('social_profile_fields')->info('The path field already is hidden on Nationality taxonomy.');
+    return;
+  }
+
+  // Manipulate path field to be hidden and save.
+  $hidden['path'] = TRUE;
+  unset($content['path']);
+  $form_display->set('hidden', $hidden)
+    ->set('content', $content)
+    ->save();
+}


### PR DESCRIPTION
## Problem (for internal)
The path field should be hide after: https://github.com/goalgorilla/open_social/pull/4139, but the Nationality taxonomy continue with this field.

## Solution (for internal)
Create a hook-update to hide path field

## Release notes (to customers)
<!-- [Required if new feature, and if applicable] A summary of the changes that were made that can be included in release notes to customers.
Please provide enough context and detail, so the editorial review is done efficiently. -->

## Issue tracker
Improved the user-experience to create taxonomy-terms, some unnecessary fields was hide.

## Theme issue tracker
N/A

## How to test
- [ ] Enable Social Profile Field module
- [ ] Create a term at Nationality taxonomy and check if path field is not available

## Change Record
N/A

## Translations
N/A
