### PR TITLE
PROD-22012: Bump version of "data_policy" to 2.0.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -128,7 +128,7 @@
         "drupal/color": "1.0.3",
         "drupal/crop": "2.4.0",
         "drupal/csv_serialization": "2.1.0 || ~3.0 || ~4.0",
-        "drupal/data_policy": "2.0.3",
+        "drupal/data_policy": "2.0.4",
         "drupal/dynamic_entity_reference": "^3.2.0",
         "drupal/editor_advanced_link": "2.2.6",
         "drupal/entity": "1.5.0",


### PR DESCRIPTION
## Description

This PR bumps the version of `data_policy` module to 2.0.4, which contains translation bugfixes.

https://www.drupal.org/project/data_policy/releases/2.0.4

- [#3492268: "Inform Block" entity body should be translatable](https://www.drupal.org/project/data_policy/issues/3492268)

## Issue tracker
https://getopensocial.atlassian.net/browse/PROD-22012

## Release notes
"Inform Block" config entity fields are translatable.

