### PR TITLE
Issue #3618389 by epapaniko: Fix default visibility config key in SocialGroupSelectorWidget

### DIFF
--- a/modules/social_features/social_group/src/Plugin/Field/FieldWidget/SocialGroupSelectorWidget.php
+++ b/modules/social_features/social_group/src/Plugin/Field/FieldWidget/SocialGroupSelectorWidget.php
@@ -243,9 +243,9 @@ class SocialGroupSelectorWidget extends Select2EntityReferenceWidget {
     // Unfortunately, validateGroupSelection is cast as a static function,
     // So I have to add this setting to the form to use it later on.
     $defaultVisibility = $this->configFactory->get('entity_access_by_field.settings')
-      ->get('defaultVisibility');
+      ->get('default_visibility');
 
-    $form['defaultVisibility'] = [
+    $form['default_visibility'] = [
       '#type' => 'value',
       '#value' => $defaultVisibility,
     ];
@@ -315,7 +315,7 @@ class SocialGroupSelectorWidget extends Select2EntityReferenceWidget {
       $allowedVisibilityOptions = self::getVisibilityOptionsForMultipleGroups(array_column($selectedGroups, 'target_id'), $entity);
     }
     else {
-      $defaultVisibility = $form_state->getValue('defaultVisibility');
+      $defaultVisibility = $form_state->getValue('default_visibility');
 
       $allowedVisibilityOptions = social_group_get_allowed_visibility_options_per_group_type(NULL, NULL, $entity);
       // Drupal selectors don't use underscores, but hyphens.


### PR DESCRIPTION
## Problem

`SocialGroupSelectorWidget` reads the site default visibility with `$this->configFactory->get('entity_access_by_field.settings')->get('defaultVisibility')`.
The actual config key defined in `entity_access_by_field.settings.yml` is `default_visibility`, so this always returns `NULL`.

Regressed in c0e43550ba96738202092a0a9a5dd682ba1d8c84 ("PROD-32720: Use on Camel Case variable naming."), which renamed the config key and a form array key alongside valid PHP variable renames.

## Solution

Use the config key that matches the schema and match the relevant form value key.
The other camelCase PHP variable renames implemented in c0e43550ba96738202092a0a9a5dd682ba1d8c84 are _not_ changed.

## Issue tracker

https://www.drupal.org/project/social/issues/3618389

## How to test
1. Set the default visibility to Public:
   `drush cset entity_access_by_field.settings default_visibility public`
2. `drush cr`
3. Go to `/node/add/event`.
4. Default visibility is "Public". This already works correctly.
5. Select a group whose only allowed visibility is "Group members". The
   "Public" and "Community" options are disabled.
6. Clear the group selection.
7. Before this change: default visibility is "Community".
   After this change: default visibility is "Public".


## Change Record
N/A

## Translations
N/A
