### PR TITLE
Issue #3613370 by epapaniko: Add primary key to user_email_send table

### DIFF
--- a/modules/social_features/social_email_broadcast/social_email_broadcast.install
+++ b/modules/social_features/social_email_broadcast/social_email_broadcast.install
@@ -37,6 +37,7 @@ function social_email_broadcast_schema(): array {
         'default' => 'immediately',
       ],
     ],
+    'primary key' => ['uid', 'name'],
     'indexes' => [
       'ues_uid' => ['uid'],
       'ues_name' => ['name'],
@@ -44,4 +45,18 @@ function social_email_broadcast_schema(): array {
   ];
 
   return $schema;
+}
+
+/**
+ * Add a primary key to user_email_send.
+ */
+function social_email_broadcast_update_130001(): ?string {
+  $schema = \Drupal::database()->schema();
+
+  if ($schema->indexExists('user_email_send', 'PRIMARY')) {
+    return \t('The user_email_send table already has a primary key, skipping.');
+  }
+
+  $schema->addPrimaryKey('user_email_send', ['uid', 'name']);
+  return \t('Added primary key to the user_email_send table.');
 }


### PR DESCRIPTION
## Problem

The status report shows the following error under "Transaction isolation level":

> Transaction isolation level: READ-COMMITTED. For this to work correctly, all
> tables must have a primary key. The following table(s) do not have a primary
> key: user_email_send.

`user_email_send` is defined in `social_email_broadcast_schema()` with `fields` and `indexes`, but without a `primary key`. 
Note that this produces a warning when the isolation level is set to `REPEATABLE-READ` and an error when it is set to `READ-COMMITTED`.

## Solution

- Add `'primary key' => ['uid', 'name']` to `hook_schema()`, so new installs create the table correctly.
- Add `social_email_broadcast_update_130001()`, which calls `addPrimaryKey()` so existing installs are fixed on update.

The update hook returns early if a primary key already exists, since some sites
may have added one manually as a workaround for this error.

## Issue tracker

https://www.drupal.org/project/social/issues/3613370

Related: [#3477972](https://www.drupal.org/project/social/issues/3477972) / PR #4326 covers the same error for `activity_notification_status`, `user_activity_digest` and `user_activity_send`.

## How to test

### Already installed sites with social_email_broadcast module enabled
- [ ] On a site where `social_email_broadcast` is installed, confirm the table has no primary key:
   ```
   drush sqlq "SHOW KEYS FROM user_email_send WHERE key_name = 'PRIMARY'"
   ```
   This returns no rows and `/admin/reports/status` shows the aforementioned error.
- [ ] Apply this PR's patch and run `drush updatedb`.
- [ ] Re-run the drush query command; it now returns two rows. Also, in `/admin/reports/status`, the error is no longer displayed.

### New installations
- [ ] Install `social_email_broadcast` on a clean site and confirm the table is created with the primary key already present. 
 Run:
 ```
 drush sqlq "SHOW KEYS FROM user_email_send WHERE key_name = 'PRIMARY'"
 ```
 Two rows are returned and no related warnings/errors in the status report, `/admin/reports/status`.

## Release notes

Fixed the "Transaction isolation level" status report error caused by the `user_email_send` table missing a primary key.