### PR TITLE
Issue #3495014: Fix display of the field and the label of the enrolment limit in the event

### DIFF
--- a/modules/social_features/social_event/modules/social_event_max_enroll/social_event_max_enroll.module
+++ b/modules/social_features/social_event/modules/social_event_max_enroll/social_event_max_enroll.module
@@ -104,6 +104,12 @@ function social_event_max_enroll_form_alter(&$form, FormStateInterface $form_sta
           ],
         ];
 
+        // Hide all `Enrollment limit` wrapper
+        // if event enrollment is disabled for event.
+        if (!$form['field_event_max_enroll']['#access'] && !$form['field_event_max_enroll_num']['#access']) {
+          $form['field_event_max_enroll_wrapper']['#access'] = FALSE;
+        }
+
         $form['field_event_max_enroll_wrapper']['field_event_max_enroll'] = $form['field_event_max_enroll'];
         $form['field_event_max_enroll_wrapper']['field_event_max_enroll_num'] = $form['field_event_max_enroll_num'];
         unset($form['field_event_max_enroll'], $form['field_event_max_enroll_num']);


### PR DESCRIPTION
## Problem (for internal)
The enrollment limit label should not be visible when the limit is disabled.

## Solution (for internal)
Add condition and check if the `Enable maximum number of event enrollments` setting is disabled and hide the `Enrollment limit` option on the event create form.

**Before:**
![Screenshot 2024-12-05 at 11 56 08](https://github.com/user-attachments/assets/554f8646-1a47-4e74-ad0c-0a00bdb40a06)

![Screenshot 2024-12-05 at 11 56 01](https://github.com/user-attachments/assets/49a59512-c2ca-4716-9846-f796221bc885)

**After:**
![Screenshot 2024-12-19 at 14 54 39](https://github.com/user-attachments/assets/5946c297-e9ca-460c-93a9-2764aeb56b68)

## Release notes (to customers)
When the Event enrollment limit is disabled the user does not see the field or the label of the enrollment limit in the event

## Issue tracker

- https://www.drupal.org/project/social/issues/3495014
- https://getopensocial.atlassian.net/browse/PROD-31507

## Theme issue tracker
<!-- *[Required if applicable] Paste a link to the drupal.org theme issue queue item, either from [socialbase](https://www.drupal.org/project/socialbase) or [socialblue](https://www.drupal.org/project/socialblue). If any other issue trackers were used, include links to those too.* -->

## How to test
- [ ] Enable the `social_event_max_enroll` module.
- [ ] Go to the `/admin/config/opensocial/event-max-enroll` page and check if the `Enable maximum number of event enrollments` checkbox is enabled.
- [ ] Go to the `/node/add/event` page.
- [ ] Scroll to the Access permissions section and find the `Enrollment limit`.
- [ ] Go to the `/admin/config/opensocial/event-max-enroll` page and uncheck the `Enable maximum number of event enrollments` checkbox.
- [ ] Go to the `/node/add/event` page.
- [ ] Scroll to the Access permissions section and check if the `Enrollment limit` is displayed.


## Change Record
<!-- *[Required if applicable] If this Pull Request changes the way that developers should do things or introduces a new API for developers then a change record to document this is needed. Please provide a draft for a change record or a link to an unpublished change record below. Existing change records can be consulted as example. Please provide a draft for a change record or a link to an unpublished change record below. [Existing change records](https://www.drupal.org/list-changes/social) can be consulted as example.* -->

## Translations
<!--
*[Optional]Translatable strings are always extracted from the latest development branch. To ensure translations remain available for platforms running older versions of Open Social the original string should be added to `translations.php` when it's changed or removed.*
- [ ] Changed or removed source strings are added to the `translations.php` file.
-->
