### PR TITLE
Issue #3509053: Fix SQL error on Profile Entity Sort with ONLY_FULL_GROUP_BY mode

### DIFF
--- a/modules/social_features/social_profile/src/Plugin/views/field/ProfileEntitySortable.php
+++ b/modules/social_features/social_profile/src/Plugin/views/field/ProfileEntitySortable.php
@@ -167,7 +167,9 @@ class ProfileEntitySortable extends RenderedEntity {
         }
         // If we have only one field for sort then use the Profile name field.
         elseif (count($order_by_fields) === 1) {
-          $this->field_alias = $definition['table'] . '.profile_name_value';
+          $profile_name_field = $definition['table'] . '.profile_name_value';
+          $this->field_alias = $profile_name_field;
+          $query->addGroupBy($profile_name_field);
         }
       }
       // Since fields should always have themselves already added, just


### PR DESCRIPTION
## Problem (for internal)

https://www.drupal.org/project/social/issues/3509053

When using the People page (admin/people) , sorting by Username triggers a SQL error when MySQL's ONLY_FULL_GROUP_BY mode is enabled. This is a common setting in modern MySQL configurations to enforce strict GROUP BY behavior, ensuring all non-aggregated fields in SELECT statements are included in the GROUP BY clause.

```
Expression #1 of ORDER BY clause is not in GROUP BY clause and contains nonaggregated column 'db.profile__profile_name.profile_name_value' which is not functionally dependent on columns in GROUP BY clause; this is incompatible with sql_mode=only_full_group_by
```

## Solution (for internal)

Add the `profile_name_value` field to the `GROUP BY` clause in the `ProfileEntitySortable` class:

```
// Add the field to the GROUP BY clause to avoid SQL error.
$query->addGroupBy('profile__profile_name.profile_name_value');
```

## Before 
![people_before](https://github.com/user-attachments/assets/4d4a9705-48bd-4f83-a5b1-e3f515225aef)

## After
![people_after](https://github.com/user-attachments/assets/41f99cde-1519-4bfe-b10e-c3d8d4c39563)

## Issue tracker
https://www.drupal.org/project/social/issues/3509053

## How to test
- [ ] Using latest version Open Social with MySQL database service. 
- [ ] As a Administrator user role 
- [ ] Try to navigate to People page 
- [ ] When Sorting based on Username field from the list it shouldn't give you Website encounter issue rather the list should be sorted correctly.
