### PR TITLE
PROD-31114: Bump Symfony Mailer module to 1.5 as minimal version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -169,7 +169,7 @@
         "drupal/shariff": "2.0.0",
         "drupal/socialbase": "2.6.8",
         "drupal/socialblue": "2.6.5",
-        "drupal/symfony_mailer": "^1.2",
+        "drupal/symfony_mailer": "^1.5",
         "drupal/token": "1.15.0",
         "drupal/ultimate_cron": "2.0.0-alpha8",
         "drupal/update_helper": "^3 || ^4",


### PR DESCRIPTION
## Problem (for internal)
Looking to forward to be compatible with Drupal 11 we need to bump Symfony Mailer module to 1.5 as minimal version.

## Solution (for internal)
Update Symfony Mailer module to 1.5 version as minimal.

## Release notes (to customers)
Symfony Mailer release notes:
- https://www.drupal.org/project/symfony_mailer/releases/1.2.1
- https://www.drupal.org/project/symfony_mailer/releases/1.3.0-beta1
- https://www.drupal.org/project/symfony_mailer/releases/1.3.0-beta2
- https://www.drupal.org/project/symfony_mailer/releases/1.3.0-rc1
- https://www.drupal.org/project/symfony_mailer/releases/1.3.0-rc2
- https://www.drupal.org/project/symfony_mailer/releases/1.3.0-rc3
- https://www.drupal.org/project/symfony_mailer/releases/1.2.2
- https://www.drupal.org/project/symfony_mailer/releases/1.3.0
- https://www.drupal.org/project/symfony_mailer/releases/1.3.1
- https://www.drupal.org/project/symfony_mailer/releases/1.4.0-beta1
- https://www.drupal.org/project/symfony_mailer/releases/1.3.2
- https://www.drupal.org/project/symfony_mailer/releases/1.4.0-beta2
- https://www.drupal.org/project/symfony_mailer/releases/1.4.0
- https://www.drupal.org/project/symfony_mailer/releases/1.4.1
- https://www.drupal.org/project/symfony_mailer/releases/1.5.0

## Issue tracker
[PROD-31114](https://getopensocial.atlassian.net/browse/PROD-31114)

## Theme issue tracker
N/A

## How to test
The CableCar already is using Symfony Mailer module in 1.5 version.
The test can be skipt.

## Change Record
N/A

## Translations
N/A



[PROD-31114]: https://getopensocial.atlassian.net/browse/PROD-31114?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ