### PR TITLE
Issue #3514353: Add patch to fix sa-core-2025-004

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,6 +44,7 @@
             },
             "drupal/core": {
                 "Issue #3508033: Fix Drupal Core issues sa-core-2025-001, 002, 003": "https://www.drupal.org/files/issues/2025-02-20/core-3508033-2.patch",
+                "Issue #3514353: Fix Drupal Core issues sa-core-2025-004": "https://www.drupal.org/files/issues/2025-03-20/core-3514353-2.patch",
                 "Restrict images to this site blocks image style derivatives": "https://www.drupal.org/files/issues/2019-05-10/2528214-54.patch",
                 "Optimize getCommentedEntity()": "https://www.drupal.org/files/issues/2018-12-28/2580551-72.patch",
                 "Default role id causes issues with validation on VBO": "https://www.drupal.org/files/issues/2018-05-24/2974925-default-rid-config-causes-illegal-error.patch",


### PR DESCRIPTION
## Problem (for internal)
Drupal released a security update for sa-core-2025-004
https://www.drupal.org/sa-core-2025-004

## Solution (for internal)
Drupal 10.2 is EOL and doesn't receive security updates anymore.

Yesterday a security announcement was made
https://www.drupal.org/sa-core-2025-004

Since we still support Open Social 12, we should make it secure.

## Release notes (to customers)
Added a patch to fix sa-core-2025-004

## Issue tracker
https://www.drupal.org/project/social/issues/3514353

## Theme issue tracker
<!-- *[Required if applicable] Paste a link to the drupal.org theme issue queue item, either from [socialbase](https://www.drupal.org/project/socialbase) or [socialblue](https://www.drupal.org/project/socialblue). If any other issue trackers were used, include links to those too.* -->

## How to test
- [ ] Try to add options to menulinks and see malicious code gets stripped.


## Change Record
<!-- *[Required if applicable] If this Pull Request changes the way that developers should do things or introduces a new API for developers then a change record to document this is needed. Please provide a draft for a change record or a link to an unpublished change record below. Existing change records can be consulted as example. Please provide a draft for a change record or a link to an unpublished change record below. [Existing change records](https://www.drupal.org/list-changes/social) can be consulted as example.* -->

## Translations
<!--
*[Optional]Translatable strings are always extracted from the latest development branch. To ensure translations remain available for platforms running older versions of Open Social the original string should be added to `translations.php` when it's changed or removed.*
- [ ] Changed or removed source strings are added to the `translations.php` file.
-->
