### PR TITLE
PROD-31161: Bump URL Embed 3.0-beta2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -88,8 +88,7 @@
                 "Issue #3454939: Declaration of Drupal\\search_api_solr\\Plugin\\search_api\\backend\\SearchApiSolrBackend::__sleep() must be compatible": "https://www.drupal.org/files/issues/2024-06-17/3454939-search-api-solr-core-10.patch"
             },
             "drupal/url_embed": {
-                "Translate dialog title": "https://www.drupal.org/files/issues/2018-03-16/url_embed_translate_dialog_title-2953591-2.patch",
-                "Issue #3491068: Combined patches for #2761187, #3386579, #3386590": "https://www.drupal.org/files/issues/2024-12-02/3491068-combined-patches_2761187_3386579_3386590.patch"
+                "Issue #3491068: Combined patches for #2761187, #3386579, #3386590": "https://www.drupal.org/files/issues/2024-12-17/3491068-combined-patches_2761187_3386579_3386590-for-url-embed-3.0.0-beta2.patch"
             },
             "drupal/views_infinite_scroll" : {
                 "Headers in table format repeat on load more instead of adding rows (v1.8)": "https://www.drupal.org/files/issues/2021-02-11/2899705-35.patch"
@@ -173,7 +172,7 @@
         "drupal/token": "1.15.0",
         "drupal/ultimate_cron": "2.0.0-alpha8",
         "drupal/update_helper": "^3 || ^4",
-        "drupal/url_embed": "2.0.0-alpha3",
+        "drupal/url_embed": "^3.0@beta",
         "drupal/variationcache": "^1.4",
         "drupal/views_bulk_operations": "4.2.7",
         "drupal/views_ef_fieldset": "1.7.0",

--- a/modules/social_features/social_embed/src/Plugin/Filter/SocialEmbedUrlEmbedFilter.php
+++ b/modules/social_features/social_embed/src/Plugin/Filter/SocialEmbedUrlEmbedFilter.php
@@ -7,6 +7,7 @@ use Drupal\Component\Utility\UrlHelper;
 use Drupal\Component\Uuid\UuidInterface;
 use Drupal\Core\Config\ConfigFactory;
 use Drupal\Core\Logger\LoggerChannelFactoryInterface;
+use Drupal\Core\Render\Renderer;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\Session\AccountProxyInterface;
 use Drupal\Core\Utility\Error;
@@ -87,6 +88,8 @@ class SocialEmbedUrlEmbedFilter extends UrlEmbedFilter {
    *   The logger channel factory service.
    * @param \Drupal\Core\Routing\RouteMatchInterface $routeMatch
    *   The route match service.
+   * @param \Drupal\Core\Render\Renderer $renderer
+   *   Renderer services.
    */
   public function __construct(
     array $configuration,
@@ -99,8 +102,10 @@ class SocialEmbedUrlEmbedFilter extends UrlEmbedFilter {
     AccountProxyInterface $current_user,
     LoggerChannelFactoryInterface $loggerFactory,
     protected RouteMatchInterface $routeMatch,
+    Renderer $renderer,
   ) {
-    parent::__construct($configuration, $plugin_id, $plugin_definition, $url_embed);
+    parent::__construct($configuration, $plugin_id, $plugin_definition, $url_embed, $renderer);
+
     $this->uuid = $uuid;
     $this->configFactory = $config_factory;
     $this->embedHelper = $embed_helper;
@@ -123,6 +128,7 @@ class SocialEmbedUrlEmbedFilter extends UrlEmbedFilter {
       $container->get('current_user'),
       $container->get('logger.factory'),
       $container->get('current_route_match'),
+      $container->get('renderer'),
     );
   }
 


### PR DESCRIPTION
## Problem (for internal)
Bump URL Embed module to 3.0-beta2 to be compatible with D11

## Solution (for internal)
Update URL Embed module to 3.0-beta2

## Release notes (to customers)
URL Embed release notes:
- https://www.drupal.org/project/url_embed/releases/3.x-dev
- https://www.drupal.org/project/url_embed/releases/3.0.0-alpha1
- https://www.drupal.org/project/url_embed/releases/3.0.0-alpha2
- https://www.drupal.org/project/url_embed/releases/3.0.0-beta1
- https://www.drupal.org/project/url_embed/releases/3.0.0-beta2

## Issue tracker
[PROD-31161](https://getopensocial.atlassian.net/browse/PROD-31161)

## Theme issue tracker
N/A

## How to test
- [ ] Enable Social Embed module
- [ ] Log in with site-manager user
- [ ] Test URL Embed button on CKEditor 5

## Change Record
N/A

## Translations
N/A


[PROD-31161]: https://getopensocial.atlassian.net/browse/PROD-31161?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ