### PR TITLE
Issue #3491376: Revert group statistics v2 table for v1

### DIFF
--- a/modules/social_features/social_group/src/GroupStatistics.php
+++ b/modules/social_features/social_group/src/GroupStatistics.php
@@ -71,7 +71,7 @@ class GroupStatistics {
    */
   protected function count(GroupInterface $group, $type) {
     // Additional caching not required since views does this for us.
-    $query = $this->database->select('group_relationship_field_data', 'gcfd');
+    $query = $this->database->select('group_content_field_data', 'gcfd');
     $query->addField('gcfd', 'gid');
     $query->condition('gcfd.gid', $group->id());
     $query->condition('gcfd.type', $group->getGroupType()->id() . '-' . $type, 'LIKE');


### PR DESCRIPTION
## Problem (for internal)
In https://www.drupal.org/project/social/issues/3489147 we reverted a plugin-id method for group v1, but the actual commit was bigger than the supplied patch, introducing another group v2 table name.

## Solution (for internal)
Revert the method to group v1

## Release notes (to customers)
We decided to revert the PR for branch 12.x to ensure that the issue is still resolved into 13.x and does not break 12.x.

## Issue tracker
https://www.drupal.org/project/social/issues/3491376

## Theme issue tracker
<!-- *[Required if applicable] Paste a link to the drupal.org theme issue queue item, either from [socialbase](https://www.drupal.org/project/socialbase) or [socialblue](https://www.drupal.org/project/socialblue). If any other issue trackers were used, include links to those too.* -->

## How to test
- [ ] Create a group and notice it doesn't crash.


## Change Record
<!-- *[Required if applicable] If this Pull Request changes the way that developers should do things or introduces a new API for developers then a change record to document this is needed. Please provide a draft for a change record or a link to an unpublished change record below. Existing change records can be consulted as example. Please provide a draft for a change record or a link to an unpublished change record below. [Existing change records](https://www.drupal.org/list-changes/social) can be consulted as example.* -->

## Translations
<!--
*[Optional]Translatable strings are always extracted from the latest development branch. To ensure translations remain available for platforms running older versions of Open Social the original string should be added to `translations.php` when it's changed or removed.*
- [ ] Changed or removed source strings are added to the `translations.php` file.
-->
