### PR TITLE
Issue #3493818: Fix invalid default_value

### DIFF
--- a/modules/social_features/social_page/config/install/field.field.node.page.field_content_visibility.yml
+++ b/modules/social_features/social_page/config/install/field.field.node.page.field_content_visibility.yml
@@ -14,7 +14,7 @@ label: Visibility
 description: ''
 required: true
 translatable: true
-default_value: null
+default_value: {  }
 default_value_callback: ''
 settings: {  }
 field_type: entity_access_field


### PR DESCRIPTION
### Problem/Motivation
Configuring the field_content_visibility of the page content type in an Open Social distribution causes the core field_ui module to throw an error, as it expects default_value to be an empty array instead of null.

```
TypeError: count(): Argument #1 ($value) must be of type Countable|array, null given in count() (line 243 of core/modules/field_ui/src/Form/FieldConfigEditForm.php).
Drupal\field_ui\Form\FieldConfigEditForm->form(Array, Object) (Line: 107)
.
.
.
```

### Steps to reproduce

- Install the Open Social distribution.
- Navigate to the "Manage fields" page for the "Page" content type.
- Click Edit button for the field field_content_visibility 
- Observe the error triggered by the core field_ui module due to the invalid default_value.

### Proposed resolution
Update the default_value key in the configuration file to use an empty array { } instead of null. The corrected configuration should look like:
`default_value: { }`
