### PR TITLE
Issue #3494301: Event address format should be displayed in a different format

### DIFF
--- a/cspell.words.txt
+++ b/cspell.words.txt
@@ -25,3 +25,5 @@ strikethrough
 Stringable
 # Address region in behat tests.
 Lvivska
+# Address label from address module
+Neighbourhood

--- a/modules/social_features/social_core/config/install/social_core.address.settings.yml
+++ b/modules/social_features/social_core/config/install/social_core.address.settings.yml
@@ -1,0 +1,2 @@
+format: '@address_line1%, @address_line2%, @address_line3%, @postal_code% @locality%, @country_code%'
+regex_pattern: '/@[\s\S]+?%, |@[\s\S]+?% |@[\s\S]+?% - /'

--- a/modules/social_features/social_core/config/schema/social_core.schema.yml
+++ b/modules/social_features/social_core/config/schema/social_core.schema.yml
@@ -37,3 +37,14 @@ field.storage_settings.social_external_identifier:
       sequence:
         type: string
         label: 'Target entity type'
+
+social_core.address.settings:
+  type: config_object
+  label: "Address format to be rendered"
+  mapping:
+    format:
+      type: string
+      label: "Address format template"
+    regex_pattern:
+      type: string
+      label: "Regex pattern to clean empty address field-item"

--- a/modules/social_features/social_core/social_core.install
+++ b/modules/social_features/social_core/social_core.install
@@ -633,3 +633,17 @@ function social_core_update_130012() : void {
     }
   }
 }
+
+/**
+ * Configure address settings config.
+ */
+function social_core_update_130013(): void {
+  /** @var \Drupal\Core\Config\ConfigFactoryInterface $config_factory */
+  $config_factory = \Drupal::service('config.factory');
+
+  $address_config = $config_factory->getEditable('social_core.address.settings');
+  $address_config
+    ->set('address_format', '@address_line1%, @address_line2%, @address_line3%, @postal_code% @locality%, @country_code%')
+    ->set('regex_pattern', '/@[\s\S]+?%, |@[\s\S]+?% |@[\s\S]+?% - /')
+    ->save();
+}

--- a/modules/social_features/social_core/social_core.install
+++ b/modules/social_features/social_core/social_core.install
@@ -111,6 +111,7 @@ function social_core_install() {
       'administer blocks',
       'administer block content',
       'access social_core dashboard',
+      'configure address format',
     ]
   );
   // Create AN Homepage block.
@@ -646,4 +647,11 @@ function social_core_update_130013(): void {
     ->set('address_format', '@address_line1%, @address_line2%, @address_line3%, @postal_code% @locality%, @country_code%')
     ->set('regex_pattern', '/@[\s\S]+?%, |@[\s\S]+?% |@[\s\S]+?% - /')
     ->save();
+}
+
+/**
+ * Grant permission to site-manager configure address format.
+ */
+function social_core_update_130014(): void {
+  user_role_grant_permissions('sitemanager', ['configure address format']);
 }

--- a/modules/social_features/social_core/social_core.install
+++ b/modules/social_features/social_core/social_core.install
@@ -644,7 +644,7 @@ function social_core_update_130013(): void {
 
   $address_config = $config_factory->getEditable('social_core.address.settings');
   $address_config
-    ->set('address_format', '@address_line1%, @address_line2%, @address_line3%, @postal_code% @locality%, @country_code%')
+    ->set('format', '@address_line1%, @address_line2%, @address_line3%, @postal_code% @locality%, @country_code%')
     ->set('regex_pattern', '/@[\s\S]+?%, |@[\s\S]+?% |@[\s\S]+?% - /')
     ->save();
 }

--- a/modules/social_features/social_core/social_core.links.menu.yml
+++ b/modules/social_features/social_core/social_core.links.menu.yml
@@ -153,3 +153,10 @@ social_core.dashboard.appearance.active_homepage_configuration.link:
   description: 'Change the image and text on the home page.'
   url: 'internal:/admin/dashboard/homepage-settings'
   weight: -90
+
+social_core.address_settings:
+  title: 'Address settings'
+  route_name: social_core.address_settings.format
+  parent: social_core.admin.config.social
+  description: 'Configure address to define how it will be rendered.'
+  weight: -100

--- a/modules/social_features/social_core/social_core.links.task.yml
+++ b/modules/social_features/social_core/social_core.links.task.yml
@@ -1,0 +1,9 @@
+social_core.address_settings.format:
+  route_name: social_core.address_settings.format
+  base_route: social_core.address_settings.format
+  title: 'Format'
+
+social_core.address_settings.regex_pattern:
+  route_name: social_core.address_settings.regex_pattern
+  base_route: social_core.address_settings.format
+  title: 'Regex Pattern'

--- a/modules/social_features/social_core/social_core.permissions.yml
+++ b/modules/social_features/social_core/social_core.permissions.yml
@@ -10,3 +10,11 @@ view debug information:
   title: 'View debug information'
   description: 'Show debug information in Open Social modules. Intended for developers only.'
   restrict access: true
+
+configure address format:
+  title: 'Configure address format'
+  description: 'The address format define how the address will be rendered to the end-user'
+
+configure regex pattern for address:
+  title: 'Configure regex pattern for address'
+  description: 'The regex pattern define the pattern of tokens variable, to empty when it empty'

--- a/modules/social_features/social_core/social_core.routing.yml
+++ b/modules/social_features/social_core/social_core.routing.yml
@@ -101,3 +101,19 @@ social_core.dashboard.appearance.active_homepage_configuration:
     _title: 'Customize home page'
   requirements:
     _permission: 'access social_core dashboard'
+
+social_core.address_settings.format:
+  path: '/admin/config/opensocial/address-settings/format'
+  defaults:
+    _form: 'Drupal\social_core\Form\AddressFormatForm'
+    _title: 'Address settings - Format'
+  requirements:
+    _permission: 'configure address format'
+
+social_core.address_settings.regex_pattern:
+  path: '/admin/config/opensocial/address-settings/regex-pattern'
+  defaults:
+    _form: 'Drupal\social_core\Form\AddressRegexPatternForm'
+    _title: 'Address settings - Regex pattern'
+  requirements:
+    _permission: 'configure regex pattern for address'

--- a/modules/social_features/social_core/src/Form/AddressFormatForm.php
+++ b/modules/social_features/social_core/src/Form/AddressFormatForm.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace Drupal\social_core\Form;
+
+use Drupal\Core\Form\ConfigFormBase;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Class AddressFormatForm.
+ */
+class AddressFormatForm extends ConfigFormBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getEditableConfigNames(): array {
+    return [
+      'social_core.address.settings',
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId(): string {
+    return 'address_format_form';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state): array {
+    $address_config = $this->config('social_core.address.settings');
+
+    $form['address_format_fieldset'] = [
+      '#type' => 'fieldset',
+      '#tree' => TRUE,
+      '#collapsible' => FALSE,
+      '#collapsed' => FALSE,
+    ];
+
+    $form['address_format_fieldset']['address_format'] = [
+      '#title' => $this->t('Address format'),
+      '#type' => 'textarea',
+      '#description' => $this->t('You can set the format address to be rendered, check available tokens below.'),
+      '#required' => TRUE,
+      '#default_value' => $address_config->get('address_format'),
+    ];
+
+    $form['address_format_fieldset']['available_tokens'] = [
+      '#title' => $this->t('Available tokens'),
+      '#type' => 'details',
+      '#open' => FALSE,
+    ];
+
+    $form['address_format_fieldset']['available_tokens']['token_table'] = [
+      '#type' => 'table',
+      '#header' => [
+        'token' => $this->t('Token'),
+        'description' => $this->t('Description'),
+      ],
+      '#rows' => [
+        [
+          'token' => '@address_line1%',
+          'description' => t('Address line 1', [], ['context' => 'Address label']),
+        ],
+        [
+          'token' => '@address_line2%',
+          'description' => t('Address line 2', [], ['context' => 'Address label']),
+        ],
+        [
+          'token' => '@address_line3%',
+          'description' => t('Address line 3', [], ['context' => 'Address label']),
+        ],
+        [
+          'token' => '@postal_code%',
+          'description' => t('Postal code', [], ['context' => 'Address label']),
+        ],
+        [
+          'token' => '@sorting_code%',
+          'description' => t('Sorting code', [], ['context' => 'Address label']),
+        ],
+        [
+          'token' => '@administrative_area%',
+          'description' => t('Administrative area (e.g. State or Province)', [], ['context' => 'Address label']),
+        ],
+        [
+          'token' => '@locality%',
+          'description' => t('Locality (e.g. City)', [], ['context' => 'Address label']),
+        ],
+        [
+          'token' => '@dependent_locality%',
+          'description' => t('Dependent locality (e.g. Neighbourhood)', [], ['context' => 'Address label']),
+        ],
+        [
+          'token' => '@country_code%',
+          'description' => t('Country', [], ['context' => 'Address label']),
+        ],
+      ],
+    ];
+
+    $form['actions']['#type'] = 'actions';
+    $form['actions']['submit'] = [
+      '#type' => 'submit',
+      '#value' => $this->t('Save'),
+    ];
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state): void {
+    $address_format = $form_state->getValue(['address_format_fieldset', 'address_format']);
+    $address_config = $this->config('social_core.address.settings');
+
+    $address_config->set('address_format', $address_format)
+      ->save();
+
+    $this->messenger()->addStatus($this->t('The address format has been updated.'));
+  }
+
+}

--- a/modules/social_features/social_core/src/Form/AddressRegexPatternForm.php
+++ b/modules/social_features/social_core/src/Form/AddressRegexPatternForm.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Drupal\social_core\Form;
+
+use Drupal\Core\Form\ConfigFormBase;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Class AddressRegexPatternForm.
+ */
+class AddressRegexPatternForm extends ConfigFormBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getEditableConfigNames(): array {
+    return [
+      'social_core.address.settings',
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId(): string {
+    return 'address_regex_pattern_form';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state): array {
+    $address_config = $this->config('social_core.address.settings');
+
+    $form['address_regex_pattern_fieldset'] = [
+      '#type' => 'fieldset',
+      '#tree' => TRUE,
+      '#collapsible' => FALSE,
+      '#collapsed' => FALSE,
+    ];
+
+    $form['address_regex_pattern_fieldset']['regex_pattern'] = [
+      '#title' => $this->t('Regex pattern'),
+      '#type' => 'textfield',
+      '#description' => $this->t('The regex pattern will be used to clean empty variable on Address field, all pattern should be registered.'),
+      '#required' => TRUE,
+      '#default_value' => $address_config->get('regex_pattern'),
+    ];
+
+    $form['actions']['#type'] = 'actions';
+    $form['actions']['submit'] = [
+      '#type' => 'submit',
+      '#value' => $this->t('Save'),
+    ];
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state): void {
+    $address_format = $form_state->getValue(['address_regex_pattern_fieldset', 'regex_pattern']);
+    $address_config = $this->config('social_core.address.settings');
+
+    $address_config->set('regex_pattern', $address_format)
+      ->save();
+
+    $this->messenger()->addStatus($this->t('The regex pattern has been updated.'));
+  }
+
+}

--- a/modules/social_features/social_core/src/Plugin/Field/FieldFormatter/AddressFormatter.php
+++ b/modules/social_features/social_core/src/Plugin/Field/FieldFormatter/AddressFormatter.php
@@ -106,8 +106,13 @@ class AddressFormatter extends FormatterBase {
    */
   public function viewElements(FieldItemListInterface $items, $langcode): array {
     $address_config = $this->configFactory->get('social_core.address.settings');
-    $address_string = $address_config->get('address_format');
+    $address_string = $address_config->get('format');
     $address_values = current($items->getValue());
+
+    // When the address field is empty, return early.
+    if (empty($address_values)) {
+      return [];
+    }
 
     foreach ($address_values as $key => $value) {
       if (empty($value)) {

--- a/modules/social_features/social_core/src/Plugin/Field/FieldFormatter/AddressFormatter.php
+++ b/modules/social_features/social_core/src/Plugin/Field/FieldFormatter/AddressFormatter.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace Drupal\social_core\Plugin\Field\FieldFormatter;
+
+use Drupal\address\Repository\CountryRepository;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Field\FieldDefinitionInterface;
+use Drupal\Core\Field\FormatterBase;
+use Drupal\Core\Field\FieldItemListInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Plugin implementation of the Address formatter.
+ *
+ * @FieldFormatter(
+ *   id = "address_formatter",
+ *   label = @Translation("Address Formatted"),
+ *   field_types = {
+ *     "address"
+ *   }
+ * )
+ */
+class AddressFormatter extends FormatterBase {
+
+  /**
+   * The country repository from address module.
+   *
+   * @var \Drupal\address\Repository\CountryRepository
+   */
+  protected $countryRepository;
+
+  /**
+   * The config factory.
+   *
+   * @var \Drupal\Core\Config\ConfigFactoryInterface
+   */
+  protected $configFactory;
+
+  /**
+   * Constructs a AddressFormatter instance.
+   *
+   * @param string $plugin_id
+   *   The plugin ID for the formatter.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   * @param \Drupal\Core\Field\FieldDefinitionInterface $field_definition
+   *   The definition of the field to which the formatter is associated.
+   * @param array $settings
+   *   The formatter settings.
+   * @param string $label
+   *   The formatter label display setting.
+   * @param string $view_mode
+   *   The view mode.
+   * @param array $third_party_settings
+   *   Any third party settings.
+   * @param \Drupal\address\Repository\CountryRepository $country_repository
+   *   Country repository from address module.
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   Config factory.
+   */
+  public function __construct(
+    $plugin_id,
+    $plugin_definition,
+    FieldDefinitionInterface $field_definition,
+    array $settings,
+    $label,
+    $view_mode,
+    array $third_party_settings,
+    CountryRepository $country_repository,
+    ConfigFactoryInterface $config_factory,
+  ) {
+    parent::__construct($plugin_id, $plugin_definition, $field_definition, $settings, $label, $view_mode, $third_party_settings);
+
+    $this->countryRepository = $country_repository;
+    $this->configFactory = $config_factory;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition): self {
+    return new static(
+      $plugin_id,
+      $plugin_definition,
+      $configuration['field_definition'],
+      $configuration['settings'],
+      $configuration['label'],
+      $configuration['view_mode'],
+      $configuration['third_party_settings'],
+      $container->get('address.country_repository'),
+      $container->get('config.factory'),
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function settingsSummary(): array {
+    $summary = [];
+    $summary[] = $this->t('Displays the address formatted.');
+    return $summary;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function viewElements(FieldItemListInterface $items, $langcode): array {
+    $address_config = $this->configFactory->get('social_core.address.settings');
+    $address_string = $address_config->get('address_format');
+    $address_values = current($items->getValue());
+
+    foreach ($address_values as $key => $value) {
+      if (empty($value)) {
+        continue;
+      }
+
+      $address_value = match ($key) {
+        'country_code' => $this->countryRepository->get($value)->getName(),
+        default => $value,
+      };
+
+      $address_string = str_replace("@" . $key . "%", $address_value, $address_string);
+    }
+
+    return ['#markup' => preg_replace($address_config->get('regex_pattern'), '', $address_string)];
+  }
+
+}

--- a/modules/social_features/social_event/config/install/core.entity_view_display.node.event.default.yml
+++ b/modules/social_features/social_event/config/install/core.entity_view_display.node.event.default.yml
@@ -36,7 +36,7 @@ content:
     third_party_settings: {  }
     region: content
   field_event_address:
-    type: address_plain
+    type: address_formatter
     weight: 1
     label: hidden
     settings: {  }

--- a/modules/social_features/social_event/config/update/social_event_update_130005.yml
+++ b/modules/social_features/social_event/config/update/social_event_update_130005.yml
@@ -1,0 +1,7 @@
+core.entity_view_display.node.event.default:
+  expected_config: {  }
+  update_actions:
+    change:
+      content:
+        field_event_address:
+          type: address_formatter

--- a/modules/social_features/social_event/social_event.install
+++ b/modules/social_features/social_event/social_event.install
@@ -296,3 +296,17 @@ function social_event_update_130004(): void {
       ->save();
   }
 }
+
+/**
+ * Set address field from event to use Address Formatted plugin.
+ */
+function social_event_update_130005(): string {
+  /** @var \Drupal\update_helper\Updater $updater */
+  $updater = \Drupal::service('update_helper.updater');
+
+  // Execute configuration update definitions with logging of success.
+  $updater->executeUpdate('social_event', __FUNCTION__);
+
+  // Output logged messages to related channel of update execution.
+  return $updater->logger()->output();
+}

--- a/modules/social_features/social_event/social_event.theme.inc
+++ b/modules/social_features/social_event/social_event.theme.inc
@@ -62,25 +62,9 @@ function template_preprocess_event_location_address(array &$variables): void {
       ? $node->get('field_event_location')->getString()
       : NULL;
 
-    $variables['address'] = NULL;
-    if (!$node->get('field_event_address')->isEmpty()) {
-      $country_list = \Drupal::service('address.country_repository')->getList();
-      $address_value = current($node->get('field_event_address')->getValue());
-      $address_sequence = ['address_line1', 'address_line2', 'address_line3', 'locality', 'country_code'];
-
-      $address = [];
-      foreach ($address_sequence as $address_key) {
-        $address[] = match ($address_key) {
-          'locality' => is_null($address_value['postal_code'])
-            ? $address_value[$address_key]
-            : sprintf('%s %s', $address_value['postal_code'], $address_value[$address_key]),
-          'country_code' => $country_list[$address_value[$address_key]],
-          default => $address_value[$address_key],
-        };
-      }
-
-      $variables['address'] = trim(implode(', ', array_filter($address)), ", ");
-    }
+    $variables['address'] = !$node->get('field_event_address')->isEmpty()
+      ? $node->get('field_event_address')->view('default')
+      : NULL;
   }
 
   // We want to use icon from the loaded file rather than embed it. Because

--- a/modules/social_features/social_event/social_event.theme.inc
+++ b/modules/social_features/social_event/social_event.theme.inc
@@ -61,9 +61,26 @@ function template_preprocess_event_location_address(array &$variables): void {
     $variables['location'] = !$node->get('field_event_location')->isEmpty()
       ? $node->get('field_event_location')->getString()
       : NULL;
-    $variables['address'] = !$node->get('field_event_address')->isEmpty()
-      ? $node->get('field_event_address')->getString()
-      : NULL;
+
+    $variables['address'] = NULL;
+    if (!$node->get('field_event_address')->isEmpty()) {
+      $country_list = \Drupal::service('address.country_repository')->getList();
+      $address_value = current($node->get('field_event_address')->getValue());
+      $address_sequence = ['address_line1', 'address_line2', 'address_line3', 'locality', 'country_code'];
+
+      $address = [];
+      foreach ($address_sequence as $address_key) {
+        $address[] = match ($address_key) {
+          'locality' => is_null($address_value['postal_code'])
+            ? $address_value[$address_key]
+            : sprintf('%s %s', $address_value['postal_code'], $address_value[$address_key]),
+          'country_code' => $country_list[$address_value[$address_key]],
+          default => $address_value[$address_key],
+        };
+      }
+
+      $variables['address'] = trim(implode(', ', array_filter($address)), ", ");
+    }
   }
 
   // We want to use icon from the loaded file rather than embed it. Because


### PR DESCRIPTION
## Problem (for internal)
In the event page we show the event address.
The format is different than the one we show on group pages and we display the Country code instead of the country name.

Correct format and order of the fields should be: Location • Street, zip code city, country (full name)
Note that there is no comma between the city and the zip code when both values are provided

## Solution (for internal)
I created a display-plugin to address type-field and it will format the address as a site-manager user had defined on admin pages.

Two new admin pages was created with different permissions.
1. Page to define the address format;
2. Page to define regex pattern from address (This page is more technical and should be used only with knowledge);

## Release notes (to customers)
The address field can be controlled how they will be rendered to the end-user in event page and that format can be controlled by site-manager.

## Issue tracker
[PROD-30807](https://getopensocial.atlassian.net/browse/PROD-30807)
[#3494301](https://www.drupal.org/project/social/issues/3494301)

## Theme issue tracker
N/A

## How to test
- [ ] Log in as site-manager
- [ ] Go to Address Format page "/admin/config/opensocial/address-settings/format" and check if exist an template register
- [ ] Create an event
- [ ] Check address field on header, it should follow the template registered on Address Format page
- [ ] Change the Address Format
- [ ] Clear cache
- [ ] Check if format changed on Event page as well
- [ ] If the new template register to address has a new pattern, example a value between parentheses, it should be registered on Regex Pattern page by an admin user

## Change Record
N/A

## Translations
N/A


[PROD-30807]: https://getopensocial.atlassian.net/browse/PROD-30807?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ