### PR TITLE
Issue #3607140: Fix InvalidParameterException when inviting a user by email before group relationship is saved

### DIFF
--- a/modules/social_features/social_group/modules/social_group_invite/social_group_invite.module
+++ b/modules/social_features/social_group/modules/social_group_invite/social_group_invite.module
@@ -721,27 +721,26 @@ function social_group_invite_tokens_alter(array &$replacements, array $context, 
   ) {
     /** @var \Drupal\group\Entity\GroupRelationshipInterface $group_content */
     $group_content = $context["data"]["group_content"];
-    $group_content_id = $group_content->get('id')->getString();
-
-    // We are using a destination for use with the register link.
-    // This destination is only used when user's don't have an account yet.
-    $destination = 'destination=/social-group-invite/' . $group_content_id . '/accept';
-    $group_invite_url = Url::fromRoute('social_group_invite.invitation.accept', ['group_content' => $group_content_id], ['absolute' => TRUE])->toString();
-
-    // For groups that only group members have access to, we should change the
-    // destination to the user's invites page.
+    $group_content_id = $group_content->get('id')->getString() ?? FALSE;
     $group = $group_content->getGroup();
-    if (
-      ($group->hasField('field_flexible_group_visibility') &&
-      !$group->get('field_flexible_group_visibility')->isEmpty() &&
-      $group->get('field_flexible_group_visibility')->getValue()[0]['value'] === 'members')
-    ) {
 
-      // Update the destination for use with the register link.
+    $members_only = ($group->hasField('field_flexible_group_visibility') &&
+      !$group->get('field_flexible_group_visibility')->isEmpty() &&
+      $group->get('field_flexible_group_visibility')->getValue()[0]['value'] === 'members');
+
+    // The ginvite module sends the email notifications in a hook_presave()
+    // before the invitation id exists, so we fallback to the invites overview
+    // route, or the group's visibility is set to members only.
+    if ($members_only || !$group_content_id) {
       $url = Url::fromRoute('social_core.my_invites')->toString();
       $destination = 'destination=' . $url;
       $group_invite_url = Url::fromRoute('social_core.my_invites', [], ['absolute' => TRUE])->toString();
     }
+    else {
+      $destination = 'destination=/social-group-invite/' . $group_content_id . '/accept';
+      $group_invite_url = Url::fromRoute('social_group_invite.invitation.accept', ['group_content' => $group_content_id], ['absolute' => TRUE])->toString();
+    }
+
     // Attach destination to accept invite. So, after sign up/sign step the
     // invite will be accepted and user  will be redirected to the invited page.
     if (


### PR DESCRIPTION
## Problem
Inviting a user to a group by email address throws fatal errors on 13.0.x and the invitation is never saved. The errors logged:
```
Symfony\Component\Routing\Exception\InvalidParameterException: Parameter "group_content" for route "social_group_invite.invitation.accept" must match "[^/]++" ("" given) to generate a corresponding URL.
```
```
Drupal\Core\Entity\EntityStorageException: Parameter "group_content" for route "social_group_invite.invitation.accept" must match "[^/]++" ("" given) to generate a corresponding URL.
```

Specifically, ginvite 3.x now sends the invitation notification from `ginvite_group_content_presave()`. This runs before the group_content entity is written to the database, so it has no id yet. `social_group_invite_tokens_alter()` then builds the accept URL with an empty `group_content` parameter, which fails the route's `[^/]++` requirement, throws, and aborts the save, so email invites are fully broken.

## Solution
Graceful degradation for the 13.0.x branch: detect the missing group_content ID (and the existing members-only case) and fall back to the `social_core.my_invites` route, which takes not parameters, instead of building the accept URL. The invitation is saved and the email links to the user's invites overview. When an ID is present, behaviour is unchanged.

I noticed `main` already resolves this by disabling ginvite's `group_content_presave` and `tokens` hooks and ensuring that a valid ID exists. That is a larger change and not a safe backport for a maintenance release, so this PR applies a minimal fix instead. Happy to align with main's approach if preferred.

## Issue tracker
[#3607140](https://www.drupal.org/project/social/issues/3607140)


## How to test
**Unregistered user**
- [ ] As a group manager, invite an unregistered email address
- [ ] Confirm no `InvalidParameterException` or `EntityStorageException` are thrown and the invitation is created.
- [ ] Open the invite email and confirm the link resolves properly to the registration page with a destination to `/my-invites`.

**Registered user**
- [ ] As a group manager, invite an existing user.
- [ ] Confirm no `InvalidParameterException` or `EntityStorageException` are thrown and the invitation is created.
- [ ] Open the invite email and confirm the link resolves properly to `/my-invites`.


## Release notes
Fixed fatal `InvalidParameterException` and `EntityStorageException` when inviting users to a group by email on 13.0.x. 
Invitations are now saved and notifications sent correctly, falling back to the invites overview link when the invitation ID is not available.

## Change Record
N/A

## Translations
N/A
