### PR TITLE
Issue #3493489: Add "Membership" request link

### DIFF
--- a/modules/social_features/social_group/modules/social_group_request/social_group_request.links.task.yml
+++ b/modules/social_features/social_group/modules/social_group_request/social_group_request.links.task.yml
@@ -1,0 +1,5 @@
+social_group_request.group_pending_members:
+  route_name: view.group_pending_members.page_1
+  base_route: entity.group.canonical
+  title: Membership requests
+  weight: 70


### PR DESCRIPTION
## Problem (for internal)
The 'Membership Requests' tab, provided by the group_pending_members view, is missing from the group page's local tasks menu. The tab works only on the URL pattern group/{}, but in our case, many modules override or modify the canonical group path, causing this tab to be missed.

## Solution (for internal)
The 'Membership Requests' tab is added by the `group_pending_members` view, but it works only for the URL pattern `group/{}` (since the view's URL is `group/{}/membership-requests`). It retrieves routes based on this URL pattern and uses the first route from the results as the base route for the tab (which should be the Group entity route). However, when additional modules are enabled (e.g., `social_challenges`, `social_group_default_route`), they may override the group route path. As a result, the group route may no longer appear in the route search results for the `group/{}` pattern.
<img width="1677" alt="Screenshot 2024-12-06 at 19 05 33" src="https://github.com/user-attachments/assets/8a4e3866-927c-4390-8c84-e39f694c3d07" />

<img width="967" alt="Screenshot 2024-12-06 at 19 07 17" src="https://github.com/user-attachments/assets/22ac8777-fa47-4013-943f-c8aaf5d1cb74" />

So the best way is to add this tab with *.tasks.yml in the `social_group_request` module

## Release notes (to customers)
Fixed the 'Membership Requests' tab.

## Issue tracker

- https://www.drupal.org/project/social/issues/3493489
- https://getopensocial.atlassian.net/browse/PROD-31257

## How to test
- [ ] Create any group
- [ ] Go to group page /group/{group_id}
- [ ] Check the tabs list - there should exist 'Membership Requests'

## Screenshots
![image](https://github.com/user-attachments/assets/beb16287-2626-4eb2-8b1f-80d2222796e3)

