### PR TITLE
Issue #3493522: Album still available in stream post when disabled

### DIFF
--- a/modules/social_features/social_album/social_album.module
+++ b/modules/social_features/social_album/social_album.module
@@ -363,13 +363,20 @@ function social_album_form_post_form_alter(&$form, FormStateInterface $form_stat
     }
   }
   elseif (isset($form['field_album'])) {
-    $form['field_album']['#states'] = [
-      'visible' => [
-        ':input[name="field_post_image[0][fids]"]' => [
-          'filled' => TRUE,
+    // Hide album select field when feature is disabled on the image post form.
+    $status = \Drupal::config('social_album.settings')->get('status');
+    if (!$status) {
+      unset($form['field_album']);
+    }
+    else {
+      $form['field_album']['#states'] = [
+        'visible' => [
+          ':input[name="field_post_image[0][fids]"]' => [
+            'filled' => TRUE,
+          ],
         ],
-      ],
-    ];
+      ];
+    }
   }
 }
 


### PR DESCRIPTION
## Problem (for internal)
<!-- *[Required] Describe the problem you're trying to solve, this should motivate why the changes you're proposing are needed.* -->
When album feature is disabled, the existing and new album is still available when a picture is posted in the general stream, user stream, group stream:

<img width="970" alt="6c4f0710-752d-4d4a-8108-eb8de066b8f2" src="https://github.com/user-attachments/assets/ae522f85-d6b8-455a-ae62-a9707ac30917" />


## Solution (for internal)
<!-- *[Required] Describe the solution you've created, elaborate on any technical choices you've made. Why is this the right solution and is a different solution not the right one? What is the reasoning behind the chosen solution?* -->
- Hide field_album in the post form when feature is disabled on the stream pages (general stream, user stream, group stream)

<!-- [Optional] If this Pull Request makes visual changes then please include some screenshots that show what has changed here. A before and after screenshot helps the reviewer determine what changes were made. -->

## Release notes (to customers)
<!-- [Required if new feature, and if applicable] A summary of the changes that were made that can be included in release notes to customers.
Please provide enough context and detail, so the editorial review is done efficiently. -->
- Fixed issue with displaying albums in the post when feature is disabled

## Issue tracker
<!-- *[Required] Paste a link to the drupal.org issue queue item. If any other issue trackers were used, include links to those too.* -->
- https://www.drupal.org/project/social/issues/3493522
- https://getopensocial.atlassian.net/browse/PROD-31434

## Theme issue tracker
<!-- *[Required if applicable] Paste a link to the drupal.org theme issue queue item, either from [socialbase](https://www.drupal.org/project/socialbase) or [socialblue](https://www.drupal.org/project/socialblue). If any other issue trackers were used, include links to those too.* -->
N/A

## How to test
- [ ] Using the latest version of Open Social with the social_album module enabled
- [ ] As a sitemanager
- [ ] Disable album feature on the `/admin/config/opensocial/album` page
- [ ] Try add a post on the /stream page (see: screen above)
- [ ] When adding a post I expect do not see a list of albums but instead it still available.
- [ ] The expected result is attained when repeating the steps with this fix applied.


## Change Record
<!-- *[Required if applicable] If this Pull Request changes the way that developers should do things or introduces a new API for developers then a change record to document this is needed. Please provide a draft for a change record or a link to an unpublished change record below. Existing change records can be consulted as example. Please provide a draft for a change record or a link to an unpublished change record below. [Existing change records](https://www.drupal.org/list-changes/social) can be consulted as example.* -->
N/A
## Translations
<!--
*[Optional]Translatable strings are always extracted from the latest development branch. To ensure translations remain available for platforms running older versions of Open Social the original string should be added to `translations.php` when it's changed or removed.*
- [ ] Changed or removed source strings are added to the `translations.php` file.
-->
N/A
