### PR TITLE
Issue #3493372: Hide operation items (Nodes and Media) from group list page

### DIFF
--- a/modules/social_features/social_group/src/Hooks/SocialGroupOperationHooks.php
+++ b/modules/social_features/social_group/src/Hooks/SocialGroupOperationHooks.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Drupal\social_group\Hooks;
+
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\hux\Attribute\Alter;
+
+/**
+ * HUX class for Operation hooks related with Group.
+ */
+final class SocialGroupOperationHooks {
+
+  /**
+   * Remove unused operation on group pages.
+   *
+   * @see \hook_entity_operation_alter()
+   */
+  #[Alter('entity_operation')]
+  public function removeUnusedOperations(array &$operations, EntityInterface $entity): void {
+    // The operations should be removed only for Groups.
+    if ($entity->getEntityTypeId() !== 'group') {
+      return;
+    }
+
+    // Operations to be removed.
+    $exclude_operations = [
+      'nodes',
+      'media',
+    ];
+
+    $operations = array_filter($operations, function ($key) use ($exclude_operations) {
+      return !in_array($key, $exclude_operations);
+    }, ARRAY_FILTER_USE_KEY);
+  }
+
+}

--- a/modules/social_features/social_group/tests/src/Unit/SocialGroupOperationHooksTest.php
+++ b/modules/social_features/social_group/tests/src/Unit/SocialGroupOperationHooksTest.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace Drupal\Tests\social_group\Unit;
+
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\social_group\Hooks\SocialGroupOperationHooks;
+use Drupal\Tests\UnitTestCase;
+
+/**
+ * Unit test for SocialGroupOperationHooks class.
+ *
+ * @group social_group
+ */
+class SocialGroupOperationHooksTest extends UnitTestCase {
+
+  /**
+   * The class under test.
+   *
+   * @var \Drupal\social_group\Hooks\SocialGroupOperationHooks
+   */
+  protected SocialGroupOperationHooks $socialGroupOperationHooks;
+
+  /**
+   * Entity class.
+   *
+   * @var \Drupal\Core\Entity\EntityInterface
+   */
+  protected EntityInterface $entity;
+
+  /**
+   * Set up the test case.
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $this->socialGroupOperationHooks = new SocialGroupOperationHooks();
+
+    $this->entity = $this->getMockBuilder('\Drupal\group\Entity\Group')
+      ->disableOriginalConstructor()
+      ->getMock();
+    $this->entity->expects($this->any())
+      ->method('getEntityTypeId')
+      ->willReturn('group');
+  }
+
+  /**
+   * Test operations from group entity with nodes.
+   */
+  public function testEntityOperationWithNodesValue(): void {
+    $operations = [
+      'delete' => $this->randomMachineName(),
+      'nodes' => $this->randomMachineName(),
+    ];
+
+    $this->socialGroupOperationHooks->removeUnusedOperations($operations, $this->entity);
+
+    $this->assertArrayHasKey('delete', $operations);
+    $this->assertArrayNotHasKey('nodes', $operations);
+  }
+
+  /**
+   * Test operations from group entity with media.
+   */
+  public function testEntityOperationWithMediaValue(): void {
+    $operations = [
+      'delete' => $this->randomMachineName(),
+      'media' => $this->randomMachineName(),
+    ];
+
+    $this->socialGroupOperationHooks->removeUnusedOperations($operations, $this->entity);
+
+    $this->assertArrayHasKey('delete', $operations);
+    $this->assertArrayNotHasKey('media', $operations);
+  }
+
+  /**
+   * Test operations from group entity with nodes and media.
+   */
+  public function testEntityOperationWithNodesAndMediaValue(): void {
+    $operations = [
+      'delete' => $this->randomMachineName(),
+      'nodes' => $this->randomMachineName(),
+      'media' => $this->randomMachineName(),
+    ];
+
+    $this->socialGroupOperationHooks->removeUnusedOperations($operations, $this->entity);
+
+    $this->assertArrayHasKey('delete', $operations);
+    $this->assertArrayNotHasKey('media', $operations);
+    $this->assertArrayNotHasKey('nodes', $operations);
+  }
+
+  /**
+   * Test operations from group entity without nodes and media.
+   */
+  public function testEntityOperationWithoutNodesAndMediaValue(): void {
+    $operations = [
+      'translate' => $this->randomMachineName(),
+      'delete' => $this->randomMachineName(),
+    ];
+
+    $this->socialGroupOperationHooks->removeUnusedOperations($operations, $this->entity);
+
+    $this->assertArrayHasKey('translate', $operations);
+    $this->assertArrayHasKey('delete', $operations);
+  }
+
+  /**
+   * Test operations from group entity without nodes and media.
+   */
+  public function testEntityOperationWithNonGroupEntity(): void {
+    $entity = $this->getMockBuilder('\Drupal\node\Entity\Node')
+      ->disableOriginalConstructor()
+      ->getMock();
+    $entity->expects($this->any())
+      ->method('getEntityTypeId')
+      ->willReturn('node');
+
+    $operations = [
+      'translate' => $this->randomMachineName(),
+      'delete' => $this->randomMachineName(),
+      'nodes' => $this->randomMachineName(),
+      'media' => $this->randomMachineName(),
+    ];
+
+    $this->socialGroupOperationHooks->removeUnusedOperations($operations, $entity);
+
+    $this->assertArrayHasKey('translate', $operations);
+    $this->assertArrayHasKey('delete', $operations);
+    $this->assertArrayHasKey('nodes', $operations);
+    $this->assertArrayHasKey('media', $operations);
+  }
+
+}


### PR DESCRIPTION
## Problem (for internal)
Probably due to the group update, on the groups overview page it is possible can see the links Nodes and Media in the list of available operations.
Those links are not expected to be there and they even give access denied currently.
We want to hide them/remove them from there

## Solution (for internal)
Hide Nodes and Media options from Operations from group list pages using hook_entity_operation_alter.
Note: Looking forward to D11 we will use HUX instead of hook on module file.

## Release notes (to customers)
The  options Nodes and Media aren't be available anymore on group list page "/admin/group".

## Issue tracker
[PROD-27612](https://getopensocial.atlassian.net/browse/PROD-27612)
[#3493372](https://www.drupal.org/project/social/issues/3493372)

## Theme issue tracker
N/A

## How to test
- [ ] Log with site-manager user
- [ ] Go to the "/admin/group"
- [ ] Check the options on Operations button

## Change Record
N/A

## Translations
N/A


[PROD-27612]: https://getopensocial.atlassian.net/browse/PROD-27612?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ